### PR TITLE
hv: vlapic_timer: add vlapic one-shot/periodic timer support

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -112,7 +112,7 @@ struct vlapic_timer {
 	struct timer timer;
 	uint32_t mode;
 	uint32_t tmicr;
-	uint32_t divisor;
+	uint32_t divisor_shift;
 };
 
 struct vlapic {


### PR DESCRIPTION
Enable guest LAPIC one-shot/periodic timer support.

Change-Id: I368e28beaa81d6566de2626bbe26c9f8972f0891
Signed-off-by: Li, Fei1 <fei1.li@intel.com>

v1 - v2 rename set_target_expiration to set_expiration