### PR TITLE
Fix the logic that sets the top-level build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ T := $(CURDIR)
 PLATFORM ?= uefi
 RELEASE ?= 0
 
-ROOT_OUT := $(T)/build
+BUILD_DIR := build
+ROOT_OUT := $(T)/$(BUILD_DIR)
 HV_OUT := $(ROOT_OUT)/hypervisor
 DM_OUT := $(ROOT_OUT)/devicemodel
 TOOLS_OUT := $(ROOT_OUT)/tools


### PR DESCRIPTION
The 'ROOT_OUT' variable does not allow to set the folder in
which all output files (objects, binaries, etc.) are built
and placed.

Overriding it from the command-line leads to 'build' folders
of the name set that are created in the tree eventually leading
to a failure during the build. This patch changes how the
output directory is constructed so that *all* output files
are put in there. It introduces a new variable called
'BUILD_DIR' to that effect.

It also incidentally fix the fact that 'make clean' only removes
that output directory which means it does not properly clean up
the tree if one overrides the 'ROOT_OUT' variable manually today.

To change where the build artefacts are placed, set 'BUILD_DIR'
to whatever you want, e.g.:
   $ make BUILD_DIR=build-test
Will create a top-level folder called 'build-test' where everything
will be put. 'make clean' will remove it (if called with the same
argument)

Fix #223 

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>