### PR TITLE
hv mmu & ept revisit

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -478,6 +478,12 @@ int ept_mmap(struct vm *vm, uint64_t hpa,
 	}
 
 	if (type == MAP_MEM || type == MAP_MMIO) {
+		/* EPT & VT-d share the same page tables, set SNP bit
+		 * to force snooping of PCIe devices if the page
+		 * is cachable
+		 */
+		if ((prot & IA32E_EPT_MT_MASK) != IA32E_EPT_UNCACHED)
+			prot |= IA32E_EPT_SNOOP_CTRL;
 		map_mem(&map_params, (void *)hpa,
 			(void *)gpa, size, prot);
 

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -234,7 +234,14 @@ int register_mmio_emulation_handler(struct vm *vm,
 
 			mmio_node->range_start = start;
 			mmio_node->range_end = end;
-			ept_mmap(vm, start, start, end - start,
+
+			/*
+			 * SOS would map all its memory at beginning, so we
+			 * should unmap it. But UOS will not, so we shouldn't
+			 * need to unmap it.
+			 */
+			if (is_vm0(vm))
+				ept_mmap(vm, start, start, end - start,
 					MAP_UNMAP, 0);
 
 			/* Return success */

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -553,14 +553,14 @@ static void rebuild_vm0_e820(void)
 int prepare_vm0_memmap_and_e820(struct vm *vm)
 {
 	unsigned int i;
-	uint32_t attr_wb = (MMU_MEM_ATTR_READ |
-			MMU_MEM_ATTR_WRITE   |
-			MMU_MEM_ATTR_EXECUTE |
-			MMU_MEM_ATTR_WB_CACHE);
-	uint32_t attr_uc = (MMU_MEM_ATTR_READ |
-			MMU_MEM_ATTR_WRITE   |
-			MMU_MEM_ATTR_EXECUTE |
-			MMU_MEM_ATTR_UNCACHED);
+	uint32_t attr_wb = (IA32E_EPT_R_BIT |
+				IA32E_EPT_W_BIT |
+				IA32E_EPT_X_BIT |
+				IA32E_EPT_WB);
+	uint32_t attr_uc = (IA32E_EPT_R_BIT |
+				IA32E_EPT_W_BIT |
+				IA32E_EPT_X_BIT |
+				IA32E_EPT_UNCACHED);
 	struct e820_entry *entry;
 
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2030,8 +2030,8 @@ int vlapic_create(struct vcpu *vcpu)
 			ept_mmap(vcpu->vm,
 				apicv_get_apic_access_addr(vcpu->vm),
 				DEFAULT_APIC_BASE, CPU_PAGE_SIZE, MAP_MMIO,
-				MMU_MEM_ATTR_WRITE | MMU_MEM_ATTR_READ |
-				MMU_MEM_ATTR_UNCACHED);
+				IA32E_EPT_W_BIT | IA32E_EPT_R_BIT |
+				IA32E_EPT_UNCACHED);
 		}
 	} else {
 		/*No APICv support*/

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -138,20 +138,20 @@ static uint32_t update_ept(struct vm *vm, uint64_t start,
 
 	switch (type) {
 	case MTRR_MEM_TYPE_WC:
-		attr = MMU_MEM_ATTR_WC;
+		attr = IA32E_EPT_WC;
 		break;
 	case MTRR_MEM_TYPE_WT:
-		attr = MMU_MEM_ATTR_WT_CACHE;
+		attr = IA32E_EPT_WT;
 		break;
 	case MTRR_MEM_TYPE_WP:
-		attr = MMU_MEM_ATTR_WP;
+		attr = IA32E_EPT_WP;
 		break;
 	case MTRR_MEM_TYPE_WB:
-		attr = MMU_MEM_ATTR_WB_CACHE;
+		attr = IA32E_EPT_WB;
 		break;
 	case MTRR_MEM_TYPE_UC:
 	default:
-		attr = MMU_MEM_ATTR_UNCACHED;
+		attr = IA32E_EPT_UNCACHED;
 	}
 
 	ept_update_mt(vm, gpa2hpa(vm, start), start, size, attr);

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -117,10 +117,10 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	map_params.pml4_base = pml4_base;
 	map_mem(&map_params, (void *)hpa,
 			(void *)gpa_rebased, size,
-			(MMU_MEM_ATTR_READ |
-			 MMU_MEM_ATTR_WRITE |
-			 MMU_MEM_ATTR_EXECUTE |
-			 MMU_MEM_ATTR_WB_CACHE));
+			(IA32E_EPT_R_BIT |
+			 IA32E_EPT_W_BIT |
+			 IA32E_EPT_X_BIT |
+			 IA32E_EPT_WB));
 
 	/* Unmap trusty memory space from sos ept mapping*/
 	map_params.pml4_base = HPA2HVA(vm0->arch_vm.nworld_eptp);
@@ -166,10 +166,10 @@ void  destroy_secure_world(struct vm *vm)
 	map_mem(&map_params, (void *)vm->sworld_control.sworld_memory.base_hpa,
 			(void *)vm->sworld_control.sworld_memory.base_gpa,
 			vm->sworld_control.sworld_memory.length,
-			(MMU_MEM_ATTR_READ |
-			 MMU_MEM_ATTR_WRITE |
-			 MMU_MEM_ATTR_EXECUTE |
-			 MMU_MEM_ATTR_WB_CACHE));
+			(IA32E_EPT_R_BIT |
+			 IA32E_EPT_W_BIT |
+			 IA32E_EPT_X_BIT |
+			 IA32E_EPT_WB));
 
 }
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -419,23 +419,21 @@ int64_t _set_vm_memmap(struct vm *vm, struct vm *target_vm,
 	if (memmap->type != MAP_UNMAP) {
 		prot = (memmap->prot != 0) ? memmap->prot : memmap->prot_2;
 		if ((prot & MEM_ACCESS_READ) != 0U)
-			attr |= MMU_MEM_ATTR_READ;
+			attr |= IA32E_EPT_R_BIT;
 		if ((prot & MEM_ACCESS_WRITE) != 0U)
-			attr |= MMU_MEM_ATTR_WRITE;
+			attr |= IA32E_EPT_W_BIT;
 		if ((prot & MEM_ACCESS_EXEC) != 0U)
-			attr |= MMU_MEM_ATTR_EXECUTE;
+			attr |= IA32E_EPT_X_BIT;
 		if ((prot & MEM_TYPE_WB) != 0U)
-			attr |= MMU_MEM_ATTR_WB_CACHE;
+			attr |= IA32E_EPT_WB;
 		else if ((prot & MEM_TYPE_WT) != 0U)
-			attr |= MMU_MEM_ATTR_WT_CACHE;
-		else if ((prot & MEM_TYPE_UC) != 0U)
-			attr |= MMU_MEM_ATTR_UNCACHED;
+			attr |= IA32E_EPT_WT;
 		else if ((prot & MEM_TYPE_WC) != 0U)
-			attr |= MMU_MEM_ATTR_WC;
+			attr |= IA32E_EPT_WC;
 		else if ((prot & MEM_TYPE_WP) != 0U)
-			attr |= MMU_MEM_ATTR_WP;
+			attr |= IA32E_EPT_WP;
 		else
-			attr |= MMU_MEM_ATTR_UNCACHED;
+			attr |= IA32E_EPT_UNCACHED;
 	}
 
 	/* create gpa to hpa EPT mapping */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -183,17 +183,6 @@
  * and only one of the MMU_MEM_ATTR_TYPE_xxx definitions
  */
 
-/* Generic memory attributes */
-#define     MMU_MEM_ATTR_READ                   0x00000001U
-#define     MMU_MEM_ATTR_WRITE                  0x00000002U
-#define     MMU_MEM_ATTR_EXECUTE                0x00000004U
-#define     MMU_MEM_ATTR_USER                   0x00000008U
-#define     MMU_MEM_ATTR_WB_CACHE               0x00000040U
-#define     MMU_MEM_ATTR_WT_CACHE               0x00000080U
-#define     MMU_MEM_ATTR_UNCACHED               0x00000100U
-#define     MMU_MEM_ATTR_WC                     0x00000200U
-#define     MMU_MEM_ATTR_WP                     0x00000400U
-
 /* Definitions for memory types related to x64 */
 #define     MMU_MEM_ATTR_BIT_READ_WRITE         IA32E_COMM_RW_BIT
 #define     MMU_MEM_ATTR_BIT_USER_ACCESSIBLE    IA32E_COMM_US_BIT


### PR DESCRIPTION
v1-v2:
1. minor fix when mask EPT cache type.

v1:
Now the hv mmu & ept map/unmap/modify logic is not clear. Map may map
mapped page tables; unmap may unmap non-mapped or unmapped page tables;
modify may modify gfn to mfn mapping besides page table attributes or
modify non-mapped page table.
We want to change this. Let's set some rules first:
1. map can only map unmapped page tables
2. unmap can only unmap mapped page tables;
3. modify can only modify mapped page tables' attributes.

Besides, we want to move configure page table attributes outsides internal
implement logic.

This patch is the serial one.
After this serial, we can achieve:
1. We would not unmap unmap non-mapped or unmapped page tables;
2. set page tables attributes at frist before call internal implement function.

Next will
1. remove cma support in the dm & sos vhm
2. remove MAP_MMIO in sos vhm then remove MAP_MMIO in hv
3. add MAP_MODIFY in hv then add MAP_MODIFY in sos vhm
4. apply rules list above in hv
