### PR TITLE
tools: acrn-crashlog: fix potential issues under common and usercrash

### DIFF
--- a/tools/acrn-crashlog/common/cmdutils.c
+++ b/tools/acrn-crashlog/common/cmdutils.c
@@ -47,7 +47,7 @@ int execv_out2file(char *argv[], char *outfile)
 
 	if (pid == 0) {
 		int res;
-		int fd;
+		int fd = -1;
 
 		if (outfile) {
 			fd = open(outfile, O_WRONLY | O_CREAT | O_TRUNC, 0664);
@@ -65,6 +65,8 @@ int execv_out2file(char *argv[], char *outfile)
 
 		res = execvp(argv[0], argv);
 		if (res == -1) {
+			if (fd > 0)
+				close(fd);
 			LOGE("execvp (%s) failed, error (%s)\n", argv[0],
 			     strerror(errno));
 			return -1;
@@ -211,8 +213,10 @@ char *exec_out2mem(char *fmt, ...)
 			memsize += 1024;
 			new = realloc(out, memsize);
 			if (!new) {
-				if (out)
+				if (out) {
 					free(out);
+					out = NULL;
+				}
 				goto end;
 			} else {
 				out = new;

--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -114,11 +114,12 @@ char *mm_get_line(struct mm_file_t *mfile, int line)
 
 	if (line <= 0 || line > mm_count_lines(mfile))
 		return NULL;
-	else if (line == 1)
+
+	if (line == 1)
 		ret = begin;
 	else {
 		next = begin;
-		for (i = 2; i <= line; i++)
+		for (i = 2; i <= line && next; i++)
 			next = strchr(next, '\n') + 1;
 		ret = next;
 	}
@@ -820,7 +821,7 @@ int read_full_binary_file(const char *path, unsigned long *size, void **data)
 	close_file(path, f);
 
 	*data = buf;
-	*size = (unsigned int)_size;
+	*size = (unsigned long)_size;
 
 	return 0;
 
@@ -1112,7 +1113,7 @@ int read_file(const char *path, unsigned long *size, void **data)
 	int len = 0;
 	int fd = 0;
 	int memsize = 1; /* for '\0' */
-	size_t result = 0;
+	ssize_t result = 0;
 	char *out = NULL;
 	char *new;
 
@@ -1129,6 +1130,8 @@ int read_file(const char *path, unsigned long *size, void **data)
 		result = read(fd, (void *)tmp, 1024);
 		if (result == 0)
 			break;
+		else if (result == -1)
+			goto free;
 
 		memsize += result;
 		new = realloc(out, memsize);
@@ -1145,7 +1148,7 @@ int read_file(const char *path, unsigned long *size, void **data)
 	close(fd);
 
 	*data = out;
-	*size = (unsigned int)len;
+	*size = (unsigned long)len;
 
 	return 0;
 

--- a/tools/acrn-crashlog/common/log_sys.c
+++ b/tools/acrn-crashlog/common/log_sys.c
@@ -19,7 +19,7 @@ void do_log(const int level,
 	char log[MAX_LOG_LEN];
 	int n = 0;
 #ifdef DEBUG_ACRN_CRASHLOG
-	const char header_fmt[] = "<%-20s%d>: ";
+	const char header_fmt[] = "<%-20s%5d>: ";
 #endif
 
 	if (level > LOG_LEVEL)
@@ -37,7 +37,7 @@ void do_log(const int level,
 #ifdef DEBUG_ACRN_CRASHLOG
 	/* header */
 	n = snprintf(log, sizeof(log), header_fmt, func, line);
-	if (n < 0 || n >= sizeof(log))
+	if (n < 0 || (size_t)n >= sizeof(log))
 		n = 0;
 #endif
 	/* msg */

--- a/tools/acrn-crashlog/common/strutils.c
+++ b/tools/acrn-crashlog/common/strutils.c
@@ -74,11 +74,16 @@ static char *strtriml(char *str)
 
 static char *strtrimr(char *str)
 {
-	char *end = str + strlen(str) - 1;
+	size_t len;
+	char *end;
 
-	while (*end == ' ' && end >= str) {
-		*end = 0;
-		end--;
+	len = strlen(str);
+	if (len > 0) {
+		end = str + strlen(str) - 1;
+		while (*end == ' ' && end >= str) {
+			*end = 0;
+			end--;
+		}
 	}
 
 	return str;
@@ -86,8 +91,12 @@ static char *strtrimr(char *str)
 
 char *strtrim(char *str)
 {
-	strtrimr(str);
-	return strtriml(str);
+	if (str) {
+		strtrimr(str);
+		return strtriml(str);
+	}
+
+	return NULL;
 }
 
 int strcnt(char *str, char c)

--- a/tools/acrn-crashlog/usercrash/debugger.c
+++ b/tools/acrn-crashlog/usercrash/debugger.c
@@ -19,10 +19,9 @@
  */
 static void print_usage(void)
 {
-	printf("debugger - tool to dump process info of a running process. ");
+	printf("debugger - tool to dump process info of a running process.\n");
 	printf("[Usage]\n");
 	printf("\t--shell cmd, debugger <pid>  (root role to run)\n");
-	printf("(root role to run)\n");
 	printf("[Option]\n");
 	printf("\t-h: print this usage message\n");
 	printf("\t-v: print debugger version\n");
@@ -48,7 +47,7 @@ int main(int argc, char *argv[])
 		print_usage();
 
 	if (getuid() != 0) {
-		LOGE("failed to execute debugger, root is required\n");
+		printf("failed to execute debugger, root is required\n");
 		exit(EXIT_FAILURE);
 	}
 

--- a/tools/acrn-crashlog/usercrash/include/packet.h
+++ b/tools/acrn-crashlog/usercrash/include/packet.h
@@ -10,7 +10,6 @@
 #define SOCKET_NAME "user_crash"
 
 #include <stdio.h>
-#include <stdbool.h>
 
 enum CrashPacketType {
 	/* Initial request from crash_dump */


### PR DESCRIPTION
This patch is to fix potential issues, which are reported by static
analysis tool, for common and usercrash.

Changes:
1. Handle the fd properly in the failing case.
2. Fix buffer overflow issues and null pointer access issues.
3. Fix the format issue in log_sys.c.
4. Remove the useless branch and adjust the function logic.
5. Add some checks for the string length before using strcpy/strcat/memcpy.
6. Fix strncpy warning issues.
7. Change the return value to unify the return type.

Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Signed-off-by: xiaojin2 <xiaojing.liu@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: Liu Xinwu <xinwu.liu@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>