### PR TITLE
tools: acrn-crashlog: Initial patch set for acrn-crashlog

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,5 +15,6 @@
 /hypervisor/                             @anthonyzxu @dongyaozu
 /devicemodel/                            @anthonyzxu @dongyaozu
 /doc/                                    @dbkinder
+/tools/acrn-crashlog/                    @dizhang417 @chengangc
 
 *.rst                                    @dbkinder

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,12 @@ tools:
 	make -C $(T)/tools/acrnlog OUT_DIR=$(TOOLS_OUT)
 	make -C $(T)/tools/acrn-manager OUT_DIR=$(TOOLS_OUT)
 	make -C $(T)/tools/acrntrace OUT_DIR=$(TOOLS_OUT)
+	make -C $(T)/tools/acrn-crashlog OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE)
 
 .PHONY: clean
 clean:
 	rm -rf $(ROOT_OUT)
-	
+
 .PHONY: install
 install: hypervisor-install devicemodel-install tools-install
 
@@ -43,4 +44,4 @@ tools-install:
 	make -C $(T)/tools/acrnlog OUT_DIR=$(TOOLS_OUT) install
 	make -C $(T)/tools/acrn-manager OUT_DIR=$(TOOLS_OUT) install
 	make -C $(T)/tools/acrntrace OUT_DIR=$(TOOLS_OUT) install
-
+	make -C $(T)/tools/acrn-crashlog OUT_DIR=$(TOOLS_OUT) install

--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -1,0 +1,30 @@
+#
+# ACRN-Crashlog Makefile
+#
+
+BASEDIR 	:= $(shell pwd)
+OUT_DIR 	?= $(BASEDIR)
+BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
+CC		:= gcc
+RM		= rm
+
+CFLAGS	:= -Wall -Wextra -pedantic
+CFLAGS	+= -m64 -D_GNU_SOURCE -DDEBUG_ACRN_CRASHLOG
+INCLUDE := -I $(BASEDIR)/common/include
+export INCLUDE
+export BUILDDIR
+
+.PHONY:all
+all:
+	$(MAKE) -C common
+	$(MAKE) -C acrnprobe
+	$(MAKE) -C usercrash
+
+.PHONY:clean
+clean:
+	$(MAKE) -C common clean
+	$(MAKE) -C acrnprobe clean
+	$(MAKE) -C usercrash clean
+	@if [ -d "$(BUILDDIR)" ]; then \
+		$(RM) -rf $(BUILDDIR); \
+	fi

--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -7,12 +7,27 @@ OUT_DIR 	?= $(BASEDIR)
 BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
 CC		:= gcc
 RM		= rm
+RELEASE 	?= 0
 
 CFLAGS	:= -Wall -Wextra -pedantic
-CFLAGS	+= -m64 -D_GNU_SOURCE -DDEBUG_ACRN_CRASHLOG
+CFLAGS	+= -m64 -D_GNU_SOURCE
+ifeq ($(RELEASE),0)
+CFLAGS	+= -DDEBUG_ACRN_CRASHLOG
+endif
 INCLUDE := -I $(BASEDIR)/common/include
 export INCLUDE
 export BUILDDIR
+export CC
+export RM
+export CFLAGS
+
+SYSTEMD_LIBS = -lsystemd
+LDCNF := $(shell ldconfig -p)
+LIB_EXIST = $(findstring libsystemd-journal.so, $(LDCNF))
+ifeq ($(strip $(LIB_EXIST)),libsystemd-journal.so)
+	SYSTEMD_LIBS = -lsystemd-journal
+endif
+export SYSTEMD_LIBS
 
 .PHONY:all
 all:
@@ -27,4 +42,54 @@ clean:
 	$(MAKE) -C usercrash clean
 	@if [ -d "$(BUILDDIR)" ]; then \
 		$(RM) -rf $(BUILDDIR); \
+	fi
+
+.PHONY:install
+install:
+	@install -d $(DESTDIR)/usr/bin/
+	@install -p -D -m 0755 $(BUILDDIR)/acrnprobe/bin/acrnprobe $(DESTDIR)/usr/bin/
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/debugger $(DESTDIR)/usr/bin/
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_c $(DESTDIR)/usr/bin/
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_s $(DESTDIR)/usr/bin/
+	@install -p -D -m 0755 data/acrnprobe_prepare.sh $(DESTDIR)/usr/bin/
+	@install -d $(DESTDIR)/usr/lib/systemd/system.conf.d/
+	@install -p -D -m 0644 data/40-watchdog.conf $(DESTDIR)/usr/lib/systemd/system.conf.d/
+	@install -d $(DESTDIR)/usr/share/defaults/telemetrics/
+	@install -p -D -m 0644 data/acrnprobe.xml $(DESTDIR)/usr/share/defaults/telemetrics/
+	@install -d $(DESTDIR)/usr/lib/systemd/system/
+	@install -p -D -m 0644 data/acrnprobe.service $(DESTDIR)/usr/lib/systemd/system/
+	@install -p -D -m 0644 data/prepare.service $(DESTDIR)/usr/lib/systemd/system/
+	@install -p -D -m 0644 data/usercrash.service $(DESTDIR)/usr/lib/systemd/system/
+
+.PHONY:uninstall
+uninstall:
+	@if [ -e "$(DESTDIR)/usr/bin/acrnprobe" ];then \
+		$(RM) $(DESTDIR)/usr/bin/acrnprobe; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/bin/acrnprobe_prepare.sh" ];then \
+		$(RM) $(DESTDIR)/usr/bin/acrnprobe_prepare.sh; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/bin/debugger" ];then \
+		$(RM) $(DESTDIR)/usr/bin/debugger; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/bin/usercrash_c" ];then \
+		$(RM) $(DESTDIR)/usr/bin/usercrash_c; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/bin/usercrash_s" ];then \
+		$(RM) $(DESTDIR)/usr/bin/usercrash_s; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/lib/systemd/system.conf.d/40-watchdog.conf" ];then \
+		$(RM) $(DESTDIR)/usr/lib/systemd/system.conf.d/40-watchdog.conf; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/share/defaults/telemetrics/acrnprobe.xml" ];then \
+		$(RM) $(DESTDIR)/usr/share/defaults/telemetrics/acrnprobe.xml; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/lib/systemd/system/acrnprobe.service" ];then \
+		$(RM) $(DESTDIR)/usr/lib/systemd/system/acrnprobe.service; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/lib/systemd/system/prepare.service" ];then \
+		$(RM) $(DESTDIR)/usr/lib/systemd/system/prepare.service; \
+	fi
+	@if [ -e "$(DESTDIR)/usr/lib/systemd/system/usercrash.service" ];then \
+		$(RM) $(DESTDIR)/usr/lib/systemd/system/usercrash.service; \
 	fi

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -1,3 +1,6 @@
+MAJOR_VERSION=1
+MINOR_VERSION=0
+
 BASEDIR 	:= $(shell pwd)
 
 LIBS		= -lpthread -lxml2 -lcrypto -lrt -lsystemd -ltelemetry
@@ -10,7 +13,7 @@ LDFLAGS 	+= $(LIBS) -Wl,--gc-sections
 
 TARGET		= $(BUILDDIR)/acrnprobe/bin/acrnprobe
 
-all: check_dirs $(TARGET)
+all: include/version.h check_dirs $(TARGET)
 
 $(BUILDDIR)/acrnprobe/obj/%.o:%.c
 	$(CC) -c $(CFLAGS) $< -o $@
@@ -35,6 +38,9 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 
 clean:
 	@echo "Clean objects and binaries"
+	@if [ -e include/version.h ]; then \
+		$(RM) -f include/version.h; \
+	fi
 	@if [ -d $(BUILDDIR)/acrnprobe/obj ]; then \
 	    find $(BUILDDIR)/acrnprobe/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \
 	fi
@@ -44,6 +50,19 @@ clean:
 	@if [ -d $(BUILDDIR)/acrnprobe/obj ]; then \
 		$(RM) -r $(BUILDDIR)/acrnprobe/obj ; \
 	fi
+
+include/version.h:
+	touch include/version.h
+	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
+	DIRTY=`git diff --name-only $(BASEDIR)`;\
+	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
+	cat $(BASEDIR)/../license_header > include/version.h;\
+	echo "#define AP_MAJOR_VERSION $(MAJOR_VERSION)" >> include/version.h;\
+	echo "#define AP_MINOR_VERSION $(MINOR_VERSION)" >> include/version.h;\
+	echo "#define AP_BUILD_VERSION "\""$$PATCH"\""" >> include/version.h;\
+	echo "#define AP_BUILD_TIME "\""$$TIME"\""" >> include/version.h;\
+	echo "#define AP_BUILD_USER "\""$(USER)"\""" >> include/version.h
 
 check_dirs:
 	@if [ ! -d $(BUILDDIR)/acrnprobe/bin ]; then \

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -25,7 +25,8 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 	$(BUILDDIR)/acrnprobe/obj/event_queue.o \
 	$(BUILDDIR)/acrnprobe/obj/event_handler.o \
 	$(BUILDDIR)/acrnprobe/obj/crash_reclassify.o \
-	$(BUILDDIR)/acrnprobe/obj/sender.o
+	$(BUILDDIR)/acrnprobe/obj/sender.o \
+	$(BUILDDIR)/acrnprobe/obj/startupreason.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -27,7 +27,9 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 	$(BUILDDIR)/acrnprobe/obj/crash_reclassify.o \
 	$(BUILDDIR)/acrnprobe/obj/sender.o \
 	$(BUILDDIR)/acrnprobe/obj/startupreason.o \
-	$(BUILDDIR)/acrnprobe/obj/property.o
+	$(BUILDDIR)/acrnprobe/obj/property.o \
+	$(BUILDDIR)/acrnprobe/obj/probeutils.o \
+	$(BUILDDIR)/acrnprobe/obj/history.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -1,0 +1,38 @@
+BASEDIR 	:= $(shell pwd)
+
+LIBS		= -lpthread -lxml2 -lcrypto -lrt -lsystemd -ltelemetry
+CFLAGS 		+= $(INCLUDE)
+CFLAGS 		+= -g -O0 -std=gnu11
+CFLAGS 		+= -ffunction-sections -fdata-sections
+
+LDFLAGS 	+= $(LIBS) -Wl,--gc-sections
+
+TARGET		= $(BUILDDIR)/acrnprobe/bin/acrnprobe
+
+all: check_dirs $(TARGET)
+
+$(BUILDDIR)/acrnprobe/obj/%.o:%.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+clean:
+	@echo "Clean objects and binaries"
+	@if [ -d $(BUILDDIR)/acrnprobe/obj ]; then \
+	    find $(BUILDDIR)/acrnprobe/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \
+	fi
+	@if [ -d $(BUILDDIR)/acrnprobe/bin ]; then \
+		$(RM) -r $(BUILDDIR)/acrnprobe/bin ; \
+	fi
+	@if [ -d $(BUILDDIR)/acrnprobe/obj ]; then \
+		$(RM) -r $(BUILDDIR)/acrnprobe/obj ; \
+	fi
+
+check_dirs:
+	@if [ ! -d $(BUILDDIR)/acrnprobe/bin ]; then \
+		mkdir -p $(BUILDDIR)/acrnprobe/bin ; \
+	fi
+	@if [ ! -d $(BUILDDIR)/acrnprobe/obj ]; then \
+		mkdir -p $(BUILDDIR)/acrnprobe/obj ; \
+	fi

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -29,7 +29,8 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 	$(BUILDDIR)/acrnprobe/obj/startupreason.o \
 	$(BUILDDIR)/acrnprobe/obj/property.o \
 	$(BUILDDIR)/acrnprobe/obj/probeutils.o \
-	$(BUILDDIR)/acrnprobe/obj/history.o
+	$(BUILDDIR)/acrnprobe/obj/history.o \
+	$(BUILDDIR)/acrnprobe/obj/android_events.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -1,7 +1,7 @@
 BASEDIR 	:= $(shell pwd)
 
 LIBS		= -lpthread -lxml2 -lcrypto -lrt -lsystemd -ltelemetry
-INCLUDE		+= -I $(BASEDIR)/include
+INCLUDE		+= -I $(BASEDIR)/include -I /usr/include/libxml2
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -g -O0 -std=gnu11
 CFLAGS 		+= -ffunction-sections -fdata-sections

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -26,7 +26,8 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 	$(BUILDDIR)/acrnprobe/obj/event_handler.o \
 	$(BUILDDIR)/acrnprobe/obj/crash_reclassify.o \
 	$(BUILDDIR)/acrnprobe/obj/sender.o \
-	$(BUILDDIR)/acrnprobe/obj/startupreason.o
+	$(BUILDDIR)/acrnprobe/obj/startupreason.o \
+	$(BUILDDIR)/acrnprobe/obj/property.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -1,6 +1,7 @@
 BASEDIR 	:= $(shell pwd)
 
 LIBS		= -lpthread -lxml2 -lcrypto -lrt -lsystemd -ltelemetry
+INCLUDE		+= -I $(BASEDIR)/include
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -g -O0 -std=gnu11
 CFLAGS 		+= -ffunction-sections -fdata-sections
@@ -14,7 +15,17 @@ all: check_dirs $(TARGET)
 $(BUILDDIR)/acrnprobe/obj/%.o:%.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
