### PR TITLE
HV: add bsp acpi info support

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -147,6 +147,7 @@ endif
 
 C_SRCS += bsp/$(PLATFORM)/vm_description.c
 C_SRCS += bsp/$(PLATFORM)/$(PLATFORM).c
+C_SRCS += bsp/$(PLATFORM)/platform_acpi_info.c
 
 ifeq ($(PLATFORM),uefi)
 C_SRCS += bsp/$(PLATFORM)/cmdline.c

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -103,3 +103,21 @@ void vm_setup_cpu_state(struct vm *vm)
 	vm_setup_cpu_cx(vm);
 	init_cx_port(vm);
 }
+
+/* This function is for power management Sx state implementation,
+ * VM need to load the Sx state data to implement S3/S5.
+ */
+int vm_load_pm_s_state(struct vm *vm)
+{
+	if ((boot_cpu_data.x86 == host_acpi_info.x86_family)
+		&& (boot_cpu_data.x86_model == host_acpi_info.x86_model)) {
+		vm->pm.sx_state_data = (struct pm_s_state_data *)
+						&host_acpi_info.pm_s_state;
+		pr_info("System S3/S5 is supported.");
+		return 0;
+	} else {
+		vm->pm.sx_state_data = NULL;
+		pr_err("System S3/S5 is NOT supported.");
+		return -1;
+	}
+}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -141,10 +141,13 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 
 	vm_setup_cpu_state(vm);
 
-	/* Create virtual uart */
-	if (is_vm0(vm))
-		vm->vuart = vuart_init(vm);
+	if (is_vm0(vm)) {
+		/* Load pm S state data */
+		vm_load_pm_s_state(vm);
 
+		/* Create virtual uart */
+		vm->vuart = vuart_init(vm);
+	}
 	vm->vpic = vpic_init(vm);
 
 	/* vpic wire_mode default is INTR */

--- a/hypervisor/bsp/include/bsp_extern.h
+++ b/hypervisor/bsp/include/bsp_extern.h
@@ -23,6 +23,7 @@
 /* EXTERNAL VARIABLES             */
 /**********************************/
 extern struct vm_description vm0_desc;
+extern const struct acpi_info host_acpi_info;
 
 /* BSP Interfaces */
 void init_bsp(void);

--- a/hypervisor/bsp/sbl/platform_acpi_info.c
+++ b/hypervisor/bsp/sbl/platform_acpi_info.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+
+const struct acpi_info host_acpi_info = {
+	6,				/* x86 family: 6 */
+	0x5C,				/* x86 model: 0x5C, ApolloLake */
+	{
+		{SPACE_SYSTEM_IO, 20, 0, 3, 0x400},	/* PM1a EVT */
+		{SPACE_SYSTEM_IO,  0, 0, 0,     0},	/* PM1b EVT */
+		{SPACE_SYSTEM_IO, 10, 0, 2, 0x404},	/* PM1a CNT */
+		{SPACE_SYSTEM_IO,  0, 0, 0,     0},	/* PM1b CNT */
+		{0x05,	0,	0},			/* _S3 Package */
+		{0x07,	0,	0},			/* _S5 Package */
+		(uint32_t *)0x7AEDCEFC,			/* Wake Vector 32 */
+		(uint64_t *)0x7AEDCF08			/* Wake Vector 64 */
+	}
+};

--- a/hypervisor/bsp/uefi/platform_acpi_info.c
+++ b/hypervisor/bsp/uefi/platform_acpi_info.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* This is a template for uninitialized host_acpi_info,
+ * we should use a user space tool running on target to generate this file.
+ */
+
+#include <hypervisor.h>
+
+const struct acpi_info host_acpi_info = {
+	-1,				/* x86 family */
+	-1,				/* x86 model */
+	{
+		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1a EVT */
+		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1b EVT */
+		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1a CNT */
+		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1b CNT */
+		{0,	0,	0},		/* _S3 Package */
+		{0,	0,	0},		/* _S5 Package */
+		(uint32_t *)0,			/* Wake Vector 32 */
+		(uint64_t *)0			/* Wake Vector 64 */
+	}
+};

--- a/hypervisor/include/arch/x86/guest/pm.h
+++ b/hypervisor/include/arch/x86/guest/pm.h
@@ -8,6 +8,7 @@
 #define PM_H
 
 void vm_setup_cpu_state(struct vm *vm);
+int vm_load_pm_s_state(struct vm *vm);
 int validate_pstate(struct vm *vm, uint64_t perf_ctl);
 struct cpu_cx_data* get_target_cx(struct vm *vm, uint8_t cn);
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -63,6 +63,7 @@ struct vm_pm_info {
 	struct cpu_px_data	px_data[MAX_PSTATE];
 	uint8_t			cx_cnt;		/* count of all Cx entries */
 	struct cpu_cx_data	cx_data[MAX_CSTATE];
+	struct pm_s_state_data	*sx_state_data;	/* data for S3/S5 implementation */
 };
 
 /* VM guest types */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -305,6 +305,30 @@ struct cpu_px_data {
 	uint64_t status;		/* success indicator */
 } __attribute__((aligned(8)));
 
+struct acpi_sx_pkg {
+	uint8_t		val_pm1a;
+	uint8_t		val_pm1b;
+	uint16_t	reserved;
+} __attribute__((aligned(8)));
+
+struct pm_s_state_data {
+	struct acpi_generic_address pm1a_evt;
+	struct acpi_generic_address pm1b_evt;
+	struct acpi_generic_address pm1a_cnt;
+	struct acpi_generic_address pm1b_cnt;
+	struct acpi_sx_pkg s3_pkg;
+	struct acpi_sx_pkg s5_pkg;
+	uint32_t *wake_vector_32;
+	uint64_t *wake_vector_64;
+}__attribute__((aligned(8)));
+
+struct acpi_info {
+	int16_t			x86_family;
+	int16_t			x86_model;
+	struct pm_s_state_data	pm_s_state;
+	/* TODO: we can add more acpi info field here if needed. */
+};
+
 /**
  * @brief Info PM command from DM/VHM.
  *


### PR DESCRIPTION
On some occations HV operates relying on host acpi info, eg. S3/S5/RTC...,
etc. Add ACPI parser code in HV would increase code size and complexity,
so a simple approach is use a c file to store all needed data in bsp.

Fow now we can store the data by hardcoding but we will provide a user
space tool shortly that run on target first to collect the data and then
generate the C file automatically.

The limitation is if ACPI data get changed due to BIOS update, we have to
regenerate the file and rebuild the HV. But this case is very rare.

Changelog:

	v3:	Remove Kconfig for different ApolloLake SKU,
		since all APL platform on SBL should use same
		ACPI table except _PSS.

	v2:	Add Kconfig support

	v1:	Initial version
