### PR TITLE
DM: Update the vcpu id type as uint16_t for vm_create_vcpu

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -259,7 +259,7 @@ add_cpu(struct vmctx *ctx, int guest_ncpus)
 	int error;
 
 	for (i = 0; i < guest_ncpus; i++) {
-		error = vm_create_vcpu(ctx, i);
+		error = vm_create_vcpu(ctx, (uint16_t)i);
 		if (error != 0) {
 			fprintf(stderr, "ERROR: could not create VCPU %d\n", i);
 			return error;

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -707,7 +707,7 @@ vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin)
 }
 
 int
-vm_create_vcpu(struct vmctx *ctx, int vcpu_id)
+vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id)
 {
 	struct acrn_create_vcpu cv;
 	int error;

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -156,7 +156,7 @@ int	vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 	uint16_t phys_bdf, int virt_pin, int phys_pin, bool pic_pin);
 int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
 
-int	vm_create_vcpu(struct vmctx *ctx, int vcpu_id);
+int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
 


### PR DESCRIPTION
Update the vcpu id type as uint16_t for vm_create_vcpu, this
keeps alignment with the updates for the structure acrn_create_vcpu
used by hcall_create_vcpu in the hypervisor.

In the device model, the caller is responsible for vcpu id type
conversion; vcpu id type is uint16_t for external interface in the
current implement.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>