### PR TITLE
doc: fix references to included .sh files

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -228,7 +228,7 @@ is included in the Clear Linux release, and
 is also available in the acrn-hypervisor/devicemodel GitHub repo (in the samples
 folder) as shown here:
 
-.. literalinclude:: ../../devicemodel/samples/bridge.sh
+.. literalinclude:: ../../devicemodel/samples/nuc/bridge.sh
    :caption: devicemodel/samples/bridge.sh
    :language: bash
 
@@ -282,7 +282,7 @@ Set up Reference UOS
    is also available in the acrn-hypervisor/devicemodel GitHub repo (in the samples
    folder) as shown here:
 
-   .. literalinclude:: ../../devicemodel/samples/launch_uos.sh
+   .. literalinclude:: ../../devicemodel/samples/nuc/launch_uos.sh
       :caption: devicemodel/samples/launch_uos.sh
       :language: bash
       :emphasize-lines: 22,24


### PR DESCRIPTION
PR #274 moved the launch_uos.sh and bridge.sh files that were included
in the documentation.  Need to fix the references in the doc to match.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>