### PR TITLE
Bug fix on address convertion

### DIFF
--- a/arch/x86/interrupt.c
+++ b/arch/x86/interrupt.c
@@ -215,11 +215,11 @@ void dump_lapic(void)
 {
 	dev_dbg(ACRN_DBG_INTR,
 		"LAPIC: TIME %08x, init=0x%x cur=0x%x ISR=0x%x IRR=0x%x",
-		mmio_read_long(0xFEE00000 + LAPIC_LVT_TIMER_REGISTER),
-		mmio_read_long(0xFEE00000 + LAPIC_INITIAL_COUNT_REGISTER),
-		mmio_read_long(0xFEE00000 + LAPIC_CURRENT_COUNT_REGISTER),
-		mmio_read_long(0xFEE00000 + LAPIC_IN_SERVICE_REGISTER_7),
-		mmio_read_long(0xFEE00000 + LAPIC_INT_REQUEST_REGISTER_7));
+		mmio_read_long((void*)(0xFEE00000 + LAPIC_LVT_TIMER_REGISTER)),
+		mmio_read_long((void*)(0xFEE00000 + LAPIC_INITIAL_COUNT_REGISTER)),
+		mmio_read_long((void*)(0xFEE00000 + LAPIC_CURRENT_COUNT_REGISTER)),
+		mmio_read_long((void*)(0xFEE00000 + LAPIC_IN_SERVICE_REGISTER_7)),
+		mmio_read_long((void*)(0xFEE00000 + LAPIC_INT_REQUEST_REGISTER_7)));
 }
 
 int vcpu_inject_extint(struct vcpu *vcpu)

--- a/arch/x86/interrupt.c
+++ b/arch/x86/interrupt.c
@@ -215,11 +215,11 @@ void dump_lapic(void)
 {
 	dev_dbg(ACRN_DBG_INTR,
 		"LAPIC: TIME %08x, init=0x%x cur=0x%x ISR=0x%x IRR=0x%x",
-		mmio_read_long((void*)(0xFEE00000 + LAPIC_LVT_TIMER_REGISTER)),
-		mmio_read_long((void*)(0xFEE00000 + LAPIC_INITIAL_COUNT_REGISTER)),
-		mmio_read_long((void*)(0xFEE00000 + LAPIC_CURRENT_COUNT_REGISTER)),
-		mmio_read_long((void*)(0xFEE00000 + LAPIC_IN_SERVICE_REGISTER_7)),
-		mmio_read_long((void*)(0xFEE00000 + LAPIC_INT_REQUEST_REGISTER_7)));
+		mmio_read_long(HPA2HVA(LAPIC_BASE + LAPIC_LVT_TIMER_REGISTER)),
+		mmio_read_long(HPA2HVA(LAPIC_BASE + LAPIC_INITIAL_COUNT_REGISTER)),
+		mmio_read_long(HPA2HVA(LAPIC_BASE + LAPIC_CURRENT_COUNT_REGISTER)),
+		mmio_read_long(HPA2HVA(LAPIC_BASE + LAPIC_IN_SERVICE_REGISTER_7)),
+		mmio_read_long(HPA2HVA(LAPIC_BASE + LAPIC_INT_REQUEST_REGISTER_7)));
 }
 
 int vcpu_inject_extint(struct vcpu *vcpu)

--- a/arch/x86/intr_lapic.c
+++ b/arch/x86/intr_lapic.c
@@ -204,7 +204,7 @@ static void map_lapic(void)
 	/* At some point we may need to translate this paddr to a vaddr. 1:1
 	 * mapping for now.
 	 */
-	lapic_info.xapic.vaddr = (void *)lapic_info.xapic.paddr;
+	lapic_info.xapic.vaddr = HPA2HVA(lapic_info.xapic.paddr);
 }
 
 int early_init_lapic(void)

