### PR TITLE
HV: Remove misuesed __unused

### DIFF
--- a/hypervisor/arch/x86/guest/vpic.c
+++ b/hypervisor/arch/x86/guest/vpic.c
@@ -247,7 +247,7 @@ static void vpic_notify_intr(struct vpic *vpic)
 	}
 }
 
-static int vpic_icw1(__unused struct vpic *vpic, struct pic *pic, uint8_t val)
+static int vpic_icw1(struct vpic *vpic, struct pic *pic, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: pic icw1 0x%x\n",
 		vpic->vm, val);
@@ -277,7 +277,7 @@ static int vpic_icw1(__unused struct vpic *vpic, struct pic *pic, uint8_t val)
 	return 0;
 }
 
-static int vpic_icw2(__unused struct vpic *vpic, struct pic *pic, uint8_t val)
+static int vpic_icw2(struct vpic *vpic, struct pic *pic, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: pic icw2 0x%x\n",
 		vpic->vm, val);
@@ -289,8 +289,7 @@ static int vpic_icw2(__unused struct vpic *vpic, struct pic *pic, uint8_t val)
 	return 0;
 }
 
-static int vpic_icw3(__unused struct vpic *vpic, struct pic *pic,
-		__unused uint8_t val)
+static int vpic_icw3(struct vpic *vpic, struct pic *pic, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: pic icw3 0x%x\n",
 		vpic->vm, val);
@@ -424,7 +423,7 @@ static int vpic_ocw2(struct vpic *vpic, struct pic *pic, uint8_t val)
 	return 0;
 }
 
-static int vpic_ocw3(__unused struct vpic *vpic, struct pic *pic, uint8_t val)
+static int vpic_ocw3(struct vpic *vpic, struct pic *pic, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: pic ocw3 0x%x\n",
 		vpic->vm, val);

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -201,7 +201,7 @@ int vmexit_handler(struct vcpu *vcpu)
 	return ret;
 }
 
-static int unhandled_vmexit_handler(__unused struct vcpu *vcpu)
+static int unhandled_vmexit_handler(struct vcpu *vcpu)
 {
 	pr_fatal("Error: Unhandled VM exit condition from guest at 0x%016llx ",
 			exec_vmread(VMX_GUEST_RIP));

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -733,7 +733,7 @@ static void fault_record_analysis(__unused uint64_t low, uint64_t high)
 #endif
 }
 
-static int dmar_fault_handler(__unused int irq, void *data)
+static int dmar_fault_handler(int irq, void *data)
 {
 	struct dmar_drhd_rt *dmar_uint = (struct dmar_drhd_rt *)data;
 	uint32_t fsr;


### PR DESCRIPTION
There are some __unused attached to variables. But, those variables
are used by the function actually.

This patch remove them. No functional change.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>