### PR TITLE
cbc_lifecycle: fix building using custom output directory

### DIFF
--- a/misc/cbc_lifecycle/Makefile
+++ b/misc/cbc_lifecycle/Makefile
@@ -1,8 +1,8 @@
 
 OUT_DIR ?= .
 
-$(OUT_DIR)/cbc_lifecycle: cbc_lifecycle.c ../../tools/acrn-manager/acrn_mngr.h
-	gcc -o $@ cbc_lifecycle.c -pthread -L$(OUT_DIR)/../../build/tools -lacrn-mngr
+$(OUT_DIR)/cbc_lifecycle: cbc_lifecycle.c $(TOOLS_OUT)/libacrn-mngr.a
+	gcc -o $@ cbc_lifecycle.c -pthread -L$(TOOLS_OUT) -lacrn-mngr
 
 clean:
 	rm $(OUT_DIR)/cbc_lifecycle


### PR DESCRIPTION
The 'cbc_lifecycle' component fails to build when using a custom
output directory (e.g.: 'make O=build-test'). This patch fixes
this by replacing a hard-coded path with the variable that points
at the right location where to find its target dependencies.

Fix #353 

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>