### PR TITLE
Add cpuinfo_x86 to cache cpu capability/feature

### DIFF
--- a/arch/x86/vmx.c
+++ b/arch/x86/vmx.c
@@ -93,17 +93,6 @@ static inline int exec_vmxon(void *addr)
 	return status;
 }
 
-bool get_vmx_cap(void)
-{
-	uint32_t eax, ebx, ecx, edx;
-
-	/* Run CPUID to determine if VTX support available */
-	cpuid(CPUID_FEATURES, &eax, &ebx, &ecx, &edx);
-
-	/* See if VMX feature bit is set in ECX */
-	return !!(ecx & CPUID_ECX_VMX);
-}
-
 int exec_vmxon_instr(void)
 {
 	uint64_t tmp64;

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -216,18 +216,35 @@ extern int phy_cpu_num;
 /* get percpu data for current pcpu */
 #define get_cpu_var(name)	per_cpu(name, get_cpu_id())
 
+/* CPUID feature words */
+enum feature_word {
+	FEAT_1_ECX,         /* CPUID[1].ECX */
+	FEAT_1_EDX,         /* CPUID[1].EDX */
+	FEAT_7_0_EBX,       /* CPUID[EAX=7,ECX=0].EBX */
+	FEAT_7_0_ECX,       /* CPUID[EAX=7,ECX=0].ECX */
+	FEAT_7_0_EDX,       /* CPUID[EAX=7,ECX=0].EDX */
+	FEAT_8000_0001_ECX, /* CPUID[8000_0001].ECX */
+	FEAT_8000_0001_EDX, /* CPUID[8000_0001].EDX */
+	FEATURE_WORDS,
+};
+
+struct cpuinfo_x86 {
+	uint8_t x86, x86_model;
+	uint32_t cpuid_leaves[FEATURE_WORDS];
+};
+
+extern struct cpuinfo_x86 boot_cpu_data;
+
 /* Function prototypes */
 void cpu_halt(uint32_t logical_id);
 uint64_t cpu_cycles_per_second(void);
 uint64_t tsc_cycles_in_period(uint16_t timer_period_in_us);
 void cpu_secondary_reset(void);
 int hv_main(int cpu_id);
-bool check_tsc_adjust_support(void);
-bool check_ibrs_ibpb_support(void);
-bool check_stibp_support(void);
 bool is_vapic_supported(void);
 bool is_vapic_intr_delivery_supported(void);
 bool is_vapic_virt_reg_supported(void);
+bool get_vmx_cap(void);
 
 /* Read control register */
 #define CPU_CR_READ(cr, result_ptr)                         \

--- a/include/arch/x86/vmx.h
+++ b/include/arch/x86/vmx.h
@@ -427,7 +427,6 @@
 #define PAGE_PROTECTED_MODE     2
 
 /* External Interfaces */
-bool get_vmx_cap(void);
 int exec_vmxon_instr(void);
 uint64_t exec_vmread(uint32_t field);
 uint64_t exec_vmread64(uint32_t field_full);


### PR DESCRIPTION
Add a global boot_cpu_data to cache common cpu capbility/feature
for detect cpu capbility/feature.

Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Xu, Anthony <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>