### PR TITLE
hypercall: bug fix on the address convertion while hypercall

### DIFF
--- a/include/common/hypercall.h
+++ b/include/common/hypercall.h
@@ -370,8 +370,8 @@ static inline int check_result(int found)
 	int found = 0;					\
 	typeof(*(ptr)) *h_ptr = (ptr);			\
 	typeof(*(ptr)) *g_ptr =				\
-		(void *)gpa2hpa_check(vm, gpa,		\
-		sizeof(*h_ptr), &found, true);		\
+		HPA2HVA(gpa2hpa_check(vm, gpa,	\
+		sizeof(*h_ptr), &found, true));		\
 	if (found) {					\
 		*h_ptr = *g_ptr;			\
 	}						\
@@ -382,8 +382,8 @@ static inline int check_result(int found)
 	int found = 0;					\
 	typeof(*(ptr)) *h_ptr = (ptr);			\
 	typeof(*(ptr)) *g_ptr =				\
-		(void *)gpa2hpa_check(vm, gpa,		\
-		sizeof(*h_ptr), &found, true);		\
+		HPA2HVA(gpa2hpa_check(vm, gpa,	\
+		sizeof(*h_ptr), &found, true));		\
 	if (found) {					\
 		*g_ptr = *h_ptr;			\
 	}						\


### PR DESCRIPTION
Before copy data between guest and host, should convert the GPA
to HVA and do the copy.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Reviewed-by: Chen, Jason Cl <jason.cj.chen@intel.com>
Reviewed-by: Yakui, Zhao <yakui.zhao@intel.com>