### PR TITLE
misc: fix cbc_attach blocks APL NUC boot for 20 seconds

### DIFF
--- a/misc/cbc_attach/Makefile
+++ b/misc/cbc_attach/Makefile
@@ -1,7 +1,7 @@
 OUT_DIR ?= .
 
 all:
-	gcc -o $(OUT_DIR)/cbc_attach cbc_attach.c -lsystemd
+	gcc -o $(OUT_DIR)/cbc_attach cbc_attach.c
 
 clean:
 	rm -rf $(OUT_DIR)/cbc_attach

--- a/misc/cbc_attach/cbc_attach.c
+++ b/misc/cbc_attach/cbc_attach.c
@@ -10,6 +10,7 @@
  */
 
 #include <getopt.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -23,7 +24,6 @@
 #include <unistd.h>
 
 #ifndef ANDROID_BUILD
-#include <systemd/sd-daemon.h>
 #define APP_INFO "v" VERSION_STRING
 #else
 #define APP_INFO ""
@@ -403,13 +403,6 @@ int main(int argc, char **argv)
 
 	} while (retry_time > 0);
 
-
-#ifndef ANDROID_BUILD
-	/* it is recommended by systemd to ignore the return value of
-	 * sd_notify()
-	 */
-	(void)sd_notify(0, "READY=1");
-#endif
 	if (success) {
 		pause();
 		cbc_attach_shutdown(&deviceFd);

--- a/misc/cbc_attach/cbc_attach.service
+++ b/misc/cbc_attach/cbc_attach.service
@@ -6,8 +6,8 @@ Before=basic.target
 
 [Service]
 ExecStart=/usr/bin/cbc_attach /dev/ttyS2
-Restart=always
-Type=notify
+Restart=no
+Type=simple
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
This patch resolved systemd be blocking for 20 seconds due to waiting the
"READY=1" from cbc_attach. And cbc_attach will retry 60 sec at the worst case
which can be reproduced on non-IOC boards.

This is one temporary solution. The final solution need modify SBL to export IOC
ACPI device through ACPI table, and also Linux IOC CBC driver need trigger
uevent which should be the trigger of launching cbc_attach service.

This patch changes the service type to simple instead of notify due to systemd is
needn't wait cbc related services. And change Restart to no due to cbc_attach
already has retry mechanism.

These changes are also reasonable for the board integrated IOC component.
So they should be keep even the long term final solution implemented.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Alex Du <alek.du@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>