### PR TITLE
HV: enable SMEP in hypervisor

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -495,6 +495,8 @@ void bsp_boot_init(void)
 		pr_fatal("Please apply the latest CPU uCode patch!");
 	}
 
+	enable_smep();
+
 	/* Initialize the shell */
 	shell_init();
 
@@ -546,6 +548,9 @@ void cpu_secondary_init(void)
 	 * primary/boot CPU
 	 */
 	enable_paging(get_paging_pml4());
+
+	enable_smep();
+
 	early_init_lapic();
 
 	/* Find the logical ID of this CPU given the LAPIC ID

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -84,6 +84,8 @@
 #define CR4_SMXE                (1<<14)	/* SMX enable */
 #define CR4_PCIDE               (1<<17)	/* PCID enable */
 #define CR4_OSXSAVE             (1<<18)
+#define CR4_SMEP                (1<<20)
+#define CR4_SMAP                (1<<21)
 /* XSAVE and Processor Extended States enable bit */
 
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -299,6 +299,7 @@ bool check_mmu_1gb_support(int page_table_type);
 void *alloc_paging_struct(void);
 void free_paging_struct(void *ptr);
 void enable_paging(uint64_t pml4_base_addr);
+void enable_smep(void);
 void init_paging(void);
 int map_mem(struct map_params *map_params, void *paddr, void *vaddr,
 		    uint64_t size, uint32_t flags);


### PR DESCRIPTION
 - this patch is to enable SMEP in hypervisor, SMEP protects
   guests' memory from supervisor-mode instruction fetches,
   in other words, hypervisor which operating in supervisor
   mode can't fetch instructions from (guests' memory)
   linear addresses that are accessible in user mode.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>