### PR TITLE
Makefile: compliant with existing conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 # global helper variables
 T := $(CURDIR)
-PLAT := uefi
-RELEASE := 0
+PLATFORM ?= uefi
+RELEASE ?= 0
 
 ROOT_OUT := $(T)/build
 HV_OUT := $(ROOT_OUT)/hypervisor
@@ -13,8 +13,8 @@ TOOLS_OUT := $(ROOT_OUT)/tools
 all: hypervisor devicemodel tools
 
 hypervisor:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLAT) RELEASE=$(RELEASE) clean
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLAT) RELEASE=$(RELEASE)
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLATFORM) RELEASE=$(RELEASE) clean
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLATFORM) RELEASE=$(RELEASE)
 
 devicemodel:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -2,7 +2,7 @@
 OUT_DIR ?= .
 
 all: acrnctl.c
-	gcc -o $(OUT_DIR)/acrnctl acrnctl.c -I../../devicemodel/include -Wall -g
+	$(CC) -o $(OUT_DIR)/acrnctl acrnctl.c -I../../devicemodel/include -Wall -g
 
 clean:
 	rm -f $(OUT_DIR)/acrnctl

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -2,7 +2,7 @@
 OUT_DIR ?= .
 
 all:
-	gcc -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread
+	$(CC) -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread
 
 clean:
 	rm $(OUT_DIR)/acrnlog

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -2,7 +2,7 @@
 OUT_DIR ?= .
 
 all:
-	gcc -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread
+	$(CC) -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread
 
 clean:
 	rm $(OUT_DIR)/acrntrace


### PR DESCRIPTION
We have some conventions in existing code and documents, these patches are to follow those conventions:
(1) Current documents presume build the code with 'make PLATFORM=uefi'
(2) Both HV and DM invoke compiler with $(CC) for flexibility, the new tools code should follow the same practice

Signed-off-by: Tonny Tzeng tonny.tzeng@intel.com