### PR TITLE
udelay waits for corresponding number of milliseconds passed to API.

### DIFF
--- a/hypervisor/lib/udelay.c
+++ b/hypervisor/lib/udelay.c
@@ -11,7 +11,7 @@ void udelay(int loop_count)
 	uint64_t dest_tsc, delta_tsc;
 
 	/* Calculate number of ticks to wait */
-	delta_tsc = CYCLES_PER_MS * loop_count;
+	delta_tsc = US_TO_TICKS(loop_count);
 	dest_tsc = rdtsc() + delta_tsc;
 
 	/* Loop until time expired */


### PR DESCRIPTION
Changed the CYCLES_PER_MS to US_TO_TICKS

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>