### PR TITLE
Revert "dm: free entries in pci_businfo[] when deinit"

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1272,9 +1272,6 @@ deinit_pci(struct vmctx *ctx)
 				    func, fi);
 			}
 		}
-
-		pci_businfo[bus] = NULL;
-		free(bi);
 	}
 }
 


### PR DESCRIPTION
This commit is reported to cause UOS reboot fail becasue the
pci_businfo[] only be allocated when calling pci_parse_slot
in dm initialization while UOS reboot will not allocate again.
So we can't free it here.

This reverts commit 7aaff68798a4ba3564e4d913678eb84c610dad6c.

Signed-off-by: Jie Deng <jie.deng@intel.com>