### PR TITLE
Ioc mediator：Support lifecycle emulation

### DIFF
--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -107,7 +107,8 @@
  * IOC mediator permits button, rtc and cardoor wakeup reasons which comes from
  * IOC firmware, others will be masked.
  */
-#define CBC_WK_RSN_ALL	(CBC_WK_RSN_BTN | CBC_WK_RSN_RTC | CBC_WK_RSN_DOR)
+#define CBC_WK_RSN_ALL \
+	(CBC_WK_RSN_BTN | CBC_WK_RSN_RTC | CBC_WK_RSN_DOR | CBC_WK_RSN_SOC)
 
 /*
  * CBC ring buffer is used to buffer bytes before build one complete CBC frame.


### PR DESCRIPTION
This patch set implements IOC mediator lifecycle work flow that including
suspend, shutdown and resume. IOC mediator needs notify suspend/shutdown
event for PM DM once received corresponding heartbeat messages from UOS.
And VM Manager needs forward S3/S5 wakeup reason to IOC DM to resume/boot UOS.

Liu Yuan (3):
  IOC mediator: Separate wakeup reason and heartbeat
  IOC mediator: Implement state transfer framework
  IOC mediator: Implement state transfer operations

v2:
  1) Replace the term of FSM with IOC state.
  2) Refine the patches order.
  3) Embed ioc_dev in cbc_pkt to simplify data exchange.