### PR TITLE
DM:fix the possible buffer overflow issue using 'strncpy'

### DIFF
--- a/devicemodel/core/sw_load_bzimage.c
+++ b/devicemodel/core/sw_load_bzimage.c
@@ -128,7 +128,7 @@ acrn_get_bzimage_setup_size(struct vmctx *ctx)
 int
 acrn_parse_kernel(char *arg)
 {
-	int len = strlen(arg);
+	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
 		strncpy(kernel_path, arg, len);
@@ -148,7 +148,7 @@ acrn_parse_kernel(char *arg)
 int
 acrn_parse_ramdisk(char *arg)
 {
-	int len = strlen(arg);
+	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
 		strncpy(ramdisk_path, arg, len);

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -101,7 +101,7 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 int
 acrn_parse_bootargs(char *arg)
 {
-	int len = strlen(arg);
+	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
 		strncpy(bootargs, arg, len);

--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -108,7 +108,7 @@ vsbl_set_bdf(int bnum, int snum, int fnum)
 int
 acrn_parse_guest_part_info(char *arg)
 {
-	int len = strlen(arg);
+	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
 		strncpy(guest_part_info_path, arg, len);
@@ -169,7 +169,7 @@ acrn_prepare_guest_part_info(struct vmctx *ctx)
 int
 acrn_parse_vsbl(char *arg)
 {
-	int len = strlen(arg);
+	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
 		strncpy(vsbl_path, arg, len);

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -908,7 +908,7 @@ basl_make_templates(void)
 {
 	const char *tmpdir;
 	int err;
-	int len;
+	size_t len;
 
 	err = 0;
 


### PR DESCRIPTION
function 'strncpy' may incorrectly check buffer boundaries
and may overflow buffers.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>