### PR TITLE
Add page mask MACRO

### DIFF
--- a/arch/x86/mmu.c
+++ b/arch/x86/mmu.c
@@ -640,7 +640,7 @@ void obtain_last_page_table_entry(struct map_params *map_params,
 	}
 
 	/* Obtain page table entry from PD table*/
-	table_addr = (void *)(table_entry&IA32E_REF_MASK);
+	table_addr = (void *)(table_entry & IA32E_REF_MASK);
 	table_entry = get_table_entry(map_params, addr,
 			table_addr, IA32E_PD);
 	table_present = check_page_table_present(map_params, table_entry);
@@ -667,7 +667,7 @@ void obtain_last_page_table_entry(struct map_params *map_params,
 	}
 
 	/* Obtain page table entry from PT table*/
-	table_addr = (void *)(table_entry&IA32E_REF_MASK);
+	table_addr = (void *)(table_entry & IA32E_REF_MASK);
 	table_entry = get_table_entry(map_params, addr,
 			table_addr, IA32E_PT);
 	table_present = check_page_table_present(map_params, table_entry);

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -41,6 +41,7 @@
 /* Define page size */
 #define CPU_PAGE_SHIFT          12
 #define CPU_PAGE_SIZE           0x1000
+#define CPU_PAGE_MASK           0xFFFFFFFFFFFFF000
 
 /* Define CPU stack alignment */
 #define CPU_STACK_ALIGN         16

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -167,7 +167,7 @@
 #define     IA32E_INDEX_MASK_BITS           9
 #define     IA32E_NUM_ENTRIES               512
 #define     IA32E_INDEX_MASK                (uint64_t)(IA32E_NUM_ENTRIES - 1)
-#define     IA32E_REF_MASK                  0x7FFFFFFFFFFFF000
+#define     IA32E_REF_MASK                  0x000FFFFFFFFFF000
 #define     IA32E_FIRST_BLOCK_INDEX         1
 
 /* Macro to get PML4 index given an address */
@@ -238,8 +238,8 @@
 #define     MMU_MEM_ATTR_TYPE_WRITE_PROTECTED \
 		(IA32E_PDPTE_PAT_BIT | IA32E_COMM_PCD_BIT | IA32E_COMM_PWT_BIT)
 
-#define ROUND_PAGE_UP(addr)  (((addr) + CPU_PAGE_SIZE - 1) & IA32E_REF_MASK)
-#define ROUND_PAGE_DOWN(addr) ((addr) & IA32E_REF_MASK)
+#define ROUND_PAGE_UP(addr)  (((addr) + CPU_PAGE_SIZE - 1) & CPU_PAGE_MASK)
+#define ROUND_PAGE_DOWN(addr) ((addr) & CPU_PAGE_MASK)
 
 struct map_params {
 	/* enum _page_table_type: HOST or EPT*/


### PR DESCRIPTION
Now used IA32E_REF_MASK when calculate the address,
it will clear bit63, should use CPU_PAGE_MASK

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>