### PR TITLE
hv: replace vlapic_init by vlapic_reset in vcpu_reset

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -281,7 +281,7 @@ void reset_vcpu(struct vcpu *vcpu)
 	vcpu->arch_vcpu.nr_sipi = 0;
 	vcpu->pending_pre_work = 0;
 	vlapic = vcpu->arch_vcpu.vlapic;
-	vlapic_init(vlapic);
+	vlapic_reset(vlapic);
 }
 
 void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state)

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1437,7 +1437,7 @@ vlapic_write(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 	return retval;
 }
 
-static void
+void
 vlapic_reset(struct vlapic *vlapic)
 {
 	struct lapic *lapic;

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -119,6 +119,7 @@ uint8_t vlapic_get_apicid(struct vlapic *vlapic);
 int vlapic_create(struct vcpu *vcpu);
 void vlapic_free(struct vcpu *vcpu);
 void vlapic_init(struct vlapic *vlapic);
+void vlapic_reset(struct vlapic *vlapic);
 void vlapic_restore(struct vlapic *vlapic, struct lapic_regs *regs);
 bool vlapic_enabled(struct vlapic *vlapic);
 uint64_t apicv_get_apic_access_addr(struct vm *vm);


### PR DESCRIPTION
This change is to fix a guest vm hang issue at vm reset, especially easy to
be seen when it's a watchdog timeout reset.
vlapic_init create and init vlapic.vlapic_timer without deleting the
timer from cpu_times list, which breaks the list, results in a timer remains
with callback points to an invalid location.

Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Yan, Like <like.yan@intel.com>