### PR TITLE
Install efi and conf file to /usr/share/acrn

### DIFF
--- a/bsp/uefi/efi/Makefile
+++ b/bsp/uefi/efi/Makefile
@@ -80,7 +80,7 @@ all: $(EFIBIN)
 	$(OBJCOPY)  --add-section .hv="$(HV_OBJDIR)/$(HV_FILE).bin"  --change-section-vma .hv=0x6e000 --set-section-flags .hv=alloc,data,contents,load  --section-alignment 0x1000 $(EFI_OBJDIR)/boot.efi  $(EFIBIN)
 
 install: $(EFIBIN)
-	install -D $(EFIBIN) $(DESTDIR)/usr/share/$(HV_FILE).efi
+	install -D $(EFIBIN) $(DESTDIR)/usr/share/acrn/$(HV_FILE).efi
 
 $(EFIBIN): $(BOOT)
 

--- a/bsp/uefi/efi/Makefile
+++ b/bsp/uefi/efi/Makefile
@@ -76,10 +76,12 @@ LDFLAGS=-T $(LDSCRIPT) -Bsymbolic -shared -nostdlib -znocombreloc \
 EFIBIN=$(HV_OBJDIR)/$(HV_FILE).efi
 BOOT=$(EFI_OBJDIR)/boot.efi
 
+CONF_FILE=$(CURDIR)/../clearlinux/acrn.conf
+
 all: $(EFIBIN)
 	$(OBJCOPY)  --add-section .hv="$(HV_OBJDIR)/$(HV_FILE).bin"  --change-section-vma .hv=0x6e000 --set-section-flags .hv=alloc,data,contents,load  --section-alignment 0x1000 $(EFI_OBJDIR)/boot.efi  $(EFIBIN)
 
-install: $(EFIBIN)
+install: $(EFIBIN) install-conf
 	install -D $(EFIBIN) $(DESTDIR)/usr/share/acrn/$(HV_FILE).efi
 
 $(EFIBIN): $(BOOT)
@@ -88,6 +90,10 @@ $(EFI_OBJDIR)/boot.efi: $(EFI_OBJDIR)/boot.so
 
 $(EFI_OBJDIR)/boot.so: $(ACRN_OBJS) $(FS)
 	$(LD) $(LDFLAGS) -o $@ $^  -lgnuefi -lefi $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+
+install-conf: $(CONF_FILE)
+	install -d $(DESTDIR)/usr/share/acrn/demo
+	install -t $(DESTDIR)/usr/share/acrn/demo -m 644 $^
 
 clean:
 	rm -f $(BOOT) $(HV_OBJDIR)/$(HV_FILE).efi $(EFI_OBJDIR)/boot.so $(ACRN_OBJS) $(FS)


### PR DESCRIPTION
Currently acrn.efi is installed to /usr/share, this PR changes the installation directory to /usr/share/acrn.

Even more the conf file was not installed, this PR install it to /usr/share/acrn/demo