--- a/arch/x86/intr_lapic.c
+++ b/arch/x86/intr_lapic.c
@@ -170,7 +170,7 @@ static inline uint32_t read_lapic_reg32(uint32_t offset)
 	if (offset < 0x20 || offset > 0x3ff)
 		return 0;
 
-	return mmio_read_long((uint64_t)lapic_info.xapic.vaddr + offset);
+	return mmio_read_long(lapic_info.xapic.vaddr + offset);
 }
 
 inline void write_lapic_reg32(uint32_t offset, uint32_t value)
@@ -178,7 +178,7 @@ inline void write_lapic_reg32(uint32_t offset, uint32_t value)
 	if (offset < 0x20 || offset > 0x3ff)
 		return;
 
-	mmio_write_long(value, (uint64_t)lapic_info.xapic.vaddr + offset);
+	mmio_write_long(value, lapic_info.xapic.vaddr + offset);
 }
 
 static void clear_lapic_isr(void)

--- a/arch/x86/mmu.c
+++ b/arch/x86/mmu.c
@@ -509,15 +509,15 @@ static void *walk_paging_struct(void *addr, void *table_base,
 	return sub_table_addr;
 }
 
-void *get_paging_pml4(void)
+uint64_t get_paging_pml4(void)
 {
 	/* Return address to caller */
-	return mmu_pml4_addr;
+	return HVA2HPA(mmu_pml4_addr);
 }
 
-void enable_paging(void *pml4_base_addr)
+void enable_paging(uint64_t pml4_base_addr)
 {
-	CPU_CR_WRITE(cr3, (unsigned long)pml4_base_addr);
+	CPU_CR_WRITE(cr3, pml4_base_addr);
 }
 
 void init_paging(void)
@@ -568,7 +568,7 @@ void init_paging(void)
 	pr_dbg("Enabling MMU ");
 
 	/* Enable paging */
-	enable_paging(mmu_pml4_addr);
+	enable_paging(HVA2HPA(mmu_pml4_addr));
 }
 
 void *alloc_paging_struct(void)

--- a/arch/x86/vtd.c
+++ b/arch/x86/vtd.c
@@ -219,17 +219,17 @@ static int register_hrhd_units(void)
 
 static uint32_t iommu_read32(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
-	return mmio_read_long(dmar_uint->drhd->reg_base_addr + offset);
+	return mmio_read_long((void*)(dmar_uint->drhd->reg_base_addr + offset));
 }
 
 static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
 	uint64_t value;
 
-	value = (mmio_read_long(dmar_uint->drhd->reg_base_addr + offset + 4));
+	value = (mmio_read_long((void*)(dmar_uint->drhd->reg_base_addr + offset + 4)));
 	value = value << 32;
-	value = value | (mmio_read_long(dmar_uint->drhd->reg_base_addr +
-					offset));
+	value = value | (mmio_read_long((void*)(dmar_uint->drhd->reg_base_addr +
+					offset)));
 
 	return value;
 }
@@ -237,7 +237,7 @@ static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 static void iommu_write32(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 			  uint32_t value)
 {
-	mmio_write_long(value, dmar_uint->drhd->reg_base_addr + offset);
+	mmio_write_long(value, (void*)(dmar_uint->drhd->reg_base_addr + offset));
 }
 
 static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
@@ -246,10 +246,10 @@ static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 	uint32_t temp;
 
 	temp = value;
-	mmio_write_long(temp, dmar_uint->drhd->reg_base_addr + offset);
+	mmio_write_long(temp, (void*)(dmar_uint->drhd->reg_base_addr + offset));
 
 	temp = value >> 32;
-	mmio_write_long(temp, dmar_uint->drhd->reg_base_addr + offset + 4);
+	mmio_write_long(temp, (void*)(dmar_uint->drhd->reg_base_addr + offset + 4));
 }
 
 /* flush cache when root table, context table updated */