-$(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o
+$(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
+	$(BUILDDIR)/common/obj/log_sys.o \
+	$(BUILDDIR)/common/obj/cmdutils.o \
+	$(BUILDDIR)/common/obj/fsutils.o \
+	$(BUILDDIR)/common/obj/strutils.o \
+	$(BUILDDIR)/acrnprobe/obj/load_conf.o \
+	$(BUILDDIR)/acrnprobe/obj/channels.o \
+	$(BUILDDIR)/acrnprobe/obj/event_queue.o \
+	$(BUILDDIR)/acrnprobe/obj/event_handler.o \
+	$(BUILDDIR)/acrnprobe/obj/crash_reclassify.o \
+	$(BUILDDIR)/acrnprobe/obj/sender.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -3,7 +3,7 @@ MINOR_VERSION=0
 
 BASEDIR 	:= $(shell pwd)
 
-LIBS		= -lpthread -lxml2 -lcrypto -lrt -lsystemd -ltelemetry
+LIBS		= -lpthread -lxml2 -lcrypto -lrt $(SYSTEMD_LIBS) -ltelemetry
 INCLUDE		+= -I $(BASEDIR)/include -I /usr/include/libxml2
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -g -O0 -std=gnu11

--- a/tools/acrn-crashlog/acrnprobe/android_events.c
+++ b/tools/acrn-crashlog/acrnprobe/android_events.c
@@ -1,0 +1,589 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <malloc.h>
+#include <openssl/sha.h>
+#include <signal.h>
+#include <limits.h>
+#include <stdlib.h>
+#include "android_events.h"
+#include "strutils.h"
+#include "cmdutils.h"
+#include "log_sys.h"
+#include "fsutils.h"
+#include "history.h"
+
+#define VM_WARNING_LINES 2000
+#define LOOP_DEV_MAX 8
+
+static char *android_img = "/data/android/android.img";
+char *loop_dev;
+
+/* Find the head of str, caller must guarantee that 'str' is not in
+ * the first line.
+ */
+static char *line_head(char *str)
+{
+	while (*str != '\n')
+		str--;
+
+	return str + 1;
+}
+
+/* Find the next event that needs to be synced.
+ * There is a history_event file in UOS side, it records UOS's events in
+ * real-time. Generally, the cursor point to the first unsynchronized line.
+ */
+static char *vm_next_event_to_sync(char *cursor, struct vm_t *vm)
+{
+	char *line_to_sync = (char *)~(0);
+	char *syncevent;
+	char *p;
+	char *type;
+	char *subtype;
+	char *target;
+	int ret;
+	int id;
+
+	if (!cursor || !vm)
+		return NULL;
+
+	/* find all syncing types start from cursor,
+	 * focus the event with smaller address.
+	 */
+	for_each_syncevent_vm(id, syncevent, vm) {
+		if (!syncevent)
+			continue;
+
+		ret = asprintf(&type, "\n%s ", syncevent);
+		if (ret < 0) {
+			LOGE("calculate vm event failed, out of memory\n");
+			return NULL;
+		}
+		/* a sync event may configured as type/subtype */
+		p = strchr(type, '/');
+		if (p) {
+			*p = 0;
+			subtype = p + 1;
+		} else {
+			subtype = NULL;
+		}
+
+		if (subtype)
+			p = strstr(cursor, subtype);
+		else
+			p = strstr(cursor, type);
+
+		if (p) {
+			target = line_head(p);
+			line_to_sync = MIN(line_to_sync, target);
+		}
+
+		free(type);
+	}
+
+	if (line_to_sync == (char *)~(0))
+		return NULL;
+	else
+		return line_to_sync;
+
+}
+
+static int generate_log_vmrecord(char *path)
+{
+	char *head = "/* This file records vm id synced/will-sync from VMs,\n"
+		     " * the tag \"<==\" indicates the events waiting to sync.\n"
+		     " */\n\n";
+
+	LOGD("generate log_vmrecordid in (%s)\n", path);
+	return overwrite_file(path, head);
+}
+
+enum refresh_type_t {
+	MM_ONLY,
+	MM_FILE
+};
+
+/**
+ * There are 2 stages in vm events sync.
+ * Stage1: record events to log_vmrecordid file.
+ * Stage2: call sender's callback for each recorded events.
+ *
+ * The design reason is to give UOS some time to log to storage.
+ */
+static int refresh_key_synced_stage1(struct sender_t *sender, struct vm_t *vm,
+					char *key, enum refresh_type_t type)
+{
+	char log_new[64];
+	char *log_vmrecordid = sender->log_vmrecordid;
+
+	if (!key || !sender || !vm)
+		return -1;
+
+	/* the length of key must be 20, and its value can not be
+	 * 00000000000000000000.
+	 */
+	if ((strlen(key) == 20) &&
+	    strcmp(key, "00000000000000000000")) {
+		sprintf(vm->last_synced_line_key[sender_id(sender)],
+			"%s", key);
+		if (type == MM_ONLY)
+			return 0;
+
+		/* create a log file, so we can locate
+		 * the right place in case of reboot
+		 */
+		if (!file_exists(log_vmrecordid))
+			generate_log_vmrecord(log_vmrecordid);
+
+		sprintf(log_new, "%s %s <==\n", vm->name, key);
+		append_file(log_vmrecordid, log_new);
+		return 0;
+	}
+
+	LOGE("try to record a invalid key (%s) for (%s)\n",
+	     key, vm->name);
+	return -1;
+}
+
+static int refresh_key_synced_stage2(struct mm_file_t *m_vm_records, char *key)
+{
+	char *begin, *end;
+	char *p;
+
+	if (*key) {
+		begin = strstr(m_vm_records->begin, " <==");
+		end = strrstr(m_vm_records->begin, key);
+		end = strchr(end, '\n');
+
+		for (p = begin; p < end; p++) {
+			if (*p == '<' || *p == '=')
+				*p = ' ';
+		}
+
+		return 0;
+	}
+
+	return -1;
+}
+
+static int get_vm_history(struct vm_t *vm, struct sender_t *sender,
+			void **data)
+{
+	char vm_history[PATH_MAX];
+	unsigned long size;
+	int ret;
+	int sid;
+
+	if (!vm || !sender)
+		return -1;
+
+	sid = sender_id(sender);
+
+	snprintf(vm_history, sizeof(vm_history), "/tmp/%s_%s",
+		 "vm_hist", vm->name);
+
+	if (get_file_size(vm_history) == (int)vm->history_size[sid])
+		return 0;
+
+	if (*data)
+		free(*data);
+	ret = read_full_binary_file(vm_history, &size, data);
+	if (ret) {
+		LOGE("read (%s) with error (%s)\n", vm_history,
+		     strerror(errno));
+		return ret;
+	}
+
+	ret = strcnt(*data, '\n');
+	if (ret > VM_WARNING_LINES) {
+		LOGW("File too large, (%d) lines in (%s)\n",
+		     ret, vm_history);
+	}
+
+	vm->history_size[sid] = size;
+
+	return size;
+}
+
+static void sync_lines_stage1(struct sender_t *sender, void *data[])
+{
+	int id, sid;
+	int ret;
+	struct vm_t *vm;
+	char *start;
+	char *line_to_sync;
+	char vmkey[SHA_DIGEST_LENGTH + 1] = {0};
+	char *vm_format = "%*[^ ]%*[ ]%[^ ]%*c";
+
+	sid = sender_id(sender);
+	for_each_vm(id, vm, conf) {
+		if (!vm)
+			continue;
+
+		if (!vm->online)
+			continue;
+
+		if (vm->last_synced_line_key[sid][0]) {
+			start = strstr(data[id],
+				       vm->last_synced_line_key[sid]);
+			if (start == NULL) {
+				LOGW("no synced id (%s), sync from head\n",
+				     vm->last_synced_line_key[sid]);
+				start = (char *)data[id];
+			} else {
+				start = next_line(start);
+			}
+		} else {
+			start = (char *)data[id];
+		}
+
+		while ((line_to_sync = vm_next_event_to_sync(start, vm))) {
+			/* It's possible that log's content isn't ready
+			 * at this moment, so we postpone the fn until
+			 * the next loop
+			 */
+			//fn(line_to_sync, vm);
+
+			vmkey[0] = 0;
+			ret = sscanf(line_to_sync, vm_format, vmkey);
+			if (ret != 1) {
+				LOGE("get a invalid line from (%s), skip\n",
+				     vm->name);
+				start = next_line(line_to_sync);
+				continue;
+			}
+
+			LOGD("stage1 %s\n", vmkey);
+			if (vmkey[0])
+				refresh_key_synced_stage1(sender, vm,
+							  vmkey, MM_FILE);
+			start = next_line(line_to_sync);
+		}
+	}
+
+}
+
+static void sync_lines_stage2(struct sender_t *sender, void *data[],
+			void (*fn)(char*, struct vm_t *))
+{
+	struct mm_file_t *m_vm_records;
+	char *line;
+	char *cursor;
+	char *record_fmt = "%[^ ]%*[ ]%[^ ]%*c";
+	char vm_name[64];
+	char vmkey[SHA_DIGEST_LENGTH + 1] = {0};
+	int id;
+	struct vm_t *vm;
+	int ret;
+
+	m_vm_records = mmap_file(sender->log_vmrecordid);
+	if (!m_vm_records) {
+		LOGE("mmap %s failed, strerror(%s)\n", sender->log_vmrecordid,
+						       strerror(errno));
+		return;
+	}
+
+	cursor = strstr(m_vm_records->begin, " <==");
+	if (!cursor)
+		goto out;
+
+	line = line_head(cursor);
+	while (line) {
+		char *vm_hist_line;
+		/* VMNAME xxxxxxxxxxxxxxxxxxxx <== */
+		ret = sscanf(line, record_fmt, vm_name, vmkey);
+		if (ret != 2) {
+			LOGE("parse vm record failed\n");
+			goto out;
+		}
+
+		for_each_vm(id, vm, conf) {
+			if (!vm)
+				continue;
+
+			if (!vm->online)
+				continue;
+
+			if (strcmp(vm->name, vm_name))
+				continue;
+
+			vm_hist_line = strstr(data[id], vmkey);
+			if (!vm_hist_line) {
+				LOGE("not find (%s) in (%s),", vmkey, vm->name);
+				LOGE("history_event in UOS was deleted?\n");
+				break;
+			}
+
+			fn(line_head(vm_hist_line), vm);
+		}
+
+		line = next_line(line);
+	}
+
+out:
+	refresh_key_synced_stage2(m_vm_records, vmkey);
+	unmap_file(m_vm_records);
+}
+
+/* This function only for initialization */
+static void get_last_line_synced(struct sender_t *sender)
+{
+	int id;
+	int ret;
+	struct vm_t *vm;
+	char vmkey[SHA_DIGEST_LENGTH + 10] = {0};
+	char word[256];
+
+	for_each_vm(id, vm, conf) {
+		if (!vm)
+			continue;
+
+		if (!vm->online)
+			continue;
+
+		/* generally only exec for each vm once */
+		if (vm->last_synced_line_key[sender_id(sender)][0])
+			continue;
+
+		snprintf(word, sizeof(word), "%s ", vm->name);
+		ret = file_read_key_value_r(sender->log_vmrecordid,
+					    word, vmkey);
+		if (ret == -ENOENT) {
+			LOGD("no log_vmrecordid under (%s), will generete\n",
+			     sender->log_vmrecordid);
+			generate_log_vmrecord(sender->log_vmrecordid);
+			continue;
+		} else if (ret == -ENOMSG) {
+			LOGD("no vm record id for (%s)\n", vm->name);
+			continue;
+		} else if (ret < 0) {
+			LOGE("read key-value in (%s) for (%s), error (%s)\n",
+			     sender->log_vmrecordid, vm->name,
+			     strerror(errno));
+			continue;
+		}
+
+		vmkey[SHA_DIGEST_LENGTH] = 0;
+		ret = refresh_key_synced_stage1(sender, vm, vmkey, MM_ONLY);
+		if (ret < 0) {
+			LOGE("get a non-key vm event (%s) for (%s)\n",
+			     vmkey, vm->name);
+			continue;
+		}
+	}
+}
+
+static int is_data_partition(char *loop_dev)
+{
+	int ret = 0;
+	char *out = exec_out2mem("debugfs -R \"ls\" %s", loop_dev);
+
+	if (!out) {
+		LOGE("debugfs -R ls %s failed, error (%s)\n", loop_dev,
+		     strerror(errno));
+		return 0;
+	}
+
+	if (strstr(out, "app-lib") &&
+	    strstr(out, "tombstones") &&
+	    strstr(out, "dalvik-cache")) {
+		ret = 1;
+	}
+
+	free(out);
+	return ret;
+}
+
+static char *setup_loop_dev(void)
+{
+
+	/* Currently UOS image(/data/android/android.img) mounted by
+	 * launch_UOS.sh, we need mount its data partition to loop device
+	 */
+	char *out;
+	char loop_dev_tmp[32];
+	int i;
+
+	if (!file_exists(android_img)) {
+		LOGW("img(%s) is not available\n", android_img);
+		return NULL;
+	}
+
+	loop_dev = exec_out2mem("losetup -f");
+	if (!loop_dev) {
+		/* get cmd out fail */
+		LOGE("losetup -f failed, error (%s)\n",
+		     strerror(errno));
+		return NULL;
+	} else if (strncmp(loop_dev, "/dev/loop", strlen("/dev/loop"))) {
+		/* it's not a loop dev */
+		LOGE("get error loop dev (%s)\n", loop_dev);
+		goto free_loop_dev;
+	} else if (strncmp(loop_dev, "/dev/loop0", strlen("/dev/loop0"))) {
+		/* it's not loop0, was img mounted? */
+		for (i = 0; i < LOOP_DEV_MAX; i++) {
+			snprintf(loop_dev_tmp, ARRAY_SIZE(loop_dev_tmp),
+				 "/dev/loop%d", i);
+			if (is_data_partition(loop_dev_tmp)) {
+				free(loop_dev);
+				loop_dev = strdup(loop_dev_tmp);
+				if (!loop_dev) {
+					LOGE("out of memory\n");
+					return NULL;
+				}
+				return loop_dev;
+			}
+		}
+	}
+	*strchr(loop_dev, '\n') = 0;
+
+	out = exec_out2mem("fdisk -lu %s", android_img);
+	if (!out) {
+		LOGE("fdisk -lu %s failed, error (%s)\n", android_img,
+		     strerror(errno));
+		goto free_loop_dev;
+	}
+
+	/* find data partition, sector unit = 512 bytes */
+	char patition_start[32] = {0};
+	char sectors[32] = {0};
+	unsigned long pstart;
+	char *partition;
+	char *partition_fmt = "%*[^ ]%*[ ]%[^ ]%*[ ]%*[^ ]%*[ ]%[^ ]%*c";
+	char *cursor = out;
+	int ret;
+
+	while (cursor &&
+	       (partition = strstr(cursor, android_img))) {
+		cursor = strchr(partition, '\n');
+		memset(patition_start, 0, sizeof(patition_start));
+		memset(sectors, 0, sizeof(sectors));
+
+		ret = sscanf(partition, partition_fmt, patition_start, sectors);
+		if (ret != 2)
+			continue;
+
+		LOGD("start (%s) sectors(%s)\n", patition_start, sectors);
+		/* size < 1G */
+		if (atoi(sectors) < 1 * 2 * 1024 * 1024)
+			continue;
+
+		pstart = atol(patition_start) * 512;
+		if (pstart == 0)
+			continue;
+
+		ret = exec_out2file(NULL, "losetup -o %lu %s %s",
+				   pstart, loop_dev, android_img);
+		/* if error occurs, is_data_partition will return false,
+		 * only print error message here.
+		 */
+		if (ret != 0)
+			LOGE("(losetup -o %lu %s %s) failed, return %d\n",
+			     pstart, loop_dev, android_img, ret);
+
+		if (is_data_partition(loop_dev)) {
+			goto success;
+		} else {
+			ret = exec_out2file(NULL, "losetup -d %s", loop_dev);
+			/* may lose a loop dev */
+			if (ret != 0)
+				LOGE("(losetup -d %s) failed, return %d\n",
+				     loop_dev, ret);
+		}
+	}
+
+	free(out);
+free_loop_dev:
+	free(loop_dev);
+
+	return NULL;
+
+success:
+	free(out);
+	return loop_dev;
+}
+
+static int ping_vm_fs(char *loop_dev)
+{
+	int id;
+	int count = 0;
+	struct vm_t *vm;
+	struct mm_file_t *vm_hist;
+	char vm_history[PATH_MAX];
+	char cmd[512];
+	char prefix[] = "#V1.0 CURRENTUPTIME";
+
+	/* ensure history_event in uos available */
+	for_each_vm(id, vm, conf) {
+		if (!vm)
+			continue;
+
+		snprintf(vm_history, sizeof(vm_history), "/tmp/%s_%s",
+			 "vm_hist", vm->name);
+		snprintf(cmd, sizeof(cmd),
+			 "dump logs/history_event %s", vm_history);
+
+		debugfs_cmd(loop_dev, cmd, NULL);
+
+		vm_hist = mmap_file(vm_history);
+		if (vm_hist == NULL) {
+			vm->online = 0;
+			LOGE("%s(%s) unavailable\n", vm->name, vm_history);
+			continue;
+		}
+
+		if (vm_hist->size &&
+		    !strncmp(vm_hist->begin, prefix, strlen(prefix))) {
+			vm->online = 1;
+			count++;
+		} else {
+			vm->online = 0;
+			LOGE("%s(%s) unavailable\n", vm->name, vm_history);
+		}
+
+		unmap_file(vm_hist);
+	}
+	return count;
+}
+
+void refresh_vm_history(struct sender_t *sender,
+		void (*fn)(char*, struct vm_t *))
+{
+	int ret;
+	int id;
+	struct vm_t *vm;
+	static void *data[VM_MAX];
+
+	if (!loop_dev) {
+		loop_dev = setup_loop_dev();
+		if (!loop_dev)
+			return;
+		LOGI("setup loop dev successful\n");
+	}
+
+	if (sender_id(sender) == 0) {
+		ret = ping_vm_fs(loop_dev);
+		if (!ret)
+			return;
+	}
+
+	get_last_line_synced(sender);
+
+	for_each_vm(id, vm, conf) {
+		if (!vm)
+			continue;
+
+		if (!vm->online)
+			continue;
+
+		get_vm_history(vm, sender, &data[id]);
+	}
+
+	sync_lines_stage2(sender, data, fn);
+	sync_lines_stage1(sender, data);
+}

--- a/tools/acrn-crashlog/acrnprobe/channels.c
+++ b/tools/acrn-crashlog/acrnprobe/channels.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "channels.h"
+
+int init_channels(void)
+{
+	return 0;
+}

--- a/tools/acrn-crashlog/acrnprobe/channels.c
+++ b/tools/acrn-crashlog/acrnprobe/channels.c
@@ -3,9 +3,516 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <errno.h>
+#include <sys/inotify.h>
+#include <sys/epoll.h>
+#include <time.h>
+#include <signal.h>
+#include "load_conf.h"
+#include "event_queue.h"
+#include "fsutils.h"
+#include "strutils.h"
 #include "channels.h"
+#include "log_sys.h"
 
+#define POLLING_TIMER_SIG 0xCEAC
+
+static void channel_oneshot(struct channel_t *cnl);
+static void channel_polling(struct channel_t *cnl);
+static void channel_inotify(struct channel_t *cnl);
+
+/**
+ * @brief structure containing implementation of each channel.
+ *
+ * This structure describes all channels, all channel_* functions would
+ * called by main thread in order.
+ */
+static struct channel_t channels[] = {
+	{"oneshot", -1, channel_oneshot},
+	{"polling", -1, channel_polling},
+	{"inotify", -1, channel_inotify},
+};
+
+#define for_each_channel(i, channel) \
+	for (i = 0, channel = &channels[0]; \
+	     i < (int)ARRAY_SIZE(channels); \
+	     i++, channel++)
+
+/**
+ * Helper function to create a event and fill event_t structure.
+ *
+ * @param event_type Type of this event.
+ * @param channel Channel where the event comes from.
+ * @param private The corresponding configuration info to the event.
+ * @param watchfd For watch channel, so far, only used by inotify.
+ * @param path File which trigger this event.
+ * @param len Length of path.
+ *
+ * @return a pointer to the filled event if successful,
+ *  or NULL on error.
+ */
+static struct event_t *create_event(enum event_type_t event_type,
+				char *channel, void *private,
+				int watchfd, char *path, int len)
+{
+	struct event_t *e;
+
+	if (len < 0)
+		return NULL;
+
+	e = malloc(sizeof(*e) + len + 1);
+	if (e) {
+		memset(e, 0, sizeof(*e) + len + 1);
+		e->watchfd = watchfd;
+		e->channel = channel;
+		e->private = (void *)private;
+		e->event_type = event_type;
+		if (path && (len > 0)) {
+			e->len = len;
+			strncpy(e->path, path, len);
+		}
+	} else {
+		LOGE("malloc failed, error (%s)\n", strerror(errno));
+	}
+
+	return e;
+}
+
+/**
+ * Only check once when process startup
+ *
+ * @param cnl Structure of channel.
+ */
+static void channel_oneshot(struct channel_t *cnl)
+{
+	int id;
+	struct crash_t *crash;
+	struct info_t *info;
+	struct event_t *e;
+	char *cname = cnl->name;
+
+	LOGD("initializing channel %s ...\n", cname);
+
+	e = create_event(REBOOT, cname, NULL, 0, NULL, 0);
+	if (e)
+		event_enqueue(e);
+
+
+	for_each_crash(id, crash, conf) {
+		if (!crash || !is_root_crash(crash))
+			continue;
+
+		if (strcmp(crash->channel, cname))
+			continue;
+
+		if (crash->trigger &&
+		    !strcmp("file", crash->trigger->type) &&
+		    file_exists(crash->trigger->path)) {
+			e = create_event(CRASH, cname, (void *)crash,
+					 0, crash->trigger->path,
+					 strlen(crash->trigger->path));
+			if (e)
+				event_enqueue(e);
+		}
+	}
+
+	for_each_info(id, info, conf) {
+		if (!info)
+			continue;
+
+		if (strcmp(info->channel, cname))
+			continue;
+
+		if (info->trigger &&
+		    !strcmp("file", info->trigger->type) &&
+		    file_exists(info->trigger->path)) {
+			e = create_event(INFO, cname, (void *)info,
+					 0, NULL, 0);
+			if (e)
+				event_enqueue(e);
+		}
+	}
+}
+
+/* TODO: implement multiple polling jobs */
+static struct polling_job_t {
+	timer_t timerid;
+	uint32_t timer_val;
+
+	enum event_type_t type;
+	void (*fn)(union sigval v);
+} vm_job;
+
+/**
+ * Callback thread of a polling job.
+ */
+static void polling_vm(union sigval v __attribute__((unused)))
+{
+
+	struct event_t *e = create_event(VM, "polling", NULL, 0, NULL, 0);
+
+	if (e)
+		event_enqueue(e);
+}
+
+/**
+ * Setup a timer with specific loop time. The callback fn will be performed
+ * after timer expire.
+ *
+ * @param pjob Polling_job filled by caller.
+ *
+ * @return 0 if successful, or -1 if not.
+ */
+static int create_polling_job(struct polling_job_t *pjob)
+{
+	struct sigevent sig_evt;
+	struct itimerspec timer_val;
+
+	memset(&sig_evt, 0, sizeof(struct sigevent));
+	sig_evt.sigev_value.sival_int = POLLING_TIMER_SIG;
+	sig_evt.sigev_notify = SIGEV_THREAD;
+	sig_evt.sigev_notify_function = pjob->fn;
+
+	if (timer_create(CLOCK_REALTIME, &sig_evt, &pjob->timerid) == -1) {
+		LOGE("timer_create failed.\n");
+		return -1;
+	}
+
+	memset(&timer_val, 0, sizeof(struct itimerspec));
+	timer_val.it_value.tv_sec = pjob->timer_val;
+	timer_val.it_interval.tv_sec = pjob->timer_val;
+
+	if (timer_settime(pjob->timerid, 0, &timer_val, NULL) == -1) {
+		LOGE("timer_settime failed.\n");
+		timer_delete(pjob->timerid);
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * Setup polling jobs. These jobs running with fixed time interval.
+ *
+ * @param cnl Structure of channel.
+ */
+static void channel_polling(struct channel_t *cnl)
+{
+	int id;
+	int ret;
+	struct vm_t *vm;
+	char *cname = cnl->name;
+
+	LOGD("initializing channel %s ...\n", cname);
+
+	/* one job for all vm polling*/
+	for_each_vm(id, vm, conf) {
+		if (!vm)
+			continue;
+
+		if (strncmp(vm->channel, "polling", strlen(vm->channel)))
+			continue;
+
+		vm_job.timer_val = atoi(vm->interval);
+	}
+
+	LOGD("start polling job with %ds\n", vm_job.timer_val);
+	vm_job.fn = polling_vm;
+	vm_job.type = VM;
+	ret = create_polling_job(&vm_job);
+	if (ret < 0) {
+		LOGE("create polling job failed\n, error (%s)\n",
+		     strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+}
+
+/**
+ * Setup inotify, watch the changes of dir/file.
+ *
+ * @param cnl Structure of channel.
+ */
+static void channel_inotify(struct channel_t *cnl)
+{
+	int inotify_fd;
+	int id;
+	struct crash_t *crash;
+	struct sender_t *sender;
+	struct uptime_t *uptime;
+	struct trigger_t *trigger;
+	char *cname = cnl->name;
+
+	LOGD("initializing channel %s ...\n", cname);
+
+	/* use this func to get "return 0" from read */
+	inotify_fd = inotify_init1(IN_NONBLOCK);
+	if (inotify_fd < 0) {
+		LOGE("inotify init fail, %s\n", strerror(errno));
+		return;
+	}
+
+	for_each_crash(id, crash, conf) {
+		if (!crash || !is_root_crash(crash))
+			continue;
+
+		if (strcmp(crash->channel, cname))
+			continue;
+
+		if (!crash->trigger)
+			continue;
+
+		trigger = crash->trigger;
+		if (!strcmp("dir", trigger->type)) {
+			if (directory_exists(trigger->path)) {
+				crash->wd = inotify_add_watch(inotify_fd,
+							      trigger->path,
+							      BASE_DIR_MASK);
+				if (crash->wd < 0) {
+					LOGE("add %s failed, error (%s)\n",
+					     trigger->path, strerror(errno));
+					exit(EXIT_FAILURE);
+				}
+				LOGI("add %s succuessed\n", trigger->path);
+			} else {
+				LOGW("path to watch (%s) isn't exsits\n",
+				     trigger->path);
+			}
+		}
+		/* TODO: else for other types to use channel inotify */
+	}
+	/* add uptime path for each sender */
+	for_each_sender(id, sender, conf) {
+		if (!sender)
+			continue;
+
+		uptime = sender->uptime;
+		uptime->wd = inotify_add_watch(inotify_fd, uptime->path,
+					       UPTIME_MASK);
+		if (uptime->wd < 0) {
+			LOGE("add %s failed, error (%s)\n",
+			     uptime->path, strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		LOGI("add %s succuessed\n", uptime->path);
+	}
+
+	cnl->fd = inotify_fd;
+}
+
+/**
+ * Handle inotify events, read out all events and enqueue.
+ *
+ * @param channel Channel structure of inotify.
+ *
+ * @return 0 if successful, or -1 if not.
+ */
+static int receive_inotify_events(struct channel_t *channel)
+{
+	int len;
+	int read_left;
+	char buf[256];
+	char *p;
+	struct event_t *e;
+	struct inotify_event *ievent;
+	enum event_type_t event_type;
+	void *private;
+
+	read_left = 0;
+	while (1) {
+		len = read(channel->fd, (char *)&buf[read_left],
+			   (int)sizeof(buf) - read_left);
+		if (len < 0) {
+			if (errno == EAGAIN)
+				break;
+			LOGE("read fail with (%d, %p, %d), error: %s\n",
+			     channel->fd, (char *)&buf[read_left],
+			     (int)sizeof(buf) - read_left, strerror(errno));
+			return -1;
+		}
+		if (len == 0)
+			break;
+
+		for (p = buf; p < buf + read_left + len;) {
+			if (p + sizeof(struct inotify_event) >
+			    &buf[0] + len + read_left) {
+				/* we dont recv the entire inotify_event yet */
+				break;
+			}
+
+			/* then we can get len */
+			ievent = (struct inotify_event *)p;
+			if (p + sizeof(struct inotify_event) + ievent->len >
+						&buf[0] + len + read_left) {
+				/* we dont recv the entire
+				 * inotify_event + name
+				 */
+				break;
+			}
+			/* we have a entire event, send it... */
+			event_type = get_conf_by_wd(ievent->wd, &private);
+			if (event_type == UNKNOWN) {
+				LOGE("get a unknown event\n");
+			} else {
+				e = create_event(event_type, channel->name,
+						 private, channel->fd,
+						 ievent->name, ievent->len);
+				if (e)
+					event_enqueue(e);
+			}
+			/* next event start */
+			p += sizeof(struct inotify_event) + ievent->len;
+		}
+		/* move the bytes that have been read out to the head of buf,
+		 * and let the rest of the buf do recv continually
+		 */
+		read_left = &buf[0] + len + read_left - p;
+		memmove(buf, p, read_left);
+	}
+
+	return 0;
+}
+
+/**
+ * Enqueue a HEART_BEAT event to event_queue.
+ */
+static void heart_beat(void)
+{
+	struct event_t *e = create_event(HEART_BEAT, NULL, NULL, 0, NULL, 0);
+
+	if (e)
+		event_enqueue(e);
+}
+
+/**
+ * Wait events asynchronously for all watch needed channels.
+ */
+static void *wait_events(void *unused __attribute__((unused)))
+{
+	int epfd;
+	int id;
+	int ret;
+	struct channel_t *channel;
+	struct epoll_event ev, *events;
+
+	epfd = epoll_create(MAXEVENTS + 1);
+	if (epfd < 0) {
+		LOGE("epoll_create failed, exiting\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ev.events = EPOLLIN | EPOLLET;
+	for_each_channel(id, channel) {
+		if (channel->fd <= 0)
+			continue;
+
+		ev.data.fd = channel->fd;
+		ret = epoll_ctl(epfd, EPOLL_CTL_ADD, channel->fd, &ev);
+		if (ret < 0) {
+			LOGE("epoll_ctl failed, exiting\n");
+			exit(EXIT_FAILURE);
+		} else
+			LOGD("add (%d) to epoll for (%s)\n", channel->fd,
+			     channel->name);
+	}
+
+	events = calloc(MAXEVENTS, sizeof(ev));
+	if (events == NULL) {
+		LOGE("calloc failed, error (%s)\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	while (1) {
+		int i;
+		int n;
+
+		n = epoll_wait(epfd, events, MAXEVENTS, HEART_RATE);
+		heart_beat();
+		for (i = 0; i < n; i++) {
+			for_each_channel(id, channel)
+				if (channel->fd == events[i].data.fd) {
+					if (events[i].events & EPOLLERR ||
+					    !(events[i].events & EPOLLIN)) {
+						LOGE("error ev, channel:%s\n",
+						     channel->name);
+						continue;
+					}
+					/* Until now, we only have
+					 * inotify channel to wait
+					 */
+					receive_inotify_events(channel);
+				}
+		}
+	}
+}
+
+/**
+ * Create a detached thread.
+ * Once these thread exit, their resources would be released immediately.
+ *
+ * @param[out] pid Pid of new thread.
+ * @param fn The entry of new thread.
+ * @param arg The arg of fn.
+ *
+ * @return 0 if successful, or errno if not.
+ */
+int create_detached_thread(pthread_t *pid, void *(*fn)(void *), void *arg)
+{
+	int ret;
+	pthread_attr_t attr;
+
+	ret = pthread_attr_init(&attr);
+	if (ret) {
+		LOGE("pthread attr init failed\n, error (%s)\n",
+		     strerror(ret));
+		return ret;
+	}
+
+	ret = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+	if (ret) {
+		LOGE("pthread attr setdetachstate failed\n, error (%s)\n",
+		     strerror(ret));
+		goto fail;
+	}
+
+	ret = pthread_create(pid, &attr, fn, arg);
+	if (ret) {
+		LOGE("pthread create failed\n, error (%s)\n",
+		     strerror(ret));
+	}
+fail:
+	pthread_attr_destroy(&attr);
+
+	return ret;
+}
+
+/**
+ * Initailize all channels, performing channel_* in channels one by one.
+ *
+ * @return 0 if successful, or errno if not.
+ */
 int init_channels(void)
 {
+	pthread_t pid;
+	int id;
+	int ret;
+	struct channel_t *channel;
+
+	for_each_channel(id, channel) {
+		channel->channel_fn(channel);
+	}
+
+	ret = create_detached_thread(&pid, &wait_events, NULL);
+	if (ret) {
+		LOGE("create wait_events fail, ret (%s)\n", strerror(ret));
+		return ret;
+	}
+
 	return 0;
 }

--- a/tools/acrn-crashlog/acrnprobe/crash_reclassify.c
+++ b/tools/acrn-crashlog/acrnprobe/crash_reclassify.c
@@ -3,8 +3,292 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <string.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include "load_conf.h"
+#include "fsutils.h"
+#include "strutils.h"
+#include "log_sys.h"
 #include "crash_reclassify.h"
 
+/**
+ * Check if file contains content or not.
+ * This function couldn't use for binary file.
+ *
+ * @param file Starting address of file cache.
+ * @param content String to be searched.
+ *
+ * @return 1 if find the same string, or 0 if not.
+ */
+static int has_content(char *file, char *content)
+{
+	if (content && strstr(file, content))
+		return 1;
+
+	return 0;
+}
+
+/**
+ * Check if file contains all configured contents or not.
+ * This function couldn't use for binary file.
+ *
+ * @param crash Crash need checking.
+ * @param file Starting address of file cache.
+ *
+ * @return 1 if all configured strings were found, or 0 if not.
+ */
+static int crash_has_all_contents(struct crash_t *crash,
+				char *file)
+{
+	int id;
+	int ret = 1;
+	char *content;
+
+	for_each_content_crash(id, content, crash) {
+		if (!content)
+			continue;
+
+		if (!has_content(file, content)) {
+			ret = 0;
+			break;
+		}
+	}
+
+	return ret;
+}
+
+/**
+ * Might content is a 2-D array, write as mc[exp][cnt]
+ * This function implements the following algorithm:
+ *
+ * r_mc[exp] = has_content(mc[exp][0]) || has_content(mc[exp][1]) || ...
+ * result = r_mc[0] && r_mc[1] && ...
+ *
+ * This function couldn't use for binary file.
+ *
+ * @param crash Crash need checking.
+ * @param file Starting address of file cache.
+ *
+ * @return 1 if result is true, or 0 if false.
+ */
+static int crash_has_mightcontents(struct crash_t *crash,
+				char *file)
+{
+	int ret = 1;
+	int ret_exp;
+	int expid, cntid;
+	char **exp;
+	char *content;
+
+	for_each_expression_crash(expid, exp, crash) {
+		if (!exp || !exp_valid(exp))
+			continue;
+
+		ret_exp = 0;
+		for_each_content_expression(cntid, content, exp) {
+			if (!content)
+				continue;
+
+			if (has_content(file, content)) {
+				ret_exp = 1;
+				break;
+			}
+		}
+		if (ret_exp == 0) {
+			ret = 0;
+			break;
+		}
+	}
+
+	return ret;
+}
+
+/**
+ * Judge the type of crash, according to configured content/mightcontent.
+ * This function couldn't use for binary file.
+ *
+ * @param crash Crash need checking.
+ * @param file Starting address of file cache.
+ *
+ * @return 1 if file matches these strings configured in crash, or 0 if not.
+ */
+static int crash_reclassify(struct crash_t *crash, char *file)
+{
+	return crash_has_all_contents(crash, file) &&
+		crash_has_mightcontents(crash, file);
+}
+
+static int _get_data(char *file, struct crash_t *crash, char **data, int index)
+{
+	char *search_key;
+	char *value;
+	char *end;
+	int size;
+	int max_size = 255;
+
+	if (!data)
+		return 0;
+
+	*data = NULL;
+
+	search_key = crash->data[index];
+	if (!search_key)
+		return 0;
+
+	value = strrstr(file, search_key);
+	if (!value)
+		return 0;
+
+	end = strchr(value, '\n');
+	if (!end)
+		return 0;
+
+	size = MIN(max_size, end - value);
+	*data =  malloc(size + 1);
+	if (*data == NULL)
+		return -ENOMEM;
+
+	strncpy(*data, value, size);
+	*(*data + size) = 0;
+	return size;
+}
+
+/**
+ * Get segment from file, according to 'data' configuread in crash.
+ * This function couldn't use for binary file.
+ *
+ * @param file Starting address of file cache.
+ * @param crash Crash need checking.
+ * @param[out] data0 Searched result, according to 'data0' configuread in crash.
+ * @param[out] data1 Searched result, according to 'data1' configuread in crash.
+ * @param[out] data2 Searched result, according to 'data2' configuread in crash.
+ *
+ * @return 0 if successful, or errno if not.
+ */
+static int get_data(char *file, struct crash_t *crash,
+			char **data0, char **data1, char **data2)
+{
+	int res;
+
+	/* to find strings which match conf words */
+	res = _get_data(file, crash, data0, 0);
+	if (res < 0)
+		goto fail;
+
+	res = _get_data(file, crash, data1, 1);
+	if (res < 0)
+		goto free_data0;
+
+	res = _get_data(file, crash, data2, 2);
+	if (res < 0)
+		goto free_data1;
+
+	return 0;
+free_data1:
+	if (data1 && *data1)
+		free(*data1);
+free_data0:
+	if (data0 && *data0)
+		free(*data0);
+fail:
+	return res;
+}
+
+/**
+ * Judge the crash type. We only got a root crash from channel, sometimes,
+ * we need to calculate a more specific type.
+ * This function reclassify the crash type by searching trigger file's content.
+ * This function couldn't use for binary file.
+ *
+ * @param rcrash Root crash obtained from channel.
+ * @param trfile Path of trigger file.
+ * @param[out] data0 Searched result, according to 'data0' configuread in crash.
+ * @param[out] data1 Searched result, according to 'data1' configuread in crash.
+ * @param[out] data2 Searched result, according to 'data2' configuread in crash.
+ *
+ * @return a pointer to the calculated crash structure if successful,
+ *	   or NULL if not.
+ */
+static struct crash_t *crash_reclassify_by_content(struct crash_t *rcrash,
+						char *trfile, char **data0,
+						char **data1, char **data2)
+{
+	int depth;
+	int level;
+	int ret;
+	struct crash_t *crash;
+	struct crash_t *ret_crash = NULL;
+	void *file;
+	unsigned long size;
+	int id;
+
+	if (!rcrash)
+		return NULL;
+
+	if (trfile) {
+		ret = read_full_binary_file(trfile, &size, &file);
+		if (ret == -1) {
+			LOGE("read %s failed, error (%s)\n",
+			     trfile, strerror(errno));
+			return NULL;
+		}
+	} else
+		return rcrash;
+
+	/* traverse every crash from leaf, return the first crash we find
+	 * consider that we have few CRASH TYPE, so just using this simple
+	 * implementation.
+	 */
+	depth = crash_depth(rcrash);
+	for (level = depth; level >= 0; level--) {
+		for_each_crash(id, crash, conf) {
+			if (!crash ||
+			    crash->trigger != rcrash->trigger ||
+			    crash->channel != rcrash->channel ||
+			    crash->level != level)
+				continue;
+
+			if (crash_reclassify(crash, file)) {
+				ret = get_data(file, crash, data0, data1,
+					       data2);
+				if (ret < 0) {
+					LOGE("get data error, error (%s)\n",
+					     strerror(-ret));
+					goto fail_data;
+				} else {
+					ret_crash = crash;
+					goto fail_data;
+				}
+			}
+		}
+	}
+
+fail_data:
+	free(file);
+
+	return ret_crash;
+}
+
+/**
+ * Initailize crash reclassify, we only got a root crash from channel,
+ * sometimes, we need to get a more specific type.
+ */
 void init_crash_reclassify(void)
 {
+	int id;
+	struct crash_t *crash;
+
+	for_each_crash(id, crash, conf) {
+		if (!crash || !is_root_crash(crash))
+			continue;
+
+		crash->reclassify = crash_reclassify_by_content;
+	}
 }

--- a/tools/acrn-crashlog/acrnprobe/crash_reclassify.c
+++ b/tools/acrn-crashlog/acrnprobe/crash_reclassify.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "crash_reclassify.h"
+
+void init_crash_reclassify(void)
+{
+}

--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "event_handler.h"
+
+int init_event_handler(void)
+{
+	return 0;
+}

--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -3,9 +3,187 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <stdio.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/time.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include "event_queue.h"
+#include "load_conf.h"
+#include "channels.h"
+#include "fsutils.h"
+#include "log_sys.h"
 #include "event_handler.h"
 
+/* Watchdog timeout in second*/
+#define WDT_TIMEOUT 300
+
+static struct event_t *last_e;
+static int event_processing;
+
+/**
+ * Handle watchdog expire.
+ *
+ * @param signal Signal which triggered this function.
+ */
+static void wdt_timeout(int signal)
+{
+	struct event_t *e;
+	struct crash_t *crash;
+	struct info_t *info;
+	int count;
+
+	if (signal == SIGALRM) {
+		LOGE("haven't received heart beat(%ds) for %ds, killing self\n",
+		     HEART_BEAT, WDT_TIMEOUT);
+
+		if (event_processing) {
+			LOGE("event (%d, %s) processing...\n",
+			     last_e->event_type, last_e->path);
+			free(last_e);
+		}
+
+		count = events_count();
+		LOGE("total %d unhandled events :\n", count);
+
+		while (count-- && (e = event_dequeue())) {
+			switch (e->event_type) {
+			case CRASH:
+				crash = (struct crash_t *)e->private;
+				LOGE("CRASH (%s, %s)\n", (char *)crash->name,
+				     e->path);
+				break;
+			case INFO:
+				info = (struct info_t *)e->private;
+				LOGE("INFO (%s)\n", (char *)info->name);
+				break;
+			case UPTIME:
+				LOGE("UPTIME\n");
+				break;
+			case HEART_BEAT:
+				LOGE("HEART_BEAT\n");
+				break;
+			case REBOOT:
+				LOGE("REBOOT\n");
+				break;
+			default:
+				LOGE("error event type %d\n", e->event_type);
+			}
+			free(e);
+		}
+
+		raise(SIGKILL);
+	}
+}
+
+/**
+ * Fed watchdog.
+ *
+ * @param timeout in second When the watchdog expire next time.
+ */
+static void watchdog_fed(int timeout)
+{
+	struct itimerval new_value;
+	int ret;
+
+	memset(&new_value, 0, sizeof(new_value));
+
+	new_value.it_value.tv_sec = timeout;
+	ret = setitimer(ITIMER_REAL, &new_value, NULL);
+	if (ret < 0) {
+		LOGE("setitimer failed, error (%s)\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+}
+
+/**
+ * Initialize watchdog. This watchdog is used to monitor event handler.
+ *
+ * @param timeout in second When the watchdog expire next time.
+ */
+static void watchdog_init(int timeout)
+{
+	struct itimerval new_value;
+	int ret;
+	sighandler_t ohdlr;
+
+	ohdlr = signal(SIGALRM, wdt_timeout);
+	if (ohdlr == SIG_ERR) {
+		LOGE("signal failed, error (%s)\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	memset(&new_value, 0, sizeof(new_value));
+
+	new_value.it_value.tv_sec = timeout;
+	ret = setitimer(ITIMER_REAL, &new_value, NULL);
+	if (ret < 0) {
+		LOGE("setitimer failed, error (%s)\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+}
+
+/**
+ * Process each event in event queue.
+ * Note that currently event handler is single threaded.
+ */
+static void *event_handle(void *unused __attribute__((unused)))
+{
+	int id;
+	struct sender_t *sender;
+	struct event_t *e;
+
+	while ((e = event_dequeue())) {
+		/* here we only handle internal event */
+		if (e->event_type == HEART_BEAT) {
+			watchdog_fed(WDT_TIMEOUT);
+			free(e);
+			continue;
+		}
+
+		/* last_e is allocated for debug purpose, the information
+		 * will be dumped if watchdog expire.
+		 */
+		last_e = malloc(sizeof(*e) + e->len);
+		if (last_e == NULL) {
+			LOGE("malloc failed, error (%s)\n", strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		event_processing = 1;
+		memcpy(last_e, e, sizeof(*e) + e->len);
+
+		for_each_sender(id, sender, conf) {
+			if (!sender)
+				continue;
+
+			sender->send(e);
+		}
+
+		if ((e->dir))
+			free(e->dir);
+		free(e);
+		event_processing = 0;
+		free(last_e);
+	}
+
+	LOGE("something goes error, %s exit\n", __func__);
+	return NULL;
+}
+
+/**
+ * Initialize event handler.
+ */
 int init_event_handler(void)
 {
+	int ret;
+	pthread_t pid;
+
+	watchdog_init(WDT_TIMEOUT);
+	ret = create_detached_thread(&pid, &event_handle, NULL);
+	if (ret) {
+		LOGE("create event handler failed (%s)\n", strerror(errno));
+		return -1;
+	}
 	return 0;
 }

--- a/tools/acrn-crashlog/acrnprobe/event_queue.c
+++ b/tools/acrn-crashlog/acrnprobe/event_queue.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "event_queue.h"
+
+void init_event(void)
+{
+}

--- a/tools/acrn-crashlog/acrnprobe/event_queue.c
+++ b/tools/acrn-crashlog/acrnprobe/event_queue.c
@@ -3,8 +3,73 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <stdio.h>
+#include <sys/queue.h>
+#include <pthread.h>
 #include "event_queue.h"
+#include "log_sys.h"
 
-void init_event(void)
+static pthread_mutex_t eq_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t pcond = PTHREAD_COND_INITIALIZER;
+TAILQ_HEAD(, event_t) event_q;
+
+/**
+ * Enqueue an event to event_queue.
+ *
+ * @param event Event to process.
+ */
+void event_enqueue(struct event_t *event)
 {
+	pthread_mutex_lock(&eq_mtx);
+	TAILQ_INSERT_TAIL(&event_q, event, entries);
+	pthread_cond_signal(&pcond);
+	LOGD("enqueue %d, (%d)%s\n", event->event_type, event->len,
+	     event->path);
+	pthread_mutex_unlock(&eq_mtx);
+}
+
+/**
+ * Count the number of events in event_queue.
+ *
+ * @return count.
+ */
+int events_count(void)
+{
+	struct event_t *e;
+	int count = 0;
+
+	pthread_mutex_lock(&eq_mtx);
+	TAILQ_FOREACH(e, &event_q, entries)
+		count++;
+	pthread_mutex_unlock(&eq_mtx);
+
+	return count;
+}
+
+/**
+ * Dequeue an event from event_queue.
+ *
+ * @return the dequeued event.
+ */
+struct event_t *event_dequeue(void)
+{
+	struct event_t *e;
+
+	pthread_mutex_lock(&eq_mtx);
+	while (TAILQ_EMPTY(&event_q))
+		pthread_cond_wait(&pcond, &eq_mtx);
+	e = TAILQ_FIRST(&event_q);
+	TAILQ_REMOVE(&event_q, e, entries);
+	LOGD("dequeue %d, (%d)%s\n", e->event_type, e->len, e->path);
+	pthread_mutex_unlock(&eq_mtx);
+
+	return e;
+}
+
+/**
+ * Initailize event_queue.
+ */
+void init_event_queue(void)
+{
+	TAILQ_INIT(&event_q);
 }

--- a/tools/acrn-crashlog/acrnprobe/history.c
+++ b/tools/acrn-crashlog/acrnprobe/history.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "history.h"
+
+void hist_raise_infoerror(char *type __attribute__((unused)))
+{
+}

--- a/tools/acrn-crashlog/acrnprobe/history.c
+++ b/tools/acrn-crashlog/acrnprobe/history.c
@@ -19,8 +19,267 @@
  * limitations under the License.
  */
 
+#include <string.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "fsutils.h"
+#include "load_conf.h"
 #include "history.h"
+#include "log_sys.h"
+#include "probeutils.h"
 
-void hist_raise_infoerror(char *type __attribute__((unused)))
+#define HISTORY_FIRST_LINE_FMT \
+		"#V1.0 CURRENTUPTIME   %-24s\n"
+#define HISTORY_BLANK_LINE2 \
+		"#EVENT  ID                    DATE                 TYPE\n"
+
+struct history_entry {
+	char *event;
+	char *type;
+	char *log;
+	const char *lastuptime; /* for uptime */
+	char *key;
+	char *eventtime;
+};
+
+char *history_file;
+static int current_lines;
+
+static void entry_to_history_line(struct history_entry *entry,
+				char newline[MAXLINESIZE])
 {
+	newline[0] = 0;
+	if (entry->log != NULL) {
+		char *ptr;
+		char tmp[MAXLINESIZE];
+
+		strncpy(tmp, entry->log, MAXLINESIZE);
+		tmp[MAXLINESIZE-1] = 0;
+		ptr = strrchr(tmp, '/');
+		if (ptr && ptr[1] == 0)
+			ptr[0] = 0;
+		snprintf(newline, MAXLINESIZE, "%-8s%-22s%-20s%s %s\n",
+			 entry->event, entry->key, entry->eventtime,
+			 entry->type, tmp);
+	} else if (entry->type != NULL && entry->type[0]) {
+		if (entry->lastuptime != NULL) {
+			snprintf(newline, MAXLINESIZE,
+				 "%-8s%-22s%-20s%-16s %s\n",
+				 entry->event, entry->key,
+				 entry->eventtime, entry->type,
+				 entry->lastuptime);
+		} else {
+			snprintf(newline, MAXLINESIZE,
+				 "%-8s%-22s%-20s%-16s\n",
+				 entry->event, entry->key, entry->eventtime,
+				 entry->type);
+		}
+	} else {
+		snprintf(newline, MAXLINESIZE, "%-8s%-22s%-20s%s\n",
+			 entry->event, entry->key, entry->eventtime,
+			 entry->lastuptime);
+	}
+}
+
+static void backup_history(void)
+{
+	int ret;
+	char *des;
+
+	ret = asprintf(&des, "%s.bak", history_file);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	ret = do_mv(history_file, des);
+	if (ret < 0) {
+		LOGE("backup %s failed, error (%s)\n", history_file,
+		     strerror(errno));
+		goto free;
+	}
+
+	ret = prepare_history();
+	if (ret < 0) {
+		LOGE("Prepare new history_file failed, exit\n");
+		exit(EXIT_FAILURE);
+	}
+
+free:
+	free(des);
+}
+
+void hist_raise_event(char *event, char *type, char *log, char *lastuptime,
+		char *key)
+{
+	char line[MAXLINESIZE];
+	char eventtime[32];
+	struct sender_t *crashlog;
+	int maxlines;
+	int ret;
+	struct history_entry entry = {
+		.event = event,
+		.type = type,
+		.log = log,
+		.lastuptime = lastuptime,
+		.key = key
+	};
+
+	/* here means user have configured the crashlog sender */
+	crashlog = get_sender_by_name("crashlog");
+	maxlines = atoi(crashlog->maxlines);
+	if (++current_lines >= maxlines) {
+		LOGW("lines of (%s) meet quota %d, backup... Pls clean!\n",
+		     history_file, maxlines);
+		backup_history();
+	}
+
+	get_current_time_long(eventtime);
+	entry.eventtime = eventtime;
+
+	entry_to_history_line(&entry, line);
+	ret = append_file(history_file, line);
+	if (ret < 0) {
+		LOGE("append (%s) failed, error (%s)\n", history_file,
+		     strerror(errno));
+		return;
+	}
+}
+
+void hist_raise_uptime(char *lastuptime)
+{
+	char boot_time[24];
+	char firstline[MAXLINESIZE];
+	int hours;
+	int ret;
+	char *key;
+	static int loop_uptime_event = 1;
+	struct sender_t *crashlog;
+	struct uptime_t *uptime;
+	static int uptime_hours;
+
+	/* user have configured the crashlog sender */
+	crashlog = get_sender_by_name("crashlog");
+	uptime = crashlog->uptime;
+	uptime_hours = atoi(uptime->eventhours);
+
+	if (lastuptime)
+		hist_raise_event(uptime->name, NULL, NULL, lastuptime,
+			    "00000000000000000000");
+	else {
+		ret = get_uptime_string(boot_time, &hours);
+		if (ret < 0) {
+			LOGE("cannot get uptime - %s\n", strerror(-ret));
+			return;
+		}
+
+		sprintf(firstline, HISTORY_FIRST_LINE_FMT, boot_time);
+		replace_file_head(history_file, firstline);
+
+		if (hours / uptime_hours >= loop_uptime_event) {
+			loop_uptime_event = (hours / uptime_hours) + 1;
+
+			key = generate_event_id(uptime->name, "");
+			if (key == NULL) {
+				LOGE("generate event id failed, error (%s)\n",
+				     strerror(errno));
+				return;
+			}
+
+			hist_raise_event(uptime->name, NULL, NULL,
+					 boot_time, key);
+			free(key);
+		}
+	}
+}
+
+void hist_raise_infoerror(char *type)
+{
+	char *key;
+
+	key = generate_event_id("ERROR", type);
+	if (key == NULL) {
+		LOGE("generate event id failed, error (%s)\n",
+		     strerror(errno));
+		return;
+	}
+
+	hist_raise_event("ERROR", type, NULL, NULL, key);
+	free(key);
+}
+
+static int get_time_firstline(char *buffer)
+{
+	char firstline[MAXLINESIZE];
+	int ret;
+	char *fmt = "%*[^ ]%*[ ]%*[^ ]%*[ ]%[^ ]%*c";
+
+	memset(firstline, 0, MAXLINESIZE);
+	ret = file_read_string(history_file, firstline, MAXLINESIZE);
+	if (ret <= 0) {
+		LOGW("file_read_string failed, %d %s\n", ret, strerror(-ret));
+		return -1;
+	}
+
+	if (!strstr(firstline, "#V1.0 "))
+		return -1;
+
+	ret = sscanf(firstline, fmt, buffer);
+	if (ret != 1) {
+		LOGE("get last time failed, %d %s\n", ret, firstline);
+		return -1;
+	}
+	return 0;
+}
+
+int prepare_history(void)
+{
+	int ret;
+	struct sender_t *crashlog;
+	char linebuf[MAXLINESIZE] = {0};
+
+	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return 0;
+
+	if (!history_file) {
+		ret = asprintf(&history_file, "%s/%s", crashlog->outdir,
+			       HISTORY_NAME);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			return -ENOMEM;
+		}
+	}
+
+	ret = get_time_firstline(linebuf);
+	if (ret == 0) {
+		current_lines = count_lines_in_file(history_file);
+		hist_raise_uptime(linebuf);
+	} else {
+		/* new history */
+		LOGW("new history\n");
+		sprintf(linebuf, HISTORY_FIRST_LINE_FMT, "0000:00:00");
+		ret = overwrite_file(history_file, linebuf);
+		if (ret < 0) {
+			LOGE("Write (%s, %s) failed, error (%s)\n",
+			     history_file, linebuf,
+			     strerror(errno));
+			return ret;
+		}
+		ret = append_file(history_file, HISTORY_BLANK_LINE2);
+		if (ret < 0) {
+			LOGE("Write (%s, %s) failed, error (%s)\n",
+			     history_file, HISTORY_BLANK_LINE2,
+			     strerror(errno));
+			return ret;
+		}
+		current_lines = count_lines_in_file(history_file);
+	}
+
+	return 0;
 }

--- a/tools/acrn-crashlog/acrnprobe/include/android_events.h
+++ b/tools/acrn-crashlog/acrnprobe/include/android_events.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __ANDROID_EVENTS_H__
+#define __ANDROID_EVENTS_H__
+#include "load_conf.h"
+
+extern char *loop_dev;
+
+void refresh_vm_history(struct sender_t *sender,
+			void (*fn)(char*, struct vm_t *));
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/channels.h
+++ b/tools/acrn-crashlog/acrnprobe/include/channels.h
@@ -6,6 +6,19 @@
 #ifndef _CHANNELS_H
 #define _CHANNELS_H
 
+#define BASE_DIR_MASK		(IN_CLOSE_WRITE | IN_DELETE_SELF | IN_MOVE_SELF)
+#define UPTIME_MASK		IN_CLOSE_WRITE
+#define MAXEVENTS 15
+#define HEART_RATE (6 * 1000) /* ms */
+
+struct channel_t {
+	char *name;
+	int fd;
+	void (*channel_fn)(struct channel_t *);
+};
+extern int create_detached_thread(pthread_t *pid,
+				void *(*fn)(void *), void *arg);
 extern int init_channels(void);
+
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/channels.h
+++ b/tools/acrn-crashlog/acrnprobe/include/channels.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CHANNELS_H
+#define _CHANNELS_H
+
+extern int init_channels(void);
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/crash_reclassify.h
+++ b/tools/acrn-crashlog/acrnprobe/include/crash_reclassify.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+extern void init_crash_reclassify(void);

--- a/tools/acrn-crashlog/acrnprobe/include/event_handler.h
+++ b/tools/acrn-crashlog/acrnprobe/include/event_handler.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+extern int init_event_handler(void);

--- a/tools/acrn-crashlog/acrnprobe/include/event_queue.h
+++ b/tools/acrn-crashlog/acrnprobe/include/event_queue.h
@@ -33,6 +33,9 @@ struct event_t {
 	char path[0]; /* keep this at tail*/
 };
 
+void event_enqueue(struct event_t *event);
+int events_count(void);
+struct event_t *event_dequeue(void);
 void init_event_queue(void);
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/event_queue.h
+++ b/tools/acrn-crashlog/acrnprobe/include/event_queue.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __EVENT_QUEUE_H__
+#define __EVENT_QUEUE_H__
+
+void init_event_queue(void);
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/event_queue.h
+++ b/tools/acrn-crashlog/acrnprobe/include/event_queue.h
@@ -6,6 +6,33 @@
 #ifndef __EVENT_QUEUE_H__
 #define __EVENT_QUEUE_H__
 
+#include <sys/queue.h>
+
+enum event_type_t {
+	CRASH,
+	INFO,
+	UPTIME,
+	HEART_BEAT,
+	REBOOT,
+	VM,
+	UNKNOWN
+};
+
+__extension__
+struct event_t {
+	int watchfd;
+	enum event_type_t event_type;
+	char *channel;
+	void *private;
+
+	TAILQ_ENTRY(event_t) entries;
+
+	/* dir to storage logs */
+	char *dir;
+	int len;
+	char path[0]; /* keep this at tail*/
+};
+
 void init_event_queue(void);
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/history.h
+++ b/tools/acrn-crashlog/acrnprobe/include/history.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __HISTORY_H__
+#define __HISTORY_H__
+
+void hist_raise_infoerror(char *type);
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/history.h
+++ b/tools/acrn-crashlog/acrnprobe/include/history.h
@@ -22,6 +22,14 @@
 #ifndef __HISTORY_H__
 #define __HISTORY_H__
 
+#define HISTORY_NAME		"history_event"
+
+extern char *history_file;
+
+int prepare_history(void);
 void hist_raise_infoerror(char *type);
+void hist_raise_uptime(char *lastuptime);
+void hist_raise_event(char *event, char *type, char *log, char *lastuptime,
+		char *key);
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __LOAD_CONF_H__
+#define __LOAD_CONF_H__
+
+#define SENDER_MAX 3
+
+struct uptime_t {
+	char *name;
+	char *frequency;
+	char *eventhours;
+
+	int wd;
+	char *path;
+};
+
+struct sender_t {
+	struct uptime_t *uptime;
+};
+
+struct conf_t {
+	struct sender_t *sender[SENDER_MAX];
+};
+
+struct conf_t conf;
+
+#define for_each_sender(id, sender, conf) \
+		for (id = 0, sender = conf.sender[0]; \
+		     id < SENDER_MAX; \
+		     id++, sender = conf.sender[id])
+
+int load_conf(char *path);
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -6,7 +6,76 @@
 #ifndef __LOAD_CONF_H__
 #define __LOAD_CONF_H__
 
+#include <stdio.h>
+#include <sys/queue.h>
+#include <openssl/sha.h>
+#include "event_queue.h"
+
+#define CONTENT_MAX 10
+#define EXPRESSION_MAX 5
+#define LOG_MAX 20
+#define TRIGGER_MAX 20
 #define SENDER_MAX 3
+#define DATA_MAX 3
+#define CRASH_MAX 20
+#define INFO_MAX 20
+#define VM_MAX 4
+#define VM_EVENT_TYPE_MAX 20
+
+struct trigger_t {
+	char *name;
+	char *type;
+	char *path;
+};
+
+struct vm_t {
+	char *name;
+	char *channel;
+	char *interval;
+	char *syncevent[VM_EVENT_TYPE_MAX];
+
+	int online;
+	unsigned long history_size[SENDER_MAX];
+	char last_synced_line_key[SENDER_MAX][SHA_DIGEST_LENGTH + 1];
+};
+
+struct log_t {
+	char *name;
+	char *type;
+	char *path;
+	char *lines;
+
+	void (*get)(struct log_t *, void *);
+};
+
+struct crash_t {
+	char *name;
+	char *channel;
+	char *interval;
+	struct trigger_t *trigger;
+	char *content[CONTENT_MAX];
+	char *mightcontent[EXPRESSION_MAX][CONTENT_MAX];
+	struct log_t *log[LOG_MAX];
+	char *data[DATA_MAX];
+
+	struct crash_t *parents;
+
+	TAILQ_ENTRY(crash_t) entries;
+	TAILQ_HEAD(, crash_t) children;
+
+	int wd;
+	int level;
+	struct crash_t *(*reclassify)(struct crash_t *, char*, char**, char**,
+				char**);
+};
+
+struct info_t {
+	char *name;
+	char *channel;
+	char *interval;
+	struct trigger_t *trigger;
+	struct log_t *log[LOG_MAX];
+};
 
 struct uptime_t {
 	char *name;
@@ -18,11 +87,25 @@ struct uptime_t {
 };
 
 struct sender_t {
+	char *name;
+	char *outdir;
+	char *maxcrashdirs;
+	char *maxlines;
+	char *spacequota;
 	struct uptime_t *uptime;
+
+	void (*send)(struct event_t *);
+	char *log_vmrecordid;
+	int sw_updated; /* each sender has their own record */
 };
 
 struct conf_t {
 	struct sender_t *sender[SENDER_MAX];
+	struct vm_t *vm[VM_MAX];
+	struct trigger_t *trigger[TRIGGER_MAX];
+	struct log_t *log[LOG_MAX];
+	struct crash_t *crash[CRASH_MAX];
+	struct info_t *info[INFO_MAX];
 };
 
 struct conf_t conf;
@@ -32,6 +115,98 @@ struct conf_t conf;
 		     id < SENDER_MAX; \
 		     id++, sender = conf.sender[id])
 
+#define for_each_trigger(id, trigger, conf) \
+		for (id = 0, trigger = conf.trigger[0]; \
+		     id < TRIGGER_MAX; \
+		     id++, trigger = conf.trigger[id])
+
+#define for_each_vm(id, vm, conf) \
+		for (id = 0, vm = conf.vm[0]; \
+		     id < VM_MAX; \
+		     id++, vm = conf.vm[id])
+
+#define for_each_syncevent_vm(id, event, vm) \
+		for (id = 0, event = vm->syncevent[0]; \
+		     id < VM_EVENT_TYPE_MAX; \
+		     id++, event = vm->syncevent[id])
+
+#define for_each_info(id, info, conf) \
+		for (id = 0, info = conf.info[0]; \
+		     id < INFO_MAX; \
+		     id++, info = conf.info[id])
+
+#define for_each_log(id, log, conf) \
+		for (id = 0, log = conf.log[0]; \
+		     id < LOG_MAX; \
+		     id++, log = conf.log[id])
+
+#define for_each_crash(id, crash, conf) \
+		for (id = 0, crash = conf.crash[0]; \
+		     id < CRASH_MAX; \
+		     id++, crash = conf.crash[id])
+
+#define for_each_log_collect(id, log, type) \
+		for (id = 0, log = type->log[0]; \
+		     id < LOG_MAX; \
+		     id++, log = type->log[id])
+
+#define for_each_content_crash(id, content, crash) \
+		for (id = 0, content = crash->content[0]; \
+		     id < CONTENT_MAX; \
+		     id++, content = crash->content[id])
+
+#define for_each_content_expression(id, content, exp) \
+		for (id = 0, content = exp[0]; \
+		     id < CONTENT_MAX; \
+		     id++, content = exp[id])
+
+#define exp_valid(exp) \
+(__extension__ \
+({ \
+		int _ret = 0; \
+		int _id; \
+		char *content; \
+		for_each_content_expression(_id, content, exp) { \
+			if (content) \
+				_ret = 1; \
+		} \
+		_ret; \
+}) \
+)
+
+#define for_each_expression_crash(id, exp, crash) \
+		for (id = 0, exp = crash->mightcontent[0]; \
+		     id < EXPRESSION_MAX; \
+		     id++, exp = crash->mightcontent[id])
+
+#define for_crash_children(crash, tcrash) \
+			TAILQ_FOREACH(crash, &tcrash->children, entries)
+
+#define is_leaf_crash(crash) \
+			(crash && TAILQ_EMPTY(&crash->children))
+
+#define is_root_crash(crash) \
+			(crash && crash->parents == NULL)
+
+#define to_collect_logs(type) \
+(__extension__ \
+({ \
+		int _id; \
+		int _ret = 0; \
+		for (_id = 0; _id < LOG_MAX; _id++) \
+			if (type->log[_id]) \
+				_ret = 1; \
+		_ret; \
+}) \
+)
+
 int load_conf(char *path);
+struct trigger_t *get_trigger_by_name(char *name);
+struct log_t *get_log_by_name(char *name);
+int sender_id(struct sender_t *sender);
+struct sender_t *get_sender_by_name(char *name);
+enum event_type_t get_conf_by_wd(int wd, void **private);
+struct crash_t *get_crash_by_wd(int wd);
+int crash_depth(struct crash_t *tcrash);
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/probeutils.h
+++ b/tools/acrn-crashlog/acrnprobe/include/probeutils.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PROBEUTILS_H__
+#define __PROBEUTILS_H__
+
+enum e_dir_mode {
+	MODE_CRASH = 0,
+	MODE_STATS,
+	MODE_VMEVENT,
+};
+
+int get_uptime_string(char newuptime[24], int *hours);
+int get_current_time_long(char buf[32]);
+unsigned long long get_uptime(void);
+char *generate_event_id(char *seed1, char *seed2);
+char *generate_eventid256(char *seed);
+void generate_crashfile(char *dir, char *event, char *hashkey,
+			char *type, char *data0,
+			char *data1, char *data2);
+char *generate_log_dir(enum e_dir_mode mode, char *hashkey);
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/property.h
+++ b/tools/acrn-crashlog/acrnprobe/include/property.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PROPERTY_H__
+#define __PROPERTY_H__
+#include "load_conf.h"
+
+#define VERSION_SIZE       256
+
+char guuid[VERSION_SIZE];
+char gbuildversion[VERSION_SIZE];
+
+int init_properties(struct sender_t *sender);
+int swupdated(struct sender_t *sender);
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/sender.h
+++ b/tools/acrn-crashlog/acrnprobe/include/sender.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+extern int init_sender(void);

--- a/tools/acrn-crashlog/acrnprobe/include/startupreason.h
+++ b/tools/acrn-crashlog/acrnprobe/include/startupreason.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extern void read_startupreason(char *startupreason);

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "load_conf.h"
+
+int load_conf(char *path __attribute__((unused)))
+{
+	return 0;
+}

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -3,9 +3,572 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+#include <string.h>
 #include "load_conf.h"
+#include "event_queue.h"
+#include "log_sys.h"
 
-int load_conf(char *path __attribute__((unused)))
+static void print(void)
 {
+	int id, id2;
+	int i, j;
+	struct sender_t *sender;
+	struct trigger_t *trigger;
+	struct vm_t *vm;
+	struct log_t *log;
+	struct info_t *info;
+	struct crash_t *crash;
+	struct crash_t *crash_tmp;
+	char buf[512];
+
+#define print_id_item(item, root, id) \
+		LOGD("%-8s(%d): %-15s:(%s)\n", #root, id, #item, root->item)
+#define print_2id_item(item, root, id, tid) \
+		LOGD("%-8s(%d): %-15s(%d):(%s)\n", \
+		     #root, id, #item, tid, root->item[tid])
+	for_each_sender(id, sender, conf) {
+		if (!sender)
+			continue;
+		print_id_item(name, sender, id);
+		print_id_item(outdir, sender, id);
+		print_id_item(maxcrashdirs, sender, id);
+		print_id_item(maxlines, sender, id);
+		print_id_item(spacequota, sender, id);
+
+		if (sender->uptime) {
+			print_id_item(uptime->name, sender, id);
+			print_id_item(uptime->path, sender, id);
+			print_id_item(uptime->frequency, sender, id);
+			print_id_item(uptime->eventhours, sender, id);
+		}
+	}
+
+	for_each_trigger(id, trigger, conf) {
+		if (!trigger)
+			continue;
+		print_id_item(name, trigger, id);
+		print_id_item(type, trigger, id);
+		print_id_item(path, trigger, id);
+	}
+
+	for_each_vm(id, vm, conf) {
+		if (!vm)
+			continue;
+		print_id_item(name, vm, id);
+		print_id_item(channel, vm, id);
+		print_id_item(interval, vm, id);
+		for (i = 0; i < VM_EVENT_TYPE_MAX; i++) {
+			if (vm->syncevent[i])
+				print_2id_item(syncevent, vm, id, i);
+		}
+	}
+
+	for_each_log(id, log, conf) {
+		if (!log)
+			continue;
+		print_id_item(name, log, id);
+		print_id_item(type, log, id);
+		print_id_item(lines, log, id);
+		print_id_item(path, log, id);
+	}
+
+	for_each_info(id, info, conf) {
+		if (!info)
+			continue;
+		print_id_item(name, info, id);
+		print_id_item(channel, info, id);
+		print_id_item(interval, info, id);
+		print_id_item(trigger->name, info, id);
+		for_each_log_collect(id2, log, info) {
+			if (!log)
+				continue;
+			LOGD("%-8s(%d): %-15s(%c):(%s)\n",
+			     "info", id, "log", 'x', log->name);
+		}
+	}
+
+	for_each_crash(id, crash, conf) {
+		if (!crash)
+			continue;
+
+		print_id_item(name, crash, id);
+		memset(buf, 0, sizeof(*buf));
+		LOGD("%-8s(%d): properties: %s, %s\n", "crash", id,
+		     is_root_crash(crash) ? "root" : "non-root",
+		     is_leaf_crash(crash) ? "leaf" : "non-leaf");
+		sprintf(buf + strlen(buf), "%-8s(%d): children: ", "crash", id);
+		for_crash_children(crash_tmp, crash)
+			sprintf(buf + strlen(buf), "%s ", crash_tmp->name);
+		LOGD("%s\n", buf);
+		print_id_item(trigger->name, crash, id);
+		print_id_item(channel, crash, id);
+		print_id_item(interval, crash, id);
+		for (i = 0; i < CONTENT_MAX; i++)
+			if (crash->content[i])
+				print_2id_item(content, crash, id, i);
+
+		for (i = 0; i < EXPRESSION_MAX; i++)
+			for (j = 0; j < CONTENT_MAX; j++)
+				if (crash->mightcontent[i][j])
+					LOGD("%-8s(%d): %-15s(%d,%d):(%s)\n",
+					     "crash", id, "mightcontent", i, j,
+					     crash->mightcontent[i][j]);
+
+		for (i = 0; i < DATA_MAX; i++)
+			if (crash->data[i])
+				print_2id_item(data, crash, id, i);
+	}
+}
+
+static int get_prop_int(xmlNodePtr cur, char *key)
+{
+	xmlChar *prop;
+	int ret = 0;
+
+	prop = xmlGetProp(cur, (const xmlChar *)key);
+	if (prop) {
+		ret = atoi((char *)prop);
+		xmlFree(prop);
+	}
+	return ret;
+
+}
+
+static int get_id_index(xmlNodePtr cur)
+{
+	return get_prop_int(cur, "id") - 1;
+}
+
+#define load_cur_content(cur, type, mem) \
+(__extension__ \
+({ \
+		xmlChar *load##mem; \
+		load##mem = xmlNodeGetContent(cur); \
+		if (load##mem) \
+			type->mem = (char *)load##mem; \
+}) \
+)
+
+#define load_cur_content_with_id(cur, type, mem) \
+(__extension__ \
+({ \
+		xmlChar *load##mem; \
+		load##mem = xmlNodeGetContent(cur); \
+		if (load##mem) \
+			type->mem[get_id_index(cur)] = (char *)load##mem; \
+}) \
+)
+
+#define load_trigger(cur, event) \
+(__extension__ \
+({ \
+		xmlChar *content = xmlNodeGetContent(cur); \
+		event->trigger = get_trigger_by_name((char *)content); \
+		xmlFree(content); \
+}) \
+)
+
+struct crash_t *get_crash_by_wd(int wd)
+{
+	int id;
+	struct crash_t *crash;
+
+	for_each_crash(id, crash, conf) {
+		if (!crash)
+			continue;
+
+		if (crash->wd == wd)
+			return crash;
+	}
+	return NULL;
+}
+
+struct uptime_t *get_uptime_by_wd(int wd)
+{
+	int id;
+	struct uptime_t  *ut;
+	struct sender_t *sender;
+
+	for_each_sender(id, sender, conf) {
+		if (!sender)
+			continue;
+
+		ut = sender->uptime;
+		if (ut->wd == wd)
+			return ut;
+	}
+
+	return NULL;
+}
+
+enum event_type_t get_conf_by_wd(int wd, void **private)
+{
+	void *conf;
+
+	conf = (void *)get_uptime_by_wd(wd);
+	if (conf) {
+		*private = conf;
+		return UPTIME;
+	}
+
+	conf = (void *)get_crash_by_wd(wd);
+	if (conf) {
+		*private = conf;
+		return CRASH;
+	}
+
+	return UNKNOWN;
+
+}
+
+int sender_id(struct sender_t *s)
+{
+	int id;
+	struct sender_t *sender;
+
+	for_each_sender(id, sender, conf) {
+		if (!sender)
+			continue;
+
+		if (s == sender)
+			return id;
+	}
+
+	return -1;
+}
+
+struct sender_t *get_sender_by_name(char *name)
+{
+	int id;
+	struct sender_t *sender;
+
+	for_each_sender(id, sender, conf) {
+		if (!sender)
+			continue;
+
+		if (strcmp(name, sender->name) == 0)
+			return sender;
+	}
+	return NULL;
+}
+
+struct trigger_t *get_trigger_by_name(char *name)
+{
+	int id;
+	struct trigger_t *trigger;
+
+	for_each_trigger(id, trigger, conf) {
+		if (!trigger)
+			continue;
+		if (strcmp(name, trigger->name) == 0)
+			return trigger;
+	}
+	return NULL;
+}
+
+struct log_t *get_log_by_name(char *name)
+{
+	int id;
+	struct log_t *log;
+
+	for_each_log(id, log, conf) {
+		if (!log)
+			continue;
+		if (strcmp(name, log->name) == 0)
+			return log;
+	}
+	return NULL;
+}
+
+int crash_depth(struct crash_t *tcrash)
+{
+	int id;
+	int level = 0;
+	struct crash_t *crash;
+
+	for_each_crash(id, crash, conf) {
+		if (!crash)
+			continue;
+
+		if (crash->channel == tcrash->channel &&
+		    crash->trigger == tcrash->trigger &&
+		    crash->level > level)
+			level = crash->level;
+	}
+	level = level - tcrash->level;
+	return level;
+}
+
+static int is_enable(xmlNodePtr cur)
+{
+	xmlChar *prop;
+	int ret = 0;
+
+	prop = xmlGetProp(cur, (const xmlChar *)"enable");
+	if (prop) {
+		ret = !xmlStrcmp((const xmlChar *)"true", prop);
+		xmlFree(prop);
+	}
+
+	return ret;
+}
+
+static int get_inherit_index(xmlNodePtr cur)
+{
+	return get_prop_int(cur, "inherit") - 1;
+}
+
+#define name_is(cur, key) \
+		(xmlStrcmp(cur->name, (const xmlChar *)key) == 0)
+
+static void parse_info(xmlNodePtr cur, struct info_t *info)
+{
+	int id;
+	xmlChar *content;
+
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, info, name);
+		else if (name_is(cur, "trigger"))
+			load_trigger(cur, info);
+		else if (name_is(cur, "channel"))
+			load_cur_content(cur, info, channel);
+		else if (name_is(cur, "log")) {
+			id = get_id_index(cur);
+			content = xmlNodeGetContent(cur);
+			info->log[id] = get_log_by_name((char *)content);
+			xmlFree(content);
+		}
+
+		cur = cur->next;
+	}
+}
+
+static void parse_log(xmlNodePtr cur, struct log_t *log)
+{
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, log, name);
+		else if (name_is(cur, "type"))
+			load_cur_content(cur, log, type);
+		else if (name_is(cur, "path"))
+			load_cur_content(cur, log, path);
+		else if (name_is(cur, "lines"))
+			load_cur_content(cur, log, lines);
+
+		cur = cur->next;
+	}
+}
+
+static void parse_crash(xmlNodePtr cur, struct crash_t *crash)
+{
+
+	int id;
+	int expression;
+	xmlChar *content;
+
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, crash, name);
+		else if (name_is(cur, "trigger"))
+			load_trigger(cur, crash);
+		else if (name_is(cur, "channel"))
+			load_cur_content(cur, crash, channel);
+		else if (name_is(cur, "content"))
+			load_cur_content_with_id(cur, crash, content);
+		else if (name_is(cur, "log")) {
+			id = get_id_index(cur);
+			content = xmlNodeGetContent(cur);
+			crash->log[id] = get_log_by_name((char *)content);
+			xmlFree(content);
+		} else if (name_is(cur, "data"))
+			load_cur_content_with_id(cur, crash, data);
+		else if (name_is(cur, "mightcontent")) {
+			id = get_id_index(cur);
+			expression = get_prop_int(cur, "expression") - 1;
+			content = xmlNodeGetContent(cur);
+			crash->mightcontent[expression][id] = (char *)content;
+		}
+		cur = cur->next;
+	}
+
+
+}
+
+static void parse_crashes(xmlNodePtr crashes)
+{
+	int id;
+	xmlNodePtr cur;
+	struct crash_t *crash;
+
+	cur = crashes->xmlChildrenNode;
+
+	while (cur) {
+		if (is_enable(cur)) {
+			crash = malloc(sizeof(*crash));
+			id = get_inherit_index(cur);
+			if (id >= 0) {
+				memcpy(crash, conf.crash[id], sizeof(*crash));
+				crash->parents = conf.crash[id];
+				crash->level++;
+				TAILQ_INSERT_TAIL(&crash->parents->children,
+						crash, entries);
+			} else {
+				memset(crash, 0, sizeof(*crash));
+			}
+			TAILQ_INIT(&crash->children);
+			id = get_id_index(cur);
+			conf.crash[id] = crash;
+			parse_crash(cur, crash);
+		}
+		cur = cur->next;
+	}
+}
+
+static void parse_vm(xmlNodePtr cur, struct vm_t *vm)
+{
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, vm, name);
+		else if (name_is(cur, "channel"))
+			load_cur_content(cur, vm, channel);
+		else if (name_is(cur, "interval"))
+			load_cur_content(cur, vm, interval);
+		else if (name_is(cur, "syncevent"))
+			load_cur_content_with_id(cur, vm, syncevent);
+
+		cur = cur->next;
+	}
+}
+
+static void parse_uptime(xmlNodePtr cur, struct sender_t *sender)
+{
+	struct uptime_t *uptime;
+	int ret;
+
+	uptime = malloc(sizeof(*uptime));
+	memset(uptime, 0, sizeof(*uptime));
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, uptime, name);
+		else if (name_is(cur, "frequency"))
+			load_cur_content(cur, uptime, frequency);
+		else if (name_is(cur, "eventhours"))
+			load_cur_content(cur, uptime, eventhours);
+
+		cur = cur->next;
+	}
+	ret = asprintf(&uptime->path, "%s/uptime", sender->outdir);
+	if (ret < 0) {
+		LOGE("build string failed\n");
+		exit(EXIT_FAILURE);
+	}
+	sender->uptime = uptime;
+}
+
+static void parse_trigger(xmlNodePtr cur, struct trigger_t *trigger)
+{
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, trigger, name);
+		else if (name_is(cur, "type"))
+			load_cur_content(cur, trigger, type);
+		else if (name_is(cur, "path"))
+			load_cur_content(cur, trigger, path);
+
+		cur = cur->next;
+	}
+}
+
+static void parse_sender(xmlNodePtr cur, struct sender_t *sender)
+{
+	cur = cur->xmlChildrenNode;
+	while (cur) {
+		if (name_is(cur, "name"))
+			load_cur_content(cur, sender, name);
+		else if (name_is(cur, "outdir"))
+			load_cur_content(cur, sender, outdir);
+		else if (name_is(cur, "maxcrashdirs"))
+			load_cur_content(cur, sender, maxcrashdirs);
+		else if (name_is(cur, "maxlines"))
+			load_cur_content(cur, sender, maxlines);
+		else if (name_is(cur, "spacequota"))
+			load_cur_content(cur, sender, spacequota);
+		else if (name_is(cur, "uptime"))
+			parse_uptime(cur, sender);
+
+		cur = cur->next;
+	}
+}
+
+#define common_parse(node, mem) \
+(__extension__ \
+({ \
+	int id; \
+	struct mem##_t *mem; \
+\
+	node = node->xmlChildrenNode; \
+\
+	while (node) { \
+		if (is_enable(node)) { \
+			mem = malloc(sizeof(*mem)); \
+			memset(mem, 0, sizeof(*mem)); \
+			id = get_id_index(node); \
+			conf.mem[id] = mem; \
+			parse_##mem(node, mem); \
+		} \
+		node = node->next; \
+	} \
+}) \
+)
+
+int load_conf(char *path)
+{
+	xmlDocPtr doc;
+	xmlNodePtr cur, node;
+
+	doc = xmlParseFile(path);
+	if (!doc) {
+		LOGI("Parsing conf (%s) fail\n", path);
+		goto error;
+	}
+
+	cur = xmlDocGetRootElement(doc);
+	if (!cur) {
+		LOGE("Get root (%s) fail\n", path);
+		goto free;
+	}
+
+	cur = cur->xmlChildrenNode;
+	while ((node = cur)) {
+		if (name_is(node, "senders"))
+			common_parse(node, sender);
+		else if (name_is(node, "triggers"))
+			common_parse(node, trigger);
+		else if (name_is(node, "vms"))
+			common_parse(node, vm);
+		else if (name_is(node, "crashes"))
+			parse_crashes(node);
+		else if (name_is(node, "logs"))
+			common_parse(node, log);
+		else if (name_is(node, "infos"))
+			common_parse(node, info);
+
+		cur = cur->next;
+	}
+	print();
+	xmlFreeDoc(doc);
 	return 0;
+free:
+	xmlFreeDoc(doc);
+error:
+	return -1;
 }

--- a/tools/acrn-crashlog/acrnprobe/main.c
+++ b/tools/acrn-crashlog/acrnprobe/main.c
@@ -20,10 +20,10 @@
 #include "event_handler.h"
 #include "channels.h"
 #include "log_sys.h"
+#include "version.h"
 
 #define CONFIG_INSTALL "/usr/share/defaults/telemetrics/acrnprobe.xml"
 #define CONFIG_CUSTOMIZE "/etc/acrnprobe.xml"
-#define VERSION "1.0"
 
 void usage(void)
 {
@@ -79,7 +79,10 @@ int main(int argc, char *argv[])
 			usage();
 			return 0;
 		case 'V':
-			printf(VERSION "\n");
+			printf("version is %d.%d-%s, build by %s@%s\n",
+				AP_MAJOR_VERSION, AP_MINOR_VERSION,
+				AP_BUILD_VERSION, AP_BUILD_USER,
+				AP_BUILD_TIME);
 			return 0;
 		case '?':
 			usage();

--- a/tools/acrn-crashlog/acrnprobe/main.c
+++ b/tools/acrn-crashlog/acrnprobe/main.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+int main(void)
+{
+	//TO BE DONE
+	//This empty function is to satisfy the dependency of Makefile.
+	//This is the entry of acrnprobe, the implementation will be filled
+	//by following patches.
+	return 0;
+}

--- a/tools/acrn-crashlog/acrnprobe/main.c
+++ b/tools/acrn-crashlog/acrnprobe/main.c
@@ -3,11 +3,121 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-int main(void)
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <malloc.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <getopt.h>
+#include <string.h>
+#include <limits.h>
+#include "load_conf.h"
+#include "fsutils.h"
+#include "crash_reclassify.h"
+#include "sender.h"
+#include "event_queue.h"
+#include "event_handler.h"
+#include "channels.h"
+#include "log_sys.h"
+
+#define CONFIG_INSTALL "/usr/share/defaults/telemetrics/acrnprobe.xml"
+#define CONFIG_CUSTOMIZE "/etc/acrnprobe.xml"
+#define VERSION "1.0"
+
+void usage(void)
 {
-	//TO BE DONE
-	//This empty function is to satisfy the dependency of Makefile.
-	//This is the entry of acrnprobe, the implementation will be filled
-	//by following patches.
+	printf("[Usage]\n");
+	printf("\tacrnprobe -c [configuration file path] [-hV]\n");
+	printf("[Options]\n");
+	printf("\t-c,  --config         Configuration file\n");
+	printf("\t-h,  --help           print the help message\n");
+	printf("\t-V,  --version        Print the program version\n");
+}
+
+static void uptime(struct sender_t *sender)
+{
+	int fd;
+	int frequency;
+	struct uptime_t *uptime;
+
+	uptime = sender->uptime;
+	frequency = atoi(uptime->frequency);
+	sleep(frequency);
+	fd = open(uptime->path, O_RDWR | O_CREAT, 0666);
+	if (fd < 0)
+		LOGE("open uptime_file with (%d, %s) failed, error (%s)\n",
+				atoi(uptime->frequency), uptime->path,
+				strerror(errno));
+	else
+		close(fd);
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	int id;
+	int op;
+	struct sender_t *sender;
+	char cfg[PATH_MAX] = {0};
+	char *config_path[2] = {CONFIG_CUSTOMIZE,
+				CONFIG_INSTALL};
+	struct option opts[] = {
+		{ "config", required_argument, NULL, 'c' },
+		{ "help", no_argument, NULL, 'h' },
+		{ "version", no_argument, NULL, 'V' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	while ((op = getopt_long(argc, argv, "c:hV", opts,
+				 NULL)) != -1) {
+		switch (op) {
+		case 'c':
+			strcpy(cfg, optarg);
+			break;
+		case 'h':
+			usage();
+			return 0;
+		case 'V':
+			printf(VERSION "\n");
+			return 0;
+		case '?':
+			usage();
+			return -1;
+		}
+	}
+
+	if (!cfg[0]) {
+		if (file_exists(config_path[0]))
+			strcpy(cfg, config_path[0]);
+		else
+			strcpy(cfg, config_path[1]);
+	}
+
+	ret = load_conf(cfg);
+	if (ret)
+		return -1;
+
+	init_crash_reclassify();
+	ret = init_sender();
+	if (ret)
+		return -1;
+
+	init_event_queue();
+	ret = init_event_handler();
+	if (ret)
+		return -1;
+
+	ret = init_channels();
+	if (ret)
+		return -1;
+
+	while (1) {
+		for_each_sender(id, sender, conf) {
+			if (!sender)
+				continue;
+			uptime(sender);
+		}
+	}
 	return 0;
 }

--- a/tools/acrn-crashlog/acrnprobe/probeutils.c
+++ b/tools/acrn-crashlog/acrnprobe/probeutils.c
@@ -1,0 +1,439 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <malloc.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <openssl/sha.h>
+#include <time.h>
+#include "property.h"
+#include "fsutils.h"
+#include "history.h"
+#include "load_conf.h"
+#include "log_sys.h"
+#include "probeutils.h"
+
+#define CRASH_CURRENT_LOG       "currentcrashlog"
+#define STATS_CURRENT_LOG       "currentstatslog"
+#define VM_CURRENT_LOG		"currentvmlog"
+
+unsigned long long get_uptime(void)
+{
+	 static long long time_ns = -1;
+	 struct timespec ts;
+
+	 clock_gettime(CLOCK_BOOTTIME, &ts);
+	 time_ns = (long long)ts.tv_sec * 1000000000LL +
+		   (long long)ts.tv_nsec;
+
+	return time_ns;
+}
+
+int get_uptime_string(char newuptime[24], int *hours)
+{
+	long long tm;
+	int seconds, minutes;
+
+	tm = get_uptime();
+
+	/* seconds */
+	*hours = (int)(tm / 1000000000LL);
+	seconds = *hours % 60;
+
+	/* minutes */
+	*hours /= 60;
+	minutes = *hours % 60;
+
+	/* hours */
+	*hours /= 60;
+
+	return snprintf(newuptime, 24, "%04d:%02d:%02d", *hours,
+			minutes, seconds);
+}
+
+int get_current_time_long(char buf[32])
+{
+	time_t t;
+	struct tm *time_val;
+
+	time(&t);
+	time_val = localtime((const time_t *)&t);
+
+	strftime(buf, 32, "%Y-%m-%d/%H:%M:%S  ", time_val);
+
+	return 0;
+}
+
+/**
+ * Compute a key with 20 characters
+ *
+ * @param[out] key The result key.
+ * @param seed1 Seed.
+ * @param seed2 Seed.
+ *
+ * @return 0 if successful, or -1 if not.
+ */
+static int compute_key(char *key, char *seed1, char *seed2)
+{
+	static SHA_CTX *sha;
+	char buf[256] = {'\0',};
+	long long time_ns = 0;
+	char *tmp_key = key;
+	unsigned char results[SHA_DIGEST_LENGTH];
+	int i;
+	int ret;
+
+	if (sha == NULL) {
+		sha = (SHA_CTX *)malloc(sizeof(SHA_CTX));
+		if (sha == NULL) {
+			LOGE("cannot create SHA_CTX memory...\n");
+			return -1;
+		}
+
+		ret = SHA1_Init(sha);
+		if (ret != 1) {
+			LOGE("SHA1_Init failed, error (%s)\n",
+			     strerror(errno));
+			free(sha);
+			sha = NULL;
+			return -1;
+		}
+	}
+
+	if (!key || !seed1 || !seed2)
+		return -1;
+
+	time_ns = get_uptime();
+	snprintf(buf, 256, "%s%s%s%s%lld", gbuildversion, guuid, seed1,
+		 seed2, time_ns);
+
+	ret = SHA1_Update(sha, (unsigned char *)buf, strlen(buf));
+	if (ret != 1) {
+		LOGE("SHA1_Update failed, error (%s)\n",
+		     strerror(errno));
+		return -1;
+	}
+
+	ret = SHA1_Final(results, sha);
+	if (ret != 1) {
+		LOGE("SHA1_Final failed, error (%s)\n",
+		     strerror(errno));
+		return -1;
+	}
+
+	for (i = 0; i < SHA_DIGEST_LENGTH / 2; i++) {
+		sprintf(tmp_key, "%02x", results[i]);
+		tmp_key += 2;
+	}
+	*tmp_key = 0;
+
+	return 0;
+}
+
+/**
+ * Compute a key with 32 characters
+ *
+ * @param[out] key The result key.
+ * @param seed Seed.
+ *
+ * @return 0 if successful, or -1 if not.
+ */
+static int compute_key256(char *key, char *seed)
+{
+	static SHA256_CTX *sha;
+	char buf[256] = {'\0',};
+	long long time_ns = 0;
+	char *tmp_key = key;
+	unsigned char results[SHA256_DIGEST_LENGTH];
+	int i;
+	int ret;
+
+	if (sha == NULL) {
+		sha = (SHA256_CTX *)malloc(sizeof(SHA256_CTX));
+		if (sha == NULL) {
+			LOGE("cannot create SHA256_CTX memory...\n");
+			return -1;
+		}
+
+		ret = SHA256_Init(sha);
+		if (ret != 1) {
+			LOGE("SHA256_Init failed, error (%s)\n",
+			     strerror(errno));
+			free(sha);
+			sha = NULL;
+			return -1;
+		}
+	}
+
+	if (!key || !seed)
+		return -1;
+
+	time_ns = get_uptime();
+	snprintf(buf, 256, "%s%s%s%lld", gbuildversion, guuid, seed,
+		 time_ns);
+
+	ret = SHA256_Update(sha, (unsigned char *)buf, strlen(buf));
+	if (ret != 1) {
+		LOGE("SHA256_Update failed, error (%s)\n",
+		     strerror(errno));
+		return -1;
+	}
+
+	ret = SHA256_Final(results, sha);
+	if (ret != 1) {
+		LOGE("SHA256_Final failed, error (%s)\n",
+		     strerror(errno));
+		return -1;
+	}
+
+	for (i = 0; i < SHA256_DIGEST_LENGTH / 2; i++) {
+		sprintf(tmp_key, "%02x", results[i]);
+		tmp_key += 2;
+	}
+	*tmp_key = 0;
+
+	return 0;
+}
+
+/**
+ * Generate a event id with 20 characters
+ *
+ * @param seed1 Seed.
+ * @param seed2 Seed.
+ *
+ * @return a pointer to result haskkey if successful, or NULL if not.
+ */
+char *generate_event_id(char *seed1, char *seed2)
+{
+	int ret;
+	char *key = (char *)malloc(SHA_DIGEST_LENGTH + 1);
+
+	if (!key)
+		return NULL;
+
+	ret = compute_key(key, seed1, seed2);
+	if (ret < 0) {
+		LOGE("compute_key error\n");
+		free(key);
+		key = NULL;
+	}
+
+	return key;
+}
+
+/**
+ * Generate a event id with 32 characters
+ *
+ * @param seed Seed.
+ *
+ * @return a pointer to result haskkey if successful, or NULL if not.
+ */
+char *generate_eventid256(char *seed)
+{
+	int ret;
+	char *key = (char *)malloc(SHA256_DIGEST_LENGTH + 1);
+
+	if (!key)
+		return NULL;
+
+	ret = compute_key256(key, seed);
+	if (ret < 0) {
+		LOGE("compute_key256 error\n");
+		free(key);
+		key = NULL;
+	}
+
+	return key;
+}
+
+/**
+ * Reserve a dir for log storage.
+ *
+ * @param mode Mode for log storage.
+ * @param[out] dir Prefix of dir path reserved.
+ * @param[out] index of dir reserved.
+ *
+ * @return 0 if successful, or -1 if not.
+ */
+static int reserve_log_folder(enum e_dir_mode mode, char *dir,
+				unsigned int *current)
+{
+	char path[512];
+	int res;
+	struct sender_t *crashlog;
+	char *outdir;
+	unsigned int maxdirs;
+
+	crashlog = get_sender_by_name("crashlog");
+	outdir = crashlog->outdir;
+
+	switch (mode) {
+	case MODE_CRASH:
+		sprintf(path, "%s/%s", outdir, CRASH_CURRENT_LOG);
+		sprintf(dir, "%s/%s", outdir, "crashlog");
+		break;
+	case MODE_STATS:
+		sprintf(path, "%s/%s", outdir, STATS_CURRENT_LOG);
+		sprintf(dir, "%s/%s", outdir, "stats");
+		break;
+	case MODE_VMEVENT:
+		sprintf(path, "%s/%s", outdir, VM_CURRENT_LOG);
+		sprintf(dir, "%s/%s", outdir, "vmevent");
+		break;
+	default:
+		LOGW("Invalid mode %d\n", mode);
+		return -1;
+	}
+
+	/* Read current value in file */
+	res = file_read_int(path, current);
+	if (res < 0)
+		return res;
+
+	maxdirs = atoi(crashlog->maxcrashdirs);
+	/* Open file in read/write mode to update the new current */
+	res = file_update_int(path, *current, maxdirs);
+	if (res < 0)
+		return res;
+
+
+	return 0;
+}
+
+#define strcat_fmt(buf, fmt, ...) \
+(__extension__ \
+({ \
+	char __buf[1024] = {'\0',}; \
+	snprintf(__buf, sizeof(__buf), fmt, ##__VA_ARGS__); \
+	strcat(buf, __buf); \
+}) \
+)
+
+/**
+ * Create a crashfile with given params.
+ *
+ * @param dir Where to generate crashfile.
+ * @param event Event name.
+ * @param hashkey Event id.
+ * @param type Subtype of this event.
+ * @param data* String obtained by get_data.
+ */
+void generate_crashfile(char *dir, char *event, char *hashkey,
+			char *type, char *data0,
+			char *data1, char *data2)
+{
+	char *buf;
+	char *path;
+	char datetime[32];
+	char uptime[32];
+	int hours;
+	int ret;
+	const int fmtsize = 128;
+	int filesize;
+
+	get_current_time_long(datetime);
+	get_uptime_string(uptime, &hours);
+
+	filesize = fmtsize + strlen(event) +
+		   strlen(hashkey) + strlen(guuid) +
+		   strlen(datetime) + strlen(uptime) +
+		   strlen(gbuildversion) + strlen(type);
+	if (data0)
+		filesize += strlen(data0);
+	if (data1)
+		filesize += strlen(data1);
+	if (data2)
+		filesize += strlen(data2);
+
+	buf = malloc(filesize);
+	if (buf == NULL) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	memset(buf, 0, filesize);
+	strcat_fmt(buf, "EVENT=%s\n", event);
+	strcat_fmt(buf, "ID=%s\n", hashkey);
+	strcat_fmt(buf, "DEVICEID=%s\n", guuid);
+	strcat_fmt(buf, "DATE=%s\n", datetime);
+	strcat_fmt(buf, "UPTIME=%s\n", uptime);
+	strcat_fmt(buf, "BUILD=%s\n", gbuildversion);
+	strcat_fmt(buf, "TYPE=%s\n", type);
+	if (data0)
+		strcat_fmt(buf, "DATA0=%s\n", data0);
+	if (data1)
+		strcat_fmt(buf, "DATA1=%s\n", data1);
+	if (data2)
+		strcat_fmt(buf, "DATA2=%s\n", data2);
+	strcat(buf, "_END\n");
+
+	ret = asprintf(&path, "%s/%s", dir, "crashfile");
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		free(buf);
+		return;
+	}
+
+	ret = overwrite_file(path, buf);
+	if (ret)
+		LOGE("new crashfile (%s) fail, error (%s)\n", path,
+		     strerror(errno));
+
+	free(buf);
+	free(path);
+}
+
+/**
+ * Create a dir for log storage.
+ *
+ * @param mode Mode for log storage.
+ * @param hashkey Event id.
+ *
+ * @return a pointer to generated path if successful, or NULL if not.
+ */
+char *generate_log_dir(enum e_dir_mode mode, char *hashkey)
+{
+	char path[PATH_MAX];
+	char dir[PATH_MAX];
+	unsigned int current;
+	int ret;
+
+	ret = reserve_log_folder(mode, dir, &current);
+	if (ret)
+		return NULL;
+
+	snprintf(path, sizeof(path), "%s%d_", dir, current);
+	strncat(path, hashkey,
+		(strlen(path) + strlen(hashkey) >= sizeof(path)) ?
+		(sizeof(path) - strlen(path)) : strlen(hashkey));
+
+	ret = mkdir(path, 0777);
+	if (ret == -1) {
+		LOGE("Cannot create dir %s\n", path);
+		hist_raise_infoerror("DIR CREATE");
+		return NULL;
+	}
+
+	return strdup(path);
+}

--- a/tools/acrn-crashlog/acrnprobe/property.c
+++ b/tools/acrn-crashlog/acrnprobe/property.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <openssl/sha.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "property.h"
+#include "log_sys.h"
+#include "fsutils.h"
+
+#define MACHINE_ID		"/etc/machine-id"
+#define OS_VERSION		"/usr/lib/os-release"
+#define OS_VERSION_KEY		"VERSION_ID="
+#define DEVICE_ID_UNKNOWN	"UnknownId"
+#define LOG_UUID		"uuid.txt"
+#define LOG_BUILDID		"buildid.txt"
+
+static void get_device_id(struct sender_t *sender)
+{
+	int ret;
+	char *loguuid;
+
+
+	ret = asprintf(&loguuid, "%s/%s", sender->outdir, LOG_UUID);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	ret = file_read_string(MACHINE_ID, guuid, VERSION_SIZE);
+	if (ret <= 0)
+		LOGE("Could not get mmc id: %d (%s)\n",
+		     ret, strerror(-ret));
+	else
+		goto write;
+
+	LOGE("Could not find DeviceId, set it to '%s'\n",
+	     DEVICE_ID_UNKNOWN);
+	strncpy(guuid, DEVICE_ID_UNKNOWN, strlen(DEVICE_ID_UNKNOWN));
+
+write:
+	overwrite_file(loguuid, guuid);
+	free(loguuid);
+}
+
+static int get_buildversion(struct sender_t *sender)
+{
+	int ret;
+	char lastbuild[VERSION_SIZE];
+	char *logbuildid;
+	char *currentbuild = gbuildversion;
+
+	ret = file_read_key_value(OS_VERSION, OS_VERSION_KEY, gbuildversion);
+	if (ret <= 0) {
+		LOGE("failed to get version from %s, error (%s)\n",
+		     OS_VERSION, strerror(-ret));
+		return ret;
+	}
+
+	ret = asprintf(&logbuildid, "%s/%s", sender->outdir, LOG_BUILDID);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return ret;
+	}
+
+	ret = file_read_string(logbuildid, lastbuild, VERSION_SIZE);
+	if (ret == -ENOENT ||
+	    (ret > 0 && strcmp(currentbuild, lastbuild))) {
+		/* build changed or file not found, overwrite it */
+		ret = overwrite_file(logbuildid, gbuildversion);
+		if (ret) {
+			LOGE("create (%s) failed, error (%s)\n", logbuildid,
+			     strerror(-ret));
+			goto free;
+		}
+
+		sender->sw_updated = 1;
+		ret = 0;
+	} else if (ret <= 0) {
+		LOGE("Cannot read %s, error (%s)\n",
+		     logbuildid, strerror(errno));
+	} else {
+		/* buildid is the same */
+		sender->sw_updated = 0;
+		ret = 0;
+	}
+free:
+	free(logbuildid);
+	return ret;
+}
+
+int swupdated(struct sender_t *sender)
+{
+	return sender->sw_updated;
+}
+
+int init_properties(struct sender_t *sender)
+{
+	int ret;
+
+	ret = get_buildversion(sender);
+	if (ret) {
+		LOGE("init properties failed\n");
+		return ret;
+	}
+	get_device_id(sender);
+	return 0;
+}

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -3,9 +3,650 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+#include <limits.h>
+#include "fsutils.h"
+#include "strutils.h"
+#include "cmdutils.h"
+#include "load_conf.h"
 #include "sender.h"
+#include "probeutils.h"
+#include "android_events.h"
+#include "history.h"
+#include "property.h"
+#include "startupreason.h"
+#include "log_sys.h"
+
+/* get_log_file_* only used to copy regular file which can be mmaped */
+static void get_log_file_complete(struct log_t *log, char *desdir)
+{
+	char *des;
+	char *name;
+	int ret;
+
+	name = log->name;
+
+	ret = asprintf(&des, "%s/%s", desdir, name);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	ret = do_copy_tail(log->path, des, 0);
+	if (ret < 0) {
+		LOGE("copy (%s) failed\n, error (%s)\n", log->path,
+		     strerror(errno));
+	}
+
+	free(des);
+}
+
+static void get_log_file_tail(struct log_t *log, char *desdir)
+{
+	char *des;
+	char timebuf[24];
+	char *name;
+	char *start;
+	int lines;
+	int hours;
+	int start_line;
+	int file_lines;
+	struct mm_file_t *mfile;
+	int ret;
+
+	lines = atoi(log->lines);
+	name = log->name;
+	get_uptime_string(timebuf, &hours);
+	ret = asprintf(&des, "%s/%s_%s", desdir, name, timebuf);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	mfile = mmap_file(log->path);
+	if (!mfile) {
+		LOGE("mmap (%s) failed, error (%s)\n", log->path,
+		     strerror(errno));
+		goto free;
+	}
+	file_lines = mm_count_lines(mfile);
+	if (file_lines <= 0) {
+		LOGW("get lines (%s, %d) failed\n", mfile->path, file_lines);
+		goto unmap;
+	}
+	start_line = MAX(file_lines - lines, 0) + 1;
+	start = mm_get_line(mfile, start_line);
+	ret = overwrite_file(des, start);
+	if (ret < 0) {
+		LOGE("create file with (%s, %p) failed, error (%s)\n",
+		     des, start, strerror(errno));
+		goto unmap;
+	}
+
+unmap:
+	unmap_file(mfile);
+free:
+	free(des);
+}
+
+static void get_log_file(struct log_t *log, char *desdir)
+{
+	int lines;
+
+	if (log->lines == NULL) {
+		get_log_file_complete(log, desdir);
+		return;
+	}
+
+	lines = atoi(log->lines);
+	if (lines > 0)
+		get_log_file_tail(log, desdir);
+	else
+		get_log_file_complete(log, desdir);
+}
+
+static void get_log_rotation(struct log_t *log, char *desdir)
+{
+	char *suffix;
+	char *prefix;
+	char *dir;
+	char *p;
+	int count;
+	char *files[512];
+	int number;
+	int target_num = -1;
+	char *target_file = NULL;
+	char *name;
+	int i;
+
+	dir = strdup(log->path);
+	if (!dir) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	/* dir      prefix    suffix
+	 * |          |          |
+	 * /tmp/hvlog/hvlog_cur.[biggest]
+	 */
+	p = strrchr(dir, '/');
+	if (p == NULL) {
+		LOGE("invalid path (%s) in log (%s), ", dir, log->name);
+		LOGE("file_rotation only support absolute path\n");
+		goto free_dir;
+	} else {
+		prefix = p + 1;
+		*p = 0;
+	}
+
+	p = strstr(prefix, ".[");
+	if (p == NULL) {
+		LOGE("invalid path (%s) in log (%s)\n", log->path, log->name);
+		goto free_dir;
+	} else {
+		suffix = p + 2;
+		*p = 0;
+	}
+
+	p = suffix + strlen(suffix) - 1;
+	if (*p == ']') {
+		*p = 0;
+	} else {
+		LOGE("invalid path (%s) in log (%s)\n", log->path, log->name);
+		goto free_dir;
+	}
+
+
+	struct log_t toget;
+
+	memcpy(&toget, log, sizeof(toget));
+	count = lsdir(dir, files, ARRAY_SIZE(files));
+	if (count > 2) {
+		for (i = 0; i < count; i++) {
+			name = strrchr(files[i], '/') + 1;
+			if (!strstr(name, prefix))
+				continue;
+
+			number = atoi(strrchr(name, '.') + 1);
+			if (!strncmp(suffix, "biggest", 7)) {
+				if (target_num == -1 ||
+				    number > target_num){
+					target_file = files[i];
+					target_num = number;
+				}
+			} else if (!strncmp(suffix, "smallest", 8)) {
+				if (target_num == -1 ||
+				    number < target_num) {
+					target_file = files[i];
+					target_num = number;
+				}
+			} else if (!strncmp(suffix, "all", 3)) {
+				toget.path = files[i];
+				toget.name = name;
+				get_log_file(&toget, desdir);
+			}
+		}
+	} else if (count < 0) {
+		LOGE("lsdir (%s) failed, error (%s)\n", dir,
+		     strerror(-count));
+		goto free;
+	}
+
+	if (!strncmp(suffix, "all", 3))
+		goto free;
+
+	if (target_file) {
+		toget.path = target_file;
+		get_log_file(&toget, desdir);
+	} else {
+		LOGW("no logs found for (%s)\n", log->name);
+		goto free;
+	}
+
+free:
+	while (count > 0)
+		free(files[--count]);
+free_dir:
+	free(dir);
+}
+
+static void get_log_node(struct log_t *log, char *desdir)
+{
+	char *des;
+	char *name;
+	int ret;
+
+	name = log->name;
+	ret = asprintf(&des, "%s/%s", desdir, name);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	ret = do_copy_eof(log->path, des);
+	if (ret < 0) {
+		LOGE("copy (%s) failed, error (%s)\n", log->path,
+		     strerror(errno));
+		goto free;
+	}
+
+free:
+	free(des);
+}
+
+static void out_via_fork(struct log_t *log, char *desdir)
+{
+	char *des;
+	int ret;
+
+	ret = asprintf(&des, "%s/%s", desdir, log->name);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	exec_out2file(des, log->path);
+	free(des);
+}
+
+static void get_log_cmd(struct log_t *log, char *desdir)
+{
+	out_via_fork(log, desdir);
+}
+
+static void crashlog_get_log(struct log_t *log, void *data)
+{
+
+	struct sender_t *crashlog;
+	unsigned long long start, end;
+	int spent;
+	int quota;
+	char *desdir = (char *)data;
+
+	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return;
+
+	quota = atoi(crashlog->spacequota);
+	if (!space_available(crashlog->outdir, quota)) {
+		hist_raise_infoerror("SPACE_FULL");
+		return;
+	}
+
+	start = get_uptime();
+	if (!strcmp("file", log->type))
+		get_log_file(log, desdir);
+	else if (!strcmp("node", log->type))
+		get_log_node(log, desdir);
+	else if (!strcmp("cmd", log->type))
+		get_log_cmd(log, desdir);
+	else if (!strcmp("file_rotation", log->type))
+		get_log_rotation(log, desdir);
+	end = get_uptime();
+
+	spent = (int)((end - start) / 1000000000LL);
+	if (spent < 5)
+		LOGD("get (%s) spend %ds\n", log->name, spent);
+	else
+		LOGW("get (%s) spend %ds\n", log->name, spent);
+}
+
+static void crashlog_send_crash(struct event_t *e)
+{
+	struct crash_t *crash;
+	struct log_t *log;
+	struct sender_t *crashlog;
+	char *key  = NULL;
+	char *trfile = NULL;
+	char *data0;
+	char *data1;
+	char *data2;
+	int id;
+	int ret;
+	int quota;
+	struct crash_t *rcrash = (struct crash_t *)e->private;
+
+	if (!strcmp(rcrash->trigger->type, "file"))
+		ret = asprintf(&trfile, "%s", rcrash->trigger->path);
+	else if (!strcmp(rcrash->trigger->type, "dir"))
+		ret = asprintf(&trfile, "%s/%s", rcrash->trigger->path,
+			       e->path);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	crash = rcrash->reclassify(rcrash, trfile, &data0, &data1, &data2);
+	if (crash == NULL) {
+		LOGE("reclassify crash (%s) failed\n", rcrash->name);
+		goto free_trfile;
+	}
+
+	/* change the class for other senders */
+	e->private = (void *)crash;
+	key = generate_event_id("CRASH", crash->name);
+	if (key == NULL) {
+		LOGE("generate event id failed, error (%s)\n",
+		     strerror(errno));
+		goto free_data;
+	}
+
+	if (to_collect_logs(crash) ||
+	    !strcmp(e->channel, "inotify")) {
+		e->dir = generate_log_dir(MODE_CRASH, key);
+		if (e->dir == NULL) {
+			LOGE("generate crashlog dir failed\n");
+			goto free_key;
+		}
+
+		generate_crashfile(e->dir, "CRASH", key,
+				   crash->name,
+				   data0, data1, data2);
+		for_each_log_collect(id, log, crash) {
+			if (!log)
+				continue;
+
+			log->get(log, (void *)e->dir);
+		}
+
+	}
+
+	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		goto free_key;
+
+	quota = atoi(crashlog->spacequota);
+	if (!space_available(crashlog->outdir, quota)) {
+		hist_raise_infoerror("SPACE_FULL");
+	} else if (!strcmp(e->channel, "inotify")) {
+		/* get the trigger file */
+		char *src;
+		char *des;
+
+		ret = asprintf(&des, "%s/%s", e->dir, e->path);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			goto free_key;
+		}
+
+		ret = asprintf(&src, "%s/%s", crash->trigger->path, e->path);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			free(des);
+			goto free_key;
+		}
+
+		ret = do_copy_tail(src, des, 0);
+		if (ret < 0) {
+			LOGE("copy (%s) to (%s) failed, error (%s)\n",
+			     src, des, strerror(-ret));
+		}
+
+		free(src);
+		free(des);
+	}
+
+	hist_raise_event("CRASH", crash->name, e->dir, "", key);
+
+free_key:
+	free(key);
+free_data:
+	free(data0);
+	free(data1);
+	free(data2);
+free_trfile:
+	free(trfile);
+}
+
+static void crashlog_send_info(struct event_t *e)
+{
+	int id;
+	struct info_t *info = (struct info_t *)e->private;
+	struct log_t *log;
+	char *key = generate_event_id("INFO", info->name);
+
+	if (key == NULL) {
+		LOGE("generate event id failed, error (%s)\n",
+		     strerror(errno));
+		return;
+	}
+
+	if (to_collect_logs(info)) {
+		e->dir = generate_log_dir(MODE_STATS, key);
+		if (e->dir == NULL) {
+			LOGE("generate crashlog dir failed\n");
+			goto free_key;
+		}
+
+		for_each_log_collect(id, log, info) {
+			if (!log)
+				continue;
+			log->get(log, (void *)e->dir);
+		}
+	}
+
+	hist_raise_event("INFO", info->name, e->dir, "", key);
+
+free_key:
+	free(key);
+}
+
+static void crashlog_send_uptime(void)
+{
+	hist_raise_uptime(NULL);
+}
+
+static void crashlog_send_reboot(void)
+{
+	char reason[MAXLINESIZE];
+	char *key;
+
+	if (swupdated(get_sender_by_name("crashlog"))) {
+		key = generate_event_id("INFO", "SWUPDATE");
+		if (key == NULL) {
+			LOGE("generate event id failed, error (%s)\n",
+			     strerror(errno));
+			return;
+		}
+
+		hist_raise_event("INFO", "SWUPDATE", NULL, "", key);
+		free(key);
+	}
+
+	read_startupreason(reason);
+	key = generate_event_id("REBOOT", reason);
+	if (key == NULL) {
+		LOGE("generate event id failed, error (%s)\n",
+		     strerror(errno));
+		return;
+	}
+
+	hist_raise_event("REBOOT", reason, NULL, "", key);
+	free(key);
+}
+
+static void crashlog_new_vmevent(char *line_to_sync, struct vm_t *vm)
+{
+	struct sender_t *crashlog;
+	char event[96] = {0};
+	char longtime[96] = {0};
+	char type[96] = {0};
+	char rest[PATH_MAX] = {0};
+	char vmkey[SHA_DIGEST_LENGTH + 1] = {0};
+	char *vmlogpath = NULL;
+	char *key;
+	char *log;
+	char *cmd;
+	int ret;
+	int quota;
+	char *dir;
+
+	/* VM events in history_event like this:
+	 *
+	 * "CRASH   xxxxxxxxxxxxxxxxxxxx  2017-11-11/03:12:59  JAVACRASH
+	 * /data/logs/crashlog0_xxxxxxxxxxxxxxxxxxxx"
+	 * "REBOOT  xxxxxxxxxxxxxxxxxxxx  2011-11-11/11:20:51  POWER-ON
+	 * 0000:00:00"
+	 */
+	char *vm_format = "%[^ ]%*[ ]%[^ ]%*[ ]%[^ ]%*[ ]%[^ ]%*[ ]%[^\n]%*c";
+
+	ret = sscanf(line_to_sync, vm_format, event, vmkey, longtime,
+		     type, rest);
+	if (ret != 5) {
+		LOGE("get a invalied line from (%s), skip\n", vm->name);
+		return;
+	}
+
+	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return;
+
+	quota = atoi(crashlog->spacequota);
+	if (!space_available(crashlog->outdir, quota)) {
+		hist_raise_infoerror("SPACE_FULL");
+		return;
+	}
+
+	key = generate_event_id("SOS", vmkey);
+	if (key == NULL) {
+		LOGE("generate event id failed, error (%s)\n",
+		     strerror(errno));
+		return;
+	}
+
+	dir = generate_log_dir(MODE_VMEVENT, key);
+	if (dir == NULL) {
+		LOGE("generate crashlog dir failed\n");
+		goto free_key;
+	}
+
+	/* if line contains log, we need dump each file in the logdir
+	 */
+	log = strstr(rest, "/logs/");
+	if (log) {
+		ret = asprintf(&vmlogpath, "%s", log + 1);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			goto free_dir;
+		}
+
+		ret = asprintf(&cmd, "rdump %s %s", vmlogpath, dir);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			free(vmlogpath);
+			goto free_dir;
+		}
+
+		debugfs_cmd(loop_dev, cmd, NULL);
+
+		free(cmd);
+		free(vmlogpath);
+	}
+
+	generate_crashfile(dir, event, key, type, vm->name,
+			   vmkey, NULL);
+	hist_raise_event(vm->name, type, dir, "", key);
+
+free_dir:
+	free(dir);
+free_key:
+	free(key);
+}
+
+static void crashlog_send(struct event_t *e)
+{
+
+	int id;
+	struct log_t *log;
+
+	for_each_log(id, log, conf) {
+		if (!log)
+			continue;
+
+		log->get = crashlog_get_log;
+	}
+	switch (e->event_type) {
+	case CRASH:
+		crashlog_send_crash(e);
+		break;
+	case INFO:
+		crashlog_send_info(e);
+		break;
+	case UPTIME:
+		crashlog_send_uptime();
+		break;
+	case REBOOT:
+		crashlog_send_reboot();
+		break;
+	case VM:
+		refresh_vm_history(get_sender_by_name("crashlog"),
+				   crashlog_new_vmevent);
+		break;
+	default:
+		LOGE("unsupoorted event type %d\n", e->event_type);
+	}
+}
 
 int init_sender(void)
 {
+	int ret;
+	int id;
+	int fd;
+	struct sender_t *sender;
+	struct uptime_t *uptime;
+
+	for_each_sender(id, sender, conf) {
+		if (!sender)
+			continue;
+
+		ret = asprintf(&sender->log_vmrecordid, "%s/vmrecordid",
+			       sender->outdir);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			return -ENOMEM;
+		}
+
+		if (!directory_exists(sender->outdir))
+			if (mkdir_p(sender->outdir) < 0) {
+				LOGE("mkdir (%s) failed, error (%s)\n",
+				     sender->outdir, strerror(errno));
+				return -errno;
+			}
+
+		ret = init_properties(sender);
+		if (ret) {
+			LOGE("init sender failed\n");
+			exit(-1);
+		}
+
+		/* touch uptime file, to add inotify */
+		uptime = sender->uptime;
+		if (uptime) {
+			fd = open(uptime->path, O_RDWR | O_CREAT, 0666);
+			if (fd < 0) {
+				LOGE("open failed with (%s, %d), error (%s)\n",
+				     uptime->path, atoi(uptime->frequency),
+				     strerror(errno));
+				return -errno;
+			}
+			close(fd);
+		}
+
+		if (!strncmp(sender->name, "crashlog",
+			     strlen(sender->name))) {
+			sender->send = crashlog_send;
+			ret = prepare_history();
+			if (ret)
+				return -1;
+		}
+	}
+
 	return 0;
 }

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -23,6 +23,17 @@
 #include "property.h"
 #include "startupreason.h"
 #include "log_sys.h"
+#include "telemetry.h"
+
+#define CRASH_SEVERITY 4
+#define INFO_SEVERITY 2
+
+struct telemd_data_t {
+	char *class;
+	char *srcdir;
+	char *eventid;
+	uint32_t severity;
+};
 
 /* get_log_file_* only used to copy regular file which can be mmaped */
 static void get_log_file_complete(struct log_t *log, char *desdir)
@@ -261,6 +272,124 @@ static void get_log_cmd(struct log_t *log, char *desdir)
 	out_via_fork(log, desdir);
 }
 
+static bool telemd_send_data(char *payload, char *eventid, uint32_t severity,
+				char *class)
+{
+	int res;
+	struct telem_ref *handle = NULL;
+	const uint32_t version = 1;
+
+	res = tm_create_record(&handle, severity, class, version);
+	if (res < 0) {
+		LOGE("failed to create record: %s\n",
+		     strerror(-res));
+		goto fail;
+	}
+
+	/* eventid with 32 character length */
+	if (eventid) {
+		res = tm_set_event_id(handle, eventid);
+		if (res < 0) {
+			LOGE("failed to set eventid: %s\n", strerror(-res));
+			goto free;
+		}
+	}
+
+	res = tm_set_payload(handle, payload);
+	if (res < 0) {
+		LOGE("failed to set payload: %s\n", strerror(-res));
+		goto free;
+	}
+
+	res = tm_send_record(handle);
+	if (res < 0) {
+		LOGE("failed to send record: %s\n", strerror(-res));
+		goto free;
+	}
+
+	tm_free_record(handle);
+	return true;
+
+free:
+	tm_free_record(handle);
+fail:
+	return false;
+}
+
+static void telemd_get_log(struct log_t *log, void *data)
+{
+	struct telemd_data_t *d = (struct telemd_data_t *)data;
+	char name[NAME_MAX];
+	char *path, *msg;
+	int ret;
+
+	if (d->srcdir == NULL)
+		goto send_nologs;
+
+	ret = dir_contains(d->srcdir, log->name, 0, name);
+	if (ret == 1) {
+		ret = asprintf(&path, "%s/%s", d->srcdir, name);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			return;
+		}
+		telemd_send_data(path, d->eventid, d->severity, d->class);
+		free(path);
+	} else if (ret == 0) {
+		LOGE("dir (%s) does not contains (%s)\n", d->srcdir,
+		     log->name);
+		goto send_nologs;
+	} else if (ret > 1) {
+		/* got multiple files */
+		int i;
+		int count;
+		char *name;
+		char *files[512];
+
+		if (!strstr(log->path, ".[all]")) {
+			LOGE("dir (%s) contains (%d) files (%s)\n",
+			     d->srcdir, ret, log->name);
+			goto send_nologs;
+		}
+
+		count = lsdir(d->srcdir, files, ARRAY_SIZE(files));
+		if (count > 2) {
+			for (i = 0; i < count; i++) {
+				name = strrchr(files[i], '/') + 1;
+				if (!strstr(name, log->name))
+					continue;
+
+				telemd_send_data(files[i], d->eventid,
+						 d->severity, d->class);
+			}
+		} else if (count < 0) {
+			LOGE("lsdir (%s) failed, error (%s)\n", d->srcdir,
+			     strerror(-count));
+			goto send_nologs;
+		}
+
+		while (count > 0)
+			free(files[--count]);
+	} else {
+		LOGE("search (%s) in dir (%s) failed, error (%s)\n", log->name,
+		     d->srcdir, strerror(-ret));
+		goto send_nologs;
+	}
+
+	return;
+
+send_nologs:
+	ret = asprintf(&msg, "no log generated on %s, check probe's log.",
+		       log->name);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	telemd_send_data(msg, d->eventid, d->severity, d->class);
+	free(msg);
+}
+
 static void crashlog_get_log(struct log_t *log, void *data)
 {
 
@@ -296,6 +425,354 @@ static void crashlog_get_log(struct log_t *log, void *data)
 		LOGD("get (%s) spend %ds\n", log->name, spent);
 	else
 		LOGW("get (%s) spend %ds\n", log->name, spent);
+}
+
+static void telemd_send_crash(struct event_t *e)
+{
+	struct crash_t *crash;
+	struct log_t *log;
+	char *class;
+	char *eventid;
+	int id;
+	int ret;
+	struct telemd_data_t data = {
+		.srcdir = e->dir,
+		.severity = CRASH_SEVERITY,
+	};
+
+	crash = (struct crash_t *)e->private;
+
+	ret = asprintf(&class, "clearlinux/crash/%s", crash->name);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	eventid = generate_eventid256(class);
+	if (eventid == NULL) {
+		LOGE("generate eventid failed, error (%s)\n", strerror(errno));
+		goto free_class;
+	}
+
+	data.class = class;
+	data.eventid = eventid;
+
+	for_each_log_collect(id, log, crash) {
+		if (!log)
+			continue;
+
+		log->get(log, (void *)&data);
+	}
+	if (!strcmp(e->channel, "inotify")) {
+		char *des;
+		/* get the trigger file */
+		ret = asprintf(&des, "%s/%s", e->dir, e->path);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			goto free_eventid;
+		}
+
+		if (!file_exists(des)) {
+			/* find the original path */
+			char *ori;
+
+			ret = asprintf(&ori, "%s/%s", crash->trigger->path,
+				       e->path);
+			if (ret < 0) {
+				LOGE("compute string failed, out of memory\n");
+				free(des);
+				goto free_eventid;
+			}
+
+			LOGW("(%s) unavailable, try the original path (%s)\n",
+			     des, ori);
+			if (!file_exists(ori)) {
+				LOGE("original path (%s) is unavailable\n",
+				     ori);
+			} else {
+				telemd_send_data(ori, eventid, CRASH_SEVERITY,
+						 class);
+			}
+
+			free(ori);
+		} else {
+			telemd_send_data(des, eventid, CRASH_SEVERITY, class);
+		}
+
+		free(des);
+	}
+free_eventid:
+	free(eventid);
+free_class:
+	free(class);
+}
+
+static void telemd_send_info(struct event_t *e)
+{
+	struct info_t *info;
+	struct log_t *log;
+	char *class;
+	char *eventid;
+	int id;
+	int ret;
+	struct telemd_data_t data = {
+		.srcdir = e->dir,
+		.severity = INFO_SEVERITY,
+	};
+
+	info = (struct info_t *)e->private;
+	ret = asprintf(&class, "clearlinux/info/%s", info->name);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	eventid = generate_eventid256(class);
+	if (eventid == NULL) {
+		LOGE("generate eventid failed, error (%s)\n", strerror(errno));
+		goto free_class;
+	}
+
+	data.class = class;
+	data.eventid = eventid;
+
+	for_each_log_collect(id, log, info) {
+		if (!log)
+			continue;
+
+		log->get(log, (void *)&data);
+	}
+
+	free(eventid);
+
+free_class:
+	free(class);
+}
+
+static void telemd_send_uptime(void)
+{
+	struct sender_t *telemd;
+	struct uptime_t *uptime;
+	char *class;
+	char boot_time[24];
+	int hours;
+	int ret;
+	static int uptime_hours;
+	static int loop_uptime_event = 1;
+
+	ret = get_uptime_string(boot_time, &hours);
+	if (ret < 0) {
+		LOGE("cannot get uptime - %s\n", strerror(-ret));
+		return;
+	}
+	telemd = get_sender_by_name("telemd");
+	uptime = telemd->uptime;
+	uptime_hours = atoi(uptime->eventhours);
+	if (hours / uptime_hours >= loop_uptime_event) {
+		char *content;
+
+		loop_uptime_event = (hours / uptime_hours) + 1;
+		ret = asprintf(&class, "clearlinux/uptime/%s", boot_time);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			return;
+		}
+
+		ret = asprintf(&content, "system boot time: %s", boot_time);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			free(class);
+			return;
+		}
+
+		telemd_send_data(content, NULL, INFO_SEVERITY, class);
+		free(class);
+		free(content);
+	}
+}
+
+static void telemd_send_reboot(void)
+{
+	struct sender_t *telemd;
+	char *class;
+	char reason[MAXLINESIZE];
+	int ret;
+
+	telemd = get_sender_by_name("telemd");
+	if (swupdated(telemd)) {
+		char *content;
+
+		ret = asprintf(&class, "clearlinux/swupdate/-");
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			return;
+		}
+
+		ret = asprintf(&content, "system update to: %s",
+			 gbuildversion);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			free(class);
+			return;
+		}
+
+		telemd_send_data(content, NULL, INFO_SEVERITY, class);
+		free(class);
+		free(content);
+	}
+
+	read_startupreason(reason);
+	ret = asprintf(&class, "clearlinux/reboot/%s", reason);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return;
+	}
+
+	telemd_send_data("reboot", NULL, INFO_SEVERITY, class);
+	free(class);
+}
+
+static void telemd_new_vmevent(char *line_to_sync, struct vm_t *vm)
+{
+	char event[96] = {0};
+	char longtime[96] = {0};
+	char type[96] = {0};
+	char rest[PATH_MAX] = {0};
+	char *vmlogpath[1] = {0};
+	char vmkey[SHA_DIGEST_LENGTH + 1] = {0};
+	char *log;
+	char *class;
+	char *eventid;
+	char *files[512];
+	int count;
+	int i;
+	uint32_t severity;
+	int ret;
+
+	/* VM events in history_event look like this:
+	 *
+	 * "CRASH   xxxxxxxxxxxxxxxxxxxx  2017-11-11/03:12:59  JAVACRASH
+	 * /data/logs/crashlog0_xxxxxxxxxxxxxxxxxxxx"
+	 * "REBOOT  xxxxxxxxxxxxxxxxxxxx  2011-11-11/11:20:51  POWER-ON
+	 * 0000:00:00"
+	 */
+	char *vm_format = "%[^ ]%*[ ]%[^ ]%*[ ]%[^ ]%*[ ]%[^ ]%*[ ]%[^\n]%*c";
+
+	ret = sscanf(line_to_sync, vm_format, event, vmkey, longtime,
+		     type, rest);
+	if (ret != 5) {
+		LOGE("get a invalied line from (%s), skip\n", vm->name);
+		return;
+	}
+
+	if (strcmp(event, "CRASH") == 0)
+		severity = CRASH_SEVERITY;
+	else
+		severity = INFO_SEVERITY;
+
+	/* if line contains log, fill vmlogpath */
+	log = strstr(rest, "/logs/");
+	if (log) {
+		struct sender_t *crashlog = get_sender_by_name("crashlog");
+
+		ret = find_file(crashlog->outdir, log + strlen("/logs/"),
+				2, vmlogpath, 1);
+		if (ret < 0) {
+			LOGE("find (%s) in (%s) failed, strerror (%s)\n",
+			     log + strlen("/logs/"), crashlog->outdir,
+			     strerror(-ret));
+			return;
+		}
+	}
+
+	ret = asprintf(&class, "%s/%s/%s", vm->name, event, type);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		goto free_vmlogpath;
+	}
+
+	eventid = generate_eventid256(class);
+	if (eventid == NULL) {
+		LOGE("generate eventid failed, error (%s)\n", strerror(errno));
+		goto free_class;
+	}
+
+	if (vmlogpath[0] == 0) {
+		telemd_send_data("no logs", eventid, severity, class);
+		goto free;
+	}
+
+	/* send logs */
+	count = lsdir(vmlogpath[0], files, ARRAY_SIZE(files));
+	if (count > 2) {
+		for (i = 0; i < count; i++) {
+			if (!strstr(files[i], "/.") &&
+			    !strstr(files[i], "/.."))
+				telemd_send_data(files[i], eventid, severity,
+						 class);
+		}
+	} else if (count == 2) {
+		char *content;
+
+		ret = asprintf(&content, "no logs under (%s)", vmlogpath[0]);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			goto free;
+		}
+
+		telemd_send_data(content, eventid, severity, class);
+		free(content);
+	} else if (count < 0) {
+		LOGE("lsdir (%s) failed, error (%s)\n", vmlogpath[0],
+		     strerror(-count));
+	} else {
+		LOGE("get (%d) files in (%s) ???\n", count, vmlogpath[0]);
+	}
+
+	while (count > 0)
+		free(files[--count]);
+
+free:
+	free(eventid);
+free_class:
+	free(class);
+free_vmlogpath:
+	if (vmlogpath[0])
+		free(vmlogpath[0]);
+}
+
+static void telemd_send(struct event_t *e)
+{
+	int id;
+	struct log_t *log;
+
+	for_each_log(id, log, conf) {
+		if (!log)
+			continue;
+
+		log->get = telemd_get_log;
+	}
+
+	switch (e->event_type) {
+	case CRASH:
+		telemd_send_crash(e);
+		break;
+	case INFO:
+		telemd_send_info(e);
+		break;
+	case UPTIME:
+		telemd_send_uptime();
+		break;
+	case REBOOT:
+		telemd_send_reboot();
+		break;
+	case VM:
+		refresh_vm_history(get_sender_by_name("telemd"),
+				   telemd_new_vmevent);
+		break;
+	default:
+		LOGE("unsupoorted event type %d\n", e->event_type);
+	}
 }
 
 static void crashlog_send_crash(struct event_t *e)
