### PR TITLE
Remove "immediate" constraint for inline assembly in bits operation

### DIFF
--- a/arch/x86/ioapic.c
+++ b/arch/x86/ioapic.c
@@ -95,9 +95,9 @@ ioapic_read_reg32(const void *ioapic_base, const uint8_t offset)
 	spinlock_irqsave_obtain(&ioapic_lock);
 
 	/* Write IOREGSEL */
-	*(uint32_t *)(ioapic_base) = offset;
+	mmio_write_long(offset, (void *)ioapic_base);
 	/* Read  IOWIN */
-	v = *(uint32_t *)(ioapic_base + IOAPIC_WINSWL_OFFSET);
+	v = mmio_read_long((void *)ioapic_base + IOAPIC_WINSWL_OFFSET);
 
 	spinlock_irqrestore_release(&ioapic_lock);
 	return v;
@@ -112,9 +112,9 @@ ioapic_write_reg32(const void *ioapic_base,
 	spinlock_irqsave_obtain(&ioapic_lock);
 
 	/* Write IOREGSEL */
-	*(uint32_t *)(ioapic_base) = offset;
+	mmio_write_long(offset, (void *)ioapic_base);
 	/* Write IOWIN */
-	*(uint32_t *)(ioapic_base + IOAPIC_WINSWL_OFFSET) = value;
+	mmio_write_long(value, (void *)ioapic_base + IOAPIC_WINSWL_OFFSET);
 
 	spinlock_irqrestore_release(&ioapic_lock);
 }

--- a/include/lib/bits.h
+++ b/include/lib/bits.h
@@ -38,7 +38,7 @@ static inline void atomic_set_char(unsigned char *p, unsigned char v)
 {
 	__asm __volatile(BUS_LOCK    "orb %b1,%0"
 			:  "+m" (*p)
-			:  "iq" (v)
+			:  "q" (v)
 			:  "cc", "memory");
 }
 
@@ -49,7 +49,7 @@ static inline void atomic_clear_char(unsigned char *p, unsigned char v)
 {
 	__asm __volatile(BUS_LOCK    "andb %b1,%0"
 			:  "+m" (*p)
-			:  "iq" (~v)
+			:  "q" (~v)
 			:  "cc", "memory");
 }
 
@@ -60,7 +60,7 @@ static inline void atomic_add_char(unsigned char *p, unsigned char v)
 {
 	__asm __volatile(BUS_LOCK    "addb %b1,%0"
 			:  "+m" (*p)
-			:  "iq" (v)
+			:  "q" (v)
 			:  "cc", "memory");
 }
 
@@ -71,7 +71,7 @@ static inline void atomic_subtract_char(unsigned char *p, unsigned char v)
 {
 	__asm __volatile(BUS_LOCK "subb %b1,%0"
 			:  "+m" (*p)
-			:  "iq" (v)
+			:  "q" (v)
 			:  "cc", "memory");
 }
 
