### PR TITLE
use efi instead of linux in acrn.conf

### DIFF
--- a/bsp/uefi/clearlinux/acrn.conf
+++ b/bsp/uefi/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title ACRN OS
-linux /EFI/org.clearlinux/acrn.efi
+efi   /EFI/org.clearlinux/acrn.efi
 options sos=bzImage pci_devices_ignore=(0:18:2) noxsave maxcpus=1 console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=/dev/sda3 rw rootwait clocksource=hpet ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x00000F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 hvlog=2M@0x1FE00000 cma=2560M@0x100000000-0


### PR DESCRIPTION
acrn.efi is an EFI executable image and not a linux kernel image.
This commit changes linux to efi in the boot-loader configuration.

For more reference please review:
https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>