### PR TITLE
hv: add sanity check for the input vcpu_id

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -218,6 +218,12 @@ int64_t hcall_create_vcpu(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
+	if ((uint32_t)vm->hw.created_vcpus != cv.vcpu_id) {
+		pr_err("vcpu %d:%d is invalid(already assigned ?)\n",
+		        vm->hw.created_vcpus, cv.vcpu_id);
+		return -EINVAL;
+	}
+
 	pcpu_id = allocate_pcpu();
 	if (-1 == pcpu_id) {
 		pr_err("%s: No physical available\n", __func__);


### PR DESCRIPTION
Previously, HV assigns vm cpuid accroding to vm->hw.created_vcpus, which is
not always same with the input vcpu_id. And the DM uses the input vcpu_id
directly later. This might cause arcn has 2 different vcpuid pointing to one vcpu

Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>