### PR TITLE
Fix compiler warnings when building for UEFI

### DIFF
--- a/bsp/uefi/efi/boot.c
+++ b/bsp/uefi/efi/boot.c
@@ -244,7 +244,7 @@ load_sos_image(EFI_HANDLE image, CHAR16 *name, CHAR16 *cmdline)
 	struct multiboot_mmap *mmap;
 	struct multiboot_info *mbi;
 
-	struct acpi_table_rsdp *rsdp;
+	struct acpi_table_rsdp *rsdp = NULL;
 	int i, j;
 
 

--- a/bsp/uefi/uefi.c
+++ b/bsp/uefi/uefi.c
@@ -136,8 +136,8 @@ int uefi_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	vlapic_restore(vcpu->arch_vcpu.vlapic, &uefi_lapic_regs);
 
 	vcpu->entry_addr = efi_ctx->entry;
-	cur_context->guest_cpu_regs.regs.rcx = efi_ctx->handle;
-	cur_context->guest_cpu_regs.regs.rdx = efi_ctx->table;
+	cur_context->guest_cpu_regs.regs.rcx = (uint64_t) efi_ctx->handle;
+	cur_context->guest_cpu_regs.regs.rdx = (uint64_t) efi_ctx->table;
 
 	/* defer irq enabling till vlapic is ready */
 	CPU_IRQ_ENABLE();

--- a/include/arch/x86/apicreg.h
+++ b/include/arch/x86/apicreg.h
@@ -521,4 +521,9 @@ struct ioapic {
 
 #define IOAPIC_RTE_INTVEC	0x000000ff /*R/W: INT vector field*/
 
+#ifdef CONFIG_EFI_STUB
+int sipi_from_efi_boot_service_exit(uint32_t dest, uint32_t mode, uint32_t vec);
+void efi_deferred_wakeup_pcpu(int cpu_id);
+#endif
+
 #endif /* _APICREG_H_ */

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -147,6 +147,8 @@
 
 #ifndef ASSEMBLER
 
+int cpu_find_logical_id(uint32_t lapic_id);
+
 /**********************************/
 /* EXTERNAL VARIABLES             */
 /**********************************/


### PR DESCRIPTION
Straight forward compiler warning fix patch when building with PLATFORM=uefi

The most controversial bits are where to place the function definitions for the uefi related functions.  Instead of adding a new header I just placed them in a CONFIG_EFI_STUB protected section of apicreg.h.  Not sure if there is a better place. 