### PR TITLE
fix "warning:range expression in switch statements are not standard"

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -431,7 +431,12 @@ vlapic_get_lvtptr(struct vlapic *vlapic, uint32_t offset)
 	switch (offset) {
 	case APIC_OFFSET_CMCI_LVT:
 		return &lapic->lvt_cmci;
-	case APIC_OFFSET_TIMER_LVT ... APIC_OFFSET_ERROR_LVT:
+	case APIC_OFFSET_TIMER_LVT:
+	case APIC_OFFSET_THERM_LVT:
+	case APIC_OFFSET_PERF_LVT:
+	case APIC_OFFSET_LINT0_LVT:
+	case APIC_OFFSET_LINT1_LVT:
+	case APIC_OFFSET_ERROR_LVT:
 		i = (offset - APIC_OFFSET_TIMER_LVT) >> 2;
 		return (&lapic->lvt_timer) + i;
 	default:
@@ -1240,15 +1245,36 @@ vlapic_read(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 	case APIC_OFFSET_SVR:
 		*data = lapic->svr;
 		break;
-	case APIC_OFFSET_ISR0 ... APIC_OFFSET_ISR7:
+	case APIC_OFFSET_ISR0:
+	case APIC_OFFSET_ISR1:
+	case APIC_OFFSET_ISR2:
+	case APIC_OFFSET_ISR3:
+	case APIC_OFFSET_ISR4:
+	case APIC_OFFSET_ISR5:
+	case APIC_OFFSET_ISR6:
+	case APIC_OFFSET_ISR7:
 		i = (offset - APIC_OFFSET_ISR0) >> 4;
 		*data = lapic->isr[i].val;
 		break;
-	case APIC_OFFSET_TMR0 ... APIC_OFFSET_TMR7:
+	case APIC_OFFSET_TMR0:
+	case APIC_OFFSET_TMR1:
+	case APIC_OFFSET_TMR2:
+	case APIC_OFFSET_TMR3:
+	case APIC_OFFSET_TMR4:
+	case APIC_OFFSET_TMR5:
+	case APIC_OFFSET_TMR6:
+	case APIC_OFFSET_TMR7:
 		i = (offset - APIC_OFFSET_TMR0) >> 4;
 		*data = lapic->tmr[i].val;
 		break;
-	case APIC_OFFSET_IRR0 ... APIC_OFFSET_IRR7:
+	case APIC_OFFSET_IRR0:
+	case APIC_OFFSET_IRR1:
+	case APIC_OFFSET_IRR2:
+	case APIC_OFFSET_IRR3:
+	case APIC_OFFSET_IRR4:
+	case APIC_OFFSET_IRR5:
+	case APIC_OFFSET_IRR6:
+	case APIC_OFFSET_IRR7:
 		i = (offset - APIC_OFFSET_IRR0) >> 4;
 		*data = lapic->irr[i].val;
 		break;
@@ -1262,7 +1288,12 @@ vlapic_read(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 		*data = lapic->icr_hi;
 		break;
 	case APIC_OFFSET_CMCI_LVT:
-	case APIC_OFFSET_TIMER_LVT ... APIC_OFFSET_ERROR_LVT:
+	case APIC_OFFSET_TIMER_LVT:
+	case APIC_OFFSET_THERM_LVT:
+	case APIC_OFFSET_PERF_LVT:
+	case APIC_OFFSET_LINT0_LVT:
+	case APIC_OFFSET_LINT1_LVT:
+	case APIC_OFFSET_ERROR_LVT:
 		*data = vlapic_get_lvt(vlapic, offset);
 #ifdef INVARIANTS
 		reg = vlapic_get_lvtptr(vlapic, offset);
@@ -1361,7 +1392,12 @@ vlapic_write(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 		lapic->icr_hi = data;
 		break;
 	case APIC_OFFSET_CMCI_LVT:
-	case APIC_OFFSET_TIMER_LVT ... APIC_OFFSET_ERROR_LVT:
+	case APIC_OFFSET_TIMER_LVT:
+	case APIC_OFFSET_THERM_LVT:
+	case APIC_OFFSET_PERF_LVT:
+	case APIC_OFFSET_LINT0_LVT:
+	case APIC_OFFSET_LINT1_LVT:
+	case APIC_OFFSET_ERROR_LVT:
 		regptr = vlapic_get_lvtptr(vlapic, offset);
 		*regptr = data;
 		vlapic_lvt_write_handler(vlapic, offset);
@@ -1390,10 +1426,12 @@ vlapic_write(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 	case APIC_OFFSET_APR:
 	case APIC_OFFSET_PPR:
 	case APIC_OFFSET_RRR:
-	case APIC_OFFSET_ISR0 ... APIC_OFFSET_ISR7:
-	case APIC_OFFSET_TMR0 ... APIC_OFFSET_TMR7:
-	case APIC_OFFSET_IRR0 ... APIC_OFFSET_IRR7:
 		break;
+/*The following cases fall to the default one:
+ *	APIC_OFFSET_ISR0 ... APIC_OFFSET_ISR7
+ *	APIC_OFFSET_TMR0 ... APIC_OFFSET_TMR7
+ *	APIC_OFFSET_IRR0 ... APIC_OFFSET_IRR7
+ */
 	case APIC_OFFSET_TIMER_CCR:
 		break;
 	default:
@@ -2258,7 +2296,12 @@ int apic_write_vmexit_handler(struct vcpu *vcpu)
 			handled = 0;
 		break;
 	case APIC_OFFSET_CMCI_LVT:
-	case APIC_OFFSET_TIMER_LVT ... APIC_OFFSET_ERROR_LVT:
+	case APIC_OFFSET_TIMER_LVT:
+	case APIC_OFFSET_THERM_LVT:
+	case APIC_OFFSET_PERF_LVT:
+	case APIC_OFFSET_LINT0_LVT:
+	case APIC_OFFSET_LINT1_LVT:
+	case APIC_OFFSET_ERROR_LVT:
 		vlapic_lvt_write_handler(vlapic, offset);
 		break;
 	case APIC_OFFSET_TIMER_ICR:

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -187,9 +187,6 @@ int rdmsr_vmexit_handler(struct vcpu *vcpu)
 
 	case MSR_IA32_MTRR_CAP:
 	case MSR_IA32_MTRR_DEF_TYPE:
-	case MSR_IA32_MTRR_PHYSBASE_0 ... MSR_IA32_MTRR_PHYSMASK_9:
-	case MSR_IA32_MTRR_FIX64K_00000 ... MSR_IA32_MTRR_FIX4K_F8000:
-	case MSR_IA32_VMX_BASIC ... MSR_IA32_VMX_TRUE_ENTRY_CTLS:
 	{
 		vcpu_inject_gp(vcpu);
 		break;
@@ -234,7 +231,14 @@ int rdmsr_vmexit_handler(struct vcpu *vcpu)
 	}
 	default:
 	{
-		pr_warn("rdmsr: %lx should not come here!", msr);
+		if (!((msr >= MSR_IA32_MTRR_PHYSBASE_0 &&
+			msr <= MSR_IA32_MTRR_PHYSMASK_9) ||
+		      (msr >= MSR_IA32_MTRR_FIX64K_00000 &&
+			msr <= MSR_IA32_MTRR_FIX4K_F8000) ||
+		      (msr >= MSR_IA32_VMX_BASIC &&
+			msr <= MSR_IA32_VMX_TRUE_ENTRY_CTLS))) {
+			pr_warn("rdmsr: %lx should not come here!", msr);
+		}
 		vcpu_inject_gp(vcpu);
 		v = 0;
 		break;
@@ -282,9 +286,6 @@ int wrmsr_vmexit_handler(struct vcpu *vcpu)
 
 	case MSR_IA32_MTRR_CAP:
 	case MSR_IA32_MTRR_DEF_TYPE:
-	case MSR_IA32_MTRR_PHYSBASE_0 ... MSR_IA32_MTRR_PHYSMASK_9:
-	case MSR_IA32_MTRR_FIX64K_00000 ... MSR_IA32_MTRR_FIX4K_F8000:
-	case MSR_IA32_VMX_BASIC ... MSR_IA32_VMX_TRUE_ENTRY_CTLS:
 	{
 		vcpu_inject_gp(vcpu);
 		break;
@@ -342,7 +343,14 @@ int wrmsr_vmexit_handler(struct vcpu *vcpu)
 	}
 	default:
 	{
-		pr_warn(0, "wrmsr: %lx should not come here!", msr);
+		if (!((msr >= MSR_IA32_MTRR_PHYSBASE_0 &&
+			msr <= MSR_IA32_MTRR_PHYSMASK_9) ||
+		      (msr >= MSR_IA32_MTRR_FIX64K_00000 &&
+			msr <= MSR_IA32_MTRR_FIX4K_F8000) ||
+		      (msr >= MSR_IA32_VMX_BASIC &&
+			msr <= MSR_IA32_VMX_TRUE_ENTRY_CTLS))) {
+			pr_warn("rdmsr: %lx should not come here!", msr);
+		}
 		vcpu_inject_gp(vcpu);
 		break;
 	}


### PR DESCRIPTION
Range expression in switch statement is in gcc extension standard(gcc
manual 6.28),not in c99 standard.
GCC manual 6.28 reference link below:
(https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Case-Ranges.html#Case-Ranges)

Signed-off-by: huihuang.shi <huihuang.shi@intel.com>