### PR TITLE
HV: debug: stop using ## __VA_ARGS__

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -28,7 +28,7 @@
  * $FreeBSD$
  */
 
-#define pr_fmt(fmt)	"vioapic: " fmt
+#define pr_prefix	"vioapic: "
 
 #include <hypervisor.h>
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -27,7 +27,7 @@
  * $FreeBSD$
  */
 
-#define pr_fmt(fmt)	"vlapic: " fmt
+#define pr_prefix		"vlapic: "
 
 #include <hypervisor.h>
 

--- a/hypervisor/arch/x86/guest/vpic.c
+++ b/hypervisor/arch/x86/guest/vpic.c
@@ -25,7 +25,7 @@
  * SUCH DAMAGE.
  */
 
-#define pr_fmt(fmt)	"vpic: " fmt
+#define pr_prefix	"vpic: "
 
 #include <hypervisor.h>
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -28,7 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define pr_fmt(fmt)	"iommu: " fmt
+#define pr_prefix		"iommu: "
 
 #include <hypervisor.h>
 

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -68,38 +68,38 @@ static inline void print_logmsg_buffer(__unused uint32_t cpu_id)
 
 #endif /* HV_DEBUG */
 
-#ifndef pr_fmt
-#define pr_fmt(fmt) fmt
+#ifndef pr_prefix
+#define pr_prefix
 #endif
 
-#define pr_fatal(fmt, ...)						\
-	do {								\
-		do_logmsg(LOG_FATAL, pr_fmt(fmt), ##__VA_ARGS__);	\
-	} while (0)
-
-#define pr_err(fmt, ...)						\
-	do {								\
-		do_logmsg(LOG_ERROR, pr_fmt(fmt), ##__VA_ARGS__);	\
-	} while (0)
-
-#define pr_warn(fmt, ...)						\
-	do {								\
-		do_logmsg(LOG_WARNING, pr_fmt(fmt), ##__VA_ARGS__);	\
-	} while (0)
-
-#define pr_info(fmt, ...)						\
-	do {								\
-		do_logmsg(LOG_INFO, pr_fmt(fmt), ##__VA_ARGS__);	\
-	} while (0)
-
-#define pr_dbg(fmt, ...)						\
-	do {								\
-		do_logmsg(LOG_DEBUG, pr_fmt(fmt), ##__VA_ARGS__);	\
-	} while (0)
-
-#define dev_dbg(lvl, fmt, ...)					\
+#define pr_fatal(...)						\
 	do {							\
-		do_logmsg(lvl, pr_fmt(fmt), ##__VA_ARGS__);	\
+		do_logmsg(LOG_FATAL, pr_prefix __VA_ARGS__);	\
+	} while (0)
+
+#define pr_err(...)						\
+	do {							\
+		do_logmsg(LOG_ERROR, pr_prefix __VA_ARGS__);	\
+	} while (0)
+
+#define pr_warn(...)						\
+	do {							\
+		do_logmsg(LOG_WARNING, pr_prefix __VA_ARGS__);	\
+	} while (0)
+
+#define pr_info(...)						\
+	do {							\
+		do_logmsg(LOG_INFO, pr_prefix __VA_ARGS__);	\
+	} while (0)
+
+#define pr_dbg(...)						\
+	do {							\
+		do_logmsg(LOG_DEBUG, pr_prefix __VA_ARGS__);	\
+	} while (0)
+
+#define dev_dbg(lvl, ...)					\
+	do {							\
+		do_logmsg(lvl, pr_prefix __VA_ARGS__);	\
 	} while (0)
 
 #define panic(...) \


### PR DESCRIPTION
It is an extension of GCC CPP to:

* allow omitting a variable macro argument entirely, and
* use ## __VA_ARGS__ to remove the the comma before ## __VA_ARGS__ when
  __VA_ARGS__ is empty.

The only use of ## _VA_ARGS__ is to define the pr_xxx() macros, with the first
argument being the format string and the rest the to-be-formatted arguments. The
format string is explicitly spelled out because another macro pr_fmt() is used
to add to the format string a prefix which is customizable by defining what
pr_fmt() expands to.

For C99 compliance, this patch changes the pr_xxx() macros in the following
pattern.

    - #define pr_fatal(fmt, ...)				\
    -     do_logmsg(LOG_FATAL, pr_fmt(fmt), ## __VA_ARGS__);	\
    + #define pr_fatal(...)					\
    +     do_logmsg(LOG_FATAL, pr_prefix __VA_ARGS__);		\

Reference:

* https://gcc.gnu.org/onlinedocs/gcc/Variadic-Macros.html#Variadic-Macros

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Reviewed-by: Kevin Tian <kevin.tian@intel.com>