### PR TITLE
HV: Guest Cstate control support

### DIFF
--- a/arch/x86/cpu_state_tbl.c
+++ b/arch/x86/cpu_state_tbl.c
@@ -73,6 +73,13 @@ struct cpu_px_data px_j3455[] = {
 	{0x320, 0, 0xA, 0xA, 0x0800, 0x0800}  /* P8 */
 };
 
+/* The table includes cpu cx info of Intel J3455 SoC */
+struct cpu_cx_data cx_j3455[] = {
+	{{SPACE_FFixedHW, 0x1, 0x2, 0x1, 0x01}, 0x1, 0x1, 0x3E8}, /* C1 */
+	{{SPACE_FFixedHW, 0x1, 0x2, 0x1, 0x21}, 0x2, 0x32, 0x0A}, /* C2 */
+	{{SPACE_FFixedHW, 0x1, 0x2, 0x1, 0x60}, 0x3, 0x96, 0x0A}  /* C3 */
+};
+
 struct cpu_state_table {
 	char			model_name[64];
 	struct cpu_state_info	state_info;
@@ -83,7 +90,7 @@ struct cpu_state_table {
 	},
 	{"Intel(R) Celeron(R) CPU J3455 @ 1.50GHz",
 		{ARRAY_SIZE(px_j3455), px_j3455,
-			0,	NULL}
+		 ARRAY_SIZE(cx_j3455), cx_j3455}
 	}
 };
 

--- a/arch/x86/cpu_state_tbl.c
+++ b/arch/x86/cpu_state_tbl.c
@@ -53,6 +53,13 @@ struct cpu_px_data px_a3960[] = {
 	{0x320, 0, 0xA, 0xA, 0x0800, 0x0800}  /* P16 */
 };
 
+/* The table includes cpu cx info of Intel A3960 SoC */
+struct cpu_cx_data cx_a3960[] = {
+	{{SPACE_FFixedHW,  0x0, 0, 0,     0}, 0x1, 0x1, 0x3E8}, /* C1 */
+	{{SPACE_SYSTEM_IO, 0x8, 0, 0, 0x415}, 0x2, 0x32, 0x0A}, /* C2 */
+	{{SPACE_SYSTEM_IO, 0x8, 0, 0, 0x419}, 0x3, 0x96, 0x0A}  /* C3 */
+};
+
 /* The table includes cpu px info of Intel J3455 SoC */
 struct cpu_px_data px_j3455[] = {
 	{0x5DD, 0, 0xA, 0xA, 0x1700, 0x1700}, /* P0 */
@@ -71,10 +78,12 @@ struct cpu_state_table {
 	struct cpu_state_info	state_info;
 } cpu_state_tbl[] = {
 	{"Intel(R) Atom(TM) Processor A3960 @ 1.90GHz",
-		{ARRAY_SIZE(px_a3960), px_a3960}
+		{ARRAY_SIZE(px_a3960), px_a3960,
+		 ARRAY_SIZE(cx_a3960), cx_a3960}
 	},
 	{"Intel(R) Celeron(R) CPU J3455 @ 1.50GHz",
-		{ARRAY_SIZE(px_j3455), px_j3455}
+		{ARRAY_SIZE(px_j3455), px_j3455,
+			0,	NULL}
 	}
 };
 
@@ -122,4 +131,15 @@ void load_cpu_state_data(void)
 
 		boot_cpu_data.state_info.px_data = state_info->px_data;
 	}
+
+	if (state_info->cx_cnt && state_info->cx_data) {
+		if (state_info->cx_cnt > MAX_CX_ENTRY) {
+			boot_cpu_data.state_info.cx_cnt = MAX_CX_ENTRY;
+		} else {
+			boot_cpu_data.state_info.cx_cnt = state_info->cx_cnt;
+		}
+
+		boot_cpu_data.state_info.cx_data = state_info->cx_data;
+	}
+
 }

--- a/arch/x86/guest/pm.c
+++ b/arch/x86/guest/pm.c
@@ -110,8 +110,24 @@ static void vm_setup_cpu_cx(struct vm *vm)
 
 }
 
+static inline void init_cx_port(struct vm *vm)
+{
+	uint8_t cx_idx;
+
+	for (cx_idx = 2; cx_idx <= vm->pm.cx_cnt; cx_idx++) {
+		struct cpu_cx_data *cx_data = vm->pm.cx_data + cx_idx;
+
+		if (cx_data->cx_reg.space_id == SPACE_SYSTEM_IO) {
+			uint16_t port = (uint16_t)cx_data->cx_reg.address;
+
+			allow_guest_io_access(vm, port, 1);
+		}
+	}
+}
+
 void vm_setup_cpu_state(struct vm *vm)
 {
 	vm_setup_cpu_px(vm);
 	vm_setup_cpu_cx(vm);
+	init_cx_port(vm);
 }

--- a/arch/x86/guest/pm.c
+++ b/arch/x86/guest/pm.c
@@ -70,11 +70,10 @@ static void vm_setup_cpu_px(struct vm *vm)
 		return;
 	}
 
