### PR TITLE
security: fortify source and format string check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ CFLAGS += -fshort-wchar -ffreestanding
 CFLAGS += -m64
 CFLAGS += -mno-red-zone
 CFLAGS += -static -nostdinc -nostdlib -fno-common
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -Wformat -Wformat-security
 
 ifdef STACK_PROTECTOR
 ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))


### PR DESCRIPTION
"-O2 -D_FORTIFY_SOURCE=2":
GCC C-Compiler can analyze the source code to be compiled and detect
certain insecure sections, that might create a security problem. The
compiler will replace the insecure function calls with special hardened
code that will perform extra runtime checks while the process is
executed.
"-Wformat -Wformat-security":
It warns about calls to "printf" and "scanf" functions where the format
string is not a string literal and there are no format arguments, as in
"printf (foo);". This may be a security hole if the format string came
from untrusted input and contains %n.

Tracked-On: 224003
Signed-off-by: wenshelx <wenshengx.wang@intel.com>