### PR TITLE
HV: ptdev: convert vectors in msi_info to unsigned integers

### DIFF
--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -29,8 +29,8 @@ struct ptdev_msi_info {
 	uint32_t pmsi_data; /* phys msi_data */
 	int msix;	/* 0-MSI, 1-MSIX */
 	int msix_entry_index; /* MSI: 0, MSIX: index of vector table*/
-	int virt_vector;
-	int phys_vector;
+	uint32_t virt_vector;
+	uint32_t phys_vector;
 };
 
 /* entry per guest vioapic pin */


### PR DESCRIPTION
Vectors are unsigned integers now. This patch converts the vectors in struct
ptdev_msi_info to uint32_t so that all variables representing interrupt vectors
are aligned.

No other changes needed except the type declarators since the other functions
manipulating vectors already takes/returns uint32_t.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>