### PR TITLE
mmu: Rename several variables related to page table type

### DIFF
--- a/arch/x86/ept.c
+++ b/arch/x86/ept.c
@@ -146,7 +146,7 @@ uint64_t gpa2hpa_check(struct vm *vm, uint64_t gpa,
 	struct entry_params entry;
 	struct map_params map_params;
 
-	map_params.page_table_type = PT_EPT;
+	map_params.page_table_type = PTT_EPT;
 	map_params.pml4_base = vm->arch_vm.nworld_eptp;
 	map_params.pml4_inverted = vm->arch_vm.m2p;
 	obtain_last_page_table_entry(&map_params, &entry,
@@ -185,7 +185,7 @@ uint64_t hpa2gpa(struct vm *vm, uint64_t hpa)
 	struct entry_params entry;
 	struct map_params map_params;
 
-	map_params.page_table_type = PT_EPT;
+	map_params.page_table_type = PTT_EPT;
 	map_params.pml4_base = vm->arch_vm.nworld_eptp;
 	map_params.pml4_inverted = vm->arch_vm.m2p;
 
@@ -535,7 +535,7 @@ int ept_mmap(struct vm *vm, uint64_t hpa,
 	struct vcpu *vcpu;
 
 	/* Setup memory map parameters */
-	map_params.page_table_type = PT_EPT;
+	map_params.page_table_type = PTT_EPT;
 	if (vm->arch_vm.nworld_eptp) {
 		map_params.pml4_base = vm->arch_vm.nworld_eptp;
 		map_params.pml4_inverted = vm->arch_vm.m2p;

--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -46,7 +46,7 @@ void create_secure_world_ept(struct vm *vm, uint64_t gpa,
 	if (vm->sworld_control.sworld_enabled && !vm->arch_vm.sworld_eptp)
 		vm->arch_vm.sworld_eptp = alloc_paging_struct();
 
-	map_params.page_table_type = PT_EPT;
+	map_params.page_table_type = PTT_EPT;
 	map_params.pml4_inverted = vm->arch_vm.m2p;
 
 	/* unmap gpa~gpa+size from guest ept mapping */

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -259,8 +259,8 @@ struct entry_params {
 };
 
 enum _page_table_type {
-	PT_HOST = 0,  /* Mapping for hypervisor */
-	PT_EPT = 1,
+	PTT_HOST = 0,  /* Mapping for hypervisor */
+	PTT_EPT = 1,
 	PAGETABLE_TYPE_UNKNOWN,
 };
 


### PR DESCRIPTION
rename 'PT_HOST' to 'PTT_HOST'
rename 'PT_EPT' to 'PTT_EPT'
rename 'ept_type' to 'table_type'

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>