### PR TITLE
DM: add 'reset' option for ptdev

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -83,6 +83,7 @@ SRCS += hw/pci/virtio/virtio_input.c
 SRCS += hw/pci/ahci.c
 SRCS += hw/pci/hostbridge.c
 SRCS += hw/pci/passthrough.c
+SRCS += hw/pci/virtio/virtio_audio.c
 SRCS += hw/pci/virtio/virtio_net.c
 SRCS += hw/pci/virtio/virtio_rnd.c
 SRCS += hw/pci/virtio/virtio_hyper_dmabuf.c

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -137,7 +137,6 @@ usage(int code)
 		"       -H: vmexit from the guest on hlt\n"
 		"       -l: LPC device configuration\n"
 		"       -m: memory size in MB\n"
-		"       -M: do not hide INTx link for MSI&INTx capable ptdev\n"
 		"       -p: pin 'vcpu' to 'hostcpu'\n"
 		"       -P: vmexit from the guest on pause\n"
 		"       -s: <slot,driver,configinfo> PCI slot config\n"
@@ -619,7 +618,6 @@ static struct option long_options[] = {
 	{"kernel",		required_argument,	0, 'k' },
 	{"ramdisk",		required_argument,	0, 'r' },
 	{"bootargs",		required_argument,	0, 'B' },
-	{"ptdev_msi",		no_argument,		0, 'M' },
 	{"version",		no_argument,		0, 'v' },
 	{"gvtargs",		required_argument,	0, 'G' },
 	{"help",		no_argument,		0, 'h' },
@@ -658,7 +656,7 @@ main(int argc, char *argv[])
 	if (signal(SIGINT, sig_handler_term) == SIG_ERR)
 		fprintf(stderr, "cannot register handler for SIGINT\n");
 
-	optstr = "abehuwxACHIMPSTWYvk:r:B:p:g:c:s:m:l:U:G:i:";
+	optstr = "abehuwxACHIPSTWYvk:r:B:p:g:c:s:m:l:U:G:i:";
 	while ((c = getopt_long(argc, argv, optstr, long_options,
 			&option_idx)) != -1) {
 		switch (c) {
@@ -773,9 +771,6 @@ main(int argc, char *argv[])
 				errx(EX_USAGE, "invalid GVT param %s", optarg);
 				exit(1);
 			}
-			break;
-		case 'M':
-			ptdev_prefer_msi(false);
 			break;
 		case 'v':
 			print_version();

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -96,8 +96,8 @@ SYSRES_MEM(PCI_EMUL_ECFG_BASE, PCI_EMUL_ECFG_SIZE);
 
 #define	PCI_EMUL_MEMLIMIT32	PCI_EMUL_ECFG_BASE
 
-#define	PCI_EMUL_MEMBASE64	0xD000000000UL
-#define	PCI_EMUL_MEMLIMIT64	0xFD00000000UL
+#define	PCI_EMUL_MEMBASE64	0x7000000000UL
+#define	PCI_EMUL_MEMLIMIT64	0x8D00000000UL
 
 static struct pci_vdev_ops *pci_emul_finddev(char *name);
 static void pci_lintr_route(struct pci_vdev *dev);

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -37,6 +37,8 @@
 #include <errno.h>
 #include <pthread.h>
 #include <pciaccess.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include "iodev.h"
 #include "vmmapi.h"
@@ -815,7 +817,7 @@ cfginit(struct vmctx *ctx, struct passthru_dev *ptdev, int bus,
 {
 	int irq_type = IRQ_MSI;
 	char reset_path[60];
-	FILE *f;
+	int fd;
 
 	bzero(&ptdev->sel, sizeof(struct pcisel));
 	ptdev->sel.bus = bus;
@@ -835,25 +837,28 @@ cfginit(struct vmctx *ctx, struct passthru_dev *ptdev, int bus,
 		irq_type = IRQ_INTX;
 	}
 
-	/* Check reset method for PCIe dev. If SOS kernel provides 'reset'
-	 * entry in sysfs, related dev has some reset capability, e.g. FLR, or
-	 * secondary bus reset. PCIe dev without any reset capability is
-	 * refused for passthrough.
+	/* If SOS kernel provides 'reset' entry in sysfs, related dev has some
+	 * reset capability, e.g. FLR, or secondary bus reset. We do 2 things:
+	 * - reset each dev before passthrough to achieve valid dev state after
+	 *   UOS reboot
+	 * - refuse to passthrough PCIe dev without any reset capability
 	 */
-	if (ptdev->pcie_cap) {
-		snprintf(reset_path, 40,
-			"/sys/bus/pci/devices/0000:%02x:%02x.%x/reset",
-			bus, slot, func);
+	snprintf(reset_path, 40,
+		"/sys/bus/pci/devices/0000:%02x:%02x.%x/reset",
+		bus, slot, func);
 
-		if ((f = fopen(reset_path, "r")))
-		       fclose(f);
-		else if (errno == ENOENT) {
-			warnx("No reset capability for PCIe %x/%x/%x, "
-					"remove it from ptdev list!!\n",
-					bus, slot, func);
-			if (!no_reset)
-				return -1;
-		}
+	fd = open(reset_path, O_WRONLY);
+	if (fd >= 0) {
+		if (write(fd, "1", 1) < 0)
+			warnx("reset dev %x/%x/%x failed!\n",
+			      bus, slot, func);
+		close(fd);
+	} else if (errno == ENOENT && ptdev->pcie_cap) {
+		warnx("No reset capability for PCIe %x/%x/%x, "
+				"remove it from ptdev list!!\n",
+				bus, slot, func);
+		if (!no_reset)
+			return -1;
 	}
 
 	if (cfginitbar(ctx, ptdev) != 0) {

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -87,9 +87,6 @@ static int memfd = -1;
 static int pciaccess_ref_cnt;
 static pthread_mutex_t ref_cnt_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-/* Prefer MSI over INTx for ptdev */
-static bool prefer_msi = true;
-
 /* Not check reset capability before assign ptdev.
  * Set false by default, that is, always check.
  */
@@ -113,12 +110,6 @@ struct passthru_dev {
 	uint16_t phys_bdf;
 	struct pci_device *phys_dev;
 };
-
-void
-ptdev_prefer_msi(bool enable)
-{
-	prefer_msi = enable;
-}
 
 void ptdev_no_reset(bool enable)
 {
@@ -939,14 +930,26 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	struct passthru_dev *ptdev;
 	struct pci_device_iterator *iter;
 	struct pci_device *phys_dev;
+	char *opt;
+	bool keep_gsi = false;
 
 	ptdev = NULL;
 	error = -EINVAL;
 
-	if (opts == NULL ||
-	    sscanf(opts, "%x/%x/%x", &bus, &slot, &func) != 3) {
-		warnx("invalid passthru options, %s", opts);
+	if (opts == NULL) {
+		warnx("Empty passthru options\n");
 		return -EINVAL;
+	}
+
+	opt = strsep(&opts, ",");
+	if (sscanf(opt, "%x/%x/%x", &bus, &slot, &func) != 3) {
+		warnx("Invalid passthru options, %s", opt);
+		return -EINVAL;
+	}
+
+	while ((opt = strsep(&opts, ",")) != NULL) {
+		if (!strncmp(opt, "keep_gsi", 8))
+			keep_gsi = true;
 	}
 
 	if (vm_assign_ptdev(ctx, bus, slot, func) != 0) {
@@ -1013,7 +1016,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	 * Forge Guest to use MSI/MSIX in this case to mitigate IRQ sharing
 	 * issue
 	 */
-	if (error == IRQ_MSI && prefer_msi)
+	if (error == IRQ_MSI && !keep_gsi)
 		return 0;
 
 	/* Allocates the virq if ptdev only support INTx */

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -72,6 +72,8 @@
 #define PCI_BDF(bus, dev, func)  (((bus & 0xFF)<<8) | ((dev & 0x1F)<<3)     \
 		| ((func & 0x7)))
 
+#define	PCI_BDF_GPU		0x00000010	/* 00:02.0 */
+
 /* Some audio driver get topology data from ACPI NHLT table, thus need copy host
  * NHLT to guest. Default audio driver doesn't require this, so make it off by
  * default to avoid unexpected failure.
@@ -1163,6 +1165,15 @@ passthru_cfgread(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 
 	/* Everything else just read from the device's config space */
 	*rv = read_config(ptdev->phys_dev, coff, bytes);
+
+	/*
+	 * return zero for graphics stolen memory since acrn does not have
+	 * support for RMRR
+	 */
+	if ((PCI_BDF(dev->bus, dev->slot, dev->func) == PCI_BDF_GPU)
+		&& (coff == PCIR_GMCH_CTL)) {
+		*rv &= ~PCIM_GMCH_CTL_GMS;
+	}
 
 	return 0;
 }

--- a/devicemodel/hw/pci/virtio/virtio_audio.c
+++ b/devicemodel/hw/pci/virtio/virtio_audio.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+/*
+ * virtio audio
+ * audio mediator device model
+ */
+
+#include <err.h>
+#include <errno.h>
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <pthread.h>
+#include <sysexits.h>
+
+#include "dm.h"
+#include "pci_core.h"
+#include "virtio.h"
+#include "virtio_kernel.h"
+#include "vmmapi.h"			/* for vmctx */
+
+/*
+ * Size of queue was chosen experimentaly in a way
+ * that it allows to do audio capture/playback without
+ * any delay for interrupt/msg send, this value should
+ * be tuned.
+ */
+#define VIRTIO_AUDIO_RINGSZ	1024
+
+/*
+ * Queue definitions.
+ * Audio mediator uses two queues: one for interrupt and the other for messages.
+ */
+#define VIRTIO_AUDIO_VQ_NUM  2
+
+const char *vbs_k_audio_dev_path = "/dev/vbs_k_audio";
+
+static int virtio_audio_debug = 1;
+#define DPRINTF(params) do { if (virtio_audio_debug) printf params; } while (0)
+#define WPRINTF(params) (printf params)
+
+struct virtio_audio {
+	struct virtio_base base;
+	struct virtio_vq_info vq[VIRTIO_AUDIO_VQ_NUM];
+	pthread_mutex_t mtx;
+	/* VBS-K variables */
+	struct {
+		enum VBS_K_STATUS kstatus;
+		int audio_fd;
+		struct vbs_dev_info kdev;
+		struct vbs_vqs_info kvqs;
+	} vbs_k;
+};
+
+static int virtio_audio_kernel_start(struct virtio_audio *virt_audio);
+static int virtio_audio_kernel_stop(struct virtio_audio *virt_audio);
+static int virtio_audio_kernel_reset(struct virtio_audio *virt_audio);
+static int virtio_audio_kernel_dev_set(struct vbs_dev_info *kdev,
+				       const char *name, int vmid, int nvq,
+				       uint32_t feature, uint64_t pio_start,
+				       uint64_t pio_len);
+static int virtio_audio_kernel_vq_set(struct vbs_vqs_info *kvqs,
+				      unsigned int nvq, unsigned int idx,
+				      uint16_t qsize, uint32_t pfn,
+				      uint16_t msix_idx, uint64_t msix_addr,
+				      uint32_t msix_data);
+
+static void virtio_audio_k_no_notify(void *base, struct virtio_vq_info *vq);
+static void virtio_audio_k_set_status(void *base, uint64_t status);
+static void virtio_audio_reset(void *base);
+
+static struct virtio_ops virtio_audio_ops_k = {
+	"virtio_audio",		/* our name */
+	VIRTIO_AUDIO_VQ_NUM,	/* we support 2 virtqueue */
+	0,			/* config reg size */
+	virtio_audio_reset,	/* reset */
+	virtio_audio_k_no_notify,	/* device-wide qnotify */
+	NULL,				/* read virtio config */
+	NULL,				/* write virtio config */
+	NULL,				/* apply negotiated features */
+	virtio_audio_k_set_status,/* called on guest set status */
+	0,					/* our capabilities */
+};
+
+static int
+virtio_audio_kernel_init(struct virtio_audio *virt_audio)
+{
+	if (virt_audio->vbs_k.audio_fd != -1) {
+		WPRINTF(("virtio_audio: Ooops! Re-entered!!\n"));
+		return -VIRTIO_ERROR_REENTER;
+	}
+
+	virt_audio->vbs_k.audio_fd = open(vbs_k_audio_dev_path, O_RDWR);
+	if (virt_audio->vbs_k.audio_fd < 0) {
+		WPRINTF(("virtio_audio: Failed to open %s!\n",
+			 vbs_k_audio_dev_path));
+		return -VIRTIO_ERROR_FD_OPEN_FAILED;
+	}
+	DPRINTF(("virtio_audio: Open %s success!\n",
+		 vbs_k_audio_dev_path));
+
+	memset(&virt_audio->vbs_k.kdev, 0, sizeof(struct vbs_dev_info));
+	memset(&virt_audio->vbs_k.kvqs, 0, sizeof(struct vbs_vqs_info));
+
+	return VIRTIO_SUCCESS;
+}
+
+static int
+virtio_audio_kernel_dev_set(struct vbs_dev_info *kdev, const char *name,
+			    int vmid, int nvq, uint32_t feature,
+			    uint64_t pio_start,
+			    uint64_t pio_len)
+{
+	/* init kdev */
+	strncpy(kdev->name, name, VBS_NAME_LEN);
+	kdev->vmid = vmid;
+	kdev->nvq = nvq;
+	kdev->negotiated_features = feature;
+	kdev->pio_range_start = pio_start;
+	kdev->pio_range_len = pio_len;
+
+	return VIRTIO_SUCCESS;
+}
+
+static int
+virtio_audio_kernel_vq_set(struct vbs_vqs_info *kvqs, unsigned int nvq,
+			   unsigned int idx, uint16_t qsize,
+			   uint32_t pfn, uint16_t msix_idx, uint64_t msix_addr,
+			   uint32_t msix_data)
+{
+	if (nvq <= idx) {
+		WPRINTF(("virtio_audio: wrong idx for vq_set!\n"));
+		return -VIRTIO_ERROR_GENERAL;
+	}
+
+	/* init kvqs */
+	kvqs->nvq = nvq;
+	kvqs->vqs[idx].qsize = qsize;
+	kvqs->vqs[idx].pfn = pfn;
+	kvqs->vqs[idx].msix_idx = msix_idx;
+	kvqs->vqs[idx].msix_addr = msix_addr;
+	kvqs->vqs[idx].msix_data = msix_data;
+
+	return VIRTIO_SUCCESS;
+}
+
+static int
+virtio_audio_kernel_start(struct virtio_audio *virt_audio)
+{
+	if (vbs_kernel_start(virt_audio->vbs_k.audio_fd,
+			     &virt_audio->vbs_k.kdev,
+			     &virt_audio->vbs_k.kvqs) < 0) {
+		WPRINTF(("virtio_audio: Failed in vbs_k_start!\n"));
+		return -VIRTIO_ERROR_START;
+	}
+
+	DPRINTF(("virtio_audio: vbs_k_started!\n"));
+	return VIRTIO_SUCCESS;
+}
+
+static int
+virtio_audio_kernel_stop(struct virtio_audio *virt_audio)
+{
+	return vbs_kernel_stop(virt_audio->vbs_k.audio_fd);
+}
+
+static int
+virtio_audio_kernel_reset(struct virtio_audio *virt_audio)
+{
+	memset(&virt_audio->vbs_k.kdev, 0, sizeof(struct vbs_dev_info));
+	memset(&virt_audio->vbs_k.kvqs, 0, sizeof(struct vbs_vqs_info));
+
+	return vbs_kernel_reset(virt_audio->vbs_k.audio_fd);
+}
+
+static void
+virtio_audio_reset(void *base)
+{
+	struct virtio_audio *virt_audio;
+
+	virt_audio = (struct virtio_audio *)base;
+
+	DPRINTF(("virtio_audio: device reset requested !\n"));
+	virtio_reset_dev(&virt_audio->base);
+	DPRINTF(("virtio_audio: kstatus %d\n", virt_audio->vbs_k.kstatus));
+	if (virt_audio->vbs_k.kstatus == VIRTIO_DEV_STARTED) {
+		DPRINTF(("virtio_audio: VBS-K reset requested!\n"));
+		virtio_audio_kernel_stop(virt_audio);
+		virtio_audio_kernel_reset(virt_audio);
+		virt_audio->vbs_k.kstatus = VIRTIO_DEV_INITIAL;
+	}
+}
+
+/* VBS-K interface function implementations */
+static void
+virtio_audio_k_no_notify(void *base, struct virtio_vq_info *vq)
+{
+	WPRINTF(("virtio_audio: VBS-K mode! Should not reach here!!\n"));
+}
+
+/*
+ * This callback gives us a chance to determine the timings
+ * to kickoff VBS-K initialization
+ */
+static void
+virtio_audio_k_set_status(void *base, uint64_t status)
+{
+	struct virtio_audio *virt_audio;
+	int nvq;
+	struct msix_table_entry *mte;
+	uint64_t msix_addr = 0;
+	uint32_t msix_data = 0;
+	int rc, i, j;
+
+	virt_audio = (struct virtio_audio *)base;
+	nvq = virt_audio->base.vops->nvq;
+
+	if (virt_audio->vbs_k.kstatus == VIRTIO_DEV_INIT_SUCCESS &&
+	    (status & VIRTIO_CR_STATUS_DRIVER_OK)) {
+		/* time to kickoff VBS-K side */
+		/* init vdev first */
+		rc = virtio_audio_kernel_dev_set(
+					&virt_audio->vbs_k.kdev,
+					virt_audio->base.vops->name,
+					virt_audio->base.dev->vmctx->vmid,
+					nvq,
+					virt_audio->base.negotiated_caps,
+					/* currently we let VBS-K handle
+					 * kick register
+					 *
+					 * FIXME: the size should be returned
+					 *  by a api in vhost.
+					 */
+					virt_audio->base.dev->bar[0].addr + 16,
+					2);
+
+		for (i = 0; i < nvq; i++) {
+			if (virt_audio->vq[i].msix_idx
+				!= VIRTIO_MSI_NO_VECTOR) {
+				j = virt_audio->vq[i].msix_idx;
+				mte = &virt_audio->base.dev->msix.table[j];
+				msix_addr = mte->addr;
+				msix_data = mte->msg_data;
+			}
+			rc = virtio_audio_kernel_vq_set(
+				&virt_audio->vbs_k.kvqs,
+				nvq, i,
+				virt_audio->vq[i].qsize,
+				virt_audio->vq[i].pfn,
+				virt_audio->vq[i].msix_idx,
+				msix_addr,
+				msix_data);
+
+			if (rc < 0) {
+				WPRINTF(("audio: kernel_set_vq failed, "
+					 "i %d ret %d\n", i, rc));
+				return;
+			}
+		}
+		rc = virtio_audio_kernel_start(virt_audio);
+		if (rc < 0) {
+			WPRINTF(("virtio_audio: kernel_start() failed\n"));
+			virt_audio->vbs_k.kstatus = VIRTIO_DEV_START_FAILED;
+		} else {
+			virt_audio->vbs_k.kstatus = VIRTIO_DEV_STARTED;
+		}
+	}
+}
+
+static int
+virtio_audio_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
+{
+	struct virtio_audio *virt_audio;
+
+	pthread_mutexattr_t attr;
+	int rc;
+
+	virt_audio = calloc(1, sizeof(struct virtio_audio));
+	if (!virt_audio) {
+		WPRINTF(("virtio_audio: calloc returns NULL\n"));
+		return -1;
+	}
+	virt_audio->vbs_k.kstatus = VIRTIO_DEV_INITIAL;
+	virt_audio->vbs_k.audio_fd = -1;
+
+	/* init mutex attribute properly */
+	rc = pthread_mutexattr_init(&attr);
+	if (rc)
+		DPRINTF(("mutexattr init failed with erro %d!\n", rc));
+
+	if (virtio_uses_msix()) {
+		rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_DEFAULT);
+		if (rc)
+			DPRINTF(("virtio_msix: mutexattr_settype "
+				 "failed with error %d!\n", rc));
+	} else {
+		rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+		if (rc)
+			DPRINTF(("virtio_intx: mutexattr_settype "
+				 "failed with error %d!\n", rc));
+	}
+
+	rc = pthread_mutex_init(&virt_audio->mtx, &attr);
+	if (rc)
+		DPRINTF(("mutex init failed with error %d!\n", rc));
+
+	virtio_linkup(&virt_audio->base,
+		      &virtio_audio_ops_k,
+		      virt_audio,
+		      dev,
+		      virt_audio->vq);
+
+	rc = virtio_audio_kernel_init(virt_audio);
+	if (rc < 0) {
+		WPRINTF(("virtio_audio: VBS-K init failed,error %d!\n", rc));
+		virt_audio->vbs_k.kstatus = VIRTIO_DEV_INIT_FAILED;
+		free(virt_audio);
+		return -1;
+	}
+	virt_audio->vbs_k.kstatus = VIRTIO_DEV_INIT_SUCCESS;
+	virt_audio->base.mtx = &virt_audio->mtx;
+
+	/* vq[0] and vq[1] are for interrupt and messages */
+	virt_audio->vq[0].qsize = VIRTIO_AUDIO_RINGSZ;
+	virt_audio->vq[1].qsize = VIRTIO_AUDIO_RINGSZ;
+
+	/* initialize config space */
+	pci_set_cfgdata16(dev, PCIR_DEVICE, VIRTIO_DEV_AUDIO);
+	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
+	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_MULTIMEDIA);
+	pci_set_cfgdata8(dev, PCIR_SUBCLASS, PCIS_MULTIMEDIA_AUDIO);
+	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_AUDIO);
+	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+
+	if (virtio_interrupt_init(&virt_audio->base, virtio_uses_msix())) {
+		free(virt_audio);
+		return -1;
+	}
+	virtio_set_io_bar(&virt_audio->base, 0);
+
+	return 0;
+}
+
+static void
+virtio_audio_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
+{
+	struct virtio_audio *virt_audio;
+
+	virt_audio = dev->arg;
+	if (!virt_audio) {
+		DPRINTF(("%s: virtio_audio is NULL!\n", __func__));
+		return;
+	}
+	if (virt_audio->vbs_k.kstatus == VIRTIO_DEV_STARTED) {
+		DPRINTF(("%s: deinit virtio_audio_k!\n", __func__));
+		virtio_audio_kernel_stop(virt_audio);
+		virtio_audio_kernel_reset(virt_audio);
+		virt_audio->vbs_k.kstatus = VIRTIO_DEV_INITIAL;
+		assert(virt_audio->vbs_k.audio_fd >= 0);
+		close(virt_audio->vbs_k.audio_fd);
+		virt_audio->vbs_k.audio_fd = -1;
+	}
+	pthread_mutex_destroy(&virt_audio->mtx);
+	DPRINTF(("%s: free struct virtio_audio!\n", __func__));
+	free((struct virtio_audio *)dev->arg);
+}
+
+struct pci_vdev_ops pci_ops_virtio_audio = {
+	.class_name	= "virtio-audio",
+	.vdev_init	= virtio_audio_init,
+	.vdev_deinit	= virtio_audio_deinit,
+	.vdev_barwrite	= virtio_pci_write,
+	.vdev_barread	= virtio_pci_read
+};
+
+DEFINE_PCI_DEVTYPE(pci_ops_virtio_audio);

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -48,6 +48,5 @@ int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,
 void *paddr_guest2host(struct vmctx *ctx, uintptr_t addr, size_t len);
 void *dm_gpa2hva(uint64_t gpa, size_t size);
 int  virtio_uses_msix(void);
-void ptdev_prefer_msi(bool enable);
 void ptdev_no_reset(bool enable);
 #endif

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1065,4 +1065,7 @@
 #define	PCIM_OSC_CTL_PCIE_AER		0x08 /* PCIe Advanced Error Reporting */
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
+/* Graphics definitions */
+#define PCIR_GMCH_CTL			0x50 /*GMCH grpahics control register */
+#define PCIM_GMCH_CTL_GMS		0xFF00 /*GMS - stolen memory bits 15:8 */
 #endif

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -283,7 +283,7 @@ fi
    -s 13,virtio-rpmb \
    -s 10,virtio-hyper_dmabuf \
    -s 11,wdt-i6300esb \
-   -s 14,passthru,0/e/0 \
+   -s 14,passthru,0/e/0,keep_gsi \
    -s 23,passthru,0/17/0 \
    -s 15,passthru,0/f/0 \
    -s 27,passthru,0/1b/0 \
@@ -292,7 +292,6 @@ fi
    $boot_ipu_option      \
    -i /run/acrn/ioc_$vm_name,0x20 \
    -l com2,/run/acrn/ioc_$vm_name \
-   -M \
    $boot_image_option \
    --enable_trusty \
    -B "$kernel_cmdline" $vm_name

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -120,6 +120,7 @@ C_SRCS += arch/x86/trusty.c
 C_SRCS += arch/x86/cpu_state_tbl.c
 C_SRCS += arch/x86/mtrr.c
 C_SRCS += arch/x86/pm.c
+S_SRCS += arch/x86/wakeup.S
 C_SRCS += arch/x86/guest/vcpu.c
 C_SRCS += arch/x86/guest/vm.c
 C_SRCS += arch/x86/guest/instr_emul_wrapper.c

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -489,7 +489,7 @@ int ept_mmap(struct vm *vm, uint64_t hpa,
 		 * to force snooping of PCIe devices if the page
 		 * is cachable
 		 */
-		if ((prot & IA32E_EPT_MT_MASK) != IA32E_EPT_UNCACHED)
+		if ((prot & IA32E_EPT_MT_MASK) != IA32E_EPT_UNCACHED && iommu_snoop)
 			prot |= IA32E_EPT_SNOOP_CTRL;
 		map_mem(&map_params, (void *)hpa,
 			(void *)gpa, size, prot);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -278,6 +278,13 @@ void reset_vcpu(struct vcpu *vcpu)
 	vcpu->ioreq_pending = 0;
 	vcpu->arch_vcpu.nr_sipi = 0;
 	vcpu->pending_pre_work = 0;
+
+	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
+	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
+	vcpu->arch_vcpu.irq_window_enabled = 0;
+	vcpu->arch_vcpu.inject_event_pending = false;
+	memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
+
 	vlapic = vcpu->arch_vcpu.vlapic;
 	vlapic_reset(vlapic);
 }

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -143,7 +143,8 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 
 	if (is_vm0(vm)) {
 		/* Load pm S state data */
-		vm_load_pm_s_state(vm);
+		if (vm_load_pm_s_state(vm) == 0)
+			register_pm1ab_handler(vm);
 
 		/* Create virtual uart */
 		vm->vuart = vuart_init(vm);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -274,7 +274,7 @@ void pause_vm(struct vm *vm)
 		pause_vcpu(vcpu, VCPU_ZOMBIE);
 }
 
-int vm_resume(struct vm *vm)
+void resume_vm(struct vm *vm)
 {
 	int i;
 	struct vcpu *vcpu = NULL;
@@ -283,8 +283,6 @@ int vm_resume(struct vm *vm)
 		resume_vcpu(vcpu);
 
 	vm->state = VM_STARTED;
-
-	return 0;
 }
 
 /* Create vm/vcpu for vm0 */

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -4,6 +4,8 @@
  */
 #include <hypervisor.h>
 
+struct run_context cpu_ctx;
+
 void restore_msrs(void)
 {
 #ifdef STACK_PROTECTOR

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -6,6 +6,9 @@
 
 struct run_context cpu_ctx;
 
+/* whether the host enter s3 success */
+uint8_t host_enter_s3_success = 1;
+
 void restore_msrs(void)
 {
 #ifdef STACK_PROTECTOR
@@ -71,12 +74,16 @@ int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 	uint32_t pm1b_cnt_val)
 {
 	uint32_t pcpu_id;
+	int ret;
 	uint64_t pmain_entry_saved;
 	uint32_t guest_wakeup_vec32;
 	uint64_t *pmain_entry;
 
+	/* We assume enter s3 success by default */
+	host_enter_s3_success = 1;
 	if (vm->pm.sx_state_data == NULL) {
 		pr_err("No Sx state info avaiable. No Sx support");
+		host_enter_s3_success = 0;
 		return -1;
 	}
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -14,3 +14,119 @@ void restore_msrs(void)
 	msr_write(MSR_IA32_FS_BASE, (uint64_t)psc);
 #endif
 }
+
+static void acpi_gas_write(struct acpi_generic_address *gas, uint32_t val)
+{
+	if (gas->space_id == SPACE_SYSTEM_MEMORY)
+		mmio_write_word(val, (void *)HPA2HVA(gas->address));
+	else
+		io_write_word(val, gas->address);
+}
+
+static uint32_t acpi_gas_read(struct acpi_generic_address *gas)
+{
+	uint32_t ret = 0;
+
+	if (gas->space_id == SPACE_SYSTEM_MEMORY)
+		ret = mmio_read_word((void *)HPA2HVA(gas->address));
+	else
+		ret = io_read_word(gas->address);
+
+	return ret;
+}
+
+void do_acpi_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+	uint32_t pm1b_cnt_val)
+{
+	uint32_t s1, s2;
+
+	acpi_gas_write(&vm->pm.sx_state_data->pm1a_cnt, pm1a_cnt_val);
+
+	if (vm->pm.sx_state_data->pm1b_cnt.address != 0)
+		acpi_gas_write(&vm->pm.sx_state_data->pm1b_cnt, pm1b_cnt_val);
+
+	while (1) {
+		/* polling PM1 state register to detect wether
+		 * the Sx state enter is interrupted by wakeup event.
+		 */
+		s1 = s2 = 0;
+
+		s1 = acpi_gas_read(&vm->pm.sx_state_data->pm1a_evt);
+
+		if (vm->pm.sx_state_data->pm1b_evt.address != 0) {
+			s2 = acpi_gas_read(&vm->pm.sx_state_data->pm1b_evt);
+			s1 |= s2;
+		}
+
+		/* According to ACPI spec 4.8.3.1.1 PM1 state register, the bit
+		 * WAK_STS(bit 15) is set if system will transition to working
+		 * state.
+		 */
+		if ((s1 & (1 << BIT_WAK_STS)) != 0)
+			break;
+	}
+}
+
+int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+	uint32_t pm1b_cnt_val)
+{
+	uint32_t pcpu_id;
+	uint64_t pmain_entry_saved;
+	uint64_t *pmain_entry;
+
+	if (vm->pm.sx_state_data == NULL) {
+		pr_err("No Sx state info avaiable. No Sx support");
+		return -1;
+	}
+
+	pause_vm(vm);	/* pause vm0 before suspend system */
+
+	pcpu_id = get_cpu_id();
+
+	/* offline all APs */
+	stop_cpus();
+
+	/* Trampoline code is relocatable now. We have to calculate
+	 * main_entry address with relocation base address
+	 */
+	pmain_entry =
+		(uint64_t *)(HPA2HVA(trampoline_start16_paddr) +
+		(uint64_t) main_entry);
+
+	/* Save default main entry and we will restore it after
+	 * back from S3. So the AP online could jmp to correct
+	 * main entry.
+	 */
+	pmain_entry_saved = *pmain_entry;
+	/* Set the main entry for resume from S3 state */
+	*pmain_entry = (uint64_t)restore_s3_context;
+
+	CPU_IRQ_DISABLE();
+	vmx_off(pcpu_id);
+
+	suspend_console();
+	suspend_ioapic();
+	suspend_iommu();
+	suspend_lapic();
+
+	__enter_s3(vm, pm1a_cnt_val, pm1b_cnt_val);
+
+	/* release the lock aquired in trampoline code */
+	spinlock_release(&trampoline_spinlock);
+
+	resume_lapic();
+	resume_iommu();
+	resume_ioapic();
+	resume_console();
+
+	exec_vmxon_instr(pcpu_id);
+	CPU_IRQ_ENABLE();
+
+	/* restore the default main entry */
+	*pmain_entry = pmain_entry_saved;
+
+	/* online all APs again */
+	start_cpus();
+
+	return 0;
+}

--- a/hypervisor/arch/x86/wakeup.S
+++ b/hypervisor/arch/x86/wakeup.S
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <vcpu.h>
+
+   .text
+   .align   8
+   .code64
+   .extern    restore_msrs
+   .extern    cpu_ctx
+   .extern    load_gdtr_and_tr
+
+   .global    __enter_s3
+__enter_s3:
+	movq %rax, CPU_CONTEXT_OFFSET_RAX + cpu_ctx(%rip)
+	movq %rbx, CPU_CONTEXT_OFFSET_RBX + cpu_ctx(%rip)
+	movq %rcx, CPU_CONTEXT_OFFSET_RCX + cpu_ctx(%rip)
+	movq %rdx, CPU_CONTEXT_OFFSET_RDX + cpu_ctx(%rip)
+	movq %rdi, CPU_CONTEXT_OFFSET_RDI + cpu_ctx(%rip)
+	movq %rsi, CPU_CONTEXT_OFFSET_RSI + cpu_ctx(%rip)
+	movq %rbp, CPU_CONTEXT_OFFSET_RBP + cpu_ctx(%rip)
+	movq %rsp, CPU_CONTEXT_OFFSET_RSP + cpu_ctx(%rip)
+	movq %r8,  CPU_CONTEXT_OFFSET_R8 + cpu_ctx(%rip)
+	movq %r9,  CPU_CONTEXT_OFFSET_R9 + cpu_ctx(%rip)
+	movq %r10, CPU_CONTEXT_OFFSET_R10 + cpu_ctx(%rip)
+	movq %r11, CPU_CONTEXT_OFFSET_R11 + cpu_ctx(%rip)
+	movq %r12, CPU_CONTEXT_OFFSET_R12 + cpu_ctx(%rip)
+	movq %r13, CPU_CONTEXT_OFFSET_R13 + cpu_ctx(%rip)
+	movq %r14, CPU_CONTEXT_OFFSET_R14 + cpu_ctx(%rip)
+	movq %r15, CPU_CONTEXT_OFFSET_R15 + cpu_ctx(%rip)
+
+	pushfq
+	popq CPU_CONTEXT_OFFSET_RFLAGS + cpu_ctx(%rip)
+
+	sidt CPU_CONTEXT_OFFSET_IDTR + cpu_ctx(%rip)
+	sldt CPU_CONTEXT_OFFSET_LDTR + cpu_ctx(%rip)
+
+	mov %cr0, %rax
+	mov %rax, CPU_CONTEXT_OFFSET_CR0 + cpu_ctx(%rip)
+
+	mov %cr3, %rax
+	mov %rax, CPU_CONTEXT_OFFSET_CR3 + cpu_ctx(%rip)
+
+	mov %cr4, %rax
+	mov %rax, CPU_CONTEXT_OFFSET_CR4 + cpu_ctx(%rip)
+
+	wbinvd
+
+	/* Will add the function call to enter Sx here*/
+
+
+/*
+ * When system resume from S3, trampoline_start64 will
+ * jump to restore_s3_context after setup temporary stack.
+ */
+.global restore_s3_context
+restore_s3_context:
+	mov CPU_CONTEXT_OFFSET_CR4 + cpu_ctx(%rip), %rax
+	mov %rax, %cr4
+
+	mov CPU_CONTEXT_OFFSET_CR3 + cpu_ctx(%rip), %rax
+	mov %rax, %cr3
+
+	mov CPU_CONTEXT_OFFSET_CR0 + cpu_ctx(%rip), %rax
+	mov %rax, %cr0
+
+	lidt CPU_CONTEXT_OFFSET_IDTR + cpu_ctx(%rip)
+	lldt CPU_CONTEXT_OFFSET_LDTR + cpu_ctx(%rip)
+
+	mov CPU_CONTEXT_OFFSET_SS + cpu_ctx(%rip), %ss
+	mov CPU_CONTEXT_OFFSET_RSP + cpu_ctx(%rip), %rsp
+
+	pushq CPU_CONTEXT_OFFSET_RFLAGS + cpu_ctx(%rip)
+	popfq
+
+	call load_gdtr_and_tr
+	call restore_msrs
+
+	movq CPU_CONTEXT_OFFSET_RAX + cpu_ctx(%rip), %rax
+	movq CPU_CONTEXT_OFFSET_RBX + cpu_ctx(%rip), %rbx
+	movq CPU_CONTEXT_OFFSET_RCX + cpu_ctx(%rip), %rcx
+	movq CPU_CONTEXT_OFFSET_RDX + cpu_ctx(%rip), %rdx
+	movq CPU_CONTEXT_OFFSET_RDI + cpu_ctx(%rip), %rdi
+	movq CPU_CONTEXT_OFFSET_RSI + cpu_ctx(%rip), %rsi
+	movq CPU_CONTEXT_OFFSET_RBP + cpu_ctx(%rip), %rbp
+	movq CPU_CONTEXT_OFFSET_R8 + cpu_ctx(%rip), %r8
+	movq CPU_CONTEXT_OFFSET_R9 + cpu_ctx(%rip), %r9
+	movq CPU_CONTEXT_OFFSET_R10 + cpu_ctx(%rip), %r10
+	movq CPU_CONTEXT_OFFSET_R11 + cpu_ctx(%rip), %r11
+	movq CPU_CONTEXT_OFFSET_R12 + cpu_ctx(%rip), %r12
+	movq CPU_CONTEXT_OFFSET_R13 + cpu_ctx(%rip), %r13
+	movq CPU_CONTEXT_OFFSET_R14 + cpu_ctx(%rip), %r14
+	movq CPU_CONTEXT_OFFSET_R15 + cpu_ctx(%rip), %r15
+
+	retq

--- a/hypervisor/arch/x86/wakeup.S
+++ b/hypervisor/arch/x86/wakeup.S
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <vcpu.h>
+#include <spinlock.h>
 
    .text
    .align   8
@@ -10,6 +11,8 @@
    .extern    restore_msrs
    .extern    cpu_ctx
    .extern    load_gdtr_and_tr
+   .extern    do_acpi_s3
+   .extern    trampoline_spinlock
 
    .global    __enter_s3
 __enter_s3:
@@ -47,7 +50,18 @@ __enter_s3:
 
 	wbinvd
 
-	/* Will add the function call to enter Sx here*/
+	movq CPU_CONTEXT_OFFSET_RDX + cpu_ctx(%rip), %rdx  /* pm1b_cnt_val */
+	movq CPU_CONTEXT_OFFSET_RDI + cpu_ctx(%rip), %rdi  /* *vm */
+	movq CPU_CONTEXT_OFFSET_RSI + cpu_ctx(%rip), %rsi  /* pm1a_cnt_val */
+
+	call do_acpi_s3
+
+	/* if do_acpi_s3 returns, which means ACRN can't enter S3 state.
+	 * Then trampoline will not be executed and we need to acquire
+	 * trampoline_spinlock here to match release in enter_sleep
+	 */
+	mov $trampoline_spinlock, %rdi
+	spinlock_obtain(%rdi)
 
 
 /*

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -270,13 +270,6 @@ handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd,
 
 		consumed = handle_dmar_devscope(dev_scope, cp, remaining);
 
-		if (((drhd->segment << 16) |
-		     (dev_scope->bus << 8) |
-		     dev_scope->devfun) == CONFIG_GPU_SBDF) {
-			ASSERT(dev_count == 1, "no dedicated iommu for gpu");
-			drhd->ignore = true;
-		}
-
 		if (consumed <= 0)
 			break;
 

--- a/hypervisor/bsp/sbl/sbl.c
+++ b/hypervisor/bsp/sbl/sbl.c
@@ -33,7 +33,7 @@ static struct dmar_drhd drhd_info_array[] = {
 		/* Ignore the iommu for intel graphic device since GVT-g needs
 		 * vtd disabled for gpu
 		 */
-		.ignore = true,
+		.ignore = false,
 		.devices = default_drhd_unit_dev_scope0,
 	},
 	{

--- a/hypervisor/bsp/uefi/include/bsp/bsp_cfg.h
+++ b/hypervisor/bsp/uefi/include/bsp/bsp_cfg.h
@@ -21,7 +21,6 @@
 #define	CONFIG_RAM_START	0x20000000
 #define	CONFIG_RAM_SIZE		0x02000000	/* 32M */
 #define	CONFIG_DMAR_PARSE_ENABLED	1
-#define	CONFIG_GPU_SBDF		0x00000010	/* 0000:00:02.0 */
 #define CONFIG_EFI_STUB       1
 #define CONFIG_UEFI_OS_LOADER_NAME  "\\EFI\\org.clearlinux\\bootloaderx64.efi"
 #define CONFIG_MTRR_ENABLED		1

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -174,8 +174,12 @@ extern uint8_t                trampoline_pdpt_addr[];
 extern uint8_t                trampoline_gdt_ptr[];
 extern uint8_t                trampoline_start64_fixup[];
 
+/* In trampoline range, hold the jump target which trampline will jump to */
+extern uint64_t               main_entry[1];
+
 extern uint64_t trampoline_start16_paddr;
 extern int ibrs_type;
+extern spinlock_t trampoline_spinlock;
 
 /*
  * To support per_cpu access, we use a special struct "per_cpu_region" to hold
@@ -260,6 +264,7 @@ bool is_vapic_virt_reg_supported(void);
 bool cpu_has_cap(uint32_t bit);
 void load_cpu_state_data(void);
 void start_cpus();
+void stop_cpus();
 
 /* Read control register */
 #define CPU_CR_READ(cr, result_ptr)                         \

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -18,7 +18,7 @@
 
 #define foreach_vcpu(idx, vm, vcpu)				\
 	for (idx = 0, vcpu = vm->hw.vcpu_array[idx];		\
-		(idx < vm->hw.num_vcpus) & (vcpu != NULL);	\
+		(idx < vm->hw.num_vcpus) && (vcpu != NULL);	\
 		idx++, vcpu = vm->hw.vcpu_array[idx])
 
 

--- a/hypervisor/include/arch/x86/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/guest/guest_pm.h
@@ -11,5 +11,6 @@ void vm_setup_cpu_state(struct vm *vm);
 int vm_load_pm_s_state(struct vm *vm);
 int validate_pstate(struct vm *vm, uint64_t perf_ctl);
 struct cpu_cx_data* get_target_cx(struct vm *vm, uint8_t cn);
+void register_pm1ab_handler(struct vm *vm);
 
 #endif /* PM_H */

--- a/hypervisor/include/arch/x86/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/guest/guest_pm.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef PM_H
-#define PM_H
+#ifndef GUEST_PM_H
+#define GUEST_PM_H
 
 void vm_setup_cpu_state(struct vm *vm);
 int vm_load_pm_s_state(struct vm *vm);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -171,6 +171,7 @@ struct vm_description {
 
 int shutdown_vm(struct vm *vm);
 void pause_vm(struct vm *vm);
+void resume_vm(struct vm *vm);
 int start_vm(struct vm *vm);
 int create_vm(struct vm_description *vm_desc, struct vm **vm);
 int prepare_vm0(void);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -172,6 +172,7 @@ struct vm_description {
 int shutdown_vm(struct vm *vm);
 void pause_vm(struct vm *vm);
 void resume_vm(struct vm *vm);
+void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec);
 int start_vm(struct vm *vm);
 int create_vm(struct vm_description *vm_desc, struct vm **vm);
 int prepare_vm0(void);

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -5,7 +5,11 @@
 
 #ifndef	HOST_PM_H
 
+#define	BIT_SLP_TYPx	10U
+#define	BIT_SLP_EN	13U
 #define	BIT_WAK_STS	15U
+
+extern uint8_t host_enter_s3_success;
 
 int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 		uint32_t pm1b_cnt_val);

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef	HOST_PM_H
+
+extern void __enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+		uint32_t pm1b_cnt_val);
+extern void restore_s3_context(void);
+
+#endif	/* ARCH_X86_PM_H */

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -5,6 +5,10 @@
 
 #ifndef	HOST_PM_H
 
+#define	BIT_WAK_STS	15U
+
+int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+		uint32_t pm1b_cnt_val);
 extern void __enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 		uint32_t pm1b_cnt_val);
 extern void restore_s3_context(void);

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -19,6 +19,7 @@
 #include <vcpu.h>
 #include <trusty.h>
 #include <guest_pm.h>
