### PR TITLE
doc: fix hypercall API doxygen errors

### DIFF
--- a/include/common/hypercall.h
+++ b/include/common/hypercall.h
@@ -329,7 +329,7 @@ int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
 /**
  * @brief Switch VCPU state between Normal/Secure World.
  *
- * @param VCPU Pointer to VCPU data structure
+ * @param vcpu Pointer to VCPU data structure
  *
  * @return 0 on success, non-zero on error.
  */
@@ -338,8 +338,8 @@ int64_t hcall_world_switch(struct vcpu *vcpu);
 /**
  * @brief Initialize environment for Trusty-OS on a VCPU.
  *
- * @param VCPU Pointer to VCPU data structure
- * @param param's guest physical address. This gpa points to
+ * @param vcpu Pointer to VCPU data structure
+ * @param param guest physical address. This gpa points to
  *              struct trusty_boot_param
  *
  * @return 0 on success, non-zero on error.


### PR DESCRIPTION
Documentation for parameters must match exactly in spelling and case.
Parameter named "vcpu" was incorrectly documented as "VCPU", and
parameter named "param" was documented as "param's".

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>