### PR TITLE
fix "function return type inconsistent"

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -64,7 +64,7 @@ inline bool cpu_has_cap(uint32_t bit)
 	if (feat_idx >= FEATURE_WORDS)
 		return false;
 
-	return !!(boot_cpu_data.cpuid_leaves[feat_idx] & (1 << feat_bit));
+	return ((boot_cpu_data.cpuid_leaves[feat_idx] & (1 << feat_bit)) != 0U);
 }
 
 static inline bool get_monitor_cap(void)
@@ -232,7 +232,7 @@ static void alloc_phy_cpu_data(uint16_t pcpu_num)
 	ASSERT(per_cpu_data_base_ptr != NULL, "");
 }
 
-int __attribute__((weak)) parse_madt(uint8_t *lapic_id_base)
+uint16_t __attribute__((weak)) parse_madt(uint8_t *lapic_id_base)
 {
 	static const uint32_t lapic_id[] = {0, 2, 4, 6};
 	uint32_t i;

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -163,9 +163,9 @@ uint64_t hpa2gpa(struct vm *vm, uint64_t hpa)
 			| (hpa & (entry.page_size - 1)));
 }
 
-int is_ept_supported(void)
+bool is_ept_supported(void)
 {
-	uint16_t status;
+	bool status;
 	uint64_t tmp64;
 
 	/* Read primary processor based VM control. */
@@ -179,14 +179,14 @@ int is_ept_supported(void)
 		/* Check if EPT is supported. */
 		if ((tmp64 & (((uint64_t)VMX_PROCBASED_CTLS2_EPT) << 32)) != 0U) {
 			/* EPT is present. */
-			status = 1;
+			status = true;
 		} else {
-			status = 0;
+			status = false;
 		}
 
 	} else {
 		/* Secondary processor based VM control is not present */
-		status = 0;
+		status = false;
 	}
 
 	return status;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -109,12 +109,12 @@ static inline void inv_tlb_one_page(void *addr)
 
 static inline bool cpu_has_vmx_ept_cap(uint32_t bit_mask)
 {
-	return !!(vmx_caps.ept & bit_mask);
+	return ((vmx_caps.ept & bit_mask) != 0U);
 }
 
 static inline bool cpu_has_vmx_vpid_cap(uint32_t bit_mask)
 {
-	return !!(vmx_caps.vpid & bit_mask);
+	return ((vmx_caps.vpid & bit_mask) != 0U);
 }
 
 int check_vmx_mmu_cap(void)

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1201,7 +1201,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	}
 
 	/* Check for EPT support */
-	if (is_ept_supported() != 0)
+	if (is_ept_supported())
 		pr_dbg("EPT is supported");
 	else
 		pr_err("Error: EPT is not supported");

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -32,9 +32,9 @@ void release_schedule_lock(uint16_t pcpu_id)
 	spinlock_release(&per_cpu(sched_ctx, pcpu_id).scheduler_lock);
 }
 
