### PR TITLE
hv: irq: fix type for vector in ioapic setup

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -304,7 +304,7 @@ void setup_ioapic_irq(void)
 {
 	int ioapic_id;
 	uint32_t gsi;
-	int vr;
+	uint32_t vr;
 
 	spinlock_init(&ioapic_lock);
 
@@ -343,7 +343,7 @@ void setup_ioapic_irq(void)
 			 */
 			if (gsi < NR_LEGACY_IRQ) {
 				vr = irq_desc_alloc_vector(gsi, false);
-				if (vr < 0) {
+				if (vr > NR_MAX_VECTOR) {
 					pr_err("failed to alloc VR");
 					gsi++;
 					continue;

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -327,7 +327,7 @@ uint32_t irq_desc_alloc_vector(uint32_t irq, bool lowpri)
 
 	/* irq should be always available at this time */
 	if (irq > NR_MAX_IRQS)
-		return false;
+		return VECTOR_INVALID;
 
 	desc = irq_desc_base + irq;
 	spinlock_irqsave_obtain(&desc->irq_lock);


### PR DESCRIPTION
Fix the type for vector in ioapic setup, which is a potential problem:
- return VECTOR_INVALID instead of false in irq_desc_alloc_vector()
  when irq is out of range;
- change variable type from int to uint32_t for vector, and correct
  the returned value check.

Signed-off-by: Yan, Like <like.yan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>