### PR TITLE
hv: add shell command to trigger crash

### DIFF
--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -1055,6 +1055,17 @@ int shell_cpuid(struct shell *p_shell, int argc, char **argv)
 	return 0;
 }
 
+int shell_trigger_crash(struct shell *p_shell, int argc, char **argv)
+{
+	char str[MAX_STR_SIZE] = {0};
+
+	snprintf(str, MAX_STR_SIZE, "trigger crash, divide by 0 ...\r\n");
+	shell_puts(p_shell, str);
+	snprintf(str, MAX_STR_SIZE, "%d\r", 1/0);
+
+	return 0;
+}
+
 int shell_terminate_serial(struct shell *p_shell)
 {
 	/* Shell shouldn't own the serial port handle anymore. */

--- a/hypervisor/debug/shell_internal.h
+++ b/hypervisor/debug/shell_internal.h
@@ -133,6 +133,9 @@ struct shell_cmd {
 #define SHELL_CMD_CPUID_PARAM		"<leaf> [subleaf]"
 #define SHELL_CMD_CPUID_HELP		"cpuid leaf [subleaf], in hexadecimal"
 
+#define SHELL_CMD_TRIGGER_CRASH			"crash"
+#define SHELL_CMD_TRIGGER_CRASH_PARAM	NULL
+#define SHELL_CMD_TRIGGER_CRASH_HELP	"trigger crash"
 
 /* Global function prototypes */
 int shell_show_req_info(struct shell *p_shell, int argc, char **argv);
@@ -169,5 +172,6 @@ void kick_shell(struct shell *p_shell);
 
 int shell_puts(struct shell *p_shell, char *str_ptr);
 int shell_set_name(struct shell *p_shell, char *name);
+int shell_trigger_crash(struct shell *p_shell, int argc, char **argv);
 
 #endif /* SHELL_INTER_H */

--- a/hypervisor/debug/shell_public.c
+++ b/hypervisor/debug/shell_public.c
@@ -125,6 +125,12 @@ static struct shell_cmd acrn_cmd[] = {
 		.help_str	= SHELL_CMD_REBOOT_HELP,
 		.fcn		= shell_reboot,
 	},
+		{
+			.str		= SHELL_CMD_TRIGGER_CRASH,
+			.cmd_param	= SHELL_CMD_TRIGGER_CRASH_PARAM,
+			.help_str	= SHELL_CMD_TRIGGER_CRASH_HELP,
+			.fcn		= shell_trigger_crash,
+		},
 };
 
 int shell_init(void)


### PR DESCRIPTION
this patch add shell command trigger crash for testing crashmode/ramdump

Signed-off-by: zhouji3x <jianfengx.zhou@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>