### PR TITLE
Enable IOC mediator by default on MRB

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -60,6 +60,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <types.h>
+#include <libgen.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -553,6 +554,33 @@ ioc_open_native_ch(const char *dev_name)
 }
 
 /*
+ * Check and create the directory.
+ * To avoid symlink failure if the directory does not exist.
+ */
+static int
+check_dir(const char *file)
+{
+	char *tmp, *dir;
+
+	tmp = strdup(file);
+	if (!tmp) {
+		DPRINTF("ioc falied to dup file, error:%s\r\n",
+				strerror(errno));
+		return -1;
+	}
+
+	dir = dirname(tmp);
+	if (access(dir, F_OK) && mkdir(dir, 0666)) {
+		DPRINTF("ioc falied to create dir:%s, erorr:%s\r\n", dir,
+				strerror(errno));
+		free(tmp);
+		return -1;
+	}
+	free(tmp);
+	return 0;
+}
+
+/*
  * Open PTY master device for IOC mediator and the PTY slave device for virtual
  * UART. The pair(master/slave) can work as a communication channel between
  * IOC mediator and virtual UART.
@@ -575,6 +603,12 @@ ioc_open_virtual_uart(const char *dev_name)
 	if (!slave_name)
 		goto pty_err;
 	if ((unlink(dev_name) < 0) && errno != ENOENT)
+		goto pty_err;
+	/*
+	 * The check_dir restriction is that only create one directory
+	 * not support multi-level directroy.
+	 */
+	if (check_dir(dev_name) < 0)
 		goto pty_err;
 	if (symlink(slave_name, dev_name) < 0)
 		goto pty_err;

--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1281,8 +1281,14 @@ ioc_parse(const char *opts)
 	snprintf(virtual_uart_path, sizeof(virtual_uart_path), "%s", param);
 	if (tmp != NULL) {
 		tmp = strtok(NULL, ",");
-		if (tmp != NULL)
+		if (tmp != NULL) {
 			ioc_boot_reason = strtoul(tmp, 0, 0);
+
+			/*
+			 * Mask invalid bits of wakeup reason for IOC mediator
+			 */
+			ioc_boot_reason &= CBC_WK_RSN_ALL;
+		}
 	}
 	free(param);
 	return 0;
@@ -1302,9 +1308,12 @@ ioc_init(struct vmctx *ctx)
 	if (ioc_is_platform_supported() != 0)
 		goto ioc_err;
 
-	/* Check IOC boot reason */
+	/*
+	 * Set default boot wakeup reason as ignition button active if met
+	 * invalid parameter.
+	 */
 	if (ioc_boot_reason == 0)
-		goto ioc_err;
+		ioc_boot_reason = CBC_WK_RSN_BTN;
 	ioc = (struct ioc_dev *)calloc(1, sizeof(struct ioc_dev));
 	if (!ioc)
 		goto ioc_err;

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -123,6 +123,8 @@ acrn-dm -T -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s
   -s 12,passthru,0/3/0 \
   -s 22,passthru,0/16/0 \
   -s 27,passthru,0/1b/0 \
+  -i /run/acrn/ioc_$vm_name,0x20 \
+  -l com2,/run/acrn/ioc_$vm_name \
   -B "root=/dev/vda2 rw rootwait maxcpus=$2 nohpet console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 i915.enable_guc_loading=0 \


### PR DESCRIPTION
Update MRB launch_uos.sh script to enable IOC mediator by default.
And change the PTY path from the /tmp/ioc_$vm_name to /run/acrn/ioc_$vm_name for aligning with acrnctl.
Set one default boot wakeup reason to avoid acrn-dm boot failed with invalid wakeup reason parameter.

v2):
   1. Avoid enable invalid wakeup reason bit.
   2. Add restriction comments in check_dir function-call.