### PR TITLE
HV: refine 'decode_instruction() function

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -400,7 +400,8 @@ int ept_violation_vmexit_handler(struct vcpu *vcpu)
 	 */
 	mmio->paddr = gpa;
 
-	if (decode_instruction(vcpu, mmio) != 0)
+	mmio->access_size = decode_instruction(vcpu);
+	if (mmio->access_size == 0)
 		goto out;
 
 	list_for_each(pos, &vcpu->vm->mmio_list) {

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -2107,7 +2107,7 @@ decode_moffset(struct vie *vie)
 }
 
 int
-vmm_decode_instruction(__unused struct vcpu *vcpu, __unused uint64_t gla,
+__decode_instruction(__unused struct vcpu *vcpu, __unused uint64_t gla,
 		enum vm_cpu_mode cpu_mode, int cs_d, struct vie *vie)
 {
 	if (decode_prefixes(vie, cpu_mode, cs_d))

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -86,10 +86,10 @@ void vie_init(struct vie *vie, const char *inst_bytes, uint32_t inst_length);
  * in VIE_INVALID_GLA instead.
  */
 #define	VIE_INVALID_GLA		(1UL << 63)	/* a non-canonical address */
-int vmm_decode_instruction(struct vcpu *vcpu, uint64_t gla,
+int __decode_instruction(struct vcpu *vcpu, uint64_t gla,
 		enum vm_cpu_mode cpu_mode, int csd, struct vie *vie);
 
 int emulate_instruction(struct vcpu *vcpu, struct mem_io *mmio);
-int decode_instruction(struct vcpu *vcpu, struct mem_io *mmio);
+uint8_t decode_instruction(struct vcpu *vcpu);
 
 #endif	/* _VMM_INSTRUCTION_EMUL_H_ */

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2178,7 +2178,7 @@ int apic_access_vmexit_handler(struct vcpu *vcpu)
 
 	vlapic = vcpu->arch_vcpu.vlapic;
 
-	decode_instruction(vcpu, &vcpu->mmio);
+	decode_instruction(vcpu);
 	if (access_type == 1) {
 		if (!emulate_instruction(vcpu, &vcpu->mmio))
 			vlapic_write(vlapic, 1, offset, vcpu->mmio.value);


### PR DESCRIPTION
update:
   1. remove 'struct mem_io *'from input arguments
   2. return 'opsize' instead of status.
   3. rename 'vmm_decode_instruction()'

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>