### PR TITLE
tools: acrn-crashlog: fix typo in Makefile

### DIFF
--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -27,7 +27,7 @@ ifeq ($(strip $(LIB_EXIST)),libsystemd-journal.so)
 	EXTRA_LIBS = -lsystemd-journal
 endif
 LIB_EXIST = $(findstring libtelemetry.so, $(LDCNF))
-ifeq ($(strip $(LIB_EXIST)),libtelemetryxx.so)
+ifeq ($(strip $(LIB_EXIST)),libtelemetry.so)
 	CFLAGS	+= -DHAVE_TELEMETRICS_CLIENT
 	EXTRA_LIBS += -ltelemetry
 endif


### PR DESCRIPTION
This patch is to fix libtelemetry.so typo in Makefile.

Signed-off-by: Liu Xinwu <xinwu.liu@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>