### PR TITLE
HV:change the cpu state to enum type

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -293,7 +293,7 @@ static int init_phy_cpu_storage(void)
 	return bsp_cpu_id;
 }
 
-static void cpu_set_current_state(uint32_t logical_id, int state)
+static void cpu_set_current_state(uint32_t logical_id, enum cpu_state state)
 {
 	spinlock_obtain(&up_count_spinlock);
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -132,13 +132,6 @@
 /* Boot CPU ID */
 #define CPU_BOOT_ID             0
 
-/* CPU states defined */
-#define CPU_STATE_RESET         0
-#define CPU_STATE_INITIALIZING  1
-#define CPU_STATE_RUNNING       2
-#define CPU_STATE_HALTED        3
-#define CPU_STATE_DEAD          4
-
 /* hypervisor stack bottom magic('intl') */
 #define SP_BOTTOM_MAGIC    0x696e746cUL
 
@@ -216,6 +209,15 @@ enum feature_word {
 	FEAT_8000_0001_EDX,     /* CPUID[8000_0001].EDX */
 	FEAT_8000_0008_EBX,     /* CPUID[8000_0008].EAX */
 	FEATURE_WORDS,
+};
+
+/* CPU states defined */
+enum cpu_state {
+	CPU_STATE_RESET = 0,
+	CPU_STATE_INITIALIZING,
+	CPU_STATE_RUNNING,
+	CPU_STATE_HALTED,
+	CPU_STATE_DEAD,
 };
 
 struct cpu_state_info {

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -32,7 +32,7 @@ struct per_cpu_region {
 	struct emul_cnx g_inst_ctxt;
 	struct host_gdt gdt;
 	struct tss_64 tss;
-	int state;
+	enum cpu_state state;
 	uint8_t mc_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t df_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t sf_stack[CONFIG_STACK_SIZE] __aligned(16);


### PR DESCRIPTION
enum cpu state is better than cpu state macro.

V1->V2:
  move enum cpu_state under #ifndef ASSEMBLER MACRO to avoid
assembler compiler scan.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>