### PR TITLE
refine: remove redundant data type definition

### DIFF
--- a/arch/x86/cpu.c
+++ b/arch/x86/cpu.c
@@ -617,7 +617,7 @@ static void start_cpus()
 
 	/* Broadcast IPIs to all other CPUs */
 	send_startup_ipi(INTR_CPU_STARTUP_ALL_EX_SELF,
-		       -1U, ((paddr_t) cpu_secondary_reset));
+		       -1U, ((uint64_t) cpu_secondary_reset));
 
 	/* Wait until global count is equal to expected CPU up count or
 	 * configured time-out has expired

--- a/arch/x86/guest/vpic.c
+++ b/arch/x86/guest/vpic.c
@@ -778,7 +778,7 @@ static int vpic_master_handler(struct vm *vm, bool in, int port, int bytes,
 }
 
 static uint32_t vpic_master_io_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t addr, size_t width)
+		struct vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0;
 
@@ -789,7 +789,7 @@ static uint32_t vpic_master_io_read(__unused struct vm_io_handler *hdlr,
 }
 
 static void vpic_master_io_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t addr, size_t width, uint32_t v)
+		struct vm *vm, uint16_t addr, size_t width, uint32_t v)
 {
 	uint32_t val = v;
 
@@ -817,7 +817,7 @@ static int vpic_slave_handler(struct vm *vm, bool in, int port, int bytes,
 }
 
 static uint32_t vpic_slave_io_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t addr, size_t width)
+		struct vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0;
 
@@ -828,7 +828,7 @@ static uint32_t vpic_slave_io_read(__unused struct vm_io_handler *hdlr,
 }
 
 static void vpic_slave_io_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t addr, size_t width, uint32_t v)
+		struct vm *vm, uint16_t addr, size_t width, uint32_t v)
 {
 	uint32_t val = v;
 
@@ -879,7 +879,7 @@ static int vpic_elc_handler(struct vm *vm, bool in, int port, int bytes,
 }
 
 static uint32_t vpic_elc_io_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t addr, size_t width)
+		struct vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0;
 
@@ -889,7 +889,7 @@ static uint32_t vpic_elc_io_read(__unused struct vm_io_handler *hdlr,
 }
 
 static void vpic_elc_io_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t addr, size_t width, uint32_t v)
+		struct vm *vm, uint16_t addr, size_t width, uint32_t v)
 {
 	uint32_t val = v;
 

--- a/arch/x86/intr_lapic.c
+++ b/arch/x86/intr_lapic.c
@@ -158,10 +158,9 @@ union lapic_base_msr {
 struct lapic_info {
 	int init_status;
 	struct {
-		paddr_t paddr;
-		vaddr_t vaddr;
+		uint64_t paddr;
+		void *vaddr;
 	} xapic;
-
 };
 
 static struct lapic_info lapic_info;
@@ -171,7 +170,7 @@ static inline uint32_t read_lapic_reg32(uint32_t offset)
 	if (offset < 0x20 || offset > 0x3ff)
 		return 0;
 
-	return mmio_read_long(lapic_info.xapic.vaddr + offset);
+	return mmio_read_long((uint64_t)lapic_info.xapic.vaddr + offset);
 }
 
 inline void write_lapic_reg32(uint32_t offset, uint32_t value)
@@ -179,7 +178,7 @@ inline void write_lapic_reg32(uint32_t offset, uint32_t value)
 	if (offset < 0x20 || offset > 0x3ff)
 		return;
 
-	mmio_write_long(value, lapic_info.xapic.vaddr + offset);
+	mmio_write_long(value, (uint64_t)lapic_info.xapic.vaddr + offset);
 }
 
 static void clear_lapic_isr(void)
@@ -205,7 +204,7 @@ static void map_lapic(void)
 	/* At some point we may need to translate this paddr to a vaddr. 1:1
 	 * mapping for now.
 	 */
-	lapic_info.xapic.vaddr = lapic_info.xapic.paddr;
+	lapic_info.xapic.vaddr = (void *)lapic_info.xapic.paddr;
 }
 
 int early_init_lapic(void)
@@ -324,7 +323,7 @@ uint32_t get_cur_lapic_id(void)
 
 int
 send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
