### PR TITLE
HV Makefile: fix detection of gnu-efi tools location

### DIFF
--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -43,27 +43,22 @@ HOST  = $(shell $(CC) -dumpmachine | sed "s/\(-\).*$$//")
 ARCH := $(shell $(CC) -dumpmachine | sed "s/\(-\).*$$//")
 
 ifeq ($(ARCH),x86_64)
-	LIBDIR := $(shell if [ -d /usr/lib64 ]; then echo /usr/lib64; \
-			else if [ -d /usr/lib ]; then echo /usr/lib; fi ; fi;)
 	FORMAT=efi-app-x86-64
 else
 	ARCH=ia32
-	LIBDIR=/usr/lib32
 	FORMAT=efi-app-ia32
 endif
 
+# Different Linux distributions have the 'gnu-efi' package install
+# its tools and libraries in different folders. The next couple of
+# variables will determine and set the right path for both the
+# tools $(GNUEFI_DIR) and libraries $(LIBDIR)
+GNUEFI_DIR := $(shell find /usr/lib* -name elf_$(ARCH)_efi.lds -type f | xargs dirname)
+LIBDIR := $(subst gnuefi,,$(GNUEFI_DIR))
+CRT0 := $(GNUEFI_DIR)/crt0-efi-$(ARCH).o
+LDSCRIPT := $(GNUEFI_DIR)/elf_$(ARCH)_efi.lds
+
 INCDIR := /usr/include
-
-# gnuefi sometimes installs these under a gnuefi/ directory, and sometimes not
-ifneq ("$(wildcard $(LIBDIR)/gnuefi/crt0-efi-$(ARCH).o)","")
-	CRT0 := $(LIBDIR)/gnuefi/crt0-efi-$(ARCH).o
-	LDSCRIPT := $(LIBDIR)/gnuefi/elf_$(ARCH)_efi.lds
-else
-	CRT0 := $(LIBDIR)/crt0-efi-$(ARCH).o
-	LDSCRIPT := $(LIBDIR)/elf_$(ARCH)_efi.lds
-endif
-
-
 
 CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \


### PR DESCRIPTION
The previous logic assumes LIBDIR to be /usr/lib64 if it exists.
some x86_64 distros, like ubuntu and debian, the default x86_64 libs(gnu-efi)
are installed into /usr/lib while /usr/lib64 is for i386
~/workspace$ dpkg -L gnu-efi | grep elf_x86_64_efi.lds
/usr/lib/elf_x86_64_efi.lds

~/workspace$ dpkg -S /usr/lib64
libc6-amd64:i386: /usr/lib64

so it failed to compile efi perviously as following errors:
-----------------
ld: cannot open linker script file /usr/lib64/elf_x86_64_efi.lds: No such file or directory
Makefile:102: recipe for target '/home/lizj/workspace/acrn-hypervisor/build/hypervisor/bsp/uefi/efi/boot.so' failed
make[2]: *** [/home/lizj/workspace/acrn-hypervisor/build/hypervisor/bsp/uefi/efi/boot.so] Error 1
make[2]: Leaving directory '/home/lizj/workspace/acrn-hypervisor/hypervisor/bsp/uefi/efi'
Makefile:191: recipe for target 'efi' failed
make[1]: *** [efi] Error 2
-----------------

v2: addressed Geoffroy's comments

Acked-by: "VanCutsem, Geoffroy" <geoffroy.vancutsem@intel.com>
Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>