### PR TITLE
HV:remove redundant field 'mmio' from 'struct emul_cnx'

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -326,7 +326,7 @@ int dm_emulate_mmio_post(struct vcpu *vcpu)
 	if (vcpu->mmio.read_write == HV_MEM_IO_READ) {
 		vcpu->mmio.value = vcpu->req.reqs.mmio_request.value;
 		/* Emulate instruction and update vcpu register set */
-		ret = emulate_instruction(vcpu, &vcpu->mmio);
+		ret = emulate_instruction(vcpu);
 		if (ret != 0)
 			goto out;
 	}
@@ -340,7 +340,7 @@ static int dm_emulate_mmio_pre(struct vcpu *vcpu, uint64_t exit_qual)
 	int status;
 
 	if (vcpu->mmio.read_write == HV_MEM_IO_WRITE) {
-		status = emulate_instruction(vcpu, &vcpu->mmio);
+		status = emulate_instruction(vcpu);
 		if (status != 0)
 			return status;
 		vcpu->req.reqs.mmio_request.value = vcpu->mmio.value;
@@ -420,7 +420,7 @@ int ept_violation_vmexit_handler(struct vcpu *vcpu)
 		}
 
 		if (mmio->read_write == HV_MEM_IO_WRITE) {
-			if (emulate_instruction(vcpu, mmio) != 0)
+			if (emulate_instruction(vcpu) != 0)
 				goto out;
 		}
 
@@ -432,7 +432,7 @@ int ept_violation_vmexit_handler(struct vcpu *vcpu)
 		hv_emulate_mmio(vcpu, mmio, mmio_handler);
 		if (mmio->read_write == HV_MEM_IO_READ) {
 			/* Emulate instruction and update vcpu register set */
-			if (emulate_instruction(vcpu, mmio) != 0)
+			if (emulate_instruction(vcpu) != 0)
 				goto out;
 		}
 

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -89,7 +89,7 @@ void vie_init(struct vie *vie, const char *inst_bytes, uint32_t inst_length);
 int __decode_instruction(struct vcpu *vcpu, uint64_t gla,
 		enum vm_cpu_mode cpu_mode, int csd, struct vie *vie);
 
-int emulate_instruction(struct vcpu *vcpu, struct mem_io *mmio);
+int emulate_instruction(struct vcpu *vcpu);
 uint8_t decode_instruction(struct vcpu *vcpu);
 
 #endif	/* _VMM_INSTRUCTION_EMUL_H_ */

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2180,11 +2180,11 @@ int apic_access_vmexit_handler(struct vcpu *vcpu)
 
 	decode_instruction(vcpu);
 	if (access_type == 1) {
-		if (!emulate_instruction(vcpu, &vcpu->mmio))
+		if (!emulate_instruction(vcpu))
 			vlapic_write(vlapic, 1, offset, vcpu->mmio.value);
 	} else if (access_type == 0) {
 		vlapic_read(vlapic, 1, offset, &vcpu->mmio.value);
-		emulate_instruction(vcpu, &vcpu->mmio);
+		emulate_instruction(vcpu);
 	}
 
 	TRACE_2L(TRC_VMEXIT_APICV_ACCESS, qual, (uint64_t)vlapic);


### PR DESCRIPTION
Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>