### PR TITLE
tools: acrn-crashlog: compile without telemetrics client

### DIFF
--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -19,15 +19,20 @@ export INCLUDE
 export BUILDDIR
 export CC
 export RM
-export CFLAGS
 
-SYSTEMD_LIBS = -lsystemd
+EXTRA_LIBS = -lsystemd
 LDCNF := $(shell ldconfig -p)
 LIB_EXIST = $(findstring libsystemd-journal.so, $(LDCNF))
 ifeq ($(strip $(LIB_EXIST)),libsystemd-journal.so)
-	SYSTEMD_LIBS = -lsystemd-journal
+	EXTRA_LIBS = -lsystemd-journal
 endif
-export SYSTEMD_LIBS
+LIB_EXIST = $(findstring libtelemetry.so, $(LDCNF))
+ifeq ($(strip $(LIB_EXIST)),libtelemetryxx.so)
+	CFLAGS	+= -DHAVE_TELEMETRICS_CLIENT
+	EXTRA_LIBS += -ltelemetry
+endif
+export CFLAGS
+export EXTRA_LIBS
 
 .PHONY:all
 all:

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -3,7 +3,7 @@ MINOR_VERSION=0
 
 BASEDIR 	:= $(shell pwd)
 
-LIBS		= -lpthread -lxml2 -lcrypto -lrt $(SYSTEMD_LIBS) -ltelemetry
+LIBS		= -lpthread -lxml2 -lcrypto -lrt $(EXTRA_LIBS)
 INCLUDE		+= -I $(BASEDIR)/include -I /usr/include/libxml2
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -g -O0 -std=gnu11

--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -157,7 +157,8 @@ static void *event_handle(void *unused __attribute__((unused)))
 			if (!sender)
 				continue;
 
-			sender->send(e);
+			if (sender->send)
+				sender->send(e);
 		}
 
 		if ((e->dir))

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -23,6 +23,8 @@
 #include "property.h"
 #include "startupreason.h"
 #include "log_sys.h"
+
+#ifdef HAVE_TELEMETRICS_CLIENT
 #include "telemetry.h"
 
 #define CRASH_SEVERITY 4
@@ -34,6 +36,7 @@ struct telemd_data_t {
 	char *eventid;
 	uint32_t severity;
 };
+#endif
 
 /* get_log_file_* only used to copy regular file which can be mmaped */
 static void get_log_file_complete(struct log_t *log, char *desdir)
@@ -272,6 +275,7 @@ static void get_log_cmd(struct log_t *log, char *desdir)
 	out_via_fork(log, desdir);
 }
 
+#ifdef HAVE_TELEMETRICS_CLIENT
 static bool telemd_send_data(char *payload, char *eventid, uint32_t severity,
 				char *class)
 {
@@ -389,6 +393,7 @@ send_nologs:
 	telemd_send_data(msg, d->eventid, d->severity, d->class);
 	free(msg);
 }
+#endif
 
 static void crashlog_get_log(struct log_t *log, void *data)
 {
@@ -427,6 +432,7 @@ static void crashlog_get_log(struct log_t *log, void *data)
 		LOGW("get (%s) spend %ds\n", log->name, spent);
 }
 
+#ifdef HAVE_TELEMETRICS_CLIENT
 static void telemd_send_crash(struct event_t *e)
 {
 	struct crash_t *crash;
@@ -774,6 +780,7 @@ static void telemd_send(struct event_t *e)
 		LOGE("unsupoorted event type %d\n", e->event_type);
 	}
 }
+#endif
 
 static void crashlog_send_crash(struct event_t *e)
 {
@@ -1122,9 +1129,11 @@ int init_sender(void)
 			ret = prepare_history();
 			if (ret)
 				return -1;
+#ifdef HAVE_TELEMETRICS_CLIENT
 		} else if (!strncmp(sender->name, "telemd",
 				    strlen(sender->name))) {
 			sender->send = telemd_send;
+#endif
 		}
 	}
 

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -6,7 +6,7 @@ all: include/version.h check_obj usercrash_s usercrash_c debugger
 CURRDIR := $(shell pwd)
 INCLUDE += -I $(CURRDIR)/include/
 
-LIBS = -levent -lpthread $(SYSTEMD_LIBS)
+LIBS = -levent -lpthread $(EXTRA_LIBS)
 
 usercrash_s: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/server.o \


### PR DESCRIPTION
Define a macro HAVE_TELEMETRICS_CLIENT to distinguish the compiling
environment which is not include telemetrics client.

Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Jack Ren <jack.ren@intel.com>