### PR TITLE
HV: Remove unnecessary vm0 check in vm0 specific func

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -552,6 +552,14 @@ static void rebuild_vm0_e820(void)
 	e820_mem.total_mem_size -= CONFIG_RAM_SIZE;
 }
 
+/**
+ * @param[inout] vm pointer to a vm descriptor
+ *
+ * @return 0 - on success
+ *
+ * @pre vm != NULL
+ * @pre is_vm0(vm) == true
+ */
 int prepare_vm0_memmap_and_e820(struct vm *vm)
 {
 	unsigned int i;
@@ -564,9 +572,6 @@ int prepare_vm0_memmap_and_e820(struct vm *vm)
 				IA32E_EPT_X_BIT |
 				IA32E_EPT_UNCACHED);
 	struct e820_entry *entry;
-
-
-	ASSERT(is_vm0(vm), "This func only for vm0");
 
 	rebuild_vm0_e820();
 	dev_dbg(ACRN_DBG_GUEST,

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -103,15 +103,19 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
 	return kernel_src_addr;
 }
 
+/**
+ * @param[inout] vm pointer to a vm descriptor
+ *
+ * @return 0		- on success
+ * @return -EINVAL	- on invalid parameters
+ *
+ * @pre vm != NULL
+ * @pre is_vm0(vm) == true
+ */
 int init_vm0_boot_info(struct vm *vm)
 {
 	struct multiboot_module *mods = NULL;
 	struct multiboot_info *mbi = NULL;
-
-	if (!is_vm0(vm)) {
-		pr_err("just for vm0 to get info!");
-		return -EINVAL;
-	}
 
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
 		ASSERT(false, "no multiboot info found");


### PR DESCRIPTION
Function prepare_vm0_memmap_and_e820 and init_vm0_boot_info are specific for vm0.
There is no need to check is_vm0 again in those functions.

This patch remove the unnecssary checks.

v1 -> v2:
   - Add pre-condition comment before the function as Junjie's suggestion.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>