### PR TITLE
Optimize patch

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -28,7 +28,7 @@ CFLAGS += -fshort-wchar -ffreestanding
 CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -static -nostdinc -nostdlib -fno-common
-CFLAGS += -O0 -D_FORTIFY_SOURCE=2
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security
 
 ifdef STACK_PROTECTOR

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -28,7 +28,7 @@ CFLAGS += -fshort-wchar -ffreestanding
 CFLAGS += -m64
 CFLAGS += -mno-red-zone
 CFLAGS += -static -nostdinc -nostdlib -fno-common
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -O0 -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security
 
 ifdef STACK_PROTECTOR
@@ -50,7 +50,7 @@ LDFLAGS += -Wl,--gc-sections -static -nostartfiles -nostdlib
 LDFLAGS += -Wl,-n,-z,max-page-size=0x1000
 LDFLAGS += -Wl,-z,noexecstack
 
-ARCH_CFLAGS += -gdwarf-2 -O0
+ARCH_CFLAGS += -gdwarf-2
 ARCH_ASFLAGS += -gdwarf-2 -DASSEMBLER=1
 ARCH_ARFLAGS +=
 ARCH_LDFLAGS +=

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -25,7 +25,7 @@ HV_FILE := acrn
 CFLAGS += -Wall -W
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -fshort-wchar -ffreestanding
-CFLAGS += -m64
+CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -static -nostdinc -nostdlib -fno-common
 CFLAGS += -O0 -D_FORTIFY_SOURCE=2

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -347,7 +347,9 @@ static uint64_t get_random_value(void)
 	asm volatile ("1: rdrand %%rax\n"
 			"jnc 1b\n"
 			"mov %%rax, %0\n"
-			: "=r"(random) :: );
+			: "=r"(random)
+			:
+			:"%rax");
 	return random;
 }
 

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -636,6 +636,7 @@ int get_vioapic_info(char *str, int str_max, int vmid)
 	size -= len;
 	str += len;
 
+	rte = 0;
 	for (pin = 0 ; pin < vioapic_pincount(vm); pin++) {
 		vioapic_get_rte(vm, pin, (void *)&rte);
 		low = rte;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -82,7 +82,7 @@ static inline int exec_vmxon(void *addr)
 			      "pushfq\n"
 			      "pop %0\n":"=r" (rflags)
 			      : "r"(addr)
-			      : "%rax");
+			      : "%rax", "cc", "memory");
 
 		/* if carry and zero flags are clear operation success */
 		if (rflags & (RFLAGS_C | RFLAGS_Z))
@@ -140,7 +140,7 @@ int exec_vmclear(void *addr)
 		"pushfq\n"
 		"pop %0\n":"=r" (rflags)
 		: "r"(addr)
-		: "%rax");
+		: "%rax", "cc", "memory");
 
 	/* if carry and zero flags are clear operation success */
 	if (rflags & (RFLAGS_C | RFLAGS_Z))
@@ -165,7 +165,7 @@ int exec_vmptrld(void *addr)
 		"pop %0\n"
 		: "=r" (rflags)
 		: "r"(addr)
-		: "%rax");
+		: "%rax", "cc");
 
 	/* if carry and zero flags are clear operation success */
 	if (rflags & (RFLAGS_C | RFLAGS_Z))

--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -68,7 +68,7 @@ endif
 
 CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \
-		-Wall -I../fs/ -D$(ARCH)
+		-Wall -I../fs/ -D$(ARCH) -O0
 
 ifeq ($(ARCH),ia32)
 	ifeq ($(HOST),x86_64)

--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -68,7 +68,7 @@ endif
 
 CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \
-		-Wall -I../fs/ -D$(ARCH) -O0
+		-Wall -I../fs/ -D$(ARCH) -O2
 
 CFLAGS += -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 

--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -70,6 +70,8 @@ CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \
 		-Wall -I../fs/ -D$(ARCH) -O0
 
+CFLAGS += -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
+
 ifeq ($(ARCH),ia32)
 	ifeq ($(HOST),x86_64)
 		CFLAGS += -m32

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -379,8 +379,9 @@ void load_cpu_state_data(void);
 /* Macro to restore rflags register */
 #define CPU_RFLAGS_RESTORE(rflags)                      \
 {                                                       \
-	asm volatile (" push %0" : : "r" (rflags));     \
-	asm volatile (" popf");                         \
+	asm volatile (" push %0\n\t"			\
+			"popf	\n\t": : "r" (rflags)	\
+			:"cc");				\
 }
 
 /* This macro locks out interrupts and saves the current architecture status

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -472,6 +472,12 @@ static inline uint8_t get_vcpu_mode(struct vcpu *vcpu)
 {
 	return vcpu->arch_vcpu.cpu_mode;
 }
+
+typedef struct _descriptor_table_{
+	uint16_t limit;
+	uint64_t base;
+}__attribute__((packed)) descriptor_table;
+
 #endif /* ASSEMBLER */
 
 #endif /* VMX_H_ */


### PR DESCRIPTION
This is one patch set that tries to enable the -O2 option.
The patch[1..5] are used to fix the issues when trying
to enable -O2 option.
The patch6 is used to enable the -O2 option.

