### PR TITLE
fix "warning: ISO C forbids zero-size array"

### DIFF
--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -58,7 +58,7 @@ struct trusty_mem {
 
 	/* The left memory is for trusty's code/data/heap/stack
 	 */
-	uint8_t left_mem[0];
+	uint8_t left_mem[];
 };
 
 static struct key_info g_key_info = {


### PR DESCRIPTION
ISO C not allowed array type whith the zero limit.
Change the array type to flexible array type.

Signed-off-by: huihuang shi <huihuang.shi@intel.com>