-	if (boot_cpu_data.state_info.px_cnt > MAX_PSTATE) {
-		vm->pm.px_cnt = MAX_PSTATE;
-	} else {
-		vm->pm.px_cnt = boot_cpu_data.state_info.px_cnt;
-	}
+	ASSERT ((boot_cpu_data.state_info.px_cnt <= MAX_PSTATE),
+		"failed to setup cpu px");
+
+	vm->pm.px_cnt = boot_cpu_data.state_info.px_cnt;
 
 	px_data_size = vm->pm.px_cnt * sizeof(struct cpu_px_data);
 

--- a/arch/x86/io.c
+++ b/arch/x86/io.c
@@ -190,6 +190,22 @@ void free_io_emulation_resource(struct vm *vm)
 	free(vm->arch_vm.iobitmap[1]);
 }
 
+void allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes)
+{
+	uint32_t *b;
+	uint32_t i;
+	uint32_t a;
+
+	b = vm->arch_vm.iobitmap[0];
+	for (i = 0; i < nbytes; i++) {
+		if (address & 0x8000)
+			b = vm->arch_vm.iobitmap[1];
+		a = address & 0x7fff;
+		b[a >> 5] &= ~(1 << (a & 0x1f));
+		address++;
+	}
+}
+
 static void deny_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes)
 {
 	uint32_t *b;

--- a/arch/x86/io.c
+++ b/arch/x86/io.c
@@ -212,8 +212,8 @@ static void deny_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbyte
 	uint32_t i;
 	uint32_t a;
 
+	b = vm->arch_vm.iobitmap[0];
 	for (i = 0; i < nbytes; i++) {
-		b = vm->arch_vm.iobitmap[0];
 		if (address & 0x8000)
 			b = vm->arch_vm.iobitmap[1];
 		a = address & 0x7fff;

--- a/common/hypercall.c
+++ b/common/hypercall.c
@@ -729,6 +729,40 @@ int64_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param)
 
 		return 0;
 	}
+	case PMCMD_GET_CX_CNT: {
+
+		if (!target_vm->pm.cx_cnt) {
+			return -1;
+		}
+
+		if (copy_to_vm(vm, &(target_vm->pm.cx_cnt), param)) {
+			pr_err("%s: Unable copy param to vm\n", __func__);
+			return -1;
+		}
+		return 0;
+	}
+	case PMCMD_GET_CX_DATA: {
+		uint8_t cx_idx;
+		struct cpu_cx_data *cx_data;
+
+		if (!target_vm->pm.cx_cnt) {
+			return -1;
+		}
+
+		cx_idx = (cmd & PMCMD_STATE_NUM_MASK) >> PMCMD_STATE_NUM_SHIFT;
+		if (!cx_idx || (cx_idx > target_vm->pm.cx_cnt)) {
+			return -1;
+		}
+
+		cx_data = target_vm->pm.cx_data + cx_idx;
+
+		if (copy_to_vm(vm, cx_data, param)) {
+			pr_err("%s: Unable copy param to vm\n", __func__);
+			return -1;
+		}
+
+		return 0;
+	}
 	default:
 		return -1;
 

