### PR TITLE
HV: fix a print typo in create_vcpu

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -83,7 +83,7 @@ int create_vcpu(int cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	if (is_vcpu_bsp(vcpu) && is_vm0(vcpu->vm)) {
 		/* Set up temporary guest page tables */
 		vm->arch_vm.guest_init_pml4 = create_guest_initial_paging(vm);
-		pr_info("VM *d VCPU %d CR3: 0x%016llx ",
+		pr_info("VM %d VCPU %d CR3: 0x%016llx ",
 			vm->attr.id, vcpu->vcpu_id,
 			vm->arch_vm.guest_init_pml4);
 	}


### PR DESCRIPTION
*d is typo of %d, fix it.

Signed-off-by: Victor Sun <victor.sun@intel.com>