### PR TITLE
ASSERT cleanup for SOS/UOS creation

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -367,6 +367,7 @@ static void get_cpu_name(void)
 
 void bsp_boot_init(void)
 {
+	int ret;
 	uint64_t start_tsc = rdtsc();
 
 	/* Clear BSS */
@@ -541,7 +542,9 @@ void bsp_boot_init(void)
 	console_setup_timer();
 
 	/* Start initializing the VM for this CPU */
-	hv_main(CPU_BOOT_ID);
+	ret = hv_main(CPU_BOOT_ID);
+	if (ret != 0)
+		panic("failed to start VM for bsp\n");
 
 	/* Control should not come here */
 	cpu_dead(CPU_BOOT_ID);
@@ -549,6 +552,7 @@ void bsp_boot_init(void)
 
 void cpu_secondary_init(void)
 {
+	int ret;
 	/* NOTE: Use of local / stack variables in this function is problematic
 	 * since the stack is switched in the middle of the function.  For this
 	 * reason, the logical id is only temporarily stored in a static
@@ -605,7 +609,9 @@ void cpu_secondary_init(void)
 	/* Wait for boot processor to signal all secondary cores to continue */
 	pcpu_sync_sleep(&pcpu_sync, 0);
 
-	hv_main(get_cpu_id());
+	ret = hv_main(get_cpu_id());
+	if (ret != 0)
+		panic("hv_main ret = %d\n", ret);
 
 	/* Control will only come here for secondary CPUs not configured for
 	 * use or if an error occurs in hv_main

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -29,7 +29,6 @@
  */
 
 #include <hypervisor.h>
-#include <bsp_extern.h>
 #include <schedule.h>
 #include <version.h>
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -292,31 +292,13 @@ int vm_resume(struct vm *vm)
 	return 0;
 }
 
-/* Finally, we will remove the array and only maintain vm0 desc */
-struct vm_description *get_vm_desc(int idx)
-{
-	struct vm_description_array *vm_desc_array;
-
-	/* Obtain base of user defined VM description array data
-	 * structure
-	 */
-	vm_desc_array = (struct vm_description_array *)get_vm_desc_base();
-	/* Obtain VM description array base */
-	if (idx >= vm_desc_array->num_vm_desc)
-		return NULL;
-	else
-		return &vm_desc_array->vm_desc_array[idx];
-}
-
 /* Create vm/vcpu for vm0 */
 int prepare_vm0(void)
 {
 	int i, ret;
 	struct vm *vm = NULL;
-	struct vm_description *vm_desc = NULL;
+	struct vm_description *vm_desc = &vm0_desc;
 
-	vm_desc = get_vm_desc(0);
-	ASSERT(vm_desc, "get vm desc failed");
 	ret = create_vm(vm_desc, &vm);
 	ASSERT(ret == 0, "VM creation failed!");
 
@@ -360,15 +342,9 @@ static inline bool vcpu_in_vm_desc(struct vcpu *vcpu,
 void vm_fixup(struct vm *vm)
 {
 	if (is_vm0(vm) && (vm->hw.exp_num_vcpus < vm->hw.num_vcpus)) {
-		struct vm_description *vm_desc = NULL;
+		struct vm_description *vm_desc = &vm0_desc;
 		struct vcpu *vcpu;
 		int i;
-
-		vm_desc = get_vm_desc(0);
-		if (vm_desc == NULL) {
-			pr_err("get VM0 description failed.");
-			return;
-		}
 
 		foreach_vcpu(i, vm, vcpu) {
 			if (!vcpu_in_vm_desc(vcpu, vm_desc)) {

--- a/hypervisor/bsp/include/bsp_extern.h
+++ b/hypervisor/bsp/include/bsp_extern.h
@@ -46,12 +46,9 @@
 /**********************************/
 /* EXTERNAL VARIABLES             */
 /**********************************/
+extern struct vm_description vm0_desc;
 
 /* BSP Interfaces */
-void    init_bsp(void);
-
-/* External Interfaces */
-struct _vm_description_array;
-const struct _vm_description_array *get_vm_desc_base(void);
+void init_bsp(void);
 
 #endif /* BSP_EXTERN_H */

--- a/hypervisor/bsp/sbl/vm_description.c
+++ b/hypervisor/bsp/sbl/vm_description.c
@@ -30,32 +30,16 @@
 
 #include <hypervisor.h>
 
-#define NUM_USER_VMS    2
-
 /* Number of CPUs in VM0 */
 #define VM0_NUM_CPUS    1
 
 /* Logical CPU IDs assigned to VM0 */
 int VM0_CPUS[VM0_NUM_CPUS] = {0};
 
-const struct vm_description_array vm_desc = {
-	/* Number of user virtual machines */
-	.num_vm_desc = NUM_USER_VMS,
-
-	/* Virtual Machine descriptions */
-	.vm_desc_array = {
-		{
-		/* Internal variable, MUSTBE init to -1 */
-		.vm_attr_name = "vm_0",
-		.vm_hw_num_cores = VM0_NUM_CPUS,
-		.vm_hw_logical_core_ids = &VM0_CPUS[0],
-		.vm_state_info_privilege = VM_PRIVILEGE_LEVEL_HIGH,
-		.vm_created = false,
-		},
-	}
+struct vm_description vm0_desc = {
+	.vm_attr_name = "vm_0",
+	.vm_hw_num_cores = VM0_NUM_CPUS,
+	.vm_hw_logical_core_ids = &VM0_CPUS[0],
+	.vm_state_info_privilege = VM_PRIVILEGE_LEVEL_HIGH,
+	.vm_created = false,
 };
-
-const struct vm_description_array *get_vm_desc_base(void)
-{
-	return &vm_desc;
-}

--- a/hypervisor/bsp/uefi/vm_description.c
+++ b/hypervisor/bsp/uefi/vm_description.c
@@ -30,31 +30,16 @@
 
 #include <hypervisor.h>
 
-#define NUM_USER_VMS    2
-
 /* Number of CPUs in VM0 */
 #define VM0_NUM_CPUS    1
 
 /* Logical CPU IDs assigned to VM0 */
 int VM0_CPUS[VM0_NUM_CPUS] = {0};
 
-const struct vm_description_array vm_desc = {
-	/* Number of user virtual machines */
-	.num_vm_desc = NUM_USER_VMS,
-
-	/* Virtual Machine descriptions */
-	.vm_desc_array = {
-		{
-		.vm_attr_name = "vm_0",
-		.vm_hw_num_cores = VM0_NUM_CPUS,
-		.vm_hw_logical_core_ids = &VM0_CPUS[0],
-		.vm_state_info_privilege = VM_PRIVILEGE_LEVEL_HIGH,
-		.vm_created = false,
-		},
-	}
+struct vm_description vm0_desc = {
+	.vm_attr_name = "vm_0",
+	.vm_hw_num_cores = VM0_NUM_CPUS,
+	.vm_hw_logical_core_ids = &VM0_CPUS[0],
+	.vm_state_info_privilege = VM_PRIVILEGE_LEVEL_HIGH,
+	.vm_created = false,
 };
-
-const struct vm_description_array *get_vm_desc_base(void)
-{
-	return &vm_desc;
-}

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -133,18 +133,28 @@ static bool is_vm0_bsp(int pcpu_id)
 
 int hv_main(int cpu_id)
 {
-	int ret = 0;
+	int ret;
 
 	pr_info("%s, Starting common entry point for CPU %d",
 			__func__, cpu_id);
-	ASSERT(cpu_id < phy_cpu_num, "cpu_id out of range");
 
-	ASSERT((uint64_t) cpu_id == get_cpu_id(),
-			"cpu_id/tsc_aux mismatch");
+	if (cpu_id >= phy_cpu_num) {
+		pr_err("%s, cpu_id %d out of range %d\n",
+			__func__, cpu_id, phy_cpu_num);
+		return -EINVAL;
+	}
+
+	if ((uint32_t) cpu_id != get_cpu_id()) {
+		pr_err("%s, cpu_id %d mismatch\n", __func__, cpu_id);
+		return -EINVAL;
+	}
 
 	/* Enable virtualization extensions */
 	ret = exec_vmxon_instr();
-	ASSERT(ret == 0, "Unable to enable VMX!");
+	if (ret != 0) {
+		pr_err("%s, Unable to enable VMX!\n", __func__);
+		return ret;
+	}
 
 	/* X2APIC mode is disabled by default. */
 	x2apic_enabled = false;
@@ -154,7 +164,7 @@ int hv_main(int cpu_id)
 
 	default_idle();
 
-	return ret;
+	return 0;
 }
 
 int get_vmexit_profile(char *str, int str_max)

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -154,8 +154,11 @@ int hv_main(int cpu_id)
 	/* X2APIC mode is disabled by default. */
 	x2apic_enabled = false;
 
-	if (is_vm0_bsp(cpu_id))
-		prepare_vm0();
+	if (is_vm0_bsp(cpu_id)) {
+		ret = prepare_vm0();
+		if (ret != 0)
+			return ret;
+	}
 
 	default_idle();
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -151,10 +151,8 @@ int hv_main(int cpu_id)
 
 	/* Enable virtualization extensions */
 	ret = exec_vmxon_instr();
-	if (ret != 0) {
-		pr_err("%s, Unable to enable VMX!\n", __func__);
+	if (ret != 0)
 		return ret;
-	}
 
 	/* X2APIC mode is disabled by default. */
 	x2apic_enabled = false;

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -125,10 +125,7 @@ void vcpu_thread(struct vcpu *vcpu)
 
 static bool is_vm0_bsp(int pcpu_id)
 {
-	struct vm_description *vm_desc = get_vm_desc(0);
-
-	ASSERT(vm_desc, "get vm desc failed");
-	return pcpu_id == vm_desc->vm_hw_logical_core_ids[0];
+	return pcpu_id == vm0_desc.vm_hw_logical_core_ids[0];
 }
 
 int hv_main(int cpu_id)

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -30,6 +30,7 @@
 
 #ifndef VM_H_
 #define VM_H_
+#include <bsp_extern.h>
 
 enum vm_privilege_level {
 	VM_PRIVILEGE_LEVEL_HIGH = 0,
@@ -209,11 +210,6 @@ struct vm_description {
 	bool                   sworld_enabled;
 };
 
-struct vm_description_array {
-	int                     num_vm_desc;
-	struct vm_description   vm_desc_array[];
-};
-
 int shutdown_vm(struct vm *vm);
 int pause_vm(struct vm *vm);
 int start_vm(struct vm *vm);
@@ -222,7 +218,6 @@ int prepare_vm0(void);
 void vm_fixup(struct vm *vm);
 
 struct vm *get_vm_from_vmid(int vm_id);
-struct vm_description *get_vm_desc(int idx);
 
 extern struct list_head vm_list;
 extern spinlock_t vm_list_lock;

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -102,8 +102,9 @@ static inline void print_logmsg_buffer(__unused uint32_t cpu_id)
 		do_logmsg(lvl, pr_prefix __VA_ARGS__);	\
 	} while (0)
 
-#define panic(...) \
-	do { pr_fatal("Instruction Decode PANIC: " __VA_ARGS__); \
+#define panic(...) 							\
+	do { pr_fatal("PANIC: %s line: %d\n", __func__, __LINE__);	\
+		pr_fatal(__VA_ARGS__); 					\
 		while (1) { asm volatile ("pause" ::: "memory"); }; } while (0)
 
 #endif /* LOGMSG_H */


### PR DESCRIPTION
v2:
1. fix cover letter comments grammar error
2. datail patch descriptions.

v1:

ASSERT will hang the whole system in debug version while doing nothing
in release version. However, in most of the case, we should not hang
the whole system: like invalid input parameter or creating an UOS. And
in release version, we shouldn't do nothing when something bad happened.

So ASSERT cleanup is necessary. This serial is just a beginning.
It will panic the system when creating SOS failed while not when create
UOS failed. It just returns error number to the caller when something
nonfatal error heppened otherwise panic when something fatal error happened.

In this serial, failure to create SOS is an fatal error.