-	uint32_t cpu_startup_dest, paddr_t cpu_startup_start_address)
+	uint32_t cpu_startup_dest, uint64_t cpu_startup_start_address)
 {
 	union apic_icr icr;
 	uint8_t shorthand;
@@ -372,7 +371,7 @@ send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 	icr.value_32.lo_32 = 0;
 	icr.bits.shorthand = shorthand;
 	icr.bits.delivery_mode = INTR_LAPIC_ICR_STARTUP;
-	icr.bits.vector = ((paddr_t) cpu_startup_start_address) >> 12;
+	icr.bits.vector = ((uint64_t) cpu_startup_start_address) >> 12;
 	write_lapic_reg32(LAPIC_INT_COMMAND_REGISTER_0, icr.value_32.lo_32);
 	wait_for_delivery();
 

--- a/arch/x86/io.c
+++ b/arch/x86/io.c
@@ -208,14 +208,14 @@ static void deny_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbyte
 
 static uint32_t
 default_io_read(__unused struct vm_io_handler *hdlr, __unused struct vm *vm,
-			ioport_t address, size_t width)
+			uint16_t address, size_t width)
 {
 	uint32_t v = io_read(address, width);
 	return v;
 }
 
 static void default_io_write(__unused struct vm_io_handler *hdlr,
-			__unused struct vm *vm, ioport_t addr,
+			__unused struct vm *vm, uint16_t addr,
 			size_t width, uint32_t v)
 {
 	io_write(v, addr, width);

--- a/arch/x86/ioapic.c
+++ b/arch/x86/ioapic.c
@@ -82,7 +82,7 @@ static uint64_t map_ioapic(
 	/* At some point we may need to translate this paddr to a vaddr.
 	 * 1:1 mapping for now.
 	 */
-	return (vaddr_t) ioapic_paddr;
+	return ioapic_paddr;
 }
 
 static inline uint32_t

--- a/bsp/uefi/efi/multiboot.h
+++ b/bsp/uefi/efi/multiboot.h
@@ -38,8 +38,6 @@
 #define _MULTIBOOT_H
 
 #include <stdint.h>
-//typedef uintptr_t uint32_t;
-typedef uintptr_t vaddr_t;
 
 struct multiboot_info;
 extern struct multiboot_info mbi;

--- a/bsp/uefi/uefi.c
+++ b/bsp/uefi/uefi.c
@@ -90,7 +90,7 @@ int sipi_from_efi_boot_service_exit(uint32_t dest, uint32_t mode, uint32_t vec)
 		if (mode == APIC_DELMODE_STARTUP) {
 			uint32_t cpu_id = cpu_find_logical_id(dest);
 			send_startup_ipi(INTR_CPU_STARTUP_USE_DEST,
-		       cpu_id, (paddr_t)(vec<<12));
+		       cpu_id, (uint64_t)(vec<<12));
 			efi_wake_up_ap_bitmap |= 1 << dest;
 		}
 
@@ -108,7 +108,7 @@ void efi_deferred_wakeup_pcpu(int cpu_id)
 	expected_up = up_count + 1;
 
 	send_startup_ipi(INTR_CPU_STARTUP_USE_DEST,
-		cpu_id, (paddr_t)cpu_secondary_reset);
+		cpu_id, (uint64_t)cpu_secondary_reset);
 
 	timeout = CPU_UP_TIMEOUT * 1000;
 

