### PR TITLE
.gitignore: add 2 entries to ignore version.h file if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+bsp/uefi/include/bsp/version.h
+bsp/sbl/include/bsp/version.h


### PR DESCRIPTION
If you build for a platform (e.g. uefi) and right after that for
another platform ('sbl'), the new build will fail and a version.h
file is left in the tree (bsp/uefi/include/bsp/version.h or
bsp/sbl/include/bsp/version.h depending on the order you built one
after the other). This commit makes git ignore any of those in case
it is there. Note that 'make clean' with the corresponding
PLATFORM variable will clean this file.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>