### PR TITLE
tools: acrn-crashlog: Defer the vm events processing when failed

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/include/android_events.h
+++ b/tools/acrn-crashlog/acrnprobe/include/android_events.h
@@ -9,7 +9,33 @@
 
 extern char *loop_dev;
 
-void refresh_vm_history(struct sender_t *sender,
-			void (*fn)(char*, struct vm_t *));
+#define VMEVT_HANDLED 0
+#define VMEVT_DEFER -1
+
+#define IGN_SPACES "%*[ ]"
+#define IGN_RESTS "%*c"
+#define IGN_ONEWORD "%*[^ ]" IGN_SPACES
+#define VM_NAME_FMT "%8[A-Z0-9]" IGN_SPACES
+
+/* These below macros were defined to obtain strings from
+ * andorid history_event
+ */
+#define ANDROID_WORD_LEN 32
+
+/* Strings are constructed by A-Z, len < 8, e.g., CRASH REBOOT */
+#define ANDROID_ENEVT_FMT "%8[A-Z]" IGN_SPACES
+/* Hashkeys are constructed by 0-9&a-z, len = 20, e.g., 0b34ae1afba54aee5cd0.
+ * But the hashkey was printed to history_event file in andorid side by using
+ * format "%22s", so also using %22 here.
+ */
+#define ANDROID_KEY_FMT "%22[0-9a-z]" IGN_SPACES
+/* Strings, e.g., 2017-11-11/03:12:59 */
+#define ANDROID_LONGTIME_FMT "%20[0-9:/-]" IGN_SPACES
+/* It's a time or a subtype of event, e.g., JAVACRASH POWER-ON 424874:19:56 */
+#define ANDROID_TYPE_FMT "%16[A-Z0-9_:-]" IGN_SPACES
+#define ANDROID_LINE_REST_FMT "%4096[^\n]" IGN_RESTS
+
+void refresh_vm_history(const struct sender_t *sender,
+			int (*fn)(const char*, const struct vm_t *));
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -203,7 +203,7 @@ struct conf_t conf;
 int load_conf(const char *path);
 struct trigger_t *get_trigger_by_name(char *name);
 struct log_t *get_log_by_name(char *name);
-int sender_id(struct sender_t *sender);
+int sender_id(const struct sender_t *sender);
 struct sender_t *get_sender_by_name(char *name);
 enum event_type_t get_conf_by_wd(int wd, void **private);
 struct crash_t *get_crash_by_wd(int wd);

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -260,7 +260,7 @@ enum event_type_t get_conf_by_wd(int wd, void **private)
 
 }
 
-int sender_id(struct sender_t *s)
+int sender_id(const struct sender_t *s)
 {
 	int id;
 	struct sender_t *sender;

--- a/tools/acrn-crashlog/acrnprobe/main.c
+++ b/tools/acrn-crashlog/acrnprobe/main.c
@@ -65,15 +65,18 @@ int main(int argc, char *argv[])
 	int op;
 	struct sender_t *sender;
 	char cfg[PATH_MAX];
-	char *config_path[2] = {CONFIG_CUSTOMIZE,
-				CONFIG_INSTALL};
-	struct option opts[] = {
+	const char * const config_path[2] = {
+		CONFIG_CUSTOMIZE,
+		CONFIG_INSTALL
+	};
+	const struct option opts[] = {
 		{ "config", required_argument, NULL, 'c' },
 		{ "help", no_argument, NULL, 'h' },
 		{ "version", no_argument, NULL, 'V' },
 		{ NULL, 0, NULL, 0 }
 	};
 
+	cfg[0] = 0;
 	while ((op = getopt_long(argc, argv, "c:hV", opts,
 				 NULL)) != -1) {
 		switch (op) {

--- a/tools/acrn-crashlog/acrnprobe/property.c
+++ b/tools/acrn-crashlog/acrnprobe/property.c
@@ -70,7 +70,8 @@ static int get_buildversion(struct sender_t *sender)
 	char *logbuildid;
 	char *currentbuild = gbuildversion;
 
-	ret = file_read_key_value(OS_VERSION, OS_VERSION_KEY, gbuildversion);
+	ret = file_read_key_value(OS_VERSION, OS_VERSION_KEY,
+				  sizeof(gbuildversion), gbuildversion);
 	if (ret <= 0) {
 		LOGE("failed to get version from %s, error (%s)\n",
 		     OS_VERSION, strerror(-ret));

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -81,7 +81,7 @@ int append_file(char *filename, char *text);
 int mm_replace_str_line(struct mm_file_t *mfile, char *replace,
 			int line);
 int replace_file_head(char *filename, char *text);
-int overwrite_file(char *filename, char *value);
+int overwrite_file(const char *filename, const char *value);
 int readline(int fd, char buffer[MAXLINESIZE]);
 int file_read_string(const char *file, char *string, int size);
 void file_reset_init(const char *filename);
@@ -93,8 +93,10 @@ int space_available(char *path, int quota);
 int count_lines_in_file(const char *filename);
 int read_full_binary_file(const char *path, unsigned long *size,
 			void **data);
-int file_read_key_value(char *path, char *key, char *value);
-int file_read_key_value_r(char *path, char *key, char *value);
+int file_read_key_value(const char *path, const char *key,
+			const size_t limit, char *value);
+int file_read_key_value_r(const char *path, const char *key,
+			const size_t limit, char *value);
 int dir_contains(const char *dir, const char *filename, int exact,
 		char *fullname);
 int lsdir(const char *dir, char *fullname[], int limit);

--- a/tools/acrn-crashlog/common/include/strutils.h
+++ b/tools/acrn-crashlog/common/include/strutils.h
@@ -9,7 +9,7 @@
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 int strlinelen(char *str);
-char *strrstr(char *s, char *str);
+char *strrstr(const char *s, const char *str);
 char *next_line(char *buf);
 char *strtrim(char *str);
 int strcnt(char *str, char c);

--- a/tools/acrn-crashlog/common/strutils.c
+++ b/tools/acrn-crashlog/common/strutils.c
@@ -37,16 +37,16 @@ int strlinelen(char *str)
  * @return a pointer to the beginning of the substring,
  *	   or NULL if the substring is not found.
  */
-char *strrstr(char *s, char *substr)
+char *strrstr(const char *s, const char *substr)
 {
-	char *found;
-	char *p = s;
+	const char *found;
+	const char *p = s;
 
 	while ((found = strstr(p, substr)))
 		p = found + 1;
 
 	if (p != s)
-		return p - 1;
+		return (char *)(p - 1);
 
 	return NULL;
 }


### PR DESCRIPTION
In the original design, acrnprobe marked all handled VMs'events as "synced"
in file vmrecordid(this patch changes the name to VM_eventsID.log).
Currently, the Android log events are not logged if the first attempt at
reading collecting them from the VM fails. This patch changes the logic
so that the acrn-crashlog tool will retry continuously.

This patch defines different tags for handled VMs'events, and only marks
VMs'events "synced" after it returns successfully.

Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: xiaojin2 <xiaojing.liu@intel.com>
Reviewed-by: Jin Zhi <zhi.jin@intel.com>
Acked-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Acked-by: Chen gang <gang.c.chen@intel.com>