### PR TITLE
tools: correct several Makefile problems

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,5 @@
 T := $(CURDIR)
-OUT_DIR ?= $(T)/build
+OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 
 .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
 all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -7,7 +7,7 @@ ifeq ($(RELEASE),0)
 CFLAGS += -g -DMNGR_DEBUG
 endif
 
-LDFLAGS := -L$(TOOLS_OUT)
+LDFLAGS := -L$(OUT_DIR)
 LDFLAGS += -lacrn-mngr
 LDFLAGS +=  -lpthread
 

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -7,7 +7,9 @@ all:
 
 clean:
 	rm -f $(OUT_DIR)/acrnlog
+ifneq ($(OUT_DIR),.)
 	rm -f $(OUT_DIR)/acrnlog.service
+endif
 
 install: $(OUT_DIR)/acrnlog
 	install -d $(DESTDIR)/usr/bin


### PR DESCRIPTION
1. mkdir ./tools/build if it does not exist;
2. correct static lib path for acrn-manager;
3. do not remove acrnlog.service if build under source code dir by default.

Reviewed-by: Geoffroy VanCutsem <geoffroy.vancutsem@intel.com>
Signed-off-by: Yan, Like <like.yan@intel.com>