### PR TITLE
ptdev: fix ptdev_hv_owned_intx under release version

### DIFF
--- a/arch/x86/assign.c
+++ b/arch/x86/assign.c
@@ -321,8 +321,8 @@ static void check_deactive_pic_intx(struct vm *vm, uint8_t phys_pin)
 
 static bool ptdev_hv_owned_intx(struct vm *vm, struct ptdev_intx_info *info)
 {
-	/* vm0 pin 4 (uart) is owned by hypervisor */
-	if (is_vm0(vm) && info->virt_pin == 4)
+	/* vm0 pin 4 (uart) is owned by hypervisor under debug version */
+	if (is_vm0(vm) && vm->vuart && info->virt_pin == 4)
 		return true;
 	else
 		return false;


### PR DESCRIPTION
for release version, the vuart is not be used - pin 4 then is not used
by hypervisor.
this patch adds check for vm0->vuart to distinguish it.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>