### PR TITLE
Trusty enabling patch series

### DIFF
--- a/Documentation/Trusty.txt
+++ b/Documentation/Trusty.txt
@@ -49,8 +49,8 @@ Note: Trusty OS is running in Secure World in the architecture above.
 **************************
 Trusty specific Hypercalls
 **************************
-1. HC_LAUNCH_TRUSTY
-   ->This Hypercall is used by UOSloader (User OS Bootloader) to request ACRN to launch Trusty.
+1. HC_INITIALIZE_TRUSTY
+   ->This Hypercall is used by UOS_Loader to request ACRN to initialize Trusty.
    ->The Trusty memory region range, entry point must be specified.
    ->Hypervisor needs to save current vCPU contexts (Normal World).
 2. HC_WORLD_SWITCH
@@ -60,7 +60,7 @@ Trusty specific Hypercalls
 
 API
 ---
-1. hcall_launch_trusty(vm_t *vm);
+1. hcall_initialize_trusty(vm_t *vm);
 2. hcall_world_switch(vm_t *vm);
 
 
@@ -71,12 +71,12 @@ Per design, UOSloader will trigger boot of Trusty. So the boot flow will be:
     UOSloader --> ACRN --> Trusty --> ACRN --> UOSloader
 
 Detail:
-1. UOSloader
+1. UOS_Loader
    1.1 load and verify trusty image from virtual disk.
    1.2 allocate runtime memory for trusty.
    1.3 do ELF relocation of trusty image and get entry address.
-   1.4 call HC_LAUNCH_TRUSTY with trusty memory base and entry address.
-2. ACRN(HC_LAUNCH_TRUSTY)
+   1.4 call HC_INITIALIZE_TRUSTY with trusty memory base and entry address.
+2. ACRN(HC_INITIALIZE_TRUSTY)
    2.1 save World context for Normal World.
    2.2 init World context for Secure World(RIP, RSP, EPT, etc.).
    2.3 resume to Secure World.
@@ -85,9 +85,9 @@ Detail:
    3.2 call HC_WORLD_SWITCH to switch back to Normal World if boot completed.
 4. ACRN(HC_WORLD_SWITCH)
    4.1 save World context for the World which caused this vmexit(Secure World)
-   4.2 restore World context for next World(Normal World(UOSloader))
-   4.3 resume to next World(UOSloader)
-5. UOSloader
+   4.2 restore World context for next World(Normal World(UOS_Loader))
+   4.3 resume to next World(UOS_Loader)
+5. UOS_Loader
    5.1 continue to boot.
 
 

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ C_SRCS += lib/crypto/hkdf.c
 C_SRCS += lib/sprintf.c
 C_SRCS += common/hv_main.c
 C_SRCS += common/hypercall.c
+C_SRCS += common/trusty_hypercall.c
 C_SRCS += common/schedule.c
 C_SRCS += common/vm_load.c
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ ARCH_LDSCRIPT_IN = bsp/ld/link_ram.ld.in
 
 INCLUDE_PATH += include
 INCLUDE_PATH += include/lib
+INCLUDE_PATH += include/lib/crypto
 INCLUDE_PATH += include/common
 INCLUDE_PATH += include/arch/x86
 INCLUDE_PATH += include/arch/x86/guest

--- a/arch/x86/guest/vmcall.c
+++ b/arch/x86/guest/vmcall.c
@@ -138,6 +138,10 @@ int vmcall_handler(struct vcpu *vcpu)
 		ret = hcall_world_switch(vcpu);
 		break;
 
+	case HC_INITIALIZE_TRUSTY:
+		ret = hcall_initialize_trusty(vcpu, param1);
+		break;
+
 	default:
 		pr_err("op %d: Invalid hypercall\n", hypcall_id);
 		ret = -1;

--- a/arch/x86/guest/vmcall.c
+++ b/arch/x86/guest/vmcall.c
@@ -134,6 +134,10 @@ int vmcall_handler(struct vcpu *vcpu)
 		ret = hcall_setup_sbuf(vm, param1);
 		break;
 