--- a/arch/x86/vtd.c
+++ b/arch/x86/vtd.c
@@ -219,17 +219,17 @@ static int register_hrhd_units(void)
 
 static uint32_t iommu_read32(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
-	return mmio_read_long((void*)(dmar_uint->drhd->reg_base_addr + offset));
+	return mmio_read_long(HPA2HVA(dmar_uint->drhd->reg_base_addr + offset));
 }
 
 static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
 	uint64_t value;
 
-	value = (mmio_read_long((void*)(dmar_uint->drhd->reg_base_addr + offset + 4)));
+	value = mmio_read_long(HPA2HVA(dmar_uint->drhd->reg_base_addr + offset + 4));
 	value = value << 32;
-	value = value | (mmio_read_long((void*)(dmar_uint->drhd->reg_base_addr +
-					offset)));
+	value = value | mmio_read_long(HPA2HVA(dmar_uint->drhd->reg_base_addr +
+					offset));
 
 	return value;
 }
@@ -237,7 +237,7 @@ static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 static void iommu_write32(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 			  uint32_t value)
 {
-	mmio_write_long(value, (void*)(dmar_uint->drhd->reg_base_addr + offset));
+	mmio_write_long(value, HPA2HVA(dmar_uint->drhd->reg_base_addr + offset));
 }
 
 static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
@@ -246,10 +246,10 @@ static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 	uint32_t temp;
 
 	temp = value;
-	mmio_write_long(temp, (void*)(dmar_uint->drhd->reg_base_addr + offset));
+	mmio_write_long(temp, HPA2HVA(dmar_uint->drhd->reg_base_addr + offset));
 
 	temp = value >> 32;
-	mmio_write_long(temp, (void*)(dmar_uint->drhd->reg_base_addr + offset + 4));
+	mmio_write_long(temp, HPA2HVA(dmar_uint->drhd->reg_base_addr + offset + 4));
 }
 
 /* flush cache when root table, context table updated */

--- a/boot/include/acpi.h
+++ b/boot/include/acpi.h
@@ -54,5 +54,5 @@ struct acpi_table_header {
 
 int parse_madt(uint8_t *lapic_id_base);
 
-uint64_t get_dmar_table(void);
+void *get_dmar_table(void);
 #endif /* !ACPI_H */

--- a/bsp/uefi/cmdline.c
+++ b/bsp/uefi/cmdline.c
@@ -103,7 +103,7 @@ int parse_hv_cmdline(void)
 		return -EINVAL;
 	}
 
-	mbi = (struct multiboot_info *)((uint64_t)boot_regs[1]);
+	mbi = (struct multiboot_info *)(HPA2HVA((uint64_t)boot_regs[1]));
 	dev_dbg(ACRN_DBG_PARSE, "Multiboot detected, flag=0x%x", mbi->mi_flags);
 
 	if (!(mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE)) {
@@ -111,7 +111,7 @@ int parse_hv_cmdline(void)
 		return -EINVAL;
 	}
 
-	start = (char *)(uint64_t)mbi->mi_cmdline;
+	start = (char *)HPA2HVA((uint64_t)mbi->mi_cmdline);
 	dev_dbg(ACRN_DBG_PARSE, "hv cmdline: %s", start);
 
 	do {

--- a/bsp/uefi/uefi.c
+++ b/bsp/uefi/uefi.c
@@ -176,12 +176,12 @@ static void efi_init(void)
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC)
 		ASSERT(0, "no multiboot info found");
 
-	mbi = (struct multiboot_info *)((uint64_t)(uint32_t)boot_regs[1]);
+	mbi = (struct multiboot_info *)HPA2HVA(((uint64_t)(uint32_t)boot_regs[1]));
 
 	if (!(mbi->mi_flags & MULTIBOOT_INFO_HAS_DRIVES))
 		ASSERT(0, "no multiboot drivers for uefi found");
 
