### PR TITLE
Support different vcpu modes

### DIFF
--- a/devicemodel/core/sw_load_bzimage.c
+++ b/devicemodel/core/sw_load_bzimage.c
@@ -314,7 +314,7 @@ acrn_sw_load_bzimage(struct vmctx *ctx)
 		if (setup_size <= 0)
 			return -1;
 		*kernel_entry_addr = (uint64_t)
-			(KERNEL_LOAD_OFF(ctx) + setup_size + 0x200);
+			(KERNEL_LOAD_OFF(ctx) + setup_size);
 		ret = acrn_prepare_zeropage(ctx, setup_size);
 		if (ret)
 			return ret;

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -211,6 +211,11 @@ static int hardware_detect_support(void)
 		return -ENODEV;
 	}
 
+	if (!cpu_has_vmx_unrestricted_guest_cap()) {
+		pr_fatal("%s, unrestricted guest not supported\n", __func__);
+		return -ENODEV;
+	}
+
 	ret = check_vmx_mmu_cap();
 	if (ret)
 		return ret;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -153,6 +153,26 @@ int copy_to_vm(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 	return 0;
 }
 
+enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu)
+{
+	struct run_context *cur_context =
+		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
+	enum vm_cpu_mode cpu_mode;
+
+	cpu_mode = get_vcpu_mode(vcpu);
+
+	if (cpu_mode == CPU_MODE_REAL)
+		return PAGING_MODE_0_LEVEL;
+	else if (cpu_mode == CPU_MODE_PROTECTED) {
+		if (cur_context->cr4 & CR4_PAE)
+			return PAGING_MODE_3_LEVEL;
+		else if (cur_context->cr0 & CR0_PG)
+			return PAGING_MODE_2_LEVEL;
+		return PAGING_MODE_0_LEVEL;
+	} else	/* compatibility or 64bit mode */
+		return PAGING_MODE_4_LEVEL;
+}
+
 uint64_t gva2gpa(struct vm *vm, uint64_t cr3, uint64_t gva)
 {
 	int level, index, shift;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -552,6 +552,7 @@ int prepare_vm0_memmap_and_e820(struct vm *vm)
 	return 0;
 }
 
