### PR TITLE
xHCI Port Sharing mode implementation

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -57,6 +57,7 @@ SRCS += hw/uart_core.c
 SRCS += hw/pci/virtio/virtio.c
 SRCS += hw/pci/virtio/virtio_kernel.c
 SRCS += hw/platform/usb_mouse.c
+SRCS += hw/platform/usb_pmapper.c
 SRCS += hw/platform/atkbdc.c
 SRCS += hw/platform/ps2mouse.c
 SRCS += hw/platform/rtc.c

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -48,6 +48,7 @@ LIBS += -lcrypto
 LIBS += -lpciaccess
 LIBS += -lz
 LIBS += -luuid
+LIBS += -lusb-1.0
 
 # hw
 SRCS += hw/block_if.c

--- a/devicemodel/README.rst
+++ b/devicemodel/README.rst
@@ -26,7 +26,8 @@ Build dependencies
    sudo yum install gcc \
           libuuid-devel \
           openssl-devel \
-          libpciaccess-devel
+          libpciaccess-devel \
+          libusb-devel
 
 * For Fedora 27
 
@@ -35,7 +36,8 @@ Build dependencies
    sudo dnf install gcc \
           libuuid-devel \
           openssl-devel \
-          libpciaccess-devel
+          libpciaccess-devel \
+          libusb-devel
 
 Build
 *****
@@ -61,7 +63,8 @@ Runtime dependencies
    sudo yum install openssl-libs \
                     zlib \
                     libpciaccess \
-                    libuuid
+                    libuuid \
+                    libusb
 
 * On Fedora 27
 
@@ -70,7 +73,8 @@ Runtime dependencies
    sudo dnf install openssl-libs \
                     zlib \
                     libpciaccess \
-                    libuuid
+                    libuuid \
+                    libusb
 
 .. _`ACRN Hypervisor`: https://github.com/projectacrn/acrn-hypervisor
 .. _`Project ACRN documentation`: https://projectacrn.github.io/

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -427,10 +427,10 @@ pci_xhci_dev_create(struct pci_xhci_vdev *xdev, void *dev_data)
 
 	/* TODO: following function pointers will be populated in future */
 	ue->ue_init     = usb_dev_init;
-	ue->ue_request  = NULL;
+	ue->ue_request  = usb_dev_request;
 	ue->ue_data     = NULL;
 	ue->ue_info	= usb_dev_info;
-	ue->ue_reset    = NULL;
+	ue->ue_reset    = usb_dev_reset;
 	ue->ue_remove   = NULL;
 	ue->ue_stop     = NULL;
 	ue->ue_deinit	= usb_dev_deinit;

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include "usb.h"
 #include "usbdi.h"
 #include "xhcireg.h"

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -282,9 +282,16 @@ umouse_event(uint8_t button, int x, int y, void *arg)
 }
 
 static void *
