### PR TITLE
Documentation: fix incorrect link in acrn-probe documentation

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/README.rst
+++ b/tools/acrn-crashlog/acrnprobe/README.rst
@@ -173,4 +173,4 @@ Configuration files
 
   Custom configuration file that ``acrnprobe`` reads.
 
-.. _`telemetrics client`: https://github.com/clearlinux/telemetrics-client
+.. _`telemetrics-client`: https://github.com/clearlinux/telemetrics-client


### PR DESCRIPTION
There is a mismatch in the 'telemetrics-clients' reference which
causes a warning (and a dead link).

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>