### PR TITLE
DM: avoid NULL pointer dereferenced in 'ioc_parse()'

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1043,7 +1043,8 @@ ioc_parse(const char *opts)
 	snprintf(virtual_uart_path, sizeof(virtual_uart_path), "%s", param);
 	if (tmp != NULL) {
 		tmp = strtok(NULL, ",");
-		ioc_boot_reason = strtoul(tmp, 0, 0);
+		if (tmp != NULL)
+			ioc_boot_reason = strtoul(tmp, 0, 0);
 	}
 	free(param);
 	return 0;


### PR DESCRIPTION
Pointer 'tmp' may be NULL before passing it to 'strtoul()'

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>