### PR TITLE
Remove ASSERT in lib functions

### DIFF
--- a/lib/mem_mgt.c
+++ b/lib/mem_mgt.c
@@ -266,7 +266,8 @@ void *malloc(unsigned int num_bytes)
 	}
 
 	/* Check if memory allocation is successful */
-	ASSERT(memory != NULL, "");
+	if (memory == NULL)
+		pr_err("Memory allocation failure: 0x%08x Byte", num_bytes);
 
 	/* Return memory pointer to caller */
 	return memory;
@@ -280,7 +281,8 @@ void *alloc_pages(unsigned int page_num)
 	memory = allocate_mem(&Paging_Memory_Pool, page_num * CPU_PAGE_SIZE);
 
 	/* Check if memory allocation is successful */
-	ASSERT(memory != NULL, "");
+	if (memory == NULL)
+		pr_err("Memory allocation failure: %d pages", page_num);
 
 	return memory;
 }

--- a/lib/memcpy.c
+++ b/lib/memcpy.c
@@ -54,7 +54,8 @@
  *
  *   OUTPUTS
  *
- *       void *             pointer to destination address
+ *       void *             pointer to destination address if successful,
+ * 			    or else return null.
  *
  ***********************************************************************/
 void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
@@ -67,12 +68,16 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
 	if (d == s)
 		return d;
 
-	ASSERT((slen != 0) && (dmax != 0) && (dmax >= slen),
-		"invalid slen or dmax.");
+	if ((slen == 0) || (dmax == 0) || (dmax < slen)) {
+		pr_err("invalid slen or dmax.");
+		return NULL;
+	}
 
-	ASSERT(((d > s) && (d > s + slen - 1))
-		|| ((d < s) && (s > d + dmax - 1)),
-		"overlap happened.");
+	if (((d > s) && (d <= s + slen - 1))
+		|| ((d < s) && (s <= d + dmax - 1))) {
+		pr_err("overlap happened.");
+		return NULL;
+	}
 
 	dest8 = (uint8_t *)d;
 	src8 = (uint8_t *)s;

--- a/lib/strcpy.c
+++ b/lib/strcpy.c
@@ -63,8 +63,10 @@ char *strcpy_s(char *d, size_t dmax, const char *s)
 	size_t dest_avail;
 	uint64_t overlap_guard;
 
-	ASSERT(s != NULL, "invalid input s.");
-	ASSERT((d != NULL) && (dmax != 0), "invalid input d or dmax.");
+	if (s == NULL || (d == NULL) || (dmax == 0)) {
+		pr_err("strcpy_s: invalid input s, d or dmax.");
+		return NULL;
+	}
 
 	if (s == d)
 		return d;
@@ -75,7 +77,11 @@ char *strcpy_s(char *d, size_t dmax, const char *s)
 	dest_base = d;
 
 	while (dest_avail > 0) {
-		ASSERT(overlap_guard != 0, "overlap happened.");
+		if (overlap_guard == 0) {
+			pr_err("strcpy_s: overlap happened.");
+			*(--d) = '\0';
+			return NULL;
+		}
 
 		*d = *s;
 		if (*d == '\0')
@@ -87,7 +93,7 @@ char *strcpy_s(char *d, size_t dmax, const char *s)
 		overlap_guard--;
 	}
 
-	ASSERT(false, "dest buffer has no enough space.");
+	pr_err("strcpy_s: dest buffer has no enough space.");
 
 	/*
 	 * to avoid a string that is not

--- a/lib/strncpy.c
+++ b/lib/strncpy.c
@@ -66,8 +66,15 @@ char *strncpy_s(char *d, size_t dmax, const char *s, size_t slen)
 	size_t dest_avail;
 	uint64_t overlap_guard;
 
-	ASSERT((d != NULL) && (s != NULL), "invlaid input d or s");
-	ASSERT((dmax != 0) && (slen != 0), "invlaid input dmax or slen");
+	if ((d == NULL) || (s == NULL)) {
+		pr_err("strncpy_s: invlaid input d or s");
+		return NULL;
+	}
+
+	if ((dmax == 0) || (slen == 0)) {
+		pr_err("strncpy_s: invlaid input dmax or slen");
+		return NULL;
+	}
 
 	if (d == s)
 		return d;
@@ -78,7 +85,11 @@ char *strncpy_s(char *d, size_t dmax, const char *s, size_t slen)
 	dest_avail = dmax;
 
 	while (dest_avail > 0) {
-		ASSERT(overlap_guard != 0, "overlap happened.");
+		if (overlap_guard == 0) {
+			pr_err("strncpy_s: overlap happened.");
+			*(--d) = '\0';
+			return NULL:
+		}
 
 		if (slen == 0) {
 			*d = '\0';
@@ -96,7 +107,7 @@ char *strncpy_s(char *d, size_t dmax, const char *s, size_t slen)
 		overlap_guard--;
 	}
 
-	ASSERT(false, "dest buffer has no enough space.");
+	pr_err("strncpy_s: dest buffer has no enough space.");
 
 	/*
 	 * to avoid a string that is not


### PR DESCRIPTION
Replace ASSERT in lib functions with error message print and return a
value indicating error to allow the caller of lib functions to handle
the error.

Signed-off-by: Yan, Like <like.yan@intel.com>