### PR TITLE
 tools: acrn-crashlog: fix potential issues for acrnprobe

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/crash_reclassify.c
+++ b/tools/acrn-crashlog/acrnprobe/crash_reclassify.c
@@ -233,7 +233,7 @@ static struct crash_t *crash_reclassify_by_content(struct crash_t *rcrash,
 		return NULL;
 
 	if (trfile) {
-		ret = read_full_binary_file(trfile, &size, &file);
+		ret = read_file(trfile, &size, &file);
 		if (ret == -1) {
 			LOGE("read %s failed, error (%s)\n",
 			     trfile, strerror(errno));

--- a/tools/acrn-crashlog/acrnprobe/history.c
+++ b/tools/acrn-crashlog/acrnprobe/history.c
@@ -132,6 +132,9 @@ void hist_raise_event(char *event, char *type, char *log, char *lastuptime,
 
 	/* here means user have configured the crashlog sender */
 	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return;
+
 	maxlines = atoi(crashlog->maxlines);
 	if (++current_lines >= maxlines) {
 		LOGW("lines of (%s) meet quota %d, backup... Pls clean!\n",
@@ -139,9 +142,11 @@ void hist_raise_event(char *event, char *type, char *log, char *lastuptime,
 		backup_history();
 	}
 
-	get_current_time_long(eventtime);
-	entry.eventtime = eventtime;
+	ret = get_current_time_long(eventtime);
+	if (ret <= 0)
+		return;
 
+	entry.eventtime = eventtime;
 	entry_to_history_line(&entry, line);
 	ret = append_file(history_file, line);
 	if (ret < 0) {
@@ -165,6 +170,9 @@ void hist_raise_uptime(char *lastuptime)
 
 	/* user have configured the crashlog sender */
 	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return;
+
 	uptime = crashlog->uptime;
 	uptime_hours = atoi(uptime->eventhours);
 

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -111,54 +111,54 @@ struct conf_t {
 struct conf_t conf;
 
 #define for_each_sender(id, sender, conf) \
-		for (id = 0, sender = conf.sender[0]; \
-		     id < SENDER_MAX; \
-		     id++, sender = conf.sender[id])
+		for (id = 0; \
+		     id < SENDER_MAX && (sender = conf.sender[id]); \
+		     id++)
 
 #define for_each_trigger(id, trigger, conf) \
-		for (id = 0, trigger = conf.trigger[0]; \
-		     id < TRIGGER_MAX; \
-		     id++, trigger = conf.trigger[id])
+		for (id = 0; \
+		     id < TRIGGER_MAX && (trigger = conf.trigger[id]); \
+		     id++)
 
 #define for_each_vm(id, vm, conf) \
-		for (id = 0, vm = conf.vm[0]; \
-		     id < VM_MAX; \
-		     id++, vm = conf.vm[id])
+		for (id = 0; \
+		     id < VM_MAX && (vm = conf.vm[id]); \
+		     id++)
 
 #define for_each_syncevent_vm(id, event, vm) \
-		for (id = 0, event = vm->syncevent[0]; \
-		     id < VM_EVENT_TYPE_MAX; \
-		     id++, event = vm->syncevent[id])
+		for (id = 0; \
+		     id < VM_EVENT_TYPE_MAX && (event = vm->syncevent[id]); \
+		     id++)
 
 #define for_each_info(id, info, conf) \
-		for (id = 0, info = conf.info[0]; \
-		     id < INFO_MAX; \
-		     id++, info = conf.info[id])
+		for (id = 0; \
+		     id < INFO_MAX && (info = conf.info[id]); \
+		     id++)
 
 #define for_each_log(id, log, conf) \
-		for (id = 0, log = conf.log[0]; \
-		     id < LOG_MAX; \
-		     id++, log = conf.log[id])
+		for (id = 0; \
+		     id < LOG_MAX && (log = conf.log[id]); \
+		     id++)
 
 #define for_each_crash(id, crash, conf) \
-		for (id = 0, crash = conf.crash[0]; \
-		     id < CRASH_MAX; \
-		     id++, crash = conf.crash[id])
+		for (id = 0; \
+		     id < CRASH_MAX && (crash = conf.crash[id]); \
+		     id++)
 
 #define for_each_log_collect(id, log, type) \
-		for (id = 0, log = type->log[0]; \
-		     id < LOG_MAX; \
-		     id++, log = type->log[id])
+		for (id = 0; \
+		     id < LOG_MAX && (log = type->log[id]); \
+		     id++)
 
 #define for_each_content_crash(id, content, crash) \
-		for (id = 0, content = crash->content[0]; \
-		     id < CONTENT_MAX; \
-		     id++, content = crash->content[id])
+		for (id = 0; \
+		     id < CONTENT_MAX && (content = crash->content[id]); \
+		     id++)
 
 #define for_each_content_expression(id, content, exp) \
-		for (id = 0, content = exp[0]; \
-		     id < CONTENT_MAX; \
-		     id++, content = exp[id])
+		for (id = 0; \
+		     id < CONTENT_MAX && (content = exp[id]); \
+		     id++)
 
 #define exp_valid(exp) \
 (__extension__ \
@@ -175,9 +175,9 @@ struct conf_t conf;
 )
 
 #define for_each_expression_crash(id, exp, crash) \
-		for (id = 0, exp = crash->mightcontent[0]; \
-		     id < EXPRESSION_MAX; \
-		     id++, exp = crash->mightcontent[id])
+		for (id = 0; \
+		     id < EXPRESSION_MAX && (exp = crash->mightcontent[id]); \
+		     id++)
 
 #define for_crash_children(crash, tcrash) \
 			TAILQ_FOREACH(crash, &tcrash->children, entries)

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -200,7 +200,7 @@ struct conf_t conf;
 }) \
 )
 
-int load_conf(char *path);
+int load_conf(const char *path);
 struct trigger_t *get_trigger_by_name(char *name);
 struct log_t *get_log_by_name(char *name);
 int sender_id(struct sender_t *sender);

--- a/tools/acrn-crashlog/acrnprobe/probeutils.c
+++ b/tools/acrn-crashlog/acrnprobe/probeutils.c
@@ -79,10 +79,10 @@ int get_current_time_long(char buf[32])
 
 	time(&t);
 	time_val = localtime((const time_t *)&t);
+	if (!time_val)
+		return -1;
 
-	strftime(buf, 32, "%Y-%m-%d/%H:%M:%S  ", time_val);
-
-	return 0;
+	return strftime(buf, 32, "%Y-%m-%d/%H:%M:%S  ", time_val);
 }
 
 /**
@@ -286,6 +286,9 @@ static int reserve_log_folder(enum e_dir_mode mode, char *dir,
 	unsigned int maxdirs;
 
 	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return -1;
+
 	outdir = crashlog->outdir;
 
 	switch (mode) {
@@ -352,7 +355,9 @@ void generate_crashfile(char *dir, char *event, char *hashkey,
 	const int fmtsize = 128;
 	int filesize;
 
-	get_current_time_long(datetime);
+	ret = get_current_time_long(datetime);
+	if (ret <= 0)
+		return;
 	get_uptime_string(uptime, &hours);
 
 	filesize = fmtsize + strlen(event) +

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -185,7 +185,7 @@ static void get_log_rotation(struct log_t *log, char *desdir)
 	if (count > 2) {
 		for (i = 0; i < count; i++) {
 			name = strrchr(files[i], '/') + 1;
-			if (!strstr(name, prefix))
+			if (!name && !strstr(name, prefix))
 				continue;
 
 			number = atoi(strrchr(name, '.') + 1);
@@ -793,7 +793,7 @@ static void crashlog_send_crash(struct event_t *e)
 	char *data1;
 	char *data2;
 	int id;
-	int ret;
+	int ret = 0;
 	int quota;
 	struct crash_t *rcrash = (struct crash_t *)e->private;
 
@@ -931,8 +931,13 @@ static void crashlog_send_reboot(void)
 {
 	char reason[MAXLINESIZE];
 	char *key;
+	struct sender_t *crashlog;
 
-	if (swupdated(get_sender_by_name("crashlog"))) {
+	crashlog = get_sender_by_name("crashlog");
+	if (!crashlog)
+		return;
+
+	if (swupdated(crashlog)) {
 		key = generate_event_id("INFO", "SWUPDATE");
 		if (key == NULL) {
 			LOGE("generate event id failed, error (%s)\n",


### PR DESCRIPTION
The aim of this patch set is to fix potential issues, which are reported by
static analysis tool, for acrnprobe.

For the convenience of review, break it into two patches.
