### PR TITLE
rename vmexit handlers

### DIFF
--- a/arch/x86/ept.c
+++ b/arch/x86/ept.c
@@ -400,7 +400,7 @@ static int dm_emulate_mmio_pre(struct vcpu *vcpu, uint64_t exit_qual)
 	return 0;
 }
 
-int ept_violation_handler(struct vcpu *vcpu)
+int ept_violation_vmexit_handler(struct vcpu *vcpu)
 {
 	int status;
 	uint64_t exit_qual;
@@ -499,7 +499,7 @@ out:
 	return status;
 }
 
-int ept_misconfig_handler(__unused struct vcpu *vcpu)
+int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu)
 {
 	int status;
 

--- a/arch/x86/guest/vmcall.c
+++ b/arch/x86/guest/vmcall.c
@@ -35,7 +35,7 @@
 #include <acrn_hv_defs.h>
 #include <hypercall.h>
 
-int vmcall_handler(struct vcpu *vcpu)
+int vmcall_vmexit_handler(struct vcpu *vcpu)
 {
 	int64_t ret = 0;
 	struct vm *vm = vcpu->vm;

--- a/arch/x86/guest/vmsr.c
+++ b/arch/x86/guest/vmsr.c
@@ -173,7 +173,7 @@ void init_msr_emulation(struct vcpu *vcpu)
 	memset(vcpu->guest_msrs, 0, msrs_count * sizeof(uint64_t));
 }
 
-int rdmsr_handler(struct vcpu *vcpu)
+int rdmsr_vmexit_handler(struct vcpu *vcpu)
 {
 	uint32_t msr;
 	uint64_t v = 0;
@@ -262,7 +262,7 @@ int rdmsr_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int wrmsr_handler(struct vcpu *vcpu)
+int wrmsr_vmexit_handler(struct vcpu *vcpu)
 {
 	uint32_t msr;
 	uint64_t v;

--- a/arch/x86/interrupt.c
+++ b/arch/x86/interrupt.c
@@ -237,7 +237,7 @@ int vcpu_inject_gp(struct vcpu *vcpu)
 	return vcpu_make_request(vcpu, ACRN_REQUEST_GP);
 }
 
-int interrupt_win_exiting_handler(struct vcpu *vcpu)
+int interrupt_window_vmexit_handler(struct vcpu *vcpu)
 {
 	int value32;
 
@@ -264,7 +264,7 @@ int interrupt_win_exiting_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int external_interrupt_handler(struct vcpu *vcpu)
+int external_interrupt_vmexit_handler(struct vcpu *vcpu)
 {
 	int vector = exec_vmread(VMX_EXIT_INT_INFO) & 0xFF;
 	struct intr_ctx ctx;
@@ -417,7 +417,7 @@ void cancel_event_injection(struct vcpu *vcpu)
 	}
 }
 
-int exception_handler(struct vcpu *vcpu)
+int exception_vmexit_handler(struct vcpu *vcpu)
 {
 	uint32_t intinfo, int_err_code;
 	uint32_t exception_vector;

--- a/arch/x86/io.c
+++ b/arch/x86/io.c
@@ -78,7 +78,7 @@ static void dm_emulate_pio_pre(struct vcpu *vcpu, uint64_t exit_qual,
 	vcpu->req.reqs.pio_request.value = req_value;
 }
 
-int io_instr_handler(struct vcpu *vcpu)
+int io_instr_vmexit_handler(struct vcpu *vcpu)
 {
 	uint32_t sz;
 	uint32_t mask;

--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -39,9 +39,9 @@ static int xsetbv_vmexit_handler(struct vcpu *vcpu);
 /* VM Dispatch table for Exit condition handling */
 static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_EXCEPTION_OR_NMI] = {
-		.handler = exception_handler},
+		.handler = exception_vmexit_handler},
 	[VMX_EXIT_REASON_EXTERNAL_INTERRUPT] = {
-		.handler = external_interrupt_handler},
+		.handler = external_interrupt_vmexit_handler},
 	[VMX_EXIT_REASON_TRIPLE_FAULT] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_INIT_SIGNAL] = {
@@ -53,13 +53,13 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_OTHER_SMI] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_INTERRUPT_WINDOW] = {
-		.handler = interrupt_win_exiting_handler},
+		.handler = interrupt_window_vmexit_handler},
 	[VMX_EXIT_REASON_NMI_WINDOW] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_TASK_SWITCH] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_CPUID] = {
-		.handler = cpuid_handler},
+		.handler = cpuid_vmexit_handler},
 	[VMX_EXIT_REASON_GETSEC] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_HLT] = {
@@ -75,7 +75,7 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_RSM] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_VMCALL] = {
-		.handler = vmcall_handler},
+		.handler = vmcall_vmexit_handler},
 	[VMX_EXIT_REASON_VMCLEAR] {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_VMLAUNCH] = {
@@ -95,17 +95,17 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_VMXON] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_CR_ACCESS] = {
-		.handler = cr_access_handler,
+		.handler = cr_access_vmexit_handler,
 		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_DR_ACCESS] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_IO_INSTRUCTION] = {
-		.handler = io_instr_handler,
+		.handler = io_instr_vmexit_handler,
 		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_RDMSR] = {
-		.handler = rdmsr_handler},
+		.handler = rdmsr_vmexit_handler},
 	[VMX_EXIT_REASON_WRMSR] = {
-		.handler = wrmsr_handler},
+		.handler = wrmsr_vmexit_handler},
 	[VMX_EXIT_REASON_ENTRY_FAILURE_INVALID_GUEST_STATE] = {
 		.handler = unhandled_vmexit_handler,
 		.need_exit_qualification = 1},
