### PR TITLE
fix parted of "missing for discarded return value"

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -967,7 +967,7 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 	}
 }
 
-int get_ptdev_info(char *str, int str_max)
+void get_ptdev_info(char *str, int str_max)
 {
 	struct ptdev_remapping_info *entry;
 	int len, size = str_max;
@@ -1014,5 +1014,4 @@ int get_ptdev_info(char *str, int str_max)
 	spinlock_release(&ptdev_lock);
 
 	snprintf(str, size, "\r\n");
-	return 0;
 }

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -237,7 +237,7 @@ int shutdown_vcpu(__unused struct vcpu *vcpu)
 	return 0;
 }
 
-int destroy_vcpu(struct vcpu *vcpu)
+void destroy_vcpu(struct vcpu *vcpu)
 {
 	ASSERT(vcpu != NULL, "Incorrect arguments");
 
@@ -254,8 +254,6 @@ int destroy_vcpu(struct vcpu *vcpu)
 	per_cpu(ever_run_vcpu, vcpu->pcpu_id) = NULL;
 	free_pcpu(vcpu->pcpu_id);
 	free(vcpu);
-
-	return 0;
 }
 
 /* NOTE:

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -606,7 +606,7 @@ bool vioapic_get_rte(struct vm *vm, int pin, void *rte)
 		return false;
 }
 
-int get_vioapic_info(char *str, int str_max, int vmid)
+void get_vioapic_info(char *str, int str_max, int vmid)
 {
 	int pin, len, size = str_max, vector, delmode;
 	uint64_t rte;
@@ -650,5 +650,4 @@ int get_vioapic_info(char *str, int str_max, int vmid)
 	}
 END:
 	snprintf(str, size, "\r\n");
-	return 0;
 }

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -260,20 +260,18 @@ int start_vm(struct vm *vm)
  * DM only pause vm for shutdown/reboot. If we need to
  * extend the pause vm for DM, this API should be extended.
  */
-int pause_vm(struct vm *vm)
+void pause_vm(struct vm *vm)
 {
 	int i;
 	struct vcpu *vcpu = NULL;
 
 	if (vm->state == VM_PAUSED)
-		return 0;
+		return;
 
 	vm->state = VM_PAUSED;
 
 	foreach_vcpu(i, vm, vcpu)
 		pause_vcpu(vcpu, VCPU_ZOMBIE);
-
-	return 0;
 }
 
 int vm_resume(struct vm *vm)

--- a/hypervisor/arch/x86/intr_lapic.c
+++ b/hypervisor/arch/x86/intr_lapic.c
@@ -316,10 +316,9 @@ void resume_lapic(void)
 	restore_lapic(&saved_lapic_regs);
 }
 
-int send_lapic_eoi(void)
+void send_lapic_eoi(void)
 {
 	write_lapic_reg32(LAPIC_EOI_REGISTER, 0);
-	return 0;
 }
 
 static void wait_for_delivery(void)

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -686,7 +686,7 @@ pri_register_handler(uint32_t irq,
 	return common_register_handler(irq, &info);
 }
 
-int get_cpu_interrupt_info(char *str, int str_max)
+void get_cpu_interrupt_info(char *str, int str_max)
 {
 	int pcpu_id;
 	uint32_t irq, vector, len, size = str_max;
@@ -727,5 +727,4 @@ int get_cpu_interrupt_info(char *str, int str_max)
 		}
 	}
 	snprintf(str, size, "\r\n");
-	return 0;
 }

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -171,7 +171,7 @@ void timer_cleanup(void)
 	per_cpu(timer_node, pcpu_id) = NULL;
 }
 
-int timer_softirq(int pcpu_id)
+void timer_softirq(int pcpu_id)
 {
 	struct per_cpu_timers *cpu_timer;
 	struct timer *timer;
@@ -207,7 +207,6 @@ int timer_softirq(int pcpu_id)
 
 	/* update nearest timer */
 	update_physical_timer(cpu_timer);
-	return 0;
 }
 
 void check_tsc(void)

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -649,20 +649,18 @@ static void dmar_set_root_table(struct dmar_drhd_rt *dmar_uint)
 	IOMMU_UNLOCK(dmar_uint);
 }
 
-static int dmar_fault_event_mask(struct dmar_drhd_rt *dmar_uint)
+static void dmar_fault_event_mask(struct dmar_drhd_rt *dmar_uint)
 {
 	IOMMU_LOCK(dmar_uint);
 	iommu_write32(dmar_uint, DMAR_FECTL_REG, DMA_FECTL_IM);
 	IOMMU_UNLOCK(dmar_uint);
-	return 0;
 }
 
