### PR TITLE
 fix "negative shift" 

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -59,7 +59,7 @@ int ibrs_type;
 inline bool cpu_has_cap(uint32_t bit)
 {
 	int feat_idx = bit >> 5;
-	int feat_bit = bit & 0x1fU;
+	uint32_t feat_bit = bit & 0x1fU;
 
 	if (feat_idx >= FEATURE_WORDS)
 		return false;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -127,7 +127,8 @@ enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu)
 static int _gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_info,
 	uint64_t gva, uint64_t *gpa, uint32_t *err_code)
 {
-	int i, index, shift;
+	int i, index;
+	uint32_t shift;
 	uint8_t *base;
 	uint64_t entry;
 	uint64_t addr, page_size;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -18,7 +18,7 @@ struct e820_mem_params e820_mem;
 struct page_walk_info {
 	uint64_t top_entry;	/* Top level paging structure entry */
 	int level;
-	int width;
+	uint32_t width;
 	bool is_user_mode;
 	bool is_write_access;
 	bool is_inst_fetch;

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1407,7 +1407,8 @@ emulate_bittest(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 		void *memarg)
 {
 	uint64_t val, rflags;
-	int error, bitmask, bitoff;
+	int error, bitmask;
+	uint32_t  bitoff;
 
 	/*
 	 * 0F BA is a Group 8 extended opcode.

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -223,8 +223,8 @@ vioapic_update_tmr(struct vcpu *vcpu)
 static uint32_t
 vioapic_read(struct vioapic *vioapic, uint32_t addr)
 {
-	uint32_t regnum;
-	int pin, rshift;
+	uint32_t regnum, rshift;
+	int pin;
 
 	regnum = addr & 0xffU;
 	switch (regnum) {
@@ -291,8 +291,8 @@ vioapic_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 {
 	uint64_t data64, mask64;
 	uint64_t last, new, changed;
-	uint32_t regnum;
-	int pin, lshift;
+	uint32_t regnum, lshift;
+	int pin;
 
 	regnum = addr & 0xffUL;
 	switch (regnum) {

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -712,8 +712,9 @@ vlapic_update_ppr(struct vlapic *vlapic)
 
 	/* update ppr */
 	{
-		int i, lastprio, curprio, vector, idx;
+		int i, lastprio, curprio, idx;
 		struct lapic_reg *isrptr;
+		uint32_t vector;
 
 		if (vlapic->isrvec_stk_top == 0 && isrvec != 0)
 			panic("isrvec_stk is corrupted: %d", isrvec);
@@ -738,9 +739,9 @@ vlapic_update_ppr(struct vlapic *vlapic)
 		 */
 		i = 1;
 		isrptr = &vlapic->apic_page->isr[0];
-		for (vector = 0; vector < 256; vector++) {
-			idx = vector / 32;
-			if ((isrptr[idx].val & (1U << (vector % 32))) != 0U) {
+		for (vector = 0U; vector < 256U; vector++) {
+			idx = vector / 32U;
+			if ((isrptr[idx].val & (1U << (vector % 32U))) != 0U) {
 				if ((i > vlapic->isrvec_stk_top) ||
 					((i < ISRVEC_STK_SIZE) &&
 					(vlapic->isrvec_stk[i] != vector))) {

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -191,7 +191,7 @@ create_rte_for_gsi_irq(uint32_t irq, uint32_t vr)
 	rte.lo_32 |= IOAPIC_RTE_INTALO;
 
 	/* Dest field */
-	rte.hi_32 |= ALL_CPUS_MASK << 24;
+	rte.hi_32 |= ALL_CPUS_MASK << 24U;
 
 	return rte;
 }

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -472,9 +472,9 @@ static struct dmar_drhd_rt *device_to_dmaru(uint16_t segment, uint8_t bus,
 	return NULL;
 }
 
-static int alloc_domain_id(void)
+static uint8_t alloc_domain_id(void)
 {
-	int i;
+	uint8_t i;
 	uint64_t mask;
 
 	spinlock_obtain(&domain_lock);
@@ -492,7 +492,7 @@ static int alloc_domain_id(void)
 	return i;
 }
 
-static void free_domain_id(int dom_id)
+static void free_domain_id(uint16_t dom_id)
 {
 	uint64_t mask = (1 << dom_id);
 

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -66,7 +66,7 @@
 #define iommu_cap_plmr(c)     (((c) >> 5) & 1UL)
 #define iommu_cap_rwbf(c)     (((c) >> 4) & 1UL)
 #define iommu_cap_afl(c)      (((c) >> 3) & 1UL)
-#define iommu_cap_ndoms(c)        (((unsigned long)1) << (4 + 2 * ((c) & 0x7UL)))
+#define iommu_cap_ndoms(c)        ((1U) << (4U + 2U * ((c) & 0x7U)))
 
 /*
  * Decoding Extended Capability Register


### PR DESCRIPTION
MISRA C doesn't allowed negative shift, changed any potential signed value
to unsigned value.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>