### PR TITLE
HV: treewide: fix C-style unsigned constants in assembly

### DIFF
--- a/hypervisor/arch/x86/cpu_primary.S
+++ b/hypervisor/arch/x86/cpu_primary.S
@@ -10,6 +10,23 @@
 #include        <idt.h>
 #include        <msr.h>
 
+/* NOTE:
+ *
+ * MISRA C requires that all unsigned constants should have the suffix 'U'
+ * (e.g. 0xffU), but the assembler may not accept such C-style constants. For
+ * example, binutils 2.26 fails to compile assembly in that case. To work this
+ * around, all unsigned constants must be explicitly spells out in assembly
+ * with a comment tracking the original expression from which the magic
+ * number is calculated. As an example:
+ *
+ *    /* 0x00000668 =
+ *     *    (CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT) *\/
+ *    movl    $0x00000668, %eax
+ *
+ * Make sure that these numbers are updated accordingly if the definition of
+ * the macros involved are changed.
+ */
+
 /* MULTIBOOT HEADER */
 #define MULTIBOOT_HEADER_MAGIC 0x1badb002
 #define MULTIBOOT_HEADER_FLAGS 0x00000002 /*flags bit 1 : enable mem_*, mmap_**/
@@ -42,10 +59,14 @@ cpu_primary_start_32:
     movl    %eax, %esp
     movl    %ebx, %ebp
 
-    /* detect whether it is in long mode */
-    movl    $MSR_IA32_EFER, %ecx
+    /* detect whether it is in long mode
+     *
+     *     0xc0000080 = MSR_IA32_EFER
+     */
+    movl    $0xc0000080, %ecx
     rdmsr
-    test     $MSR_IA32_EFER_LMA_BIT, %eax
+    /* 0x400 = MSR_IA32_EFER_LMA_BIT */
+    test     $0x400, %eax
 
     /* jump to 64bit entry if it is already in long mode */
     jne      cpu_primary_start_64
@@ -56,11 +77,14 @@ cpu_primary_start_32:
 
     /* Disable paging */
     mov     %cr0, %ebx
-    andl    $~CR0_PG, %ebx
+    /* 0x7fffffff = ~CR0_PG */
+    andl    $0x7fffffff, %ebx
     mov     %ebx, %cr0
 
-    /* Set DE, PAE, MCE and OS support bits in CR4 */
-    movl    $(CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT), %eax
+    /* Set DE, PAE, MCE and OS support bits in CR4
+     * 0x00000668 =
+     *    (CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT) */
+    movl    $0x00000668, %eax
     mov     %eax, %cr4
 
     /* Set CR3 to PML4 table address */
@@ -68,15 +92,19 @@ cpu_primary_start_32:
     mov     %edi, %cr3
 
     /* Set LME bit in EFER */
-    movl    $MSR_IA32_EFER, %ecx
+
+    /* 0xc0000080 = MSR_IA32_EFER */
+    movl    $0xc0000080, %ecx
     rdmsr
-    orl     $MSR_IA32_EFER_LME_BIT, %eax
+    /* 0x00000100 = MSR_IA32_EFER_LME_BIT */
+    orl     $0x00000100, %eax
     wrmsr
 
     /* Enable paging, protection, numeric error and co-processor
        monitoring in CR0 to enter long mode */
     mov     %cr0, %ebx
-    orl     $(CR0_PG | CR0_PE | CR0_MP | CR0_NE), %ebx
+    /* 0x80000023 = (CR0_PG | CR0_PE | CR0_MP | CR0_NE) */
+    orl     $0x80000023, %ebx
     mov     %ebx, %cr0
 
     /* Load temportary GDT pointer value */
@@ -134,7 +162,8 @@ after:
     /* Initialize temporary stack pointer */
     movq    $_ld_bss_end, %rsp
     add     $CPU_PAGE_SIZE,%rsp
-    and     $(~(CPU_STACK_ALIGN - 1)),%rsp
+    /* 16 = CPU_STACK_ALIGN */
+    and     $(~(16 - 1)),%rsp
 
     // load all selector registers with appropriate values
     xor     %edx, %edx
@@ -146,8 +175,11 @@ after:
     mov     %edx,%fs  // Was 32bit POC Data
     mov     %edx,%gs  // Was 32bit POC CLS
 
-   /* Push sp magic to top of stack for call trace */
-   pushq   $SP_BOTTOM_MAGIC
+   /* Push sp magic to top of stack for call trace
+    *
+    *     0x696e746c = SP_BOTTOM_MAGIC
+    */
+   pushq   $0x696e746c
    /* continue with chipset level initialization */
    call     bsp_boot_init
 