-	efi_ctx = (struct efi_ctx *)(uint64_t)mbi->mi_drives_addr;
+	efi_ctx = (struct efi_ctx *)HPA2HVA((uint64_t)mbi->mi_drives_addr);
 	ASSERT(efi_ctx != NULL, "no uefi context found");
 
 	vm_sw_loader = uefi_sw_loader;

--- a/bsp/uefi/uefi.c
+++ b/bsp/uefi/uefi.c
@@ -166,7 +166,7 @@ void *get_rsdp_from_uefi(void)
 	if (!efi_initialized)
 		efi_init();
 
-	return efi_ctx->rsdp;
+	return HPA2HVA(efi_ctx->rsdp);
 }
 
 static void efi_init(void)

--- a/debug/uart16550.c
+++ b/debug/uart16550.c
@@ -93,7 +93,7 @@ static inline uint32_t uart16550_read_reg(uint64_t base, uint32_t reg_idx)
 	if (serial_port_mapped) {
 		return io_read_byte((uint16_t)base + reg_idx);
 	} else {
-		return mmio_read_long((uint64_t)((uint32_t*)base + reg_idx));
+		return mmio_read_long((void*)((uint32_t*)base + reg_idx));
 	}
 }
 
@@ -103,7 +103,7 @@ static inline void uart16550_write_reg(uint64_t base,
 	if (serial_port_mapped) {
 		io_write_byte(val, (uint16_t)base + reg_idx);
 	} else {
-		mmio_write_long(val, (uint64_t)((uint32_t*)base + reg_idx));
+		mmio_write_long(val, (void*)((uint32_t*)base + reg_idx));
 	}
 }
 

--- a/debug/uart16550.c
+++ b/debug/uart16550.c
@@ -93,7 +93,7 @@ static inline uint32_t uart16550_read_reg(uint64_t base, uint32_t reg_idx)
 	if (serial_port_mapped) {
 		return io_read_byte((uint16_t)base + reg_idx);
 	} else {
-		return mmio_read_long((void*)((uint32_t*)base + reg_idx));
+		return mmio_read_long((void*)((uint32_t*)HPA2HVA(base) + reg_idx));
 	}
 }
 
@@ -103,7 +103,7 @@ static inline void uart16550_write_reg(uint64_t base,
 	if (serial_port_mapped) {
 		io_write_byte(val, (uint16_t)base + reg_idx);
 	} else {
-		mmio_write_long(val, (void*)((uint32_t*)base + reg_idx));
+		mmio_write_long(val, (void*)((uint32_t*)HPA2HVA(base) + reg_idx));
 	}
 }
 
@@ -339,5 +339,5 @@ void uart16550_set_property(int enabled, int port_mapped, uint64_t base_addr)
 {
 	uart_enabled = enabled;
 	serial_port_mapped = port_mapped;
-	Tgt_Uarts[0].base_address = (uint32_t) base_addr;
+	Tgt_Uarts[0].base_address = base_addr;
 }

--- a/include/arch/x86/io.h
+++ b/include/arch/x86/io.h
@@ -180,7 +180,7 @@ int dm_emulate_pio_post(struct vcpu *vcpu);
  *  @param value The 32 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write_long(uint32_t value, uint64_t addr)
+static inline void mmio_write_long(uint32_t value, void *addr)
 {
 	*((uint32_t *)addr) = value;
 }
@@ -190,7 +190,7 @@ static inline void mmio_write_long(uint32_t value, uint64_t addr)
  *  @param value The 16 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write_word(uint32_t value, uint64_t addr)
+static inline void mmio_write_word(uint32_t value, void *addr)
 {
 	*((uint16_t *)addr) = value;
 }
@@ -200,7 +200,7 @@ static inline void mmio_write_word(uint32_t value, uint64_t addr)
  *  @param value The 8 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write_byte(uint32_t value, uint64_t addr)
+static inline void mmio_write_byte(uint32_t value, void *addr)
 {
 	*((uint8_t *)addr) = value;
 }
