### PR TITLE
Use Docker for building ACRN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
+sudo: required
+
 language: c
-compiler:
- - gcc
-script: make clean && make all
+
+services:
+  - docker
+
+before_install:
+  - docker ps -a
+
+script:
+  - docker build -t shrmrf/acrn-hypervisor .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM clearlinux:base
+
+MAINTAINER shrmrf "https://github.com/shrmrf"
+
+# Install packages for building acrn
+# RUN swupd update
+RUN swupd bundle-add  os-core-dev
+
+RUN git config --global http.sslVerify false
+
+COPY  . /root/acrn-hypervisor
+RUN cd /root/acrn-hypervisor; make clean && make PLATFORM=uefi


### PR DESCRIPTION
Hello projectacrn team,

As @gvancuts suggested in the other pull request, I created an example `Dockerfile` and associated `.travis.yml` script.

The [build is running fine](https://travis-ci.org/shrmrf/acrn-hypervisor) for me.