### PR TITLE
enable rdtscp instruction for guest OS all vCPUs

### DIFF
--- a/arch/x86/vmexit.c
+++ b/arch/x86/vmexit.c
@@ -246,13 +246,6 @@ static int write_cr0(struct vcpu *vcpu, uint64_t value)
 		exec_vmwrite(VMX_ENTRY_CONTROLS, value32);
 		pr_dbg("VMX_ENTRY_CONTROLS: 0x%x ", value32);
 
-		/* Disable unrestricted mode */
-		value32 = exec_vmread(VMX_PROC_VM_EXEC_CONTROLS2);
-		value32 |= (VMX_PROCBASED_CTLS2_EPT |
-			    VMX_PROCBASED_CTLS2_RDTSCP);
-		exec_vmwrite(VMX_PROC_VM_EXEC_CONTROLS2, value32);
-		pr_dbg("VMX_PROC_VM_EXEC_CONTROLS2: 0x%x ", value32);
-
 		/* Set up EFER */
 		value64 = exec_vmread64(VMX_GUEST_IA32_EFER_FULL);
 		value64 |= (MSR_IA32_EFER_SCE_BIT |

--- a/arch/x86/vmx.c
+++ b/arch/x86/vmx.c
@@ -910,8 +910,8 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	 */
 	value32 = msr_read(MSR_IA32_VMX_PROCBASED_CTLS2);
 	value32 |= (VMX_PROCBASED_CTLS2_EPT |
-		    /* VMX_PROCBASED_CTLS2_RDTSCP | */
-		    VMX_PROCBASED_CTLS2_UNRESTRICT);
+			VMX_PROCBASED_CTLS2_RDTSCP |
+			VMX_PROCBASED_CTLS2_UNRESTRICT);
 
 	if (is_vapic_supported()) {
 		value32 |= VMX_PROCBASED_CTLS2_VAPIC;


### PR DESCRIPTION
before just AP can run "rdtscp" intruction, if run it on BSP,
it will cause "illegal instruction"; now align BSP & AP.
also remove duplicated code.

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>