### PR TITLE
init: separate init function based on different stack

### DIFF
--- a/hypervisor/arch/x86/cpu_primary.S
+++ b/hypervisor/arch/x86/cpu_primary.S
@@ -175,11 +175,6 @@ after:
     mov     %edx,%fs  // Was 32bit POC Data
     mov     %edx,%gs  // Was 32bit POC CLS
 
-   /* Push sp magic to top of stack for call trace
-    *
-    *     0x696e746c = SP_BOTTOM_MAGIC
-    */
-   pushq   $0x696e746c
    /* continue with chipset level initialization */
    call     bsp_boot_init
 

--- a/hypervisor/arch/x86/trampoline.S
+++ b/hypervisor/arch/x86/trampoline.S
@@ -163,12 +163,6 @@ trampoline_start64:
 
     lea     trampoline_pdpt_addr(%rip), %rsp
 
-    /* Push sp magic to top of stack for call trace
-     *
-     *     0x696e746c = SP_BOTTOM_MAGIC
-     */
-    pushq   $0x696e746c
-
     /* Jump to C entry */
     movq    main_entry(%rip), %rax
     jmp     %rax


### PR DESCRIPTION
for bsp_boot_init/cpu_secondary_init, they are on temp stack.
for bsp_boot_post/cpu_secondary_post, they are on runtime stack.
define SWITCH_TO MACRO to switch runtime stack then jump to post functions.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>