@@ -82,7 +82,7 @@ static inline void atomic_set_short(unsigned short *p, unsigned short v)
 {
 	__asm __volatile(BUS_LOCK "orw %w1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -93,7 +93,7 @@ static inline void atomic_clear_short(unsigned short *p, unsigned short v)
 {
 	__asm __volatile(BUS_LOCK "andw %w1,%0"
 			:  "+m" (*p)
-			:  "ir" (~v)
+			:  "r" (~v)
 			:  "cc", "memory");
 }
 
@@ -104,7 +104,7 @@ static inline void atomic_add_short(unsigned short *p, unsigned short v)
 {
 	__asm __volatile(BUS_LOCK "addw %w1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -115,7 +115,7 @@ static inline void atomic_subtract_short(unsigned short *p, unsigned short v)
 {
 	__asm __volatile(BUS_LOCK "subw %w1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -126,7 +126,7 @@ static inline void atomic_set_int(unsigned int *p, unsigned int v)
 {
 	__asm __volatile(BUS_LOCK "orl %1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -137,7 +137,7 @@ static inline void atomic_clear_int(unsigned int *p, unsigned int v)
 {
 	__asm __volatile(BUS_LOCK "andl %1,%0"
 			:  "+m" (*p)
-			:  "ir" (~v)
+			:  "r" (~v)
 			:  "cc", "memory");
 }
 
@@ -148,7 +148,7 @@ static inline void atomic_add_int(unsigned int *p, unsigned int v)
 {
 	__asm __volatile(BUS_LOCK "addl %1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -159,7 +159,7 @@ static inline void atomic_subtract_int(unsigned int *p, unsigned int v)
 {
 	__asm __volatile(BUS_LOCK "subl %1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -189,7 +189,7 @@ static inline void atomic_set_long(unsigned long *p, unsigned long v)
 {
 	__asm __volatile(BUS_LOCK "orq %1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -200,7 +200,7 @@ static inline void atomic_clear_long(unsigned long *p, unsigned long v)
 {
 	__asm __volatile(BUS_LOCK "andq %1,%0"
 			:  "+m" (*p)
-			:  "ir" (~v)
+			:  "r" (~v)
 			:  "cc", "memory");
 }
 
@@ -211,7 +211,7 @@ static inline void atomic_add_long(unsigned long *p, unsigned long v)
 {
 	__asm __volatile(BUS_LOCK "addq %1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -222,7 +222,7 @@ static inline void atomic_subtract_long(unsigned long *p, unsigned long v)
 {
 	__asm __volatile(BUS_LOCK "subq %1,%0"
 			:  "+m" (*p)
-			:  "ir" (v)
+			:  "r" (v)
 			:  "cc", "memory");
 }
 
@@ -439,7 +439,7 @@ bitmap_set(int mask, unsigned long *bits)
 	/*  (*bits) |= (1UL<<mask); */
 	__asm __volatile(BUS_LOCK "orq %1,%0"
 			:  "+m" (*bits)
-			:  "ir" (1UL<<mask)
+			:  "r" (1UL<<mask)
 			:  "cc", "memory");
 }
 
@@ -449,7 +449,7 @@ bitmap_clr(int mask, unsigned long *bits)
 	/* (*bits) &= ~(1UL<<mask); */
 	__asm __volatile(BUS_LOCK "andq %1,%0"
 			:  "+m" (*bits)
-			:  "ir" (~(1UL<<mask))
+			:  "r" (~(1UL<<mask))
 			:  "cc", "memory");
 }
 
@@ -463,7 +463,7 @@ bitmap_isset(int mask, unsigned long *bits)
 
 	__asm __volatile("btq %2,%1\n\tsbbl %0, %0"
 			: "=r" (ret), "=m" (*bits)
-			: "ir" ((long)(mask) & 0x3f)
+			: "r" ((long)(mask) & 0x3f)
 			: "cc", "memory");
 	return (!!ret);
 }
@@ -475,7 +475,7 @@ bitmap_test_and_set(int mask, unsigned long *bits)
 
 	__asm __volatile(BUS_LOCK  "btsq %2,%1\n\tsbbl %0,%0"
 			: "=r" (ret), "=m" (*bits)
-			: "ir" ((long)(mask & 0x3f))
+			: "r" ((long)(mask & 0x3f))
 			: "cc", "memory");
 	return (!!ret);
 }
@@ -492,7 +492,7 @@ bitmap_test_and_clear(int mask, unsigned long *bits)
 
 	__asm __volatile(BUS_LOCK  "btrq %2,%1\n\tsbbl %0,%0"
 			: "=r" (ret), "=m" (*bits)
-			: "ir" ((long)(mask) & 0x3f)
+			: "r" ((long)(mask) & 0x3f)
 			: "cc", "memory");
 	return (!!ret);
 }
@@ -507,7 +507,7 @@ bitmap_setof(int mask, unsigned long *bits)
 
 	__asm __volatile(BUS_LOCK "xchgq %1,%0"
 			:  "+m" (*bits)
-			:  "ir" ((1UL<<mask))
+			:  "r" ((1UL<<mask))
 			:  "cc", "memory");
 
 }


### PR DESCRIPTION
1. The immediate constraint is removed for the inline assembly in Bits operation
2. Use the mmio_read/write_long for IOAPIC mmio access