### PR TITLE
Revert "VMX: change PAT register default value"

### DIFF
--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -12,7 +12,7 @@ extern struct efi_ctx* efi_ctx;
 
 #define PAT_POWER_ON_VALUE	(PAT_MEM_TYPE_WB + \
 				((uint64_t)PAT_MEM_TYPE_WT << 8) + \
-				((uint64_t)PAT_MEM_TYPE_WC << 16) + \
+				((uint64_t)PAT_MEM_TYPE_UCM << 16) + \
 				((uint64_t)PAT_MEM_TYPE_UC << 24) + \
 				((uint64_t)PAT_MEM_TYPE_WB << 32) + \
 				((uint64_t)PAT_MEM_TYPE_WT << 40) + \


### PR DESCRIPTION
This reverts commit 3a3aeac09f477d5cba7bb85be2c0e9c7f9d0bf72.
MTRR has been emulated in hypervisor, then don't need this workaround
patch.

Signed-off-by: Fei Jiang <fei.jiang@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>