### PR TITLE
IOC mediator: Disable hardware flow control by default

### DIFF
--- a/misc/cbc_attach/cbc_attach.service
+++ b/misc/cbc_attach/cbc_attach.service
@@ -5,7 +5,7 @@ After=sysinit.target local.target
 Before=basic.target
 
 [Service]
-ExecStart=/usr/bin/cbc_attach -f /dev/ttyS2
+ExecStart=/usr/bin/cbc_attach /dev/ttyS2
 Restart=always
 Type=notify
 


### PR DESCRIPTION
This is one workaround patch to resolve read/write failed for /dev/cbc-lifecycle
and /dev/cbc-signals cdev nodes. It cause cbc_lifecycle service can't send
heartbeat to IOC firmware, also can't receive any signal data from IOC firmware.

This patch need to be revert once the IOC firmware or CBC driver fixed the root
cause.

The [-f] option means enable hardware flow control by set CRTSCTS attribute for
c_cflag of termios, without [-f] option will unset the attribute.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Vineetha G Jaya Kumaran <vineetha.g.jaya.kumaran@intel.com>
Reviewed-by: Alex Du <alek.du@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>