### PR TITLE
tools: acrnctl: Fix regression of acrnctl list

### DIFF
--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -86,7 +86,7 @@ static void process_msg(struct mngr_msg *msg)
 
 /* vm states data and helper functions */
 
-#define ACRN_DM_SOCK_ROOT	"/run/acrn"
+#define ACRN_DM_SOCK_ROOT	"/run/acrn/mngr"
 
 struct vmm_struct {
 	char name[MAX_NAME_LEN];
@@ -168,9 +168,9 @@ static void vmm_update(void)
 	pvmname = NULL;
 
 	snprintf(cmd, sizeof(cmd),
-		 "find %s/ -name \"*.socket\" | "
-		 "sed \"s/\\/run\\/acrn\\///g\" | "
-		 "sed \"s/-monitor.socket//g\"", ACRN_DM_SOCK_ROOT);
+			"find %s/ -name \"*monitor.*.socket\" | "
+			"sed \"s/\\/run\\/acrn\\/mngr\\///g\" | "
+			"awk -F. \'{ print $1 }\'", ACRN_DM_SOCK_ROOT);
 	shell_cmd(cmd, cmd_out, sizeof(cmd_out));
 
 	/* Properly null-terminate cmd_out */


### PR DESCRIPTION
commit(4d274a5 Tools: acrn-manager-interface) change location and naming scheme
to the follow.
    /run/acrn/mngr/vmname.monitor.pid.socket

This patch adapt parse vmname according new naming scheme.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>