### PR TITLE
hv: Makefile flags initialization

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -19,6 +19,15 @@ BASEDIR := $(shell pwd)
 HV_OBJDIR ?= $(CURDIR)/build
 HV_FILE := acrn
 
+# initialize the flags we used
+CFLAGS :=
+ASFLAGS :=
+LDFLAGS :=
+ARCH_CFLAGS :=
+ARCH_ASFLAGS :=
+ARCH_ARFLAGS :=
+ARCH_LDFLAGS :=
+
 .PHONY: default
 default: all
 


### PR DESCRIPTION
For hypervisor, we initliaze the flags used in build command
to empty to avoid flags set in default env impact to hypervisor
build.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: VanCutsem Geoffroy <geoffroy.vancutsem@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>