### PR TITLE
hv: add hardware_detect_support to detect which hardware we support

### DIFF
--- a/common/hv_main.c
+++ b/common/hv_main.c
@@ -150,10 +150,6 @@ int hv_main(int cpu_id)
 	ASSERT((uint64_t) cpu_id == get_cpu_id(),
 			"cpu_id/tsc_aux mismatch");
 
-	/* Check if virtualization extensions are supported */
-	ret = cpu_has_cap(X86_FEATURE_VMX);
-	ASSERT(ret == 1, "VMX not supported!");
-
 	/* Enable virtualization extensions */
 	ret = exec_vmxon_instr();
 	ASSERT(ret == 0, "Unable to enable VMX!");

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -225,14 +225,13 @@ extern uint64_t pcpu_active_bitmap;
 /* CPUID feature words */
 enum feature_word {
 	FEAT_1_ECX = 0,         /* CPUID[1].ECX */
-	FEAT_1_EDX = 1,         /* CPUID[1].EDX */
-	FEAT_7_0_EBX = 2,       /* CPUID[EAX=7,ECX=0].EBX */
-	FEAT_7_0_ECX = 3,       /* CPUID[EAX=7,ECX=0].ECX */
-	FEAT_7_0_EDX = 4,       /* CPUID[EAX=7,ECX=0].EDX */
-	FEAT_8000_0000_EAX = 5, /* CPUID[8000_0000].EAX */
-	FEAT_8000_0001_ECX = 6, /* CPUID[8000_0001].ECX */
-	FEAT_8000_0001_EDX = 7, /* CPUID[8000_0001].EDX */
-	FEAT_8000_0008_EAX = 8, /* CPUID[8000_0008].EAX */
+	FEAT_1_EDX,             /* CPUID[1].EDX */
+	FEAT_7_0_EBX,           /* CPUID[EAX=7,ECX=0].EBX */
+	FEAT_7_0_ECX,           /* CPUID[EAX=7,ECX=0].ECX */
+	FEAT_7_0_EDX,           /* CPUID[EAX=7,ECX=0].EDX */
+	FEAT_8000_0001_ECX,     /* CPUID[8000_0001].ECX */
+	FEAT_8000_0001_EDX,     /* CPUID[8000_0001].EDX */
+	FEAT_8000_0008_EBX,     /* CPUID[8000_0008].EAX */
 	FEATURE_WORDS,
 };
 
@@ -243,6 +242,9 @@ struct cpu_state_info {
 
 struct cpuinfo_x86 {
 	uint8_t x86, x86_model;
+	uint8_t x86_virt_bits;
+	uint8_t x86_phys_bits;
+	uint32_t extended_cpuid_level;
 	uint64_t physical_address_mask;
 	uint32_t cpuid_leaves[FEATURE_WORDS];
 	char model_name[64];

--- a/include/arch/x86/cpufeatures.h
+++ b/include/arch/x86/cpufeatures.h
@@ -54,6 +54,7 @@
 #define X86_FEATURE_x2APIC	((FEAT_1_ECX << 5) + 21)
 #define X86_FEATURE_MOVBE	((FEAT_1_ECX << 5) + 22)
 #define X86_FEATURE_POPCNT	((FEAT_1_ECX << 5) + 23)
+#define X86_FEATURE_TSC_DEADLINE	((FEAT_1_ECX << 5) + 24)
 #define X86_FEATURE_AES		((FEAT_1_ECX << 5) + 25)
 #define X86_FEATURE_XSAVE	((FEAT_1_ECX << 5) + 26)
 #define X86_FEATURE_OSXSAVE	((FEAT_1_ECX << 5) + 27)
@@ -93,13 +94,17 @@
 
 /* Intel-defined CPU features, CPUID level 0x00000007 (EBX)*/
 #define X86_FEATURE_TSC_ADJ	((FEAT_7_0_EBX << 5) +  1)
+#define X86_FEATURE_SMEP	((FEAT_7_0_EBX << 5) +  7)
 #define X86_FEATURE_INVPCID	((FEAT_7_0_EBX << 5) + 10)
+#define X86_FEATURE_SMAP	((FEAT_7_0_EBX << 5) + 20)
 
 /* Intel-defined CPU features, CPUID level 0x00000007 (EDX)*/
 #define X86_FEATURE_IBRS_IBPB	((FEAT_7_0_EDX << 5) + 26)
 #define X86_FEATURE_STIBP	((FEAT_7_0_EDX << 5) + 27)
 
 /* Intel-defined CPU features, CPUID level 0x80000001 (EDX)*/
+#define X86_FEATURE_NX		((FEAT_8000_0001_EDX << 5) + 20)
 #define X86_FEATURE_PAGE1GB	((FEAT_8000_0001_EDX << 5) + 26)
+#define X86_FEATURE_LM		((FEAT_8000_0001_EDX << 5) + 29)
 
 #endif /*__X86_CPUFEATURES_H__*/

--- a/include/arch/x86/mmu.h
+++ b/include/arch/x86/mmu.h
@@ -170,7 +170,7 @@
 #define     IA32E_NUM_ENTRIES               512
 #define     IA32E_INDEX_MASK                (uint64_t)(IA32E_NUM_ENTRIES - 1)
 #define     IA32E_REF_MASK			\
-	(boot_cpu_data.physical_address_mask)
+		(boot_cpu_data.physical_address_mask)
 #define     IA32E_FIRST_BLOCK_INDEX         1
 
 /* Macro to get PML4 index given an address */
@@ -326,6 +326,7 @@ int unmap_mem(struct map_params *map_params, void *paddr, void *vaddr,
 		      uint64_t size, uint32_t flags);
 int modify_mem(struct map_params *map_params, void *paddr, void *vaddr,
 		       uint64_t size, uint32_t flags);
+int check_vmx_mmu_cap(void);
 void invept(struct vcpu *vcpu);
 bool check_continuous_hpa(struct vm *vm, uint64_t gpa, uint64_t size);
 int obtain_last_page_table_entry(struct map_params *map_params,


### PR DESCRIPTION
Now just add some basic feature/capability detect (not all). Vapic
didn't add here for if we must support vapic then the code which
for vapic not supported must remove, like mmio apic r/w.

Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>