### PR TITLE
hv: refine the address used in sbl multiboot code

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -415,13 +415,14 @@ void init_e820(void)
 	unsigned int i;
 
 	if (boot_regs[0] == MULTIBOOT_INFO_MAGIC) {
-		struct multiboot_info *mbi =
-			(struct multiboot_info *)((uint64_t)boot_regs[1]);
+		struct multiboot_info *mbi = (struct multiboot_info *)
+			(HPA2HVA((uint64_t)boot_regs[1]));
+
 		pr_info("Multiboot info detected\n");
 		if ((mbi->mi_flags & 0x40U) != 0U) {
 			struct multiboot_mmap *mmap =
 				(struct multiboot_mmap *)
-				((uint64_t)mbi->mi_mmap_addr);
+				HPA2HVA((uint64_t)mbi->mi_mmap_addr);
 			e820_entries = mbi->mi_mmap_length/
 				sizeof(struct multiboot_mmap);
 			if (e820_entries > E820_MAX_ENTRIES) {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -30,21 +30,21 @@ struct vm_hw_info {
 };
 
 struct sw_linux {
-	void *ramdisk_src_addr;
-	void *ramdisk_load_addr;
+	void *ramdisk_src_addr;		/* HVA */
+	void *ramdisk_load_addr;	/* GPA */
 	uint32_t ramdisk_size;
-	void *bootargs_src_addr;
-	void *bootargs_load_addr;
+	void *bootargs_src_addr;	/* HVA */
+	void *bootargs_load_addr;	/* GPA */
 	uint32_t bootargs_size;
-	void *dtb_src_addr;
-	void *dtb_load_addr;
+	void *dtb_src_addr;		/* HVA */
+	void *dtb_load_addr;		/* GPA */
 	uint32_t dtb_size;
 };
 
 struct sw_kernel_info {
-	void *kernel_src_addr;
-	void *kernel_load_addr;
-	void *kernel_entry_addr;
+	void *kernel_src_addr;		/* HVA */
+	void *kernel_load_addr;		/* GPA */
+	void *kernel_entry_addr;	/* GPA */
 	uint32_t kernel_size;
 };
 

--- a/hypervisor/include/hypervisor.h
+++ b/hypervisor/include/hypervisor.h
@@ -34,6 +34,7 @@
 #define HVA2HPA(x) ((uint64_t)(x))
 /* gpa --> hpa -->hva */
 #define GPA2HVA(vm, x) HPA2HVA(gpa2hpa(vm, x))
+#define HVA2GPA(vm, x) hpa2gpa(vm, HVA2HPA(x))
 #endif	/* !ASSEMBLER */
 
 #endif /* HYPERVISOR_H */


### PR DESCRIPTION
Update the structure definition to define the address type
(HVA vs HPA vs GPA) explicitly.

Convert address to HVA before access the GPA/HPA type of address.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>