### PR TITLE
debug: make ASSERT empty under release version

### DIFF
--- a/include/debug/assert.h
+++ b/include/debug/assert.h
@@ -40,12 +40,7 @@ void __assert(uint32_t line, const char *file, char *txt);
 		__assert(__LINE__, __FILE__, "fatal error");\
 	}
 #else
-#define ASSERT(x, ...)				\
-	if (!(x)) {				\
-		do {				\
-			asm volatile ("pause" ::: "memory");	\
-		} while (1);			\
-	}
+#define ASSERT(x, ...)	do { } while(0)
 #endif
 
 /* Force a compilation error if condition is false */


### PR DESCRIPTION
ASSERT is only for debug purpose, for release version, it should try
error handling instead of deadloop there.

v1:
- change the ASSERT under release version to empty code

TODO: revise all ASSERT usage

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong (Eddie.dong@intel.com)