### PR TITLE
guest.h: Condition operator fix of foreach_vcpu loop

### DIFF
--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -18,7 +18,7 @@
 
 #define foreach_vcpu(idx, vm, vcpu)				\
 	for (idx = 0, vcpu = vm->hw.vcpu_array[idx];		\
-		(idx < vm->hw.num_vcpus) & (vcpu != NULL);	\
+		(idx < vm->hw.num_vcpus) && (vcpu != NULL);	\
 		idx++, vcpu = vm->hw.vcpu_array[idx])
 
 


### PR DESCRIPTION
The for loop statement should work in both & and &&, but it seems
make more sense to have && when executing a condtion.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>