### PR TITLE
doc: add doc build infrastructure for tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ devicemodel/build/
 devicemodel/include/version.h
 doc/doxygen
 doc/_build
+doc/tools
 build
 *.bak
 *.sav

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -35,7 +35,10 @@ help:
 doxy:
 	$(Q)(cat acrn.doxyfile) | doxygen - > doc.log 2>&1
 
-html: doxy
+content:
+	$(Q)scripts/extract_content.py
+
+html: doxy content
 	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(O) >> doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh doc.log
 
@@ -44,6 +47,7 @@ html: doxy
 
 clean:
 	rm -fr $(BUILDDIR) doxygen
+	rm -fr tools
 
 # Copy material over to the GitHub pages staging repo
 # along with a README

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,6 +33,7 @@ Sections
    release_notes.rst
    contribute/index.rst
    api/index.rst
+   tools.rst
 
 Indices and Tables
 ******************

--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017, Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to move docs from different places into the doc directory
+# to fix the website and external links
+
+import os
+import shutil
+import re
+import sys
+import fnmatch
+
+
+# direcories to search for .rst files
+CONTENT_DIRS = ["tools"]
+
+# directives to parse for included files
+DIRECTIVES = ["figure","include","image","literalinclude"]
+
+# should get this from the environment...
+ACRN_BASE = "../"
+
+def get_rst_files(dir):
+    matches = []
+    for root, dirnames, filenames in os.walk('%s/%s' %(ACRN_BASE, dir)):
+        for filename in fnmatch.filter(filenames, '*.rst'):
+            matches.append(os.path.join(root, filename))
+    for file in matches:
+        frel = file.replace(ACRN_BASE,"").strip("/")
+        dir=os.path.dirname(frel)
+        if not os.path.exists(os.path.join(ACRN_BASE, "doc", dir)):
+            os.makedirs(os.path.join(ACRN_BASE, "doc", dir))
+
+        shutil.copyfile(file, os.path.join(ACRN_BASE, "doc", frel))
+
+        with open(file, encoding="utf-8") as f:
+            content = f.readlines()
+        content = [x.strip() for x in content]
+        directives = "|".join(DIRECTIVES)
+        pattern = re.compile("\s*\.\.\s+(%s)::\s+(.*)" %directives)
+        for l in content:
+            m = pattern.match(l)
+            if m:
+                inf = m.group(2)
+                ind = os.path.dirname(inf)
+                if not os.path.exists(os.path.join(ACRN_BASE, "doc", dir, ind)):
+                    os.makedirs(os.path.join(ACRN_BASE, "doc", dir, ind))
+
+                shutil.copyfile(os.path.join(ACRN_BASE, dir, inf),
+                        os.path.join(ACRN_BASE, "doc", dir, inf))
+
+        f.close()
+
+def main():
+    for d in CONTENT_DIRS:
+        get_rst_files(d)
+
+if __name__ == "__main__":
+    main()

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -1,0 +1,9 @@
+.. _tools:
+
+Tools
+#####
+
+.. toctree::
+   :glob:
+
+   tools/**


### PR DESCRIPTION
The tools documentation is maintained within the tools folder and
outside of the doc folder. We need to temporarily pull that content
within the doc folder for generating the documentation set. (We're using
a script developed for the Zephyr project for just this purpose.)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>