-int allocate_pcpu(void)
+uint16_t allocate_pcpu(void)
 {
-	int i;
+	uint16_t i;
 
 	for (i = 0; i < phys_cpu_num; i++) {
 		if (bitmap_test_and_set(i, &pcpu_used_bitmap) == 0)

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -37,7 +37,7 @@ static inline uint32_t sbuf_calculate_allocate_size(uint32_t ele_num,
 		return 0;
 	}
 
-	return sbuf_allocate_size;
+	return (uint32_t) sbuf_allocate_size;
 }
 
 struct shared_buf *sbuf_allocate(uint32_t ele_num, uint32_t ele_size)

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -98,7 +98,7 @@ static int fifo_numchars(struct fifo *fifo)
  *
  * Return an interrupt reason if one is available.
  */
-static int uart_intr_reason(struct vuart *vu)
+static uint8_t uart_intr_reason(struct vuart *vu)
 {
 	if ((vu->lsr & LSR_OE) != 0 && (vu->ier & IER_ELSI) != 0)
 		return IIR_RLS;
@@ -131,7 +131,7 @@ static void uart_init(struct vuart *vu)
  */
 static void uart_toggle_intr(struct vuart *vu)
 {
-	char intr_reason;
+	uint8_t intr_reason;
 
 	intr_reason = uart_intr_reason(vu);
 
@@ -229,7 +229,8 @@ static uint32_t uart_read(__unused struct vm_io_handler *hdlr,
 		struct vm *vm, uint16_t offset,
 		__unused size_t width)
 {
-	char iir, intr_reason, reg;
+	char iir, reg;
+	uint8_t intr_reason;
 	struct vuart *vu = vm_vuart(vm);
 	offset -= vu->base;
 	vuart_lock(vu);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -363,7 +363,7 @@ static inline void clflush(volatile void *p)
 extern uint8_t CPU_Boot_Page_Tables_Start_VM[];
 
 /* External Interfaces */
-int     is_ept_supported(void);
+bool is_ept_supported(void);
 uint64_t create_guest_initial_paging(struct vm *vm);
 void    destroy_ept(struct vm *vm);
 uint64_t  gpa2hpa(struct vm *vm, uint64_t gpa);

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -425,7 +425,7 @@ static inline uint8_t get_vcpu_mode(struct vcpu *vcpu)
 
 static inline bool cpu_has_vmx_unrestricted_guest_cap(void)
 {
-       return !!(msr_read(MSR_IA32_VMX_MISC) & VMX_SUPPORT_UNRESTRICTED_GUEST);
+       return ((msr_read(MSR_IA32_VMX_MISC) & VMX_SUPPORT_UNRESTRICTED_GUEST) != 0UL);
 }
 
 typedef struct _descriptor_table_{

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -23,7 +23,7 @@ void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);
 
 void set_pcpu_used(uint16_t pcpu_id);
-int allocate_pcpu(void);
+uint16_t allocate_pcpu(void);
 void free_pcpu(uint16_t pcpu_id);
 
 void add_vcpu_to_runqueue(struct vcpu *vcpu);

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -174,13 +174,13 @@ build_bitmap_clear(bitmap_clear, BUS_LOCK, nr, addr)
  */
 static inline bool bitmap_test(int nr, volatile unsigned long *addr)
 {
-	int ret;
+	int32_t ret;
 
 	asm volatile("btq %2,%1\n\tsbbl %0, %0"
 			: "=r" (ret), "=m" (*addr)
 			: "r" ((long)(nr & 0x3f))
 			: "cc", "memory");
-	return (!!ret);
+	return (ret != 0);
 }
 
 /*
@@ -191,12 +191,12 @@ static inline bool bitmap_test(int nr, volatile unsigned long *addr)
 #define build_bitmap_testandset(name, lock, nr, addr)	\
 static inline bool name(int nr, volatile unsigned long *addr)	\
 {							\
-	int ret;					\
+	int32_t ret;					\
 	asm volatile(lock "btsq %2,%1\n\tsbbl %0,%0"	\
 			: "=r" (ret), "=m" (*addr)	\
 			: "r" ((long)(nr & 0x3f))	\
 			: "cc", "memory");		\
-	return (!!ret);					\
+	return (ret != 0);			        \
 }
 build_bitmap_testandset(__bitmap_test_and_set, "", nr, addr)
 build_bitmap_testandset(bitmap_test_and_set, BUS_LOCK, nr, addr)
@@ -209,12 +209,12 @@ build_bitmap_testandset(bitmap_test_and_set, BUS_LOCK, nr, addr)
 #define build_bitmap_testandclear(name, lock, nr, addr)	\
 static inline bool name(int nr, volatile unsigned long *addr)	\
 {							\
-	int ret;					\
+	int32_t ret;					\
 	asm volatile(lock "btrq %2,%1\n\tsbbl %0,%0"	\
 			: "=r" (ret), "=m" (*addr)	\
 			: "r" ((long)(nr & 0x3f))	\
 			: "cc", "memory");		\
-	return (!!ret);					\
+	return (ret != 0);			        \
 }
 build_bitmap_testandclear(__bitmap_test_and_clear, "", nr, addr)
 build_bitmap_testandclear(bitmap_test_and_clear, BUS_LOCK, nr, addr)


### PR DESCRIPTION
MISRA C required function return type should be consistented.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>