### PR TITLE
hv: fix error use of list_del for delete timer

### DIFF
--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -96,7 +96,7 @@ int add_timer(struct timer *timer)
 void del_timer(struct timer *timer)
 {
 	if (timer && !list_empty(&timer->node))
-		list_del(&timer->node);
+		list_del_init(&timer->node);
 }
 
 static int request_timer_irq(int pcpu_id,


### PR DESCRIPTION
We should use list_del_init here. Otherwise it would misorder the
timer list if we would delete timer more than once if there're more
than one timer on it.

Change-Id: I2d18248173ced1ea1b723352327d2c3d0efc4900
Signed-off-by: Li, Fei1 <fei1.li@intel.com>