### PR TITLE
Tools Makefiles: enhancement to keep source code tree clean

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -1,10 +1,11 @@
 MAJOR_VERSION=1
 MINOR_VERSION=0
 
-BASEDIR 	:= $(shell pwd)
+VERSION_H	= $(BUILDDIR)/include/acrnprobe/version.h
 
 LIBS		= -lpthread -lxml2 -lcrypto -lrt $(EXTRA_LIBS)
-INCLUDE		+= -I $(BASEDIR)/include -I /usr/include/libxml2
+INCLUDE		+= -I $(CURDIR)/include -I /usr/include/libxml2
+INCLUDE		+= -I $(BUILDDIR)/include/acrnprobe
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -g -O0 -std=gnu11
 CFLAGS 		+= -ffunction-sections -fdata-sections
@@ -13,7 +14,8 @@ LDFLAGS 	+= $(LIBS) -Wl,--gc-sections
 
 TARGET		= $(BUILDDIR)/acrnprobe/bin/acrnprobe
 
-all: include/version.h check_dirs $(TARGET)
+.PHONY: all check_dirs
+all: $(VERSION_H) check_dirs $(TARGET)
 
 $(BUILDDIR)/acrnprobe/obj/%.o:%.c
 	$(CC) -c $(CFLAGS) $< -o $@
@@ -36,10 +38,11 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 	$(BUILDDIR)/acrnprobe/obj/android_events.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
+.PHONY: clean
 clean:
 	@echo "Clean objects and binaries"
-	@if [ -e include/version.h ]; then \
-		$(RM) -f include/version.h; \
+	@if [ -e $(VERSION_H) ]; then \
+		$(RM) -f $(VERSION_H); \
 	fi
 	@if [ -d $(BUILDDIR)/acrnprobe/obj ]; then \
 	    find $(BUILDDIR)/acrnprobe/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \
@@ -51,18 +54,21 @@ clean:
 		$(RM) -r $(BUILDDIR)/acrnprobe/obj ; \
 	fi
 
-include/version.h:
-	touch include/version.h
+$(VERSION_H):
+	@if [ ! -d $(BUILDDIR)/include/acrnprobe ]; then \
+		mkdir -p $(BUILDDIR)/include/acrnprobe ; \
+	fi
+	touch $(VERSION_H)
 	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
-	DIRTY=`git diff --name-only $(BASEDIR)`;\
+	DIRTY=`git diff --name-only $(CURDIR)`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
-	cat $(BASEDIR)/../license_header > include/version.h;\
-	echo "#define AP_MAJOR_VERSION $(MAJOR_VERSION)" >> include/version.h;\
-	echo "#define AP_MINOR_VERSION $(MINOR_VERSION)" >> include/version.h;\
-	echo "#define AP_BUILD_VERSION "\""$$PATCH"\""" >> include/version.h;\
-	echo "#define AP_BUILD_TIME "\""$$TIME"\""" >> include/version.h;\
-	echo "#define AP_BUILD_USER "\""$(USER)"\""" >> include/version.h
+	cat $(CURDIR)/../license_header > $(VERSION_H);\
+	echo "#define AP_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
+	echo "#define AP_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\
+	echo "#define AP_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION_H);\
+	echo "#define AP_BUILD_TIME "\""$$TIME"\""" >> $(VERSION_H);\
+	echo "#define AP_BUILD_USER "\""$(USER)"\""" >> $(VERSION_H)
 
 check_dirs:
 	@if [ ! -d $(BUILDDIR)/acrnprobe/bin ]; then \

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -1,10 +1,13 @@
 MAJOR_VERSION=1
 MINOR_VERSION=0
 
-all: include/version.h check_obj usercrash_s usercrash_c debugger
+VERSION_H = $(BUILDDIR)/include/usercrash/version.h
 
-CURRDIR := $(shell pwd)
-INCLUDE += -I $(CURRDIR)/include/
+.PHONY: all check_obj
+all: $(VERSION_H) check_obj usercrash_s usercrash_c debugger
+
+INCLUDE += -I $(CURDIR)/include/
+INCLUDE += -I $(BUILDDIR)/include/usercrash
 
 LIBS = -levent -lpthread $(EXTRA_LIBS)
 
