### PR TITLE
doc: fix doxygen comments in virtio.h

### DIFF
--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -904,7 +904,7 @@ int virtio_pci_modern_cfgread(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  * @param dev Pointer to struct pci_vdev which emulates a PCI device.
  * @param coff Register offset in bytes within PCI configuration space.
  * @param bytes Access range in bytes.
- * @param value The value to write.
+ * @param val The value to write.
  *
  * @return 0 on handled and non-zero on non-handled.
  */


### PR DESCRIPTION
Fixes a recent PR #311 that added a new API but the doxygen comments for
one of the parameters didn't match the parameter name.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>