### PR TITLE
Jmp to vm_exit directly if vm-entry fails in vmresume

### DIFF
--- a/arch/x86/vmx_asm.S
+++ b/arch/x86/vmx_asm.S
@@ -109,6 +109,9 @@ next:
     /* Execute a VM resume */
     vmresume
 
+    /* jump to vm_exit directly when it fails in vmresume */
+    jmp         vm_exit
+
 vm_launch:
 
     /* Execute a VM launch */


### PR DESCRIPTION
…ails in vmresume

It is possible that the vm-entry fails in vmresume instr under some scenarios.
It will pass to next instruction following vmresume. In such case it will call
the vmlaunch again.

Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>