### PR TITLE
IOC mediator: Enable IOC for android in launch_uos.sh

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -295,6 +295,8 @@ fi
    -s 27,passthru,0/1b/0 \
    -s 24,passthru,0/18/0 \
    -s 18,passthru,4/0/0 \
+   -i /run/acrn/ioc_$vm_name,0x20 \
+   -l com2,/run/acrn/ioc_$vm_name \
    -M \
    $boot_image_option \
    --enable_trusty \


### PR DESCRIPTION
Enable IOC for android on MRB by default.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>
Reviewed-by: Like Yan <like.yan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>