### PR TITLE
Add range check for 'vm0_gpa' before creating EPT

### DIFF
--- a/common/hypercall.c
+++ b/common/hypercall.c
@@ -444,6 +444,14 @@ int64_t hcall_set_vm_memmap(struct vm *vm, uint64_t vmid, uint64_t param)
 	dev_dbg(ACRN_DBG_HYCALL, "[vm%d] gpa=0x%x hpa=0x%x size=0x%x",
 			vmid, memmap.remote_gpa, hpa, memmap.length);
 
+	if (((hpa <= CONFIG_RAM_START) &&
+		(hpa + memmap.length > CONFIG_RAM_START)) ||
+		((hpa >= CONFIG_RAM_START) &&
+		(hpa < CONFIG_RAM_START + CONFIG_RAM_SIZE))) {
+		pr_err("%s: ERROR! overlap the HV memory region.", __func__);
+		return -1;
+	}
+
 	/* Check prot */
 	attr = 0;
 	if (memmap.type != MAP_UNMAP) {


### PR DESCRIPTION
Input('vm0_gpa') should be validated when handling
hypercall 'HC_VM_SET_MEMMAP to create EPT for UOS
in 'hcall_set_vm_memmap()' function.
at least 'hpa' range (from 'vm0_gpa') can't overlap
hypervisor memory region.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>