### PR TITLE
hv: cache tsc_offset

### DIFF
--- a/arch/x86/guest/vlapic.c
+++ b/arch/x86/guest/vlapic.c
@@ -1973,8 +1973,9 @@ vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t val)
 			cancel_timer(vlapic->last_timer, vcpu->pcpu_id);
 			vlapic->last_timer = -1;
 		} else {
-			/*transfer guest tsc to host tsc*/
-			val -= exec_vmread64(VMX_TSC_OFFSET_FULL);
+			/* transfer guest tsc to host tsc */
+			val -= vcpu->arch_vcpu.contexts[vcpu->
+					arch_vcpu.cur_context].tsc_offset;
 
 			vlapic->last_timer = update_timer(vlapic->last_timer,
 					tsc_periodic_time,

--- a/arch/x86/guest/vmsr.c
+++ b/arch/x86/guest/vmsr.c
@@ -191,8 +191,8 @@ int rdmsr_handler(struct vcpu *vcpu)
 	}
 	case MSR_IA32_TIME_STAMP_COUNTER:
 	{
-		/*Add the TSC_offset to host TSC to get guest TSC */
-		v = rdtsc() + exec_vmread64(VMX_TSC_OFFSET_FULL);
+		/* Add the TSC_offset to host TSC to get guest TSC */
+		v = rdtsc() + vcpu->arch_vcpu.contexts[cur_context].tsc_offset;
 		break;
 	}
 
@@ -287,7 +287,8 @@ int wrmsr_handler(struct vcpu *vcpu)
 	case MSR_IA32_TIME_STAMP_COUNTER:
 	{
 		/*Caculate TSC offset from changed TSC MSR value*/
-		exec_vmwrite64(VMX_TSC_OFFSET_FULL, v - rdtsc());
+		cur_context->tsc_offset = v - rdtsc();
+		exec_vmwrite64(VMX_TSC_OFFSET_FULL, cur_context->tsc_offset);
 		break;
 	}
 

--- a/arch/x86/trusty.c
+++ b/arch/x86/trusty.c
@@ -206,11 +206,8 @@ void  destroy_secure_world(struct vm *vm)
 
 static void save_world_ctx(struct run_context *context)
 {
-	/* VMCS Execution field */
-	context->tsc_offset = exec_vmread64(VMX_TSC_OFFSET_FULL);
-
 	/* VMCS GUEST field */
-	/* CR3, RIP, RSP, RFLAGS already saved on VMEXIT */
+	/* TSC_OFFSET, CR3, RIP, RSP, RFLAGS already saved on VMEXIT */
 	context->cr0 = exec_vmread(VMX_GUEST_CR0);
 	context->cr4 = exec_vmread(VMX_GUEST_CR4);
 	context->dr7 = exec_vmread(VMX_GUEST_DR7);

--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -481,9 +481,8 @@ static int rdtsc_handler(struct vcpu *vcpu)
 	/* Read the host TSC value */
 	CPU_RDTSCP_EXECUTE(&host_tsc, &id);
 
-	/* Get the guest TSC offset value from VMCS */
-	tsc_offset =
-	    exec_vmread64(VMX_TSC_OFFSET_FULL);
+	/* Get current world's TSC offset */
+	tsc_offset = cur_context->tsc_offset;
 
 	/* Update the guest TSC value by following: TSC_guest = TSC_host +
 	 * TSC_guest_Offset
@@ -509,9 +508,8 @@ static int rdtscp_handler(struct vcpu *vcpu)
 	/* Read the host TSC value */
 	CPU_RDTSCP_EXECUTE(&host_tsc, &id);
 
-	/* Get the guest TSC offset value from VMCS */
-	tsc_offset =
-	    exec_vmread64(VMX_TSC_OFFSET_FULL);
+	/* Get current world's TSC offset */
+	tsc_offset = cur_context->tsc_offset;
 
 	/* Update the guest TSC value by following: * TSC_guest = TSC_host +
 	 * TSC_guest_Offset


### PR DESCRIPTION
Guest write tsc: cache the offset into run_context.tsc_offset;
Guest read tsc : use run_context.tsc_offset to calculate guest_tsc.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>