### PR TITLE
exception: only trap #MC

### DIFF
--- a/hypervisor/arch/x86/interrupt.c
+++ b/hypervisor/arch/x86/interrupt.c
@@ -470,6 +470,12 @@ int exception_vmexit_handler(struct vcpu *vcpu)
 	vcpu->arch_vcpu.exception_info.exception = exception_vector;
 	vcpu->arch_vcpu.exception_info.error = int_err_code;
 
+	if (exception_vector == IDT_MC) {
+		/* just print error message for #MC, it then will be injected
+		 * back to guest */
+		pr_fatal("Exception #MC got from guest!");
+	}
+
 	TRACE_4I(TRC_VMEXIT_EXCEPTION_OR_NMI,
 			exception_vector, int_err_code, 2, 0);
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -974,9 +974,9 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 
 	/* Set up guest exception mask bitmap setting a bit * causes a VM exit
 	 * on corresponding guest * exception - pg 2902 24.6.3
-	 * enable VM exit on MC and DB
+	 * enable VM exit on MC only
 	 */
-	value32 = (1 << IDT_MC) | (1u << IDT_DB);
+	value32 = (1 << IDT_MC);
 	exec_vmwrite(VMX_EXCEPTION_BITMAP, value32);
 
 	/* Set up page fault error code mask - second paragraph * pg 2902


### PR DESCRIPTION
HV only print out message for #MC then inject it back to guest.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>