### PR TITLE
DM:fix suspicious dereference of pointer in 'pci_emul_deinit()

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -792,9 +792,10 @@ pci_emul_deinit(struct vmctx *ctx, struct pci_vdev_ops *ops, int bus, int slot,
 	if (fi->fi_param)
 		free(fi->fi_param);
 
-	pci_emul_free_bars(fi->fi_devi);
-	if (fi->fi_devi)
+	if (fi->fi_devi) {
+		pci_emul_free_bars(fi->fi_devi);
 		free(fi->fi_devi);
+	}
 }
 
 void


### PR DESCRIPTION
  suspicious dereference of pointer 'fi->fi_devi'
  by passing it to function 'pci_emul_free_bars()'
  before  NULL check.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>