### PR TITLE
Makefile: fix PLATFORM variable at install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 install: hypervisor-install devicemodel-install tools-install
 
 hypervisor-install:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLAT) RELEASE=$(RELEASE) install
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLATFORM) RELEASE=$(RELEASE) install
 
 devicemodel-install:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install


### PR DESCRIPTION
The variable PLAT was renamed to PLATFORM, but was not updated in the
install target giving a failure when installing ACRN hypervisor.

Fixes: fc2b6fbe86e8 ("Makefile: keep using 'PLATFORM' variable for existing documentation")

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>