### PR TITLE
Use Clearlinux standard bootloader

### DIFF
--- a/bsp/uefi/include/bsp/bsp_cfg.h
+++ b/bsp/uefi/include/bsp/bsp_cfg.h
@@ -48,5 +48,5 @@
 #define	CONFIG_DMAR_PARSE_ENABLED	1
 #define	CONFIG_GPU_SBDF		0x00000010	/* 0000:00:02.0 */
 #define CONFIG_EFI_STUB       1
-#define CONFIG_UEFI_OS_LOADER_NAME  "\\EFI\\org.clearlinux\\bootloaderx64_origin.efi"
+#define CONFIG_UEFI_OS_LOADER_NAME  "\\EFI\\org.clearlinux\\bootloaderx64.efi"
 #endif /* BSP_CFG_H */


### PR DESCRIPTION
Update the hypervisor to use the standard Clearlinux bootloader.
This replaces the previous mechanism where the user had to make
a copy of the bootloader and call it bootloaderx64_origin.efi.
This is no longer needed and will simplify the instructions for
how to install the ACRN hypervisor with a Clearlinux-based
Service OS

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>