@@ -645,6 +1122,9 @@ int init_sender(void)
 			ret = prepare_history();
 			if (ret)
 				return -1;
+		} else if (!strncmp(sender->name, "telemd",
+				    strlen(sender->name))) {
+			sender->send = telemd_send;
 		}
 	}
 

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "sender.h"
+
+int init_sender(void)
+{
+	return 0;
+}

--- a/tools/acrn-crashlog/acrnprobe/startupreason.c
+++ b/tools/acrn-crashlog/acrnprobe/startupreason.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <malloc.h>
+#include "fsutils.h"
+#include "startupreason.h"
+#include "log_sys.h"
+
+#define MAX_KERNEL_COMMAND_LINE_SIZE 4096
+#define CURRENT_KERNEL_CMDLINE "/proc/cmdline"
+
+static int get_cmdline_bootreason(char *bootreason)
+{
+	int res, len = MAX_KERNEL_COMMAND_LINE_SIZE;
+	char *p, *p1, *p2;
+	char *cmdline;
+	const char key[] = "bootreason=";
+
+	cmdline = malloc(len);
+	if (!cmdline) {
+		LOGE("failed to allocate memory to read %s\n",
+		     CURRENT_KERNEL_CMDLINE);
+		return -1;
+	}
+	res = file_read_string(CURRENT_KERNEL_CMDLINE, cmdline, len);
+	if (res <= 0) {
+		LOGE("failed to read file %s - %s\n",
+		     CURRENT_KERNEL_CMDLINE, strerror(errno));
+		free(cmdline);
+		return -1;
+	}
+
+	p = strstr(cmdline, key);
+	if (!p) {
+		free(cmdline);
+		return 0;
+	}
+	p += strlen(key);
+	p1 = strstr(p, " ");
+	p2 = strstr(p, "\n");
+	if (p2 && !p1)
+		*p2 = '\0';
+	else if (p2 && p2 < p1)
+		*p2 = '\0';
+	else if (p1)
+		*p1 = '\0';
+
+	strncpy(bootreason, p, strlen(p) + 1);
+	free(cmdline);
+	return strlen(bootreason);
+}
+
+static void get_default_bootreason(char *bootreason)
+{
+	int ret;
+	unsigned int i;
+	char bootreason_prop[MAX_KERNEL_COMMAND_LINE_SIZE];
+
+	ret = get_cmdline_bootreason(bootreason_prop);
+	if (ret <= 0)
+		return;
+
+	for (i = 0; i < strlen(bootreason_prop); i++)
+		bootreason[i] = toupper(bootreason_prop[i]);
+	bootreason[i] = '\0';
+
+}
+
+void read_startupreason(char *startupreason)
+{
+	strcpy(startupreason, "UNKNOWN");
+	get_default_bootreason(startupreason);
+}

