### PR TITLE
dm: check pci_vdev before using

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -821,7 +821,7 @@ static void
 pci_emul_deinit(struct vmctx *ctx, struct pci_vdev_ops *ops, int bus, int slot,
 		int func, struct funcinfo *fi)
 {
-	if (ops->vdev_deinit)
+	if (ops->vdev_deinit && fi->fi_devi)
 		(*ops->vdev_deinit)(ctx, fi->fi_devi, fi->fi_param);
 	if (fi->fi_param)
 		free(fi->fi_param);


### PR DESCRIPTION
acrn-dm runs to segmentation fault when failed to create VMs with
improper parameters.

If vdevs failed to be created, they are still be freed in deinit(),
and dereference the null pointers leads to segfault.

Signed-off-by: Xinyun Liu <xinyun.liu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>