### PR TITLE
DM: cleanup for header inclusions

### DIFF
--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -25,8 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
@@ -34,7 +32,6 @@
 #include <stdbool.h>
 
 #include "vmmapi.h"
-#include "vmm.h"
 #include "acpi.h"
 #include "inout.h"
 #include "mevent.h"

--- a/devicemodel/core/console.c
+++ b/devicemodel/core/console.c
@@ -24,10 +24,8 @@
  * SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <sys/cdefs.h>
-#include <sys/types.h>
 
+#include <stdio.h>
 #include "gc.h"
 #include "console.h"
 

--- a/devicemodel/core/consport.c
+++ b/devicemodel/core/consport.c
@@ -26,16 +26,11 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
-#include <sys/select.h>
-#include <err.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <termios.h>
 #include <unistd.h>
 #include <stdbool.h>
-#include <sysexits.h>
 
 #include "inout.h"
 #include "lpc.h"

--- a/devicemodel/core/gc.c
+++ b/devicemodel/core/gc.c
@@ -1,5 +1,3 @@
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -34,13 +34,9 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <ctype.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <assert.h>
 
-#include "vmm.h"
-#include "vhm_ioctl_defs.h"
 #include "vmmapi.h"
 
 #define HUGETLB_LV1		0

--- a/devicemodel/core/inout.c
+++ b/devicemodel/core/inout.c
@@ -26,18 +26,10 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/mman.h>
-#include <linux/uio.h>
 #include <stdio.h>
-#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 
-#include "vmm.h"
-#include "vmmapi.h"
-#include "dm.h"
 #include "inout.h"
 
 SET_DECLARE(inout_port_set, struct inout_port);

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -26,10 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
-#include <sys/mman.h>
-#include <sys/time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -43,8 +39,6 @@
 #include <stdbool.h>
 #include <getopt.h>
 
-#include "types.h"
-#include "vmm.h"
 #include "vmmapi.h"
 #include "sw_load.h"
 #include "cpuset.h"

--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -32,16 +32,13 @@
  * so it can be searched within the range.
  */
 
-#include <sys/cdefs.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <assert.h>
 #include <pthread.h>
 
 #include "vmm.h"
-#include "types.h"
 #include "mem.h"
 #include "tree.h"
 

--- a/devicemodel/core/mevent.c
+++ b/devicemodel/core/mevent.c
@@ -31,24 +31,17 @@
  * using EPOLL, and having events be persistent by default.
  */
 
-#include <sys/cdefs.h>
 #include <assert.h>
-#include <err.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
-#include <string.h>
-#include <sysexits.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <sys/epoll.h>
 #include <sys/queue.h>
 #include <pthread.h>
 
 #include "mevent.h"
-#include "vmm.h"
 #include "vmmapi.h"
 
 #define	MEVENT_MAX	64

--- a/devicemodel/core/mptbl.c
+++ b/devicemodel/core/mptbl.c
@@ -26,8 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -35,7 +33,6 @@
 #include "mptable.h"
 #include "acpi.h"
 #include "dm.h"
-#include "mptbl.h"
 #include "pci_core.h"
 
 #define MPTABLE_BASE		0xF0000

--- a/devicemodel/core/post.c
+++ b/devicemodel/core/post.c
@@ -26,9 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
-#include <stdbool.h>
 #include <assert.h>
 
 #include "inout.h"

--- a/devicemodel/core/smbiostbl.c
+++ b/devicemodel/core/smbiostbl.c
@@ -24,20 +24,15 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <assert.h>
 #include <openssl/md5.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
-#include <uuid/uuid.h>
 
-#include "vmm.h"
 #include "vmmapi.h"
 #include "dm.h"
-#include "smbiostbl.h"
 
 #define SMBIOS_BASE		0xF1000
 

--- a/devicemodel/core/sw_load_bzimage.c
+++ b/devicemodel/core/sw_load_bzimage.c
@@ -28,11 +28,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <stdbool.h>
-#include <stdint.h>
 
