### PR TITLE
HV: Fix compiler warnings in string.c

### DIFF
--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -10,19 +10,11 @@
 
 #include <hypervisor.h>
 
-#ifndef ULONG_MAX
 #define ULONG_MAX       ((uint64_t)(~0UL))              /* 0xFFFFFFFF */
-#endif
-
-#ifndef LONG_MAX
 #define LONG_MAX        ((long)(ULONG_MAX >> 1))        /* 0x7FFFFFFF */
-#endif
-
-#ifndef LONG_MIN
 #define LONG_MIN        ((long)(~LONG_MAX))             /* 0x80000000 */
-#endif
 
-#define ISSPACE(c) (((c) & 0xFFU == ' ') || ((c) & 0xFFU == '\t'))
+#define ISSPACE(c) ((((c) & 0xFFU) == ' ') || (((c) & 0xFFU) == '\t'))
 
 /*
  * Convert a string to a long integer - decimal support only.


### PR DESCRIPTION
 lib/string.c: In function 'strtoul_hex':
 lib/string.c:25:26: warning: suggest parentheses around comparison in
 operand of '&' [-Wparentheses]

 .define ISSPACE(c) (((c) & 0xFFU == ' ') || ((c) & 0xFFU == '\t'))

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>