### PR TITLE
HV:treewide:Cleanup the type for parameters of bitmap operations

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -541,7 +541,7 @@ static void bsp_boot_post(void)
 	start_cpus();
 
 	/* Trigger event to allow secondary CPUs to continue */
-	__bitmap_set(0, &pcpu_sync);
+	__bitmap_set(0U, &pcpu_sync);
 
 	ASSERT(get_cpu_id() == CPU_BOOT_ID, "");
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -387,7 +387,7 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 	return ret;
 }
 
-void request_vcpu_pre_work(struct vcpu *vcpu, int pre_work_id)
+void request_vcpu_pre_work(struct vcpu *vcpu, uint16_t pre_work_id)
 {
 	bitmap_set(pre_work_id, &vcpu->pending_pre_work);
 }

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -130,7 +130,7 @@
 #define CPU_MHZ_TO_KHZ          1000
 
 /* Boot CPU ID */
-#define CPU_BOOT_ID             0
+#define CPU_BOOT_ID             0U
 
 /* CPU states defined */
 #define CPU_STATE_RESET         0

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -287,7 +287,7 @@ void resume_vcpu(struct vcpu *vcpu);
 void schedule_vcpu(struct vcpu *vcpu);
 int prepare_vcpu(struct vm *vm, uint16_t pcpu_id);
 
-void request_vcpu_pre_work(struct vcpu *vcpu, int pre_work_id);
+void request_vcpu_pre_work(struct vcpu *vcpu, uint16_t pre_work_id);
 
 #endif
 

--- a/hypervisor/include/arch/x86/softirq.h
+++ b/hypervisor/include/arch/x86/softirq.h
@@ -13,7 +13,7 @@
 #define SOFTIRQ_MASK		((1UL<<SOFTIRQ_MAX)-1)
 
 /* used for atomic value for prevent recursive */
-#define SOFTIRQ_ATOMIC		63
+#define SOFTIRQ_ATOMIC		63U
 
 void enable_softirq(uint16_t cpu_id);
 void disable_softirq(uint16_t cpu_id);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -7,8 +7,8 @@
 #ifndef	_HV_CORE_SCHEDULE_
 #define	_HV_CORE_SCHEDULE_
 
-#define	NEED_RESCHEDULE		(1)
-#define	NEED_OFFLINE		(2)
+#define	NEED_RESCHEDULE		(1U)
+#define	NEED_OFFLINE		(2U)
 
 struct sched_context {
 	spinlock_t runqueue_lock;


### PR DESCRIPTION
For reducing sign conversion in hypervisor:
Update parameters of bitmap operations as unsigned type;
Update the input of related caller as unsigned type when the
caller's input parameter is const variable or the variable is
only used by bitmap operations.

V1-->V2:
	(1) Explicit casting for the first parameter
	    of all bitmap operations;
	(2) Remove mask operation for explicit casting
	    of all bitmap operations, since masking is
	    useless. Otherwise, this trucation is dangerous.
V2-->V3:
	(1) Explicit casting for all bitmap operations parameter;
	(2) Masking bit offset with 6-bit;
	(3) Add few comments about bit offset.
V3-->V4:
        add '\' for some statement of bitmap macro

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>