### PR TITLE
UEFI: update acrn.conf and Document

### DIFF
--- a/Documentation/ACRN_UEFI.txt
+++ b/Documentation/ACRN_UEFI.txt
@@ -4,11 +4,10 @@ Usage of acrn.efi
 
 Suggest to follow the following step:
 a. Build out the acrn.efi image with command "make PLATFORM=uefi".
-b. Rename the original os loader file that is located at
-\\EFI\\BOOT\\BOOTX64.EFI as CL_BL.EFI which name can be user defined
-in the config file bsp/uefi/include/bsp/bsp_cfg.h, the default name
-is CL_BL.EFI.
-c. Copy acrn.efi to \\EFI\\BOOT\\, and rename it to BOOTX64.EFI
-d. Reboot
-e. If you want to recover to origianal os loader, just replace
-the BOOTX64.EFI with the CL_BL.EFI.
+b. Rename the original os loader file named bootloaderx64.efi that is located at \\EFI\\org.clearlinux\\ to bootloaderx64_origin.efi
+which name can be user defined in the config file bsp/uefi/include/bsp/bsp_cfg.h, the default name is "EFI\\org.clearlinux\\bootloaderx64_origin.efi".
+c. Copy acrn.efi to \\EFI\\org.clearlinux\\, and rename it to bootloaderx64.efi.
+d. Update the bsp/uefi/clearlinux/acrn.conf file by filling the field <UUID of rootfs partition> with the your native rootfs partition uuid.
+e. Copy bsp/uefi/clearlinux/acrn.conf to loader\\entries\\ directory.
+f. Reboot.
+g. If you want to recover to original os loader, just replace the bootloaderx64.efi with bootloaderx64_origin.efi.

--- a/bsp/uefi/clearlinux/acrn.conf
+++ b/bsp/uefi/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
-title The ACRN Hypervisor
-efi   /EFI/org.clearlinux/acrn.efi
-options sos=kernel-org.clearlinux.pk414-sos.4.14.23-19 pci_devices_ignore=(0:18:2) noxsave maxcpus=1 console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=/dev/sda3 rw rootwait clocksource=hpet ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x00000F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 hvlog=2M@0x1FE00000 cma=2560M@0x100000000-0
+title The ACRN Service OS
+linux   /EFI/org.clearlinux/kernel-org.clearlinux.pk414-sos.4.14.23-19
+options pci_devices_ignore=(0:18:2) noxsave maxcpus=1 console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=PARTUUID=<UUID of rootfs partition> rw rootwait clocksource=hpet ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x00000F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 hvlog=2M@0x1FE00000 cma=2560M@0x100000000-0

--- a/bsp/uefi/efi/boot.c
+++ b/bsp/uefi/efi/boot.c
@@ -333,7 +333,6 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 	char *section;
 	EFI_DEVICE_PATH *path;
 	CHAR16 *bootloader_name;
-	CHAR16 *bootloader_name_with_path;
 	EFI_HANDLE bootloader_image;
 
 	InitializeLib(image, _table);
@@ -367,15 +366,12 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 
 	/* load hypervisor and begin to run on it */
 	err = switch_to_guest_mode(image);
-
 	if (err != EFI_SUCCESS)
 		goto failed;
 
 	/* load and start the default bootloader */
 	bootloader_name = ch8_2_ch16(CONFIG_UEFI_OS_LOADER_NAME);
-	bootloader_name_with_path =
-		PoolPrint(L"%s%s", L"\\EFI\\BOOT\\", bootloader_name);
-	path = FileDevicePath(info->DeviceHandle, bootloader_name_with_path);
+	path = FileDevicePath(info->DeviceHandle, bootloader_name);
 	if (!path)
 		goto free_args;
 

--- a/bsp/uefi/include/bsp/bsp_cfg.h
+++ b/bsp/uefi/include/bsp/bsp_cfg.h
@@ -48,5 +48,5 @@
 #define	CONFIG_DMAR_PARSE_ENABLED	1
 #define	CONFIG_GPU_SBDF		0x00000010	/* 0000:00:02.0 */
 #define CONFIG_EFI_STUB       1
-#define CONFIG_UEFI_OS_LOADER_NAME  "CL_BL.EFI"
+#define CONFIG_UEFI_OS_LOADER_NAME  "\\EFI\\org.clearlinux\\bootloaderx64_origin.efi"
 #endif /* BSP_CFG_H */


### PR DESCRIPTION
Since the boot flow had been changed to that sos kernel is lanuched
by cl bootloader directly, replace the payload acrn.efi with bzImage.efi
in the acrn.conf file, and specify ROOTDEV with UUID in the command line.

The UEFI firmware launches the EFI/org.clearlinux/bootloaderx64.efi
as os loader not the EFI/BOOT/BOOTX64.EFI, so fix the issue in the document
ACRN_UEFI.txt which guides user with incorrect steps.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Reviewed-by: Jack, Ren <jack.ren@intel.com>