### PR TITLE
add cbc_lifecycle service systemd support

### DIFF
--- a/misc/cbc_lifecycle/Makefile
+++ b/misc/cbc_lifecycle/Makefile
@@ -7,6 +7,7 @@ $(OUT_DIR)/cbc_lifecycle: cbc_lifecycle.c ../../tools/acrn-manager/acrn_mngr.h
 clean:
 	rm $(OUT_DIR)/cbc_lifecycle
 
-install: $(OUT_DIR)/cbc_lifecycle
+install: $(OUT_DIR)/cbc_lifecycle cbc_lifecycle.service
 	install -d $(DESTDIR)/usr/bin
-	install -t $(DESTDIR)/usr/bin $^
+	install -t $(DESTDIR)/usr/bin $<
+	install -p -D -m 0644 cbc_lifecycle.service $(DESTDIR)/usr/lib/systemd/system/

--- a/misc/cbc_lifecycle/cbc_lifecycle.service
+++ b/misc/cbc_lifecycle/cbc_lifecycle.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=CBC lifecycle service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/cbc_lifecycle
+Restart=always
+Type=notify
+ExecStop=/usr/bin/killall -s TERM cbc_lifecycle
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Now cbc_attach service installed by default and thus we can enable
cbc_lifecycle service too.

Signed-off-by: Alek Du <alek.du@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>