### PR TITLE
HV: Fix wrong comment of trace_entry size

### DIFF
--- a/hypervisor/include/debug/trace.h
+++ b/hypervisor/include/debug/trace.h
@@ -50,7 +50,7 @@
 #define TRACE_FUNC_EXIT			0xFE
 #define TRACE_STR			0xFF
 
-/* sizeof(trace_entry) == 3 x 64bit */
+/* sizeof(trace_entry) == 4 x 64bit */
 struct trace_entry {
 	uint64_t tsc; /* TSC */
 	uint64_t id;


### PR DESCRIPTION
sizeof trace_entry is 4 * 64bit

No functional change.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>