### PR TITLE
hv: Not to destroy ept of trusty memory if it's not initialized.

### DIFF
--- a/arch/x86/ept.c
+++ b/arch/x86/ept.c
@@ -125,8 +125,15 @@ void destroy_ept(struct vm *vm)
 {
 	free_ept_mem(HPA2HVA(vm->arch_vm.nworld_eptp));
 	free_ept_mem(HPA2HVA(vm->arch_vm.m2p));
-	/* Destroy Secure world ept */
-	if (vm->sworld_control.sworld_enabled)
+
+	/*
+	 * If secure world is initialized, destroy Secure world ept.
+	 * There are two cases secure world is not initialized:
+	 *  - trusty is not enabled. Check sworld_enabled.
+	 *  - trusty is enabled. But not initialized yet.
+	 *    Check vm->arch_vm.sworld_eptp.
+	 */
+	if (vm->sworld_control.sworld_enabled && vm->arch_vm.sworld_eptp)
 		free_ept_mem(HPA2HVA(vm->arch_vm.sworld_eptp));
 }
 


### PR DESCRIPTION
If guest reboot is issued before trusty init hypercall is issued,
we shouldn't destroy ept fo trusty memory because the ept is not
created yet.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>