### PR TITLE
irq: convert irq/vector numbers to unsigned

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -308,7 +308,7 @@ ptdev_update_irq_handler(struct vm *vm, struct ptdev_remapping_info *entry)
 
 /* active intr with irq registering */
 static struct ptdev_remapping_info *
-ptdev_activate_entry(struct ptdev_remapping_info *entry, int phys_irq,
+ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq,
 		bool lowpri)
 {
 	struct dev_handler_node *node;
@@ -350,7 +350,7 @@ static bool ptdev_hv_owned_intx(struct vm *vm, struct ptdev_intx_info *info)
 }
 
 static void ptdev_build_physical_msi(struct vm *vm, struct ptdev_msi_info *info,
-		int vector)
+		uint32_t vector)
 {
 	uint64_t vdmask, pdmask;
 	uint32_t dest, delmode;
@@ -785,7 +785,7 @@ int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
 
 	if (!is_entry_active(entry)) {
 		/* update msi source and active entry */
-		ptdev_activate_entry(entry, -1, lowpri);
+		ptdev_activate_entry(entry, IRQ_INVALID, lowpri);
 	}
 
 	/* build physical config MSI, update to info->pmsi_xxx */
@@ -854,7 +854,7 @@ int ptdev_intx_pin_remap(struct vm *vm, struct ptdev_intx_info *info)
 {
 	struct ptdev_remapping_info *entry;
 	uint64_t rte;
-	int phys_irq;
+	uint32_t phys_irq;
 	int phys_pin;
 	bool lowpri = !is_vm0(vm);
 	bool need_switch_vpin_src = false;
@@ -1088,7 +1088,7 @@ void ptdev_release_all_entries(struct vm *vm)
 }
 
 static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
-		int *irq, int *vector, uint64_t *dest, bool *lvl_tm,
+		uint32_t *irq, uint32_t *vector, uint64_t *dest, bool *lvl_tm,
 		int *pin, int *vpin, int *bdf, int *vbdf)
 {
 	if (is_entry_active(entry)) {
@@ -1101,7 +1101,7 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 				*lvl_tm = true;
 			else
 				*lvl_tm = false;
-			*pin = -1;
+			*pin = IRQ_INVALID;
 			*vpin = -1;
 			*bdf = entry->phys_bdf;
 			*vbdf = entry->virt_bdf;
@@ -1130,7 +1130,7 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 		*vector = dev_to_vector(entry->node);
 	} else {
 		strcpy_s(type, 16, "NONE");
-		*irq = -1;
+		*irq = IRQ_INVALID;
 		*vector = 0;
 		*dest = 0;
 		*lvl_tm = 0;
@@ -1144,7 +1144,8 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 int get_ptdev_info(char *str, int str_max)
 {
 	struct ptdev_remapping_info *entry;
-	int len, size = str_max, irq, vector;
+	int len, size = str_max;
+	uint32_t irq, vector;
 	char type[16];
 	uint64_t dest;
 	bool lvl_tm;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -99,7 +99,7 @@ int create_vcpu(int cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
 
 	/* Initialize exception field in VCPU context */
-	vcpu->arch_vcpu.exception_info.exception = -1;
+	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
 
 	/* Initialize cur context */
 	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -137,11 +137,11 @@ enum irqstate {
 };
 
 static int
-vioapic_set_irqstate(struct vm *vm, int irq, enum irqstate irqstate)
+vioapic_set_irqstate(struct vm *vm, uint32_t irq, enum irqstate irqstate)
 {
 	struct vioapic *vioapic;
 
-	if (irq < 0 || irq >= vioapic_pincount(vm))
+	if (irq >= (uint32_t)vioapic_pincount(vm))
 		return -EINVAL;
 
 	vioapic = vm_ioapic(vm);
@@ -167,19 +167,19 @@ vioapic_set_irqstate(struct vm *vm, int irq, enum irqstate irqstate)
 }
 
 int
-vioapic_assert_irq(struct vm *vm, int irq)
+vioapic_assert_irq(struct vm *vm, uint32_t irq)
 {
 	return vioapic_set_irqstate(vm, irq, IRQSTATE_ASSERT);
 }
 
 int
-vioapic_deassert_irq(struct vm *vm, int irq)
+vioapic_deassert_irq(struct vm *vm, uint32_t irq)
 {
 	return vioapic_set_irqstate(vm, irq, IRQSTATE_DEASSERT);
 }
 
 int
-vioapic_pulse_irq(struct vm *vm, int irq)
+vioapic_pulse_irq(struct vm *vm, uint32_t irq)
 {
 	return vioapic_set_irqstate(vm, irq, IRQSTATE_PULSE);
 }
@@ -258,7 +258,7 @@ vioapic_read(struct vioapic *vioapic, uint32_t addr)
  * register to clear related IRR.
  */
 static void
-vioapic_write_eoi(struct vioapic *vioapic, int32_t vector)
+vioapic_write_eoi(struct vioapic *vioapic, uint32_t vector)
 {
 	struct vm *vm = vioapic->vm;
 	int pin;
@@ -477,7 +477,7 @@ vioapic_mmio_write(void *vm, uint64_t gpa, uint64_t wval,
 }
 
 void
-vioapic_process_eoi(struct vm *vm, int vector)
+vioapic_process_eoi(struct vm *vm, uint32_t vector)
 {
 	struct vioapic *vioapic;
 	int pin;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -83,13 +83,13 @@ do {									\
 static void *apicv_apic_access_addr;
 
 static int
-apicv_set_intr_ready(struct vlapic *vlapic, int vector, bool level);
+apicv_set_intr_ready(struct vlapic *vlapic, uint32_t vector, bool level);
 
 static int
-apicv_pending_intr(struct vlapic *vlapic, int *vecptr);
+apicv_pending_intr(struct vlapic *vlapic, uint32_t *vecptr);
 
 static void
-apicv_set_tmr(struct vlapic *vlapic, int vector, bool level);
+apicv_set_tmr(struct vlapic *vlapic, uint32_t vector, bool level);
 
 static void
 apicv_batch_set_tmr(struct vlapic *vlapic);
@@ -366,14 +366,14 @@ vlapic_esr_write_handler(struct vlapic *vlapic)
  * Returns 1 if the vcpu needs to be notified of the interrupt and 0 otherwise.
  */
 static int
-vlapic_set_intr_ready(struct vlapic *vlapic, int vector, bool level)
+vlapic_set_intr_ready(struct vlapic *vlapic, uint32_t vector, bool level)
 {
 	struct lapic *lapic;
 	struct lapic_reg *irrptr, *tmrptr;
 	uint32_t mask;
 	int idx;
 
-	ASSERT((vector >= 0) && (vector <= NR_MAX_VECTOR),
+	ASSERT(vector <= NR_MAX_VECTOR,
 		"invalid vector %d", vector);
 
 	lapic = vlapic->apic_page;
@@ -742,7 +742,7 @@ vlapic_set_error(struct vlapic *vlapic, uint32_t mask)
 }
 
 static int
-vlapic_trigger_lvt(struct vlapic *vlapic, int vector)
+vlapic_trigger_lvt(struct vlapic *vlapic, uint32_t vector)
 {
 	uint32_t lvt;
 
@@ -1081,7 +1081,7 @@ vlapic_icrlo_write_handler(struct vlapic *vlapic)
 }
 
 int
-vlapic_pending_intr(struct vlapic *vlapic, int *vecptr)
+vlapic_pending_intr(struct vlapic *vlapic, uint32_t *vecptr)
 {
 	struct lapic *lapic = vlapic->apic_page;
 	int i, bitpos;
@@ -1111,7 +1111,7 @@ vlapic_pending_intr(struct vlapic *vlapic, int *vecptr)
 }
 
 void
-vlapic_intr_accepted(struct vlapic *vlapic, int vector)
+vlapic_intr_accepted(struct vlapic *vlapic, uint32_t vector)
 {
 	struct lapic *lapic = vlapic->apic_page;
 	struct lapic_reg *irrptr, *isrptr;
@@ -1584,7 +1584,7 @@ vlapic_enabled(struct vlapic *vlapic)
 }
 
 void
-vlapic_set_tmr(struct vlapic *vlapic, int vector, bool level)
+vlapic_set_tmr(struct vlapic *vlapic, uint32_t vector, bool level)
 {
 	struct lapic *lapic;
 	struct lapic_reg *tmrptr;
@@ -1613,7 +1613,7 @@ vlapic_apicv_batch_set_tmr(struct vlapic *vlapic)
 }
 
 void
-vlapic_apicv_set_tmr(struct vlapic *vlapic, int vector, bool level)
+vlapic_apicv_set_tmr(struct vlapic *vlapic, uint32_t vector, bool level)
 {
 	if (vlapic->ops.apicv_set_tmr != NULL)
 		vlapic->ops.apicv_set_tmr(vlapic, vector, level);
@@ -1622,7 +1622,7 @@ vlapic_apicv_set_tmr(struct vlapic *vlapic, int vector, bool level)
 void
 vlapic_reset_tmr(struct vlapic *vlapic)
 {
-	int vector;
+	uint32_t vector;
 
 	dev_dbg(ACRN_DBG_LAPIC,
 			"vlapic resetting all vectors to edge-triggered");
@@ -1635,9 +1635,9 @@ vlapic_reset_tmr(struct vlapic *vlapic)
 
 void
 vlapic_set_tmr_one_vec(struct vlapic *vlapic, __unused int delmode,
-	int vector, bool level)
+	uint32_t vector, bool level)
 {
-	ASSERT((vector >= 0) && (vector <= NR_MAX_VECTOR),
+	ASSERT(vector <= NR_MAX_VECTOR,
 		"invalid vector %d", vector);
 
 	/*
@@ -1662,7 +1662,7 @@ vlapic_set_tmr_one_vec(struct vlapic *vlapic, __unused int delmode,
 }
 
 int
-vlapic_set_intr(struct vcpu *vcpu, int vector, bool level)
+vlapic_set_intr(struct vcpu *vcpu, uint32_t vector, bool level)
 {
 	struct vlapic *vlapic;
 	int ret = 0;
@@ -1687,7 +1687,7 @@ vlapic_set_intr(struct vcpu *vcpu, int vector, bool level)
 }
 
 int
-vlapic_set_local_intr(struct vm *vm, int cpu_id, int vector)
+vlapic_set_local_intr(struct vm *vm, int cpu_id, uint32_t vector)
 {
 	struct vlapic *vlapic;
 	uint64_t dmask = 0;
@@ -2013,7 +2013,7 @@ void vlapic_free(struct vcpu *vcpu)
  * APIC-v functions
  * **/
 static int
-apicv_set_intr_ready(struct vlapic *vlapic, int vector, __unused bool level)
+apicv_set_intr_ready(struct vlapic *vlapic, uint32_t vector, __unused bool level)
 {
 	struct pir_desc *pir_desc;
 	uint64_t mask;
@@ -2030,7 +2030,7 @@ apicv_set_intr_ready(struct vlapic *vlapic, int vector, __unused bool level)
 }
 
 static int
-apicv_pending_intr(struct vlapic *vlapic, __unused int *vecptr)
+apicv_pending_intr(struct vlapic *vlapic, __unused uint32_t *vecptr)
 {
 	struct pir_desc *pir_desc;
 	struct lapic *lapic;
@@ -2061,7 +2061,7 @@ apicv_pending_intr(struct vlapic *vlapic, __unused int *vecptr)
 }
 
 static void
-apicv_set_tmr(__unused struct vlapic *vlapic, int vector, bool level)
+apicv_set_tmr(__unused struct vlapic *vlapic, uint32_t vector, bool level)
 {
 	uint64_t mask, val;
 
@@ -2234,7 +2234,7 @@ int veoi_vmexit_handler(struct vcpu *vcpu)
 {
 	struct vlapic *vlapic = NULL;
 
-	int vector;
+	uint32_t vector;
 	struct lapic *lapic;
 	struct lapic_reg *tmrptr;
 	uint32_t idx, mask;

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -99,11 +99,11 @@ struct pir_desc {
 
 struct vlapic_ops {
 	int (*apicv_set_intr_ready)
-		(struct vlapic *vlapic, int vector, bool level);
-	int (*apicv_pending_intr)(struct vlapic *vlapic, int *vecptr);
-	void (*apicv_intr_accepted)(struct vlapic *vlapic, int vector);
+		(struct vlapic *vlapic, uint32_t vector, bool level);
+	int (*apicv_pending_intr)(struct vlapic *vlapic, uint32_t *vecptr);
+	void (*apicv_intr_accepted)(struct vlapic *vlapic, uint32_t vector);
 	void (*apicv_post_intr)(struct vlapic *vlapic, int hostcpu);
-	void (*apicv_set_tmr)(struct vlapic *vlapic, int vector, bool level);
+	void (*apicv_set_tmr)(struct vlapic *vlapic, uint32_t vector, bool level);
 	void (*apicv_batch_set_tmr)(struct vlapic *vlapic);
 	void (*enable_x2apic_mode)(struct vlapic *vlapic);
 };

--- a/hypervisor/arch/x86/guest/vpic.c
+++ b/hypervisor/arch/x86/guest/vpic.c
@@ -58,7 +58,7 @@ struct pic {
 	bool		rotate;
 	bool		sfn;		/* special fully-nested mode */
 
-	int		irq_base;
+	uint32_t	irq_base;
 	uint8_t		request;	/* Interrupt Request Register (IIR) */
 	uint8_t		service;	/* Interrupt Service (ISR) */
 	uint8_t		mask;		/* Interrupt Mask Register (IMR) */
@@ -489,12 +489,12 @@ static void vpic_set_pinstate(struct vpic *vpic, int pin, bool newstate)
 	vpic_notify_intr(vpic);
 }
 
-static int vpic_set_irqstate(struct vm *vm, int irq, enum irqstate irqstate)
+static int vpic_set_irqstate(struct vm *vm, uint32_t irq, enum irqstate irqstate)
 {
 	struct vpic *vpic;
 	struct pic *pic;
 
-	if (irq < 0 || irq > 15)
+	if (irq > 15)
 		return -EINVAL;
 
 	vpic = vm_pic(vm);
@@ -524,26 +524,26 @@ static int vpic_set_irqstate(struct vm *vm, int irq, enum irqstate irqstate)
 }
 
 /* hypervisor interface: assert/deassert/pulse irq */
-int vpic_assert_irq(struct vm *vm, int irq)
+int vpic_assert_irq(struct vm *vm, uint32_t irq)
 {
 	return vpic_set_irqstate(vm, irq, IRQSTATE_ASSERT);
 }
 
-int vpic_deassert_irq(struct vm *vm, int irq)
+int vpic_deassert_irq(struct vm *vm, uint32_t irq)
 {
 	return vpic_set_irqstate(vm, irq, IRQSTATE_DEASSERT);
 }
 
-int vpic_pulse_irq(struct vm *vm, int irq)
+int vpic_pulse_irq(struct vm *vm, uint32_t irq)
 {
 	return vpic_set_irqstate(vm, irq, IRQSTATE_PULSE);
 }
 
-int vpic_set_irq_trigger(struct vm *vm, int irq, enum vpic_trigger trigger)
+int vpic_set_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger trigger)
 {
 	struct vpic *vpic;
 
-	if (irq < 0 || irq > 15)
+	if (irq > 15)
 		return -EINVAL;
 
 	/*
@@ -575,11 +575,11 @@ int vpic_set_irq_trigger(struct vm *vm, int irq, enum vpic_trigger trigger)
 	return 0;
 }
 
-int vpic_get_irq_trigger(struct vm *vm, int irq, enum vpic_trigger *trigger)
+int vpic_get_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger *trigger)
 {
 	struct vpic *vpic;
 
-	if (irq < 0 || irq > 15)
+	if (irq > 15)
 		return -EINVAL;
 
 	vpic = vm_pic(vm);
@@ -593,7 +593,7 @@ int vpic_get_irq_trigger(struct vm *vm, int irq, enum vpic_trigger *trigger)
 	return 0;
 }
 
-void vpic_pending_intr(struct vm *vm, int *vecptr)
+void vpic_pending_intr(struct vm *vm, uint32_t *vecptr)
 {
 	struct vpic *vpic;
 	struct pic *pic;
@@ -616,7 +616,7 @@ void vpic_pending_intr(struct vm *vm, int *vecptr)
 	 * interrupt vector instead.
 	 */
 	if (pin == -1) {
-		*vecptr = -1;
+		*vecptr = VECTOR_INVALID;
 		VPIC_UNLOCK(vpic);
 		return;
 	}
@@ -646,7 +646,7 @@ static void vpic_pin_accepted(struct pic *pic, int pin)
 	}
 }
 
-void vpic_intr_accepted(struct vm *vm, int vector)
+void vpic_intr_accepted(struct vm *vm, uint32_t vector)
 {
 	struct vpic *vpic;
 	int pin;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -22,7 +22,7 @@ struct gsi_table {
 	void  *addr;
 };
 static struct gsi_table gsi_table[NR_MAX_GSI];
-static int nr_gsi;
+static uint32_t nr_gsi;
 static spinlock_t ioapic_lock;
 
 /*
@@ -144,7 +144,7 @@ ioapic_set_rte_entry(void *ioapic_addr,
 }
 
 static inline struct ioapic_rte
-create_rte_for_legacy_irq(int irq, int vr)
+create_rte_for_legacy_irq(uint32_t irq, uint32_t vr)
 {
 	struct ioapic_rte rte = {0, 0};
 
@@ -169,7 +169,7 @@ create_rte_for_legacy_irq(int irq, int vr)
 }
 
 static inline struct ioapic_rte
-create_rte_for_gsi_irq(int irq, int vr)
+create_rte_for_gsi_irq(uint32_t irq, uint32_t vr)
 {
 	struct ioapic_rte rte = {0, 0};
 
@@ -192,7 +192,7 @@ create_rte_for_gsi_irq(int irq, int vr)
 	return rte;
 }
 
-static void ioapic_set_routing(int gsi, int vr)
+static void ioapic_set_routing(uint32_t gsi, uint32_t vr)
 {
 	void *addr;
 	struct ioapic_rte rte;
@@ -211,7 +211,7 @@ static void ioapic_set_routing(int gsi, int vr)
 		rte.lo_32);
 }
 
-void ioapic_get_rte(int irq, uint64_t *rte)
+void ioapic_get_rte(uint32_t irq, uint64_t *rte)
 {
 	void *addr;
 	struct ioapic_rte _rte;
@@ -226,7 +226,7 @@ void ioapic_get_rte(int irq, uint64_t *rte)
 	*rte = *rte << 32 | _rte.lo_32;
 }
 
-void ioapic_set_rte(int irq, uint64_t raw_rte)
+void ioapic_set_rte(uint32_t irq, uint64_t raw_rte)
 {
 	void *addr;
 	struct ioapic_rte rte;
@@ -244,17 +244,17 @@ void ioapic_set_rte(int irq, uint64_t raw_rte)
 		rte.lo_32);
 }
 
-int irq_gsi_num(void)
+uint32_t irq_gsi_num(void)
 {
 	return nr_gsi;
 }
 
-bool irq_is_gsi(int irq)
+bool irq_is_gsi(uint32_t irq)
 {
 	return irq < nr_gsi;
 }
 
-int irq_to_pin(int irq)
+int irq_to_pin(uint32_t irq)
 {
 	if (irq_is_gsi(irq))
 		return gsi_table[irq].pin;
@@ -262,9 +262,9 @@ int irq_to_pin(int irq)
 		return -1;
 }
 
-int pin_to_irq(int pin)
+uint32_t pin_to_irq(int pin)
 {
-	int i;
+	uint32_t i;
 
 	if (pin < 0)
 		return IRQ_INVALID;
@@ -277,7 +277,7 @@ int pin_to_irq(int pin)
 }
 
 void
-irq_gsi_mask_unmask(int irq, bool mask)
+irq_gsi_mask_unmask(uint32_t irq, bool mask)
 {
 	void *addr = gsi_table[irq].addr;
 	int pin = gsi_table[irq].pin;
@@ -299,7 +299,7 @@ irq_gsi_mask_unmask(int irq, bool mask)
 void setup_ioapic_irq(void)
 {
 	int ioapic_id;
-	int gsi;
+	uint32_t gsi;
 	int vr;
 
 	spinlock_init(&ioapic_lock);
@@ -328,7 +328,7 @@ void setup_ioapic_irq(void)
 				gsi_table[gsi].pin = pin;
 
 			/* pinned irq before use it */
-			if (irq_mark_used(gsi) < 0) {
+			if (irq_mark_used(gsi) > NR_MAX_IRQS) {
 				pr_err("failed to alloc IRQ[%d]", gsi);
 				gsi++;
 				continue;
@@ -359,7 +359,7 @@ void setup_ioapic_irq(void)
 
 void dump_ioapic(void)
 {
-	int irq;
+	uint32_t irq;
 
 	for (irq = 0; irq < nr_gsi; irq++) {
 		void *addr = gsi_table[irq].addr;
@@ -386,7 +386,7 @@ void get_rte_info(struct ioapic_rte *rte, bool *mask, bool *irr,
 
 int get_ioapic_info(char *str, int str_max_len)
 {
-	int irq, len, size = str_max_len;
+	uint32_t irq, len, size = str_max_len;
 
 	len = snprintf(str, size,
 	"\r\nIRQ\tPIN\tRTE.HI32\tRTE.LO32\tVEC\tDST\tDM\tTM\tDELM\tIRR\tMASK");

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -20,7 +20,7 @@ static int kick_notification(__unused int irq, __unused void *data)
 static int request_notification_irq(dev_handler_t func, void *data,
 				const char *name)
 {
-	int irq = -1; /* system allocate */
+	uint32_t irq = IRQ_INVALID; /* system allocate */
 	struct dev_handler_node *node = NULL;
 
 	if (notification_node != NULL) {

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -791,14 +791,14 @@ static int dmar_fault_handler(__unused int irq, void *data)
 
 static int dmar_setup_interrupt(struct dmar_drhd_rt *dmar_uint)
 {
-	int vector;
+	uint32_t vector;
 
 	if (dmar_uint->dmar_irq_node) {
 		dev_dbg(ACRN_DBG_IOMMU, "%s: irq already setup", __func__);
 		return 0;
 	}
 
-	dmar_uint->dmar_irq_node = normal_register_handler(-1,
+	dmar_uint->dmar_irq_node = normal_register_handler(IRQ_INVALID,
 					dmar_fault_handler,
 					dmar_uint, true, false,
 					"dmar_fault_event");

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -177,7 +177,7 @@ struct vcpu_arch {
 	/* Holds the information needed for IRQ/exception handling. */
 	struct {
 		/* The number of the exception to raise. */
-		int exception;
+		uint32_t exception;
 
 		/* The error number for the exception. */
 		int error;

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -37,9 +37,9 @@
 struct vioapic *vioapic_init(struct vm *vm);
 void	vioapic_cleanup(struct vioapic *vioapic);
 
-int	vioapic_assert_irq(struct vm *vm, int irq);
-int	vioapic_deassert_irq(struct vm *vm, int irq);
-int	vioapic_pulse_irq(struct vm *vm, int irq);
+int	vioapic_assert_irq(struct vm *vm, uint32_t irq);
+int	vioapic_deassert_irq(struct vm *vm, uint32_t irq);
+int	vioapic_pulse_irq(struct vm *vm, uint32_t irq);
 void	vioapic_update_tmr(struct vcpu *vcpu);
 
 int	vioapic_mmio_write(void *vm, uint64_t gpa,
@@ -48,7 +48,7 @@ int	vioapic_mmio_read(void *vm, uint64_t gpa,
 	    uint64_t *rval, int size);
 
 int	vioapic_pincount(struct vm *vm);
-void	vioapic_process_eoi(struct vm *vm, int vector);
+void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
 bool	vioapic_get_rte(struct vm *vm, int pin, void *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 		void *handler_private_data);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -46,7 +46,7 @@ uint64_t vlapic_get_cr8(struct vlapic *vlapic);
  * Note that the vector does not automatically transition to the ISR as a
  * result of calling this function.
  */
-int vlapic_pending_intr(struct vlapic *vlapic, int *vecptr);
+int vlapic_pending_intr(struct vlapic *vlapic, uint32_t *vecptr);
 
 /*
  * Transition 'vector' from IRR to ISR. This function is called with the
@@ -54,7 +54,7 @@ int vlapic_pending_intr(struct vlapic *vlapic, int *vecptr);
  * accept this interrupt (i.e. RFLAGS.IF = 1 and no conditions exist that
  * block interrupt delivery).
  */
-void vlapic_intr_accepted(struct vlapic *vlapic, int vector);
+void vlapic_intr_accepted(struct vlapic *vlapic, uint32_t vector);
 
 struct vlapic *vm_lapic_from_vcpuid(struct vm *vm, int vcpu_id);
 struct vlapic *vm_lapic_from_pcpuid(struct vm *vm, int pcpu_id);
@@ -69,18 +69,18 @@ int vlapic_mmio_write(struct vcpu *vcpu, uint64_t gpa, uint64_t wval, int size);
  * Signals to the LAPIC that an interrupt at 'vector' needs to be generated
  * to the 'cpu', the state is recorded in IRR.
  */
-int vlapic_set_intr(struct vcpu *vcpu, int vector, bool trig);
+int vlapic_set_intr(struct vcpu *vcpu, uint32_t vector, bool trig);
 
 #define	LAPIC_TRIG_LEVEL	true
 #define	LAPIC_TRIG_EDGE		false
 static inline int
-vlapic_intr_level(struct vcpu *vcpu, int vector)
+vlapic_intr_level(struct vcpu *vcpu, uint32_t vector)
 {
 	return vlapic_set_intr(vcpu, vector, LAPIC_TRIG_LEVEL);
 }
 
 static inline int
-vlapic_intr_edge(struct vcpu *vcpu, int vector)
+vlapic_intr_edge(struct vcpu *vcpu, uint32_t vector)
 {
 	return vlapic_set_intr(vcpu, vector, LAPIC_TRIG_EDGE);
 }
@@ -89,7 +89,7 @@ vlapic_intr_edge(struct vcpu *vcpu, int vector)
  * Triggers the LAPIC local interrupt (LVT) 'vector' on 'cpu'.  'cpu' can
  * be set to -1 to trigger the interrupt on all CPUs.
  */
-int vlapic_set_local_intr(struct vm *vm, int cpu, int vector);
+int vlapic_set_local_intr(struct vm *vm, int cpu, uint32_t vector);
 
 int vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg);
 
@@ -105,7 +105,7 @@ void vlapic_reset_tmr(struct vlapic *vlapic);
  * this 'vlapic'.
  */
 void vlapic_set_tmr_one_vec(struct vlapic *vlapic, int delmode,
-		int vector, bool level);
+		uint32_t vector, bool level);
 
 void
 vlapic_apicv_batch_set_tmr(struct vlapic *vlapic);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -93,14 +93,14 @@ enum vpic_trigger {
 void *vpic_init(struct vm *vm);
 void vpic_cleanup(struct vm *vm);
 
-int vpic_assert_irq(struct vm *vm, int irq);
-int vpic_deassert_irq(struct vm *vm, int irq);
-int vpic_pulse_irq(struct vm *vm, int irq);
+int vpic_assert_irq(struct vm *vm, uint32_t irq);
+int vpic_deassert_irq(struct vm *vm, uint32_t irq);
+int vpic_pulse_irq(struct vm *vm, uint32_t irq);
 
-void vpic_pending_intr(struct vm *vm, int *vecptr);
-void vpic_intr_accepted(struct vm *vm, int vector);
-int vpic_set_irq_trigger(struct vm *vm, int irq, enum vpic_trigger trigger);
-int vpic_get_irq_trigger(struct vm *vm, int irq, enum vpic_trigger *trigger);
+void vpic_pending_intr(struct vm *vm, uint32_t *vecptr);
+void vpic_intr_accepted(struct vm *vm, uint32_t vector);
+int vpic_set_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger trigger);
+int vpic_get_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger *trigger);
 
 struct vm_io_handler *vpic_create_io_handler(int flags, uint32_t port,
 	uint32_t len);

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -22,13 +22,13 @@
 void setup_ioapic_irq(void);
 int get_ioapic_info(char *str, int str_max_len);
 
-bool irq_is_gsi(int irq);
-int irq_gsi_num(void);
-int irq_to_pin(int irq);
-int pin_to_irq(int pin);
-void irq_gsi_mask_unmask(int irq, bool mask);
-void ioapic_set_rte(int irq, uint64_t rte);
-void ioapic_get_rte(int irq, uint64_t *rte);
+bool irq_is_gsi(uint32_t irq);
+uint32_t irq_gsi_num(void);
+int irq_to_pin(uint32_t irq);
+uint32_t pin_to_irq(int pin);
+void irq_gsi_mask_unmask(uint32_t irq, bool mask);
+void ioapic_set_rte(uint32_t irq, uint64_t rte);
+void ioapic_get_rte(uint32_t irq, uint64_t *rte);
 
 extern uint16_t legacy_irq_to_pin[];
 extern uint16_t pic_ioapic_pin_map[];

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -26,9 +26,9 @@
 
 #define NR_MAX_VECTOR		0xFF
 #define VECTOR_INVALID		(NR_MAX_VECTOR + 1)
+#define NR_MAX_IRQS		(256+16)
 #define IRQ_INVALID		(NR_MAX_IRQS+1)
 
-#define NR_MAX_IRQS (256+16)
 #define DEFAULT_DEST_MODE	IOAPIC_RTE_DESTLOG
 #define DEFAULT_DELIVERY_MODE	IOAPIC_RTE_DELLOPRI
 #define ALL_CPUS_MASK		((1 << phy_cpu_num) - 1)
@@ -97,15 +97,15 @@ struct intr_excp_ctx {
 	uint64_t ss;
 };
 
-int irq_mark_used(int irq);
-int irq_alloc(void);
+uint32_t irq_mark_used(uint32_t irq);
+uint32_t irq_alloc(void);
 
-int irq_desc_alloc_vector(int irq, bool lowpri);
-void irq_desc_try_free_vector(int irq);
+uint32_t irq_desc_alloc_vector(uint32_t irq, bool lowpri);
+void irq_desc_try_free_vector(uint32_t irq);
 
-int irq_to_vector(int irq);
-int dev_to_irq(struct dev_handler_node *node);
-int dev_to_vector(struct dev_handler_node *node);
+uint32_t irq_to_vector(uint32_t irq);
+uint32_t dev_to_irq(struct dev_handler_node *node);
+uint32_t dev_to_vector(struct dev_handler_node *node);
 
 int handle_level_interrupt_common(struct irq_desc *desc, void *handler_data);
 int common_handler_edge(struct irq_desc *desc, void *handler_data);
@@ -113,21 +113,21 @@ int common_dev_handler_level(struct irq_desc *desc, void *handler_data);
 int quick_handler_nolock(struct irq_desc *desc, void *handler_data);
 
 typedef int (*irq_handler_t)(struct irq_desc*, void*);
-void update_irq_handler(int irq, irq_handler_t func);
+void update_irq_handler(uint32_t irq, irq_handler_t func);
 
 int init_default_irqs(unsigned int cpu);
 
 void dispatch_interrupt(struct intr_excp_ctx *ctx);
 
 struct dev_handler_node*
-pri_register_handler(int irq,
-		int vector,
+pri_register_handler(uint32_t irq,
+		uint32_t vector,
 		dev_handler_t func,
 		void *dev_data,
 		const char *name);
 
 struct dev_handler_node*
-normal_register_handler(int irq,
+normal_register_handler(uint32_t irq,
 		dev_handler_t func,
 		void *dev_data,
 		bool share,
@@ -139,7 +139,7 @@ int get_cpu_interrupt_info(char *str, int str_max);
 
 void setup_notification(void);
 
-typedef void (*spurious_handler_t)(int);
+typedef void (*spurious_handler_t)(uint32_t vector);
 extern spurious_handler_t spurious_handler;
 
 /*
@@ -162,7 +162,7 @@ int vcpu_inject_nmi(struct vcpu *vcpu);
 int vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code);
 int vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code);
 int vcpu_make_request(struct vcpu *vcpu, int eventid);
-int vcpu_queue_exception(struct vcpu *vcpu, int32_t vector, uint32_t err_code);
+int vcpu_queue_exception(struct vcpu *vcpu, uint32_t vector, uint32_t err_code);
 
 int exception_vmexit_handler(struct vcpu *vcpu);
 int interrupt_window_vmexit_handler(struct vcpu *vcpu);


### PR DESCRIPTION
Currently irq and vector numbers are used inconsistently.

    * Sometimes vector or irq ids is used in bit operations, indicating
      that they should be unsigned (which is required by MISRA C).

    * At the same time we use -1 to indicate an unknown irq (in
      common_register_handler()) or unavailable irq (in
      alloc_irq()). Also (irq < 0) or (vector < 0) are used for error
      checking. These indicate that irq or vector ids should be signed.

This patch converts irq and vector numbers to unsigned 32-bit integers, and
replace the previous -1 with IRQ_INVALID or VECTOR_INVALID. The branch
conditions are updated accordingly.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>