### PR TITLE
fix MISRA C"Literal zero used in pointer context"

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -216,7 +216,7 @@ int register_mmio_emulation_handler(struct vm *vm,
 	}
 
 	/* Ensure both a read/write handler and range check function exist */
-	if ((read_write != HV_NULL) && (end > start)) {
+	if ((read_write != NULL) && (end > start)) {
 		/* Allocate memory for node */
 		mmio_node =
 		(struct mem_io_node *)calloc(1, sizeof(struct mem_io_node));

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -130,7 +130,7 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 
 int vmexit_handler(struct vcpu *vcpu)
 {
-	struct vm_exit_dispatch *dispatch = HV_NULL;
+	struct vm_exit_dispatch *dispatch = NULL;
 	uint16_t basic_exit_reason;
 	int ret;
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -100,7 +100,7 @@ int exec_vmxon_instr(uint32_t pcpu_id)
 	else
 		vmxon_region_va = HPA2HVA(per_cpu(vmxon_region_pa, pcpu_id));
 
-	if (vmxon_region_va != 0) {
+	if (vmxon_region_va != NULL) {
 		/* Initialize vmxon page with revision id from IA32 VMX BASIC
 		 * MSR
 		 */

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -257,7 +257,7 @@ int parse_madt(uint8_t *lapic_id_base)
 	ASSERT(global_rsdp != NULL, "fail to get rsdp");
 
 	madt = get_acpi_tbl(ACPI_SIG_MADT);
-	ASSERT(madt != 0, "fail to get madt");
+	ASSERT(madt != NULL, "fail to get madt");
 
 	return _parse_madt(madt, lapic_id_base);
 }

--- a/hypervisor/include/lib/types.h
+++ b/hypervisor/include/lib/types.h
@@ -7,9 +7,6 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-/* Define NULL value */
-#define		HV_NULL			0
-
 /* Defines for TRUE / FALSE conditions */
 #define		HV_FALSE		0
 #define		HV_TRUE			1

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -123,7 +123,7 @@ static const char *get_flags(const char *s, int *flags)
 		 * found
 		 */
 		pos = strchr(flagchars, *s);
-		if (pos == 0)
+		if (pos == NULL)
 			break;
 
 		/* apply matching flags and continue with the next character */
@@ -214,7 +214,7 @@ static int format_number(struct print_param *param)
 				return res;
 
 			/* invalidate prefix */
-			param->vars.prefix = 0;
+			param->vars.prefix = NULL;
 			param->vars.prefixlen = 0;
 		}
 

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -278,7 +278,7 @@ strtol(const char *nptr, char **endptr, register int base)
                 acc = neg ? LONG_MIN : LONG_MAX;
         else if (neg)
                 acc = -acc;
-        if (endptr != 0)
+        if (endptr != NULL)
                 *endptr = (char *) (any ? s - 1 : nptr);
         return acc;
 }
@@ -340,7 +340,7 @@ strtoul(const char *nptr, char **endptr, register int base)
                 acc = ULONG_MAX;
         else if (neg)
                 acc = -acc;
-        if (endptr != 0)
+        if (endptr != NULL)
                 *endptr = (char *) (any ? s - 1 : nptr);
         return acc;
 }


### PR DESCRIPTION
MISRC C required pointer to zero should be replace with NULL

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>