--- a/tools/acrn-crashlog/common/Makefile
+++ b/tools/acrn-crashlog/common/Makefile
@@ -1,0 +1,20 @@
+objects = log_sys.o
+
+all: check_obj $(objects)
+check_obj:
+	@if [ ! -d $(BUILDDIR)/common/obj ]; then \
+		mkdir -p $(BUILDDIR)/common/obj/; \
+	fi
+
+$(objects):%.o:%.c
+	$(CC) -c $(CFLAGS) $(INCLUDE) $< -o $(BUILDDIR)/common/obj/$@
+
+.PHONY:clean
+clean:
+	@echo "Clean objects and binaries"
+	@if [ -d $(BUILDDIR)/common/obj ]; then \
+		find $(BUILDDIR)/common/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \
+	fi
+	@if [ -d $(BUILDDIR)/common/obj ]; then \
+		$(RM) -r $(BUILDDIR)/common/obj ; \
+	fi

--- a/tools/acrn-crashlog/common/Makefile
+++ b/tools/acrn-crashlog/common/Makefile
@@ -1,4 +1,5 @@
-objects = log_sys.o
+objects = log_sys.o \
+	  strutils.o
 
 all: check_obj $(objects)
 check_obj:

--- a/tools/acrn-crashlog/common/Makefile
+++ b/tools/acrn-crashlog/common/Makefile
@@ -1,5 +1,6 @@
 objects = log_sys.o \
