### PR TITLE
hv: Save secure world memory info into vm instead of vm0

### DIFF
--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -151,9 +151,9 @@ void create_secure_world_ept(struct vm *vm, uint64_t gpa,
 
 	/* Backup secure world info, will be used when
 	 * destroy secure world */
-	vm0->sworld_control.sworld_memory.base_gpa = gpa;
-	vm0->sworld_control.sworld_memory.base_hpa = hpa;
-	vm0->sworld_control.sworld_memory.length = size;
+	vm->sworld_control.sworld_memory.base_gpa = gpa;
+	vm->sworld_control.sworld_memory.base_hpa = hpa;
+	vm->sworld_control.sworld_memory.length = size;
 
 	mmu_invept(vm->current_vcpu);
 	mmu_invept(vm0->current_vcpu);


### PR DESCRIPTION
A bugfix for saving secure world memory info.
Maybe there are multiple UOS, each VM has its own secure
world and normal world, should save memory info into individual VM.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>