### PR TITLE
sprintf: bug fix in sprintf implemented code

### DIFF
--- a/lib/sprintf.c
+++ b/lib/sprintf.c
@@ -634,7 +634,7 @@ static int charmem(int cmd, const char *s, int sz, void *hnd)
 				n++;
 			}
 
-		} else {
+		} else if (sz > 0) {
 			while (*s && n < sz) {
 				if (n < param->sz - param->wrtn)
 					*p = *s;


### PR DESCRIPTION
In the case that the copy sz is 0, it is unnecessary to do copy.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Reviewed-by: Chen, Jason Cl <jason.cj.chen@intel.com>
Reviewed-by: Yakui, Zhao <yakui.zhao@intel.com>