### PR TITLE
Configure install locations in a single place.

### DIFF
--- a/Defs.mk
+++ b/Defs.mk
@@ -1,0 +1,6 @@
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+# See LICENSE for terms.
+
+INSTALL_BINDIR := /usr/bin
+INSTALL_LIBDIR := /usr/lib/acrn
+INSTALL_SHAREDIR := /usr/share/acrn

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -1,6 +1,9 @@
 #
 # ACRN-DM
 #
+
+include ../Defs.mk
+
 MAJOR_VERSION=0
 MINOR_VERSION=1
 RC_VERSION=4
@@ -158,8 +161,7 @@ $(DM_OBJDIR)/%.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 install: $(DM_OBJDIR)/$(PROGRAM) install-samples
-	install -D $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)/usr/bin/$(PROGRAM)
+	install -D --mode=0755 $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)$(INSTALL_BINDIR)/$(PROGRAM)
 
 install-samples: $(SAMPLES)
-	install -d $(DESTDIR)/usr/share/acrn/demo
-	install -t $(DESTDIR)/usr/share/acrn/demo $^
+	install -D -t $(DESTDIR)$(INSTALL_SHAREDIR)/demo $^

--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -30,6 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+include ../../../../Defs.mk
+
 RELEASE:=0
 HV_OBJDIR:=build
 HV_FILE:=acrn
@@ -92,7 +94,7 @@ all: $(EFIBIN)
 	$(OBJCOPY)  --add-section .hv="$(HV_OBJDIR)/$(HV_FILE).bin"  --change-section-vma .hv=0x6e000 --set-section-flags .hv=alloc,data,contents,load  --section-alignment 0x1000 $(EFI_OBJDIR)/boot.efi  $(EFIBIN)
 
 install: $(EFIBIN) install-conf
-	install -D $(EFIBIN) $(DESTDIR)/usr/share/acrn/$(HV_FILE).efi
+	install -D $(EFIBIN) $(DESTDIR)$(INSTALL_LIBDIR)/$(HV_FILE).efi
 
 $(EFIBIN): $(BOOT)
 
@@ -102,8 +104,7 @@ $(EFI_OBJDIR)/boot.so: $(ACRN_OBJS) $(FS)
 	$(LD) $(LDFLAGS) -o $@ $^  -lgnuefi -lefi $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 install-conf: $(CONF_FILE)
-	install -d $(DESTDIR)/usr/share/acrn/demo
-	install -t $(DESTDIR)/usr/share/acrn/demo -m 644 $^
+	install -D --mode=0644 $^ $(DESTDIR)$(INSTALL_SHAREDIR)/demo/acrn.conf
 
 clean:
 	rm -f $(BOOT) $(HV_OBJDIR)/$(HV_FILE).efi $(EFI_OBJDIR)/boot.so $(ACRN_OBJS) $(FS)

--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -2,6 +2,8 @@
 # ACRN-Crashlog Makefile
 #
 
+include ../../Defs.mk
+
 BASEDIR 	:= $(shell pwd)
 OUT_DIR 	?= $(BASEDIR)
 BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
@@ -51,37 +53,33 @@ clean:
 
 .PHONY:install
 install:
-	@install -d $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/acrnprobe/bin/acrnprobe $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/debugger $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_c $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_s $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 data/acrnprobe_prepare.sh $(DESTDIR)/usr/bin/
-	@install -d $(DESTDIR)/usr/lib/systemd/system.conf.d/
-	@install -p -D -m 0644 data/40-watchdog.conf $(DESTDIR)/usr/lib/systemd/system.conf.d/
-	@install -d $(DESTDIR)/usr/share/defaults/telemetrics/
-	@install -p -D -m 0644 data/acrnprobe.xml $(DESTDIR)/usr/share/defaults/telemetrics/
-	@install -d $(DESTDIR)/usr/lib/systemd/system/
-	@install -p -D -m 0644 data/acrnprobe.service $(DESTDIR)/usr/lib/systemd/system/
-	@install -p -D -m 0644 data/prepare.service $(DESTDIR)/usr/lib/systemd/system/
-	@install -p -D -m 0644 data/usercrash.service $(DESTDIR)/usr/lib/systemd/system/
+	@install -p -D -m 0755 $(BUILDDIR)/acrnprobe/bin/acrnprobe $(DESTDIR)$(INSTALL_BINDIR)
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/debugger $(DESTDIR)$(INSTALL_BINDIR)
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_c $(DESTDIR)$(INSTALL_BINDIR)
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_s $(DESTDIR)$(INSTALL_BINDIR)
+	@install -p -D -m 0755 data/acrnprobe_prepare.sh $(DESTDIR)$(INSTALL_BINDIR)
+	@install -p -D -m 0644 data/40-watchdog.conf $(DESTDIR)/usr/lib/systemd/system.conf.d/40-watchdog.conf
+	@install -p -D -m 0644 data/acrnprobe.xml $(DESTDIR)/usr/share/defaults/telemetrics/acrnprobe.xml
+	@install -p -D -m 0644 data/acrnprobe.service $(DESTDIR)/usr/lib/systemd/system/acrnprobe.service
+	@install -p -D -m 0644 data/prepare.service $(DESTDIR)/usr/lib/systemd/system/prepare.service
+	@install -p -D -m 0644 data/usercrash.service $(DESTDIR)/usr/lib/systemd/system/usercrash.service
 
 .PHONY:uninstall
 uninstall:
