### PR TITLE
fix "ISO C99 does not support '_Static_assert'"

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -351,55 +351,60 @@ void bsp_boot_init(void)
 	/* Build time sanity checks to make sure hard-coded offset
 	*  is matching the actual offset!
 	*/
-	_Static_assert(offsetof(struct cpu_regs, rax) ==
+	ASSERT(sizeof(struct trusty_startup_param)
+			+ sizeof(struct key_info) < 0x1000,
+		"trusty_startup_param + key_info > 1Page size(4KB)!");
+
+	ASSERT(NR_WORLD == 2, "Only 2 Worlds supported!");
+	ASSERT(offsetof(struct cpu_regs, rax) ==
 		VMX_MACHINE_T_GUEST_RAX_OFFSET,
 		"cpu_regs rax offset not match");
-	_Static_assert(offsetof(struct cpu_regs, rbx) ==
+	ASSERT(offsetof(struct cpu_regs, rbx) ==
 		VMX_MACHINE_T_GUEST_RBX_OFFSET,
 		"cpu_regs rbx offset not match");
-	_Static_assert(offsetof(struct cpu_regs, rcx) ==
+	ASSERT(offsetof(struct cpu_regs, rcx) ==
 		VMX_MACHINE_T_GUEST_RCX_OFFSET,
 		"cpu_regs rcx offset not match");
-	_Static_assert(offsetof(struct cpu_regs, rdx) ==
+	ASSERT(offsetof(struct cpu_regs, rdx) ==
 		VMX_MACHINE_T_GUEST_RDX_OFFSET,
 		"cpu_regs rdx offset not match");
-	_Static_assert(offsetof(struct cpu_regs, rbp) ==
+	ASSERT(offsetof(struct cpu_regs, rbp) ==
 		VMX_MACHINE_T_GUEST_RBP_OFFSET,
 		"cpu_regs rbp offset not match");
-	_Static_assert(offsetof(struct cpu_regs, rsi) ==
+	ASSERT(offsetof(struct cpu_regs, rsi) ==
 		VMX_MACHINE_T_GUEST_RSI_OFFSET,
 		"cpu_regs rsi offset not match");
-	_Static_assert(offsetof(struct cpu_regs, rdi) ==
+	ASSERT(offsetof(struct cpu_regs, rdi) ==
 		VMX_MACHINE_T_GUEST_RDI_OFFSET,
 		"cpu_regs rdi offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r8) ==
+	ASSERT(offsetof(struct cpu_regs, r8) ==
 		VMX_MACHINE_T_GUEST_R8_OFFSET,
 		"cpu_regs r8 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r9) ==
+	ASSERT(offsetof(struct cpu_regs, r9) ==
 		VMX_MACHINE_T_GUEST_R9_OFFSET,
 		"cpu_regs r9 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r10) ==
+	ASSERT(offsetof(struct cpu_regs, r10) ==
 		VMX_MACHINE_T_GUEST_R10_OFFSET,
 		"cpu_regs r10 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r11) ==
+	ASSERT(offsetof(struct cpu_regs, r11) ==
 		VMX_MACHINE_T_GUEST_R11_OFFSET,
 		"cpu_regs r11 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r12) ==
+	ASSERT(offsetof(struct cpu_regs, r12) ==
 		VMX_MACHINE_T_GUEST_R12_OFFSET,
 		"cpu_regs r12 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r13) ==
+	ASSERT(offsetof(struct cpu_regs, r13) ==
 		VMX_MACHINE_T_GUEST_R13_OFFSET,
 		"cpu_regs r13 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r14) ==
+	ASSERT(offsetof(struct cpu_regs, r14) ==
 		VMX_MACHINE_T_GUEST_R14_OFFSET,
 		"cpu_regs r14 offset not match");
-	_Static_assert(offsetof(struct cpu_regs, r15) ==
+	ASSERT(offsetof(struct cpu_regs, r15) ==
 		VMX_MACHINE_T_GUEST_R15_OFFSET,
 		"cpu_regs r15 offset not match");
-	_Static_assert(offsetof(struct run_context, cr2) ==
+	ASSERT(offsetof(struct run_context, cr2) ==
 		VMX_MACHINE_T_GUEST_CR2_OFFSET,
 		"run_context cr2 offset not match");
-	_Static_assert(offsetof(struct run_context, ia32_spec_ctrl) ==
+	ASSERT(offsetof(struct run_context, ia32_spec_ctrl) ==
 		VMX_MACHINE_T_GUEST_SPEC_CTRL_OFFSET,
 		"run_context ia32_spec_ctrl offset not match");
 

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -421,7 +421,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 	void *addr = NULL;
 	void *pml4_addr = GPA2HVA(vm, GUEST_INIT_PAGE_TABLE_START);
 
-	_Static_assert((GUEST_INIT_PAGE_TABLE_START + 7 * PAGE_SIZE_4K) <
+	ASSERT((GUEST_INIT_PAGE_TABLE_START + 7 * PAGE_SIZE_4K) <
 		RSDP_F_ADDR, "RSDP fix segment could be override");
 
 	if (GUEST_INIT_PAGE_TABLE_SKIP_SIZE <

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -7,18 +7,7 @@
 #include <hypervisor.h>
 #include <hkdf.h>
 
-_Static_assert(NR_WORLD == 2, "Only 2 Worlds supported!");
-
 #define TRUSTY_VERSION 1
-
-struct trusty_startup_param {
-	uint32_t size_of_this_struct;
-	uint32_t mem_size;
-	uint64_t tsc_per_ms;
-	uint64_t trusty_mem_base;
-	uint32_t reserved;
-	uint8_t padding[4];
-};
 
 struct trusty_mem {
 	/* The first page of trusty memory is reserved for key_info and
@@ -43,10 +32,6 @@ static struct key_info g_key_info = {
 	.platform = 3,
 	.num_seeds = 1
 };
-
-_Static_assert(sizeof(struct trusty_startup_param)
-			+ sizeof(struct key_info) < 0x1000,
-		"trusty_startup_param + key_info > 1Page size(4KB)!");
 
 #define save_segment(seg, SEG_NAME) \
 { \

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -106,6 +106,15 @@ struct secure_world_control {
 	struct secure_world_memory sworld_memory;
 };
 
+struct trusty_startup_param {
+	uint32_t size_of_this_struct;
+	uint32_t mem_size;
+	uint64_t tsc_per_ms;
+	uint64_t trusty_mem_base;
+	uint32_t reserved;
+	uint8_t padding[4];
+};
+
 void switch_world(struct vcpu *vcpu, int next_world);
 bool initialize_trusty(struct vcpu *vcpu, uint64_t param);
 void destroy_secure_world(struct vm *vm);


### PR DESCRIPTION
Acked-by:Eddie Dong
_Static_assert is supported in C11 standard.
Please see N1570(C11 mannual) 6.4.1.
replace _Static_assert with ASSERT.

Signed-off-by: huihuang shi <huihuang.shi@intel.com>