### PR TITLE
doc: add missing param documentation hypercall.h

### DIFF
--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -337,6 +337,7 @@ int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
 /**
  * @brief Get VCPU Power state.
  *
+ * @param vm pointer to VM data structure
  * @param cmd cmd to show get which VCPU power state data
  * @param param VCPU power state data
  *


### PR DESCRIPTION
Add missing documentation for hcall_get_cpu_pm_state vm parameter

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>