### PR TITLE
HV: Remove 'register' prefix for data type

### DIFF
--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -41,8 +41,8 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
 int udiv64(uint64_t dividend, uint64_t divisor, struct udiv_result *res);
 int udiv32(uint32_t dividend, uint32_t divisor, struct udiv_result *res);
 int atoi(const char *str);
-long strtol(const char *nptr, char **endptr, register int base);
-uint64_t strtoul(const char *nptr, char **endptr, register int base);
+long strtol(const char *nptr, char **endptr, int base);
+uint64_t strtoul(const char *nptr, char **endptr, int base);
 
 extern uint64_t tsc_hz;
 #define US_TO_TICKS(x)	((x) * tsc_hz / 1000000UL)

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -207,13 +207,13 @@ const uint8_t _sch_toupper[256] = {
  * alphabets and digits are each contiguous.
  */
 long
-strtol(const char *nptr, char **endptr, register int base)
+strtol(const char *nptr, char **endptr, int base)
 {
-        register const char *s = nptr;
-        register uint64_t acc;
-        register int c;
-        register uint64_t cutoff;
-        register int neg = 0, any, cutlim;
+	const char *s = nptr;
+	uint64_t acc;
+	int c;
+	uint64_t cutoff;
+	int neg = 0, any, cutlim;
 
         /*
          * Skip white space and pick up leading +/- sign if any.
@@ -290,13 +290,13 @@ strtol(const char *nptr, char **endptr, register int base)
  * alphabets and digits are each contiguous.
  */
 uint64_t
-strtoul(const char *nptr, char **endptr, register int base)
+strtoul(const char *nptr, char **endptr, int base)
 {
-        register const char *s = nptr;
-        register uint64_t acc;
-        register int c;
-        register uint64_t cutoff;
-        register int neg = 0, any, cutlim;
+	const char *s = nptr;
+	uint64_t acc;
+	int c;
+	uint64_t cutoff;
+	int neg = 0, any, cutlim;
 
         /*
          * See strtol for comments as to the logic used.


### PR DESCRIPTION
- it is unnecessary.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>