@@ -134,10 +134,10 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 	[VMX_EXIT_REASON_LDTR_TR_ACCESS] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_EPT_VIOLATION] = {
-		.handler = ept_violation_handler,
+		.handler = ept_violation_vmexit_handler,
 		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_EPT_MISCONFIGURATION] = {
-		.handler = ept_misconfig_handler,
+		.handler = ept_misconfig_vmexit_handler,
 		.need_exit_qualification = 1},
 	[VMX_EXIT_REASON_INVEPT] = {
 		.handler = unhandled_vmexit_handler},
@@ -310,7 +310,7 @@ static int read_cr3(struct vcpu *vcpu, uint64_t *value)
 	return 0;
 }
 
-int cpuid_handler(struct vcpu *vcpu)
+int cpuid_vmexit_handler(struct vcpu *vcpu)
 {
 	struct run_context *cur_context =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
@@ -326,7 +326,7 @@ int cpuid_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int cr_access_handler(struct vcpu *vcpu)
+int cr_access_vmexit_handler(struct vcpu *vcpu)
 {
 	uint64_t *regptr;
 	struct run_context *cur_context =

--- a/include/arch/x86/guest/guest.h
+++ b/include/arch/x86/guest/guest.h
@@ -97,8 +97,8 @@ extern struct e820_entry e820[E820_MAX_ENTRIES];
 extern uint32_t boot_regs[];
 extern struct e820_mem_params e820_mem;
 
-int rdmsr_handler(struct vcpu *vcpu);
-int wrmsr_handler(struct vcpu *vcpu);
+int rdmsr_vmexit_handler(struct vcpu *vcpu);
+int wrmsr_vmexit_handler(struct vcpu *vcpu);
 void init_msr_emulation(struct vcpu *vcpu);
 
 extern const char vm_exit[];

--- a/include/arch/x86/io.h
+++ b/include/arch/x86/io.h
@@ -167,7 +167,7 @@ struct vm_io_handler {
 #define IO_ATTR_NO_ACCESS       2
 
 /* External Interfaces */
-int io_instr_handler(struct vcpu *vcpu);
+int io_instr_vmexit_handler(struct vcpu *vcpu);
 void   setup_io_bitmap(struct vm *vm);
 void   free_io_emulation_resource(struct vm *vm);
 void   register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,

--- a/include/arch/x86/irq.h
+++ b/include/arch/x86/irq.h
@@ -156,9 +156,9 @@ int vcpu_inject_nmi(struct vcpu *vcpu);
 int vcpu_inject_gp(struct vcpu *vcpu);
 int vcpu_make_request(struct vcpu *vcpu, int eventid);
 
-int exception_handler(struct vcpu *vcpu);
-int interrupt_win_exiting_handler(struct vcpu *vcpu);
-int external_interrupt_handler(struct vcpu *vcpu);
+int exception_vmexit_handler(struct vcpu *vcpu);
+int interrupt_window_vmexit_handler(struct vcpu *vcpu);
+int external_interrupt_vmexit_handler(struct vcpu *vcpu);
 int acrn_do_intr_process(struct vcpu *vcpu);
 int interrupt_init(uint32_t logical_id);
 

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -396,8 +396,8 @@ uint64_t  hpa2gpa(struct vm *vm, uint64_t hpa);
 int ept_mmap(struct vm *vm, uint64_t hpa,
 	uint64_t gpa, uint64_t size, uint32_t type, uint32_t prot);
 
-int     ept_violation_handler(struct vcpu *vcpu);
-int     ept_misconfig_handler(struct vcpu *vcpu);
+int     ept_violation_vmexit_handler(struct vcpu *vcpu);
+int     ept_misconfig_vmexit_handler(struct vcpu *vcpu);
 int     dm_emulate_mmio_post(struct vcpu *vcpu);
 
 #endif /* ASSEMBLER not defined */

--- a/include/arch/x86/vmexit.h
+++ b/include/arch/x86/vmexit.h
@@ -37,9 +37,9 @@ struct vm_exit_dispatch {
 };
 
 struct vm_exit_dispatch *vmexit_handler(struct vcpu *vcpu);
-int vmcall_handler(struct vcpu *vcpu);
-int cpuid_handler(struct vcpu *vcpu);
-int cr_access_handler(struct vcpu *vcpu);
+int vmcall_vmexit_handler(struct vcpu *vcpu);
+int cpuid_vmexit_handler(struct vcpu *vcpu);
+int cr_access_vmexit_handler(struct vcpu *vcpu);
 int get_vmexit_profile(char *str, int str_max);
 
 #define VM_EXIT_QUALIFICATION_BIT_MASK(exit_qual, MSB, LSB)   \


### PR DESCRIPTION
this patch is to align the suffix of the handlers' name.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>