### PR TITLE
cpuid restruct

### DIFF
--- a/arch/x86/guest/ucode.c
+++ b/arch/x86/guest/ucode.c
@@ -40,7 +40,7 @@ uint64_t get_microcode_version(void)
 	uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
 
 	msr_write(MSR_IA32_BIOS_SIGN_ID, 0);
-	native_cpuid_count(CPUID_FEATURES, 0, &eax, &ebx, &ecx, &edx);
+	cpuid(CPUID_FEATURES, &eax, &ebx, &ecx, &edx);
 	val = msr_read(MSR_IA32_BIOS_SIGN_ID);
 
 	return val;

--- a/arch/x86/guest/vm.c
+++ b/arch/x86/guest/vm.c
@@ -170,7 +170,9 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 			ptdev_vm_init(vm);
 			vm->sw.req_buf = 0;
 
-			vm->state = VM_CREATED;
+			status = set_vcpuid_entries(vm);
+			if (status)
+				vm->state = VM_CREATED;
 		}
 
 	}

--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -316,7 +316,7 @@ int cpuid_handler(struct vcpu *vcpu)
 	struct run_context *cur_context =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
 
-	emulate_cpuid(vcpu, (uint32_t)cur_context->guest_cpu_regs.regs.rax,
+	guest_cpuid(vcpu,
 		(uint32_t *)&cur_context->guest_cpu_regs.regs.rax,
 		(uint32_t *)&cur_context->guest_cpu_regs.regs.rbx,
 		(uint32_t *)&cur_context->guest_cpu_regs.regs.rcx,

--- a/include/arch/x86/guest/vm.h
+++ b/include/arch/x86/guest/vm.h
@@ -39,7 +39,7 @@ enum vm_privilege_level {
 
 #define	MAX_VM_NAME_LEN		16
 struct vm_attr {
-	char name[16];	/* Virtual machine name string */
+	char name[MAX_VM_NAME_LEN];	/* Virtual machine name string */
 	int id;		/* Virtual machine identifier */
 	int boot_idx;	/* Index indicating the boot sequence for this VM */
 };
@@ -134,6 +134,19 @@ struct vm_arch {
 	/* reference to virtual platform to come here (as needed) */
 };
 
+#define CPUID_CHECK_SUBLEAF	(1 << 0)
+#define MAX_VM_VCPUID_ENTRIES	64
+struct vcpuid_entry {
+	uint32_t eax;
+	uint32_t ebx;
+	uint32_t ecx;
+	uint32_t edx;
+	uint32_t leaf;
+	uint32_t subleaf;
+	uint32_t flags;
+	uint32_t padding;
+};
+
 struct vpic;
 struct vm {
 	struct vm_attr attr;	/* Reference to this VM's attributes */
@@ -167,6 +180,9 @@ struct vm {
 
 	unsigned char GUID[16];
 	struct secure_world_control sworld_control;
+
+	uint32_t vcpuid_entry_nr, vcpuid_level, vcpuid_xlevel;
+	struct vcpuid_entry vcpuid_entries[MAX_VM_VCPUID_ENTRIES];
 };
 
 struct vm_description {


### PR DESCRIPTION
Generate all common virtual cpuid entries for flexible support of
guest VCPUID emulation, by decoupling from PCPUID.

Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Xu, Anthony <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Chen, Jason CJ <jason.cj.chen@intel.com>