### PR TITLE
hv: bugfix - MMIO access size was not properly initialized.

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -90,6 +90,6 @@ int vmm_decode_instruction(struct vcpu *vcpu, uint64_t gla,
 		enum vm_cpu_mode cpu_mode, int csd, struct vie *vie);
 
 int emulate_instruction(struct vcpu *vcpu, struct mem_io *mmio);
-int analyze_instruction(struct vcpu *vcpu, struct mem_io *mmio);
+int decode_instruction(struct vcpu *vcpu, struct mem_io *mmio);
 
 #endif	/* _VMM_INSTRUCTION_EMUL_H_ */

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -380,7 +380,7 @@ void vm_gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa)
 		vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].cr3, gva);
 }
 
-int analyze_instruction(struct vcpu *vcpu, struct mem_io *mmio)
+int decode_instruction(struct vcpu *vcpu, struct mem_io *mmio)
 {
 	uint64_t guest_rip_gva, guest_rip_gpa;
 	char *guest_rip_hva;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2181,7 +2181,7 @@ int apic_access_vmexit_handler(struct vcpu *vcpu)
 
 	vlapic = vcpu->arch_vcpu.vlapic;
 
-	analyze_instruction(vcpu, &vcpu->mmio);
+	decode_instruction(vcpu, &vcpu->mmio);
 	if (access_type == 1) {
 		if (!emulate_instruction(vcpu, &vcpu->mmio))
 			vlapic_write(vlapic, 1, offset, vcpu->mmio.value);


### PR DESCRIPTION
 MMIO access size is not initialized before
 instruction emulation.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>