-	@if [ -e "$(DESTDIR)/usr/bin/acrnprobe" ];then \
-		$(RM) $(DESTDIR)/usr/bin/acrnprobe; \
+	@if [ -e "$(DESTDIR)$(INSTALL_BINDIR)/acrnprobe" ];then \
+		$(RM) $(DESTDIR)$(INSTALL_BINDIR)/acrnprobe; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/acrnprobe_prepare.sh" ];then \
-		$(RM) $(DESTDIR)/usr/bin/acrnprobe_prepare.sh; \
+	@if [ -e "$(DESTDIR)$(INSTALL_BINDIR)/acrnprobe_prepare.sh" ];then \
+		$(RM) $(DESTDIR)$(INSTALL_BINDIR)/acrnprobe_prepare.sh; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/debugger" ];then \
-		$(RM) $(DESTDIR)/usr/bin/debugger; \
+	@if [ -e "$(DESTDIR)$(INSTALL_BINDIR)/debugger" ];then \
+		$(RM) $(DESTDIR)$(INSTALL_BINDIR)/debugger; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/usercrash_c" ];then \
-		$(RM) $(DESTDIR)/usr/bin/usercrash_c; \
+	@if [ -e "$(DESTDIR)$(INSTALL_BINDIR)/usercrash_c" ];then \
+		$(RM) $(DESTDIR)$(INSTALL_BINDIR)/usercrash_c; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/usercrash_s" ];then \
-		$(RM) $(DESTDIR)/usr/bin/usercrash_s; \
+	@if [ -e "$(DESTDIR)$(INSTALL_BINDIR)/usercrash_s" ];then \
+		$(RM) $(DESTDIR)$(INSTALL_BINDIR)/usercrash_s; \
 	fi
 	@if [ -e "$(DESTDIR)/usr/lib/systemd/system.conf.d/40-watchdog.conf" ];then \
 		$(RM) $(DESTDIR)/usr/lib/systemd/system.conf.d/40-watchdog.conf; \

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -1,3 +1,4 @@
+include ../../Defs.mk
 
 OUT_DIR ?= .
 
@@ -8,5 +9,4 @@ clean:
 	rm -f $(OUT_DIR)/acrnctl
 
 install: $(OUT_DIR)/acrnctl
-	install -d $(DESTDIR)/usr/bin
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnctl
+	install -D --mode=0755 $(OUT_DIR)/acrnctl $(DESTDIR)$(INSTALL_BINDIR)/acrnctl

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -1,4 +1,6 @@
 
+include ../../Defs.mk
+
 OUT_DIR ?= .
 
 all:
@@ -8,5 +10,4 @@ clean:
 	rm $(OUT_DIR)/acrnlog
 
 install: $(OUT_DIR)/acrnlog
-	install -d $(DESTDIR)/usr/bin
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnlog
+	install -D --mode=0755 $(OUT_DIR)/acrnlog $(DESTDIR)$(INSTALL_BINDIR)/acrnlog

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -1,3 +1,4 @@
+include ../../Defs.mk
 
 OUT_DIR ?= .
 
@@ -8,5 +9,4 @@ clean:
 	rm $(OUT_DIR)/acrntrace
 
 install: $(OUT_DIR)/acrntrace
-	install -d $(DESTDIR)/usr/bin
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrntrace
+	install -D --mode=0755 $(OUT_DIR)/acrntrace $(DESTDIR)$(INSTALL_BINDIR)/acrntrace


### PR DESCRIPTION
Also, fix default install destinations for some files (most notably
binaries should be located in /usr/lib/acrn).

This is needed to correctly package acrn.