### PR TITLE
Documentation: update the contributing guide to use new LICENSE file

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -19,8 +19,9 @@ Licensing is very important to open source projects. It helps ensure the
 software continues to be available under the terms that the author
 desired.
 
-Project ACRN uses a BSD-3-Clause license, as found in the license_header in
-the project's GitHub repo.
+Project ACRN uses a BSD-3-Clause license, as found in the
+`LICENSE <https://github.com/projectacrn/acrn-hypervisor/blob/master/LICENSE>`__
+in the project's GitHub repo.
 
 A license tells you what rights you have as a developer, as provided by
 the copyright holder. It is important that the contributor fully


### PR DESCRIPTION
Update the "Contributing Guidelines" document to point at the
top-level LICENSE file that was created after the merger of
the three acrn-{hypervisor,devicemodel,documentation} repositories

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>