### PR TITLE
Tools:acrn-manager: use RELEASE in Makefile

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,7 +11,7 @@ acrnlog:
 	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR)
 
 acrn-manager:
-	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR)
+	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
 
 acrntrace:
 	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR)

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -1,23 +1,39 @@
 
 OUT_DIR ?= .
 
+CFLAGS := -Wall
+CFLAGS += -I../../devicemodel/include
+ifeq ($(RELEASE),0)
+CFLAGS += -g -DMNGR_DEBUG
+endif
+
+LDFLAGS := -L$(TOOLS_OUT)
+LDFLAGS += -lacrn-mngr
+LDFLAGS +=  -lpthread
+
 .PHONY: all
-all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrnctl
+all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnctl
 
 $(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h
-	$(CC) -c acrn_mngr.c -DMNGR_DEBUG -I../../devicemodel/include -Wall -g -o $(OUT_DIR)/acrn_mngr.o
+	$(CC) $(CFLAGS) -c acrn_mngr.c -o $(OUT_DIR)/acrn_mngr.o
 	ar -cr $@ $(OUT_DIR)/acrn_mngr.o
-	cp ./acrn_mngr.h $(OUT_DIR)/
 
-$(OUT_DIR)/acrnctl: acrnctl.c acrn_mngr.h
-	$(CC) -o $(OUT_DIR)/acrnctl acrnctl.c acrn_vm_ops.c -I../../devicemodel/include -L$(TOOLS_OUT) -lacrn-mngr -lpthread -Wall -g
+ifneq ($(OUT_DIR),.)
+$(OUT_DIR)/acrn_mngr.h:
+	cp ./acrn_mngr.h $(OUT_DIR)/
+endif
+
+$(OUT_DIR)/acrnctl: acrnctl.c acrn_mngr.h $(OUT_DIR)/libacrn-mngr.a
+	$(CC) -o $(OUT_DIR)/acrnctl acrnctl.c acrn_vm_ops.c $(CFLAGS) $(LDFLAGS)
 
 .PHONY: clean
 clean:
 	rm -f $(OUT_DIR)/acrnctl
 	rm -f $(OUT_DIR)/acrn_mngr.o
 	rm -f $(OUT_DIR)/libacrn-mngr.a
+ifneq ($(OUT_DIR),.)
 	rm -f $(OUT_DIR)/acrn_mngr.h
+endif
 
 .PHONY: install
 install: $(OUT_DIR)/acrnctl


### PR DESCRIPTION
The debug macro -DMNGR_DEBUG is selected by RELEASE value.
E.g., run 'make RELEASE=1' at the root of source code.

Acked-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>