### PR TITLE
DM: initialize 'create_vm' before reference it in 'vm_opn'

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -112,6 +112,7 @@ vm_open(const char *name)
 	int error, retry = 10;
 	uuid_t vm_uuid;
 
+	memset(&create_vm, 0, sizeof(struct acrn_create_vm));
 	ctx = calloc(1, sizeof(struct vmctx) + strlen(name) + 1);
 	assert(ctx != NULL);
 	assert(devfd == -1);


### PR DESCRIPTION
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>