### PR TITLE
hv mmu & ept revisit serial 2

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -829,7 +829,7 @@ main(int argc, char *argv[])
 		}
 
 		vm_set_memflags(ctx, memflags);
-		err = vm_setup_memory(ctx, memsize, VM_MMAP_ALL);
+		err = vm_setup_memory(ctx, memsize);
 		if (err) {
 			fprintf(stderr, "Unable to setup memory (%d)\n", errno);
 			goto fail;

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -385,8 +385,7 @@ vm_setup_memory(struct vmctx *ctx, size_t memsize, enum vm_mmap_style vms)
 		objsize = ctx->lowmem;
 	}
 
-	if (hugetlb)
-		return hugetlb_setup_memory(ctx);
+	return hugetlb_setup_memory(ctx);
 
 	/*
 	 * Stake out a contiguous region covering the guest physical memory
@@ -431,10 +430,8 @@ vm_setup_memory(struct vmctx *ctx, size_t memsize, enum vm_mmap_style vms)
 void
 vm_unsetup_memory(struct vmctx *ctx)
 {
-	if (hugetlb) {
-		hugetlb_unsetup_memory(ctx);
-		return;
-	}
+	hugetlb_unsetup_memory(ctx);
+	return;
 
 	if (ctx->lowmem > 0)
 		munmap(ctx->mmap_lowmem, ctx->lowmem);

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -90,6 +90,7 @@
 
 /* Guest memory management */
 #define IC_ID_MEM_BASE                  0x40UL
+/* IC_ALLOC_MEMSEG not used */
 #define IC_ALLOC_MEMSEG                 _IC_ID(IC_ID, IC_ID_MEM_BASE + 0x00)
 #define IC_SET_MEMSEG                   _IC_ID(IC_ID, IC_ID_MEM_BASE + 0x01)
 
@@ -104,17 +105,6 @@
 /* Power management */
 #define IC_ID_PM_BASE                   0x60UL
 #define IC_PM_GET_CPU_STATE            _IC_ID(IC_ID, IC_ID_PM_BASE + 0x00)
-
-/**
- * struct vm_memseg - memory segment info for guest
- *
- * @len: length of memory segment
- * @gpa: guest physical start address of memory segment
- */
-struct vm_memseg {
-	uint64_t len;
-	uint64_t gpa;
-};
 
 #define VM_MEMMAP_SYSMEM       0
 #define VM_MMIO         1

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -159,6 +159,4 @@ int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
 int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
-
-extern bool hugetlb;
 #endif	/* _VMMAPI_H_ */

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -53,8 +53,6 @@ struct vmctx {
 	int     memflags;
 	size_t  lowmem;
 	size_t  highmem;
-	char    *mmap_lowmem;
-	char    *mmap_highmem;
 	char    *baseaddr;
 	char    *name;
 	uuid_t	vm_uuid;
@@ -63,16 +61,6 @@ struct vmctx {
 	void *atkbdc_base;
 	void *vrtc;
 	void *ioc_dev;
-};
-
-/*
- * Different styles of mapping the memory assigned to a VM into the address
- * space of the controlling process.
- */
-enum vm_mmap_style {
-	VM_MMAP_NONE,		/* no mapping */
-	VM_MMAP_ALL,		/* fully and statically mapped */
-	VM_MMAP_SPARSE,		/* mappings created on-demand */
 };
 
 /*
@@ -122,7 +110,7 @@ void	vm_destroy(struct vmctx *ctx);
 int	vm_parse_memsize(const char *optarg, size_t *memsize);
 int	vm_map_memseg_vma(struct vmctx *ctx, size_t len, vm_paddr_t gpa,
 	uint64_t vma, int prot);
-int	vm_setup_memory(struct vmctx *ctx, size_t len, enum vm_mmap_style s);
+int	vm_setup_memory(struct vmctx *ctx, size_t len);
 void	vm_unsetup_memory(struct vmctx *ctx);
 bool	check_hugetlb_support(void);
 int	hugetlb_setup_memory(struct vmctx *ctx);

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -107,7 +107,7 @@ else
 fi
 
 
-acrn-dm -T -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
   -s 8,wdt-i6300esb \
@@ -274,7 +274,7 @@ else
   GVT_args=''
 fi
 
- acrn-dm -T -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
    -l com1,stdio \
    -s 9,virtio-net,$tap \
    -s 3,virtio-blk$boot_dev_flag,/data/$5/$5.img \

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -19,7 +19,7 @@ mem_size=1000M
 # make sure there is enough 2M hugepages in the pool
 echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 
-acrn-dm -T -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -330,38 +330,26 @@ Set up Reference UOS
 Device Manager memory allocation mechanism
 ==========================================
 
-There are two Device Manager memory allocation mechanisms available:
+The ACRN Device Manager (DM) virtual memory allocation uses the HugeTLB mechanism.
+(You can read more about `HugeTLB in the linux kernel <https://linuxgazette.net/155/krishnakumar.html>`_
+for more information about how this mechanism works.)
 
-- Contiguous Memory Allocator (CMA), and 
-- Huge Page Tables (HugeTLB).  HugeTLB is the default.
+For hugeTLB to work, you'll need to reserve huge pages:
 
-To choose CMA, do the following:
+  - For a (large) 1GB huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
+    (for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in
+    ``acrn.conf`` (for EFI)
 
-1) Add ``cma=reserved_mem_size@recommend_memory_offset-0``, (for example
-   ``cma=2560M@0x100000000-0``) to the SOS cmdline in ``acrn.conf``
+  - For a (smaller) 2MB huge page reservation, after the SOS starts up, run the
+    command::
 
-2) Start ``acrn-dm`` *without* the ``-T`` option
+       echo reserved_pg_num > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 
-To support HugeTLB, do the following:
-
-1) Do huge page reservation
-
-   - For 1G huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
-     (for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in
-     ``acrn.conf`` (for EFI)
-
-   - For 2M huge page reservation, after the SOS starts up, run the
-     command::
-
-        echo reserved_pg_num > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
-
-   .. note::
-      You can use 2M reserving method to do reservation for 1G page size, but it
-      may fail.  For an EFI platform, you may skip 1G page reservation
-      by using a 2M page, but make sure your huge page reservation size is
-      large enough for your usage.
-
-2)  Start ``acrn-dm`` *with* the ``-T`` option.
+  .. note::
+     You can use 2M reserving method to do reservation for 1G page size, but it
+     may fail.  For an EFI platform, you may skip 1G page reservation
+     by using a 2M page, but make sure your huge page reservation size is
+     large enough for your usage.
 
 Build ACRN from Source
 **********************


### PR DESCRIPTION
v1-v2:
1. remove how to support cma document.
2. remove sample script about how to use hugetlb by default 
3. remove git commit changed-id

v1:
Now the hv mmu & ept map/unmap/modify logic is not clear. Map may map 
mapped page tables; unmap may unmap non-mapped or unmapped page tables;
modify may modify gfn to mfn mapping besides page table attributes or
modify non-mapped page table.
We want to change this. Let's set some rules first:
1. map can only map unmapped page tables
2. unmap can only unmap mapped page tables;
3. modify can only modify mapped page tables' attributes.

Besides, we want to move configure page table attributes outsides internal
implement logic.

This patch is the serial two 1st half.
After this serial, we can achieve:
1. emove cma support in the dm;

Note:
We should remove the "-T" option in script for launch UOS.

Next will
1. remove cma support in the dm vhm
2. remove MAP_MMIO in sos vhm then remove MAP_MMIO in hv
3. add MAP_MODIFY in hv then add MAP_MODIFY in sos vhm
4. apply rules list above in hv