-	  strutils.o
+	  strutils.o \
+	  cmdutils.o
 
 all: check_obj $(objects)
 check_obj:

--- a/tools/acrn-crashlog/common/Makefile
+++ b/tools/acrn-crashlog/common/Makefile
@@ -1,6 +1,7 @@
 objects = log_sys.o \
 	  strutils.o \
-	  cmdutils.o
+	  cmdutils.o \
+	  fsutils.o
 
 all: check_obj $(objects)
 check_obj:

--- a/tools/acrn-crashlog/common/cmdutils.c
+++ b/tools/acrn-crashlog/common/cmdutils.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <unistd.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <malloc.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <sys/wait.h>
+#include "cmdutils.h"
+#include "strutils.h"
+#include "log_sys.h"
+
+/**
+ * Execute a command described in an array of pointers to null-terminated
+ * strings, and redirect the output to specified file. The file will be
+ * created/truncated if it exists/non-exists. This function will be blocked
+ * until the child process exits.
+ *
+ * @param argv An array of pointers to null-terminated strings that
+ *		represent the argument list available to the new program.
+ *		The array of pointers must be terminated by a null pointer.
+ * @param outfile File to record command's output, NULL means that this
+ *		  function doesn't handle command's output.
+ *
+ * @return If a child process could not be created, or its status could not be
+ *	   retrieved, or it was killed/stopped by signal, the return value
+ *	   is -1.
+ *	   If all system calls succeed, then the return value is the
+ *	   termination status of the child process used to execute command.
+ */
+int execv_out2file(char *argv[], char *outfile)
+{
+	pid_t pid;
+
+	pid = fork();
+	if (pid < 0) {
+		LOGE("fork error (%s)\n", strerror(errno));
+		return -1;
+	}
+
+	if (pid == 0) {
+		int res;
+		int fd;
+
+		if (outfile) {
+			fd = open(outfile, O_WRONLY | O_CREAT | O_TRUNC, 0664);
+			if (fd < 0) {
+				LOGE("open error (%s)\n", strerror(errno));
+				return -1;
+			}
+			res = dup2(fd, STDOUT_FILENO);
+			if (res < 0) {
+				close(fd);
+				LOGE("dup2 error (%s)\n", strerror(errno));
+				return -1;
+			}
+		}
+
+		res = execvp(argv[0], argv);
+		if (res == -1) {
+			LOGE("execvp (%s) failed, error (%s)\n", argv[0],
+			     strerror(errno));
+			return -1;
+		}
+	} else {
+		pid_t res;
+		int status;
+		int exit_status;
+
+		res = waitpid(pid, &status, 0);
+		if (res == -1) {
+			LOGE("waitpid failed, error (%s)\n", strerror(errno));
+			return res;
+		}
+
+		if (WIFEXITED(status)) {
+			exit_status = WEXITSTATUS(status);
+			if (!exit_status)
+				LOGI("%s exited, status=0\n", argv[0]);
+			else
+				LOGE("%s exited, status=%d\n", argv[0],
+				     exit_status);
+			return exit_status;
+		} else if (WIFSIGNALED(status)) {
+			LOGE("%s killed by signal %d\n", argv[0],
+			     WTERMSIG(status));
+		} else if (WIFSTOPPED(status)) {
+			LOGE("%s stopped by signal %d\n", argv[0],
+			     WSTOPSIG(status));
+		}
+
+	}
+
+	return -1;
+}
+
+int debugfs_cmd(char *loop_dev, char *cmd, char *outfile)
+{
+	char *argv[5] = {"debugfs", "-R", NULL, NULL, 0};
+
+	argv[2] = cmd;
+	argv[3] = loop_dev;
+	return  execv_out2file(argv, outfile);
+}
+
+/**
+ * Execute a command described in format string, and redirect the output
+ * to specified file. The file will be created/truncated if it
+ * exists/non-exists. This function will be blocked until the child process
+ * exits.
+ *
+ * @param outfile File to record command's output, NULL means that this
+ *		  function doesn't handle command's output.
+ * @param fmt Format string of command.
+ *
+ * @return If a child process could not be created, or its status could not be
+ *	   retrieved, or it was killed/stopped by signal, the return value
+ *	   is -1.
+ *	   If all system calls succeed, then the return value is the
+ *	   termination status of the child process used to execute command.
+ */
+int exec_out2file(char *outfile, char *fmt, ...)
+{
+	va_list args;
+	char *cmd;
+	char *start;
+	char *p;
+	int ret;
+	int argc;
+	char **argv;
+	int i = 0;
+
+	va_start(args, fmt);
+	ret = vasprintf(&cmd, fmt, args);
+	va_end(args);
+	if (ret < 0)
+		return ret;
+
+	strtrim(cmd);
+	argc = strcnt(cmd, ' ') + 1;
+
+	argv = (char **)calloc(argc + 1, sizeof(char *));
+	if (argv == NULL) {
+		free(cmd);
+		LOGE("calloc failed, error (%s)\n", strerror(errno));
+		return -1;
+	}
+
+	/* string to argv[] */
+	start = cmd;
+	argv[i++] = start;
+	while (start && (p = strchr(start, ' '))) {
+		argv[i++] = p + 1;
+		*p = 0;
+		if (*(p + 1) != '"')
+			start = p + 1;
+		else
+			start = strchr(p + 2, '"');
+	}
+
+	ret = execv_out2file(argv, outfile);
+
+	free(argv);
+	free(cmd);
+
+	return ret;
+}
+
+/**
+ * Execute a command described in format string, and redirect the output
+ * to memory. The memory is allocated by this function and needs to be freed
+ * after return.
+ *
+ * @param fmt Format string of command.
+ *
+ * @return a pointer to command's output if successful, or NULL if not.
+ */
+char *exec_out2mem(char *fmt, ...)
+{
+	va_list args;
+	char *cmd;
+	FILE *pp;
+	char *out = NULL;
+	char *new;
+	char tmp[1024];
+	int memsize = 0;
+	int newlen = 0;
+	int len = 0;
+	int ret;
+
+	va_start(args, fmt);
+	ret = vasprintf(&cmd, fmt, args);
+	va_end(args);
+	if (ret < 0)
+		return NULL;
+
+	pp = popen(cmd, "r");
+	if (!pp)
+		goto free_cmd;
+
+	while (fgets(tmp, 1024, pp) != NULL) {
+		newlen += strlen(tmp);
+		if (newlen + 1 > memsize) {
+			memsize += 1024;
+			new = realloc(out, memsize);
+			if (!new) {
+				if (out)
+					free(out);
+				goto end;
+			} else {
+				out = new;
+			}
+		}
+		memcpy(out + len, tmp, strlen(tmp) + 1);
+
+		len = newlen;
+	}
+
+end:
+	pclose(pp);
+free_cmd:
+	free(cmd);
+
+	return out;
+}

