### PR TITLE
HV: treewide: convert suffix ULL to UL

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -801,8 +801,8 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 /* The GDT defined below compatible with linux kernel */
 #define GUEST_INIT_GDT_DESC_0	(0x0)
 #define GUEST_INIT_GDT_DESC_1	(0x0)
-#define GUEST_INIT_GDT_DESC_2	(0x00CF9B000000FFFFULL) /* Linear Code */
-#define GUEST_INIT_GDT_DESC_3	(0x00CF93000000FFFFULL) /* Linear Data */
+#define GUEST_INIT_GDT_DESC_2	(0x00CF9B000000FFFFUL) /* Linear Code */
+#define GUEST_INIT_GDT_DESC_3	(0x00CF93000000FFFFUL) /* Linear Data */
 
 static const uint64_t guest_init_gdt[] = {
 	GUEST_INIT_GDT_DESC_0,

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -13,7 +13,7 @@
 #define BUP_MKHI_BOOTLOADER_SEED_LEN    64
 
 /* Trusty EPT rebase gpa: 511G */
-#define TRUSTY_EPT_REBASE_GPA (511ULL*1024ULL*1024ULL*1024ULL)
+#define TRUSTY_EPT_REBASE_GPA (511UL * 1024UL * 1024UL * 1024UL)
 #define TRUSTY_MEMORY_SIZE        0x01000000
 
 /* Structure of seed info */
@@ -122,4 +122,3 @@ void destroy_secure_world(struct vm *vm);
 void trusty_set_dseed(void *dseed, uint8_t seed_num);
 
 #endif /* TRUSTY_H_ */
-

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -96,7 +96,7 @@ int udiv64(uint64_t dividend, uint64_t divisor, struct udiv_result *res)
 	/* align divisor and dividend. */
 	bits = clz64(divisor) - clz64(dividend);
 	divisor <<= bits;
-	mask = 1ULL << bits;
+	mask = 1UL << bits;
 	/* division loop */
 	do {
 		if (dividend >= divisor) {

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -273,7 +273,7 @@ static int print_pow2(struct print_param *param,
 	int ret;
 
 	/* calculate mask */
-	mask = (1ULL << shift) - 1;
+	mask = (1UL << shift) - 1;
 
 	/* determine digit translation table */
 	digits = ((param->vars.flags & PRINT_FLAG_UPPER) != 0) ?
@@ -469,7 +469,7 @@ int do_print(const char *fmt, struct print_param *param,
 
 			/* initialize the variables for the next argument */
 			memset(&(param->vars), 0, sizeof(param->vars));
-			param->vars.mask = 0xFFFFFFFFFFFFFFFFULL;
+			param->vars.mask = 0xFFFFFFFFFFFFFFFFUL;
 
 			/*
 			 * analyze the format specification:


### PR DESCRIPTION
It is already assumed that ''long'' has 8-bytes, and thus there is no need to use ULL to indicate a 8-byte unsigned constant.

This patch changes all ULL suffixes found in the hypervisor to UL. Also remove a trailing empty line in trusty.h.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>