### PR TITLE
fix "ISO C99 does not support '_Static_assert'"

### DIFF
--- a/hypervisor/include/debug/assert.h
+++ b/hypervisor/include/debug/assert.h
@@ -30,6 +30,13 @@
 
 #ifndef ASSERT_H
 #define ASSERT_H
+#define __STDC_99__	199901L
+
+/* Force a compilation error if condition is false */
+#if __STDC_VERSION__ == __STDC_99__
+#define _Static_assert(expr, error)	\
+	extern char Static_Error[(expr) ? 1 : -1]
+#endif
 
 #ifdef HV_DEBUG
 void __assert(uint32_t line, const char *file, char *txt);


### PR DESCRIPTION
_Static_assert is supported in C11 standard.
Please see N1570(C11 mannual) 6.4.1.
acked-by kevin
Signed-off-by: huihuang.shi <huihuang.shi@intel.com>