### PR TITLE
Virtio 1.0 cap pci cfg

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1086,6 +1086,7 @@ pci_emul_capwrite(struct pci_vdev *dev, int offset, int bytes, uint32_t val)
 		pciecap_cfgwrite(dev, capoff, offset, bytes, val);
 		break;
 	default:
+		CFGWRITE(dev, offset, val, bytes);
 		break;
 	}
 }

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -233,6 +233,8 @@ int	pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx,
 void	pci_emul_free_bars(struct pci_vdev *pdi);
 int	pci_emul_add_capability(struct pci_vdev *dev, u_char *capdata,
 				int caplen);
+int	pci_emul_find_capability(struct pci_vdev *dev, uint8_t capid,
+				 int *p_capoff);
 int	pci_emul_add_msicap(struct pci_vdev *pi, int msgnum);
 int	pci_emul_add_pciecap(struct pci_vdev *pi, int pcie_device_type);
 void	pci_generate_msi(struct pci_vdev *pi, int msgnum);

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -518,6 +518,7 @@ struct virtio_base {
 	uint8_t config_generation;	/**< configuration generation */
 	uint32_t device_feature_select;	/**< current selected device feature */
 	uint32_t driver_feature_select;	/**< current selected guest feature */
+	int cfg_coff;			/**< PCI cfg access capability offset */
 };
 
 #define	VIRTIO_BASE_LOCK(vb)					\
@@ -872,6 +873,44 @@ void virtio_dev_error(struct virtio_base *base);
  * @return 0 on success and non-zero on fail.
  */
 int virtio_set_modern_bar(struct virtio_base *base, bool use_notify_pio);
+
+/**
+ * @brief Handle PCI configuration space reads.
+ *
+ * Handle virtio PCI configuration space reads. Only the specific registers
+ * that need speical operation are handled in this callback. For others just
+ * fallback to pci core. This interface is only valid for virtio modern.
+ *
+ * @param ctx Pointer to struct vmctx representing VM context.
+ * @param vcpu VCPU ID.
+ * @param dev Pointer to struct pci_vdev which emulates a PCI device.
+ * @param coff Register offset in bytes within PCI configuration space.
+ * @param bytes Access range in bytes.
+ * @param rv The value returned as read.
+ *
+ * @return 0 on handled and non-zero on non-handled.
+ */
+int virtio_pci_modern_cfgread(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
+			      int coff, int bytes, uint32_t *rv);
+/**
+ * @brief Handle PCI configuration space writes.
+ *
+ * Handle virtio PCI configuration space writes. Only the specific registers
+ * that need speical operation are handled in this callback. For others just
+ * fallback to pci core. This interface is only valid for virtio modern.
+ *
+ * @param ctx Pointer to struct vmctx representing VM context.
+ * @param vcpu VCPU ID.
+ * @param dev Pointer to struct pci_vdev which emulates a PCI device.
+ * @param coff Register offset in bytes within PCI configuration space.
+ * @param bytes Access range in bytes.
+ * @param value The value to write.
+ *
+ * @return 0 on handled and non-zero on non-handled.
+ */
+int virtio_pci_modern_cfgwrite(struct vmctx *ctx, int vcpu,
+			       struct pci_vdev *dev, int coff, int bytes,
+			       uint32_t val);
 
 /**
  * @}


### PR DESCRIPTION
The VIRTIO_PCI_CAP_PCI_CFG capability creates an alternative access method to the common configuration, notification, ISR and device-specific configuration regions.

The capability is immediately followed by an additional field like so:
struct virtio_pci_cfg_cap {
        struct virtio_pci_cap cap;
            uint8_t pci_cfg_data[4]; /* Data for BAR access. */ }

To access a device region, the driver writes into the capability structure (ie. within the PCI configuration space) as follows:

- The driver sets the BAR to access by writing to cap.bar
- The driver sets the size of the access by writing 1, 2 or 4 to cap.length
- The driver sets the offset within the BAR by writing to cap.offset

At that point, pci_cfg_data will provide a window of size cap.length into the given cap.bar at offset cap.offset.

v1 --> v2:
- add check of the input p_capoff in pci_emul_find_capability
- revise the commit message of 2/3 to clarify the current issue
- add check of the return value of virtio_find_capability
- use *rv instead of reading from config space again in
  virtio_pci_modern_cfgread
- use val instead of reading from config space again in
  virtio_pci_modern_cfgwrite
