### PR TITLE
fix "warning:ISO C forbids 'return' with expression,in function retur…

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1119,8 +1119,10 @@ vlapic_intr_accepted(struct vlapic *vlapic, int vector)
 	struct lapic_reg *irrptr, *isrptr;
 	int idx, stk_top;
 
-	if (vlapic->ops.apicv_intr_accepted)
-		return (*vlapic->ops.apicv_intr_accepted)(vlapic, vector);
+	if (vlapic->ops.apicv_intr_accepted) {
+		(*vlapic->ops.apicv_intr_accepted)(vlapic, vector);
+		return;
+	}
 
 	/*
 	 * clear the ready bit for vector being accepted in irr


### PR DESCRIPTION
…ning void"

returning void function must return void.

Signed-off-by: huihuang.shi <huihuang.shi@intel.com>