### PR TITLE
Fix struct assignment: no memcpy with -nostdlib.

### DIFF
--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -294,7 +294,8 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 	/* TODO: prepare vkey_info */
 
 	/* copy key_info to the first page of trusty memory */
-	mem->first_page.key_info = g_key_info;
+	memcpy_s(&mem->first_page.key_info, sizeof(mem->first_page.key_info),
+            &g_key_info, sizeof(g_key_info));
 
 	memset(mem->first_page.key_info.dseed_list, 0,
 			sizeof(mem->first_page.key_info.dseed_list));


### PR DESCRIPTION
This fixes link error for struct assignment introduced in 4af2f04bd2f.

Use `memcpy_s` instead of struct assignment.

The error seen on current master:
```
gcc <...> -o src/acrn-hypervisor/build/acrn.out -static -nostdlib
<...>
src/acrn-hypervisor/build/arch/x86/trusty.o: In function `setup_trusty_info':
src/acrn-hypervisor/arch/x86/trusty.c:297: undefined reference to `memcpy'
```