### PR TITLE
refomatted GET_DATA_SIZE macro

### DIFF
--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -47,8 +47,8 @@ uint64_t get_microcode_version(void)
  * According to SDM vol 3 Table 9-7. If data_size field of uCode
  * header is zero, the ucode length is 2000
  */
-#define	GET_DATA_SIZE(hdptr)	((hdptr)->data_size ?\
-			((hdptr)->data_size) : 2000)
+#define	GET_DATA_SIZE(hdptr)	\
+	((hdptr)->data_size ? ((hdptr)->data_size) : 2000)
 void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
 {
 	uint64_t hva, gpa, gva;


### PR DESCRIPTION
The macro GET_DATA_SIZE's code style is not correct,
it is merged by accident,the Pull Request #262
<fix "obsolete use of designated initializer without '='"> 
have two commid id,the second commit changed the ucode.c
by mistake.

Now fixed.
Signed-off-by: huihuang.shi <huihuang.shi@intel.com>