@@ -178,20 +210,21 @@ cpu_primary32_gdt_ptr:
     .align  CPU_PAGE_SIZE
     .global cpu_boot32_page_tables_start
 cpu_boot32_page_tables_start:
-    .quad   cpu_primary32_pdpt_addr + (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
+    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    .quad   cpu_primary32_pdpt_addr + 0x3
     .align  CPU_PAGE_SIZE
 cpu_primary32_pdpt_addr:
     address = 0
     .rept   4
-    .quad   cpu_primary32_pdt_addr + address + \
-                                        (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
+    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    .quad   cpu_primary32_pdt_addr + address + 0x3
     address = address + CPU_PAGE_SIZE
     .endr
     .align  CPU_PAGE_SIZE
 cpu_primary32_pdt_addr:
     address = 0
     .rept  2048
-    .quad  address + (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
+    /* 0x83 = (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    .quad  address + 0x83
     address = address + 0x200000
     .endr
-

--- a/hypervisor/arch/x86/trampoline.S
+++ b/hypervisor/arch/x86/trampoline.S
@@ -20,6 +20,22 @@
 #include        <mmu.h>
 #include        <msr.h>
 
+/* NOTE:
+ *
+ * MISRA C requires that all unsigned constants should have the suffix 'U'
+ * (e.g. 0xffU), but the assembler may not accept such C-style constants. For
+ * example, binutils 2.26 fails to compile assembly in that case. To work this
+ * around, all unsigned constants must be explicitly spells out in assembly
+ * with a comment tracking the original expression from which the magic
+ * number is calculated. As an example:
+ *
+ *    /* 0x00000668 =
+ *     *    (CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT) *\/
+ *    movl    $0x00000668, %eax
+ *
+ * Make sure that these numbers are updated accordingly if the definition of
+ * the macros involved are changed.
+ */
 
     .extern     cpu_secondary_init
     .extern     cpu_logical_id
@@ -78,7 +94,9 @@ trampoline_fixup_target:
 
     /* Set DE, PAE, MCE and OS support bits in CR4 */
 
-    movl    $(CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT), %eax
+    /* 0x00000668 =
+     *    (CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT) */
+    movl    $0x00000668, %eax
     mov     %eax, %cr4
 
     /* Set CR3 to PML4 table address */
@@ -89,16 +107,19 @@ trampoline_fixup_target:
 
     /* Set LME bit in EFER */
 
-    movl    $MSR_IA32_EFER, %ecx
+    /* 0xc0000080 = MSR_IA32_EFER */
+    movl    $0xc0000080, %ecx
     rdmsr
-    orl     $MSR_IA32_EFER_LME_BIT, %eax
+    /* 0x00000100 = MSR_IA32_EFER_LME_BIT */
+    orl     $0x00000100, %eax
     wrmsr
 
     /* Enable paging, protection, numeric error and co-processor
        monitoring in CR0 to enter long mode */
 
     mov     %cr0, %ebx
-    orl     $(CR0_PG | CR0_PE | CR0_MP | CR0_NE), %ebx
+    /* 0x80000023 = (CR0_PG | CR0_PE | CR0_MP | CR0_NE) */
+    orl     $0x80000023, %ebx
     mov     %ebx, %cr0
 
     /* Load temportary GDT pointer value */
@@ -142,8 +163,11 @@ trampoline_start64:
 
     lea     trampoline_pdpt_addr(%rip), %rsp
 
-    /* Push sp magic to top of stack for call trace */
-    pushq   $SP_BOTTOM_MAGIC
+    /* Push sp magic to top of stack for call trace
+     *
+     *     0x696e746c = SP_BOTTOM_MAGIC
+     */
+    pushq   $0x696e746c
 
     /* Jump to C entry */
     movq    main_entry(%rip), %rax
@@ -180,21 +204,23 @@ CPU_Boot_Page_Tables_ptr:
     .align  CPU_PAGE_SIZE
     .global CPU_Boot_Page_Tables_Start
 CPU_Boot_Page_Tables_Start:
-    .quad   trampoline_pdpt_addr + (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
+    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    .quad   trampoline_pdpt_addr + 0x3
     .align  CPU_PAGE_SIZE
     .global trampoline_pdpt_addr
 trampoline_pdpt_addr:
     address = 0
     .rept   4
-    .quad   trampoline_pdt_addr + address + \
-                                        (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
+    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    .quad   trampoline_pdt_addr + address + 0x3
     address = address + CPU_PAGE_SIZE
     .endr
     .align  CPU_PAGE_SIZE
 trampoline_pdt_addr:
     address = 0
     .rept  2048
-    .quad  address + (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT)
+    /* 0x83 = (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    .quad  address + 0x83
     address = address + 0x200000
     .endr
 

--- a/hypervisor/arch/x86/vmx_asm.S
+++ b/hypervisor/arch/x86/vmx_asm.S
@@ -11,6 +11,23 @@
 #include <cpu.h>
 #include <types.h>
 
+/* NOTE:
+ *
+ * MISRA C requires that all unsigned constants should have the suffix 'U'
+ * (e.g. 0xffU), but the assembler may not accept such C-style constants. For
+ * example, binutils 2.26 fails to compile assembly in that case. To work this
+ * around, all unsigned constants must be explicitly spells out in assembly
+ * with a comment tracking the original expression from which the magic
+ * number is calculated. As an example:
+ *
+ *    /* 0x00000668 =
+ *     *    (CR4_DE | CR4_PAE | CR4_MCE | CR4_OSFXSR | CR4_OSXMMEXCPT) *\/
+ *    movl    $0x00000668, %eax
+ *
+ * Make sure that these numbers are updated accordingly if the definition of
+ * the macros involved are changed.
+ */
+
     .text
 
 /*int vmx_vmrun(struct run_context *context, int launch, int ibrs_type) */
@@ -40,15 +57,19 @@ vmx_vmrun:
     cmp         $IBRS_NONE,%rdx
     je          next
 
-    movl        $MSR_IA32_SPEC_CTRL,%ecx
+    /* 0x00000048 = MSR_IA32_SPEC_CTRL */
+    movl        $0x00000048,%ecx
     mov         VMX_MACHINE_T_GUEST_SPEC_CTRL_OFFSET(%rdi),%rax
     movl        $0,%edx
     wrmsr
 
 next:
 
-    /* Load VMCS_HOST_RSP_FIELD field value */
-    mov         $VMX_HOST_RSP,%rdx
+    /* Load VMCS_HOST_RSP_FIELD field value
+     *
+     *     0x00006c14 = VMX_HOST_RSP
+     */
+    mov         $0x00006c14,%rdx
 
     /* Write the current stack pointer to the VMCS_HOST_RSP_FIELD */
     vmwrite     %rsp,%rdx
@@ -165,11 +186,15 @@ vm_eval_error:
     cmp         $IBRS_OPT,%rdx
     je          ibrs_opt
 
-    /* Save guest MSR SPEC_CTRL, low 32 bit is enough */
-    movl        $MSR_IA32_SPEC_CTRL,%ecx
+    /* Save guest MSR SPEC_CTRL, low 32 bit is enough
+     *
+     *     0x00000048 = MSR_IA32_SPEC_CTRL
+     */
+    movl        $0x00000048,%ecx
     rdmsr
     mov         %rax,VMX_MACHINE_T_GUEST_SPEC_CTRL_OFFSET(%rsi)
-    movl        $SPEC_ENABLE_IBRS,%eax
+    /* 0x1 = SPEC_ENABLE_IBRS */
+    movl        $0x1,%eax
     movl        $0,%edx
     wrmsr
 
@@ -177,16 +202,22 @@ vm_eval_error:
 
 ibrs_opt:
 
-    movl        $MSR_IA32_PRED_CMD,%ecx
-    movl        $PRED_SET_IBPB,%eax
+    /* 0x00000049 = MSR_IA32_PRED_CMD */
+    movl        $0x00000049,%ecx
+    /* 0x1 = PRED_SET_IBPB */
+    movl        $0x1,%eax
     movl        $0,%edx
     wrmsr
 
-    /* Save guest MSR SPEC_CTRL, low 32 bit is enough */
-    movl        $MSR_IA32_SPEC_CTRL,%ecx
+    /* Save guest MSR SPEC_CTRL, low 32 bit is enough
+     *
+     *     0x00000048 = MSR_IA32_SPEC_CTRL
+     */
+    movl        $0x00000048,%ecx
     rdmsr
     mov         %rax,VMX_MACHINE_T_GUEST_SPEC_CTRL_OFFSET(%rsi)
-    movl        $SPEC_ENABLE_STIBP,%eax
+    /* 0x2 = SPEC_ENABLE_STIBP */
+    movl        $0x2,%eax
     movl        $0,%edx
     wrmsr
 
@@ -221,4 +252,3 @@ stuff_rsb:
 vm_return:
     /* Return to caller */
     ret
-


### PR DESCRIPTION
MISRA C requires that unsigned constants should have the 'U' suffix, while this
C syntax is not accepted by binutils assembler per binutil manual.

This patch explicitly spells out the unsigned constants used in the assembly
files while tracking the original expressions in comments. This fixes build
failure when using binutils <= 2.26.

This patch fixes #480.

v2 -> v3:

    * Explicitly spell out the unsigned constants in assembly, instead of
      duplicating the macros in headers which break the integrity of the
      definitions.

v1 -> v2:

    * Define different macros instead of wrapping all unsigned constants.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>