-static int dmar_fault_event_unmask(struct dmar_drhd_rt *dmar_uint)
+static void dmar_fault_event_unmask(struct dmar_drhd_rt *dmar_uint)
 {
 	IOMMU_LOCK(dmar_uint);
 	iommu_write32(dmar_uint, DMAR_FECTL_REG, 0);
 	IOMMU_UNLOCK(dmar_uint);
-	return 0;
 }
 
 static void dmar_fault_msi_write(struct dmar_drhd_rt *dmar_uint,

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -141,7 +141,7 @@ int hv_main(int cpu_id)
 	return 0;
 }
 
-int get_vmexit_profile(char *str, int str_max)
+void get_vmexit_profile(char *str, int str_max)
 {
 	int cpu, i, len, size = str_max;
 
@@ -173,5 +173,4 @@ int get_vmexit_profile(char *str, int str_max)
 		}
 	}
 	snprintf(str, size, "\r\n");
-	return 0;
 }

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -146,7 +146,7 @@ static void _get_req_info_(struct vhm_request *req, int *id, char *type,
 	}
 }
 
-int get_req_info(char *str, int str_max)
+void get_req_info(char *str, int str_max)
 {
 	int i, len, size = str_max, client_id;
 	union vhm_request_buffer *req_buf;
@@ -189,5 +189,4 @@ int get_req_info(char *str, int str_max)
 	}
 	spinlock_release(&vm_list_lock);
 	snprintf(str, size, "\r\n");
-	return 0;
 }

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -19,14 +19,12 @@ uint32_t get_serial_handle(void)
 	return serial_handle;
 }
 
-static int print_char(char x)
+static void print_char(char x)
 {
 	serial_puts(serial_handle, &x, 1);
 
 	if (x == '\n')
 		serial_puts(serial_handle, "\r", 1);
-
-	return 0;
 }
 
 int console_init(void)
@@ -44,8 +42,10 @@ int console_putc(int ch)
 
 	spinlock_obtain(&lock);
 
-	if (serial_handle != SERIAL_INVALID_HANDLE)
-		res = print_char(ch);
+	if (serial_handle != SERIAL_INVALID_HANDLE) {
+		print_char(ch);
+		res = 0;
+	}
 
 	spinlock_release(&lock);
 

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -61,7 +61,7 @@ static void fifo_init(struct fifo *fifo, int sz)
 	fifo_reset(fifo);
 }
 
-static char fifo_putchar(struct fifo *fifo, char ch)
+static void fifo_putchar(struct fifo *fifo, char ch)
 {
 	fifo->buf[fifo->windex] = ch;
 	if (fifo->num < fifo->size) {
@@ -71,7 +71,6 @@ static char fifo_putchar(struct fifo *fifo, char ch)
 		fifo->rindex = (fifo->rindex + 1) % fifo->size;
 		fifo->windex = (fifo->windex + 1) % fifo->size;
 	}
-	return 0;
 }
 
 static char fifo_getchar(struct fifo *fifo)

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -35,7 +35,7 @@ enum {
 struct vhm_request;
 
 int acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req);
