### PR TITLE
VMX: bug fix on operating vmx

### DIFF
--- a/arch/x86/guest/vmsr.c
+++ b/arch/x86/guest/vmsr.c
@@ -163,7 +163,7 @@ void init_msr_emulation(struct vcpu *vcpu)
 	}
 
 	/* Set up MSR bitmap - pg 2904 24.6.9 */
-	value64 = (int64_t) vcpu->vm->arch_vm.msr_bitmap;
+	value64 = HVA2HPA(vcpu->vm->arch_vm.msr_bitmap);
 	exec_vmwrite64(VMX_MSR_BITMAP_FULL, value64);
 	pr_dbg("VMX_MSR_BITMAP: 0x%016llx ", value64);
 


### PR DESCRIPTION
Switch all the referenced virtual address to physical address
include ept mapping, vmcs field, vmxon, vmclear, and vmptrld.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Reviewed-by: Chen, Jason Cl <jason.cj.chen@intel.com>
Reviewed-by: Yakui, Zhao <yakui.zhao@intel.com>