### PR TITLE
HV:treewide:transfer the struct member types to non-basic types

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -115,11 +115,11 @@ int create_vcpu(uint16_t cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	*rtn_vcpu_handle = vcpu;
 
 	vcpu->launched = false;
-	vcpu->paused_cnt = 0;
+	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
 	vcpu->ioreq_pending = 0;
 	vcpu->arch_vcpu.nr_sipi = 0;
-	vcpu->pending_pre_work = 0;
+	vcpu->pending_pre_work = 0U;
 	vcpu->state = VCPU_INIT;
 
 	return 0;
@@ -273,11 +273,11 @@ void reset_vcpu(struct vcpu *vcpu)
 	vcpu->state = VCPU_INIT;
 
 	vcpu->launched = false;
-	vcpu->paused_cnt = 0;
+	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
 	vcpu->ioreq_pending = 0;
 	vcpu->arch_vcpu.nr_sipi = 0;
-	vcpu->pending_pre_work = 0;
+	vcpu->pending_pre_work = 0U;
 
 	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
 	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -307,7 +307,7 @@ void vuart_register_io_handler(struct vm *vm)
 	struct vm_io_range range = {
 		.flags = IO_ATTR_RW,
 		.base = 0x3f8,
-		.len = 8
+		.len = 8U
 	};
 
 	register_io_emulation_handler(vm, &range, uart_read, uart_write);

--- a/hypervisor/include/arch/x86/gdt.h
+++ b/hypervisor/include/arch/x86/gdt.h
@@ -271,7 +271,7 @@ struct tss_64 {
  * Definition of the GDT descriptor.
  */
 struct host_gdt_descriptor {
-	unsigned short len;
+	uint16_t len;
 	struct host_gdt *gdt;
 } __packed;
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -243,13 +243,13 @@ struct vcpu {
 	volatile enum vcpu_state state;	/* State of this VCPU */
 	/* State of debug request for this VCPU */
 	volatile enum vcpu_state dbg_req_state;
-	unsigned long sync;	/*hold the bit events*/
+	uint64_t sync;	/*hold the bit events*/
 	struct vlapic *vlapic;	/* per vCPU virtualized LAPIC */
 
 	struct list_head run_list; /* inserted to schedule runqueue */
-	unsigned long pending_pre_work; /* any pre work pending? */
+	uint64_t pending_pre_work; /* any pre work pending? */
 	bool launched; /* Whether the vcpu is launched on target pcpu */
-	unsigned int paused_cnt; /* how many times vcpu is paused */
+	uint32_t paused_cnt; /* how many times vcpu is paused */
 	int running; /* vcpu is picked up and run? */
 	int ioreq_pending; /* ioreq is ongoing or not? */
 

--- a/hypervisor/include/arch/x86/idt.h
+++ b/hypervisor/include/arch/x86/idt.h
@@ -67,7 +67,7 @@ struct host_idt {
  * Definition of the IDT descriptor.
  */
 struct host_idt_descriptor {
-	unsigned short len;
+	uint16_t len;
 	struct host_idt *idt;
 } __packed;
 

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -11,7 +11,7 @@
 struct vm_io_range {
 	uint16_t base;		/* IO port base */
 	uint16_t len;		/* IO port range */
-	int flags;		/* IO port attributes */
+	uint32_t flags;		/* IO port attributes */
 };
 
 /* Write 1 byte to specified I/O port */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -13,7 +13,7 @@
 struct sched_context {
 	spinlock_t runqueue_lock;
 	struct list_head runqueue;
-	unsigned long flags;
+	uint64_t flags;
 	struct vcpu *curr_vcpu;
 	spinlock_t scheduler_lock;
 };


### PR DESCRIPTION
The struct member types should be transfer to non-basic types,
chaned it to length-prefix(uint32_t,int32_t ...) type.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>