### PR TITLE
modified the lapic_id type to uint8_t

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -54,7 +54,7 @@ static void vapic_cap_detect(void);
 static void cpu_xsave_init(void);
 static void cpu_set_logical_id(uint32_t logical_id);
 static void print_hv_banner(void);
-int cpu_find_logical_id(uint32_t lapic_id);
+int cpu_find_logical_id(uint8_t lapic_id);
 static void pcpu_sync_sleep(unsigned long *sync, int mask_bit);
 int ibrs_type;
 static uint64_t __attribute__((__section__(".bss_noinit"))) start_tsc;
@@ -252,7 +252,7 @@ static void alloc_phy_cpu_data(uint16_t pcpu_num)
 
 uint16_t __attribute__((weak)) parse_madt(uint8_t *lapic_id_base)
 {
-	static const uint32_t lapic_id[] = {0, 2, 4, 6};
+	static const uint8_t lapic_id[] = {0U, 2U, 4U, 6U};
 	uint32_t i;
 
 	for (i = 0; i < ARRAY_SIZE(lapic_id); i++)
@@ -631,7 +631,7 @@ static void cpu_secondary_post(void)
 	cpu_dead(get_cpu_id());
 }
 
-int cpu_find_logical_id(uint32_t lapic_id)
+int cpu_find_logical_id(uint8_t lapic_id)
 {
 	int i;
 

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -331,12 +331,13 @@ static void wait_for_delivery(void)
 	} while (tmp.bits.delivery_status != 0U);
 }
 
-uint32_t get_cur_lapic_id(void)
+uint8_t get_cur_lapic_id(void)
 {
-	uint32_t lapic_id;
+	uint32_t lapic_id_reg;
+	uint8_t lapic_id;
 
-	lapic_id = read_lapic_reg32(LAPIC_ID_REGISTER);
-	lapic_id = (lapic_id >> 24);
+	lapic_id_reg = read_lapic_reg32(LAPIC_ID_REGISTER);
+	lapic_id = (lapic_id_reg >> 24U);
 
 	return lapic_id;
 }

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -675,13 +675,13 @@ static void dmar_fault_msi_write(struct dmar_drhd_rt *dmar_uint,
 {
 	uint32_t data;
 	uint32_t addr_low;
-	uint32_t lapic_id = get_cur_lapic_id();
+	uint8_t lapic_id = get_cur_lapic_id();
 
 	data = DMAR_MSI_DELIVERY_LOWPRI | vector;
 	/* redirection hint: 0
 	 * destination mode: 0
 	 */
-	addr_low = 0xFEE00000U | ((lapic_id & 0xFFU) << 12);
+	addr_low = 0xFEE00000U | ((uint32_t)(lapic_id) << 12U);
 
 	IOMMU_LOCK(dmar_uint);
 	iommu_write32(dmar_uint, DMAR_FEDATA_REG, data);

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -153,7 +153,7 @@
 
 #ifndef ASSEMBLER
 
-int cpu_find_logical_id(uint32_t lapic_id);
+int cpu_find_logical_id(uint8_t lapic_id);
 
 /**********************************/
 /* EXTERNAL VARIABLES             */

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -160,7 +160,7 @@ void save_lapic(struct lapic_regs *regs);
 int early_init_lapic(void);
 int init_lapic(uint16_t cpu_id);
 void send_lapic_eoi(void);
-uint32_t get_cur_lapic_id(void);
+uint8_t get_cur_lapic_id(void);
 int send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 		uint32_t cpu_startup_dest,
 		uint64_t cpu_startup_start_address);


### PR DESCRIPTION
According intel mannual and ACPI mannual,lapic_id length is 1 byte.

V1->V2:
  Add U suffix to the numeric when do arithmetic operation on lapic.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>