### PR TITLE
add a makefile under project root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ devicemodel/build/
 devicemodel/include/version.h
 doc/doxygen
 doc/_build
+build
 *.bak
 *.sav
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+
+# global helper variables
+T := $(CURDIR)
+PLAT := uefi
+RELEASE := 0
+
+ROOT_OUT := $(T)/build
+HV_OUT := $(ROOT_OUT)/hypervisor
+DM_OUT := $(ROOT_OUT)/devicemodel
+TOOLS_OUT := $(ROOT_OUT)/tools
+
+.PHONY: all hypervisor devicemodel tools
+all: hypervisor devicemodel tools
+
+hypervisor:
+	cd $(T)/hypervisor; \
+	make HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLAT) RELEASE=$(RELEASE) clean; \
+	make HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLAT) RELEASE=$(RELEASE)
+
+devicemodel:
+	cd $(T)/devicemodel; \
+	make DM_OBJDIR=$(DM_OUT) clean; \
+	make DM_OBJDIR=$(DM_OUT)
+
+tools:
+	mkdir -p $(TOOLS_OUT)
+	cd $(T)/tools/acrnlog; \
+	make OUT_DIR=$(TOOLS_OUT);
+	cd $(T)/tools/acrn-manager; \
+	make OUT_DIR=$(TOOLS_OUT);
+	cd $(T)/tools/acrntrace; \
+	make OUT_DIR=$(TOOLS_OUT);
+
+.PHONY: clean
+clean:
+	rm -rf $(ROOT_OUT)
+	
+
+

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -1,5 +1,8 @@
+
+OUT_DIR ?= .
+
 all: acrnctl.c
-	gcc -o acrnctl acrnctl.c -I../../include -Wall -g
+	gcc -o $(OUT_DIR)/acrnctl acrnctl.c -I../../devicemodel/include -Wall -g
 
 clean:
 	rm -f acrnctl

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -1,5 +1,8 @@
+
+OUT_DIR ?= .
+
 all:
-	gcc -g acrnlog.c -o acrnlog -lpthread
+	gcc -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread
 
 clean:
 	rm acrnlog

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -1,5 +1,8 @@
+
+OUT_DIR ?= .
+
 all:
-	gcc -o acrntrace acrntrace.c sbuf.c -I. -lpthread
+	gcc -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread
 
 clean:
 	rm acrntrace


### PR DESCRIPTION
it can be used as following:
  make ==> to make hypervisor & devicemodel & tools
also modify tools makefile to support out-dir setting.

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Jack Ren <jack.ren@intel.com>