+	case HC_WORLD_SWITCH:
+		ret = hcall_world_switch(vcpu);
+		break;
+
 	default:
 		pr_err("op %d: Invalid hypercall\n", hypcall_id);
 		ret = -1;

--- a/arch/x86/io.c
+++ b/arch/x86/io.c
@@ -45,8 +45,6 @@ int dm_emulate_pio_post(struct vcpu *vcpu)
 		0xFFFFFFFFul >> (32 - 8 * vcpu->req.reqs.pio_request.size);
 	uint64_t *rax;
 
-	ASSERT(cur_context == 0, "pio emulation only happen in normal wrold");
-
 	rax = &vcpu->arch_vcpu.contexts[cur_context].guest_cpu_regs.regs.rax;
 	vcpu->req.reqs.pio_request.value =
 		req_buf->req_queue[cur].reqs.pio_request.value;
@@ -91,9 +89,6 @@ int io_instr_handler(struct vcpu *vcpu)
 	int cur_context_idx = vcpu->arch_vcpu.cur_context;
 	struct run_context *cur_context;
 	int status = -EINVAL;
-
-	ASSERT(cur_context_idx == 0,
-		"pio emulation only happen in normal wrold");
 
 	cur_context = &vcpu->arch_vcpu.contexts[cur_context_idx];
 	exit_qual = vcpu->arch_vcpu.exit_qualification;

--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -317,7 +317,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 	mem->first_page.startup_param.size_of_this_struct =
 			sizeof(struct trusty_startup_param);
 	mem->first_page.startup_param.mem_size = mem_size;