--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -1,0 +1,626 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <malloc.h>
+#include <sys/sendfile.h>
+#include <sys/vfs.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+#include "fsutils.h"
+#include "cmdutils.h"
+#include "strutils.h"
+#include "log_sys.h"
+
+#define MAX_SEARCH_DIRS 4096
+
+/**
+ * Help function to do fclose. In some cases (full partition),
+ * file closure could fail, so get error message here.
+ *
+ * @param filename Path of file.
+ * @param fp FILE pointer open by fopen.
+ *
+ * @return Upon successful completion 0 is returned.
+ *         Otherwise, EOF is returned and errno is set to indicate the error.
+ */
+static int close_file(const char *filename, FILE *fp)
+{
+	int res;
+
+	errno = 0;
+	res = fclose(fp);
+	if (res != 0) {
+		/* File closure could fail in some cases (full partition) */
+		LOGE("fclose on %s failed - error is %s\n",
+			filename, strerror(errno));
+	}
+
+	return res;
+}
+
+/**
+ * Create the dir, make parent directories as needed.
+ *
+ * @param path Target dir to make.
+ * @param mode Dir mode.
+ *
+ * @return 0 if successful, or a negative errno-style value if not.
+ */
+int mkdir_p(char *path)
+{
+	if (!path)
+		return -EINVAL;
+
+	/* return 0 if path exists */
+	return exec_out2file(NULL, "mkdir -p %s", path);
+}
+
+/**
+ * Count file lines.
+ * This function defaults to all text files ending with \n.
+ *
+ * @param mfile File opened by mmap_file.
+ *
+ * @return file lines if successful, or a negative errno-style value if not.
+ */
+int mm_count_lines(struct mm_file_t *mfile)
+{
+	if (!mfile || mfile->size < 0)
+		return -EINVAL;
+
+	return strcnt(mfile->begin, '\n');
+}
+
+/**
+ * Get the head of specified line from area mapped by mmap_file.
+ *
+ * @param mfile File opened by mmap_file.
+ * @param line Target line.
+ *
+ * @return a pointer to the head of line if successful, or NULL if not.
+ */
+char *mm_get_line(struct mm_file_t *mfile, int line)
+{
+	char *begin = mfile->begin;
+	char *next;
+	int i;
+	char *ret;
+
+	if (line <= 0 || line > mm_count_lines(mfile))
+		return NULL;
+	else if (line == 1)
+		ret = begin;
+	else {
+		next = begin;
+		for (i = 2; i <= line; i++)
+			next = strchr(next, '\n') + 1;
+		ret = next;
+	}
+
+	return ret;
+}
+
+/**
+ * Replace the content in specified line.
+ *
+ * @param mfile File opened by mmap_file.
+ * @param replace New content.
+ * @param line Target line.
+ *
+ * @return 0 lines if successful, or a negative errno-style value if not.
+ */
+int mm_replace_str_line(struct mm_file_t *mfile, char *replace, int line)
+{
+	int len, rmlen, offset;
+	int res;
+	int move_size = 0;
+	char *add_buf;
+	char *to_replace;
+	int oldsize = mfile->size;
+	int fd = mfile->fd;
+
+	len = strlen(replace);
+	add_buf = malloc(len + 1);
+	if (add_buf == NULL)
+		return -ENOMEM;
+
+	if (replace[len - 1] != '\n')
+		sprintf(add_buf, "%s\n", replace);
+	else
+		sprintf(add_buf, "%s", replace);
+	len = strlen(add_buf);
+
+	to_replace = mm_get_line(mfile, line);
+	if (to_replace == NULL) {
+		LOGE("no line %d in %s\n", line, mfile->path);
+		free(add_buf);
+		return -EINVAL;
+	}
+	rmlen = strlinelen(to_replace);
+	offset = len - rmlen;
+
+	/* resize the file and add/del the space to add_buf */
+	if (offset > 0) {
+		int newsize = oldsize + offset;
+
+		/* shift right */
+		res = ftruncate(fd, newsize);
+		if (res < 0) {
+			free(add_buf);
+			return -errno;
+		}
+
+		if ((newsize / PAGE_SIZE) > (oldsize / PAGE_SIZE)) {
+			/* the size crosses PAGESIZE, we need remap */
+			char *old_addr;
+
+			old_addr = mfile->begin;
+			mfile->begin = mremap(old_addr, oldsize, newsize,
+					      MREMAP_MAYMOVE);
+			if (mfile->begin == MAP_FAILED) {
+				free(add_buf);
+				return -errno;
+			}
+			/* refresh the target place after remap */
+			to_replace = mm_get_line(mfile, line);
+		}
+
+		mfile->size = newsize;
+		move_size = mfile->begin + oldsize - to_replace;
+		memmove(to_replace + offset, to_replace, move_size);
+	} else if (offset < 0) {
+		/* shift left the next line */
+		move_size = mfile->begin + oldsize - to_replace - rmlen;
+		memmove(to_replace + len, to_replace + rmlen, move_size);
+		mfile->size += offset;
+
+		res = ftruncate(fd, oldsize + offset);
+		if (res < 0) {
+			free(add_buf);
+			return -errno;
+		}
+	} /* else we don't need shift */
+
+	memcpy(to_replace, add_buf, len);
+	free(add_buf);
+
+	return 0;
+}
+
+/**
+ * Open a file and map it. The structure mm_file_t maintains the major
+ * infomations of this file.
+ *
+ * @param path File path need mmap.
+ *
+ * @return a pointer to the structure mm_file_t if succuessful, or NULL if not.
+ */
+struct mm_file_t *mmap_file(const char *path)
+{
+	struct mm_file_t *mfile;
+	int size;
+
+	mfile = malloc(sizeof(struct mm_file_t));
+	if (!mfile) {
+		LOGE("malloc failed, error (%s)\n", strerror(errno));
+		return NULL;
+	}
+
+	mfile->path = strdup(path);
+	if (!mfile->path) {
+		LOGE("strdup failed, error (%s)\n", strerror(errno));
+		goto free_mfile;
+	}
+
+	mfile->fd = open(mfile->path, O_RDWR);
+	if (mfile->fd < 0) {
+		LOGE("open (%s) failed, error (%s)\n", path, strerror(errno));
+		goto free_path;
+	}
+
+	mfile->size = get_file_size(path);
+	if (mfile->size < 0) {
+		LOGE("get filesize of (%s) failed, error (%s)\n",
+		     path, strerror(errno));
+		goto close_fd;
+	}
+	size = mfile->size > 0 ? mfile->size : PAGE_SIZE;
+	mfile->begin = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED,
+			    mfile->fd, 0);
+	if (mfile->begin == MAP_FAILED) {
+		LOGE("mmap (%s) failed, error (%s)\n", path, strerror(errno));
+		goto close_fd;
+	}
+
+	return mfile;
+
+close_fd:
+	close(mfile->fd);
+free_path:
+	free(mfile->path);
+free_mfile:
+	free(mfile);
+	return NULL;
+
+}
+
+/**
+ * Close and unmap the file opened by mmap_file.
+ *
+ * @param mfile File opened by mmap_file.
+ */
+void unmap_file(struct mm_file_t *mfile)
+{
+	close(mfile->fd);
+	munmap(mfile->begin, mfile->size);
+	free(mfile->path);
+	free(mfile);
+}
+
+/**
+ * Copy the tail data from a file which supports mmap(2)-like operations
+ * to new file.
+ *
+ * @param src File path to copy, this file supports mmap(2)-like operations
+ *            (i.e., it cannot be a socket).
+ * @param dest New file path to generate.
+ * @param limit Size of data, if limit equals 0, this function
+ *	  will copy entire file.
+ *
+ * @return The number of bytes written to new file if successful,
+ *         or a negative errno-style value if not.
+ */
+int do_copy_tail(char *src, char *dest, int limit)
+{
+	int rc = 0;
+	int fsrc = -1, fdest = -1;
+	struct stat info;
+	off_t offset = 0;
+
+	if (src == NULL || dest == NULL)
+		return -EINVAL;
+
+	if (stat(src, &info) < 0)
+		return -errno;
+
+	fsrc = open(src, O_RDONLY);
+	if (fsrc < 0)
+		return -errno;
+
+	fdest = open(dest, O_WRONLY | O_CREAT | O_TRUNC, 0660);
+	if (fdest < 0) {
+		close(fsrc);
+		return -errno;
+	}
+
+	if ((limit == 0) || (info.st_size < limit))
+		limit = info.st_size;
+
+	if (info.st_size > limit)
+		offset = info.st_size - limit;
+
+	rc = sendfile(fdest, fsrc, &offset, limit);
+
+	close(fsrc);
+	close(fdest);
+
+	return rc == -1 ? -errno : rc;
+}
+
+/**
+ * Move a file.
+ *
+ * @param src Old file path.
+ * @param dest New file path.
+ *
+ * @return 0 if successful, or a negative errno-style value if not.
+ */
+int do_mv(char *src, char *dest)
+{
+	struct stat info;
+
+	if (src == NULL || dest == NULL)
+		return -EINVAL;
+
+	if (stat(src, &info) < 0)
+		return -errno;
+
+	/* check if destination exists */
+	if (stat(dest, &info)) {
+		/* an error, unless the destination was missing */
+		if (errno != ENOENT) {
+			LOGE("failed on '%s', err:%s", dest, strerror(errno));
+			return -errno;
+		}
+	}
+	/* attempt to move it */
+	if (rename(src, dest)) {
+		LOGE("failed on '%s', err:%s\n", src, strerror(errno));
+		return -errno;
+	}
+
+	return 0;
+}
+
+/**
+ * Add a string to the end of file.
+ *
+ * @param filename Path of file.
+ * @param text String need to be appended.
+ *
+ * @return 0 if successful, or a negative errno-style value if not.
+ */
+int append_file(char *filename, char *text)
+{
+	int fd, res, len;
+
+	if (!filename || !text)
+		return -EINVAL;
+
+	len = strlen(text);
+	if (!len)
+		return -EINVAL;
+
+	fd = open(filename, O_RDWR | O_APPEND);
+	if (fd < 0)
+		return -errno;
+
+	res = write(fd, text, len);
+	close(fd);
+
+	return (res == -1 ? -errno : res);
+}
+
+/**
+ * Replace a string from the beginning of file.
+ *
+ * @param filename Path of file.
+ * @param text String need to replace.
+ *
+ * @return 0 if successful, or a negative errno-style value if not.
+ */
+int replace_file_head(char *filename, char *text)
+{
+	FILE *fp;
+
+	fp = fopen(filename, "r+");
+	if (fp == NULL)
+		return -errno;
+
+	errno = 0;
+	fputs(text, fp);
+	close_file(filename, fp);
+	if (errno != 0)
+		return -errno;
+
+	return 0;
+}
+
+/**
+ * Change the entire file content to specified string.
+ * The file is created if it does not exist, otherwise it is truncated.
+ *
+ * @param filename Path of file.
+ * @param text String need to be appended.
+ *
+ * @return 0 if successful, or a negative errno-style value if not.
+ */
+int overwrite_file(char *filename, char *value)
+{
+	FILE *fp;
+	int ret = 0;
+
+	if (!filename || !value)
+		return -EINVAL;
+
+	fp = fopen(filename, "w+");
+	if (fp == NULL)
+		return -errno;
+
+	if (fprintf(fp, "%s", value) <= 0)
+		ret = -errno;
+
+	close_file(filename, fp);
+
+	return ret;
+}
+
+/**
+ * Read line from file descriptor.
+ *
+ * @param fd File descriptor.
+ * @param[out] buffer Content of line.
+ *
+ * @return length of line if successful, or a negative errno-style value if not.
+ */
+int readline(int fd, char buffer[MAXLINESIZE])
+{
+	int size = 0, res;
+	char *pbuffer = &buffer[0];
+
+	/* Read the file until end of line or file */
+	while ((res = read(fd, pbuffer, 1)) == 1 && size < MAXLINESIZE-1) {
+		if (pbuffer[0] == '\n') {
+			buffer[++size] = 0;
+			return size;
+		}
+		pbuffer++;
+		size++;
+	}
+
+	/* Check the last read result */
+	if (res < 0) {
+		/* ernno is checked in the upper layer as we could
+		 * print the filename here
+		 */
+		return res;
+	}
+	/* last line */
+	buffer[size] = 0;
+
+	return size;
+}
+
+/**
+ * Read the first line from file.
+ *
+ * @param file Path of file.
+ * @param[out] string String read out.
+ * @param[out] size Size of string.
+ *
+ * @return length of string if successful, or a negative errno-style value
+ *	   if not.
+ */
+int file_read_string(const char *file, char *string, int size)
+{
+	FILE *fp;
+	char *res;
+	char *end;
+
+	if (!file || !string)
+		return -EINVAL;
+
+	if (!file_exists(file))
+		return -ENOENT;
+
+	fp = fopen(file, "r");
+	if (!fp)
+		return -errno;
+
+	res = fgets(string, size, fp);
+
+	close_file(file, fp);
+
+	if (!res)
+		return -errno;
+
+	end = strchr(string, '\n');
+	if (end)
+		*end = 0;
+	return strlen(string);
+}
+
+/**
+ * Reset the string in file to zero.
+ *
+ * @param filename Path of file.
+ */
+void file_reset_init(const char *filename)
+{
+	FILE *fp;
+
+	fp = fopen(filename, "w");
+	if (fp == NULL) {
+		LOGE("Cannot reset %s - %s\n", filename,
+		    strerror(errno));
+		return;
+	}
+	fprintf(fp, "%4u", 0);
+	close_file(filename, fp);
+}
+
+/**
+ * Read the string in file and convert it to type int.
+ *
+ * @param filename Path of file.
+ * @param[out] pcurrent The result read out.
+ *
+ * @return 0 if successful, or a negative errno-style value if not.
+ */
+int file_read_int(const char *filename, unsigned int *pcurrent)
+{
+	FILE *fp;
+	int res;
+
+	/* Open file in reading */
+	fp = fopen(filename, "r");
+	if (fp != NULL) {
+		/* Read current value from file */
+		res = fscanf(fp, "%4u", pcurrent);
+		if (res != 1) {
+			/* Set it to 0 by default */
+			*pcurrent = 0;
+			LOGE("read KO res=%d, current=%d - error is %s\n",
+			     res, *pcurrent, strerror(errno));
+			res = 0;
+		}
+		/* Close file */
+		res = close_file(filename, fp);
+	} else if (errno == ENOENT) {
+		LOGI("File %s does not exist, fall back to folder 0.\n",
+		     filename);
+		/* Initialize file */
+		file_reset_init(filename);
+		*pcurrent = 0;
+		res = 0;
+	} else {
+		LOGE("Cannot open file %s - error is %s.\n", filename,
+		     strerror(errno));
+		res = -errno;
+	}
+
+	return res;
+}
+
+/**
+ * Update the string in file to specified value.
+ *
+ * @param filename Path of file.
+ * @param current The number to record.
+ * @param max The max value file can record, this function would record
+ *        remainder((current+1) % max)) if the specified value exceeds max.
+ *
+ * @return 0 if successful, or a negative value if not.
+ */
+int file_update_int(const char *filename, unsigned int current,
+		    unsigned int max)
+{
+	FILE *fp;
+	int res;
+
+	/* Open file in reading and writing */
+	fp = fopen(filename, "r+");
+	if (fp == NULL) {
+		LOGE("Cannot open the file %s in update mode\n", filename);
+		return -1;
+	}
+
+	/* Write new current value in file */
+	res = fprintf(fp, "%4u", ((current + 1) % max));
+	if (res <= 0) {
+		LOGE("Cannot update file %s - error is %s.\n",
+			filename, strerror(errno));
+		/* Close file */
+		close_file(filename, fp);
+		return -1;
+	}
+
+	/* Close file */
+	return close_file(filename, fp);
+}

--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -624,3 +624,534 @@ int file_update_int(const char *filename, unsigned int current,
 	/* Close file */
 	return close_file(filename, fp);
 }
+
+/**
+ * Copy file in a read/write loop.
+ *
+ * @param src Path of source file.
+ * @param dest Path of destin file.
+ *
+ * @return 0 if successful, or a negative value if not.
+ */
+int do_copy_eof(const char *src, const char *des)
+{
+	char buffer[CPBUFFERSIZE];
+	int rc = 0;
+	int fd1 = -1, fd2 = -1;
+	struct stat info;
+	int r_count, w_count = 0;
+
+	if (src == NULL || des == NULL)
+		return -EINVAL;
+
+	if (stat(src, &info) < 0) {
+		LOGE("can not open file: %s\n", src);
+		return -errno;
+	}
+
+	fd1 = open(src, O_RDONLY);
+	if (fd1 < 0)
+		return -errno;
+
+	fd2 = open(des, O_WRONLY | O_CREAT | O_TRUNC, 0660);
+	if (fd2 < 0) {
+		LOGE("can not open file: %s\n", des);
+		close(fd1);
+		return -errno;
+	}
+
+	/* Start copy loop */
+	while (1) {
+		/* Read data from src */
+		r_count = read(fd1, buffer, CPBUFFERSIZE);
+		if (r_count < 0) {
+			LOGE("read failed, err:%s\n", strerror(errno));
+			rc = -1;
+			break;
+		}
+
+		if (r_count == 0)
+			break;
+
+		/* Copy data to des */
+		w_count = write(fd2, buffer, r_count);
+		if (w_count < 0) {
+			LOGE("write failed, err:%s\n", strerror(errno));
+			rc = -1;
+			break;
+		}
+		if (r_count != w_count) {
+			LOGE("write failed, r_count:%d w_count:%d\n",
+			     r_count, w_count);
+			rc = -1;
+			break;
+		}
+	}
+
+	if (fd1 >= 0)
+		close(fd1);
+	if (fd2 >= 0)
+		close(fd2);
+
+	return rc;
+}
+
+/**
+ * Check the storage space.
+ *
+ * @param path Path to the file system.
+ * @param quota Threshold value.
+ * @return 1 if the percentage of using space is lower than the specified quota.
+ *         or 0 if not.
+ */
+int space_available(char *path, int quota)
+{
+	struct statfs diskInfo;
+	unsigned long long totalBlocks;
+	unsigned long long totalSize;
+	unsigned long long freeDisk;
+	int mbTotalsize;
+	int mbFreedisk;
+	int ret;
+
+	/* quota is valid in range (0, 100) */
+	if (quota <= 0 || quota > 100)
+		return 0;
+
+	ret = statfs(path, &diskInfo);
+	if (ret < 0) {
+		LOGE("statfs (%s) failed, error (%s)\n", path,
+		     strerror(errno));
+		return 0;
+	}
+	totalBlocks = diskInfo.f_bsize;
+	totalSize = totalBlocks * diskInfo.f_blocks;
+	freeDisk = diskInfo.f_bfree * totalBlocks;
+	mbTotalsize = totalSize >> 20;
+	mbFreedisk = freeDisk >> 20;
+	if ((float)mbFreedisk / (float)mbTotalsize >
+	    1 - ((float)quota / (float)100))
+		return 1;
+
+	LOGE("space meet quota[%d] total=%dMB, free=%dMB\n", quota,
+	     mbTotalsize, mbFreedisk);
+	return 0;
+}
+
+/**
+ * Count file lines.
+ *
+ * @param filename Path of file to count lines.
+ *
+ * @return lines of file is successful, or a negative errno-style value if not.
+ */
+int count_lines_in_file(const char *filename)
+{
+	struct mm_file_t *f;
+	int ret;
+
+	f = mmap_file(filename);
+	if (!f)
+		return -errno;
+
+	ret = mm_count_lines(f);
+
+	unmap_file(f);
+
+	return ret;
+}
+
+/**
+ * Read binary file.
+ *
+ * @param path File path to read.
+ * @param[out] File size being read.
+ * @param[out] data File content.
+ *
+ * @return 0 if successful, or -1 if not.
+ */
+int read_full_binary_file(const char *path, unsigned long *size, void **data)
+{
+	FILE *f;
+	long _size;
+	void *buf;
+	int err;
+
+	if (!path || !data || !size) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	f = fopen(path, "rb");
+	if (!f)
+		return -1;
+
+	if (fseek(f, 0, SEEK_END) == -1) {
+		err = errno;
+		goto close;
+	}
+
+	_size = ftell(f);
+	if (_size == -1) {
+		err = errno;
+		goto close;
+	} else if (!_size) {
+		err = ERANGE;
+		goto close;
+	}
+
+	if (fseek(f, 0, SEEK_SET) == -1) {
+		err = errno;
+		goto close;
+	}
+
+	buf = malloc(_size + 10);
+	if (!buf) {
+		err = ENOMEM;
+		goto close;
+	}
+
+	memset(buf, 0, _size + 10);
+	if (fread(buf, 1, _size, f) != (unsigned int)_size) {
+		err = EBADF;
+		goto free;
+	}
+
+	close_file(path, f);
+
+	*data = buf;
+	*size = (unsigned int)_size;
+
+	return 0;
+
+free:
+	free(buf);
+close:
+	close_file(path, f);
+	errno = err;
+	return -1;
+}
+
+static int _file_read_key_value(char *path, char op, char *key, char *value)
+{
+	int fd;
+	int size;
+	int len;
+	char *data;
+	char *msg = NULL;
+	char *end, *start;
+
+	if (!key || !path) {
+		errno = EINVAL;
+		return -errno;
+	}
+
+	if (op != 'l' && op != 'r') {
+		errno = EINVAL;
+		return -errno;
+	}
+
+	size = get_file_size(path);
+	if (size < 0)
+		return size;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -errno;
+
+	data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (data == MAP_FAILED)
+		goto close;
+
+	if (op == 'l')
+		msg = strstr(data, key);
+	else if (op == 'r')
+		msg = strrstr(data, key);
+	if (!msg) {
+		errno = ENOMSG;
+		goto unmap;
+	}
+	end = strchr(msg, '\n');
+	if (end == NULL)
+		end = data + size;
+
+	start = msg + strlen(key);
+	len = end - start;
+	memcpy(value, start, len);
+	*(value + len) = 0;
+
+	munmap(data, size);
+	close(fd);
+
+	return len;
+
+unmap:
+	munmap(data, size);
+close:
+	close(fd);
+	return -errno;
+}
+
+int file_read_key_value(char *path, char *key, char *value)
+{
+	return _file_read_key_value(path, 'l', key, value);
+}
+
+int file_read_key_value_r(char *path, char *key, char *value)
+{
+	return _file_read_key_value(path, 'r', key, value);
+}
+
+int dir_contains(const char *dir, const char *filename, int exact,
+		char *fullname)
+{
+	int ret, count = 0;
+	struct dirent **filelist;
+	char *name;
+
+	if (!dir || !filename)
+		return -EINVAL;
+
+	/* pass parameters to scandir's filter is not convenience, so we use
+	 * this implementation.
+	 */
+	ret = scandir(dir, &filelist, 0, 0);
+	if (ret < 0)
+		return -errno;
+
+	while (ret--) {
+		name = filelist[ret]->d_name;
+		if (exact) {
+			if (!strcmp(name, filename))
+				count++;
+		} else {
+			if (strstr(name, filename)) {
+				count++;
+				if (fullname)
+					strcpy(fullname, name);
+			}
+		}
+		free(filelist[ret]);
+	}
+
+	free(filelist);
+
+	return count;
+}
+
+int lsdir(const char *dir, char *fullname[], int limit)
+{
+	int ret, num, count = 0;
+	int i;
+	struct dirent **filelist;
+	char *name;
+
+	if (!dir || !fullname)
+		return -EINVAL;
+
+	num = scandir(dir, &filelist, 0, 0);
+	if (num < 0)
+		return -errno;
+	if (num > limit) {
+		LOGE("(%s) contains (%d) files, meet limit (%d)\n",
+		     dir, num, limit);
+		count = -EINVAL;
+		goto free_list;
+	}
+
+	for (i = 0; i < num; i++) {
+		name = filelist[i]->d_name;
+		ret = asprintf(&fullname[count++], "%s/%s", dir, name);
+		if (ret < 0) {
+			LOGE("compute string failed, out of memory\n");
+			count = -ENOMEM;
+			goto free_fname;
+		}
+	}
+
+	for (i = 0; i < num; i++)
+		free(filelist[i]);
+	free(filelist);
+
+	return count;
+
+free_fname:
+	for (i = 0; i < count; i++)
+		free(fullname[i]);
+
+free_list:
+	for (i = 0; i < num; i++)
+		free(filelist[i]);
+	free(filelist);
+
+	return count;
+}
+
+static int is_subdir(const struct dirent *entry)
+{
+	return (entry->d_type == DT_DIR) &&
+		strcmp(entry->d_name, ".") &&
+		strcmp(entry->d_name, "..");
+}
+
+static void expand_dir(char *_dirs[], int *count, int depth, int max_depth)
+{
+	int files;
+	int i;
+	int res;
+	struct dirent **filelist;
+	char *subdir;
+	char *name;
+	char *current_dir = _dirs[*count - 1];
+
+	if (depth > max_depth)
+		return;
+
+
+	files = scandir(current_dir, &filelist, is_subdir, 0);
+	if (files < 0) {
+		LOGE("lsdir failed, error (%s)\n", strerror(-files));
+		return;
+	}
+
+	for (i = 0; i < files; i++) {
+		if (*count >= MAX_SEARCH_DIRS) {
+			LOGE("too many dirs(%d) under %s\n",
+			     *count, _dirs[0]);
+			goto free;
+		}
+
+		name = filelist[i]->d_name;
+		res = asprintf(&subdir, "%s/%s", current_dir, name);
+		if (res < 0) {
+			LOGE("compute string failed, out of memory\n");
+			goto free;
+		}
+
+		_dirs[*count] = subdir;
+		(*count)++;
+		expand_dir(_dirs, count, depth++, max_depth);
+	}
+free:
+	for (i = 0; i < files; i++)
+		free(filelist[i]);
+	free(filelist);
+}
+
+/**
+ * Find target file in specified dir.
+ *
+ * @param dir Where to start search.
+ * @param target_file Target file to search.
+ * @param depth File's depth in the directory tree.
+ * @param path[out] Searched file path in given dir.
+ * @param limit The number of files uplayer want to get.
+ *
+ * @return the count of searched files if successful, or a negative
+ *	   errno-style value if not.
+ */
+int find_file(char *dir, char *target_file, int depth, char *path[], int limit)
+{
+	int i, ret;
+	int count = 0;
+	char *_dirs[MAX_SEARCH_DIRS];
+	int dirs;
+
+	if (depth < 1 || !dir || !target_file || !path || limit <= 0)
+		return -EINVAL;
+
+	ret = asprintf(&_dirs[0], "%s", dir);
+	if (ret < 0) {
+		LOGE("compute string failed, out of memory\n");
+		return -ENOMEM;
+	}
+	dirs = 1;
+
+	/* expand all dirs */
+	expand_dir(_dirs, &dirs, 1, depth);
+	for (i = 0; i < dirs; i++) {
+		if (count >= limit)
+			goto free;
+
+		ret = dir_contains(_dirs[i], target_file, 1, NULL);
+		if (ret == 1) {
+			ret = asprintf(&path[count++], "%s/%s",
+				       _dirs[i], target_file);
+			if (ret < 0) {
+				LOGE("compute string failed, out of memory\n");
+				ret = -ENOMEM;
+				goto fail;
+			}
+		} else if (ret > 1) {
+			LOGE("found (%d) (%s) under (%s)??\n",
+			     ret, target_file, dir);
+		} else if (ret < 0) {
+			LOGE("dir_contains failed, error (%s)\n",
+			     strerror(-ret));
+		}
+	}
+
+free:
+	for (i = 0; i < dirs; i++)
+		free(_dirs[i]);
+
+	return count;
+fail:
+	for (i = 0; i < dirs; i++)
+		free(_dirs[i]);
+
+	for (i = 0; i < count; i++)
+		free(path[i]);
+
+	return ret;
+}
+
+int read_file(const char *path, unsigned long *size, void **data)
+{
+	char tmp[1024] = "\0";
+	int len = 0;
+	int fd = 0;
+	int memsize = 1; /* for '\0' */
+	size_t result = 0;
+	char *out = NULL;
+	char *new;
+
+	if (!path || !data || !size) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return -1;
+
+	while (1) {
+		result = read(fd, (void *)tmp, 1024);
+		if (result == 0)
+			break;
+
+		memsize += result;
+		new = realloc(out, memsize);
+		if (!new)
+			goto free;
+
+		out = new;
+		memcpy(out + len, tmp, result);
+		out[memsize - 1] = 0;
+
+		len += result;
+	}
+
+	close(fd);
+
+	*data = out;
+	*size = (unsigned int)len;
+
+	return 0;
+
+free:
+	if (out)
+		free(out);
+	close(fd);
+	return -1;
+}

--- a/tools/acrn-crashlog/common/include/cmdutils.h
+++ b/tools/acrn-crashlog/common/include/cmdutils.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+int execv_out2file(char *argv[], char *outfile);
+int debugfs_cmd(char *loop_dev, char *cmd, char *outfile);
+int exec_out2file(char *outfile, char *fmt, ...);
+char *exec_out2mem(char *fmt, ...);

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -88,5 +88,17 @@ void file_reset_init(const char *filename);
 int file_read_int(const char *filename, unsigned int *pcurrent);
 int file_update_int(const char *filename, unsigned int current,
 			unsigned int max);
+int do_copy_eof(const char *src, const char *des);
+int space_available(char *path, int quota);
+int count_lines_in_file(const char *filename);
+int read_full_binary_file(const char *path, unsigned long *size,
+			void **data);
+int file_read_key_value(char *path, char *key, char *value);
+int file_read_key_value_r(char *path, char *key, char *value);
+int dir_contains(const char *dir, const char *filename, int exact,
+		char *fullname);
+int lsdir(const char *dir, char *fullname[], int limit);
+int find_file(char *dir, char *target_file, int depth, char *path[], int limit);
+int read_file(const char *path, unsigned long *size, void **data);
 
 #endif

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FSUTILS_H__
+#define __FSUTILS_H__
+
+#include <sys/stat.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <errno.h>
+
+#define MAX(a, b)                (((a) > (b)) ? (a) : (b))
+#define MIN(a, b)                (((a) > (b)) ? (b) : (a))
+
+#define KB                      (1024)
+#define MB                      (KB * KB)
+#define MAXLINESIZE             (4 * KB)
+#define CPBUFFERSIZE            (4 * KB)
+#define PAGE_SIZE               (4 * KB)
+
+struct mm_file_t {
+	char *path;
+	int fd;
+	char *begin;
+	int size;
+};
+
+static inline int file_exists(const char *filename)
+{
+	struct stat info;
+
+	return (stat(filename, &info) == 0);
+}
+
+static inline int directory_exists(char *path)
+{
+	struct stat info;
+
+	return (stat(path, &info) == 0 && S_ISDIR(info.st_mode));
+}
+
+static inline int get_file_size(const char *filepath)
+{
+	struct stat info;
+
+	if (filepath == NULL)
+		return -ENOENT;
+
+	if (stat(filepath, &info) < 0)
+		return -errno;
+
+	return info.st_size;
+}
+
+char *mm_get_line(struct mm_file_t *mfile, int line);
+int mkdir_p(char *path);
+int mm_count_lines(struct mm_file_t *mfile);
+struct mm_file_t *mmap_file(const char *path);
+void unmap_file(struct mm_file_t *mfile);
+int do_copy_tail(char *src, char *dest, int limit);
+int do_mv(char *src, char *dest);
+int append_file(char *filename, char *text);
+int mm_replace_str_line(struct mm_file_t *mfile, char *replace,
+			int line);
+int replace_file_head(char *filename, char *text);
+int overwrite_file(char *filename, char *value);
+int readline(int fd, char buffer[MAXLINESIZE]);
+int file_read_string(const char *file, char *string, int size);
+void file_reset_init(const char *filename);
+int file_read_int(const char *filename, unsigned int *pcurrent);
+int file_update_int(const char *filename, unsigned int current,
+			unsigned int max);
+
+#endif

--- a/tools/acrn-crashlog/common/include/log_sys.h
+++ b/tools/acrn-crashlog/common/include/log_sys.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __LOG_SYS_H__
+#define __LOG_SYS_H__
+
+#include <stdarg.h>
+#include <syslog.h>
+
+void do_log(int level,
+#ifdef DEBUG_ACRN_CRASHLOG
+		const char *func, int line,
+#endif
+		...);
+
+#define MAX_LOG_LEN 1024
+#define LOG_LEVEL LOG_WARNING
+
+#ifdef DEBUG_ACRN_CRASHLOG
+#define LOGE(...) \
+		do_log(LOG_ERR, __func__, __LINE__,  __VA_ARGS__)
+
+#define LOGW(...) \
+		do_log(LOG_WARNING, __func__, __LINE__, __VA_ARGS__)
+
+#define LOGI(...) \
+		do_log(LOG_INFO, __func__, __LINE__, __VA_ARGS__)
+
+#define LOGD(...) \
+		do_log(LOG_DEBUG, __func__, __LINE__, __VA_ARGS__)
+#else
+#define LOGE(...) \
+		do_log(LOG_ERR, __VA_ARGS__)
+
+#define LOGW(...) \
+		do_log(LOG_WARNING, __VA_ARGS__)
+
+#define LOGI(...) \
+		do_log(LOG_INFO, __VA_ARGS__)
+
+#define LOGD(...) \
+		do_log(LOG_DEBUG, __VA_ARGS__)
+#endif
+
+#endif

