### PR TITLE
HV: correct loglevel definitions and default values

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -81,11 +81,11 @@ config HEAP_SIZE
 
 config CONSOLE_LOGLEVEL_DEFAULT
 	int "Default loglevel on the serial console"
-	default 2
+	default 3
 
 config MEM_LOGLEVEL_DEFAULT
 	int "Default loglevel in memory"
-	default 4
+	default 5
 
 config LOW_RAM_SIZE
 	hex "Size of the low RAM region"

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -28,14 +28,8 @@
 #define SHELL_INPUT_LINE_OTHER(v)	(((v) + 1) % 2)
 
 /* The initial log level*/
-uint32_t console_loglevel;
-uint32_t mem_loglevel;
-#ifdef CONFIG_CONSOLE_LOGLEVEL_DEFAULT
 uint32_t console_loglevel = CONFIG_CONSOLE_LOGLEVEL_DEFAULT;
-#endif
-#ifdef CONFIG_MEM_LOGLEVEL_DEFAULT
 uint32_t mem_loglevel = CONFIG_MEM_LOGLEVEL_DEFAULT;
-#endif
 
 static int string_to_argv(char *argv_str, void *p_argv_mem,
 		__unused uint32_t argv_mem_size, int *p_argc, char ***p_argv)


### PR DESCRIPTION
1. remove duplicated definitions of mem_loglevel/console_loglevel;
2. Set default loglevels to display important messages:
 - CONSOLE_LOGLEVEL_DEFALUT is changed from 2 to 3;
 - MEM_LOGLEVEL_DEFAULT is changed from 4 to 5.

Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Yan, Like <like.yan@intel.com>