--- a/include/arch/x86/cpu.h
+++ b/include/arch/x86/cpu.h
@@ -236,8 +236,10 @@ enum feature_word {
 };
 
 struct cpu_state_info {
-	uint8_t			px_cnt;
+	uint8_t			px_cnt;		/* count of all Px states */
 	struct cpu_px_data	*px_data;
+	uint8_t 		cx_cnt;		/* count of all Cx entries */
+	struct cpu_cx_data	*cx_data;
 };
 
 struct cpuinfo_x86 {
@@ -254,7 +256,13 @@ struct cpuinfo_x86 {
 
 extern struct cpuinfo_x86 boot_cpu_data;
 
-#define MAX_PSTATE	20
+#define MAX_PSTATE	20	/* max num of supported Px count */
+#define MAX_CSTATE	8	/* max num of supported Cx count */
+
+/* We support MAX_CSTATE num of Cx, means have (MAX_CSTATE - 1) Cx entries,
+ * i.e. supported Cx entry index range from 1 to MAX_CX_ENTRY.
+ */
+#define MAX_CX_ENTRY	(MAX_CSTATE - 1)
 
 /* Function prototypes */
 void cpu_dead(uint32_t logical_id);

--- a/include/arch/x86/guest/pm.h
+++ b/include/arch/x86/guest/pm.h
@@ -33,5 +33,6 @@
 
 void vm_setup_cpu_state(struct vm *vm);
 int validate_pstate(struct vm *vm, uint64_t perf_ctl);
+struct cpu_cx_data* get_target_cx(struct vm *vm, uint8_t cn);
 
 #endif /* PM_H */

--- a/include/arch/x86/guest/vm.h
+++ b/include/arch/x86/guest/vm.h
@@ -81,8 +81,10 @@ struct vm_sw_info {
 };
 
 struct vm_pm_info {
-	uint8_t			px_cnt;
+	uint8_t			px_cnt;		/* count of all Px states */
 	struct cpu_px_data	px_data[MAX_PSTATE];
+	uint8_t			cx_cnt;		/* count of all Cx entries */
+	struct cpu_cx_data	cx_data[MAX_CSTATE];
 };
 
 /* VM guest types */

--- a/include/arch/x86/io.h
+++ b/include/arch/x86/io.h
@@ -170,6 +170,7 @@ struct vm_io_handler {
 int io_instr_vmexit_handler(struct vcpu *vcpu);
 void   setup_io_bitmap(struct vm *vm);
 void   free_io_emulation_resource(struct vm *vm);
+void   allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes);
 void   register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr);

--- a/include/public/acrn_common.h
+++ b/include/public/acrn_common.h
@@ -328,8 +328,10 @@ struct cpu_px_data {
 /**
  * @brief Info PM command from DM/VHM.
  *
- * The command would specify request type(i.e. get px count or data) for
- * specific VM and specific VCPU with specific state number.like P(n).
+ * The command would specify request type(e.g. get px count or data) for
+ * specific VM and specific VCPU with specific state number.
+ * For Px, PMCMD_STATE_NUM means Px number from 0 to (MAX_PSTATE - 1),
+ * For Cx, PMCMD_STATE_NUM means Cx entry index from 1 to MAX_CX_ENTRY.
  */
 #define PMCMD_VMID_MASK		0xff000000
 #define PMCMD_VCPUID_MASK	0x00ff0000
@@ -343,6 +345,8 @@ struct cpu_px_data {
 enum pm_cmd_type {
 	PMCMD_GET_PX_CNT,
 	PMCMD_GET_PX_DATA,
+	PMCMD_GET_CX_CNT,
+	PMCMD_GET_CX_DATA,
 };
 
 /**

--- a/include/public/acrn_common.h
+++ b/include/public/acrn_common.h
@@ -292,6 +292,30 @@ struct acrn_vm_pci_msix_remap {
  * @brief Info The power state data of a VCPU.
  *
  */
+
+#define SPACE_SYSTEM_MEMORY     0
+#define SPACE_SYSTEM_IO         1
+#define SPACE_PCI_CONFIG        2
+#define SPACE_Embedded_Control  3
+#define SPACE_SMBUS             4
+#define SPACE_PLATFORM_COMM     10
+#define SPACE_FFixedHW          0x7F
+
+struct acrn_register {
+	uint8_t 	space_id;
+	uint8_t 	bit_width;
+	uint8_t 	bit_offset;
+	uint8_t 	access_size;
+	uint64_t	address;
+} __attribute__((aligned(8)));
+
+struct cpu_cx_data {
+	struct acrn_register cx_reg;
+	uint8_t 	type;
+	uint32_t	latency;
+	uint64_t	power;
+} __attribute__((aligned(8)));
+
 struct cpu_px_data {
 	uint64_t core_frequency;	/* megahertz */
 	uint64_t power;			/* milliWatts */


### PR DESCRIPTION
Like guest pstate control, guest must have intel_idle driver or acpi-idle
driver enabled in kernel to enable guest cstate control. Especialy for
acpi-idle subsystem, idle space info is needed in ACPI FACP or DSDT table.

Acrn Cx enabling is similar with Px enabling implementation:

	1. Hard code the host Cx data in HV;
	2. Host load the host Cx data and store them to boot_cpu_data
	   during boot;
	3. Each VM has a Cx data copy saved in its pminfo when create VM;
	4. Add a VHM service in kernel that could interact with HV and DM
	   on data transtion. HV would expose native cx data to VHM/DM
	   without validation, because guest OS would check it before
	   enter idle;
	5. Before launching UOS, DM query HV the supported Cx data;
	6. DM generate the ACPI CST objects for UOS with these Cx data;
	7. For CPU partioned HV, we don't need to trap on idle operation,
	   when CPU need to be shared in the future, we will enable the
	   idle trap then;

change log:

	v4: 1) Change term of cx_entry_cnt to cx_cnt to keep consistence
	       with px_cnt;
	    2) Disable idle vmexit handler for now;
	    3) Add cx_data of APL NUC;

	v3:
	    1) Change term of Cx to Cx entry to make concept clear;
	    2) Initialize vm cx data entry array size from MAX_CX_ENTRY
	       to MAX_CSTATE, i.e. treat cx_data[0] as a dummy place holder
	       representing C0, then cx_data[idx] representing indexed Cx
	       entry;
	    3) VHM hypercall transit native cx data, so that guest could
	       execute idle instruction natively without vm exit which
	       impact performance;
	    4) Remove idle lantency check in trap, just favor decisions
	       from guest OS.
	    
	v2: VHM hypercall should transit virtualized cx data, not original
	    host cx data from VM pminfo;

	v1: initial version;

