### PR TITLE
makefile: adjust linker path in Makefile

### DIFF
--- a/bsp/uefi/efi/Makefile
+++ b/bsp/uefi/efi/Makefile
@@ -55,8 +55,15 @@ endif
 INCDIR := /usr/include
 
 # gnuefi sometimes installs these under a gnuefi/ directory, and sometimes not
-CRT0 := $(LIBDIR)/crt0-efi-$(ARCH).o
-LDSCRIPT := $(LIBDIR)/elf_$(ARCH)_efi.lds
+ifneq ("$(wildcard $(LIBDIR)/gnuefi/crt0-efi-$(ARCH).o)","")
+	CRT0 := $(LIBDIR)/gnuefi/crt0-efi-$(ARCH).o
+	LDSCRIPT := $(LIBDIR)/gnuefi/elf_$(ARCH)_efi.lds
+else
+	CRT0 := $(LIBDIR)/crt0-efi-$(ARCH).o
+	LDSCRIPT := $(LIBDIR)/elf_$(ARCH)_efi.lds
+endif
+
+
 
 CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \


### PR DESCRIPTION
As mentioned in https://github.com/projectacrn/acrn-documentation/pull/38 , 
on some operating systems, the ``gnu-efi`` package installs the
linker under a ``gnuefi`` folder in ``${LIBDIR}``. This is the
case in Fedora for example. Check if the gnuefi folder is there
and use it if it is, in the path to the linker.  This PR fixes the Makefile rather
than documenting how to edit it yourself.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>