### PR TITLE
HV: treewide: drop debug-only helpers in release build

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -902,6 +902,7 @@ void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 		remove_msix_remapping(vm, virt_bdf, i);
 }
 
+#ifdef HV_DEBUG
 static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 		uint32_t *irq, uint32_t *vector, uint64_t *dest, bool *lvl_tm,
 		int *pin, int *vpin, int *bdf, int *vbdf)
@@ -1004,3 +1005,4 @@ void get_ptdev_info(char *str, int str_max)
 
 	snprintf(str, size, "\r\n");
 }
+#endif /* HV_DEBUG */

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -608,6 +608,7 @@ bool vioapic_get_rte(struct vm *vm, int pin, void *rte)
 		return false;
 }
 
+#ifdef HV_DEBUG
 void get_vioapic_info(char *str, int str_max, int vmid)
 {
 	int pin, len, size = str_max, vector, delmode;
@@ -653,3 +654,4 @@ void get_vioapic_info(char *str, int str_max, int vmid)
 END:
 	snprintf(str, size, "\r\n");
 }
+#endif /* HV_DEBUG */

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -414,6 +414,7 @@ void resume_ioapic(void)
 	}
 }
 
+#ifdef HV_DEBUG
 void get_rte_info(struct ioapic_rte *rte, bool *mask, bool *irr,
 	bool *phys, int *delmode, bool *level, int *vector, uint32_t *dest)
 {
@@ -469,3 +470,4 @@ int get_ioapic_info(char *str, int str_max_len)
 	snprintf(str, size, "\r\n");
 	return 0;
 }
+#endif /* HV_DEBUG */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -664,6 +664,7 @@ pri_register_handler(uint32_t irq,
 	return common_register_handler(irq, &info);
 }
 
+#ifdef HV_DEBUG
 void get_cpu_interrupt_info(char *str, int str_max)
 {
 	uint16_t pcpu_id;
@@ -706,6 +707,7 @@ void get_cpu_interrupt_info(char *str, int str_max)
 	}
 	snprintf(str, size, "\r\n");
 }
+#endif /* HV_DEBUG */
 
 int interrupt_init(uint32_t cpu_id)
 {

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -141,6 +141,7 @@ int32_t hv_main(uint16_t cpu_id)
 	return 0;
 }
 
+#ifdef HV_DEBUG
 void get_vmexit_profile(char *str, int str_max)
 {
 	uint16_t cpu, i;
@@ -175,3 +176,4 @@ void get_vmexit_profile(char *str, int str_max)
 	}
 	snprintf(str, size, "\r\n");
 }
+#endif /* HV_DEBUG */

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -96,6 +96,7 @@ int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req)
 	return 0;
 }
 
+#ifdef HV_DEBUG
 static void _get_req_info_(struct vhm_request *req, int *id, char *type,
 	char *state, char *dir, long *addr, long *val)
 {
@@ -191,3 +192,4 @@ void get_req_info(char *str, int str_max)
 	spinlock_release(&vm_list_lock);
 	snprintf(str, size, "\r\n");
 }
+#endif /* HV_DEBUG */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -35,7 +35,6 @@ enum {
 struct vhm_request;
 
 int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req);
-void get_req_info(char *str, int str_max);
 
 /*
  * VCPU related APIs
@@ -129,6 +128,11 @@ int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code);
 
 uint32_t create_guest_init_gdt(struct vm *vm, uint32_t *limit);
+
+#ifdef HV_DEBUG
+void get_req_info(char *str, int str_max);
+#endif /* HV_DEBUG */
+
 #endif	/* !ASSEMBLER */
 
 #endif /* GUEST_H*/

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -53,5 +53,8 @@ bool	vioapic_get_rte(struct vm *vm, int pin, void *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 		void *handler_private_data);
 
+#ifdef HV_DEBUG
 void get_vioapic_info(char *str, int str_max, int vmid);
+#endif /* HV_DEBUG */
+
 #endif

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -20,7 +20,6 @@
 #define GSI_SET_RTE(irq, rte) ioapic_set_rte((irq), (rte))
 
 void setup_ioapic_irq(void);