--- a/tools/acrn-crashlog/common/include/strutils.h
+++ b/tools/acrn-crashlog/common/include/strutils.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __STRUTILS_H__
+#define __STRUTILS_H__
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+int strlinelen(char *str);
+char *strrstr(char *s, char *str);
+char *next_line(char *buf);
+char *strtrim(char *str);
+int strcnt(char *str, char c);
+
+#endif

--- a/tools/acrn-crashlog/common/log_sys.c
+++ b/tools/acrn-crashlog/common/log_sys.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <systemd/sd-journal.h>
+#include "log_sys.h"
+
+void do_log(int level,
+#ifdef DEBUG_ACRN_CRASHLOG
+			const char *func, int line,
+#endif
+			...)
+{
+	va_list args;
+	char *fmt;
+	char log[MAX_LOG_LEN] = {0};
+#ifdef DEBUG_ACRN_CRASHLOG
+	char header_fmt[] = "<%-20s%d>: ";
+#endif
+
+	if (level > LOG_LEVEL)
+		return;
+
+#ifdef DEBUG_ACRN_CRASHLOG
+	va_start(args, line);
+#else
+	va_start(args, level);
+#endif
+	fmt = va_arg(args, char *);
+	if (!fmt)
+		return;
+
+#ifdef DEBUG_ACRN_CRASHLOG
+	/* header */
+	snprintf(log, sizeof(log) - 1, header_fmt, func, line);
+#endif
+	/* msg */
+	vsnprintf(log + strlen(log), sizeof(log) - strlen(log) - 1, fmt, args);
+	va_end(args);
+
+	sd_journal_print(level, log);
+}

--- a/tools/acrn-crashlog/common/strutils.c
+++ b/tools/acrn-crashlog/common/strutils.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <string.h>
+#include <errno.h>
+
+/**
+ * Get the length of line.
+ *
+ * @param str Start address of line.
+ *
+ * @return the length of line if successful, or -1 if not.
+ *	   This function return length of string if string doesn't contain \n.
+ */
+int strlinelen(char *str)
+{
+	char *tag;
+
+	if (!str)
+		return -1;
+
+	tag = strchr(str, '\n');
+	if (tag)
+		return tag - str + 1;
+
+	return strlen(str);
+}
+
+/**
+ * Find the last occurrence of the substring str in the string s.
+ *
+ * @param s Range of search.
+ * @param substr String to be found.
+ *
+ * @return a pointer to the beginning of the substring,
+ *	   or NULL if the substring is not found.
+ */
+char *strrstr(char *s, char *substr)
+{
+	char *found;
+	char *p = s;
+
+	while ((found = strstr(p, substr)))
+		p = found + 1;
+
+	if (p != s)
+		return p - 1;
+
+	return NULL;
+}
+
+char *next_line(char *buf)
+{
+	char *p;
+
+	p  = strchr(buf, '\n');
+	/* if meet end of buf, the return value is also NULL */
+	if (p)
+		return p + 1;
+
+	return NULL;
+}
+
+static char *strtriml(char *str)
+{
+	char *p = str;
+
+	while (*p == ' ')
+		p++;
+	return memmove(str, p, strlen(p) + 1);
+}
+
+static char *strtrimr(char *str)
+{
+	char *end = str + strlen(str) - 1;
+
+	while (*end == ' ' && end >= str) {
+		*end = 0;
+		end--;
+	}
+
+	return str;
+}
+
+char *strtrim(char *str)
+{
+	strtrimr(str);
+	return strtriml(str);
+}
+
+int strcnt(char *str, char c)
+{
+	int cnt = 0;
+	char *p = str;
+	char *found;
+
+	if (!str)
+		return -EINVAL;
+
+	while ((found = strchr(p, c))) {
+		p = found + 1;
+		cnt++;
+	}
+
+	return cnt;
+}

--- a/tools/acrn-crashlog/data/40-watchdog.conf
+++ b/tools/acrn-crashlog/data/40-watchdog.conf
@@ -1,0 +1,2 @@
+[Manager]
+RuntimeWatchdogSec=40

--- a/tools/acrn-crashlog/data/acrnprobe.service
+++ b/tools/acrn-crashlog/data/acrnprobe.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ACRN crashlog probe
+Requires=telemd.socket
+Requires=usercrash_s
+After=usercrash.service
+After=prepare.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/acrnprobe
+ExecStop=/usr/bin/killall -s TERM acrnprobe
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<conf>
+	<senders>
+		<sender id="1" enable="true">
+			<name>crashlog</name>
+			<outdir>/var/log/crashlog</outdir>
+			<maxcrashdirs>1000</maxcrashdirs>
+			<maxlines>5000</maxlines>
+			<spacequota>90</spacequota>
+			<uptime>
+				<name>UPTIME</name>
+				<frequency>5</frequency>
+				<eventhours>6</eventhours>
+			</uptime>
+		</sender>
+		<sender id="2" enable="true">
+			<name>telemd</name>
+			<outdir>/var/log/acrnprobe</outdir>
+			<uptime>
+				<name>UPTIME</name>
+				<frequency>5</frequency>
+				<eventhours>6</eventhours>
+			</uptime>
+		</sender>
+	</senders>
+
+	<triggers>
+		<trigger id="1" enable="true">
+			<name>t_pstore</name>
+			<type>file</type>
+			<path>/sys/fs/pstore/console-ramoops</path>
+		</trigger>
+		<trigger id="2" enable="true">
+			<name>t_boot</name>
+			<type>file</type>
+			<path>/proc/cmdline</path>
+		</trigger>
+		<trigger id="3" enable="true">
+			<name>t_usercrash</name>
+			<type>dir</type>
+			<path>/var/log/usercrashes</path>
+		</trigger>
+	</triggers>
+
+	<vms enable="true">
+		<vm id="1" enable="true">
+			<name>VM1</name>
+			<channel>polling</channel>
+			<interval>60</interval>
+			<syncevent id="1">CRASH/TOMBSTONE</syncevent>
+			<syncevent id="2">CRASH/UIWDT</syncevent>
+			<syncevent id="3">CRASH/IPANIC</syncevent>
+			<syncevent id="4">REBOOT</syncevent>
+		</vm>
+	</vms>
+
+	<logs>
+		<log id="1" enable="true">
+			<name>pstore</name>
+			<type>file</type>
+			<path>/sys/fs/pstore/console-ramoops</path>
+		</log>
+		<log id='2' enable='true'>
+			<name>kmsg</name>
+			<type>cmd</type>
+			<path>dmesg</path>
+		</log>
+		<log id='3' enable='true'>
+			<name>cmdline</name>
+			<type>node</type>
+			<path>/proc/cmdline</path>
+		</log>
+		<log id='4' enable='true'>
+			<name>syslog</name>
+			<type>cmd</type>
+			<path>journalctl -b -0 -n 300 --no-pager</path>
+		</log>
+		<log id='5' enable='true'>
+			<name>acrnlog_cur</name>
+			<type>file_rotation</type>
+			<path>/tmp/acrnlog/acrnlog_cur.[biggest]</path>
+			<lines>500</lines>
+		</log>
+		<log id='6' enable='true'>
+			<name>acrnlog_last</name>
+			<type>file_rotation</type>
+			<path>/tmp/acrnlog/acrnlog_last.[all]</path>
+		</log>
+	</logs>
+
+	<crashes>
+		<crash id='1' inherit='0' enable='true'>
+			<name>IPANIC</name>
+			<trigger>t_pstore</trigger>
+			<channel>oneshot</channel>
+			<log id='1'>pstore</log>
+			<data id='1'>kernel BUG at</data>
+			<data id='2'>EIP is at</data>
+			<data id='3'>Comm:</data>
+		</crash>
+		<crash id='2' inherit='1' enable='true'>
+			<name>IPANIC_SWWDT</name>
+			<content id='1'>BUG: soft lockup - CPU#</content>
+		</crash>
+		<crash id='3' inherit='2' enable='true'>
+			<name>IPANIC_SWWDT_FAKE</name>
+			<mightcontent expression='1' id='1'>EIP: panic_dbg_set</mightcontent>
+			<mightcontent expression='1' id='2'>RIP: panic_dbg_set</mightcontent>
+		</crash>
+		<crash id='4' inherit='0' enable='true'>
+			<name>USERCRASH</name>
+			<trigger>t_usercrash</trigger>
+			<channel>inotify</channel>
+			<log id='1'>kmsg</log>
+			<log id='2'>syslog</log>
+		</crash>
+		<crash id='5' inherit='1' enable='true'>
+			<name>IPANIC_HWWDT</name>
+			<content id='1'>Watchdog detected hard LOCKUP on cpu</content>
+		</crash>
+	</crashes>
+
+	<infos>
+		<info id='1' enable='true'>
+			<name>BOOT_LOGS</name>
+			<trigger>t_boot</trigger>
+			<channel>oneshot</channel>
+			<log id='1'>kmsg</log>
+			<log id='2'>cmdline</log>
+			<log id='3'>acrnlog_cur</log>
+			<log id='4'>acrnlog_last</log>
+		</info>
+	</infos>
+
+
+
+</conf>

