### PR TITLE
DM: using 'strncpy' coding style cleanup

### DIFF
--- a/devicemodel/core/sw_load_bzimage.c
+++ b/devicemodel/core/sw_load_bzimage.c
@@ -131,8 +131,7 @@ acrn_parse_kernel(char *arg)
 	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
-		strncpy(kernel_path, arg, len);
-		kernel_path[len] = '\0';
+		strncpy(kernel_path, arg, len + 1);
 		if (check_image(kernel_path) != 0){
 			fprintf(stderr, "SW_LOAD: check_image failed for '%s'\n",
 				kernel_path);
@@ -151,8 +150,7 @@ acrn_parse_ramdisk(char *arg)
 	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
-		strncpy(ramdisk_path, arg, len);
-		ramdisk_path[len] = '\0';
+		strncpy(ramdisk_path, arg, len + 1);
 		if (check_image(ramdisk_path) != 0){
 			fprintf(stderr, "SW_LOAD: check_image failed for '%s'\n",
 				ramdisk_path);

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -104,8 +104,7 @@ acrn_parse_bootargs(char *arg)
 	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
-		strncpy(bootargs, arg, len);
-		bootargs[len] = '\0';
+		strncpy(bootargs, arg, len + 1);
 		with_bootargs = 1;
 		printf("SW_LOAD: get bootargs %s\n", bootargs);
 		return 0;

--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -111,8 +111,7 @@ acrn_parse_guest_part_info(char *arg)
 	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
-		strncpy(guest_part_info_path, arg, len);
-		guest_part_info_path[len] = '\0';
+		strncpy(guest_part_info_path, arg, len + 1);
 		assert(check_image(guest_part_info_path) == 0);
 
 		with_guest_part_info = true;
@@ -172,8 +171,7 @@ acrn_parse_vsbl(char *arg)
 	size_t len = strlen(arg);
 
 	if (len < STR_LEN) {
-		strncpy(vsbl_path, arg, len);
-		vsbl_path[len] = '\0';
+		strncpy(vsbl_path, arg, len + 1);
 		assert(check_image(vsbl_path) == 0);
 
 		vsbl_file_name = vsbl_path;

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -922,7 +922,7 @@ basl_make_templates(void)
 	len = strlen(tmpdir);
 
 	if ((len + sizeof(ASL_TEMPLATE) + 1) < MAXPATHLEN) {
-		strncpy(basl_template, tmpdir, len);
+		strncpy(basl_template, tmpdir, len + 1);
 		while (len > 0 && basl_template[len - 1] == '/')
 			len--;
 		basl_template[len] = '/';
@@ -937,7 +937,7 @@ basl_make_templates(void)
 		 */
 		if ((len + sizeof(ASL_TEMPLATE) + 1 +
 		     sizeof(ASL_SUFFIX)) < MAXPATHLEN) {
-			strncpy(basl_stemplate, tmpdir, len);
+			strncpy(basl_stemplate, tmpdir, len + 1);
 			basl_stemplate[len] = '/';
 			strncpy(&basl_stemplate[len + 1], ASL_TEMPLATE,
 					MAXPATHLEN - len - 1);


### PR DESCRIPTION
- check buffer boundaries to avoid buffer overflow

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>