### PR TITLE
doc: fix formatting in acrnlog doc

### DIFF
--- a/tools/acrnlog/README.rst
+++ b/tools/acrnlog/README.rst
@@ -24,20 +24,13 @@ limitation temporarily or permanently.
 
 Options:
 
-    -h
-        display the help
-
-    -t:
-	specify a polling interval (ms). Once buffer is empty, acrnlog stops
-	and starts reading in specified interval.
-	If an incomplete log warning is reported, please try with a smaller
-	interval to get a complete log.
-
-    -s:
-	limit the size of each log file, in KB. 0 means no limitation.
-
-    -n:
-	specify the number of log files to keep, old files would be deleted.
+  -h  display help
+  -t  specify a polling interval (ms). Once buffer is empty, acrnlog stops
+      and starts reading in specified interval.
+      If an incomplete log warning is reported, please try with a smaller
+      interval to get a complete log.
+  -s  limit the size of each log file, in KB. 0 means no limitation.
+  -n  specify the number of log files to keep, old files would be deleted.
 
 Temporary log file changes
 ==========================


### PR DESCRIPTION
A merged change had problems with the formatting of acrnlog options.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>