### PR TITLE
apicv: only write VMX_ENTRY_EXCEPTION_EC when error code valid

### DIFF
--- a/hypervisor/arch/x86/interrupt.c
+++ b/hypervisor/arch/x86/interrupt.c
@@ -383,8 +383,9 @@ int acrn_handle_pending_request(struct vcpu *vcpu)
 
 	/* handling cancelled event injection when vcpu is switched out */
 	if (vcpu->arch_vcpu.inject_event_pending) {
-		exec_vmwrite(VMX_ENTRY_EXCEPTION_ERROR_CODE,
-			vcpu->arch_vcpu.inject_info.error_code);
+		if (vcpu->arch_vcpu.inject_info.intr_info & (EXCEPTION_ERROR_CODE_VALID << 8))
+			exec_vmwrite(VMX_ENTRY_EXCEPTION_ERROR_CODE,
+				vcpu->arch_vcpu.inject_info.error_code);
 
 		exec_vmwrite(VMX_ENTRY_INT_INFO_FIELD,
 			vcpu->arch_vcpu.inject_info.intr_info);


### PR DESCRIPTION
if error code not valid, do not vmwrite VMX_ENTRY_EXCEPTION_EC. In cancel_event_injection, the
inject_info.error_core is not assigned if error code not valid.

Signed-off-by: Chris Ye <chris.ye@intel.com>