### PR TITLE
fix "warning:redefinition of typedef 'uint32_t'"

### DIFF
--- a/hypervisor/include/lib/types.h
+++ b/hypervisor/include/lib/types.h
@@ -48,7 +48,6 @@
 /* Define standard data types.  These definitions allow software components
  * to perform in the same manner on different target platforms.
  */
-typedef unsigned int uint32_t;
 typedef signed char int8_t;
 typedef unsigned char uint8_t;
 typedef signed short int16_t;


### PR DESCRIPTION
uint32_t occures two times in hypervisor/include/lib/types.h,
remove one of them.
acked-by kevin
Signed-off-by: huihuang.shi <huihuang.shi@intel.com>