### PR TITLE
doc: add graphviz extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,9 @@ sys.path.insert(0, os.path.abspath('.'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['breathe']
+extensions = ['breathe', 'sphinx.ext.graphviz']
+
+graphviz_output_format='svg'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
graphviz lets us create graphic images via a text language rather than
creating drawings in other tools (eliminating the need to keep the
sources for the images available, such as a powerpoint file).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>