### PR TITLE
dm: free entries in pci_businfo[] when deinit

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1272,6 +1272,9 @@ deinit_pci(struct vmctx *ctx)
 				    func, fi);
 			}
 		}
+
+		pci_businfo[bus] = NULL;
+		free(bi);
 	}
 }
 


### PR DESCRIPTION
Entries of pci_businfo[] allocated in function "pci_parse_slot"
using calloc need to be freed when deinit.

Signed-off-by: Jie Deng <jie.deng@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Anthony Xu <anthony.xu@intel.com>
Reviewed-by: Kevin Tian <kevin.tian@intel.com>