@@ -33,18 +36,21 @@ debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 $(BUILDDIR)/usercrash/obj/%.o:%.c
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
-include/version.h:
-	touch include/version.h
+$(VERSION_H):
+	@if [ ! -d $(BUILDDIR)/include/usercrash ]; then \
+		mkdir -p $(BUILDDIR)/include/usercrash ; \
+	fi
+	touch $(VERSION_H)
 	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
-	DIRTY=`git diff --name-only $(CURRDIR)`;\
+	DIRTY=`git diff --name-only $(CURDIR)`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
-	cat $(CURRDIR)/../license_header > include/version.h;\
-	echo "#define UC_MAJOR_VERSION $(MAJOR_VERSION)" >> include/version.h;\
-	echo "#define UC_MINOR_VERSION $(MINOR_VERSION)" >> include/version.h;\
-	echo "#define UC_BUILD_VERSION "\""$$PATCH"\""" >> include/version.h;\
-	echo "#define UC_BUILD_TIME "\""$$TIME"\""" >> include/version.h;\
-	echo "#define UC_BUILD_USER "\""$(USER)"\""" >> include/version.h
+	cat $(CURDIR)/../license_header > $(VERSION_H);\
+	echo "#define UC_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
+	echo "#define UC_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\
+	echo "#define UC_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION_H);\
+	echo "#define UC_BUILD_TIME "\""$$TIME"\""" >> $(VERSION_H);\
+	echo "#define UC_BUILD_USER "\""$(USER)"\""" >> $(VERSION_H)
 
 check_obj:
 	@if [ ! -d $(BUILDDIR)/usercrash/bin ]; then \
@@ -54,11 +60,11 @@ check_obj:
 		mkdir -p $(BUILDDIR)/usercrash/obj ; \
 	fi
 
-.PHONY:clean
+.PHONY: clean
 clean:
 	@echo "Clean objects and binaries"
-	@if [ -e include/version.h ]; then \
-		$(RM) -f include/version.h; \
+	@if [ -e $(VERSION_H) ]; then \
+		$(RM) -f $(VERSION_H); \
 	fi
 	@if [ -d $(BUILDDIR)/usercrash/obj ]; then \
 		find $(BUILDDIR)/usercrash/obj -name "*.o" -exec $(RM) {} \; 2>&1 || exit 0; \

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -1,21 +1,24 @@
 
 OUT_DIR ?= .
 
+.PHONY: all
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrnctl
 
 $(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h
-	$(CC) -c acrn_mngr.c -DMNGR_DEBUG -I../../devicemodel/include -Wall -g
-	ar -cr $@ acrn_mngr.o
+	$(CC) -c acrn_mngr.c -DMNGR_DEBUG -I../../devicemodel/include -Wall -g -o $(OUT_DIR)/acrn_mngr.o
+	ar -cr $@ $(OUT_DIR)/acrn_mngr.o
 	cp ./acrn_mngr.h $(OUT_DIR)/
 
 $(OUT_DIR)/acrnctl: acrnctl.c
 	$(CC) -o $(OUT_DIR)/acrnctl acrnctl.c -I../../devicemodel/include -Wall -g
 
+.PHONY: clean
 clean:
 	rm -f $(OUT_DIR)/acrnctl
-	rm -f acrn_mngr.o
+	rm -f $(OUT_DIR)/acrn_mngr.o
 	rm -f $(OUT_DIR)/libacrn-mngr.a
 
+.PHONY: install
 install: $(OUT_DIR)/acrnctl
 	install -d $(DESTDIR)/usr/bin
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnctl


### PR DESCRIPTION
Running 'make' will leave 3 files in the source code tree that
are not cleaned by a subsequent 'make clean'. These are:
* tools/acrn-crashlog/acrnprobe/include/version.h
* tools/acrn-crashlog/usercrash/include/version.h
* tools/acrn-manager/acrn_mngr.o
(as reported by 'git status' after 'make')

This patch changes the location of these files so they are
created in the target build directory and hence properly
cleaned when running 'make clean'

Other minor changes to the Makefiles include:
* Remove BASEDIR by the built-in CURDIR variable
* Add .PHONY targets

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>