### PR TITLE
hv: add MTRR_ENABLED entry to Kconfig

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -112,3 +112,7 @@ config UEFI_OS_LOADER_NAME
 	string "UEFI OS loader name"
 	depends on PLATFORM_UEFI
 	default "\\EFI\\org.clearlinux\\bootloaderx64.efi"
+
+config MTRR_ENABLED
+	bool
+	default y


### PR DESCRIPTION
MTRR feature was added after commit bce7ed17151d4af96 ("HV: config:
add Kconfig and defconfigs"), so the generated config.h doesn't
include CONFIG_MTRR_ENABLED

Signed-off-by: Zide Chen <zide.chen@intel.com>