### PR TITLE
lapic: continuous LVT registers as an array

### DIFF
--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -158,12 +158,7 @@ struct lapic {
 	uint32_t lvt_cmci;	PAD3;
 	uint32_t icr_lo;	PAD3;
 	uint32_t icr_hi;	PAD3;
-	uint32_t lvt_timer;	PAD3;
-	uint32_t lvt_thermal;	PAD3;
-	uint32_t lvt_pcint;	PAD3;
-	uint32_t lvt_lint0;	PAD3;
-	uint32_t lvt_lint1;	PAD3;
-	uint32_t lvt_error;	PAD3;
+	struct lapic_reg	lvt[6];
 	uint32_t icr_timer;	PAD3;
 	uint32_t ccr_timer;	PAD3;
 	/* reserved */		PAD4;
@@ -421,12 +416,12 @@ struct ioapic {
 #define	APIC_EXTF_IER_CAP	0x00000001
 
 /* LVT table indices */
-#define	APIC_LVT_LINT0		0
-#define	APIC_LVT_LINT1		1
-#define	APIC_LVT_TIMER		2
-#define	APIC_LVT_ERROR		3
-#define	APIC_LVT_PMC		4
-#define	APIC_LVT_THERMAL	5
+#define	APIC_LVT_TIMER		0
+#define	APIC_LVT_THERMAL	1
+#define	APIC_LVT_PMC		2
+#define	APIC_LVT_LINT0		3
+#define	APIC_LVT_LINT1		4
+#define	APIC_LVT_ERROR		5
 #define	APIC_LVT_CMCI		6
 #define	APIC_LVT_MAX		APIC_LVT_CMCI
 


### PR DESCRIPTION
Pointer arithmetic is currently used to calculate the address of a specific
Local Vector Table (LVT) register (except LVT_CMCI) in lapic, since the
registers are continuously placed with fixed padding in between. However each of
these registers are declared as a single uint32_t in struct lapic, resulting
pointer arithmetic on a non-array pointer which violates MISRA C requirements.

This patch refactors struct lapic by converting the LVT registers fields (again
except LVT_CMCI) to an array named lvt. The LVT indices are reordered to reflect
the order of the LVT registers on hardware, and reused to index this lvt array.

The code before and after the changes is semantically equivalent.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Reviewed-by: Kevin Tian <kevin.tian@intel.com>