### PR TITLE
fix "obsolete use of designated initializer without '='"

### DIFF
--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -50,7 +50,8 @@ uint64_t get_microcode_version(void)
  * According to SDM vol 3 Table 9-7. If data_size field of uCode
  * header is zero, the ucode length is 2000
  */
-#define	GET_DATA_SIZE(hdptr)	((hdptr)->data_size ? : 2000)
+#define	GET_DATA_SIZE(hdptr)	((hdptr)->data_size ?\
+			((hdptr)->data_size) : 2000)
 void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
 {
 	uint64_t hva, gpa, gva;

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -76,7 +76,7 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_VMCALL] = {
 		.handler = vmcall_vmexit_handler},
-	[VMX_EXIT_REASON_VMCLEAR] {
+	[VMX_EXIT_REASON_VMCLEAR] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_VMLAUNCH] = {
 		.handler = unhandled_vmexit_handler},


### PR DESCRIPTION
According in C99 manual 6.7.8,'=' is required.

Signed-off-by: huihuang.shi <huihuang.shi@intel.com>