### PR TITLE
Support DRD capability for APL xHCI.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -958,6 +958,17 @@ pci_xhci_portregs_write(struct pci_xhci_vdev *xdev,
 	}
 }
 
+static void
+pci_xhci_excap_write(struct pci_xhci_vdev *xdev, uint64_t offset,
+			uint64_t value)
+{
+	/* TODO: The default extended capabilities are readonly. Need implement
+	 * related write operations once writable capabilities get supported in
+	 * future.
+	 */
+	UPRINTF(LWRN, "write invalid offset 0x%lx\r\n", offset);
+}
+
 struct xhci_dev_ctx *
 pci_xhci_get_dev_ctx(struct pci_xhci_vdev *xdev, uint32_t slot)
 {
@@ -2732,6 +2743,8 @@ pci_xhci_write(struct vmctx *ctx,
 		pci_xhci_dbregs_write(xdev, offset, value);
 	else if (offset < xdev->excapoff)
 		pci_xhci_rtsregs_write(xdev, offset, value);
+	else if (offset < xdev->regsend)
+		pci_xhci_excap_write(xdev, offset, value);
 	else
 		UPRINTF(LWRN, "write invalid offset %ld\r\n", offset);
 

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -102,6 +102,18 @@ enum {
 	.reserve = 0x00							\
 }
 
+/* Intel ApolloLake xHCI extended capability for DRD. */
+#define DEFINE_EXCP_VENDOR_DRD(capid, next_ptr, reg0, reg1)		\
+	struct pci_xhci_excap_drd_apl  excap_drd_apl = {		\
+		{							\
+			.cap_id = capid,				\
+			.cap_ptr = next_ptr				\
+		},							\
+		.padding = {0},						\
+		.drdcfg0 = reg0,					\
+		.drdcfg1 = reg1						\
+	}
+
 struct xhci_slot_ctx {
 	volatile uint32_t	dwSctx0;
 #define	XHCI_SCTX_0_ROUTE_SET(x)		((x) & 0xFFFFF)

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -86,6 +86,22 @@ enum {
 #define	XHCI_TD_ALIGN			64	/* bytes */
 #define	XHCI_PAGE_SIZE			4096	/* bytes */
 
+/* xHCI extended capability supported protocol fileds */
+#define DEFINE_EXCP_PROT(name, next_ptr, revmaj, portoff, portcnt)	\
+	struct pci_xhci_excap_prot excap_##name = {			\
+	{								\
+		.cap_id = XHCI_ID_PROTOCOLS,				\
+		.cap_ptr = next_ptr					\
+	},								\
+	.rev_min = 0x00,						\
+	.rev_maj = revmaj,						\
+	.string = "USB"#revmaj,						\
+	.port_off = portoff,						\
+	.port_cnt = portcnt,						\
+	.psic_prot_def = 0x00,						\
+	.reserve = 0x00							\
+}
+
 struct xhci_slot_ctx {
 	volatile uint32_t	dwSctx0;
 #define	XHCI_SCTX_0_ROUTE_SET(x)		((x) & 0xFFFFF)

--- a/devicemodel/include/xhcireg.h
+++ b/devicemodel/include/xhcireg.h
@@ -227,6 +227,7 @@
 #define	XHCI_ID_VIRTUALIZATION	0x0004
 #define	XHCI_ID_MSG_IRQ		0x0005
 #define	XHCI_ID_USB_LOCAL_MEM	0x0006
+#define	XHCI_ID_DRD_INTEL	0x00C0
 
 /*
  * xHCI extended capability pointer in HCCPARAMS1.
@@ -238,6 +239,35 @@
 /* xHCI extended capability group end marker */
 #define	EXCAP_GROUP_END		0xFFFF
 #define	EXCAP_GROUP_NULL	NULL
+
+/* Intel APL xHCI DRD Configuration registers */
+#define	XHCI_DRD_MUX_CFG0		0x0000
+#define	XHCI_DRD_MUX_CFG1		0x0004
+#define	XCHI_DRD_CFG0_MODE_MASK		0x0003
+#define	XHCI_DRD_CFG0_DYN		0
+#define	XHCI_DRD_CFG0_HOST_MODE		1
+#define	XHCI_DRD_CFG0_DEV_MODE		2
+#define	XHCI_DRD_CFG0_SYNC		(1 << 2)
+#define	XHCI_DRD_CFG0_SWITCH_EN		(1 << 16)
+#define	XHCI_DRD_CFG0_IDPIN		(1 << 20)
+#define	XHCI_DRD_CFG0_IDPIN_EN		(1 << 21)
+#define	XHCI_DRD_CFG0_VBUS_VALID	(1 << 24)
+#define	XHCI_DRD_CFG1_HOST_MODE		(1 << 29)
+
+/* Intel APL xHCI DRD register related bases */
+#define	XHCI_APL_DRDCAP_BASE		0x8070
+#define	XHCI_APL_DRDREGS_BASE		0x80D8
+
+/* setting drd for host mode */
+#define	XHCI_NATIVE_DRD_DEV_MODE	"D"
+
+/* setting drd for device mode */
+#define	XHCI_NATIVE_DRD_HOST_MODE	"H"
+#define	XHCI_NATIVE_DRD_SWITCH_PATH	\
+	"/sys/devices/platform/intel_usb_dr_phy.0/mux_state"
+
+/* return value after setting drd device node */
+#define	XHCI_NATIVE_DRD_WRITE_SZ	2
 
 /* XHCI register R/W wrappers */
 #define	XREAD1(sc, what, a) \

--- a/devicemodel/include/xhcireg.h
+++ b/devicemodel/include/xhcireg.h
@@ -228,6 +228,17 @@
 #define	XHCI_ID_MSG_IRQ		0x0005
 #define	XHCI_ID_USB_LOCAL_MEM	0x0006
 
+/*
+ * xHCI extended capability pointer in HCCPARAMS1.
+ * The excap offset is calculated by left shift 2
+ * bits which equals 0x8000
+ */
+#define	XHCI_EXCAP_PTR		0x2000
+
+/* xHCI extended capability group end marker */
+#define	EXCAP_GROUP_END		0xFFFF
+#define	EXCAP_GROUP_NULL	NULL
+
 /* XHCI register R/W wrappers */
 #define	XREAD1(sc, what, a) \
 	bus_space_read_1((sc)->sc_io_tag, (sc)->sc_io_hdl, \


### PR DESCRIPTION
On Intel ApolloLake platform, there has one couple USB2/USB3 ports
shared one couple USB2/USB3 PHY with xDCI(dwc3) controller to support
dual role mode. There has one hardware logic inside xHCI controller
to support dynamic USB PHY switch between xHCI and xDCI. And two
xHCI mmio registers are used for controling this logic, which are exposed
as xHCI extended capability for software.
This patch set implements USB dual role switch for Intel ApolloLake platform.
DRD which means dual role device is used for switching xHCI and xDCI between
PHY USB2&USB3.