### PR TITLE
Add handle EOI case when APIC-write VM exit

### DIFF
--- a/arch/x86/guest/vlapic.c
+++ b/arch/x86/guest/vlapic.c
@@ -2384,6 +2384,9 @@ int apicv_write_exit_handler(struct vcpu *vcpu)
 	case APIC_OFFSET_ID:
 		vlapic_id_write_handler(vlapic);
 		break;
+	case APIC_OFFSET_EOI:
+		vlapic_process_eoi(vlapic);
+		break;
 	case APIC_OFFSET_LDR:
 		vlapic_ldr_write_handler(vlapic);
 		break;


### PR DESCRIPTION
 -If "virtual-interrupt delivery" VM-execution control is 0,
  Processor will causes an APIC-write VM exit if page offset
  is 0xB0 (EOI), SDM Vol3, Chapter 29.4.3

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>