### PR TITLE
DM: Remove 'strictio' from UOS bootargs' options

### DIFF
--- a/devicemodel/core/inout.c
+++ b/devicemodel/core/inout.c
@@ -88,13 +88,12 @@ register_default_iohandler(int start, int size)
 }
 
 int
-emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *pio_request,
-	      int strict)
+emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *pio_request)
 {
 	int bytes, flags, in, port;
 	inout_func_t handler;
 	void *arg;
-	int i, retval;
+	int retval;
 
 	bytes = pio_request->size;
 	in = (pio_request->direction == REQUEST_READ);
@@ -104,17 +103,6 @@ emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *pio_request,
 	assert(bytes == 1 || bytes == 2 || bytes == 4);
 
 	handler = inout_handlers[port].handler;
-
-	if (strict) {
-		if (handler == default_inout)
-			return -1;
-
-		for (i = 1; i < bytes; i++) {
-			if (inout_handlers[port + i].handler != handler)
-				return -1;
-		}
-	}
-
 	flags = inout_handlers[port].flags;
 	arg = inout_handlers[port].arg;
 

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -77,7 +77,6 @@ static int guest_vmexit_on_hlt, guest_vmexit_on_pause;
 static int virtio_msix = 1;
 static int x2apic_mode;	/* default is xAPIC */
 
-static int strictio;
 static int strictmsr = 1;
 
 static int acpi;
@@ -302,7 +301,7 @@ vmexit_inout(struct vmctx *ctx, struct vhm_request *vhm_req, int *pvcpu)
 	bytes = vhm_req->reqs.pio_request.size;
 	in = (vhm_req->reqs.pio_request.direction == REQUEST_READ);
 
-	error = emulate_inout(ctx, pvcpu, &vhm_req->reqs.pio_request, strictio);
+	error = emulate_inout(ctx, pvcpu, &vhm_req->reqs.pio_request);
 	if (error) {
 		fprintf(stderr, "Unhandled %s%c 0x%04x\n",
 				in ? "in" : "out",
@@ -606,7 +605,6 @@ static struct option long_options[] = {
 	{"memsize",		required_argument,	0, 'm' },
 	{"ioapic",		no_argument,		0, 'I' },
 	{"vmexit_pause",	no_argument,		0, 'P' },
-	{"strictio",		no_argument,		0, 'e' },
 	{"rtc_localtime",	no_argument,		0, 'u' },
 	{"uuid",		required_argument,	0, 'U' },
 	{"strictmsr",		no_argument,		0, 'w' },
@@ -721,9 +719,6 @@ main(int argc, char *argv[])
 			break;
 		case 'P':
 			guest_vmexit_on_pause = 1;
-			break;
-		case 'e':
-			strictio = 1;
 			break;
 		case 'u':
 			vrtc_enable_localtime(0);

--- a/devicemodel/include/inout.h
+++ b/devicemodel/include/inout.h
@@ -71,8 +71,7 @@ struct inout_port {
 	DATA_SET(inout_port_set, __CONCAT(__inout_port, __LINE__))
 
 void	init_inout(void);
-int	emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *req,
-		      int strict);
+int	emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *req);
 int	register_inout(struct inout_port *iop);
 int	unregister_inout(struct inout_port *iop);
 int	init_bvmcons(void);


### PR DESCRIPTION
 - UOS will boot fail if 'strictio' is enabled ('-e' option), in this
   case (with '-e'), device model will block all PIO accesses whose
   handlers were not registered, after that, device model program will
   exit, hence UOS boot fail.

   actually, such kind of accesses exist, e.g. UOS would program
   PIT registers (port address: 0x43) if hpet is disabled.

 - For debug, we can trap unexpected PIO access in 'default_inout()'

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>