### PR TITLE
replace malloc and memset with calloc

### DIFF
--- a/arch/x86/vtd.c
+++ b/arch/x86/vtd.c
@@ -208,9 +208,8 @@ static int register_hrhd_units(void)
 	}
 
 	for (i = 0; i < info->drhd_count; i++) {
-		drhd_rt = malloc(sizeof(struct dmar_drhd_rt));
+		drhd_rt = calloc(1, sizeof(struct dmar_drhd_rt));
 		ASSERT(drhd_rt != NULL, "");
-		memset(drhd_rt, 0, sizeof(struct dmar_drhd_rt));
 		drhd_rt->drhd = &info->drhd_units[i];
 		dmar_register_hrhd(drhd_rt);
 	}

--- a/debug/sbuf.c
+++ b/debug/sbuf.c
@@ -83,13 +83,12 @@ struct shared_buf *sbuf_allocate(uint32_t ele_num, uint32_t ele_size)
 	if (!sbuf_allocate_size)
 		return NULL;
 
-	sbuf = malloc(sbuf_allocate_size);
+	sbuf = calloc(1, sbuf_allocate_size);
 	if (sbuf == NULL) {
 		pr_err("%s no memory!", __func__);
 		return NULL;
 	}
 
-	memset(sbuf, 0, SBUF_HEAD_SIZE);
 	sbuf->ele_num = ele_num;
 	sbuf->ele_size = ele_size;
 	sbuf->size = ele_num * ele_size;


### PR DESCRIPTION
malloc: allocate a block of memory, the contents of the block are undefined.
calloc: allocate a block of memory for an array of num elements and initializes all its bits to zero.

Signed-off-by: yechunliang <yechunliangcn@163.com>