### PR TITLE
bugfix: make remove_intx_remapping static

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -422,7 +422,7 @@ add_intx_remapping(struct vm *vm, uint8_t virt_pin,
 }
 
 /* deactive & remove mapping entry of vpin for vm */
-void remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin)
+static void remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin)
 {
 	int phys_irq;
 	struct ptdev_remapping_info *entry;


### PR DESCRIPTION
remove_intx_remapping is not global function.

Unlike global functions in C, access to static functions is restricted to the file where they are declared. Another reason for making functions static can be reuse of the same function name in other files

Signed-off-by: Chris Ye <chris.ye@intel.com>