-umouse_init(struct usb_hci *hci, char *opt)
+umouse_init(void *pdata, char *opt)
 {
 	struct umouse_vdev *dev;
+	struct usb_hci *hci;
+
+	hci = pdata;
+	if (!hci) {
+		UPRINTF(LFTL, "umouse: invalid hci\r\n");
+		return NULL;
+	}
 
 	dev = calloc(1, sizeof(struct umouse_vdev));
 	if (!dev) {

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -809,6 +809,7 @@ struct usb_devemu ue_mouse = {
 	.ue_emu =	"tablet",
 	.ue_usbver =	3,
 	.ue_usbspeed =	USB_SPEED_HIGH,
+	.ue_devtype =	USB_DEV_STATIC,
 	.ue_init =	umouse_init,
 	.ue_request =	umouse_request,
 	.ue_data =	umouse_data_handler,

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -310,8 +310,6 @@ umouse_init(void *pdata, char *opt)
 	return dev;
 }
 
-#define	UREQ(x, y)	((x) | ((y) << 8))
-
 static int
 umouse_request(void *scarg, struct usb_data_xfer *xfer)
 {

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+
+#include <pthread.h>
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include "usb.h"
+#include "usbdi.h"
+#include "usb_core.h"
+#include "usb_pmapper.h"
+
+#undef LOG_TAG
+#define LOG_TAG "USBPM: "
+
+static struct usb_dev_sys_ctx_info g_ctx;
+
+static void *
+usb_dev_sys_thread(void *arg)
+{
+	struct timeval t = {1, 0};
+
+	while (g_ctx.thread_exit == 0 &&
+		libusb_handle_events_timeout(g_ctx.libusb_ctx, &t) >= 0)
+		; /* nothing */
+
+	UPRINTF(LINF, "poll thread exit\n\r");
+	return NULL;
+}
+
+static int
+usb_dev_native_sys_conn_cb(struct libusb_context *ctx, struct libusb_device
+		*ldev, libusb_hotplug_event event, void *pdata)
+{
+	UPRINTF(LDBG, "connect event\r\n");
+
+	if (!ctx || !ldev) {
+		UPRINTF(LFTL, "connect callback fails!\n");
+		return -1;
+	}
+
+	if (g_ctx.conn_cb)
+		g_ctx.conn_cb(g_ctx.hci_data, ldev);
+
+	return 0;
+}
+
+static int
+usb_dev_native_sys_disconn_cb(struct libusb_context *ctx, struct libusb_device
+		*ldev, libusb_hotplug_event event, void *pdata)
+{
+	UPRINTF(LDBG, "disconnect event\r\n");
+
+	if (!ctx || !ldev) {
+		UPRINTF(LFTL, "disconnect callback fails!\n");
+		return -1;
+	}
+
+	if (g_ctx.disconn_cb)
+		g_ctx.disconn_cb(g_ctx.hci_data, NULL);
+
+	return 0;
+}
+
+int
+usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
+		usb_dev_sys_cb notify_cb, usb_dev_sys_cb intr_cb,
+		void *hci_data, int log_level)
+{
+	libusb_hotplug_event native_conn_evt;
+	libusb_hotplug_event native_disconn_evt;
+	libusb_hotplug_flag flags;
+	libusb_hotplug_callback_handle native_conn_handle;
+	libusb_hotplug_callback_handle native_disconn_handle;
+	int native_pid, native_vid, native_cls, rc;
+
+	assert(conn_cb);
+	assert(disconn_cb);
+	usb_set_log_level(log_level);
+
+	if (g_ctx.libusb_ctx) {
+		UPRINTF(LFTL, "port mapper is already initialized.\r\n");
+		return -1;
+	}
+
+	rc = libusb_init(&g_ctx.libusb_ctx);
+	if (rc < 0) {
+		UPRINTF(LFTL, "libusb_init fails, rc:%d\r\n", rc);
+		return -1;
+	}
+
+	g_ctx.hci_data     = hci_data;
+	g_ctx.conn_cb      = conn_cb;
+	g_ctx.disconn_cb   = disconn_cb;
+	native_conn_evt    = LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED;
+	native_disconn_evt = LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT;
+	native_pid         = LIBUSB_HOTPLUG_MATCH_ANY;
+	native_vid         = LIBUSB_HOTPLUG_MATCH_ANY;
+	native_cls         = LIBUSB_HOTPLUG_MATCH_ANY;
+	flags              = 0;
+
+	/* register connect callback */
+	rc = libusb_hotplug_register_callback(g_ctx.libusb_ctx, native_conn_evt,
+			flags, native_vid, native_pid, native_cls,
+			usb_dev_native_sys_conn_cb, NULL, &native_conn_handle);
+	if (rc != LIBUSB_SUCCESS)
+		goto errout;
+
+	/* register disconnect callback */
+	rc = libusb_hotplug_register_callback(g_ctx.libusb_ctx,
+			native_disconn_evt, flags, native_vid, native_pid,
+			native_cls, usb_dev_native_sys_disconn_cb, NULL,
+			&native_disconn_handle);
+	if (rc != LIBUSB_SUCCESS) {
+		libusb_hotplug_deregister_callback(g_ctx.libusb_ctx,
+				native_conn_handle);
+		goto errout;
+	}
+
+	if (pthread_create(&g_ctx.thread, NULL, usb_dev_sys_thread, NULL)) {
+		libusb_hotplug_deregister_callback(g_ctx.libusb_ctx,
+				native_conn_handle);
+		libusb_hotplug_deregister_callback(g_ctx.libusb_ctx,
+				native_disconn_handle);
+		goto errout;
+	}
+	return 0;
+
+errout:
+	if (g_ctx.libusb_ctx)
+		libusb_exit(g_ctx.libusb_ctx);
+
+	g_ctx.libusb_ctx = NULL;
+	return -1;
+}

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -44,6 +44,21 @@
 
 static struct usb_dev_sys_ctx_info g_ctx;
 
+static inline int
+usb_dev_err_convert(int err)
+{
+	switch (err) {
+	case LIBUSB_ERROR_TIMEOUT: return USB_ERR_TIMEOUT;
+	case LIBUSB_ERROR_PIPE: return USB_ERR_STALLED;
+	case LIBUSB_ERROR_NO_DEVICE: return USB_ERR_INVAL;
+	case LIBUSB_ERROR_BUSY: return USB_ERR_IN_USE;
+	case LIBUSB_ERROR_OVERFLOW: return USB_ERR_TOO_DEEP;
+	default:
+		break; /* add more when required */
+	}
+	return USB_ERR_IOERROR;
+}
+
 static int
 usb_dev_native_toggle_if_drivers(struct usb_dev *udev, int attach)
 {

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -864,6 +864,8 @@ static int
 usb_dev_native_sys_disconn_cb(struct libusb_context *ctx, struct libusb_device
 		*ldev, libusb_hotplug_event event, void *pdata)
 {
+	uint8_t port;
+
 	UPRINTF(LDBG, "disconnect event\r\n");
 
 	if (!ctx || !ldev) {
@@ -871,8 +873,9 @@ usb_dev_native_sys_disconn_cb(struct libusb_context *ctx, struct libusb_device
 		return -1;
 	}
 
+	port = libusb_get_port_number(ldev);
 	if (g_ctx.disconn_cb)
-		g_ctx.disconn_cb(g_ctx.hci_data, NULL);
+		g_ctx.disconn_cb(g_ctx.hci_data, &port);
 
 	return 0;
 }

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -219,3 +219,31 @@ usb_native_is_port_existed(uint8_t bus_num, uint8_t port_num)
 	close(fd);
 	return 1;
 }
+
+void usb_parse_log_level(char level)
+{
+	switch (level) {
+	case 'F':
+	case 'f':
+		usb_set_log_level(LFTL);
+		break;
+	case 'W':
+	case 'w':
+		usb_set_log_level(LWRN);
+		break;
+	case 'I':
+	case 'i':
+		usb_set_log_level(LINF);
+		break;
+	case 'D':
+	case 'd':
+		usb_set_log_level(LDBG);
+		break;
+	case 'V':
+	case 'v':
+		usb_set_log_level(LVRB);
+		break;
+	default:
+		usb_set_log_level(LFTL);
+	}
+}

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -36,6 +36,7 @@
 #include "usb_core.h"
 
 SET_DECLARE(usb_emu_set, struct usb_devemu);
+int usb_log_level;
 
 struct usb_devemu *
 usb_emu_finddev(char *name)

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -24,6 +24,57 @@
  * SUCH DAMAGE.
  */
 
+/*
+ * USB emulation designed as following diagram. It devided into three layers:
+ *   HCD: USB host controller device layer, like xHCI, eHCI...
+ *   USB core: middle abstraction layer for USB statck.
+ *   USB Port Mapper: This layer supports to share physical USB
+ *     devices(physical ports) to spcified virtual USB port of
+ *     HCD DM. All the commands and data transfers are through
+ *     Libusb to access native USB stack.
+ *
+ *              +---------------+
+ *              |               |
+ *   +----------+----------+    |
+ *   |       ACRN DM       |    |
+ *   | +-----------------+ |    |
+ *   | |   HCD (xHCI)    | |    |
+ *   | +-----------------+ |    |
+ *   |          |          |    |
+ *   | +-----------------+ |    |
+ *   | |    USB Core     | |    |
+ *   | +-----------------+ |    |
+ *   |          |          |    |
+ *   | +-----------------+ |    |
+ *   | | USB Port Mapper | |    |
+ *   | +-----------------+ |    |
+ *   |          |          |    |
+ *   | +-----------------+ |    |
+ *   | |      Libusb     | |    |
+ *   | +-----------------+ |    |
+ *   +---------------------+    |
+ *    Service OS User Space     |     User OS User Space
+ *                              |
+ *  --------------------------  |  ---------------------------
+ *                              |
+ *   Service OS Kernel Space    |    User OS Kernel Space
+ *                              |
+ *                              |    +-----------------+
+ *                              |    |     USB Core    |
+ *                              |    +-----------------+
+ *                              |             |
+ *                              |    +-----------------+
+ *                              |    |       HCD       |
+ *                              |    | (xHCI/uHCI/...) |
+ *                              |    +--------+--------+
+ *                              |             |
+ *                              +-------------+
+ * Current distribution:
+ *   HCD: xhci.{h,c}
+ *   USB core: usb_core.{h,c}
+ *   USB device: usb_mouse.c usb_pmapper.{h,c}
+ */
+
 #include <sys/cdefs.h>
 #include <sys/types.h>
 #include <sys/queue.h>

--- a/devicemodel/include/usb.h
+++ b/devicemodel/include/usb.h
@@ -107,6 +107,7 @@
 
 #define	USB_BUS_RESET_DELAY	100	/* ms */
 
+#define	UREQ(x, y)	((x) | ((y) << 8))
 /*
  * USB record layout in memory:
  *

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -62,7 +62,7 @@ struct usb_devemu {
 #define	USB_EMUL_SET(x)	DATA_SET(usb_emu_set, x)
 
 /*
- * USB device events to notify HCI when state changes
+ * USB device events to notify HCD when state changes
  */
 enum hci_usbev {
 	USBDEV_ATTACH,

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -49,15 +49,17 @@ struct usb_devemu {
 	int	ue_usbspeed;	/* usb device speed */
 
 	/* instance creation */
-	void	*(*ue_init)(struct usb_hci *hci, char *opt);
+	void	*(*ue_init)(void *pdata, char *opt);
 
 	/* handlers */
 	int	(*ue_request)(void *sc, struct usb_data_xfer *xfer);
 	int	(*ue_data)(void *sc, struct usb_data_xfer *xfer, int dir,
 			   int epctx);
+	int	(*ue_info)(void *sc, int type, void *value, int size);
 	int	(*ue_reset)(void *sc);
 	int	(*ue_remove)(void *sc);
 	int	(*ue_stop)(void *sc);
+	void	(*ue_deinit)(void *pdata);
 };
 #define	USB_EMUL_SET(x)	DATA_SET(usb_emu_set, x)
 

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -205,6 +205,7 @@ enum USB_ERRCODE {
 extern int usb_log_level;
 inline int usb_get_log_level(void)		{ return usb_log_level; }
 inline void usb_set_log_level(int level)	{ usb_log_level = level; }
+void usb_parse_log_level(char level);
 struct usb_devemu *usb_emu_finddev(char *name);
 int usb_native_is_bus_existed(uint8_t bus_num);
 int usb_native_is_ss_port(uint8_t bus_of_port);

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -141,6 +141,18 @@ enum USB_ERRCODE {
 #define	USB_DATA_XFER_UNLOCK(x)	\
 	pthread_mutex_unlock(&((x)->mtx))
 
+#define LOG_TAG "USB: "
+#define LFTL 0
+#define LWRN 1
+#define LINF 2
+#define LDBG 3
+#define LVRB 4
+#define UPRINTF(lvl, fmt, args...) \
+	do { if (lvl <= usb_log_level) printf(LOG_TAG fmt, ##args); } while (0)
+
+extern int usb_log_level;
+inline int usb_get_log_level(void)		{ return usb_log_level; }
+inline void usb_set_log_level(int level)	{ usb_log_level = level; }
 struct usb_devemu *usb_emu_finddev(char *name);
 
 struct usb_data_xfer_block *usb_data_xfer_append(struct usb_data_xfer *xfer,

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -31,12 +31,38 @@
 
 #include <stdlib.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include "types.h"
 
 #define	USB_MAX_XFER_BLOCKS	8
-
 #define	USB_XFER_OUT		0
 #define	USB_XFER_IN		1
+
+#define USB_DIR_OUT              0
+#define USB_DIR_IN               0x80
+
+#define LIBUSB_TIMEOUT           10000
+
+#define USB_CFG_ATT_ONE          (1 << 7) /* should always be set */
+#define USB_CFG_ATT_SELFPOWER    (1 << 6)
+#define USB_CFG_ATT_WAKEUP       (1 << 5)
+#define USB_CFG_ATT_BATTERY      (1 << 4)
+
+enum endpoint_type {
+	USB_ENDPOINT_CONTROL = 0,
+	USB_ENDPOINT_ISOC,
+	USB_ENDPOINT_BULK,
+	USB_ENDPOINT_INT,
+	USB_ENDPOINT_INVALID = 255
+};
+
+#define USB_INTERFACE_INVALID 255
+
+enum token_type {
+	TOKEN_OUT = 0,
+	TOKEN_IN,
+	TOKEN_SETUP
+};
 
 struct usb_hci;
 struct usb_device_request;
@@ -108,6 +134,7 @@ struct usb_data_xfer {
 	int	ndata;				/* # of data items */
 	int	head;
 	int	tail;
+	int	status;
 	pthread_mutex_t mtx;
 };
 

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -196,11 +196,17 @@ enum USB_ERRCODE {
 #define UPRINTF(lvl, fmt, args...) \
 	do { if (lvl <= usb_log_level) printf(LOG_TAG fmt, ##args); } while (0)
 
+#define NATIVE_USBSYS_DEVDIR "/sys/bus/usb/devices"
+#define NATIVE_USB2_SPEED "480"
+#define NATIVE_USB3_SPEED "5000"
+
 extern int usb_log_level;
 inline int usb_get_log_level(void)		{ return usb_log_level; }
 inline void usb_set_log_level(int level)	{ usb_log_level = level; }
 struct usb_devemu *usb_emu_finddev(char *name);
-
+int usb_native_is_bus_existed(uint8_t bus_num);
+int usb_native_is_ss_port(uint8_t bus_of_port);
+int usb_native_is_port_existed(uint8_t bus_num, uint8_t port_num);
 struct usb_data_xfer_block *usb_data_xfer_append(struct usb_data_xfer *xfer,
 						 void *buf,
 						 int blen,

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -199,6 +199,8 @@ enum USB_ERRCODE {
 #define NATIVE_USBSYS_DEVDIR "/sys/bus/usb/devices"
 #define NATIVE_USB2_SPEED "480"
 #define NATIVE_USB3_SPEED "5000"
+#define USB_NATIVE_NUM_PORT 255
+#define USB_NATIVE_NUM_BUS 255
 
 extern int usb_log_level;
 inline int usb_get_log_level(void)		{ return usb_log_level; }

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -118,6 +118,10 @@ struct usb_dev_sys_ctx_info {
 	pthread_t thread;
 	int thread_exit;
 
+	/* handles of callback */
+	libusb_hotplug_callback_handle conn_handle;
+	libusb_hotplug_callback_handle disconn_handle;
+
 	/*
 	 * The following callback funtions will be registered by
 	 * the code from HCD(eg: XHCI, EHCI...) emulation layer.
@@ -137,6 +141,7 @@ struct usb_dev_sys_ctx_info {
 int usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
 		usb_dev_sys_cb notify_cb, usb_dev_sys_cb intr_cb,
 		void *hci_data, int log_level);
+void usb_dev_sys_deinit(void);
 void *usb_dev_init(void *pdata, char *opt);
 void usb_dev_deinit(void *pdata);
 int usb_dev_info(void *pdata, int type, void *value, int size);

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -32,9 +32,17 @@
 #ifndef _USB_DEVICE_H
 #define _USB_DEVICE_H
 #include <libusb-1.0/libusb.h>
+#include "usb_core.h"
 
 #define USB_NUM_INTERFACE 16
 #define USB_NUM_ENDPOINT  15
+
+#define USB_EP_ADDR(d) ((d)->bEndpointAddress)
+#define USB_EP_ATTR(d) ((d)->bmAttributes)
+#define USB_EP_PID(d) (USB_EP_ADDR(d) & USB_DIR_IN ? TOKEN_IN : TOKEN_OUT)
+#define USB_EP_TYPE(d) (USB_EP_ATTR(d) & 0x3)
+#define USB_EP_NR(d) (USB_EP_ADDR(d) & 0xF)
+#define USB_EP_ERR_TYPE 0xFF
 
 enum {
 	USB_INFO_VERSION,
@@ -106,4 +114,6 @@ int usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
 void *usb_dev_init(void *pdata, char *opt);
 void usb_dev_deinit(void *pdata);
 int usb_dev_info(void *pdata, int type, void *value, int size);
+int usb_dev_request(void *pdata, struct usb_data_xfer *xfer);
+int usb_dev_reset(void *pdata);
 #endif

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -36,6 +36,15 @@
 #define USB_NUM_INTERFACE 16
 #define USB_NUM_ENDPOINT  15
 
+enum {
+	USB_INFO_VERSION,
+	USB_INFO_SPEED,
+	USB_INFO_BUS,
+	USB_INFO_PORT,
+	USB_INFO_VID,
+	USB_INFO_PID
+};
+
 struct usb_dev_ep {
 	uint8_t pid;
 	uint8_t type;
@@ -48,6 +57,9 @@ struct usb_dev {
 	int speed;
 	int configuration;
 	uint8_t port;
+	uint8_t bus;
+	uint8_t pid;
+	uint16_t vid;
 
 	/* interface info */
 	int if_num;
@@ -91,5 +103,7 @@ struct usb_dev_sys_ctx_info {
 int usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
 		usb_dev_sys_cb notify_cb, usb_dev_sys_cb intr_cb,
 		void *hci_data, int log_level);
-
+void *usb_dev_init(void *pdata, char *opt);
+void usb_dev_deinit(void *pdata);
+int usb_dev_info(void *pdata, int type, void *value, int size);
 #endif

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _USB_DEVICE_H
+#define _USB_DEVICE_H
+#include <libusb-1.0/libusb.h>
+
+#define USB_NUM_INTERFACE 16
+#define USB_NUM_ENDPOINT  15
+
+struct usb_dev_ep {
+	uint8_t pid;
+	uint8_t type;
+};
+
+struct usb_dev {
+	/* physical device info */
+	int addr;
+	int version;
+	int speed;
+	int configuration;
+	uint8_t port;
+
+	/* interface info */
+	int if_num;
+	int alts[USB_NUM_INTERFACE];
+
+	/* endpoints info */
+	struct usb_dev_ep epc;
+	struct usb_dev_ep epi[USB_NUM_ENDPOINT];
+	struct usb_dev_ep epo[USB_NUM_ENDPOINT];
+
+	/* libusb data */
+	libusb_device           *ldev;
+	libusb_device_handle    *handle;
+};
+
+/* callback type used by code from HCD layer */
+typedef int (*usb_dev_sys_cb)(void *hci_data, void *dev_data);
+
+struct usb_dev_sys_ctx_info {
+	/*
+	 * Libusb related global variables
+	 */
+	libusb_context *libusb_ctx;
+	pthread_t thread;
+	int thread_exit;
+
+	/*
+	 * The following callback funtions will be registered by
+	 * the code from HCD(eg: XHCI, EHCI...) emulation layer.
+	 */
+	usb_dev_sys_cb conn_cb;
+	usb_dev_sys_cb disconn_cb;
+
+	/*
+	 * private data from HCD layer
+	 */
+	void *hci_data;
+};
+
+/* intialize the usb_dev subsystem and register callbacks for HCD layer */
+int usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
+		usb_dev_sys_cb notify_cb, usb_dev_sys_cb intr_cb,
+		void *hci_data, int log_level);
+
+#endif

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -83,6 +83,30 @@ struct usb_dev {
 	libusb_device_handle    *handle;
 };
 
+/*
+ * The purpose to implement struct usb_dev_req is to adapt
+ * struct usb_data_xfer to make a proper data format to talk
+ * with libusb.
+ */
+struct usb_dev_req {
+	struct usb_dev *udev;
+	int    in;
+	int    seq;
+	/*
+	 * buffer could include data from multiple
+	 * usb_data_xfer_block, so here need some
+	 * data to record it.
+	 */
+	uint8_t	*buffer;
+	int     buf_length;
+	int     blk_start;
+	int     blk_count;
+
+	struct usb_data_xfer *xfer;
+	struct libusb_transfer *libusb_xfer;
+	struct usb_data_xfer_block *setup_blk;
+};
+
 /* callback type used by code from HCD layer */
 typedef int (*usb_dev_sys_cb)(void *hci_data, void *dev_data);
 
@@ -100,6 +124,8 @@ struct usb_dev_sys_ctx_info {
 	 */
 	usb_dev_sys_cb conn_cb;
 	usb_dev_sys_cb disconn_cb;
+	usb_dev_sys_cb notify_cb;
+	usb_dev_sys_cb intr_cb;
 
 	/*
 	 * private data from HCD layer
@@ -116,4 +142,5 @@ void usb_dev_deinit(void *pdata);
 int usb_dev_info(void *pdata, int type, void *value, int size);
 int usb_dev_request(void *pdata, struct usb_data_xfer *xfer);
 int usb_dev_reset(void *pdata);
+int usb_dev_data(void *pdata, struct usb_data_xfer *xfer, int dir, int epctx);
 #endif


### PR DESCRIPTION
Those patches enable xHCI emulation which supports ports sharing for
specified Guest OS.