### PR TITLE
Documentation: fix minor rendering issue in GSG

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -446,6 +446,7 @@ repository has three main components in it:
 #. The ACRN tools source code located in the ``tools`` directory
 
 You can build all these components in one go as follows:
+
 .. code-block:: console
 
    $ git clone https://github.com/projectacrn/acrn-hypervisor


### PR DESCRIPTION
Fix a minor rendering issue in the Getting Started Guide where a
code-block is not appearing as such.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>