### PR TITLE
revise type of 'exit_reason' and 'inst_len' in vcpu_arch

### DIFF
--- a/arch/x86/guest/instr_emul.c
+++ b/arch/x86/guest/instr_emul.c
@@ -1665,9 +1665,9 @@ vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum vm_reg_name seg,
 }
 
 void
-vie_init(struct vie *vie, const char *inst_bytes, int inst_length)
+vie_init(struct vie *vie, const char *inst_bytes, uint32_t inst_length)
 {
-	ASSERT(inst_length >= 0 && inst_length <= VIE_INST_SIZE,
+	ASSERT(inst_length <= VIE_INST_SIZE,
 		"%s: invalid instruction length (%d)", __func__, inst_length);
 
 	memset(vie, 0, sizeof(struct vie));

--- a/arch/x86/guest/instr_emul.h
+++ b/arch/x86/guest/instr_emul.h
@@ -72,7 +72,7 @@ int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum vm_reg_name seg,
 	struct seg_desc *desc, uint64_t off, int length, int addrsize, int prot,
 	uint64_t *gla);
 
-void vie_init(struct vie *vie, const char *inst_bytes, int inst_length);
+void vie_init(struct vie *vie, const char *inst_bytes, uint32_t inst_length);
 
 /*
  * Decode the instruction fetched into 'vie' so it can be emulated.

--- a/arch/x86/guest/vcpu.c
+++ b/arch/x86/guest/vcpu.c
@@ -136,7 +136,8 @@ int create_vcpu(int cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 
 int start_vcpu(struct vcpu *vcpu)
 {
-	uint64_t rip, instlen;
+	uint32_t instlen;
+	uint64_t rip;
 	struct run_context *cur_context =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
 	int64_t status = 0;

--- a/include/arch/x86/guest/vcpu.h
+++ b/include/arch/x86/guest/vcpu.h
@@ -214,10 +214,10 @@ struct vcpu_arch {
 	uint64_t msr_tsc_aux;
 
 	/* VCPU context state information */
-	uint64_t exit_reason;
+	uint32_t exit_reason;
 	uint64_t exit_interrupt_info;
 	uint64_t exit_qualification;
-	uint8_t inst_len;
+	uint32_t inst_len;
 
 	/* Information related to secondary / AP VCPU start-up */
 	uint8_t cpu_mode;


### PR DESCRIPTION
 SDM 24.9.1 Volume3:
 - 'Exit reason' field in VMCS is 32 bits.

 SDM 24.9.4 in Volume3
 - 'VM-exit instruction length' field
   in VMCS is 32 bits.

 This patch is to redefine the data types of above fields
 in 'struct vcpu_arch' and udpate the code using these
 two fields.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>