### PR TITLE
doc: adjust known issues pattern

### DIFF
--- a/doc/.known-issues/doc/hypercall.conf
+++ b/doc/.known-issues/doc/hypercall.conf
@@ -3,13 +3,7 @@
 #
 #
 ^(?P<filename>[-._/\w]+/api/hypercall_api.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
-^.*union vhm_request::\@0 vhm_request::\@1
-^[- \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
-^.*union vhm_request::\@2  vhm_request::reqs
-^[- \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
-^.*union vhm_request_buffer::\@3 vhm_request_buffer::\@4
+^.*union vhm_request::\@0  vhm_request::reqs
 ^[- \t]*\^
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^[ \t]*
@@ -27,7 +21,7 @@
 ^.*vhm_request.reqs
 ^[- \t]*\^
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
-^.*union hc_ptdev_irq::\@5  hc_ptdev_irq::is
+^.*union hc_ptdev_irq::\@1  hc_ptdev_irq::is
 ^[- \t]*\^
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^[ \t]*


### PR DESCRIPTION
Changes to the nested unnamed unions in type definitions require a tweak
to the pattern matching used to detect known issues reported by the API
doc generation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>