### PR TITLE
mmu:create temporary page tables for guest at run time 

### DIFF
--- a/arch/x86/cpu_secondary.S
+++ b/arch/x86/cpu_secondary.S
@@ -162,36 +162,4 @@ cpu_secondary_pdt_addr:
     address = address + 0x200000
     .endr
 
-
-/*******************************************************************
- *         GUEST initial 4G page table
- *
- * guest starts with long mode, HV needs to prepare Guest identity
- * mapped page table.
- *
- * guest page tables covers 4G size, with 2M page size.
- *
- * HV copy this page table (6 pages) to guest address
- * CPU_Boot_Page_Tables_Start_VM before  executing guest instruction.
- *
- ******************************************************************/
-    .align  CPU_PAGE_SIZE
-    .global CPU_Boot_Page_Tables_Start_VM
-CPU_Boot_Page_Tables_Start_VM:
-    .quad   vm_cpu_pdpt_addr + (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
-    .align  CPU_PAGE_SIZE
-vm_cpu_pdpt_addr:
-    address = 0
-    .rept   4
-    .quad   vm_cpu_pdt_addr + address + (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
-    address = address + CPU_PAGE_SIZE
-    .endr
-    .align  CPU_PAGE_SIZE
-vm_cpu_pdt_addr:
-    address = 0
-    .rept  2048
-    .quad  address + (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
-    address = address + 0x200000
-    .endr
-
     .end

--- a/arch/x86/ept.c
+++ b/arch/x86/ept.c
@@ -41,21 +41,6 @@
 
 #define ACRN_DBG_EPT	6
 
-void *create_guest_paging(struct vm *vm)
-{
-	void *hva_dest;
-	void *hva_src;
-
-	/* copy guest identity mapped 4G page table to guest */
-	hva_dest = GPA2HVA(vm,
-			(uint64_t)CPU_Boot_Page_Tables_Start_VM);
-	hva_src = (void *)(_ld_cpu_secondary_reset_load
-			+ (CPU_Boot_Page_Tables_Start_VM
-			- _ld_cpu_secondary_reset_start));
-	/* 2MB page size, need to copy 6 pages */
-	memcpy_s(hva_dest, 6 * CPU_PAGE_SIZE, hva_src, 6 * CPU_PAGE_SIZE);
-	return (void *)CPU_Boot_Page_Tables_Start_VM;
-}
 
 static uint64_t find_next_table(uint32_t table_offset, void *table_base)
 {

--- a/arch/x86/guest/vcpu.c
+++ b/arch/x86/guest/vcpu.c
@@ -98,9 +98,10 @@ int create_vcpu(int cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	/* Is this VCPU a VM BSP, create page hierarchy for this VM */
 	if (is_vcpu_bsp(vcpu)) {
 		/* Set up temporary guest page tables */
-		vm->arch_vm.guest_pml4 = create_guest_paging(vm);
+		vm->arch_vm.guest_init_pml4 = create_guest_initial_paging(vm);
 		pr_info("VM *d VCPU %d CR3: 0x%016llx ",
-			vm->attr.id, vcpu->vcpu_id, vm->arch_vm.guest_pml4);
+			vm->attr.id, vcpu->vcpu_id,
+			vm->arch_vm.guest_init_pml4);
 	}
 
 	/* Allocate VMCS region for this VCPU */

--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -38,9 +38,6 @@
 
 _Static_assert(NR_WORLD == 2, "Only 2 Worlds supported!");
 
-/* Trusty EPT rebase gpa: 511G */
-#define TRUSTY_EPT_REBASE_GPA (511ULL*1024ULL*1024ULL*1024ULL)
-
 #define TRUSTY_VERSION 1
 
 struct trusty_startup_param {

--- a/arch/x86/vmx.c
+++ b/arch/x86/vmx.c
@@ -270,7 +270,7 @@ static void init_guest_state(struct vcpu *vcpu)
 	} else if (get_vcpu_mode(vcpu) == PAGE_PROTECTED_MODE) {
 		cur_context->cr0 = ((uint64_t)CR0_PG | CR0_PE | CR0_NE);
 		cur_context->cr4 = ((uint64_t)CR4_PSE | CR4_PAE | CR4_MCE | CR4_VMXE);
-		cur_context->cr3 = (uint64_t)vm->arch_vm.guest_pml4 | CR3_PWT;
+		cur_context->cr3 = vm->arch_vm.guest_init_pml4 | CR3_PWT;
 	}
 
 	value = cur_context->cr0;

--- a/common/vm_load.c
+++ b/common/vm_load.c
@@ -124,7 +124,7 @@ int load_guest(struct vm *vm, struct vcpu *vcpu)
 	pr_info("VCPU%d Entry: 0x%llx, RSI: 0x%016llx, cr3: 0x%016llx",
 			vcpu->vcpu_id, vcpu->entry_addr,
 			cur_context->guest_cpu_regs.regs.rsi,
-			vm->arch_vm.guest_pml4);
+			vm->arch_vm.guest_init_pml4);
 
 	return ret;
 }

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -43,6 +43,9 @@
 #define CPU_PAGE_SIZE           0x1000
 #define CPU_PAGE_MASK           0xFFFFFFFFFFFFF000
 
+#define MMU_PTE_PAGE_SHIFT	CPU_PAGE_SHIFT
+#define MMU_PDE_PAGE_SHIFT	21
+
 /* Define CPU stack alignment */
 #define CPU_STACK_ALIGN         16
 

--- a/include/arch/x86/guest/vm.h
+++ b/include/arch/x86/guest/vm.h
@@ -113,7 +113,7 @@ struct vm_state_info {
 };
 
 struct vm_arch {
-	void *guest_pml4;	/* Guest pml4 */
+	uint64_t guest_init_pml4;/* Guest init pml4 */
 	/* EPT hierarchy for Normal World */
 	uint64_t nworld_eptp;
 	/* EPT hierarchy for Secure World

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -381,7 +381,7 @@ extern uint8_t CPU_Boot_Page_Tables_Start_VM[];
 
 /* External Interfaces */
 int     is_ept_supported(void);
-void   *create_guest_paging(struct vm *vm);
+uint64_t create_guest_initial_paging(struct vm *vm);
 void    destroy_ept(struct vm *vm);
 uint64_t  gpa2hpa(struct vm *vm, uint64_t gpa);
 uint64_t  gpa2hpa_check(struct vm *vm, uint64_t gpa,

--- a/include/arch/x86/trusty.h
+++ b/include/arch/x86/trusty.h
@@ -36,6 +36,10 @@
 #define MMC_PROD_NAME_WITH_PSN_LEN      15
 #define BUP_MKHI_BOOTLOADER_SEED_LEN    64
 
+/* Trusty EPT rebase gpa: 511G */
+#define TRUSTY_EPT_REBASE_GPA (511ULL*1024ULL*1024ULL*1024ULL)
+#define TRUSTY_MEMORY_SIZE        0x01000000
+
 /* Structure of seed info */
 struct seed_info {
 	uint8_t cse_svn;


### PR DESCRIPTION
Before this patch, guest temporary page tables were generated by hardcode
at compile time, HV will copy this page tables to guest before guest
launch.

This patch creates temporary page tables at runtime for the range of 0~4G,
and create page tables to cover new range(511G~511G+16M) with trusty
requirement.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>