-	mem->first_page.startup_param.tsc_per_ms = TIME_MS_DELTA;
+	mem->first_page.startup_param.tsc_per_ms = CYCLES_PER_MS;
 	mem->first_page.startup_param.trusty_mem_base = TRUSTY_EPT_REBASE_GPA;
 
 	/* According to trusty boot protocol, it will use RDI as the

--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -31,6 +31,29 @@
 #include <hv_lib.h>
 #include <acrn_common.h>
 #include <hv_arch.h>
+#include <acrn_hv_defs.h>
+#include <hv_debug.h>
+
+_Static_assert(NR_WORLD == 2, "Only 2 Worlds supported!");
+
+/* Trusty EPT rebase gpa: 511G */
+#define TRUSTY_EPT_REBASE_GPA (511ULL*1024ULL*1024ULL*1024ULL)
+
+#define save_segment(seg, SEG_NAME) \
+{ \
+	seg.selector = exec_vmread(VMX_GUEST_##SEG_NAME##_SEL); \
+	seg.base = exec_vmread(VMX_GUEST_##SEG_NAME##_BASE); \
+	seg.limit = exec_vmread(VMX_GUEST_##SEG_NAME##_LIMIT); \
+	seg.attr = exec_vmread(VMX_GUEST_##SEG_NAME##_ATTR); \
+}
+
+#define load_segment(seg, SEG_NAME) \
+{ \
+	exec_vmwrite(VMX_GUEST_##SEG_NAME##_SEL, seg.selector); \
+	exec_vmwrite(VMX_GUEST_##SEG_NAME##_BASE, seg.base); \
+	exec_vmwrite(VMX_GUEST_##SEG_NAME##_LIMIT, seg.limit); \
+	exec_vmwrite(VMX_GUEST_##SEG_NAME##_ATTR, seg.attr); \
+}
 
 void create_secure_world_ept(struct vm *vm, uint64_t gpa,
 		uint64_t size, uint64_t rebased_gpa)
@@ -97,3 +120,122 @@ void create_secure_world_ept(struct vm *vm, uint64_t gpa,
 
 }
 
+static void save_world_ctx(struct run_context *context)
+{
+	/* VMCS Execution field */
+	context->tsc_offset = exec_vmread64(VMX_TSC_OFFSET_FULL);
+
+	/* VMCS GUEST field */
+	/* CR3, RIP, RSP, RFLAGS already saved on VMEXIT */
+	context->cr0 = exec_vmread(VMX_GUEST_CR0);
+	context->cr4 = exec_vmread(VMX_GUEST_CR4);
+	context->dr7 = exec_vmread(VMX_GUEST_DR7);
+	context->ia32_debugctl = exec_vmread64(VMX_GUEST_IA32_DEBUGCTL_FULL);
+	context->ia32_pat = exec_vmread64(VMX_GUEST_IA32_PAT_FULL);
+	context->ia32_efer = exec_vmread64(VMX_GUEST_IA32_EFER_FULL);
+	context->ia32_sysenter_cs = exec_vmread(VMX_GUEST_IA32_SYSENTER_CS);
+	context->ia32_sysenter_esp = exec_vmread(VMX_GUEST_IA32_SYSENTER_ESP);
+	context->ia32_sysenter_eip = exec_vmread(VMX_GUEST_IA32_SYSENTER_EIP);
+	save_segment(context->cs, CS);
+	save_segment(context->ss, SS);
+	save_segment(context->ds, DS);
+	save_segment(context->es, ES);
+	save_segment(context->fs, FS);
+	save_segment(context->gs, GS);
+	save_segment(context->tr, TR);
+	save_segment(context->ldtr, LDTR);
+	/* Only base and limit for IDTR and GDTR */
+	context->idtr.base = exec_vmread(VMX_GUEST_IDTR_BASE);
+	context->idtr.limit = exec_vmread(VMX_GUEST_IDTR_LIMIT);
+	context->gdtr.base = exec_vmread(VMX_GUEST_GDTR_BASE);
+	context->gdtr.limit = exec_vmread(VMX_GUEST_GDTR_LIMIT);
+
+	/* MSRs which not in the VMCS */
+	context->ia32_star = msr_read(MSR_IA32_STAR);
+	context->ia32_lstar = msr_read(MSR_IA32_LSTAR);
+	context->ia32_fmask = msr_read(MSR_IA32_FMASK);
+	context->ia32_kernel_gs_base = msr_read(MSR_IA32_KERNEL_GS_BASE);
+
+	/* FX area */
+	asm volatile("fxsave (%0)"
+			: : "r" (context->fxstore_guest_area) : "memory");
+}
+
+static void load_world_ctx(struct run_context *context)
+{
+	/* VMCS Execution field */
+	exec_vmwrite64(VMX_TSC_OFFSET_FULL, context->tsc_offset);
+
+	/* VMCS GUEST field */
+	exec_vmwrite(VMX_GUEST_CR0, context->cr0);
+	exec_vmwrite(VMX_GUEST_CR3, context->cr3);
+	exec_vmwrite(VMX_GUEST_CR4, context->cr4);
+	exec_vmwrite(VMX_GUEST_RIP, context->rip);
+	exec_vmwrite(VMX_GUEST_RSP, context->rsp);
+	exec_vmwrite(VMX_GUEST_RFLAGS, context->rflags);
+	exec_vmwrite(VMX_GUEST_DR7, context->dr7);
+	exec_vmwrite64(VMX_GUEST_IA32_DEBUGCTL_FULL, context->ia32_debugctl);
+	exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, context->ia32_pat);
+	exec_vmwrite64(VMX_GUEST_IA32_EFER_FULL, context->ia32_efer);
+	exec_vmwrite(VMX_GUEST_IA32_SYSENTER_CS, context->ia32_sysenter_cs);
+	exec_vmwrite(VMX_GUEST_IA32_SYSENTER_ESP, context->ia32_sysenter_esp);
+	exec_vmwrite(VMX_GUEST_IA32_SYSENTER_EIP, context->ia32_sysenter_eip);
+	load_segment(context->cs, CS);
+	load_segment(context->ss, SS);
+	load_segment(context->ds, DS);
+	load_segment(context->es, ES);
+	load_segment(context->fs, FS);
+	load_segment(context->gs, GS);
+	load_segment(context->tr, TR);
+	load_segment(context->ldtr, LDTR);
+	/* Only base and limit for IDTR and GDTR */
+	exec_vmwrite(VMX_GUEST_IDTR_BASE, context->idtr.base);
+	exec_vmwrite(VMX_GUEST_IDTR_LIMIT, context->idtr.limit);
+	exec_vmwrite(VMX_GUEST_GDTR_BASE, context->gdtr.base);
+	exec_vmwrite(VMX_GUEST_GDTR_LIMIT, context->gdtr.limit);
+
+	/* MSRs which not in the VMCS */
+	msr_write(MSR_IA32_STAR, context->ia32_star);
+	msr_write(MSR_IA32_LSTAR, context->ia32_lstar);
+	msr_write(MSR_IA32_FMASK, context->ia32_fmask);
+	msr_write(MSR_IA32_KERNEL_GS_BASE, context->ia32_kernel_gs_base);
+
+	/* FX area */
+	asm volatile("fxrstor (%0)" : : "r" (context->fxstore_guest_area));
+}
+
+static void copy_smc_param(struct run_context *prev_ctx,
+				struct run_context *next_ctx)
+{
+	next_ctx->guest_cpu_regs.regs.rdi = prev_ctx->guest_cpu_regs.regs.rdi;
+	next_ctx->guest_cpu_regs.regs.rsi = prev_ctx->guest_cpu_regs.regs.rsi;
+	next_ctx->guest_cpu_regs.regs.rdx = prev_ctx->guest_cpu_regs.regs.rdx;
+	next_ctx->guest_cpu_regs.regs.rbx = prev_ctx->guest_cpu_regs.regs.rbx;
+}
+
+void switch_world(struct vcpu *vcpu, int next_world)
+{
+	struct vcpu_arch *arch_vcpu = &vcpu->arch_vcpu;
+
+	/* save previous world context */
+	save_world_ctx(&arch_vcpu->contexts[!next_world]);
+
+	/* load next world context */
+	load_world_ctx(&arch_vcpu->contexts[next_world]);
+
+	/* Copy SMC parameters: RDI, RSI, RDX, RBX */
+	copy_smc_param(&arch_vcpu->contexts[!next_world],
+			&arch_vcpu->contexts[next_world]);
+
+	/* load EPTP for next world */
+	if (next_world == NORMAL_WORLD) {
+		exec_vmwrite64(VMX_EPT_POINTER_FULL,
+			((uint64_t)vcpu->vm->arch_vm.nworld_eptp) | (3<<3) | 6);
+	} else {
+		exec_vmwrite64(VMX_EPT_POINTER_FULL,
+			((uint64_t)vcpu->vm->arch_vm.sworld_eptp) | (3<<3) | 6);
+	}
+
+	/* Update world index */
+	arch_vcpu->cur_context = next_world;
+}

--- a/arch/x86/vtd.c
+++ b/arch/x86/vtd.c
@@ -105,7 +105,7 @@
 #define IOMMU_LOCK(u) spinlock_obtain(&((u)->lock))
 #define IOMMU_UNLOCK(u) spinlock_release(&((u)->lock))
 
-#define DMAR_OP_TIMEOUT TIME_MS_DELTA
+#define DMAR_OP_TIMEOUT CYCLES_PER_MS
 
 #define DMAR_WAIT_COMPLETION(offset, condition, status) \
 	do {                                                \
@@ -114,7 +114,7 @@
 			status = iommu_read32(dmar_uint, offset);   \
 			if (condition)                              \
 				break;                                  \
-			ASSERT((rdtsc() - start < TIME_MS_DELTA),        \
+			ASSERT((rdtsc() - start < CYCLES_PER_MS),        \
 				"DMAR OP Timeout!");   \
 			asm volatile ("pause" ::: "memory");        \
 		}                                               \

--- a/common/hypercall.c
+++ b/common/hypercall.c
@@ -40,6 +40,18 @@
 
 #define ACRN_DBG_HYCALL	6
 
+bool is_hypercall_from_ring0(void)
+{
+	uint64_t cs_sel;
+
+	cs_sel = exec_vmread(VMX_GUEST_CS_SEL);
+	/* cs_selector[1:0] is CPL */
+	if ((cs_sel & 0x3) == 0)
+		return true;
+
+	return false;
+}
+
 int64_t hcall_get_api_version(struct vm *vm, uint64_t param)
 {
 	struct hc_api_version version;

--- a/common/trusty_hypercall.c
+++ b/common/trusty_hypercall.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <hypervisor.h>
+#include <hv_lib.h>
+#include <acrn_common.h>
+#include <hv_arch.h>
+#include <hypercall.h>
+#include <acrn_hv_defs.h>
+#include <hv_debug.h>
+
+int64_t hcall_world_switch(struct vcpu *vcpu)
+{
+	int next_world_id = !(vcpu->arch_vcpu.cur_context);
+
+	if (!is_hypercall_from_ring0()) {
+		pr_err("%s() is only allowed from RING-0!\n", __func__);
+		return -1;
+	}
+
+	if (!vcpu->vm->sworld_control.sworld_enabled) {
+		pr_err("Secure World is not enabled!\n");
+		return -1;
+	}
+
+	if (!vcpu->vm->arch_vm.sworld_eptp) {
+		pr_err("Trusty is not launched!\n");
+		return -1;
+	}
+
+	ASSERT(next_world_id < NR_WORLD,
+		"world_id exceed max number of Worlds");
+
+	switch_world(vcpu, next_world_id);
+	return 0;
+}

--- a/debug/console.c
+++ b/debug/console.c
@@ -231,6 +231,6 @@ void console_setup_timer(void)
 {
 	/* Start an one-shot timer */
 	if (add_timer(console_timer_callback, 0,
-		rdtsc() + TIME_MS_DELTA * CONSOLE_KICK_TIMER_TIMEOUT) < 0)
+		rdtsc() + CYCLES_PER_MS * CONSOLE_KICK_TIMER_TIMEOUT) < 0)
 		pr_err("Failed to add console kick timer");
 }

--- a/include/arch/x86/trusty.h
+++ b/include/arch/x86/trusty.h
@@ -128,5 +128,7 @@ struct secure_world_control {
 	struct secure_world_memory sworld_memory;
 };
 
+void switch_world(struct vcpu *vcpu, int next_world);
+
 #endif /* TRUSTY_H_ */
 

--- a/include/arch/x86/trusty.h
+++ b/include/arch/x86/trusty.h
@@ -122,8 +122,6 @@ struct secure_world_memory {
 struct secure_world_control {
 	/* Whether secure world is enabled for current VM */
 	bool sworld_enabled;
-	/* key info structure */
-	struct key_info key_info;
 	/* Secure world memory structure */
 	struct secure_world_memory sworld_memory;
 };

--- a/include/arch/x86/trusty.h
+++ b/include/arch/x86/trusty.h
@@ -129,6 +129,7 @@ struct secure_world_control {
 };
 
 void switch_world(struct vcpu *vcpu, int next_world);
+bool initialize_trusty(struct vcpu *vcpu, uint64_t param);
 
 #endif /* TRUSTY_H_ */
 

--- a/include/common/hypercall.h
+++ b/include/common/hypercall.h
@@ -336,6 +336,17 @@ int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
 int64_t hcall_world_switch(struct vcpu *vcpu);
 
 /**
+ * @brief Initialize environment for Trusty-OS on a VCPU.
+ *
+ * @param VCPU Pointer to VCPU data structure
+ * @param param's guest physical address. This gpa points to
+ *              struct trusty_boot_param
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int64_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param);
+
+/**
  * @}
  */
 

--- a/include/common/hypercall.h
+++ b/include/common/hypercall.h
@@ -39,6 +39,7 @@
 
 struct vhm_request;
 
+bool is_hypercall_from_ring0(void);
 int acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req);
 int acrn_insert_request_nowait(struct vcpu *vcpu, struct vhm_request *req);
 int get_req_info(char *str, int str_max);
@@ -324,6 +325,15 @@ int64_t hcall_reset_ptdev_intr_info(struct vm *vm, uint64_t vmid,
  * @return 0 on success, non-zero on error.
  */
 int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
+
+/**
+ * @brief Switch VCPU state between Normal/Secure World.
+ *
+ * @param VCPU Pointer to VCPU data structure
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int64_t hcall_world_switch(struct vcpu *vcpu);
 
 /**
  * @}

--- a/include/lib/rtl.h
+++ b/include/lib/rtl.h
@@ -67,7 +67,7 @@ int udiv32(uint32_t dividend, uint32_t divisor, struct udiv_result *res);
 
 extern uint64_t tsc_clock_freq;
 #define US_TO_TICKS(x)	((x)*tsc_clock_freq/1000000UL)
-#define TIME_MS_DELTA	US_TO_TICKS(1000UL)
+#define CYCLES_PER_MS	US_TO_TICKS(1000UL)
 
 #define TICKS_TO_US(x)	((((x) * (1000000UL >> 8)) / tsc_clock_freq) << 8)
 #define TICKS_TO_MS(x)	(((x) * 1000UL) / tsc_clock_freq)

--- a/include/public/acrn_hv_defs.h
+++ b/include/public/acrn_hv_defs.h
@@ -95,7 +95,7 @@
 
 /* Trusty */
 #define HC_ID_TRUSTY_BASE           0x70UL
-#define HC_LAUNCH_TRUSTY            _HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x00)
+#define HC_INITIALIZE_TRUSTY        _HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x00)
 #define HC_WORLD_SWITCH             _HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x01)
 #define HC_GET_SEC_INFO             _HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x02)
 
@@ -224,6 +224,26 @@ struct hc_api_version {
 
 	/** hypervisor api minor version */
 	uint32_t minor_version;
+} __aligned(8);
+
+/**
+ * Trusty boot params, used for HC_INITIALIZE_TRUSTY
+ */
+struct trusty_boot_param {
+	/** sizeof this structure */
+	uint32_t size_of_this_struct;
+
+	/** version of this structure */
+	uint32_t version;
+
+	/** trusty runtime memory base address */
+	uint32_t base_addr;
+
+	/** trusty entry point */
+	uint32_t entry_point;
+
+	/** trusty runtime memory size */
+	uint32_t mem_size;
 } __aligned(8);
 
 /**

--- a/include/public/acrn_hv_defs.h
+++ b/include/public/acrn_hv_defs.h
@@ -229,4 +229,5 @@ struct hc_api_version {
 /**
  * @}
  */
+
 #endif /* ACRN_HV_DEFS_H */

--- a/lib/udelay.c
+++ b/lib/udelay.c
@@ -36,7 +36,7 @@ void udelay(int loop_count)
 	uint64_t dest_tsc, delta_tsc;
 
 	/* Calculate number of ticks to wait */
-	delta_tsc = TIME_MS_DELTA * loop_count;
+	delta_tsc = CYCLES_PER_MS * loop_count;
 	dest_tsc = rdtsc() + delta_tsc;
 
 	/* Loop until time expired */


### PR DESCRIPTION
This patch series enables trusty feature base on ACRN hypervisor.

There are four main parts of this patch series.
1. HC_WORLD_SWITCH hypercall
   This hypercall is used to simulate Secure Monitor Call(SMC) instruction to
   switch vCPU world state between Normal World and Secure World.
2. HC_INITIALIZE_TRUSTY hypercall
   This hypercall is used by UOS_Loader to request hypervisor to init Secure World
   environment and launch Trusty-OS.
3. Add key_info for Trusty
   key_info is a structure which contains many sensetive info such like seed,
   rpmp_key, platform, manufacturing state, etc. This structure must be provided
   when Trusty OS boot up, otherwise Trusty OS will fail to boot. Per previsous
   design, hypervisor will got key_info from bootloader and derive vkey_info for
   Trusty. Currently, bootloader did not pass key_info to hypervisor, so for
   trusty bring-up, a dummy key_info is used temporarily.
4. Remove pio emulation assertion for Normal World
   Currently, the UOS serial log is printed through IO(0x3f8). Secure World also
   print serial log by this IO port. So the assert should removed for Trusty OS
   booting up.
5. Rename TIME_MS_DELTA to CYCLES_PERMS
   TIME_MS_DELTA is not clear enough, so rename it to CYCLES_PER_MS.

For more trusty detail design, please read Documentation/Trusty.txt for reference.