### PR TITLE
doc: update doc building tools versions

### DIFF
--- a/doc/howtos/process/docbuild.rst
+++ b/doc/howtos/process/docbuild.rst
@@ -111,10 +111,10 @@ Our documentation processing has been tested to run with:
 
 * Python 3.6.3
 * Doxygen version 1.8.13
-* Sphinx version 1.6.7
-* Breathe version 4.7.3
+* Sphinx version 1.7.5
+* Breathe version 4.9.1
 * docutils version 0.14
-* sphinx_rtd_theme version 0.2.4
+* sphinx_rtd_theme version 0.4.0
 
 Depending on your Linux version, install the needed tools:
 

--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -1,4 +1,4 @@
-breathe==4.7.3
-sphinx==1.6.7
+breathe==4.9.1
+sphinx==1.7.5
 docutils==0.14
 sphinx_rtd_theme


### PR DESCRIPTION
The latest versions of Sphinx and Breathe work well together so we're
updating the requirements.txt installation information (and
documentation) to use the latest versions of these tools.

Fixes: #395
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>