### PR TITLE
devops: Add CODEOWNERS for GitHub review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS for autoreview assigning in github
+
+# File pattern follows the same rules used in .gitignore files,
+# Note: doc/ means files in any folder named doc, and its subfolders
+# while doc/* means files in any folder named doc, but not its subfolders.
+#
+# Ordering is important: the last matching pattern takes precedence.
+# Put global owners at the top, and detailed reviewers later
+#
+# Additional reviewers can be assigned manually
+
+# Default/global reviewers (if not overridden later)
+*                                        @anthonyzxu @dongyaozu
+
+/hypervisor/                             @anthonyzxu @dongyaozu
+/devicemodel/                            @anthonyzxu @dongyaozu
+/doc/                                    @dbkinder
+
+*.rst                                    @dbkinder


### PR DESCRIPTION
Seed an initial CODEOWNERS file.  Update as owners for specific areas
are defined.

You can use a CODEOWNERS file to define individuals or teams that are
responsible for code in a repository. The listed names must have write
permissions for the repository.

Code owners are automatically requested for review when someone opens a
pull request that modifies code that they own. When someone with admin
or owner permissions has enabled required reviews, they also can
optionally require approval from a code owner before the author can
merge a pull request in the repository.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>