### PR TITLE
treewide: fix declarations of functions with empty parameter lists

### DIFF
--- a/arch/x86/cpu.c
+++ b/arch/x86/cpu.c
@@ -84,7 +84,7 @@ static void cpu_set_logical_id(uint32_t logical_id);
 static void print_hv_banner(void);
 int cpu_find_logical_id(uint32_t lapic_id);
 #ifndef CONFIG_EFI_STUB
-static void start_cpus();
+static void start_cpus(void);
 #endif
 static void pcpu_sync_sleep(unsigned long *sync, int mask_bit);
 int ibrs_type;
@@ -206,7 +206,7 @@ static int init_phy_cpu_storage(void)
 	 * allocate memory to save all lapic_id detected in parse_mdt.
 	 * We allocate 4K size which could save 4K CPUs lapic_id info.
 	 */
-	lapic_id_base = alloc_page(CPU_PAGE_SIZE);
+	lapic_id_base = alloc_page();
 	ASSERT(lapic_id_base != NULL, "fail to alloc page");
 
 	pcpu_num = parse_madt(lapic_id_base);

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -311,7 +311,7 @@ struct mem_io_node {
 };
 
 void *get_paging_pml4(void);
-void *alloc_paging_struct();
+void *alloc_paging_struct(void);
 void enable_paging(void *pml4_base_addr);
 void init_paging(void);
 void map_mem(struct map_params *map_params, void *paddr, void *vaddr,

--- a/include/lib/mem_mgt.h
+++ b/include/lib/mem_mgt.h
@@ -48,7 +48,7 @@ struct mem_pool {
 /* APIs exposing memory allocation/deallocation abstractions */
 void *malloc(unsigned int num_bytes);
 void *calloc(unsigned int num_elements, unsigned int element_size);
-void *alloc_page();
+void *alloc_page(void);
 void *alloc_pages(unsigned int page_num);
 void free(void *ptr);
 


### PR DESCRIPTION
According to C99:

    The empty list in a function declarator that is not part of a definition of
    that function specifies that no information about the number or types of the
    parameters is supplied.

This means gcc is happy with the following code, which is undesirable.

    void foo();    /* declaration with an empty parameter list */

    void bar() {
        foo();     /* OK */
        foo(1);    /* OK */
        foo(1, 2); /* OK */
    }

This patch fixes declarations of functions with empty parameter lists by adding
an unnamed parameter of type void, which is the standard way to specify that a
function has no parameters. The following coccinelle script is used.

    @@
    type T;
    identifier f;
    @@

    -T f();
    +T f(void);

New compilation errors are fixed accordingly.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>