+#ifdef CONFIG_START_VM0_BSP_64BIT
 /*******************************************************************
  *         GUEST initial page table
  *
@@ -680,6 +681,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 
 	return GUEST_INIT_PAGE_TABLE_START;
 }
+#endif
 
 /*******************************************************************
  *         GUEST initial GDT table

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -281,7 +281,7 @@ static void get_guest_paging_info(struct vcpu *vcpu, struct emul_cnx *emul_cnx)
 		vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].cr3;
 	emul_cnx->paging.cpl = cpl;
 	emul_cnx->paging.cpu_mode = get_vcpu_mode(vcpu);
-	emul_cnx->paging.paging_mode = PAGING_MODE_FLAT;/*maybe change later*/
+	emul_cnx->paging.paging_mode = get_vcpu_paging_mode(vcpu);
 }
 
 static int mmio_read(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t *rval,

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -158,6 +158,9 @@ int start_vcpu(struct vcpu *vcpu)
 	/* Save guest CR3 register */
 	cur_context->cr3 = exec_vmread(VMX_GUEST_CR3);
 
+	/* Save guest IA32_EFER register */
+	cur_context->ia32_efer = exec_vmread64(VMX_GUEST_IA32_EFER_FULL);
+
 	/* Obtain current VCPU instruction pointer and length */
 	cur_context->rip = exec_vmread(VMX_GUEST_RIP);
 	vcpu->arch_vcpu.inst_len = exec_vmread(VMX_EXIT_INSTR_LEN);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -7,6 +7,11 @@
 #include <hypervisor.h>
 #include <schedule.h>
 
+#ifdef CONFIG_EFI_STUB
+#include <acrn_efi.h>
+extern struct efi_ctx* efi_ctx;
+#endif
+
 vm_sw_loader_t vm_sw_loader;
 
 /***********************************************************************
@@ -67,14 +72,16 @@ int create_vcpu(int cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 			vcpu->pcpu_id, vcpu->vm->attr.id, vcpu->vcpu_id,
 			is_vcpu_bsp(vcpu) ? "PRIMARY" : "SECONDARY");
 
-	/* Is this VCPU a VM BSP, create page hierarchy for this VM */
-	if (is_vcpu_bsp(vcpu)) {
+#ifdef CONFIG_START_VM0_BSP_64BIT
+	/* Is this VCPU a VM0 BSP, create page hierarchy for this VM */
+	if (is_vcpu_bsp(vcpu) && is_vm0(vcpu->vm)) {
 		/* Set up temporary guest page tables */
 		vm->arch_vm.guest_init_pml4 = create_guest_initial_paging(vm);
 		pr_info("VM *d VCPU %d CR3: 0x%016llx ",
 			vm->attr.id, vcpu->vcpu_id,
 			vm->arch_vm.guest_init_pml4);
 	}
+#endif
 
 	/* Allocate VMCS region for this VCPU */
 	vcpu->arch_vcpu.vmcs = alloc_page();
@@ -319,8 +326,24 @@ int prepare_vcpu(struct vm *vm, int pcpu_id)
 		/* Load VM SW */
 		if (!vm_sw_loader)
 			vm_sw_loader = general_sw_loader;
+		if (is_vm0(vcpu->vm)) {
+			vcpu->arch_vcpu.cpu_mode = CPU_MODE_PROTECTED;
+#ifdef CONFIG_EFI_STUB
+			if ((efi_ctx->efer & MSR_IA32_EFER_LMA_BIT) &&
+			    (efi_ctx->cs_ar & 0x2000))
+				vcpu->arch_vcpu.cpu_mode = CPU_MODE_64BIT;
+#elif CONFIG_START_VM0_BSP_64BIT
+			vcpu->arch_vcpu.cpu_mode = CPU_MODE_64BIT;
+#endif
+		} else {
+#ifdef CONFIG_EFI_STUB
+			/* currently non-vm0 will boot kernel directly */
+			vcpu->arch_vcpu.cpu_mode = CPU_MODE_PROTECTED;
+#else
+			vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
+#endif
+		}
 		vm_sw_loader(vm, vcpu);
-		vcpu->arch_vcpu.cpu_mode = CPU_MODE_64BIT;
 	} else {
 		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 	}

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -351,6 +351,11 @@ static bool init_secure_world_env(struct vcpu *vcpu,
 		TRUSTY_EPT_REBASE_GPA + size;
 	vcpu->arch_vcpu.contexts[SECURE_WORLD].tsc_offset = 0;
 
+	vcpu->arch_vcpu.contexts[SECURE_WORLD].cr0 =
+		vcpu->arch_vcpu.contexts[NORMAL_WORLD].cr0;
+	vcpu->arch_vcpu.contexts[SECURE_WORLD].cr4 =
+		vcpu->arch_vcpu.contexts[NORMAL_WORLD].cr4;
+
 	exec_vmwrite(VMX_GUEST_RSP,
 		TRUSTY_EPT_REBASE_GPA + size);
 	exec_vmwrite(VMX_TSC_OFFSET_FULL,

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -657,6 +657,7 @@ static void init_guest_state(struct vcpu *vcpu)
 		limit = 0xffff;
 
 	} else if (vcpu_mode == CPU_MODE_PROTECTED) {
+		/* Linear data segment in guest init gdt */
 		es = ss = ds = fs = gs = 0x18;
 		limit = 0xffffffff;
 	} else if (vcpu_mode == CPU_MODE_64BIT) {

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -122,8 +122,10 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	zeropage = (struct zero_page *)
 			vm->sw.kernel_info.kernel_src_addr;
 	kernel_entry_offset = (zeropage->hdr.setup_sects + 1) * 512;
-	/* 64bit entry is the 512bytes after the start */
-	kernel_entry_offset += 512;
+	if (vcpu->arch_vcpu.cpu_mode == CPU_MODE_64BIT)
+		/* 64bit entry is the 512bytes after the start */
+		kernel_entry_offset += 512;
+
 	vm->sw.kernel_info.kernel_entry_addr =
 		(void *)((unsigned long)vm->sw.kernel_info.kernel_load_addr
 			+ kernel_entry_offset);

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -123,6 +123,8 @@ extern vm_sw_loader_t vm_sw_loader;
 
 int copy_from_vm(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
 int copy_to_vm(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+
+uint32_t create_guest_init_gdt(struct vm *vm, uint32_t *limit);
 #endif	/* !ASSEMBLER */
 
 #endif /* GUEST_H*/

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -75,11 +75,13 @@ enum vm_cpu_mode {
 	CPU_MODE_64BIT,			/* IA-32E mode (CS.L = 1) */
 };
 
+/* Use # of paging level to identify paging mode */
 enum vm_paging_mode {
-	PAGING_MODE_FLAT,
-	PAGING_MODE_32,
-	PAGING_MODE_PAE,
-	PAGING_MODE_64,
+	PAGING_MODE_0_LEVEL = 0,	/* Flat */
+	PAGING_MODE_2_LEVEL = 2,	/* 32bit paging, 2-level */
+	PAGING_MODE_3_LEVEL = 3,	/* PAE paging, 3-level */
+	PAGING_MODE_4_LEVEL = 4,	/* 64bit paging, 4-level */
+	PAGING_MODE_NUM,
 };
 
 /*
@@ -95,6 +97,8 @@ void vm_gva2gpa(struct vcpu *vcpu, uint64_t gla, uint64_t *gpa);
 struct vcpu *get_primary_vcpu(struct vm *vm);
 struct vcpu *vcpu_from_vid(struct vm *vm, int vcpu_id);
 struct vcpu *vcpu_from_pid(struct vm *vm, int pcpu_id);
+
+enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu);
 
 void init_e820(void);
 void obtain_e820_mem_info(void);

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -91,8 +91,9 @@ bool is_vm0(struct vm *vm);
 bool vm_lapic_disabled(struct vm *vm);
 uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
 
-uint64_t gva2gpa(struct vm *vm, uint64_t cr3, uint64_t gva);
-void vm_gva2gpa(struct vcpu *vcpu, uint64_t gla, uint64_t *gpa);
+int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
+int vm_gva2gpa(struct vcpu *vcpu, uint64_t gla, uint64_t *gpa,
+	uint32_t *err_code);
 
 struct vcpu *get_primary_vcpu(struct vm *vm);
 struct vcpu *vcpu_from_vid(struct vm *vm, int vcpu_id);

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -382,52 +382,13 @@
 #define RFLAGS_C (1<<0)
 #define RFLAGS_Z (1<<6)
 
-/*
- * Handling of CR0:
- *
- *   - PE (0) Must always be 1. Attempt to write to it must lead to a VM exit.
- *   - MP (1) coprocessor related => no action needed
- *   - EM (2) coprocessor related => no action needed
- *   - TS (3) no action needed
- *   - ET (4) typically hardcoded to 1. => no action needed
- *   - NE (5) coprocessor related => no action needed
- *   - WP (16) inhibits supervisor level procedures to write into ro-pages
- *             => no action needed
- *   - AM (18) alignment mask => no action needed
- *   - NW (29) not write through => no action
- *   - CD (30) cache disable => no action
- *   - PG (31) paging => must always be 1. Attempt to write to it must lead to
- *             a VM exit.
- */
+/* CR0 bits hv want to trap to track status change */
+#define CR0_TRAP_MASK (CR0_PE | CR0_PG | CR0_WP)
+#define CR0_RESERVED_MASK ~(CR0_PG | CR0_CD | CR0_NW | CR0_AM | CR0_WP | \
+			   CR0_NE |  CR0_ET | CR0_TS | CR0_EM | CR0_MP | CR0_PE)
 
-/* we must guard protected mode and paging */
-#define CR0_GUEST_HOST_MASK (CR0_PE | CR0_PG | CR0_WP)
-/* initially, the guest runs in protected mode enabled, but with no paging */
-#define CR0_READ_SHADOW      CR0_PE
-
-/*
- * Handling of CR4:
- *
- *   - VME (0) must always be 0 => must lead to a VM exit
- *   - PVI (1) must always be 0 => must lead to a VM exit
- *   - TSD (2) don't care
- *   - DE  (3) don't care
- *   - PSE (4) must always be 1 => must lead to a VM exit
- *   - PAE (5) must always be 0 => must lead to a VM exit
- *   - MCE (6) don't care
- *   - PGE (7) => important for TLB flush
- *   - PCE (8) don't care
- *   - OSFXSR (9) don't care
- *   - OSXMMEXCPT (10) don't care
- *   - VMXE (13) must always be 1 => must lead to a VM exit
- *   - SMXE (14) must always be 0 => must lead to a VM exit
- *   - PCIDE (17) => important for TLB flush
- *   - OSXSAVE (18) don't care
- */
-
-#define CR4_GUEST_HOST_MASK (CR4_VME | CR4_PVI | CR4_PSE | CR4_PAE | \
-			CR4_VMXE | CR4_SMXE | CR4_PGE | CR4_PCIDE)
-#define CR4_READ_SHADOW (CR4_PGE | CR4_PSE)
+/* CR4 bits hv want to trap to track status change */
+#define CR4_TRAP_MASK (CR4_PSE | CR4_PAE)
 
 /* External Interfaces */
 int exec_vmxon_instr(void);

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -390,6 +390,8 @@
 /* CR4 bits hv want to trap to track status change */
 #define CR4_TRAP_MASK (CR4_PSE | CR4_PAE)
 
+#define VMX_SUPPORT_UNRESTRICTED_GUEST (1<<5)
+
 /* External Interfaces */
 int exec_vmxon_instr(void);
 uint64_t exec_vmread(uint32_t field);
@@ -410,11 +412,15 @@ static inline uint8_t get_vcpu_mode(struct vcpu *vcpu)
 	return vcpu->arch_vcpu.cpu_mode;
 }
 
+static inline bool cpu_has_vmx_unrestricted_guest_cap(void)
+{
+       return !!(msr_read(MSR_IA32_VMX_MISC) & VMX_SUPPORT_UNRESTRICTED_GUEST);
+}
+
 typedef struct _descriptor_table_{
 	uint16_t limit;
 	uint64_t base;
 }__attribute__((packed)) descriptor_table;
-
 #endif /* ASSEMBLER */
 
 #endif /* VMX_H_ */


### PR DESCRIPTION
Note: this patch series need to work with new vSBL (start from real mode) on SBL platform!

In current code, hv only support starting vcpu from real mode or 64bit mode.
And sos/uos bsp can only start from 64bit mode. gva2gpa translation only works
on long mode.

This patch series adds support to start vcpu from protected mode. And has the
following vcpu start mode settings:
- For sbl platform:
This patch starts sos bsp from protected mode by default.
CONFIG_START_VM0_BSP_64BIT is defined to allow start sos bsp
from 64bit mode. If a config CONFIG_START_VM0_BSP_64BIT
defined in config file, then sos bsp will start from 64bit mode.
This patch start uos bsp from real mode, which needs the integration
of virtual bootloader (vsbl).
- For uefi platform:
This patch sets sos bsp vcpu mode according to the uefi context.
This patch starts uos bsp from protected mode, because vsbl is not ready
to publish for uefi platform yet. After vsbl is ready, can change to
start uos bsp from real mode.

This patch adds support to do gva2gpa translation in different paing modes.

This patch series assumes that VMX supports "unrestricted guest" feature to
support guest real mode and unpaged protected mode.
If hardware doesn't support "unrestricted guest", hardware capability check fails.