-#include "acrn_common.h"
 #include "vmmapi.h"
 #include "sw_load.h"
 

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -28,9 +28,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <stdbool.h>
-#include <stdint.h>
 
 #include "vmmapi.h"
 #include "sw_load.h"

--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -30,10 +30,8 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdbool.h>
-#include <stdint.h>
 
 #include "dm.h"
-#include "acrn_common.h"
 #include "vmmapi.h"
 #include "sw_load.h"
 #include "acpi.h"

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -26,15 +26,9 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
 
-#include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <sys/uio.h>
-#include <sys/user.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -43,15 +37,8 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <uuid/uuid.h>
 
-#include "types.h"
-#include "cpuset.h"
-#include "segments.h"
-#include "specialreg.h"
 
-#include "vmm.h"
-#include "vhm_ioctl_defs.h"
 
 #include "vmmapi.h"
 #include "mevent.h"

--- a/devicemodel/core/vrpmb.c
+++ b/devicemodel/core/vrpmb.c
@@ -25,17 +25,13 @@
  *
  */
 
-#include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <unistd.h>
-#include <openssl/rand.h>
 
 #include "types.h"
 #include "vrpmb.h"
-#include "acrn_common.h"
 
 struct key_material {
 	uint8_t key[RPMB_KEY_LEN];

--- a/devicemodel/hw/block_if.c
+++ b/devicemodel/hw/block_if.c
@@ -26,7 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
 #include <sys/param.h>
 #include <sys/queue.h>
 #include <sys/stat.h>
@@ -41,11 +40,9 @@
 #include <string.h>
 #include <pthread.h>
 #include <signal.h>
-#include <sysexits.h>
 #include <unistd.h>
 
 #include "dm.h"
-#include "mevent.h"
 #include "block_if.h"
 #include "ahci.h"
 

--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -27,18 +27,10 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
 #include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/uio.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <strings.h>
-#include <unistd.h>
 #include <assert.h>
 #include <pthread.h>
 #include <inttypes.h>

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -26,9 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -38,10 +35,8 @@
 #include <assert.h>
 #include <stdbool.h>
 
-#include "vmm.h"
 #include "vmmapi.h"
 #include "acpi.h"
-#include "dm.h"
 #include "inout.h"
 #include "ioapic.h"
 #include "mem.h"

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -5,22 +5,13 @@
  *
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <sys/stat.h>
-#include <sys/uio.h>
-#include <sys/ioctl.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
-#include <strings.h>
 #include <unistd.h>
 #include <assert.h>
-#include <pthread.h>
-#include <openssl/md5.h>
 
 #include "dm.h"
 #include "pci_core.h"

--- a/devicemodel/hw/pci/hostbridge.c
+++ b/devicemodel/hw/pci/hostbridge.c
@@ -26,8 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <pthread.h>
 #include "pci_core.h"
 
 static int

--- a/devicemodel/hw/pci/irq.c
+++ b/devicemodel/hw/pci/irq.c
@@ -26,8 +26,6 @@
  */
 
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <assert.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -36,11 +34,8 @@
 
 #include "types.h"
 #include "acpi.h"
-#include "vmm.h"
 #include "vmmapi.h"
-#include "inout.h"
 #include "pci_core.h"
-#include "irq.h"
 #include "lpc.h"
 
 /*

--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -27,14 +27,11 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
 
-#include "vmm.h"
 #include "vmmapi.h"
 #include "acpi.h"
 #include "inout.h"

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -26,9 +26,6 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <sys/user.h>
@@ -38,22 +35,14 @@
 #include <string.h>
 #include <err.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <sysexits.h>
-#include <unistd.h>
 #include <pthread.h>
 #include <pciaccess.h>
 
-#include "pcireg.h"
 #include "iodev.h"
-#include "vmm.h"
 #include "vmmapi.h"
-#include "vhm_ioctl_defs.h"
 #include "pciio.h"
 #include "pci_core.h"
-#include "mem.h"
 #include "acpi.h"
-#include "dm.h"
 
 #ifndef _PATH_DEVPCI
 #define	_PATH_DEVPCI	"/dev/pci"

--- a/devicemodel/hw/pci/uart.c
+++ b/devicemodel/hw/pci/uart.c
@@ -26,11 +26,8 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <stdio.h>
 
-#include "dm.h"
 #include "pci_core.h"
 #include "uart_core.h"
 

--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -24,11 +24,8 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <sys/uio.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <stddef.h>
 #include <pthread.h>
 

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -26,19 +26,11 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
 #include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/uio.h>
-#include <sys/ioctl.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <strings.h>
-#include <unistd.h>
 #include <assert.h>
 #include <pthread.h>
 #include <openssl/md5.h>

--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -28,13 +28,8 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <sys/uio.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -44,8 +39,6 @@
 #include <unistd.h>
 #include <assert.h>
 #include <pthread.h>
-#include <libgen.h>
-#include <sysexits.h>
 #include <termios.h>
 
 #include "dm.h"

--- a/devicemodel/hw/pci/virtio/virtio_heci.c
+++ b/devicemodel/hw/pci/virtio/virtio_heci.c
@@ -8,8 +8,6 @@
  * HECI device virtualization.
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <sys/ioctl.h>
 #include <linux/mei.h>
 #include <errno.h>

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -5,10 +5,7 @@
  *
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
 #include <sys/types.h>
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -26,35 +26,25 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/select.h>
 #include <sys/uio.h>
-#include <sys/ioctl.h>
 #include <net/ethernet.h>
 #ifndef NETMAP_WITH_LIBS
 #define NETMAP_WITH_LIBS
 #endif
-#include <err.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <unistd.h>
 #include <assert.h>
 #include <openssl/md5.h>
 #include <pthread.h>
-#include <sysexits.h>
 
-#include "types.h"
 #include "dm.h"
 #include "pci_core.h"
 #include "mevent.h"
 #include "virtio.h"
 #include "netmap_user.h"
-#include <net/if.h>
 #include <linux/if_tun.h>
 
 #define VIRTIO_NET_RINGSZ	1024

--- a/devicemodel/hw/pci/virtio/virtio_rnd.c
+++ b/devicemodel/hw/pci/virtio/virtio_rnd.c
@@ -31,10 +31,6 @@
  * once it has been seeded at bootup.
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/uio.h>
-#include <err.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,7 +38,6 @@
 #include <unistd.h>
 #include <assert.h>
 #include <pthread.h>
-#include <sysexits.h>
 
 #include "dm.h"
 #include "pci_core.h"

--- a/devicemodel/hw/pci/virtio/virtio_rpmb.c
+++ b/devicemodel/hw/pci/virtio/virtio_rpmb.c
@@ -35,11 +35,6 @@
  *
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/uio.h>
-#include <err.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -47,7 +42,6 @@
 #include <unistd.h>
 #include <assert.h>
 #include <pthread.h>
-#include <sysexits.h>
 
 #include "dm.h"
 #include "pci_core.h"
@@ -55,7 +49,6 @@
 #include "vmmapi.h"
 #include <fcntl.h>
 #include <sys/ioctl.h>
-#include <linux/types.h>
 #include "rpmb.h"
 #include "rpmb_sim.h"
 #include "rpmb_backend.h"

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -18,7 +18,6 @@
 #include <assert.h>
 #include <stdbool.h>
 
-#include "vmm.h"
 #include "vmmapi.h"
 #include "mevent.h"
 #include "pci_core.h"

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -76,15 +76,9 @@
  *                +--------+   +--------+
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/uio.h>
 #include <sys/types.h>
-#include <sys/queue.h>
-#include <sys/fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <pthread.h>
 #include <unistd.h>
@@ -96,7 +90,6 @@
 #include "dm.h"
 #include "pci_core.h"
 #include "xhci.h"
-#include "usb_core.h"
 #include "usb_pmapper.h"
 
 #undef LOG_TAG

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -50,7 +50,6 @@
  *         DSDT  ->   0xf2800 (variable - can go up to 0x100000)
  */
 
-#include <sys/cdefs.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <errno.h>
@@ -63,8 +62,6 @@
 #include <stdbool.h>
 #include <fcntl.h>
 
-#include "vmm.h"
-#include "vmmapi.h"
 #include "dm.h"
 #include "acpi.h"
 #include "pci_core.h"

--- a/devicemodel/hw/platform/acpi/acpi_pm.c
+++ b/devicemodel/hw/platform/acpi/acpi_pm.c
@@ -9,9 +9,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-#include "vmm.h"
 #include "vmmapi.h"
-#include "dm.h"
 #include "acpi.h"
 
 static inline int get_vcpu_pm_info(struct vmctx *ctx, int vcpu_id,

--- a/devicemodel/hw/platform/atkbdc.c
+++ b/devicemodel/hw/platform/atkbdc.c
@@ -25,8 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <stdint.h>
 #include <assert.h>
 #include <errno.h>
@@ -34,18 +32,15 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <pthread.h>
 
 #include "acpi.h"
 #include "inout.h"
-#include "pci_core.h"
 #include "irq.h"
 #include "lpc.h"
 #include "atkbdc.h"
 #include "ps2kbd.h"
 #include "ps2mouse.h"
-#include "vmm.h"
 #include "vmmapi.h"
 
 static void

--- a/devicemodel/hw/platform/cmos_io.c
+++ b/devicemodel/hw/platform/cmos_io.c
@@ -26,10 +26,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <signal.h>
-#include <time.h>
 #include <assert.h>
 
 #include "inout.h"

--- a/devicemodel/hw/platform/ioapic.c
+++ b/devicemodel/hw/platform/ioapic.c
@@ -25,16 +25,10 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
-#include <stdio.h>
-#include <stdbool.h>
 
+#include <stdio.h>
 #include "vmm.h"
-#include "vmmapi.h"
-#include "ioapic.h"
 #include "pci_core.h"
-#include "lpc.h"
 
 /* 16 IRQs reserved for kdb/mouse, COM1/2, RTC... */
 #define LEGACY_IRQ_NUM	16

--- a/devicemodel/hw/platform/ps2kbd.c
+++ b/devicemodel/hw/platform/ps2kbd.c
@@ -25,8 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/types.h>
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/devicemodel/hw/platform/rpmb/rpmb_sim.c
+++ b/devicemodel/hw/platform/rpmb/rpmb_sim.c
@@ -25,19 +25,10 @@
  * SUCH DAMAGE.
  */
 
-#include <ctype.h>
 #include <errno.h>
-#include <stdbool.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <fcntl.h>
 #include <inttypes.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdint.h>
 #include <openssl/hmac.h>
 
 #include "rpmb.h"

--- a/devicemodel/hw/platform/rtc.c
+++ b/devicemodel/hw/platform/rtc.c
@@ -24,9 +24,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/param.h>
-#include <sys/queue.h>
 #include <pthread.h>
 #include <string.h>
 #include <assert.h>
@@ -38,7 +35,6 @@
 #include <time.h>
 
 #include "vmmapi.h"
-#include "vmm.h"
 #include "inout.h"
 #include "mc146818rtc.h"
 #include "rtc.h"

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -24,15 +24,12 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-#include <sys/time.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
-#include "types.h"
 #include "usb.h"
 #include "usbdi.h"
 #include "usb_core.h"

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include "usb.h"
 #include "usbdi.h"
-#include "usb_core.h"
 #include "usb_pmapper.h"
 
 #undef LOG_TAG

--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -27,18 +27,15 @@
  * $FreeBSD$
  */
 
-#include <sys/cdefs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <err.h>
 #include <fcntl.h>
 #include <termios.h>
 #include <unistd.h>
 #include <stdbool.h>
 #include <string.h>
 #include <pthread.h>
-#include <sysexits.h>
 
 #include "types.h"
 #include "mevent.h"

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -75,14 +75,10 @@
  *   USB device: usb_mouse.c usb_pmapper.{h,c}
  */
 
-#include <sys/cdefs.h>
 #include <sys/types.h>
-#include <sys/queue.h>
 #include <assert.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include "usb_core.h"


### PR DESCRIPTION
used https://gitlab.com/esr/deheader to detect and remove unnecessary
header file inclusions

Signed-off-by: Zide Chen <zide.chen@intel.com>