### PR TITLE
enable TSC-offset & add TSC MSR emulation

### DIFF
--- a/arch/x86/guest/vlapic.c
+++ b/arch/x86/guest/vlapic.c
@@ -1973,6 +1973,9 @@ vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t val)
 			cancel_timer(vlapic->last_timer, vcpu->pcpu_id);
 			vlapic->last_timer = -1;
 		} else {
+			/*transfer guest tsc to host tsc*/
+			val -= exec_vmread64(VMX_TSC_OFFSET_FULL);
+
 			vlapic->last_timer = update_timer(vlapic->last_timer,
 					tsc_periodic_time,
 					(long)vcpu,

--- a/arch/x86/vmx.c
+++ b/arch/x86/vmx.c
@@ -880,7 +880,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	 * the IA32_VMX_PROCBASED_CTRLS MSR are always read as 1 --- A.3.2
 	 */
 	value32 = msr_read(MSR_IA32_VMX_PROCBASED_CTLS);
-	value32 |= (/* VMX_PROCBASED_CTLS_TSC_OFF | */
+	value32 |= (VMX_PROCBASED_CTLS_TSC_OFF |
 		    /* VMX_PROCBASED_CTLS_RDTSC | */
 		    VMX_PROCBASED_CTLS_IO_BITMAP |
 		    VMX_PROCBASED_CTLS_MSR_BITMAP |
@@ -1011,7 +1011,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	exec_vmwrite64(VMX_EXECUTIVE_VMCS_PTR_FULL, 0);
 
 	/* Setup Time stamp counter offset - pg 2902 24.6.5 */
-	/* exec_vmwrite64(VMX_TSC_OFFSET_FULL, VMX_TSC_OFFSET_HIGH, 0); */
+	exec_vmwrite64(VMX_TSC_OFFSET_FULL, 0);
 
 	/* Set up the link pointer */
 	exec_vmwrite64(VMX_VMS_LINK_PTR_FULL, 0xFFFFFFFFFFFFFFFF);


### PR DESCRIPTION
enable TSC offset in VMX, so if TSC MSR is changed by guest OS,
write a caculated value into TSC-offset, then host TSC will not be changed.

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: He, Min <min.he@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>