@@ -211,7 +211,7 @@ static inline void mmio_write_byte(uint32_t value, uint64_t addr)
  *
  *  @return The 32 bit value read from the given address.
  */
-static inline uint32_t mmio_read_long(uint64_t addr)
+static inline uint32_t mmio_read_long(void *addr)
 {
 	return *((uint32_t *)addr);
 }
@@ -222,7 +222,7 @@ static inline uint32_t mmio_read_long(uint64_t addr)
  *
  *  @return The 16 bit value read from the given address.
  */
-static inline uint16_t mmio_read_word(uint64_t addr)
+static inline uint16_t mmio_read_word(void *addr)
 {
 	return *((uint16_t *)addr);
 }
@@ -233,7 +233,7 @@ static inline uint16_t mmio_read_word(uint64_t addr)
  *
  *  @return The 8 bit  value read from the given address.
  */
-static inline uint8_t mmio_read_byte(uint64_t addr)
+static inline uint8_t mmio_read_byte(void *addr)
 {
 	return *((uint8_t *)addr);
 }
@@ -245,7 +245,7 @@ static inline uint8_t mmio_read_byte(uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_or_long(uint32_t mask, uint64_t addr)
+static inline void mmio_or_long(uint32_t mask, void *addr)
 {
 	*((uint32_t *)addr) |= mask;
 }
@@ -257,7 +257,7 @@ static inline void mmio_or_long(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_or_word(uint32_t mask, uint64_t addr)
+static inline void mmio_or_word(uint32_t mask, void *addr)
 {
 	*((uint16_t *)addr) |= mask;
 }
@@ -269,7 +269,7 @@ static inline void mmio_or_word(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_or_byte(uint32_t mask, uint64_t addr)
+static inline void mmio_or_byte(uint32_t mask, void *addr)
 {
 	*((uint8_t *)addr) |= mask;
 }
@@ -281,7 +281,7 @@ static inline void mmio_or_byte(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_and_long(uint32_t mask, uint64_t addr)
+static inline void mmio_and_long(uint32_t mask, void *addr)
 {
 	*((uint32_t *)addr) &= ~mask;
 }
@@ -293,7 +293,7 @@ static inline void mmio_and_long(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_and_word(uint32_t mask, uint64_t addr)
+static inline void mmio_and_word(uint32_t mask, void *addr)
 {
 	*((uint16_t *)addr) &= ~mask;
 }
@@ -305,7 +305,7 @@ static inline void mmio_and_word(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_and_byte(uint32_t mask, uint64_t addr)
+static inline void mmio_and_byte(uint32_t mask, void *addr)
 {
 	*((uint8_t *)addr) &= ~mask;
 }
@@ -323,7 +323,7 @@ static inline void mmio_and_byte(uint32_t mask, uint64_t addr)
  *               mask are cleared at the memory address.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_rmw_long(uint32_t set, uint32_t clear, uint64_t addr)
+static inline void mmio_rmw_long(uint32_t set, uint32_t clear, void *addr)
 {
 	*((uint32_t *)addr) =
 	    (*((uint32_t *)addr) & ~clear) | set;
@@ -342,7 +342,7 @@ static inline void mmio_rmw_long(uint32_t set, uint32_t clear, uint64_t addr)
  *               mask are cleared at the memory address.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_rmw_word(uint32_t set, uint32_t clear, uint64_t addr)
+static inline void mmio_rmw_word(uint32_t set, uint32_t clear, void *addr)
 {
 	*((uint16_t *)addr) =
 	    (*((uint16_t *)addr) & ~clear) | set;
@@ -361,7 +361,7 @@ static inline void mmio_rmw_word(uint32_t set, uint32_t clear, uint64_t addr)
  *               mask are cleared at the memory address.
  *  @param addr The memory address to read from/write to.
  */
-static inline void mmio_rmw_byte(uint32_t set, uint32_t clear, uint64_t addr)
+static inline void mmio_rmw_byte(uint32_t set, uint32_t clear, void *addr)
 {
 	*((uint8_t *)addr) = (*((uint8_t *)addr) & ~clear) | set;
 }
@@ -371,7 +371,7 @@ static inline void mmio_rmw_byte(uint32_t set, uint32_t clear, uint64_t addr)
  *  @param value The 32 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void __mmio_write_long(uint32_t value, uint64_t addr)
+static inline void __mmio_write_long(uint32_t value, void *addr)
 {
 	*((uint32_t *)addr) = value;
 }
@@ -381,7 +381,7 @@ static inline void __mmio_write_long(uint32_t value, uint64_t addr)
  *  @param value The 16 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void __mmio_write_word(uint32_t value, uint64_t addr)
+static inline void __mmio_write_word(uint32_t value, void *addr)
 {
 	*((uint16_t *)addr) = value;
 }
@@ -391,7 +391,7 @@ static inline void __mmio_write_word(uint32_t value, uint64_t addr)
  *  @param value The 8 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void __mmio_write_byte(uint32_t value, uint64_t addr)
+static inline void __mmio_write_byte(uint32_t value, void *addr)
 {
 	*((uint8_t *)addr) = value;
 }
@@ -402,7 +402,7 @@ static inline void __mmio_write_byte(uint32_t value, uint64_t addr)
  *
  *  @return The 32 bit value read from the given address.
  */
-static inline uint32_t __mmio_read_long(uint64_t addr)
+static inline uint32_t __mmio_read_long(void *addr)
 {
 	return *((uint32_t *)addr);
 }
@@ -413,7 +413,7 @@ static inline uint32_t __mmio_read_long(uint64_t addr)
  *
  *  @return The 16 bit value read from the given address.
  */
-static inline uint16_t __mmio_read_word(uint64_t addr)
+static inline uint16_t __mmio_read_word(void *addr)
 {
 	return *((uint16_t *)addr);
 }
@@ -424,7 +424,7 @@ static inline uint16_t __mmio_read_word(uint64_t addr)
  *
  *  @return The 32 16 value read from the given address.
  */
-static inline uint8_t __mmio_read_byte(uint64_t addr)
+static inline uint8_t __mmio_read_byte(void *addr)
 {
 	return *((uint8_t *)addr);
 }
@@ -436,7 +436,7 @@ static inline uint8_t __mmio_read_byte(uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_or_long(uint32_t mask, uint64_t addr)
+static inline void __mmio_or_long(uint32_t mask, void *addr)
 {
 	*((uint32_t *)addr) |= mask;
 }
@@ -448,7 +448,7 @@ static inline void __mmio_or_long(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_or_word(uint32_t mask, uint64_t addr)
+static inline void __mmio_or_word(uint32_t mask, void *addr)
 {
 	*((uint16_t *)addr) |= mask;
 }
@@ -460,7 +460,7 @@ static inline void __mmio_or_word(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_or_byte(uint32_t mask, uint64_t addr)
+static inline void __mmio_or_byte(uint32_t mask, void *addr)
 {
 	*((uint8_t *)addr) |= mask;
 }
@@ -472,7 +472,7 @@ static inline void __mmio_or_byte(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_and_long(uint32_t mask, uint64_t addr)
+static inline void __mmio_and_long(uint32_t mask, void *addr)
 {
 	*((uint32_t *)addr) &= ~mask;
 }
@@ -484,7 +484,7 @@ static inline void __mmio_and_long(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_and_word(uint32_t mask, uint64_t addr)
+static inline void __mmio_and_word(uint32_t mask, void *addr)
 {
 	*((uint16_t *)addr) &= ~mask;
 }
@@ -496,7 +496,7 @@ static inline void __mmio_and_word(uint32_t mask, uint64_t addr)
  *              location.
  *  @param addr The memory address to read from/write to.
  */
-static inline void __mmio_and_byte(uint32_t mask, uint64_t addr)
+static inline void __mmio_and_byte(uint32_t mask, void *addr)
 {
 	*((uint8_t *)addr) &= ~mask;
 }
@@ -516,7 +516,7 @@ static inline void __mmio_and_byte(uint32_t mask, uint64_t addr)
  *  @param addr The memory address to read from/write to.
  */
 static inline void
-__mmio_rmw_long(uint32_t set, uint32_t clear, uint64_t addr)
+__mmio_rmw_long(uint32_t set, uint32_t clear, void *addr)
 {
 	*((uint32_t *)addr) =
 	    (*((uint32_t *)addr) & ~clear) | set;
@@ -537,7 +537,7 @@ __mmio_rmw_long(uint32_t set, uint32_t clear, uint64_t addr)
  *  @param addr The memory address to read from/write to.
  */
 static inline void
-__mmio_rmw_word(uint32_t set, uint32_t clear, uint64_t addr)
+__mmio_rmw_word(uint32_t set, uint32_t clear, void *addr)
 {
 	*((uint16_t *)addr) =
 	    (*((uint16_t *)addr) & ~clear) | set;
@@ -558,7 +558,7 @@ __mmio_rmw_word(uint32_t set, uint32_t clear, uint64_t addr)
  *  @param addr The memory address to read from/write to.
  */
 static inline void
-__mmio_rmw_byte(uint32_t set, uint32_t clear, uint64_t addr)
+__mmio_rmw_byte(uint32_t set, uint32_t clear, void *addr)
 {
 	*((uint8_t *)addr) = (*((uint8_t *)addr) & ~clear) | set;
 }
@@ -570,7 +570,7 @@ __mmio_rmw_byte(uint32_t set, uint32_t clear, uint64_t addr)
  * @param mask    The mask to apply to the value read.
  * @param value   The 32 bit value to write.
  */
-static inline void setl(uint64_t addr, uint32_t mask, uint32_t value)
+static inline void setl(void *addr, uint32_t mask, uint32_t value)
 {
 	mmio_write_long((mmio_read_long(addr) & ~mask) | value, addr);
 }
@@ -582,7 +582,7 @@ static inline void setl(uint64_t addr, uint32_t mask, uint32_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 16 bit value to write.
  */
-static inline void setw(uint64_t addr, uint32_t mask, uint32_t value)
+static inline void setw(void *addr, uint32_t mask, uint32_t value)
 {
 	mmio_write_word((mmio_read_word(addr) & ~mask) | value, addr);
 }
@@ -594,7 +594,7 @@ static inline void setw(uint64_t addr, uint32_t mask, uint32_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 8 bit value to write.
  */
-static inline void setb(uint64_t addr, uint32_t mask, uint32_t value)
+static inline void setb(void *addr, uint32_t mask, uint32_t value)
 {
 	mmio_write_byte((mmio_read_byte(addr) & ~mask) | value, addr);
 }

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -314,10 +314,10 @@ struct mem_io_node {
 	uint64_t range_end;
 };
 
-void *get_paging_pml4(void);
+uint64_t get_paging_pml4(void);
 void *alloc_paging_struct(void);
 void free_paging_struct(void *ptr);
-void enable_paging(void *pml4_base_addr);
+void enable_paging(uint64_t pml4_base_addr);
 void init_paging(void);
 int map_mem(struct map_params *map_params, void *paddr, void *vaddr,
 		    uint64_t size, uint32_t flags);


### PR DESCRIPTION
a, Change the address arguments type of mmio access api from uint64_t
   to void*.
b, before referencing to physical address of devs such as lapic, ioapic,
   vtd, and uart, switch to virtual address.
c, before referencing to phisical address of acpi tables, switch it to
   virtual address.
d, before pasing commandline from boot param, switch the phisical address
   of param to virtaul address.