### PR TITLE
HV: code cleanup for cpu state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ C_SRCS += arch/x86/guest/vmsr.c
 C_SRCS += arch/x86/guest/vioapic.c
 C_SRCS += arch/x86/guest/instr_emul.c
 C_SRCS += arch/x86/guest/ucode.c
+C_SRCS += arch/x86/guest/pm.c
 C_SRCS += lib/spinlock.c
 C_SRCS += lib/udelay.c
 C_SRCS += lib/strnlen.c

--- a/arch/x86/cpu.c
+++ b/arch/x86/cpu.c
@@ -36,7 +36,6 @@
 #include <schedule.h>
 #include <version.h>
 #include <hv_debug.h>
-#include <cpu_state_tbl.h>
 
 #ifdef CONFIG_EFI_STUB
 extern uint32_t efi_physical_available_ap_bitmap;

--- a/arch/x86/cpu_state_tbl.c
+++ b/arch/x86/cpu_state_tbl.c
@@ -28,11 +28,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <hv_lib.h>
-#include <cpu.h>
 #include <acrn_common.h>
+#include <hv_lib.h>
 #include <hv_arch.h>
-#include <cpu_state_tbl.h>
 
 /* The table includes cpu px info of Intel A3960 SoC */
 struct cpu_px_data px_a3960[] = {
@@ -68,9 +66,16 @@ struct cpu_px_data px_j3455[] = {
 	{0x320, 0, 0xA, 0xA, 0x0800, 0x0800}  /* P8 */
 };
 
-struct cpu_state_table cpu_state_tbl[] = {
-	{"Intel(R) Atom(TM) Processor A3960 @ 1.90GHz", 17, px_a3960},
-	{"Intel(R) Celeron(R) CPU J3455 @ 1.50GHz", 9, px_j3455}
+struct cpu_state_table {
+	char			model_name[64];
+	struct cpu_state_info	state_info;
+} cpu_state_tbl[] = {
+	{"Intel(R) Atom(TM) Processor A3960 @ 1.90GHz",
+		{ARRAY_SIZE(px_a3960), px_a3960}
+	},
+	{"Intel(R) Celeron(R) CPU J3455 @ 1.50GHz",
+		{ARRAY_SIZE(px_j3455), px_j3455}
+	}
 };
 
 static int get_state_tbl_idx(char *cpuname)
@@ -95,9 +100,10 @@ static int get_state_tbl_idx(char *cpuname)
 void load_cpu_state_data(void)
 {
 	int tbl_idx;
+	struct cpu_state_info *state_info;
 
-	boot_cpu_data.px_cnt = 0;
-	boot_cpu_data.px_data = NULL;
+	memset(&boot_cpu_data.state_info, 0,
+			sizeof(struct cpu_state_info));
 
 	tbl_idx = get_state_tbl_idx(boot_cpu_data.model_name);
 	if (tbl_idx < 0) {
@@ -105,72 +111,15 @@ void load_cpu_state_data(void)
 		return;
 	}
 
-	if (!((cpu_state_tbl + tbl_idx)->px_cnt)
-		|| !((cpu_state_tbl + tbl_idx)->px_data)) {
-		/* The state table must be wrong. */
-		return;
-	}
+	state_info = &(cpu_state_tbl + tbl_idx)->state_info;
 
-	if ((cpu_state_tbl + tbl_idx)->px_cnt > MAX_PSTATE) {
-		boot_cpu_data.px_cnt = MAX_PSTATE;
-	} else {
-		boot_cpu_data.px_cnt = (cpu_state_tbl + tbl_idx)->px_cnt;
-	}
-
-	boot_cpu_data.px_data = (cpu_state_tbl + tbl_idx)->px_data;
-
-}
-
-int validate_pstate(struct vm *vm, uint64_t perf_ctl)
-{
-	struct cpu_px_data *px_data;
-	int i, px_cnt;
-
-	if (is_vm0(vm)) {
-		return 0;
-	}
-
-	px_cnt = vm->pm.px_cnt;
-	px_data = vm->pm.px_data;
-
-	if (!px_cnt || !px_data) {
-		return -1;
-	}
-
-	for (i = 0; i < px_cnt; i++) {
-		if ((px_data + i)->control == (perf_ctl & 0xffff)) {
-			return 0;
+	if (state_info->px_cnt && state_info->px_data) {
+		if (state_info->px_cnt > MAX_PSTATE) {
+			boot_cpu_data.state_info.px_cnt = MAX_PSTATE;
+		} else {
+			boot_cpu_data.state_info.px_cnt = state_info->px_cnt;
 		}
+
+		boot_cpu_data.state_info.px_data = state_info->px_data;
 	}
-
-	return -1;
-}
-
-void vm_setup_cpu_px(struct vm *vm)
-{
-	uint32_t px_data_size;
-
-	vm->pm.px_cnt = 0;
-	memset(vm->pm.px_data, 0, MAX_PSTATE * sizeof(struct cpu_px_data));
-
-	if ((!boot_cpu_data.px_cnt) || (!boot_cpu_data.px_data)) {
-		return;
-	}
-
-	if (boot_cpu_data.px_cnt > MAX_PSTATE) {
-		vm->pm.px_cnt = MAX_PSTATE;
-	} else {
-		vm->pm.px_cnt = boot_cpu_data.px_cnt;
-	}
-
-	px_data_size = vm->pm.px_cnt * sizeof(struct cpu_px_data);
-
-	memcpy_s(vm->pm.px_data, px_data_size,
-			boot_cpu_data.px_data, px_data_size);
-
-}
-
-void vm_setup_cpu_state(struct vm *vm)
-{
-	vm_setup_cpu_px(vm);
 }

--- a/arch/x86/guest/vm.c
+++ b/arch/x86/guest/vm.c
@@ -34,7 +34,6 @@
 #include <bsp_extern.h>
 #include <hv_debug.h>
 #include <multiboot.h>
-#include <cpu_state_tbl.h>
 
 /* Local variables */
 

--- a/arch/x86/guest/vmsr.c
+++ b/arch/x86/guest/vmsr.c
@@ -33,7 +33,6 @@
 #include <hv_arch.h>
 #include <hv_debug.h>
 #include <ucode.h>
-#include <cpu_state_tbl.h>
 
 /*MRS need to be emulated, the order in this array better as freq of ops*/
 static const uint32_t emulated_msrs[] = {

--- a/common/hypercall.c
+++ b/common/hypercall.c
@@ -37,7 +37,6 @@
 #include <acrn_hv_defs.h>
 #include <hv_debug.h>
 #include <version.h>
-#include <cpu_state_tbl.h>
 
 #define ACRN_DBG_HYCALL	6
 

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -236,13 +236,17 @@ enum feature_word {
 	FEATURE_WORDS,
 };
 
+struct cpu_state_info {
+	uint8_t			px_cnt;
+	struct cpu_px_data	*px_data;
+};
+
 struct cpuinfo_x86 {
 	uint8_t x86, x86_model;
 	uint64_t physical_address_mask;
 	uint32_t cpuid_leaves[FEATURE_WORDS];
 	char model_name[64];
-	uint8_t			px_cnt;
-	struct cpu_px_data	*px_data;
+	struct cpu_state_info state_info;
 };
 
 extern struct cpuinfo_x86 boot_cpu_data;
@@ -259,6 +263,7 @@ bool is_vapic_supported(void);
 bool is_vapic_intr_delivery_supported(void);
 bool is_vapic_virt_reg_supported(void);
 bool cpu_has_cap(uint32_t bit);
+void load_cpu_state_data(void);
 
 /* Read control register */
 #define CPU_CR_READ(cr, result_ptr)                         \

--- a/include/arch/x86/guest/pm.h
+++ b/include/arch/x86/guest/pm.h
@@ -28,36 +28,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HV_ARCH_H
-#define HV_ARCH_H
+#ifndef PM_H
+#define PM_H
 
-#include <cpu.h>
-#include <gdt.h>
-#include <idt.h>
-#include <apicreg.h>
-#include <ioapic.h>
-#include <lapic.h>
-#include <msr.h>
-#include <io.h>
-#include <vcpu.h>
-#include <trusty.h>
-#include <pm.h>
-#include <vm.h>
-#include <cpuid.h>
-#include <mmu.h>
-#include <intr_ctx.h>
-#include <irq.h>
-#include <timer.h>
-#include <softirq.h>
-#include <vmx.h>
-#include <assign.h>
-#include <vtd.h>
+void vm_setup_cpu_state(struct vm *vm);
+int validate_pstate(struct vm *vm, uint64_t perf_ctl);
 
-#include <vpic.h>
-#include <vlapic.h>
-#include <vioapic.h>
-#include <guest.h>
-#include <vmexit.h>
-#include <cpufeatures.h>
-
-#endif /* HV_ARCH_H */
+#endif /* PM_H */


### PR DESCRIPTION
Split pm.c from cpu_state_tbl.c to put guest power management related
functions, keep cpu_state_tbl.c to store host cpu state table and
related functions.

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Kevin Tian <kevin.tian@intel.com>