### PR TITLE
hv: add build type and detail time to version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ $(VERSION):
 	@COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
 	DIRTY=`git diff-index --name-only HEAD`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-	TIME=`date "+%Y%m%d"`;\
+	TIME=`date "+%F %T"`;\
+	if [ $(RELEASE) = 0 ];then BUILD_TYPE="DBG";else BUILD_TYPE="REL";fi;\
 	cat license_header > $(VERSION);\
 	echo "#define HV_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION);\
 	echo "#define HV_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION);\
@@ -230,6 +231,7 @@ $(VERSION):
 	echo "#define HV_API_MAJOR_VERSION $(API_MAJOR_VERSION)" >> $(VERSION);\
 	echo "#define HV_API_MINOR_VERSION $(API_MINOR_VERSION)" >> $(VERSION);\
 	echo "#define HV_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION);\
+	echo "#define HV_BUILD_TYPE "\""$$BUILD_TYPE"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TIME "\""$$TIME"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_USER "\""$(USER)"\""" >> $(VERSION)
 

--- a/arch/x86/cpu.c
+++ b/arch/x86/cpu.c
@@ -500,15 +500,15 @@ void bsp_boot_init(void)
 		       LOG_DESTINATION);
 
 	if (HV_RC_VERSION)
-		printf("HV version %d.%d-rc%d-%s-%s build by %s, start time %lluus\r\n",
+		printf("HV version %d.%d-rc%d-%s-%s %s build by %s, start time %lluus\r\n",
 			HV_MAJOR_VERSION, HV_MINOR_VERSION, HV_RC_VERSION,
-			HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_USER,
-			TICKS_TO_US(start_tsc));
+			HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE,
+			HV_BUILD_USER, TICKS_TO_US(start_tsc));
 	else
-		printf("HV version %d.%d-%s-%s build by %s, start time %lluus\r\n",
+		printf("HV version %d.%d-%s-%s %s build by %s, start time %lluus\r\n",
 			HV_MAJOR_VERSION, HV_MINOR_VERSION,
-			HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_USER,
-			TICKS_TO_US(start_tsc));
+			HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE,
+			HV_BUILD_USER, TICKS_TO_US(start_tsc));
 
 	printf("API version %d.%d\r\n",
 			HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);


### PR DESCRIPTION
- Add "DBG" or "REL" to indicate the DBG build or REL build explicityly;
- Change the build time format to "%F %T".

Example:
HV version 0.1-rc4-2018-04-28 14:20:32-b2d7282-dirty DBG build by like

Signed-off-by: Yan, Like <like.yan@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>