+#include <host_pm.h>
 #include <vm.h>
 #include <cpuid.h>
 #include <mmu.h>

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -18,7 +18,7 @@
 #include <mtrr.h>
 #include <vcpu.h>
 #include <trusty.h>
-#include <pm.h>
+#include <guest_pm.h>
 #include <vm.h>
 #include <cpuid.h>
 #include <mmu.h>

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -206,6 +206,8 @@ struct dmar_info {
 
 extern struct dmar_info *get_dmar_info(void);
 
+extern bool iommu_snoop;
+
 struct iommu_domain;
 
 /* Assign a device specified by bus & devfun to a iommu domain */

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -70,7 +70,7 @@ static inline void suspend_console(void)
 	del_timer(&console_timer);
 }
 
-static inline void resume_console_enable(void)
+static inline void resume_console(void)
 {
 	console_setup_timer();
 }
@@ -101,7 +101,7 @@ static inline void console_setup_timer(void) {}
 static inline uint32_t get_serial_handle(void) { return 0; }
 
 static inline void suspend_console(void) {}
-static inline void resume_console_enable(void) {}
+static inline void resume_console(void) {}
 #endif
 
 #endif /* CONSOLE_H */


### PR DESCRIPTION
WIFI dev has no FLR, so 'reset' in sysfs calls secondary bus reset,
which cause PCI configuration mess(all FF) then passthrough failure.
To fix it, this patch makes no reset before passthrough by default,
until append this option.

Signed-off-by: Edwin Zhai <edwin.zhai@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>