### PR TITLE
build: Using id tool to get builder username

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -158,6 +158,7 @@ include/version.h:
 	DIRTY=`git diff-index --name-only HEAD`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
+	USER=`id -u -n`; \
 	echo "/*" > include/version.h; \
 	sed 's/^/ * /' ../LICENSE >> include/version.h; \
 	echo " */" >> include/version.h; \
@@ -167,7 +168,7 @@ include/version.h:
 	echo "#define DM_RC_VERSION $(RC_VERSION)" >> include/version.h;\
 	echo "#define DM_BUILD_VERSION "\""$$PATCH"\""" >> include/version.h;\
 	echo "#define DM_BUILD_TIME "\""$$TIME"\""" >> include/version.h;\
-	echo "#define DM_BUILD_USER "\""$(USER)"\""" >> include/version.h
+	echo "#define DM_BUILD_USER "\""$$USER"\""" >> include/version.h
 
 $(DM_OBJDIR)/%.o: %.c $(HEADERS)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -242,6 +242,7 @@ $(VERSION):
 	DIRTY=`git diff-index --name-only HEAD`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	TIME=`date "+%F %T"`;\
+	USER=`id -u -n`; \
 	if [ $(CONFIG_RELEASE) = "n" ];then BUILD_TYPE="DBG";else BUILD_TYPE="REL";fi;\
 	echo "/*" > $(VERSION); \
 	sed 's/^/ * /' ../LICENSE >> $(VERSION); \
@@ -255,7 +256,7 @@ $(VERSION):
 	echo "#define HV_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TYPE "\""$$BUILD_TYPE"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TIME "\""$$TIME"\""" >> $(VERSION);\
-	echo "#define HV_BUILD_USER "\""$(USER)"\""" >> $(VERSION)
+	echo "#define HV_BUILD_USER "\""$$USER"\""" >> $(VERSION)
 
 $(HV_OBJDIR)/%.o: %.c $(HV_OBJDIR)/$(HV_CONFIG_H)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -16,6 +16,7 @@ TARGET		= $(BUILDDIR)/acrnprobe/bin/acrnprobe
 
 .PHONY: all check_dirs
 all: $(VERSION_H) check_dirs $(TARGET)
+	rm -f $(VERSION_H)
 
 $(BUILDDIR)/acrnprobe/obj/%.o:%.c
 	$(CC) -c $(CFLAGS) $< -o $@
@@ -63,12 +64,13 @@ $(VERSION_H):
 	DIRTY=`git diff --name-only $(CURDIR)`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
+	USER=`id -u -n`; \
 	cat $(CURDIR)/../license_header > $(VERSION_H);\
 	echo "#define AP_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
 	echo "#define AP_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\
 	echo "#define AP_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION_H);\
 	echo "#define AP_BUILD_TIME "\""$$TIME"\""" >> $(VERSION_H);\
-	echo "#define AP_BUILD_USER "\""$(USER)"\""" >> $(VERSION_H)
+	echo "#define AP_BUILD_USER "\""$$USER"\""" >> $(VERSION_H)
 
 check_dirs:
 	@if [ ! -d $(BUILDDIR)/acrnprobe/bin ]; then \

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -5,6 +5,7 @@ VERSION_H = $(BUILDDIR)/include/usercrash/version.h
 
 .PHONY: all check_obj
 all: $(VERSION_H) check_obj usercrash_s usercrash_c debugger
+	rm -f $(VERSION_H)
 
 INCLUDE += -I $(CURDIR)/include/
 INCLUDE += -I $(BUILDDIR)/include/usercrash
@@ -45,12 +46,13 @@ $(VERSION_H):
 	DIRTY=`git diff --name-only $(CURDIR)`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
+	USER=`id -u -n`; \
 	cat $(CURDIR)/../license_header > $(VERSION_H);\
 	echo "#define UC_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
 	echo "#define UC_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\
 	echo "#define UC_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION_H);\
 	echo "#define UC_BUILD_TIME "\""$$TIME"\""" >> $(VERSION_H);\
-	echo "#define UC_BUILD_USER "\""$(USER)"\""" >> $(VERSION_H)
+	echo "#define UC_BUILD_USER "\""$$USER"\""" >> $(VERSION_H)
 
 check_obj:
 	@if [ ! -d $(BUILDDIR)/usercrash/bin ]; then \


### PR DESCRIPTION
Some build environment might has no USER pre-defined. So use id tool to
get builder username instead of USER environemnt.

Also add a version cleanup for tools to keep them updated.

Signed-off-by: Shuo Liu <shuo.a.liu@intel.com>
Acked-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>