### PR TITLE
doc: fix references from scripts

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -223,13 +223,13 @@ Without a network bridge, the SOS and UOS are not able to talk to each
 other.
 
 A sample `bridge.sh
-<https://github.com/projectacrn/acrn-hypervisor/devicemodel/tree/master/samples/bridge.sh>`__
+<https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/devicemodel/samples/nuc/bridge.sh>`__
 is included in the Clear Linux release, and
 is also available in the acrn-hypervisor/devicemodel GitHub repo (in the samples
 folder) as shown here:
 
-.. literalinclude:: ../../devicemodel/samples/bridge.sh
-   :caption: devicemodel/samples/bridge.sh
+.. literalinclude:: ../../devicemodel/samples/nuc/bridge.sh
+   :caption: devicemodel/samples/nuc/bridge.sh
    :language: bash
 
 By default, the script is located in the ``/usr/share/acrn/samples/nuc/``
@@ -277,13 +277,13 @@ Set up Reference UOS
 #. Edit and Run the launch_uos.sh script to launch the UOS.
 
    A sample `launch_uos.sh
-   <https://github.com/projectacrn/acrn-hypervisor/devicemodel/tree/master/samples/launch_uos.sh>`__
+   <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/devicemodel/samples/nuc/launch_uos.sh>`__
    is included in the Clear Linux release, and
    is also available in the acrn-hypervisor/devicemodel GitHub repo (in the samples
    folder) as shown here:
 
-   .. literalinclude:: ../../devicemodel/samples/launch_uos.sh
-      :caption: devicemodel/samples/launch_uos.sh
+   .. literalinclude:: ../../devicemodel/samples/nuc/launch_uos.sh
+      :caption: devicemodel/samples/nuc/launch_uos.sh
       :language: bash
       :emphasize-lines: 22,24
 

--- a/doc/getting_started/up2.rst
+++ b/doc/getting_started/up2.rst
@@ -194,7 +194,7 @@ terminal, and from there launch the UOS.
 
 .. code-block:: none
 
-      $ cd /usr/share/acrn/demo
+      $ cd /usr/share/acrn/samples/nuc
       $ sudo ./launch_UOS.sh
 
 |image0|


### PR DESCRIPTION
The sambles scripts where moved to another directory but did not update
all the references in the documentation.

Fixes: 977d48d55042 ("hypervisor: install acrn.efi to /usr/lib")
Fixes: 9563e248b784 ("samples: move samples to specifi platform diretory")

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>