### PR TITLE
add acrnbridge-install to Makefile install target

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -28,7 +28,7 @@ clean:
 	rm -rf $(OUT_DIR)
 
 .PHONY: install
-install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install
+install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
 
 acrn-crashlog-install:
 	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) install


### PR DESCRIPTION
This was missed out. Added
to fix the makefile install target.

Signed-off-by: Tan Shen Joon <shen.joon.tan@intel.com>
Acked-by: Geoffroy Van Cutsem <Geoffroy.vancutsem@intel.com>