-int get_req_info(char *str, int str_max);
+void get_req_info(char *str, int str_max);
 
 /*
  * VCPU related APIs

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -260,7 +260,7 @@ struct vcpu* get_ever_run_vcpu(int pcpu_id);
 int create_vcpu(int cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle);
 int start_vcpu(struct vcpu *vcpu);
 int shutdown_vcpu(struct vcpu *vcpu);
-int destroy_vcpu(struct vcpu *vcpu);
+void destroy_vcpu(struct vcpu *vcpu);
 
 void reset_vcpu(struct vcpu *vcpu);
 void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state);

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -53,5 +53,5 @@ bool	vioapic_get_rte(struct vm *vm, int pin, void *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 		void *handler_private_data);
 
-int get_vioapic_info(char *str, int str_max, int vmid);
+void get_vioapic_info(char *str, int str_max, int vmid);
 #endif

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -170,7 +170,7 @@ struct vm_description {
 };
 
 int shutdown_vm(struct vm *vm);
-int pause_vm(struct vm *vm);
+void pause_vm(struct vm *vm);
 int start_vm(struct vm *vm);
 int create_vm(struct vm_description *vm_desc, struct vm **vm);
 int prepare_vm0(void);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -135,7 +135,7 @@ normal_register_handler(uint32_t irq,
 		const char *name);
 void unregister_handler_common(struct dev_handler_node *node);
 
-int get_cpu_interrupt_info(char *str, int str_max);
+void get_cpu_interrupt_info(char *str, int str_max);
 
 void setup_notification(void);
 
@@ -157,11 +157,11 @@ extern spurious_handler_t spurious_handler;
 #define HV_ARCH_VCPU_BLOCKED_BY_MOVSS       (1<<1)
 #define HV_ARCH_VCPU_BLOCKED_BY_STI         (1<<0)
 
-int vcpu_inject_extint(struct vcpu *vcpu);
-int vcpu_inject_nmi(struct vcpu *vcpu);
+void vcpu_inject_extint(struct vcpu *vcpu);
+void vcpu_inject_nmi(struct vcpu *vcpu);
 int vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code);
 int vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code);
-int vcpu_make_request(struct vcpu *vcpu, int eventid);
+void vcpu_make_request(struct vcpu *vcpu, int eventid);
 int vcpu_queue_exception(struct vcpu *vcpu, uint32_t vector, uint32_t err_code);
 
 int exception_vmexit_handler(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -159,7 +159,7 @@ void write_lapic_reg32(uint32_t offset, uint32_t value);
 void save_lapic(struct lapic_regs *regs);
 int early_init_lapic(void);
 int init_lapic(uint32_t cpu_id);
-int send_lapic_eoi(void);
+void send_lapic_eoi(void);
 uint32_t get_cur_lapic_id(void);
 int send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 		uint32_t cpu_startup_dest,

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -54,7 +54,7 @@ static inline void initialize_timer(struct timer *timer,
 int add_timer(struct timer *timer);
 void del_timer(struct timer *timer);
 
-int timer_softirq(int pcpu_id);
+void timer_softirq(int pcpu_id);
 void timer_init(void);
 void timer_cleanup(void);
 void check_tsc(void);

--- a/hypervisor/include/arch/x86/vmexit.h
+++ b/hypervisor/include/arch/x86/vmexit.h
@@ -16,7 +16,7 @@ int vmexit_handler(struct vcpu *vcpu);
 int vmcall_vmexit_handler(struct vcpu *vcpu);
 int cpuid_vmexit_handler(struct vcpu *vcpu);
 int cr_access_vmexit_handler(struct vcpu *vcpu);
-int get_vmexit_profile(char *str, int str_max);
+void get_vmexit_profile(char *str, int str_max);
 
 #define VM_EXIT_QUALIFICATION_BIT_MASK(exit_qual, MSB, LSB)   \
 	(exit_qual & (((1UL << (MSB+1))-1) - ((1UL << (LSB))-1)))

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -70,7 +70,7 @@ extern spinlock_t softirq_dev_lock;
 void ptdev_softirq(int cpu);
 void ptdev_init(void);
 void ptdev_release_all_entries(struct vm *vm);
-int get_ptdev_info(char *str, int str_max);
+void get_ptdev_info(char *str, int str_max);
 
 struct ptdev_remapping_info *ptdev_dequeue_softirq(void);
 struct ptdev_remapping_info *alloc_entry(struct vm *vm,

--- a/hypervisor/include/lib/spinlock.h
+++ b/hypervisor/include/lib/spinlock.h
@@ -19,18 +19,16 @@ typedef struct _spinlock {
 } spinlock_t;
 
 /* Function prototypes */
-int spinlock_init(spinlock_t *lock);
-int spinlock_obtain(spinlock_t *lock);
+void spinlock_init(spinlock_t *lock);
+void spinlock_obtain(spinlock_t *lock);
 
-static inline int spinlock_release(spinlock_t *lock)
+static inline void spinlock_release(spinlock_t *lock)
 {
 	/* Increment tail of queue */
 	asm volatile ("   lock incl %[tail]\n"
 				:
 				: [tail] "m" (lock->tail)
 				: "cc", "memory");
-
-	return 0;
 }
 
 #else /* ASSEMBLER */

--- a/hypervisor/lib/spinlock.c
+++ b/hypervisor/lib/spinlock.c
@@ -6,12 +6,11 @@
 
 #include <hv_lib.h>
 
-inline int spinlock_init(spinlock_t *lock)
+inline void spinlock_init(spinlock_t *lock)
 {
 	memset(lock, 0, sizeof(spinlock_t));
-	return 0;
 }
-int spinlock_obtain(spinlock_t *lock)
+void spinlock_obtain(spinlock_t *lock)
 {
 
 	/* The lock function atomically increments and exchanges the head
@@ -31,5 +30,4 @@ int spinlock_obtain(spinlock_t *lock)
 		      [head] "m"(lock->head),
 		      [tail] "m"(lock->tail)
 		      : "cc", "memory");
-	return 0;
 }


### PR DESCRIPTION
MISRA C required that return value should be used, missing for it should
add "(void)" prefix before the function call.
Some function can be declared without return value to avoid this problem.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>