--- a/debug/console.c
+++ b/debug/console.c
@@ -171,7 +171,7 @@ void console_dump_bytes(const void *p, unsigned int len)
 	/* dump all bytes */
 	while (x < e) {
 		/* write the address of the first byte in the row */
-		printf("%08x: ", (vaddr_t) x);
+		printf("%08x: ", (uint64_t) x);
 		/* print one row (16 bytes) as hexadecimal values */
 		for (i = 0; i < 16; i++)
 			printf("%02x ", x[i]);

--- a/debug/serial_internal.h
+++ b/debug/serial_internal.h
@@ -153,7 +153,7 @@ struct uart_config {
  */
 struct tgt_uart {
 	char uart_id[SERIAL_ID_MAX_LENGTH];
-	mmio_addr_t base_address;
+	uint64_t base_address;
 	uint32_t clock_frequency;
 	uint32_t buffer_size;
 	unsigned int open_count;

--- a/debug/uart16550.c
+++ b/debug/uart16550.c
@@ -88,26 +88,22 @@ enum UART_REG_IDX{
 #define UART_CLOCK_RATE		CPU_OSC_CLOCK
 #define UART_BUFFER_SIZE		2048
 
-static inline uint32_t uart16550_read_reg(uint32_t base, uint32_t reg_idx)
+static inline uint32_t uart16550_read_reg(uint64_t base, uint32_t reg_idx)
 {
 	if (serial_port_mapped) {
-		return io_read_byte((ioport_t)
-			((uint8_t *)(uint64_t)base + reg_idx));
+		return io_read_byte((uint16_t)base + reg_idx);
 	} else {
-		return mmio_read_long((mmio_addr_t)
-			((uint32_t *)(uint64_t)base + reg_idx));
+		return mmio_read_long((uint64_t)((uint32_t*)base + reg_idx));
 	}
 }
 
-static inline void uart16550_write_reg(uint32_t base,
+static inline void uart16550_write_reg(uint64_t base,
 	uint32_t val, uint32_t reg_idx)
 {
 	if (serial_port_mapped) {
-		io_write_byte(val, (ioport_t)
-			((uint8_t *)(uint64_t)base + reg_idx));
+		io_write_byte(val, (uint16_t)base + reg_idx);
 	} else {
-		mmio_write_long(val, (mmio_addr_t)
-			((uint32_t *)(uint64_t)base + reg_idx));
+		mmio_write_long(val, (uint64_t)((uint32_t*)base + reg_idx));
 	}
 }
 

--- a/debug/vuart.c
+++ b/debug/vuart.c
@@ -153,7 +153,7 @@ static void uart_toggle_intr(struct vuart *vu)
 }
 
 static void uart_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t offset,
+		struct vm *vm, uint16_t offset,
 		__unused size_t width, uint32_t value)
 {
 	struct vuart *vu = vm_vuart(vm);
@@ -231,7 +231,7 @@ done:
 }
 
 static uint32_t uart_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, ioport_t offset,
+		struct vm *vm, uint16_t offset,
 		__unused size_t width)
 {
 	char iir, intr_reason, reg;

--- a/include/arch/x86/io.h
+++ b/include/arch/x86/io.h
@@ -83,7 +83,7 @@ static inline uint32_t io_read_long(uint16_t port)
 	return value;
 }
 
-static inline void io_write(uint32_t v, ioport_t addr, size_t sz)
+static inline void io_write(uint32_t v, uint16_t addr, size_t sz)
 {
 	if (sz == 1)
 		io_write_byte(v, addr);
@@ -93,7 +93,7 @@ static inline void io_write(uint32_t v, ioport_t addr, size_t sz)
 		io_write_long(v, addr);
 }
 
-static inline uint32_t io_read(ioport_t addr, size_t sz)
+static inline uint32_t io_read(uint16_t addr, size_t sz)
 {
 	if (sz == 1)
 		return io_read_byte(addr);
@@ -108,17 +108,17 @@ struct vcpu;
 
 typedef
 uint32_t (*io_read_fn_t)(struct vm_io_handler *, struct vm *,
-				ioport_t, size_t);
+				uint16_t, size_t);
 
 typedef
 void (*io_write_fn_t)(struct vm_io_handler *, struct vm *,
-				ioport_t, size_t, uint32_t);
+				uint16_t, size_t, uint32_t);
 
 /* Describes a single IO handler description entry. */
 struct vm_io_handler_desc {
 
 	/** The base address of the IO range for this description. */
-	ioport_t addr;
+	uint16_t addr;
 	/** The number of bytes covered by this description. */
 	size_t len;
 
@@ -180,7 +180,7 @@ int dm_emulate_pio_post(struct vcpu *vcpu);
  *  @param value The 32 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write_long(uint32_t value, mmio_addr_t addr)
+static inline void mmio_write_long(uint32_t value, uint64_t addr)
 {
 	*((uint32_t *)addr) = value;
 }
@@ -190,7 +190,7 @@ static inline void mmio_write_long(uint32_t value, mmio_addr_t addr)
  *  @param value The 16 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write_word(uint32_t value, mmio_addr_t addr)
+static inline void mmio_write_word(uint32_t value, uint64_t addr)
 {
 	*((uint16_t *)addr) = value;
 }
@@ -200,7 +200,7 @@ static inline void mmio_write_word(uint32_t value, mmio_addr_t addr)
  *  @param value The 8 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write_byte(uint32_t value, mmio_addr_t addr)
+static inline void mmio_write_byte(uint32_t value, uint64_t addr)
 {
 	*((uint8_t *)addr) = value;
 }
@@ -211,7 +211,7 @@ static inline void mmio_write_byte(uint32_t value, mmio_addr_t addr)
  *
  *  @return The 32 bit value read from the given address.
  */
-static inline uint32_t mmio_read_long(mmio_addr_t addr)
+static inline uint32_t mmio_read_long(uint64_t addr)
 {
 	return *((uint32_t *)addr);
 }
@@ -222,7 +222,7 @@ static inline uint32_t mmio_read_long(mmio_addr_t addr)
  *
  *  @return The 16 bit value read from the given address.
  */
-static inline uint16_t mmio_read_word(mmio_addr_t addr)
+static inline uint16_t mmio_read_word(uint64_t addr)
 {
 	return *((uint16_t *)addr);
 }
@@ -233,7 +233,7 @@ static inline uint16_t mmio_read_word(mmio_addr_t addr)
  *
  *  @return The 8 bit  value read from the given address.
  */
-static inline uint8_t mmio_read_byte(mmio_addr_t addr)
+static inline uint8_t mmio_read_byte(uint64_t addr)
 {
 	return *((uint8_t *)addr);
 }
@@ -245,7 +245,7 @@ static inline uint8_t mmio_read_byte(mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_or_long(uint32_t mask, mmio_addr_t addr)
+static inline void mmio_or_long(uint32_t mask, uint64_t addr)
 {
 	*((uint32_t *)addr) |= mask;
 }
@@ -257,7 +257,7 @@ static inline void mmio_or_long(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_or_word(uint32_t mask, mmio_addr_t addr)
+static inline void mmio_or_word(uint32_t mask, uint64_t addr)
 {
 	*((uint16_t *)addr) |= mask;
 }
@@ -269,7 +269,7 @@ static inline void mmio_or_word(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_or_byte(uint32_t mask, mmio_addr_t addr)
+static inline void mmio_or_byte(uint32_t mask, uint64_t addr)
 {
 	*((uint8_t *)addr) |= mask;
 }
@@ -281,7 +281,7 @@ static inline void mmio_or_byte(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_and_long(uint32_t mask, mmio_addr_t addr)
+static inline void mmio_and_long(uint32_t mask, uint64_t addr)
 {
 	*((uint32_t *)addr) &= ~mask;
 }
@@ -293,7 +293,7 @@ static inline void mmio_and_long(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_and_word(uint32_t mask, mmio_addr_t addr)
+static inline void mmio_and_word(uint32_t mask, uint64_t addr)
 {
 	*((uint16_t *)addr) &= ~mask;
 }
@@ -305,7 +305,7 @@ static inline void mmio_and_word(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_and_byte(uint32_t mask, mmio_addr_t addr)
+static inline void mmio_and_byte(uint32_t mask, uint64_t addr)
 {
 	*((uint8_t *)addr) &= ~mask;
 }
@@ -323,7 +323,7 @@ static inline void mmio_and_byte(uint32_t mask, mmio_addr_t addr)
  *               mask are cleared at the memory address.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_rmw_long(uint32_t set, uint32_t clear, mmio_addr_t addr)
+static inline void mmio_rmw_long(uint32_t set, uint32_t clear, uint64_t addr)
 {
 	*((uint32_t *)addr) =
 	    (*((uint32_t *)addr) & ~clear) | set;
@@ -342,7 +342,7 @@ static inline void mmio_rmw_long(uint32_t set, uint32_t clear, mmio_addr_t addr)
  *               mask are cleared at the memory address.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_rmw_word(uint32_t set, uint32_t clear, mmio_addr_t addr)
+static inline void mmio_rmw_word(uint32_t set, uint32_t clear, uint64_t addr)
 {
 	*((uint16_t *)addr) =
 	    (*((uint16_t *)addr) & ~clear) | set;
@@ -361,7 +361,7 @@ static inline void mmio_rmw_word(uint32_t set, uint32_t clear, mmio_addr_t addr)
  *               mask are cleared at the memory address.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_rmw_byte(uint32_t set, uint32_t clear, mmio_addr_t addr)
+static inline void mmio_rmw_byte(uint32_t set, uint32_t clear, uint64_t addr)
 {
 	*((uint8_t *)addr) = (*((uint8_t *)addr) & ~clear) | set;
 }
@@ -371,7 +371,7 @@ static inline void mmio_rmw_byte(uint32_t set, uint32_t clear, mmio_addr_t addr)
  *  @param value The 32 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void __mmio_write_long(uint32_t value, mmio_addr_t addr)
+static inline void __mmio_write_long(uint32_t value, uint64_t addr)
 {
 	*((uint32_t *)addr) = value;
 }
@@ -381,7 +381,7 @@ static inline void __mmio_write_long(uint32_t value, mmio_addr_t addr)
  *  @param value The 16 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void __mmio_write_word(uint32_t value, mmio_addr_t addr)
+static inline void __mmio_write_word(uint32_t value, uint64_t addr)
 {
 	*((uint16_t *)addr) = value;
 }
@@ -391,7 +391,7 @@ static inline void __mmio_write_word(uint32_t value, mmio_addr_t addr)
  *  @param value The 8 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void __mmio_write_byte(uint32_t value, mmio_addr_t addr)
+static inline void __mmio_write_byte(uint32_t value, uint64_t addr)
 {
 	*((uint8_t *)addr) = value;
 }
@@ -402,7 +402,7 @@ static inline void __mmio_write_byte(uint32_t value, mmio_addr_t addr)
  *
  *  @return The 32 bit value read from the given address.
  */
-static inline uint32_t __mmio_read_long(mmio_addr_t addr)
+static inline uint32_t __mmio_read_long(uint64_t addr)
 {
 	return *((uint32_t *)addr);
 }
@@ -413,7 +413,7 @@ static inline uint32_t __mmio_read_long(mmio_addr_t addr)
  *
  *  @return The 16 bit value read from the given address.
  */
-static inline uint16_t __mmio_read_word(mmio_addr_t addr)
+static inline uint16_t __mmio_read_word(uint64_t addr)
 {
 	return *((uint16_t *)addr);
 }
@@ -424,7 +424,7 @@ static inline uint16_t __mmio_read_word(mmio_addr_t addr)
  *
  *  @return The 32 16 value read from the given address.
  */
-static inline uint8_t __mmio_read_byte(mmio_addr_t addr)
+static inline uint8_t __mmio_read_byte(uint64_t addr)
 {
 	return *((uint8_t *)addr);
 }
@@ -436,7 +436,7 @@ static inline uint8_t __mmio_read_byte(mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_or_long(uint32_t mask, mmio_addr_t addr)
+static inline void __mmio_or_long(uint32_t mask, uint64_t addr)
 {
 	*((uint32_t *)addr) |= mask;
 }
@@ -448,7 +448,7 @@ static inline void __mmio_or_long(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_or_word(uint32_t mask, mmio_addr_t addr)
+static inline void __mmio_or_word(uint32_t mask, uint64_t addr)
 {
 	*((uint16_t *)addr) |= mask;
 }
@@ -460,7 +460,7 @@ static inline void __mmio_or_word(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_or_byte(uint32_t mask, mmio_addr_t addr)
+static inline void __mmio_or_byte(uint32_t mask, uint64_t addr)
 {
 	*((uint8_t *)addr) |= mask;
 }
@@ -472,7 +472,7 @@ static inline void __mmio_or_byte(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_and_long(uint32_t mask, mmio_addr_t addr)
+static inline void __mmio_and_long(uint32_t mask, uint64_t addr)
 {
 	*((uint32_t *)addr) &= ~mask;
 }
@@ -484,7 +484,7 @@ static inline void __mmio_and_long(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_and_word(uint32_t mask, mmio_addr_t addr)
+static inline void __mmio_and_word(uint32_t mask, uint64_t addr)
 {
 	*((uint16_t *)addr) &= ~mask;
 }
@@ -496,7 +496,7 @@ static inline void __mmio_and_word(uint32_t mask, mmio_addr_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_and_byte(uint32_t mask, mmio_addr_t addr)
+static inline void __mmio_and_byte(uint32_t mask, uint64_t addr)
 {
 	*((uint8_t *)addr) &= ~mask;
 }
@@ -516,7 +516,7 @@ static inline void __mmio_and_byte(uint32_t mask, mmio_addr_t addr)
  *  @param addr The memory address to read from/write to.
  */
 static inline void
-__mmio_rmw_long(uint32_t set, uint32_t clear, mmio_addr_t addr)
+__mmio_rmw_long(uint32_t set, uint32_t clear, uint64_t addr)
 {
 	*((uint32_t *)addr) =
 	    (*((uint32_t *)addr) & ~clear) | set;
@@ -537,7 +537,7 @@ __mmio_rmw_long(uint32_t set, uint32_t clear, mmio_addr_t addr)
  *  @param addr The memory address to read from/write to.
  */
 static inline void
-__mmio_rmw_word(uint32_t set, uint32_t clear, mmio_addr_t addr)
+__mmio_rmw_word(uint32_t set, uint32_t clear, uint64_t addr)
 {
 	*((uint16_t *)addr) =
 	    (*((uint16_t *)addr) & ~clear) | set;
@@ -558,7 +558,7 @@ __mmio_rmw_word(uint32_t set, uint32_t clear, mmio_addr_t addr)
  *  @param addr The memory address to read from/write to.
  */
 static inline void
-__mmio_rmw_byte(uint32_t set, uint32_t clear, mmio_addr_t addr)
+__mmio_rmw_byte(uint32_t set, uint32_t clear, uint64_t addr)
 {
 	*((uint8_t *)addr) = (*((uint8_t *)addr) & ~clear) | set;
 }
@@ -570,7 +570,7 @@ __mmio_rmw_byte(uint32_t set, uint32_t clear, mmio_addr_t addr)
  * @param mask    The mask to apply to the value read.
  * @param value   The 32 bit value to write.
  */
-static inline void setl(mmio_addr_t addr, uint32_t mask, uint32_t value)
+static inline void setl(uint64_t addr, uint32_t mask, uint32_t value)
 {
 	mmio_write_long((mmio_read_long(addr) & ~mask) | value, addr);
 }
@@ -582,7 +582,7 @@ static inline void setl(mmio_addr_t addr, uint32_t mask, uint32_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 16 bit value to write.
  */
-static inline void setw(mmio_addr_t addr, uint32_t mask, uint32_t value)
+static inline void setw(uint64_t addr, uint32_t mask, uint32_t value)
 {
 	mmio_write_word((mmio_read_word(addr) & ~mask) | value, addr);
 }
@@ -594,7 +594,7 @@ static inline void setw(mmio_addr_t addr, uint32_t mask, uint32_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 8 bit value to write.
  */
-static inline void setb(mmio_addr_t addr, uint32_t mask, uint32_t value)
+static inline void setb(uint64_t addr, uint32_t mask, uint32_t value)
 {
 	mmio_write_byte((mmio_read_byte(addr) & ~mask) | value, addr);
 }

--- a/include/arch/x86/lapic.h
+++ b/include/arch/x86/lapic.h
@@ -187,7 +187,7 @@ int send_lapic_eoi(void);
 uint32_t get_cur_lapic_id(void);
 int send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 		uint32_t cpu_startup_dest,
-		paddr_t cpu_startup_start_address);
+		uint64_t cpu_startup_start_address);
 /* API to send an IPI to a single guest */
 void send_single_ipi(uint32_t pcpu_id, uint32_t vector);
 

--- a/include/lib/types.h
+++ b/include/lib/types.h
@@ -58,10 +58,6 @@ typedef unsigned int uint32_t;
 typedef unsigned long uint64_t;
 typedef signed long int64_t;
 typedef unsigned int size_t;
-typedef unsigned long mmio_addr_t;
-typedef unsigned long vaddr_t;
-typedef unsigned long paddr_t;
-typedef unsigned long ioport_t;
 typedef __builtin_va_list va_list;
 
 typedef uint8_t bool;


### PR DESCRIPTION
remove data defination of mmio_addr_t, vaddr_t, paddr_t,
and ioport_t.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
