### PR TITLE
Refine guest control register initialization

### DIFF
--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1327,23 +1327,13 @@ static void override_uefi_vmcs(struct vcpu *vcpu)
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
 
 	if (get_vcpu_mode(vcpu) == CPU_MODE_64BIT) {
-		/* Set up guest CR0 field */
-		field = VMX_GUEST_CR0;
-		cur_context->cr0 = efi_ctx->cr0 | CR0_PG | CR0_PE | CR0_NE;
-		exec_vmwrite(field, cur_context->cr0 & 0xFFFFFFFF);
-		pr_dbg("VMX_GUEST_CR0: 0x%016llx ", cur_context->cr0);
-
-		/* Set up guest CR3 field */
-		field = VMX_GUEST_CR3;
-		cur_context->cr3 = efi_ctx->cr3;
-		exec_vmwrite(field, cur_context->cr3 & 0xFFFFFFFF);
-		pr_dbg("VMX_GUEST_CR3: 0x%016llx ", cur_context->cr3);
-
-		/* Set up guest CR4 field */
-		field = VMX_GUEST_CR4;
-		cur_context->cr4 = efi_ctx->cr4 | CR4_VMXE;
-		exec_vmwrite(field, cur_context->cr4 & 0xFFFFFFFF);
-		pr_dbg("VMX_GUEST_CR4: 0x%016llx ", cur_context->cr4);
+		/* CR4 should be set before CR0, because when set CR0, CR4 value
+		 * will be checked. */
+		/* VMXE is always on bit when set CR4, and not allowed to be set
+		 * from input cr4 value */
+		vmx_write_cr4(vcpu, efi_ctx->cr4 & ~CR4_VMXE);
+		vmx_write_cr3(vcpu, efi_ctx->cr3);
+		vmx_write_cr0(vcpu, efi_ctx->cr0 | CR0_PG | CR0_PE | CR0_NE);
 
 		/* Selector */
 		field = VMX_GUEST_CS_SEL;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -463,20 +463,22 @@ static void init_guest_state(struct vcpu *vcpu)
 	if (vcpu_mode == CPU_MODE_64BIT)
 		cur_context->ia32_efer = MSR_IA32_EFER_LME_BIT;
 
-	/* Setup guest control register values */
-	/* Set up guest CRO field */
+	/* Setup guest control register values
+	 * cr4 should be set before cr0, because when set cr0, cr4 value will be
+	 * checked.
+	 */
 	if (vcpu_mode == CPU_MODE_REAL) {
 		vmx_write_cr4(vcpu, 0);
-		vmx_write_cr0(vcpu, CR0_ET | CR0_NE);
 		vmx_write_cr3(vcpu, 0);
+		vmx_write_cr0(vcpu, CR0_ET | CR0_NE);
 	} else if (vcpu_mode == CPU_MODE_PROTECTED) {
 		vmx_write_cr4(vcpu, 0);
-		vmx_write_cr0(vcpu, CR0_ET | CR0_NE | CR0_PE);
 		vmx_write_cr3(vcpu, 0);
+		vmx_write_cr0(vcpu, CR0_ET | CR0_NE | CR0_PE);
 	} else if (vcpu_mode == CPU_MODE_64BIT) {
 		vmx_write_cr4(vcpu, CR4_PSE | CR4_PAE | CR4_MCE);
-		vmx_write_cr0(vcpu, CR0_PG | CR0_PE | CR0_NE);
 		vmx_write_cr3(vcpu, vm->arch_vm.guest_init_pml4 | CR3_PWT);
+		vmx_write_cr0(vcpu, CR0_PG | CR0_PE | CR0_NE);
 	}
 
 	/***************************************************/


### PR DESCRIPTION
This patch series ajust the order of control registers for more clear  in logic, but no change in guest init stage.
And in current code, on uefi platform, vmcs will be overwritten according to uefi context, using the exec_vmwrite directly. This patch series uses vmx_write_cr<#> interface to init control registers, which can be more clear, and some check logic can be reused.
Add comment to point out CR4 value should be inited before CR0, due to CR4 value will be checked when set CR0.
