### PR TITLE
trusty: initialize tsc_offset to zero

### DIFF
--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -386,8 +386,12 @@ static bool init_secure_world_env(struct vcpu *vcpu,
 	vcpu->arch_vcpu.contexts[SECURE_WORLD].rip = entry_gpa;
 	vcpu->arch_vcpu.contexts[SECURE_WORLD].rsp =
 		TRUSTY_EPT_REBASE_GPA + size;
+	vcpu->arch_vcpu.contexts[SECURE_WORLD].tsc_offset = 0;
+
 	exec_vmwrite(VMX_GUEST_RSP,
 		TRUSTY_EPT_REBASE_GPA + size);
+	exec_vmwrite(VMX_TSC_OFFSET_FULL,
+		vcpu->arch_vcpu.contexts[SECURE_WORLD].tsc_offset);
 
 	return setup_trusty_info(vcpu, size, base_hpa);
 }


### PR DESCRIPTION
Per trusty design, trusty requires a monotonic increasing
secure tick(TSC) at run time. This secure tick will used
to mitigate password/pin force attack, control key expiration,
etc.

Currently, the TSC_OFFSET is enabled. And guest will got
(host_tsc + tsc_offset) when execute rdtsc/rdtscp/rdmsr to
aquire tsc value. The host_tsc is always keeping increasing
during the runtime.

So initialize tsc_offset of trusty to 0 will ensure the
secure tick feature.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>