### PR TITLE
ptdev: change remapping entry from virtual to physical based

### DIFF
--- a/arch/x86/ioapic.c
+++ b/arch/x86/ioapic.c
@@ -76,8 +76,26 @@ uint16_t legacy_irq_to_pin[NR_LEGACY_IRQ] = {
 	15, /* IRQ15*/
 };
 
-static void *map_ioapic(
-		uint64_t ioapic_paddr)
+uint16_t pic_ioapic_pin_map[NR_LEGACY_PIN] = {
+	2, /* pin0*/
+	1, /* pin1*/
+	0, /* pin2*/
+	3, /* pin3*/
+	4, /* pin4*/
+	5, /* pin5*/
+	6, /* pin6*/
+	7, /* pin7*/
+	8, /* pin8*/
+	9, /* pin9*/
+	10, /* pin10*/
+	11, /* pin11*/
+	12, /* pin12*/
+	13, /* pin13*/
+	14, /* pin14*/
+	15, /* pin15*/
+};
+
+static void *map_ioapic(uint64_t ioapic_paddr)
 {
 	/* At some point we may need to translate this paddr to a vaddr.
 	 * 1:1 mapping for now.

--- a/common/hypercall.c
+++ b/common/hypercall.c
@@ -618,12 +618,12 @@ int64_t hcall_set_ptdev_intr_info(struct vm *vm, uint64_t vmid, uint64_t param)
 	}
 
 	if (irq.type == IRQ_INTX)
-		ptdev_add_intx_remapping(target_vm,
+		ret = ptdev_add_intx_remapping(target_vm,
 				irq.virt_bdf, irq.phys_bdf,
 				irq.is.intx.virt_pin, irq.is.intx.phys_pin,
 				irq.is.intx.pic_pin);
 	else if (irq.type == IRQ_MSI || irq.type == IRQ_MSIX)
-		ptdev_add_msix_remapping(target_vm,
+		ret = ptdev_add_msix_remapping(target_vm,
 				irq.virt_bdf, irq.phys_bdf,
 				irq.is.msix.vector_cnt);
 

--- a/include/arch/x86/assign.h
+++ b/include/arch/x86/assign.h
@@ -33,7 +33,8 @@
 
 enum ptdev_intr_type {
 	PTDEV_INTR_MSI,
-	PTDEV_INTR_INTX
+	PTDEV_INTR_INTX,
+	PTDEV_INTR_INV,
 };
 
 enum ptdev_vpin_source {
@@ -61,7 +62,11 @@ struct ptdev_intx_info {
 	uint8_t phys_pin;
 };
 
-/* entry per each allocated irq/vector */
+/* entry per each allocated irq/vector
+ * it represents a pass-thru device's remapping data entry which collecting
+ * information related with its vm and msi/intx mapping & interaction nodes
+ * with interrupt handler and softirq.
+ */
 struct ptdev_remapping_info {
 	struct vm *vm;
 	uint16_t virt_bdf;	/* PCI bus:slot.func*/
@@ -86,10 +91,10 @@ int ptdev_intx_pin_remap(struct vm *vm, struct ptdev_intx_info *info);
 void ptdev_softirq(int cpu);
 void ptdev_init(void);
 void ptdev_release_all_entries(struct vm *vm);
-void ptdev_add_intx_remapping(struct vm *vm, uint16_t virt_bdf,
+int ptdev_add_intx_remapping(struct vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin, bool pic_pin);
 void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin);
-void ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
+int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, int vector_count);
 void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 		int vector_count);

--- a/include/arch/x86/ioapic.h
+++ b/include/arch/x86/ioapic.h
@@ -36,6 +36,7 @@
  */
 #define IOAPIC_MAX_LINES	120
 #define NR_LEGACY_IRQ		16
+#define NR_LEGACY_PIN	NR_LEGACY_IRQ
 #define NR_MAX_GSI	(NR_IOAPICS*IOAPIC_MAX_LINES)
 
 #define GSI_MASK_IRQ(irq) irq_gsi_mask_unmask((irq), true)
@@ -54,4 +55,5 @@ void ioapic_set_rte(int irq, uint64_t rte);
 void ioapic_get_rte(int irq, uint64_t *rte);
 
 extern uint16_t legacy_irq_to_pin[];
+extern uint16_t pic_ioapic_pin_map[];
 #endif /* IOAPIC_H */


### PR DESCRIPTION
currently, pass-thru devices are managed by per-vm's remapping entries
which is virtual based:
- MSI entry is identified by virt_bdf+msix_index
- INTx entry is identified by virt_pin+vpin_src
it works but it's not a good design for physical resource management, for
example a physical IOAPIC pin could belong to different vm's INTx entries,
the Device Model then must make sure there is no resource conflict from
application's level.

This patch change the design from virtual to physical based:
- MSI entry is identified by phys_bdf+msix_index
- INTx entry is identified by phys_pin
The physical resource is directly managed in hypervisor, a miss adding
entry will be found by hypervisor and return error message with failure.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Xu, Anthony <anthony.xu@intel.com>