--- a/tools/acrn-crashlog/data/acrnprobe_prepare.sh
+++ b/tools/acrn-crashlog/data/acrnprobe_prepare.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (C) <2018> Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# modify the core_pattern
+echo "|/usr/bin/usercrash_c %p %e %s" > /proc/sys/kernel/core_pattern
+
+conf="/usr/share/defaults/telemetrics/telemetrics.conf"
+
+grep -q "record_server_delivery_enabled=false" $conf
+if [ "$?" -eq "0" ];then
+	exit;
+fi
+
+telemd_services=(
+hprobe.timer
+telemd-update-trigger.service
+pstore-clean.service
+pstore-probe.service
+oops-probe.service
+klogscanner.service
+journal-probe.service
+bert-probe.service
+)
+
+for ((i=0;i<${#telemd_services[*]};i++))
+do
+	if [ ! -L "/etc/systemd/system/${telemd_services[$i]}" ];then
+		systemctl mask ${telemd_services[$i]} --now
+	fi
+done
+
+# modify the configure file
+
+sed -i "s/server_delivery_enabled=true/server_delivery_enabled=false/g" $conf
+sed -i "s/record_retention_enabled=false/record_retention_enabled=true/g" $conf
+
+# restart telemd
+sleep 3
+systemctl restart telemd.service

--- a/tools/acrn-crashlog/data/prepare.service
+++ b/tools/acrn-crashlog/data/prepare.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=ACRN probe prepare
+Requires=telemd.service
+After=telemd.service
+Before=acrnprobe.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /usr/bin/acrnprobe_prepare.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/acrn-crashlog/data/usercrash.service
+++ b/tools/acrn-crashlog/data/usercrash.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ACRN usercrash Demon
+Requires=telemd.socket
+After=telemd.service
+Before=acrnprobe.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/usercrash_s
+ExecStop=/usr/bin/killall -s TERM usercrash_s
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/acrn-crashlog/license_header
+++ b/tools/acrn-crashlog/license_header
@@ -1,0 +1,5 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -12,7 +12,11 @@ usercrash_s: $(BUILDDIR)/usercrash/obj/protocol.o \
 
 usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/client.o \
-	$(BUILDDIR)/common/obj/log_sys.o
+	$(BUILDDIR)/usercrash/obj/crash_dump.o \
+	$(BUILDDIR)/common/obj/log_sys.o \
+	$(BUILDDIR)/common/obj/cmdutils.o \
+	$(BUILDDIR)/common/obj/fsutils.o \
+	$(BUILDDIR)/common/obj/strutils.o
 	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
 
 $(BUILDDIR)/usercrash/obj/%.o:%.c

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -1,4 +1,7 @@
-all: check_obj usercrash_s usercrash_c debugger
+MAJOR_VERSION=1
+MINOR_VERSION=0
+
+all: include/version.h check_obj usercrash_s usercrash_c debugger
 
 CURRDIR := $(shell pwd)
 INCLUDE += -I $(CURRDIR)/include/
@@ -30,6 +33,19 @@ debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 $(BUILDDIR)/usercrash/obj/%.o:%.c
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
+include/version.h:
+	touch include/version.h
+	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
+	DIRTY=`git diff --name-only $(CURRDIR)`;\
+	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
+	cat $(CURRDIR)/../license_header > include/version.h;\
+	echo "#define UC_MAJOR_VERSION $(MAJOR_VERSION)" >> include/version.h;\
+	echo "#define UC_MINOR_VERSION $(MINOR_VERSION)" >> include/version.h;\
+	echo "#define UC_BUILD_VERSION "\""$$PATCH"\""" >> include/version.h;\
+	echo "#define UC_BUILD_TIME "\""$$TIME"\""" >> include/version.h;\
+	echo "#define UC_BUILD_USER "\""$(USER)"\""" >> include/version.h
+
 check_obj:
 	@if [ ! -d $(BUILDDIR)/usercrash/bin ]; then \
 		mkdir -p $(BUILDDIR)/usercrash/bin ; \
@@ -41,6 +57,9 @@ check_obj:
 .PHONY:clean
 clean:
 	@echo "Clean objects and binaries"
+	@if [ -e include/version.h ]; then \
+		$(RM) -f include/version.h; \
+	fi
 	@if [ -d $(BUILDDIR)/usercrash/obj ]; then \
 		find $(BUILDDIR)/usercrash/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \
 	fi

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -1,4 +1,4 @@
-all: check_obj usercrash_s usercrash_c
+all: check_obj usercrash_s usercrash_c debugger
 
 CURRDIR := $(shell pwd)
 INCLUDE += -I $(CURRDIR)/include/
@@ -12,6 +12,14 @@ usercrash_s: $(BUILDDIR)/usercrash/obj/protocol.o \
 
 usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/client.o \
+	$(BUILDDIR)/usercrash/obj/crash_dump.o \
+	$(BUILDDIR)/common/obj/log_sys.o \
+	$(BUILDDIR)/common/obj/cmdutils.o \
+	$(BUILDDIR)/common/obj/fsutils.o \
+	$(BUILDDIR)/common/obj/strutils.o
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
+
+debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 	$(BUILDDIR)/usercrash/obj/crash_dump.o \
 	$(BUILDDIR)/common/obj/log_sys.o \
 	$(BUILDDIR)/common/obj/cmdutils.o \

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -1,0 +1,33 @@
+all: check_obj usercrash_s usercrash_c
+
+LIBS = -levent -lpthread
+
+usercrash_s: $(BUILDDIR)/usercrash/obj/server.o
+	$(CC) -g $(CFLAGS) $(LIBS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
+
+usercrash_c: $(BUILDDIR)/usercrash/obj/client.o
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
+
+$(BUILDDIR)/usercrash/obj/%.o:%.c
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
+
+check_obj:
+	@if [ ! -d $(BUILDDIR)/usercrash/bin ]; then \
+		mkdir -p $(BUILDDIR)/usercrash/bin ; \
+	fi
+	@if [ ! -d $(BUILDDIR)/usercrash/obj ]; then \
+		mkdir -p $(BUILDDIR)/usercrash/obj ; \
+	fi
+
+.PHONY:clean
+clean:
+	@echo "Clean objects and binaries"
+	@if [ -d $(BUILDDIR)/usercrash/obj ]; then \
+		find $(BUILDDIR)/usercrash/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \
+	fi
+	@if [ -d $(BUILDDIR)/usercrash/bin ]; then \
+		$(RM) -r $(BUILDDIR)/usercrash/bin ; \
+	fi
+	@if [ -d $(BUILDDIR)/usercrash/obj ]; then \
+		$(RM) -r $(BUILDDIR)/usercrash/obj ; \
+	fi

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -1,11 +1,18 @@
 all: check_obj usercrash_s usercrash_c
 
+CURRDIR := $(shell pwd)
+INCLUDE += -I $(CURRDIR)/include/
+
 LIBS = -levent -lpthread
 
-usercrash_s: $(BUILDDIR)/usercrash/obj/server.o
+usercrash_s: $(BUILDDIR)/usercrash/obj/protocol.o \
+	$(BUILDDIR)/usercrash/obj/server.o \
+	$(BUILDDIR)/common/obj/log_sys.o
 	$(CC) -g $(CFLAGS) $(LIBS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
 
-usercrash_c: $(BUILDDIR)/usercrash/obj/client.o
+usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
+	$(BUILDDIR)/usercrash/obj/client.o \
+	$(BUILDDIR)/common/obj/log_sys.o
 	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
 
 $(BUILDDIR)/usercrash/obj/%.o:%.c

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -6,12 +6,12 @@ all: include/version.h check_obj usercrash_s usercrash_c debugger
 CURRDIR := $(shell pwd)
 INCLUDE += -I $(CURRDIR)/include/
 
-LIBS = -levent -lpthread
+LIBS = -levent -lpthread $(SYSTEMD_LIBS)
 
 usercrash_s: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/server.o \
 	$(BUILDDIR)/common/obj/log_sys.o
-	$(CC) -g $(CFLAGS) $(LIBS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS)
 
 usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/client.o \
@@ -20,7 +20,7 @@ usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/common/obj/cmdutils.o \
 	$(BUILDDIR)/common/obj/fsutils.o \
 	$(BUILDDIR)/common/obj/strutils.o
-	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS)
 
 debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 	$(BUILDDIR)/usercrash/obj/crash_dump.o \
@@ -28,7 +28,7 @@ debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 	$(BUILDDIR)/common/obj/cmdutils.o \
 	$(BUILDDIR)/common/obj/fsutils.o \
 	$(BUILDDIR)/common/obj/strutils.o
-	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ -lsystemd
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS)
 
 $(BUILDDIR)/usercrash/obj/%.o:%.c
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<

--- a/tools/acrn-crashlog/usercrash/client.c
+++ b/tools/acrn-crashlog/usercrash/client.c
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crash_dump.h"
+#include "packet.h"
+#include "log_sys.h"
+#include "protocol.h"
+
 /**
  * Usercrash works as C/S model: usercrash_c works as usercrash client to
  * collect crash logs and information once crash event occurs. For each time,
@@ -12,11 +40,188 @@
  * completed.
  */
 
-int main(void)
+/**
+ * @sockfd: the socket fd.
+ * set_timeout is used to set timeout for the sockfd, in case client is blocked
+ * when client cannot receive the data from server, or send data to server
+ */
+static int set_timeout(int sockfd)
 {
-	//TO BE DONE
-	//This empty function is to satisfy the dependency of Makefile.
-	//This is the entry of usercrash_c, the implementation will be
-	//filled by following patches.
+	struct timeval timeout = {50, 0};
+
+	if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+				sizeof(timeout)) != 0) {
+		LOGE("failed to set receive timeout\n");
+		return -1;
+	}
+	if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+				sizeof(timeout)) != 0) {
+		LOGE("failed to set send timeout\n");
+		return -1;
+	}
+	return 0;
+}
+
+/**
+ * @pid: crash process pid.
+ * @usercrashd_socket: client socket fd pointer, get the value from
+ * usercrashd_connect function.
+ * @output_fd: file fd, receives from server to store dump file.
+ * @name: crash process name
+ * usercrashd_connect is used to connect to server, and get the crash file fd
+ * from server
+ */
+bool usercrashd_connect(int pid, int *usercrashd_socket,
+		int *output_fd, char *name)
+{
+	int sockfd;
+	int tmp_output_fd;
+	ssize_t rc;
+	int flags;
+	struct crash_packet packet = {0};
+
+	sockfd = socket_local_client(SOCKET_NAME, SOCK_SEQPACKET);
+	if (sockfd == -1) {
+		LOGE("failed to connect to usercrashd, error (%s)\n",
+			strerror(errno));
+		return false;
+	}
+	packet.packet_type = kDumpRequest;
+	packet.pid = pid;
+	strncpy(packet.name, name, COMM_NAME_LEN - 1);
+	if (set_timeout(sockfd)) {
+		close(sockfd);
+		return -1;
+	}
+	if (write(sockfd, &packet, sizeof(packet)) !=
+				sizeof(packet)) {
+		LOGE("failed to write DumpRequest packet, error (%s)\n",
+			strerror(errno));
+		close(sockfd);
+		return false;
+	}
+
+	rc = recv_fd(sockfd, &packet, sizeof(packet),
+				&tmp_output_fd);
+	if (rc == -1) {
+		LOGE("failed to read response to DumpRequest packet, ");
+		LOGE("error (%s)\n", strerror(errno));
+		close(sockfd);
+		return false;
+	} else if (rc != sizeof(packet)) {
+		LOGE("received DumpRequest response packet of incorrect ");
+		LOGE("length (expected %lu, got %ld)\n", sizeof(packet), rc);
+		goto fail;
+	}
+	if (packet.packet_type != kPerformDump) {
+		LOGE("unexpected dump response:%d\n", packet.packet_type);
+		goto fail;
+	}
+
+	/**
+	 * Make the fd O_APPEND so that our output is guaranteed to be at the
+	 * end of a file. (This also makes selinux rules consistent, because
+	 * selinux distinguishes between writing to a regular fd, and writing
+	 * to an fd with O_APPEND)
+	 */
+	flags = fcntl(tmp_output_fd, F_GETFL);
+	if (fcntl(tmp_output_fd, F_SETFL, flags | O_APPEND) != 0) {
+		LOGE("failed to set output fd flags, error (%s)\n",
+					strerror(errno));
+		goto fail;
+	}
+
+	*usercrashd_socket = sockfd;
+	*output_fd = tmp_output_fd;
+
+	return true;
+fail:
+	close(sockfd);
+	close(tmp_output_fd);
+	return false;
+
+}
+
+/**
+ * @usercrashd_socket: client socket fd, used to communicate with server.
+ * usercrashd_notify_completion is used to tell the server it has done the
+ * dump, the server will pop another crash from the queue and execute the dump
+ * process
+ */
+bool usercrashd_notify_completion(int usercrashd_socket)
+{
+	struct crash_packet packet = {0};
+
+	packet.packet_type = kCompletedDump;
+	if (set_timeout(usercrashd_socket)) {
+		close(usercrashd_socket);
+		return -1;
+	}
+	if (write(usercrashd_socket, &packet,
+				sizeof(packet)) != sizeof(packet)) {
+		return false;
+	}
+	return true;
+}
+
+static void print_usage(void)
+{
+	printf("It's the client role of usercrash.\n");
+	printf("[Usage]\n");
+	printf("\t--coredump, usercrash_c <pid> <comm> <sig> ");
+	printf("(root role to run)\n");
+	printf("[Option]\n");
+	printf("\t-h: print this usage message\n");
+	printf("\t-v: print usercrash_c version\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int pid;
+	int sig;
+	int out_fd;
+	int sock;
+	int ret;
+
+	if (argc > 1) {
+		if (strcmp(argv[1], "-v") == 0) {
+			printf("usercrash_c version is 1.0\n");
+			return 0;
+		}
+		if (strcmp(argv[1], "-h") == 0) {
+			print_usage();
+			return 0;
+		}
+	} else
+		print_usage();
+
+	if (getuid() != 0) {
+		LOGE("failed to execute usercrash_c, root is required\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (argc == 4) {
+		/* it's from coredump */
+		pid = atoi(argv[1]);
+		sig = atoi(argv[3]);
+		ret = usercrashd_connect(pid, &sock, &out_fd, argv[2]);
+		if (!ret) {
+			LOGE("usercrashd_connect failed, error (%s)\n",
+					strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		crash_dump(pid, sig, out_fd);
+		close(out_fd);
+		if (!usercrashd_notify_completion(sock)) {
+			LOGE("failed to notify usercrashd of completion");
+			close(sock);
+			exit(EXIT_FAILURE);
+		}
+		close(sock);
+	} else {
+		print_usage();
+		return 0;
+	}
+
 	return 0;
 }

--- a/tools/acrn-crashlog/usercrash/client.c
+++ b/tools/acrn-crashlog/usercrash/client.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Usercrash works as C/S model: usercrash_c works as usercrash client to
+ * collect crash logs and information once crash event occurs. For each time,
+ * usercrash_c receives 3 params from core_dump and sends connect request event
+ * to usercrash_s, then it receives file fd from server to fill crash info into
+ * the file. After this work is done, it will notify server that dump work is
+ * completed.
+ */
+
+int main(void)
+{
+	//TO BE DONE
+	//This empty function is to satisfy the dependency of Makefile.
+	//This is the entry of usercrash_c, the implementation will be
+	//filled by following patches.
+	return 0;
+}

--- a/tools/acrn-crashlog/usercrash/client.c
+++ b/tools/acrn-crashlog/usercrash/client.c
@@ -30,6 +30,7 @@
 #include "packet.h"
 #include "log_sys.h"
 #include "protocol.h"
+#include "version.h"
 
 /**
  * Usercrash works as C/S model: usercrash_c works as usercrash client to
@@ -185,7 +186,10 @@ int main(int argc, char *argv[])
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "-v") == 0) {
-			printf("usercrash_c version is 1.0\n");
+			printf("version is %d.%d-%s, build by %s@%s\n",
+				UC_MAJOR_VERSION, UC_MINOR_VERSION,
+				UC_BUILD_VERSION, UC_BUILD_USER,
+				UC_BUILD_TIME);
 			return 0;
 		}
 		if (strcmp(argv[1], "-h") == 0) {

--- a/tools/acrn-crashlog/usercrash/crash_dump.c
+++ b/tools/acrn-crashlog/usercrash/crash_dump.c
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include "log_sys.h"
+#include "crash_dump.h"
+#include "cmdutils.h"
+#include "fsutils.h"
+#include "strutils.h"
+
+#define GET_TID "/proc/%d/status"
+#define GET_COMM "/proc/%d/exe"
+#define GET_K_STACK "/proc/%d/stack"
+#define GET_MAPS "/proc/%d/maps"
+#define GET_OPEN_FILES "/proc/%d/fd"
+#define DEBUGGER_SIGNAL (__SIGRTMIN + 3)
+#define DUMP_FILE "/tmp/core"
+#define BUFFER_SIZE 8196
+#define LINK_LEN 512
+
+static void loginfo(int fd, const char *fmt, ...)
+{
+	char buf[512];
+	va_list ap;
+	size_t len;
+
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+
+	len = strlen(buf);
+	if (len <= 0)
+		return;
+
+	write(fd, buf, len);
+}
+
+static const char *get_signame(int sig)
+{
+	switch (sig) {
+	case SIGABRT:
+		return "SIGABRT";
+	case SIGBUS:
+		return "SIGBUS";
+	case SIGFPE:
+		return "SIGFPE";
+	case SIGILL:
+		return "SIGILL";
+	case SIGSEGV:
+		return "SIGSEGV";
+#if defined(SIGSTKFLT)
+	case SIGSTKFLT:
+		return "SIGSTKFLT";
+#endif
+	case SIGSTOP:
+		return "SIGSTOP";
+	case SIGSYS:
+		return "SIGSYS";
+	case SIGTRAP:
+		return "SIGTRAP";
+	case DEBUGGER_SIGNAL:
+		return "<debuggerd signal>";
+	default:
+		return "?";
+	}
+}
+
+/**
+ * Save core dump to file.
+ * @filename: core dump file name
+ * return 0 on success, or -1 on error
+ */
+static int save_coredump(const char *filename)
+{
+	size_t read;
+	char input_buffer[BUFFER_SIZE];
+	FILE *dump_file;
+
+	/* open dump file in write and binary mode */
+	dump_file = fopen(filename, "wb");
+	if (dump_file != NULL) {
+		/* Read from STDIN and write to dump file */
+		while (1) {
+			read = fread(input_buffer, 1, BUFFER_SIZE, stdin);
+			if (read > 0) {
+				if (fwrite(input_buffer, 1, read, dump_file) <=
+							0) {
+					LOGE("fwrite error\n");
+					goto fail;
+				}
+				continue;
+			} else if (read == 0) {
+				break;
+			}
+
+			LOGE("fread error\n");
+			goto fail;
+		}
+		fclose(dump_file);
+		return 0;
+	}
+
+	LOGE("fopen core file failed\n");
+	return -1;
+
+fail:
+	fclose(dump_file);
+	return -1;
+}
+
+static int get_backtrace(int pid, int fd, int sig, char *comm)
+{
+	char *membkt;
+	char format[512];
+
+	loginfo(fd, "\nBackTrace:\n\n");
+	memset(format, 0, sizeof(format));
+	if (sig == DEBUGGER_SIGNAL) {
+		snprintf(format, sizeof(format), "-p %d", pid);
+	} else {
+		snprintf(format, sizeof(format), "%s %s", comm, DUMP_FILE);
+		if (save_coredump(DUMP_FILE) == -1) {
+			LOGE("save core file failed\n");
+			return -1;
+		}
+	}
+	membkt = exec_out2mem(GET_GDB_INFO, format);
+	if (!membkt) {
+		LOGE("get gdb info failed\n");
+		return -1;
+	}
+	write(fd, membkt, strlen(membkt));
+	free(membkt);
+	return 0;
+
+}
+
+/**
+ * Save process proc info to file.
+ * @pid: process pid
+ * @fd: usercrash file fd
+ * @path: process proc path
+ * @name: a string save to file
+ * return 0 on success, or -1 on error
+ */
+static int save_proc_info(int pid, int fd, char *path, char *name)
+{
+	int ret;
+	char *data;
+	char format[128];
+	unsigned long size;
+
+	loginfo(fd, "\n%s:\n\n", name);
+	memset(format, 0, sizeof(format));
+	snprintf(format, sizeof(format), path, pid);
+	ret = read_file(format, &size, (void *)&data);
+	if (ret) {
+		LOGE("read file failed\n");
+		return -1;
+	}
+	write(fd, data, size);
+	free(data);
+	return 0;
+
+}
+
+static int get_openfiles(int pid, int fd, char *path, char *name)
+{
+	int ret;
+	int loop;
+	int fdcount;
+	char *fdname;
+	char format[128];
+	char *files[256];
+	char linkname[LINK_LEN];
+
+	loginfo(fd, "\n%s:\n\n", name);
+	memset(format, 0, sizeof(format));
+	snprintf(format, sizeof(format), path, pid);
+	fdcount = lsdir(format, files, ARRAY_SIZE(files));
+	if (fdcount < 0) {
+		LOGE("get fd list failed\n");
+		return -1;
+	}
+	for (loop = 2; loop < fdcount; loop++) {
+		memset(linkname, 0, LINK_LEN);
+		ret = readlink(files[loop], linkname, LINK_LEN);
+		if (ret < 0 || ret >= LINK_LEN) {
+			LOGE("get fd link fd failed\n");
+			continue;
+		}
+		fdname = strrchr(files[loop], '/') + 1;
+		loginfo(fd, "%s -> %s\n", fdname, linkname);
+	}
+	for (loop = 0; loop < fdcount; loop++)
+		free(files[loop]);
+
+	return 0;
+}
+
+static int save_usercrash_file(int pid, int tgid, char *comm,
+		int sig, int out_fd)
+{
+	int ret;
+
+	loginfo(out_fd, "*** *** *** *** *** *** *** *** *** *** *** *** *** ");
+	loginfo(out_fd, "*** *** ***\n");
+	loginfo(out_fd, "pid: %d, tgid: %d, comm: %s\n\n\n", pid, tgid, comm);
+	loginfo(out_fd, "signal: %d (%s)\n", sig, get_signame(sig));
+
+	ret = save_proc_info(pid, out_fd, GET_K_STACK, "Stack");
+	if (ret) {
+		LOGE("save stack failed\n");
+		return -1;
+	}
+
+	ret = save_proc_info(pid, out_fd, GET_MAPS, "Maps");
+	if (ret) {
+		LOGE("save maps failed\n");
+		return -1;
+	}
+
+	ret = get_openfiles(pid, out_fd, GET_OPEN_FILES, "Open files");
+	if (ret) {
+		LOGE("save openfiles failed\n");
+		return -1;
+	}
+
+	ret = get_backtrace(pid, out_fd, sig, comm);
+	if (ret) {
+		LOGE("save backtrace failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int get_key_value(int pid, char *path, char *key, char *value)
+{
+	int len;
+	int ret;
+	unsigned long size;
+	char *data;
+	char *msg;
+	char *start;
+	char *end;
+	char format[128];
+
+	memset(format, 0, sizeof(format));
+	snprintf(format, sizeof(format), path, pid);
+	ret = read_file(format, &size, (void *)&data);
+	if (ret) {
+		LOGE("read file failed\n");
+		return -1;
+	}
+	msg = strstr(data, key);
+	if (!msg) {
+		LOGE("find key:%s failed\n", key);
+		free(data);
+		return -1;
+	}
+	end = strchr(msg, '\n');
+	if (end == NULL)
+		end = data + size;
+	start = msg + strlen(key);
+	len = end - start;
+	memcpy(value, start, len);
+	*(value + len) = 0;
+	free(data);
+
+	return 0;
+}
+
+/**
+ * Get and save process info to out_fd.
+ * @pid: process pid
+ * @sig: signal from core dump
+ * @out_fd: file fd to save info
+ */
+void crash_dump(int pid, int sig, int out_fd)
+{
+	int tgid;
+	int ret;
+	char comm[LINK_LEN];
+	char result[16];
+	char format[128];
+
+	memset(format, 0, sizeof(format));
+	snprintf(format, sizeof(format), GET_COMM, pid);
+	ret = readlink(format, comm, LINK_LEN);
+	if (ret < 0 || ret >= LINK_LEN) {
+		LOGE("get process exe link failed\n");
+		return;
+	}
+	comm[ret] = '\0';
+
+	ret = get_key_value(pid, GET_TID, "Tgid:", result);
+	if (ret) {
+		LOGE("get Tgid error\n");
+		return;
+	}
+	tgid = atoi(result);
+	if (!sig)
+		sig = DEBUGGER_SIGNAL;
+	if (save_usercrash_file(pid, tgid, comm, sig, out_fd))
+		LOGE("dump log file failed\n");
+}

--- a/tools/acrn-crashlog/usercrash/debugger.c
+++ b/tools/acrn-crashlog/usercrash/debugger.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include "crash_dump.h"
+#include "log_sys.h"
+
+/**
+ * Debugger can work without server when uses "debugger pid" commands to
+ * debug the running process. This function will dump the process info on the
+ * screen, also you can relocate the info to a file.
+ */
+static void print_usage(void)
+{
+	printf("debugger - tool to dump process info of a running process. ");
+	printf("[Usage]\n");
+	printf("\t--shell cmd, debugger <pid>  (root role to run)\n");
+	printf("(root role to run)\n");
+	printf("[Option]\n");
+	printf("\t-h: print this usage message\n");
+	printf("\t-v: print debugger version\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int pid;
+
+	if (argc > 1) {
+		if (strcmp(argv[1], "-v") == 0) {
+			printf("debugger version is 1.0\n");
+			return 0;
+		}
+		if (strcmp(argv[1], "-h") == 0) {
+			print_usage();
+			return 0;
+		}
+	} else
+		print_usage();
+
+	if (getuid() != 0) {
+		LOGE("failed to execute debugger, root is required\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (argc == 2) {
+		/* it's from shell cmd */
+		pid = atoi(argv[1]);
+		crash_dump(pid, 0, STDOUT_FILENO);
+	} else {
+		print_usage();
+		return 0;
+	}
+
+	return 0;
+}

--- a/tools/acrn-crashlog/usercrash/debugger.c
+++ b/tools/acrn-crashlog/usercrash/debugger.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include "crash_dump.h"
 #include "log_sys.h"
+#include "version.h"
 
 /**
  * Debugger can work without server when uses "debugger pid" commands to
@@ -33,7 +34,10 @@ int main(int argc, char *argv[])
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "-v") == 0) {
-			printf("debugger version is 1.0\n");
+			printf("version is %d.%d-%s, build by %s@%s\n",
+				UC_MAJOR_VERSION, UC_MINOR_VERSION,
+				UC_BUILD_VERSION, UC_BUILD_USER,
+				UC_BUILD_TIME);
 			return 0;
 		}
 		if (strcmp(argv[1], "-h") == 0) {

--- a/tools/acrn-crashlog/usercrash/include/crash_dump.h
+++ b/tools/acrn-crashlog/usercrash/include/crash_dump.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CRASH_DUMP_H
+#define CRASH_DUMP_H
+
+/**
+ * So far, crash_dump use gdb command to dump process info. But in the future,
+ * we will replace gdb command with a better implementation.
+ */
+#define GET_GDB_INFO "/usr/bin/gdb %s -batch "\
+			"-ex 'bt' "\
+			"-ex 'printf \"\nRegisters\n\"' "\
+			"-ex 'info registers' "\
+			"-ex 'printf \"\n\nMemory near rax\n\"' "\
+			"-ex 'x/16x $rax-0x20' "\
+			"-ex 'x/48x $rax' "\
+			"-ex 'printf \"\n\nMemory near rbx\n\"' "\
+			"-ex 'x/16x $rbx-0x20' "\
+			"-ex 'x/48x $rbx' "\
+			"-ex 'printf \"\n\nMemory near rcx\n\"' "\
+			"-ex 'x/16x $rcx-0x20' "\
+			"-ex 'x/48x $rcx' "\
+			"-ex 'printf \"\n\nMemory near rdx\n\"' "\
+			"-ex 'x/16x $rdx-0x20' "\
+			"-ex 'x/48x $rdx' "\
+			"-ex 'printf \"\n\nMemory near rsi\n\"' "\
+			"-ex 'x/16x $rsi-0x20' "\
+			"-ex 'x/48x $rsi' "\
+			"-ex 'printf \"\n\nMemory near rdi\n\"' "\
+			"-ex 'x/16x $rdi-0x20' "\
+			"-ex 'x/48x $rdi' "\
+			"-ex 'printf \"\n\nMemory near rbp\n\"' "\
+			"-ex 'x/16x $rbp-0x20' "\
+			"-ex 'x/48x $rbp' "\
+			"-ex 'printf \"\n\nMemory near rsp\n\"' "\
+			"-ex 'x/16x $rsp-0x20' "\
+			"-ex 'x/48x $rsp' "\
+			"-ex 'printf \"\n\ncode around rip\n\"' "\
+			"-ex 'x/8i $rip-0x20' "\
+			"-ex 'x/48i $rip' "\
+			"-ex 'printf \"\nThreads\n\n\"' "\
+			"-ex 'info threads' "\
+			"-ex 'printf \"\nThreads backtrace\n\n\"' "\
+			"-ex 'thread apply all bt' "\
+			"-ex 'quit'"
+
+void crash_dump(int pid, int sig, int out_fd);
+
+#endif

--- a/tools/acrn-crashlog/usercrash/include/packet.h
+++ b/tools/acrn-crashlog/usercrash/include/packet.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CLIENT_H
+#define CLIENT_H
+
+#define COMM_NAME_LEN 64
+#define SOCKET_NAME "user_crash"
+
+#include <stdio.h>
+#include <stdbool.h>
+
+enum CrashPacketType {
+	/* Initial request from crash_dump */
+	kDumpRequest = 0,
+
+	/* Notification of a completed crash dump */
+	kCompletedDump,
+
+	/* Responses to kRequest */
+	kPerformDump
+};
+
+struct crash_packet {
+	enum CrashPacketType packet_type;
+	int pid;
+	char name[COMM_NAME_LEN];
+};
+
+#endif

--- a/tools/acrn-crashlog/usercrash/include/protocol.h
+++ b/tools/acrn-crashlog/usercrash/include/protocol.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PROTOCOL_H
+#define PROTOCOL_H
+
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/cdefs.h>
+
+#define RESERVED_SOCKET_PREFIX "/tmp/"
+
+int linux_get_control_socket(const char *name);
+
+int socket_local_client(const char *name, int type);
+ssize_t send_fd(int sockfd, const void *data, size_t len, int fd);
+ssize_t recv_fd(int sockfd, void *data, size_t len, int *out_fd);
+
+#endif

--- a/tools/acrn-crashlog/usercrash/protocol.c
+++ b/tools/acrn-crashlog/usercrash/protocol.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "protocol.h"
+#include "log_sys.h"
+
+/* Documented in header file. */
+static int socket_make_sockaddr_un(const char *name,
+		struct sockaddr_un *p_addr, socklen_t *alen)
+{
+	size_t namelen;
+
+	memset(p_addr, 0, sizeof(struct sockaddr_un));
+	namelen = strlen(name) + strlen(RESERVED_SOCKET_PREFIX);
+	/* unix_path_max appears to be missing on linux */
+	if (namelen > sizeof(*p_addr)-
+			offsetof(struct sockaddr_un, sun_path) - 1) {
+		return -1;
+	}
+	strcpy(p_addr->sun_path, RESERVED_SOCKET_PREFIX);
+	strcat(p_addr->sun_path, name);
+	p_addr->sun_family = AF_LOCAL;
+	*alen = namelen + offsetof(struct sockaddr_un, sun_path) + 1;
+	return 0;
+}
+
+/**
+ * connect to peer named "name" on fd
+ * returns same fd or -1 on error.
+ * fd is not closed on error. that's your job.
+ *
+ */
+static int socket_local_client_connect(int fd, const char *name)
+{
+	struct sockaddr_un addr;
+	socklen_t alen;
+	int err;
+
+	err = socket_make_sockaddr_un(name, &addr, &alen);
+
+	if (err < 0)
+		goto error;
+
+	if (connect(fd, (struct sockaddr *) &addr, alen) < 0) {
+		LOGE("connect to usercrashd failed ,error (%s)\n",
+				strerror(errno));
+		goto error;
+	}
+
+	return fd;
+
+error:
+	return -1;
+}
+
+/**
+ * connect to peer named "name"
+ * returns fd or -1 on error
+ */
+int socket_local_client(const char *name, int type)
+{
+	int s;
+
+	s = socket(AF_LOCAL, type, 0);
+	if (s < 0)
+		return -1;
+
+	if (socket_local_client_connect(s, name) < 0) {
+		close(s);
+		return -1;
+	}
+
+	return s;
+}
+
+static int socket_bind(int fd, const char *name)
+{
+	struct sockaddr_un addr;
+	socklen_t alen;
+
+	addr.sun_family = AF_UNIX;
+	strcpy(addr.sun_path, name);
+	unlink(addr.sun_path);
+	alen = strlen(addr.sun_path) + sizeof(addr.sun_family);
+
+	if (bind(fd, (struct sockaddr *)&addr, alen) == -1)
+		return -1;
+
+	return fd;
+}
+
+static int create_socket_server(const char *name, int type)
+{
+	int err;
+	int fd;
+
+	fd = socket(AF_UNIX, type, 0);
+	if (fd < 0)
+		return -1;
+
+	err = socket_bind(fd, name);
+
+	if (err < 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+int linux_get_control_socket(const char *name)
+{
+	char socketName[64];
+
+	snprintf(socketName, sizeof(socketName), RESERVED_SOCKET_PREFIX "%s",
+				name);
+	return create_socket_server(socketName, SOCK_SEQPACKET);
+}
+
+ssize_t send_fd(int sockfd, const void *data, size_t len, int fd)
+{
+	char cmsg_buf[CMSG_SPACE(sizeof(int))];
+	struct msghdr msg;
+	struct iovec iov;
+	struct cmsghdr *cmsg;
+
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = (void *)data;
+	iov.iov_len = len;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = cmsg_buf;
+	msg.msg_controllen = sizeof(cmsg_buf);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	*(int *)(CMSG_DATA(cmsg)) = fd;
+
+	return sendmsg(sockfd, &msg, 0);
+}
+
+ssize_t recv_fd(int sockfd, void *data, size_t len, int *out_fd)
+{
+	char cmsg_buf[CMSG_SPACE(sizeof(int))];
+	struct msghdr msg;
+	struct iovec iov;
+	struct cmsghdr *cmsg;
+	ssize_t result;
+	bool received_fd;
+	int fd;
+
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = (void *)data;
+	iov.iov_len = len;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = cmsg_buf;
+	msg.msg_controllen = sizeof(cmsg_buf);
+	msg.msg_flags = 0;
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+
+	result = recvmsg(sockfd, &msg, 0);
+	if (result == -1)
+		return -1;
+
+	received_fd = msg.msg_controllen == sizeof(cmsg_buf);
+	if (received_fd)
+		fd = *(int *)(CMSG_DATA(cmsg));
+	else
+		return -1;
+
+	if ((msg.msg_flags & MSG_TRUNC) != 0) {
+		errno = EFBIG;
+		goto fail;
+	} else if ((msg.msg_flags & MSG_CTRUNC) != 0) {
+		errno = ERANGE;
+		goto fail;
+	}
+
+	if (out_fd) {
+		*out_fd = fd;
+	} else if (received_fd) {
+		errno = ERANGE;
+		goto fail;
+	}
+
+	return result;
+fail:
+	close(fd);
+	return -1;
+}

--- a/tools/acrn-crashlog/usercrash/server.c
+++ b/tools/acrn-crashlog/usercrash/server.c
@@ -42,6 +42,7 @@
 #include "packet.h"
 #include "protocol.h"
 #include "log_sys.h"
+#include "version.h"
 
 #define FILE_PATH_LEN_MAX 256
 
@@ -389,7 +390,10 @@ int main(int argc, char *argv[])
 		while ((opt = getopt(argc, argv, "vh")) != -1) {
 			switch (opt) {
 			case 'v':
-				printf("usercrash_s version is 1.0\n");
+				printf("version is %d.%d-%s, build by %s@%s\n",
+					UC_MAJOR_VERSION, UC_MINOR_VERSION,
+					UC_BUILD_VERSION, UC_BUILD_USER,
+					UC_BUILD_TIME);
 				break;
 			case 'h':
 				print_usage();

--- a/tools/acrn-crashlog/usercrash/server.c
+++ b/tools/acrn-crashlog/usercrash/server.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Usercrash works as C/S model: usercrash_s works as usercrash server, which
+ * is to handle events from client in endless loop. Once server receives events
+ * from client, it will create usercrash_0x file under /var/log/usercrashes/
+ * and send file fd to client. Then server will wait for client filling the
+ * event info completely to the crash file. After client's work has been done,
+ * server will be responsiable to free the crash node and process other events.
+ */
+
+int main(void)
+{
+	//TO BE DONE
+	//This empty function is to satisfy the dependency of Makefile.
+	//This is the entry of usercrash_s, the implementation will be filled
+	//by following patches.
+	return 0;
+}

--- a/tools/acrn-crashlog/usercrash/server.c
+++ b/tools/acrn-crashlog/usercrash/server.c
@@ -3,6 +3,48 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+#include <malloc.h>
+#include <event2/event.h>
+#include <event2/listener.h>
+#include <event2/thread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <sys/cdefs.h>
+
+#include "packet.h"
+#include "protocol.h"
+#include "log_sys.h"
+
+#define FILE_PATH_LEN_MAX 256
+
 /**
  * Usercrash works as C/S model: usercrash_s works as usercrash server, which
  * is to handle events from client in endless loop. Once server receives events
@@ -12,11 +54,424 @@
  * server will be responsiable to free the crash node and process other events.
  */
 
-int main(void)
+struct crash_node {
+	int crash_fd;
+	int pid;
+	int out_fd;
+	char name[COMM_NAME_LEN];
+	struct event *crash_event;
+	char crash_path[FILE_PATH_LEN_MAX];
+
+	TAILQ_ENTRY(crash_node) entries;
+};
+
+static const char usercrash_directory[] = "/var/log/usercrashes";
+static int usercrash_count = 50;
+static int next_usercrash;
+
+static int kMaxConcurrentDumps = 1;
+static int num_concurrent_dumps;
+TAILQ_HEAD(, crash_node) queue_t;
+static pthread_mutex_t queue_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+
+static void push_back(struct crash_node *crash);
+static struct crash_node *pop_front(void);
+
+/* Forward declare the callbacks so they can be placed in a sensible order */
+static void crash_accept_cb(struct evconnlistener *listener,
+		evutil_socket_t sockfd, struct sockaddr*, int, void*);
+static void crash_request_cb(evutil_socket_t sockfd, short ev, void *arg);
+static void crash_completed_cb(evutil_socket_t sockfd, short ev, void *arg);
+
+static void __attribute__((__unused__)) debuggerd_register_handlers(
+			struct sigaction *action)
 {
-	//TO BE DONE
-	//This empty function is to satisfy the dependency of Makefile.
-	//This is the entry of usercrash_s, the implementation will be filled
-	//by following patches.
+	sigaction(SIGABRT, action, NULL);
+	sigaction(SIGBUS, action, NULL);
+	sigaction(SIGFPE, action, NULL);
+	sigaction(SIGILL, action, NULL);
+	sigaction(SIGSEGV, action, NULL);
+#if defined(SIGSTKFLT)
+	sigaction(SIGSTKFLT, action, NULL);
+#endif
+	sigaction(SIGSYS, action, NULL);
+	sigaction(SIGTRAP, action, NULL);
+}
+
+static void free_crash(struct crash_node *crash)
+{
+	event_free(crash->crash_event);
+	close(crash->crash_fd);
+	free(crash);
+}
+
+static void push_back(struct crash_node *crash)
+{
+	pthread_mutex_lock(&queue_mtx);
+	TAILQ_INSERT_TAIL(&queue_t, crash, entries);
+	pthread_mutex_unlock(&queue_mtx);
+}
+
+static struct crash_node *pop_front(void)
+{
+	struct crash_node *crash = NULL;
+
+	pthread_mutex_lock(&queue_mtx);
+	if (!TAILQ_EMPTY(&queue_t)) {
+		crash = TAILQ_FIRST(&queue_t);
+		TAILQ_REMOVE(&queue_t, crash, entries);
+	}
+	pthread_mutex_unlock(&queue_mtx);
+
+	return crash;
+}
+
+static void find_oldest_usercrash(void)
+{
+	int i;
+	int oldest_usercrash = 0;
+	time_t oldest_time = LONG_MAX;
+	char path[FILE_PATH_LEN_MAX];
+	struct stat st;
+
+	memset(path, 0, FILE_PATH_LEN_MAX);
+	for (i = 0; i < usercrash_count; ++i) {
+		snprintf(path, sizeof(path), "%s/usercrash_%02d",
+				usercrash_directory, i);
+		if (stat(path, &st) != 0) {
+			if (errno == ENOENT) {
+				oldest_usercrash = i;
+				break;
+			}
+
+			LOGE("failed to stat %s\n", path);
+			continue;
+		}
+
+		if (st.st_mtime < oldest_time) {
+			oldest_usercrash = i;
+			oldest_time = st.st_mtime;
+		}
+	}
+	next_usercrash = oldest_usercrash;
+}
+
+static int get_usercrash(struct crash_node *crash)
+{
+	/**
+	 * If kMaxConcurrentDumps is greater than 1, then theoretically the
+	 * same filename could be handed out to multiple processes. Unlink and
+	 * create the file, instead of using O_TRUNC, to avoid two processes
+	 * interleaving their output
+	 */
+	int result;
+	char file_name[FILE_PATH_LEN_MAX];
+
+	memset(file_name, 0, FILE_PATH_LEN_MAX);
+	snprintf(file_name, sizeof(file_name), "%s/usercrash_%02d",
+				usercrash_directory, next_usercrash);
+
+	if (unlink(file_name) != 0 && errno != ENOENT) {
+		LOGE("failed to unlink usercrash at %s\n", file_name);
+		return -1;
+	}
+	result = open(file_name, O_CREAT | O_WRONLY, 0644);
+	if (result == -1) {
+		LOGE("failed to create usercrash at %s\n", file_name);
+		return -1;
+
+	}
+	next_usercrash = (next_usercrash + 1) % usercrash_count;
+	crash->out_fd = result;
+	strncpy(crash->crash_path, file_name, FILE_PATH_LEN_MAX - 1);
+
+	return 0;
+}
+
+static void perform_request(struct crash_node *crash)
+{
+	ssize_t rc;
+	struct crash_packet response = {0};
+
+	if (get_usercrash(crash)) {
+		LOGE("server exit for open usercrash file failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	LOGI("Prepare to write the '%s' log to %s\n",
+				crash->name, crash->crash_path);
+	response.packet_type = kPerformDump;
+	rc = send_fd(crash->crash_fd, &response,
+				sizeof(response), crash->out_fd);
+	close(crash->out_fd);
+	if (rc == -1) {
+		LOGE("failed to send response to CrashRequest\n");
+		goto fail;
+	} else if (rc != sizeof(response)) {
+		LOGE("crash socket write returned short\n");
+		goto fail;
+	} else {
+		struct timeval timeout = { 100, 0 };
+		struct event_base *base = event_get_base(crash->crash_event);
+
+		event_assign(crash->crash_event, base, crash->crash_fd,
+				EV_TIMEOUT | EV_READ,
+				crash_completed_cb, crash);
+		event_add(crash->crash_event, &timeout);
+	}
+
+	++num_concurrent_dumps;
+	return;
+
+fail:
+	free_crash(crash);
+}
+
+static void dequeue_requests(void)
+{
+	while (!TAILQ_EMPTY(&queue_t) &&
+				num_concurrent_dumps < kMaxConcurrentDumps) {
+		struct crash_node *next_crash = pop_front();
+
+		perform_request(next_crash);
+	}
+}
+
+static void crash_accept_cb(struct evconnlistener *listener,
+			evutil_socket_t sockfd,
+		struct sockaddr *sa __attribute__((unused)),
+		int socklen __attribute__((unused)),
+		void *user_data __attribute__((unused)))
+{
+	struct event_base *base = evconnlistener_get_base(listener);
+	struct crash_node *crash = (struct crash_node *)malloc(
+					sizeof(struct crash_node));
+
+	struct timeval timeout = { 1, 0 };
+	struct event *crash_event = event_new(base, sockfd,
+			EV_TIMEOUT | EV_READ, crash_request_cb, crash);
+
+	if (!crash) {
+		LOGE("Malloc memory for crash failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	memset(crash, 0, sizeof(struct crash_node));
+	crash->crash_fd = sockfd;
+	crash->crash_event = crash_event;
+	event_add(crash_event, &timeout);
+}
+
+static void crash_request_cb(evutil_socket_t sockfd, short ev, void *arg)
+{
+	ssize_t rc;
+	struct crash_node *crash = arg;
+	struct crash_packet request = {0};
+
+	if ((ev & EV_TIMEOUT) != 0) {
+		LOGE("crash request timed out\n");
+		goto fail;
+	} else if ((ev & EV_READ) == 0) {
+		LOGE("usercrash server received unexpected event ");
+		LOGE("from crash socket\n");
+		goto fail;
+	}
+
+	rc = read(sockfd, &request, sizeof(request));
+	if (rc == -1) {
+		LOGE("failed to read from crash socket\n");
+		goto fail;
+	} else if (rc != sizeof(request)) {
+		LOGE("crash socket received short read of length %lu ", rc);
+		LOGE("(expected %lu)\n", sizeof(request));
+		goto fail;
+	}
+
+	if (request.packet_type != kDumpRequest) {
+		LOGE("unexpected crash packet type, expected kDumpRequest, ");
+		LOGE("received %d\n", request.packet_type);
+		goto fail;
+	}
+	crash->pid = request.pid;
+	strncpy(crash->name, request.name, COMM_NAME_LEN - 1);
+
+	LOGI("received crash request from pid %d, name: %s\n",
+				crash->pid, crash->name);
+
+	if (num_concurrent_dumps == kMaxConcurrentDumps) {
+		LOGI("enqueueing crash request for pid %d\n", crash->pid);
+		push_back(crash);
+	} else {
+		perform_request(crash);
+	}
+
+	return;
+
+fail:
+	free_crash(crash);
+}
+
+static void crash_completed_cb(evutil_socket_t sockfd, short ev, void *arg)
+{
+	ssize_t rc;
+	struct crash_node *crash = arg;
+	struct crash_packet request = {0};
+
+	--num_concurrent_dumps;
+
+	if ((ev & EV_TIMEOUT) != 0) {
+		LOGE("error for crash request timed out, error (%s)\n",
+			strerror(errno));
+		goto out;
+	} else if ((ev & EV_READ) == 0) {
+		LOGE("usercrash server received unexpected event ");
+		LOGE("from crash socket\n");
+		goto out;
+	}
+
+	rc = read(sockfd, &request, sizeof(request));
+	if (rc == -1) {
+		LOGE("failed to read from crash socket\n");
+		goto out;
+	} else if (rc != sizeof(request)) {
+		LOGE("crash socket received short read of length %lu, ", rc);
+		LOGE("(expected %lu)\n", sizeof(request));
+		goto out;
+	}
+
+	if (request.packet_type != kCompletedDump) {
+		LOGE("unexpected crash packet type, expected kCompletedDump, ");
+		LOGE("received %d\n", request.packet_type);
+		goto out;
+	}
+
+	if (crash->crash_path) {
+		LOGI("usercrash log written to: %s, ", crash->crash_path);
+		LOGI("crash process name is: %s\n", crash->name);
+	}
+
+out:
+	free_crash(crash);
+	/* If there's something queued up, let them proceed */
+	dequeue_requests();
+}
+
+static void sig_handler(int sig)
+{
+	LOGE("received fatal signal: %d\n", sig);
+	exit(EXIT_FAILURE);
+}
+
+static void print_usage(void)
+{
+	printf("usercrash - tool to dump crash info for the crashes in the ");
+	printf("userspace on sos. It's the server role of usercrash.\n");
+	printf("[Usage] usercrash_s (root role to run)\n");
+	printf("[Option]\n");
+	printf("\t-h: print this usage message\n");
+	printf("\t-v: print usercrash_s version\n");
+	printf("[Output] crash log is in %s folder\n", usercrash_directory);
+}
+
+int main(int argc, char *argv[])
+{
+	char socket_path[128];
+	DIR *dir;
+	int fd;
+	evutil_socket_t crash_socket;
+	int opt;
+	struct sigaction action;
+	struct event_base *base;
+	struct evconnlistener *listener;
+
+	if (argc > 1) {
+		while ((opt = getopt(argc, argv, "vh")) != -1) {
+			switch (opt) {
+			case 'v':
+				printf("usercrash_s version is 1.0\n");
+				break;
+			case 'h':
+				print_usage();
+				break;
+			default:
+				printf("unknown option\n");
+				exit(EXIT_FAILURE);
+			}
+		}
+		return 0;
+	}
+
+	if (getuid() != 0) {
+		LOGE("failed to boot usercrash_s, root is required\n");
+		exit(EXIT_FAILURE);
+	}
+
+	dir = opendir(usercrash_directory);
+	if (dir == NULL) {
+		fd = mkdir(usercrash_directory, 0755);
+		if (fd == -1) {
+			LOGE("create log folder failed, error (%s)\n",
+					strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+		if (chmod(usercrash_directory, 0755) == -1) {
+			LOGE("failed to change usercrash folder priority, ");
+			LOGE("error (%s)\n", strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+	} else {
+		closedir(dir);
+	}
+
+	/* Don't try to connect to ourselves if we crash */
+	memset(&action, 0, sizeof(struct sigaction));
+	action.sa_handler = sig_handler;
+	debuggerd_register_handlers(&action);
+
+	find_oldest_usercrash();
+
+	/**
+	 * evutil_socket_t on other platform except WIN32 platform is int
+	 * type, but on WIN32 platform evutil_socket_t is intptr_t type.
+	 * So, considering compatibility, here need to transfer socket fd to
+	 * evutil_socket_t type.
+	 */
+	crash_socket = (evutil_socket_t)linux_get_control_socket(SOCKET_NAME);
+
+	if (crash_socket == -1) {
+		LOGE("failed to get socket from init, error (%s)\n",
+					strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+	snprintf(socket_path, sizeof(socket_path), "%s/%s",
+			RESERVED_SOCKET_PREFIX, SOCKET_NAME);
+	if (chmod(socket_path, 0622) == -1) {
+		LOGE("failed to change usercrashd_crash priority\n");
+		exit(EXIT_FAILURE);
+	}
+
+	evutil_make_socket_nonblocking(crash_socket);
+
+	base = event_base_new();
+	if (!base) {
+		LOGE("failed to create event_base\n");
+		exit(EXIT_FAILURE);
+	}
+
+	TAILQ_INIT(&queue_t);
+	listener = evconnlistener_new(base, crash_accept_cb, NULL,
+			LEV_OPT_CLOSE_ON_FREE, -1, crash_socket);
+	if (!listener) {
+		LOGE("failed to create evconnlistener: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	LOGI("usercrash_s successfully initialized\n");
+	event_base_dispatch(base);
+
+	evconnlistener_free(listener);
+	event_base_free(base);
+
 	return 0;
 }


### PR DESCRIPTION
This patch set is the initial patch set for acrn-crashlog.

Signed-off-by: xiaojin2 <xiaojing.liu@intel.com>
Signed-off-by: Liu Xinwu <xinwu.liu@intel.com>
Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhang Yanmin <yanmin.zhang@intel.com>
Reviewed-by: Liu Chuansheng <chuansheng.liu@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Acked-by: Eddie Dong <Eddie.dong@intel.com>

The purpose of acrn-crashlog is to collect any useful logs/information after each crash/event occurs on SOS, hypervisor and AaaG. It creates the central place to consolidate all the crash logs on the platform. And it provides abundant logs for developers to debug/analyze the crashes.

The acrn-crashlog works as a probe of telemetrics-client.
It's running on SOS to collect all the crash/events logs occurred on hypervisor, SOS and AaaG. It is autostarted at boot, running as daemon and sending the crashlog path to the telmetrics-client. The telemetrics-client records events of interest and reports them to the backend using telemd telemetrics daemon. The type of events/logs are implemented as probe. The work flow of is decribed as
following:
                crashlog path                  log content
acrnprobe------------>telemetircs-client---------->backend

For more details of telemetrics, please refer the link:
https://github.com/clearlinux/telemetrics-client
https://github.com/clearlinux/telemetrics-backend

The source code structure of this patch set:
acrn-crashlog/
├── acrnprobe
│   └── include
├── common
│   └── include
├── data
└── usercrash
    └── include

- acrnprobe: the core component of acrn-crashlog, which is
  to probe on telmetrics-client, and collects all the
  crash/events logs on the platform. Crashlog on hypervisor
  could be collected with acrnlog. Crashlog on user space
  of SOS could be collected with usercrash, and kernel
  crashlog could be collected with the inherent mechanism,
  like ipanic, pstore and etc. Crashlog on AaaG could be
  collected with monitoring the change of related folders
  on the sos image, like /data/logs/. acrnprobe also
  provides a flexible way to allow users to config which
  crash/event they want to collect through xml file easily.
- common: some utils for logs, exec and text.
- data: configuration files, service files and shell script.
- usercrash: to implement the tool which get the crash info
  for the crashing process in userspace.

Usage:
The crashlog can be retrieved with telem_journal command:
  telem_journal -i

Build Requirements:
libevent-dev
openssl-dev
libxml2-dev
telemetrics-client-dev
check-dev
systemd-dev
