### PR TITLE
misc: disable cbc_lifecycle service always restart by systemd

### DIFF
--- a/misc/cbc_lifecycle/cbc_lifecycle.service
+++ b/misc/cbc_lifecycle/cbc_lifecycle.service
@@ -4,7 +4,7 @@ Description=CBC lifecycle service
 [Service]
 Type=simple
 ExecStart=/usr/bin/cbc_lifecycle
-Restart=always
+Restart=no
 ExecStop=/usr/bin/killall -s TERM cbc_lifecycle
 
 [Install]


### PR DESCRIPTION
Due to cbc_lifecycle service already has its own retry mechanism,so change the
Restart type to "no".

This change is also indirectly avoid cbc_lifecycle always restart for the
non-IOC boards. Actually, there has one defect for current IOC CBC architecture
due to lack IOC hardware detection mechanism. The related guys are already aware
it and WIP.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Alex Du <alek.du@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>