### PR TITLE
UEFI: bug fix on redundant waking up APs

### DIFF
--- a/bsp/uefi/uefi.c
+++ b/bsp/uefi/uefi.c
@@ -104,6 +104,12 @@ void efi_deferred_wakeup_pcpu(int cpu_id)
 {
 	uint32_t timeout;
 	uint32_t expected_up;
+	static uint32_t waked_pcpu_bitmap;
+
+	if ((1 << cpu_id) & waked_pcpu_bitmap)
+		return;
+
+	waked_pcpu_bitmap |= 1 << cpu_id;
 
 	expected_up = up_count + 1;
 


### PR DESCRIPTION
Due to redundant waking up APs When rebooting UOS, the crash occurs
and fail to reboot UOS.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>