### PR TITLE
HV: Remove vm->attr.name

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -102,8 +102,6 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 		if (bitmap_test_and_set(id, &vmid_bitmap) == 0)
 			break;
 	vm->attr.id = vm->attr.boot_idx = id;
-	snprintf(&vm->attr.name[0], MAX_VM_NAME_LEN, "vm_%d",
-		vm->attr.id);
 
 	atomic_store(&vm->hw.created_vcpus, 0);
 

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -474,7 +474,7 @@ int shell_list_vm(struct shell *p_shell,
 		/* Create output string consisting of VM name and VM id
 		 */
 		snprintf(temp_str, MAX_STR_SIZE,
-				"%-24s %-16d %-8s\r\n", vm->attr.name,
+				"vm_%-24d %-16d %-8s\r\n", vm->attr.id,
 				vm->attr.id, state);
 
 		/* Output information for this task */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -16,7 +16,6 @@ enum vm_privilege_level {
 
 #define	MAX_VM_NAME_LEN		16
 struct vm_attr {
-	char name[MAX_VM_NAME_LEN];	/* Virtual machine name string */
 	int id;		/* Virtual machine identifier */
 	int boot_idx;	/* Index indicating the boot sequence for this VM */
 };


### PR DESCRIPTION
We define attr.name in struct vm and named as ("vm_%d", attr.id). attr.name only
be used in debug tool vm_list. It does't deserve to do so in OS created flow
(aka function create_vm). It's better to handle this in vm_list tool.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@inte.com>