### PR TITLE
cbc_lifecycle: fix a service typo

### DIFF
--- a/misc/cbc_lifecycle/cbc_lifecycle.service
+++ b/misc/cbc_lifecycle/cbc_lifecycle.service
@@ -5,7 +5,6 @@ Description=CBC lifecycle service
 Type=simple
 ExecStart=/usr/bin/cbc_lifecycle
 Restart=always
-Type=notify
 ExecStop=/usr/bin/killall -s TERM cbc_lifecycle
 
 [Install]


### PR DESCRIPTION
The service type was set twice and inconsistent.

Signed-off-by: Alek Du <alek.du@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>
Reviewed-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>