### PR TITLE
hv: rename VM exit handlers in vlapic

### DIFF
--- a/arch/x86/guest/vlapic.c
+++ b/arch/x86/guest/vlapic.c
@@ -2337,7 +2337,7 @@ apicv_inject_pir(struct vlapic *vlapic)
 	}
 }
 
-int apic_access_exit_handler(struct vcpu *vcpu)
+int apic_access_vmexit_handler(struct vcpu *vcpu)
 {
 	bool ret;
 	int access_type, offset;
@@ -2366,7 +2366,7 @@ int apic_access_exit_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int apicv_virtualized_eoi_exit_handler(struct vcpu *vcpu)
+int veoi_vmexit_handler(struct vcpu *vcpu)
 {
 	struct vlapic *vlapic = NULL;
 
@@ -2395,7 +2395,7 @@ int apicv_virtualized_eoi_exit_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int apicv_write_exit_handler(struct vcpu *vcpu)
+int apic_write_vmexit_handler(struct vcpu *vcpu)
 {
 	bool retu;
 	uint64_t qual;
@@ -2455,8 +2455,8 @@ int apicv_write_exit_handler(struct vcpu *vcpu)
 	return handled;
 }
 
-int apic_tpr_below_threshold_exit_handler(__unused struct vcpu *vcpu)
+int tpr_below_threshold_vmexit_handler(__unused struct vcpu *vcpu)
 {
-	pr_err("Unhandled %s,", __func__);
+	pr_err("Unhandled %s.", __func__);
 	return 0;
 }

--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -123,12 +123,12 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_ENTRY_FAILURE_MACHINE_CHECK] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_TPR_BELOW_THRESHOLD] = {
-		.handler = apic_tpr_below_threshold_exit_handler},
+		.handler = tpr_below_threshold_vmexit_handler},
 	[VMX_EXIT_REASON_APIC_ACCESS] = {
-		.handler = apic_access_exit_handler,
+		.handler = apic_access_vmexit_handler,
 		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_VIRTUALIZED_EOI] = {
-		.handler = apicv_virtualized_eoi_exit_handler,
+		.handler = veoi_vmexit_handler,
 		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_GDTR_IDTR_ACCESS] = {
 		.handler = unhandled_vmexit_handler},
@@ -153,7 +153,7 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_XSETBV] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_APIC_WRITE] = {
-		.handler = apicv_write_exit_handler,
+		.handler = apic_write_vmexit_handler,
 		.need_exit_qualification = 1}
 };
 

--- a/include/arch/x86/guest/vlapic.h
+++ b/include/arch/x86/guest/vlapic.h
@@ -125,10 +125,10 @@ uint64_t apicv_get_apic_access_addr(struct vm *vm);
 uint64_t apicv_get_apic_page_addr(struct vlapic *vlapic);
 bool vlapic_apicv_enabled(struct vcpu *vcpu);
 void apicv_inject_pir(struct vlapic *vlapic);
-int apic_access_exit_handler(struct vcpu *vcpu);
-int apicv_write_exit_handler(struct vcpu *vcpu);
-int apicv_virtualized_eoi_exit_handler(struct vcpu *vcpu);
-int apic_tpr_below_threshold_exit_handler(struct vcpu *vcpu);
+int apic_access_vmexit_handler(struct vcpu *vcpu);
+int apic_write_vmexit_handler(struct vcpu *vcpu);
+int veoi_vmexit_handler(struct vcpu *vcpu);
+int tpr_below_threshold_vmexit_handler(struct vcpu *vcpu);
 
 void calcvdest(struct vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 #endif	/* _VLAPIC_H_ */


### PR DESCRIPTION
to keep aligned with the vmexit reasons' name defined in
SPEC.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>