### PR TITLE
rename 'req_buf' field in 'struct vm_sw_info'

### DIFF
--- a/arch/x86/ept.c
+++ b/arch/x86/ept.c
@@ -353,7 +353,7 @@ int dm_emulate_mmio_post(struct vcpu *vcpu)
 	int cur = vcpu->vcpu_id;
 	struct vhm_request_buffer *req_buf;
 
-	req_buf = (struct vhm_request_buffer *)(vcpu->vm->sw.req_buf);
+	req_buf = (struct vhm_request_buffer *)(vcpu->vm->sw.io_shared_page);
 
 	vcpu->req.reqs.mmio_request.value =
 		req_buf->req_queue[cur].reqs.mmio_request.value;

--- a/arch/x86/guest/vm.c
+++ b/arch/x86/guest/vm.c
@@ -169,7 +169,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 
 			/* Populate return VM handle */
 			*rtn_vm = vm;
-			vm->sw.req_buf = NULL;
+			vm->sw.io_shared_page = NULL;
 
 			status = set_vcpuid_entries(vm);
 			if (status)

--- a/arch/x86/io.c
+++ b/arch/x86/io.c
@@ -44,7 +44,7 @@ int dm_emulate_pio_post(struct vcpu *vcpu)
 		0xFFFFFFFFul >> (32 - 8 * vcpu->req.reqs.pio_request.size);
 	uint64_t *rax;
 
-	req_buf = (struct vhm_request_buffer *)(vcpu->vm->sw.req_buf);
+	req_buf = (struct vhm_request_buffer *)(vcpu->vm->sw.io_shared_page);
 
 	rax = &vcpu->arch_vcpu.contexts[cur_context].guest_cpu_regs.regs.rax;
 	vcpu->req.reqs.pio_request.value =

--- a/include/arch/x86/guest/vm.h
+++ b/include/arch/x86/guest/vm.h
@@ -76,8 +76,8 @@ struct vm_sw_info {
 	struct sw_kernel_info kernel_info;
 	/* Additional information specific to Linux guests */
 	struct sw_linux linux_info;
-	/* HVA to guest OS's request buffer */
-	void *req_buf;
+	/* HVA to IO shared page */
+	void *io_shared_page;
 };
 
 struct vm_pm_info {


### PR DESCRIPTION
 - rename it to 'io_shared_page' to keep consistent
   with ACRN HDL foils.

 - update related code that reference this data structure.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>