### PR TITLE
HV: remove redundant code in cpu_secondary_init

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -549,12 +549,8 @@ void cpu_secondary_init(void)
 	early_init_lapic();
 
 	/* Find the logical ID of this CPU given the LAPIC ID
-	 * temp_logical_id =
-	 * cpu_find_logical_id(get_cur_lapic_id());
+	 * and Set state for this CPU to initializing
 	 */
-	cpu_find_logical_id(get_cur_lapic_id());
-
-	/* Set state for this CPU to initializing */
 	cpu_set_current_state(cpu_find_logical_id
 			      (get_cur_lapic_id()),
 			      CPU_STATE_INITIALIZING);


### PR DESCRIPTION
cpu_find_logical_id() is called redundantly, remove one.

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>