### PR TITLE
Tools: add Makefile for all tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,7 @@ devicemodel: tools
 
 tools:
 	mkdir -p $(TOOLS_OUT)
-	make -C $(T)/tools/acrnlog OUT_DIR=$(TOOLS_OUT)
-	make -C $(T)/tools/acrn-manager OUT_DIR=$(TOOLS_OUT)
-	make -C $(T)/tools/acrntrace OUT_DIR=$(TOOLS_OUT)
-	make -C $(T)/tools/acrn-crashlog OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE)
+	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE)
 
 misc: tools
 	mkdir -p $(MISC_OUT)
@@ -41,6 +38,7 @@ misc: tools
 
 .PHONY: clean
 clean:
+	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) clean
 	rm -rf $(ROOT_OUT)
 
 .PHONY: install
@@ -56,10 +54,7 @@ devicemodel-install:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install
 
 tools-install:
-	make -C $(T)/tools/acrnlog OUT_DIR=$(TOOLS_OUT) install
-	make -C $(T)/tools/acrn-manager OUT_DIR=$(TOOLS_OUT) install
-	make -C $(T)/tools/acrntrace OUT_DIR=$(TOOLS_OUT) install
-	make -C $(T)/tools/acrn-crashlog OUT_DIR=$(TOOLS_OUT) install
+	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) install
 
 misc-install:
 	make -C $(T)/misc OUT_DIR=$(MISC_OUT) install

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,40 @@
+T := $(CURDIR)
+OUT_DIR ?= $(T)/build
+
+.PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace
+all: acrn-crashlog acrnlog acrn-manager acrntrace
+
+acrn-crashlog:
+	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
+
+acrnlog:
+	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR)
+
+acrn-manager:
+	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR)
+
+acrntrace:
+	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR)
+
+.PHONY: clean
+clean:
+	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) clean
+	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) clean
+	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR) clean
+	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR) clean
+	rm -rf $(OUT_DIR)
+
+.PHONY: install
+install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install
+
+acrn-crashlog-install:
+	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) install
+
+acrnlog-install:
+	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR) install
+
+arcn-manager-install:
+	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) install
+
+acrntrace-install:
+	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR) install

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -17,6 +17,7 @@ clean:
 	rm -f $(OUT_DIR)/acrnctl
 	rm -f $(OUT_DIR)/acrn_mngr.o
 	rm -f $(OUT_DIR)/libacrn-mngr.a
+	rm -f $(OUT_DIR)/acrn_mngr.h
 
 .PHONY: install
 install: $(OUT_DIR)/acrnctl

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -6,7 +6,8 @@ all:
 	cp acrnlog.service $(OUT_DIR)/acrnlog.service
 
 clean:
-	rm $(OUT_DIR)/acrnlog
+	rm -f $(OUT_DIR)/acrnlog
+	rm -f $(OUT_DIR)/acrnlog.service
 
 install: $(OUT_DIR)/acrnlog
 	install -d $(DESTDIR)/usr/bin

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -5,7 +5,7 @@ all:
 	$(CC) -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread
 
 clean:
-	rm $(OUT_DIR)/acrntrace
+	rm -f $(OUT_DIR)/acrntrace
 
 install: $(OUT_DIR)/acrntrace
 	install -d $(DESTDIR)/usr/bin


### PR DESCRIPTION
Add a Makefile under ./tools to avoid changing top-level Makefile frequently

Acked-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Signed-off-by: Yan, Like <like.yan@intel.com>