### PR TITLE
[acrn-dev] [PATCH] VMX: change PAT register default value

### DIFF
--- a/arch/x86/vmx.c
+++ b/arch/x86/vmx.c
@@ -40,7 +40,7 @@ extern struct efi_ctx* efi_ctx;
 
 #define PAT_POWER_ON_VALUE	(PAT_MEM_TYPE_WB + \
 				((uint64_t)PAT_MEM_TYPE_WT << 8) + \
-				((uint64_t)PAT_MEM_TYPE_UCM << 16) + \
+				((uint64_t)PAT_MEM_TYPE_WC << 16) + \
 				((uint64_t)PAT_MEM_TYPE_UC << 24) + \
 				((uint64_t)PAT_MEM_TYPE_WB << 32) + \
 				((uint64_t)PAT_MEM_TYPE_WT << 40) + \


### PR DESCRIPTION
This is workaround patch to resolve Disti performance issue.
In kernel 4.14, PAT is skipped to initialize if MTRR is not enabled,
while graphics driver need set WC to GGTT memory to accelerate memcpy,
if PAT is not initialized, default PAT register will treat UC- as
uncacheable, which will impact gfx performance. Change PAT default
register value to treat UC- as WC to workaroud this problem.

Revert me when PAT/MTRR strong correlation is removed in kernel.

Signed-off-by: Fei Jiang <fei.jiang@intel.com>