### PR TITLE
fix MISRA C:"Statement with no side effect"

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -565,13 +565,11 @@ vioapic_pincount(struct vm *vm)
 }
 
 int vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
-		void *handler_private_data)
+		__unused void *handler_private_data)
 {
 	struct vm *vm = vcpu->vm;
 	uint64_t gpa = mmio->paddr;
 	int ret = 0;
-
-	(void)handler_private_data;
 
 	/* Note all RW to IOAPIC are 32-Bit in size */
 	ASSERT(mmio->access_size == 4,

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1118,7 +1118,7 @@ vlapic_intr_accepted(struct vlapic *vlapic, int vector)
 	int idx, stk_top;
 
 	if (vlapic->ops.apicv_intr_accepted) {
-		(*vlapic->ops.apicv_intr_accepted)(vlapic, vector);
+		vlapic->ops.apicv_intr_accepted(vlapic, vector);
 		return;
 	}
 
@@ -1609,14 +1609,14 @@ void
 vlapic_apicv_batch_set_tmr(struct vlapic *vlapic)
 {
 	if (vlapic->ops.apicv_batch_set_tmr != NULL)
-		(*vlapic->ops.apicv_batch_set_tmr)(vlapic);
+		vlapic->ops.apicv_batch_set_tmr(vlapic);
 }
 
 void
 vlapic_apicv_set_tmr(struct vlapic *vlapic, int vector, bool level)
 {
 	if (vlapic->ops.apicv_set_tmr != NULL)
-		(*vlapic->ops.apicv_set_tmr)(vlapic, vector, level);
+		vlapic->ops.apicv_set_tmr(vlapic, vector, level);
 }
 
 void


### PR DESCRIPTION
V2->V3 modified the description
V1->V2 add __unused to handler_private_data

while misra c analyse callback function, it will dereference the pointer
plus an implicit getting address when extra parentheses with inner
star(example:(*foo)()). the first dereference should be removed.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
reviewed-by: Li,Fei1 <fei1.li@intel.com>
reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>