### PR TITLE
apicv: cancel event injection if vcpu is scheduled out

### DIFF
--- a/common/schedule.c
+++ b/common/schedule.c
@@ -147,6 +147,9 @@ static void context_switch_out(struct vcpu *vcpu)
 	if (vcpu == NULL)
 		return;
 
+	/* cancel event(int, gp, nmi and exception) injection */
+	cancel_event_injection(vcpu);
+
 	atomic_store_rel_32(&vcpu->running, 0);
 	/* do prev vcpu context switch out */
 	/* For now, we don't need to invalid ept.

--- a/include/arch/x86/guest/vcpu.h
+++ b/include/arch/x86/guest/vcpu.h
@@ -185,6 +185,11 @@ struct run_context {
 #define NORMAL_WORLD	0
 #define SECURE_WORLD	1
 
+struct event_injection_info {
+	uint32_t intr_info;
+	uint32_t error_code;
+};
+
 struct vcpu_arch {
 	int cur_context;
 	struct run_context contexts[NR_WORLD];
@@ -221,6 +226,8 @@ struct vcpu_arch {
 
 	/* interrupt injection information */
 	uint64_t pending_intr;
+	bool inject_event_pending;
+	struct event_injection_info inject_info;
 
 	/* per vcpu lapic */
 	void *vlapic;

--- a/include/arch/x86/irq.h
+++ b/include/arch/x86/irq.h
@@ -161,4 +161,6 @@ int interrupt_win_exiting_handler(struct vcpu *vcpu);
 int external_interrupt_handler(struct vcpu *vcpu);
 int acrn_do_intr_process(struct vcpu *vcpu);
 int interrupt_init(uint32_t logical_id);
+
+void cancel_event_injection(struct vcpu *vcpu);
 #endif /* IRQ_H */


### PR DESCRIPTION
And re-inject the event after vcpu is scheduled in.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>