### PR TITLE
Makefile: add a target to build sbl hypervisor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ hypervisor:
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLATFORM) RELEASE=$(RELEASE) clean
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLATFORM) RELEASE=$(RELEASE)
 
+sbl-hypervisor:
+	@mkdir -p $(HV_OUT)-sbl
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl PLATFORM=sbl RELEASE=$(RELEASE) clean
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl PLATFORM=sbl RELEASE=$(RELEASE)
+
 devicemodel:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT)
@@ -37,6 +42,9 @@ install: hypervisor-install devicemodel-install tools-install
 
 hypervisor-install:
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) PLATFORM=$(PLATFORM) RELEASE=$(RELEASE) install
+
+sbl-hypervisor-install:
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl PLATFORM=sbl RELEASE=$(RELEASE) install
 
 devicemodel-install:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install


### PR DESCRIPTION
To build with only one command the sbl and efi hypervisor a target was
added which build the SBL hypervisor version.

Now you can call "make all sbl-hypervisor" and
"make install sbl-hypervisor-install"

This HELPS autospec 

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>