### PR TITLE
align the coding style when access VMEXIT_QUAL

### DIFF
--- a/arch/x86/ept.c
+++ b/arch/x86/ept.c
@@ -414,7 +414,7 @@ int ept_violation_handler(struct vcpu *vcpu)
 	uint64_t gpa;
 
 	/* Handle page fault from guest */
-	exit_qual = exec_vmread(VMX_EXIT_QUALIFICATION);
+	exit_qual = vcpu->arch_vcpu.exit_qualification;
 
 	memset(&vcpu->req, 0, sizeof(struct vhm_request));
 

--- a/arch/x86/guest/vlapic.c
+++ b/arch/x86/guest/vlapic.c
@@ -2316,7 +2316,7 @@ int apicv_virtualized_eoi_exit_handler(struct vcpu *vcpu)
 {
 	struct vlapic *vlapic = NULL;
 
-	int vector = exec_vmread(VMX_EXIT_QUALIFICATION) & 0xFF;
+	int vector;
 	struct lapic *lapic;
 	struct lapic_reg *tmrptr;
 	uint32_t idx, mask;
@@ -2325,6 +2325,7 @@ int apicv_virtualized_eoi_exit_handler(struct vcpu *vcpu)
 
 	vlapic =  vcpu->arch_vcpu.vlapic;
 	lapic = vlapic->apic_page;
+	vector = (vcpu->arch_vcpu.exit_qualification) & 0xFF;
 
 	tmrptr = &lapic->tmr[0];
 	idx = vector / 32;
@@ -2347,7 +2348,7 @@ int apicv_write_exit_handler(struct vcpu *vcpu)
 	int error, handled, offset;
 	struct vlapic *vlapic = NULL;
 
-	qual = exec_vmread(VMX_EXIT_QUALIFICATION);
+	qual = vcpu->arch_vcpu.exit_qualification;
 	offset = (qual & 0xFFF);
 
 	handled = 1;

--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -125,9 +125,11 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_TPR_BELOW_THRESHOLD] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_APIC_ACCESS] = {
-		.handler = apicv_access_exit_handler},
+		.handler = apicv_access_exit_handler,
+		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_VIRTUALIZED_EOI] = {
-		.handler = apicv_virtualized_eoi_exit_handler},
+		.handler = apicv_virtualized_eoi_exit_handler,
+		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_GDTR_IDTR_ACCESS] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_LDTR_TR_ACCESS] = {
@@ -151,7 +153,8 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_XSETBV] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_APIC_WRITE] = {
-		.handler = apicv_write_exit_handler}
+		.handler = apicv_write_exit_handler,
+		.need_exit_qualification = 1}
 };
 
 struct vm_exit_dispatch *vmexit_handler(struct vcpu *vcpu)


### PR DESCRIPTION
 - align coding style to avoid redundant operations
   when operating on reading  VMX_EXIT_QUALIFICATION

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>