### PR TITLE
Fix cbc_attach service

### DIFF
--- a/misc/cbc_attach/cbc_attach.service
+++ b/misc/cbc_attach/cbc_attach.service
@@ -5,7 +5,7 @@ After=sysinit.target local.target
 Before=basic.target
 
 [Service]
-ExecStart=/usr/bin/cbc_attach -f /dev/ttyS2
+ExecStart=/usr/bin/cbc_attach /dev/ttyS2
 Restart=always
 Type=notify
 


### PR DESCRIPTION
Michael Yao suggested to change the systemd service from cbc_attach.
Was:       cbc_attach -f /dev/ttyS2
Should be: cbc_attach /dev/ttyS2

~~When performed "make install" the acrn-manager-install fail.
So, fix typo at acrn-manager-install in tools/Makefile~~
This is addressed by #376, updated PR with only one commit.