### PR TITLE
HV:transfer page_table_type type

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -190,7 +190,7 @@ void invept(struct vcpu *vcpu)
 		_invept(INVEPT_TYPE_ALL_CONTEXTS, desc);
 }
 
-bool check_mmu_1gb_support(int page_table_type)
+bool check_mmu_1gb_support(enum _page_table_type page_table_type)
 {
 	bool status = false;
 
@@ -201,7 +201,8 @@ bool check_mmu_1gb_support(int page_table_type)
 	return status;
 }
 
-static inline uint32_t check_page_table_present(int page_table_type,
+static inline uint32_t
+check_page_table_present(enum _page_table_type page_table_type,
 		uint64_t table_entry)
 {
 	if (page_table_type == PTT_EPT) {
@@ -227,7 +228,8 @@ static inline uint32_t check_page_table_present(int page_table_type,
 
 static uint32_t map_mem_region(void *vaddr, void *paddr,
 		void *table_base, uint64_t attr, uint32_t table_level,
-		int table_type, enum mem_map_request_type request_type)
+		enum _page_table_type table_type,
+		enum mem_map_request_type request_type)
 {
 	uint64_t table_entry;
 	uint32_t table_offset;

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -213,9 +213,15 @@
 #define ROUND_PAGE_UP(addr)  (((addr) + CPU_PAGE_SIZE - 1) & CPU_PAGE_MASK)
 #define ROUND_PAGE_DOWN(addr) ((addr) & CPU_PAGE_MASK)
 
+enum _page_table_type {
+	PTT_HOST = 0,  /* Mapping for hypervisor */
+	PTT_EPT = 1,
+	PAGETABLE_TYPE_UNKNOWN,
+};
+
 struct map_params {
 	/* enum _page_table_type: HOST or EPT*/
-	int  page_table_type;
+	enum _page_table_type page_table_type;
 	/* used HVA->HPA for HOST, used GPA->HPA for EPT */
 	void *pml4_base;
 	/* used HPA->HVA for HOST, used HPA->GPA for EPT */
@@ -228,12 +234,6 @@ struct entry_params {
 	uint64_t entry_off;
 	uint64_t entry_val;
 	uint64_t page_size;
-};
-
-enum _page_table_type {
-	PTT_HOST = 0,  /* Mapping for hypervisor */
-	PTT_EPT = 1,
-	PAGETABLE_TYPE_UNKNOWN,
 };
 
 /* Represent the 4 levels of translation tables in IA-32e paging mode */
@@ -284,7 +284,7 @@ struct mem_io_node {
 };
 
 uint64_t get_paging_pml4(void);
-bool check_mmu_1gb_support(int page_table_type);
+bool check_mmu_1gb_support(enum _page_table_type page_table_type);
 void *alloc_paging_struct(void);
 void free_paging_struct(void *ptr);
 void enable_paging(uint64_t pml4_base_addr);


### PR DESCRIPTION
struct map_params's member page_table_type is enum _page_table_type,
transferred it.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>