### PR TITLE
check validity of 'VM-exit Int-Info' before extracting vector

### DIFF
--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -162,7 +162,7 @@ struct vm_exit_dispatch *vmexit_handler(struct vcpu *vcpu)
 	uint16_t basic_exit_reason;
 
 	/* Obtain interrupt info */
-	vcpu->arch_vcpu.exit_interrupt_info =
+	vcpu->arch_vcpu.idt_vectoring_info =
 	    exec_vmread(VMX_IDT_VEC_INFO_FIELD);
 
 	/* Calculate basic exit reason (low 16-bits) */

--- a/include/arch/x86/guest/vcpu.h
+++ b/include/arch/x86/guest/vcpu.h
@@ -215,7 +215,7 @@ struct vcpu_arch {
 
 	/* VCPU context state information */
 	uint32_t exit_reason;
-	uint64_t exit_interrupt_info;
+	uint32_t idt_vectoring_info;
 	uint64_t exit_qualification;
 	uint32_t inst_len;
 

--- a/include/arch/x86/vmx.h
+++ b/include/arch/x86/vmx.h
@@ -376,6 +376,7 @@
 /* VMX entry/exit Interrupt info */
 #define VMX_INT_INFO_ERR_CODE_VALID	(1<<11)
 #define VMX_INT_INFO_VALID		(1<<31)
+#define VMX_INT_TYPE_MASK		(0x700)
 #define VMX_INT_TYPE_EXT_INT		0
 #define VMX_INT_TYPE_NMI		2
 #define VMX_INT_TYPE_HW_EXP		3


### PR DESCRIPTION
1. In function 'exception_vmexit_handler()' ,
   Extract exception vector and other info. only if
   bit31 (Valid) of 'VM-Exit Interruption-Information
   field is set. -Intel SDM 24.9.2, Vol3

2.  Rename 'exit-interrupt_info' to 'idt_vectoring_info'
    in 'struct vcpu_arch', which is consistent to
    SDM 24.9.3, Vol3

3. 'IDT-vectoring information' in VMCS is 32bit
    -Intel SDM 24.9.3, Vol3

    Set the type of 'idt_vectoring_info' in 'struct vcpu_arch'
    to 'uint32_t' instead of 'uint64_t'.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>