### PR TITLE
Add `make doc` target to top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,10 @@ HV_OUT := $(ROOT_OUT)/hypervisor
 DM_OUT := $(ROOT_OUT)/devicemodel
 TOOLS_OUT := $(ROOT_OUT)/tools
 MISC_OUT := $(ROOT_OUT)/misc
+DOC_OUT := $(ROOT_OUT)/doc
 export TOOLS_OUT
 
-.PHONY: all hypervisor devicemodel tools misc
+.PHONY: all hypervisor devicemodel tools misc doc
 all: hypervisor devicemodel tools misc
 
 hypervisor:
@@ -36,9 +37,13 @@ misc: tools
 	mkdir -p $(MISC_OUT)
 	make -C $(T)/misc OUT_DIR=$(MISC_OUT)
 
+doc:
+	make -C $(T)/doc html BUILDDIR=$(DOC_OUT)
+
 .PHONY: clean
 clean:
 	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) clean
+	make -C $(T)/doc BUILDDIR=$(DOC_OUT) clean
 	rm -rf $(ROOT_OUT)
 
 .PHONY: install

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,7 +12,7 @@ SPHINXOPTS    ?= -q
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = "Project ACRN"
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      ?= _build
 
 DOC_TAG      ?= development
 RELEASE      ?= latest

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ PUBLISHDIR    = ../../projectacrn.github.io/$(RELEASE)
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(OPTS)
 	@echo ""
 	@echo "make publish"
 	@echo "   publish generated html to projectacrn.github.io site:"
@@ -39,7 +39,7 @@ content:
 	$(Q)scripts/extract_content.py
 
 html: doxy content
-	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(O) >> doc.log 2>&1
+	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh doc.log
 
 
@@ -61,6 +61,6 @@ publish:
 
 
 # Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+# "make mode" option.  $(OPTS) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile doxy
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(OPTS)

--- a/doc/acrn.doxyfile
+++ b/doc/acrn.doxyfile
@@ -1045,7 +1045,7 @@ VERBATIM_HEADERS       = YES
 # generated with the -Duse-libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+#CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1053,7 +1053,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+#CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index


### PR DESCRIPTION
There are multiple commits in this PR as there were some (unrelated) problems that I had to fix in order to test my changes.

**Note:** that this does **not** enable the documentation build by default but with this, we're one very short step away from enabling it (and which would allow us to close #218).

**Note2:** the documentation build is still broken since we merged #387 . A fix for that is being reviewed on the mailing list so it's not being addressed in this PR.