-int get_ioapic_info(char *str, int str_max_len);
 
 bool irq_is_gsi(uint32_t irq);
 uint32_t irq_gsi_num(void);
@@ -36,4 +35,9 @@ void resume_ioapic(void);
 
 extern uint16_t legacy_irq_to_pin[];
 extern uint16_t pic_ioapic_pin_map[];
+
+#ifdef HV_DEBUG
+int get_ioapic_info(char *str, int str_max_len);
+#endif /* HV_DEBUG */
+
 #endif /* IOAPIC_H */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -74,8 +74,6 @@ int init_default_irqs(uint16_t cpu);
 
 void dispatch_interrupt(struct intr_excp_ctx *ctx);
 
-void get_cpu_interrupt_info(char *str, int str_max);
-
 void setup_notification(void);
 
 typedef void (*spurious_handler_t)(uint32_t vector);
@@ -110,4 +108,9 @@ int acrn_handle_pending_request(struct vcpu *vcpu);
 int interrupt_init(uint32_t logical_id);
 
 void cancel_event_injection(struct vcpu *vcpu);
+
+#ifdef HV_DEBUG
+void get_cpu_interrupt_info(char *str, int str_max);
+#endif /* HV_DEBUG */
+
 #endif /* ARCH_IRQ_H */

--- a/hypervisor/include/arch/x86/vmexit.h
+++ b/hypervisor/include/arch/x86/vmexit.h
@@ -16,7 +16,6 @@ int vmexit_handler(struct vcpu *vcpu);
 int vmcall_vmexit_handler(struct vcpu *vcpu);
 int cpuid_vmexit_handler(struct vcpu *vcpu);
 int cr_access_vmexit_handler(struct vcpu *vcpu);
-void get_vmexit_profile(char *str, int str_max);
 
 #define VM_EXIT_QUALIFICATION_BIT_MASK(exit_qual, MSB, LSB)   \
 	(exit_qual & (((1UL << (MSB+1))-1) - ((1UL << (LSB))-1)))
@@ -47,5 +46,9 @@ void get_vmexit_profile(char *str, int str_max);
 	(VM_EXIT_QUALIFICATION_BIT_MASK(exit_qual, 6, 6) >> 6)
 #define VM_EXIT_IO_INSTRUCTION_PORT_NUMBER(exit_qual) \
 	(VM_EXIT_QUALIFICATION_BIT_MASK(exit_qual, 31, 16) >> 16)
+
+#ifdef HV_DEBUG
+void get_vmexit_profile(char *str, int str_max);
+#endif /* HV_DEBUG */
 
 #endif /* VMEXIT_H_ */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -70,7 +70,6 @@ extern spinlock_t softirq_dev_lock;
 void ptdev_softirq(__unused uint16_t cpu);
 void ptdev_init(void);
 void ptdev_release_all_entries(struct vm *vm);
-void get_ptdev_info(char *str, int str_max);
 
 struct ptdev_remapping_info *ptdev_dequeue_softirq(void);
 struct ptdev_remapping_info *alloc_entry(struct vm *vm,
@@ -80,5 +79,9 @@ struct ptdev_remapping_info *ptdev_activate_entry(
 		struct ptdev_remapping_info *entry,
 		int phys_irq, bool lowpri);
 void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
+
+#ifdef HV_DEBUG
+void get_ptdev_info(char *str, int str_max);
+#endif /* HV_DEBUG */
 
 #endif /* PTDEV_H */


### PR DESCRIPTION
There are multiple helpers for collecting info to be printed on the ACRN uart
console. They are unreachable code in release builds in which the uart console
is removed.

To define a precise boundary for safety-related activities, this patch wraps the
declarations and definitions to these helpers with "#ifdef HV_DEBUG" so that
these unreachable APIs will be dropped in release builds.

v1 -> v2:

    * Fix coding style: no empty lines between #ifdef and the wrapped code.
    * Also drop get_rte_info() in ioapic.c, which is solely used by
      get_ioapic_info().

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>