### PR TITLE
Update return value type as unint16 for bit operations

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -75,11 +75,11 @@ inline struct vcpu *get_primary_vcpu(struct vm *vm)
 
 inline uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 {
-	int vcpu_id;
+	uint16_t vcpu_id;
 	uint64_t dmask = 0;
 	struct vcpu *vcpu;
 
-	while ((vcpu_id = ffs64(vdmask)) >= 0) {
+	while ((vcpu_id = ffs64(vdmask)) != INVALID_BIT_INDEX) {
 		bitmap_clear(vcpu_id, &vdmask);
 		vcpu = vcpu_from_vid(vm, vcpu_id);
 		ASSERT(vcpu != NULL, "vcpu_from_vid failed");

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2104,7 +2104,7 @@ apicv_pending_intr(struct vlapic *vlapic, __unused uint32_t *vecptr)
 	for (i = 3; i >= 0; i--) {
 		pirval = pir_desc->pir[i];
 		if (pirval != 0) {
-			vpr = (i * 64 + fls64(pirval)) & 0xF0U;
+			vpr = (((uint32_t)(i * 64) + (uint32_t)fls64(pirval)) & 0xF0U);
 			return (vpr > ppr);
 		}
 	}
@@ -2188,7 +2188,7 @@ apicv_inject_pir(struct vlapic *vlapic)
 	struct pir_desc *pir_desc;
 	struct lapic_regs *lapic;
 	uint64_t val, pirval;
-	int rvi, pirbase = -1, i;
+	uint16_t rvi, pirbase = 0U, i;
 	uint16_t intr_status_old, intr_status_new;
 	struct lapic_reg *irr = NULL;
 
@@ -2197,17 +2197,16 @@ apicv_inject_pir(struct vlapic *vlapic)
 		return;
 
 	pirval = 0;
-	pirbase = -1;
 	lapic = vlapic->apic_page;
 	irr = &lapic->irr[0];
 
-	for (i = 0; i < 4; i++) {
+	for (i = 0U; i < 4U; i++) {
 		val = atomic_readandclear64((long *)&pir_desc->pir[i]);
 		if (val != 0) {
-			irr[i * 2].val |= val;
-			irr[(i * 2) + 1].val |= val >> 32;
+			irr[i * 2U].val |= val;
+			irr[(i * 2U) + 1U].val |= val >> 32;
 
-			pirbase = 64*i;
+			pirbase = 64U*i;
 			pirval = val;
 		}
 	}

--- a/hypervisor/arch/x86/guest/vpic.c
+++ b/hypervisor/arch/x86/guest/vpic.c
@@ -231,7 +231,7 @@ static void vpic_notify_intr(struct vpic *vpic)
 			ASSERT(vcpu != NULL, "vm%d, vcpu0", vpic->vm->attr.id);
 			vcpu_inject_extint(vcpu);
 		} else {
-			vlapic_set_local_intr(vpic->vm, BROADCAST_PCPU_ID, APIC_LVT_LINT0);
+			vlapic_set_local_intr(vpic->vm, BROADCAST_CPU_ID, APIC_LVT_LINT0);
 			/* notify vioapic pin0 if existing
 			 * For vPIC + vIOAPIC mode, vpic master irq connected
 			 * to vioapic pin0 (irq2)

--- a/hypervisor/arch/x86/softirq.c
+++ b/hypervisor/arch/x86/softirq.c
@@ -42,7 +42,7 @@ void exec_softirq(void)
 	uint16_t cpu_id = get_cpu_id();
 	volatile uint64_t *bitmap = &per_cpu(softirq_pending, cpu_id);
 
-	int softirq_id;
+	uint16_t softirq_id;
 
 	if (cpu_id >= phys_cpu_num)
 		return;
@@ -61,7 +61,7 @@ again:
 
 	while (1) {
 		softirq_id = ffs64(*bitmap);
-		if ((softirq_id < 0) || (softirq_id >= SOFTIRQ_MAX))
+		if ((softirq_id == INVALID_BIT_INDEX) || (softirq_id >= SOFTIRQ_MAX))
 			break;
 
 		bitmap_clear(softirq_id, bitmap);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -220,7 +220,7 @@ int64_t hcall_create_vcpu(struct vm *vm, uint64_t vmid, uint64_t param)
 	}
 
 	pcpu_id = allocate_pcpu();
-	if (INVALID_PCPU_ID == pcpu_id) {
+	if (pcpu_id == INVALID_CPU_ID) {
 		pr_err("%s: No physical available\n", __func__);
 		return -1;
 	}

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -41,7 +41,7 @@ uint16_t allocate_pcpu(void)
 			return i;
 	}
 
-	return INVALID_PCPU_ID;
+	return INVALID_CPU_ID;
 }
 
 void set_pcpu_used(uint16_t pcpu_id)

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -211,6 +211,20 @@ enum feature_word {
 	FEATURE_WORDS,
 };
 
+/**
+ *The invalid cpu_id (INVALID_CPU_ID) is error
+ *code for error handling, this means that
+ *caller can't find a valid physical cpu
+ *or virtual cpu.
+ */
+#define INVALID_CPU_ID 0xffffU
+/**
+ *The broadcast id (BROADCAST_CPU_ID)
+ *used to notify all valid phyiscal cpu
+ *or virtual cpu.
+ */
+#define BROADCAST_CPU_ID 0xfffeU
+
 /* CPU states defined */
 enum cpu_state {
 	CPU_STATE_RESET = 0,

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -96,15 +96,6 @@
 #define CPUID_EXTEND_FUNCTION_4      0x80000004
 #define CPUID_EXTEND_ADDRESS_SIZE    0x80000008
 
-/**pcpu id type is uint16_t,
-*The broadcast id (BROADCAST_PCPU_ID) 
-* used to notify all valid pcpu, 
-*the invalid pcpu id (INVALID_PCPU_ID) is error
-*code for error handling.
-*/
-#define INVALID_PCPU_ID 0xffffU
-#define BROADCAST_PCPU_ID 0xfffeU
-
 
 static inline void __cpuid(uint32_t *eax, uint32_t *ebx,
 				uint32_t *ecx, uint32_t *edx)

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -89,7 +89,7 @@ vlapic_intr_edge(struct vcpu *vcpu, uint32_t vector)
  * Triggers the LAPIC local interrupt (LVT) 'vector' on 'cpu'.  'cpu' can
  * be set to -1 to trigger the interrupt on all CPUs.
  */
-int vlapic_set_local_intr(struct vm *vm, int vcpu_id, uint32_t vector);
+int vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id, uint32_t vector);
 
 int vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg);
 

--- a/hypervisor/include/arch/x86/softirq.h
+++ b/hypervisor/include/arch/x86/softirq.h
@@ -7,9 +7,9 @@
 #ifndef SOFTIRQ_H
 #define SOFTIRQ_H
 
-#define SOFTIRQ_TIMER		0
-#define SOFTIRQ_DEV_ASSIGN	1
-#define SOFTIRQ_MAX		2
+#define SOFTIRQ_TIMER		0U
+#define SOFTIRQ_DEV_ASSIGN	1U
+#define SOFTIRQ_MAX		2U
 #define SOFTIRQ_MASK		((1UL<<SOFTIRQ_MAX)-1)
 
 /* used for atomic value for prevent recursive */

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -91,10 +91,11 @@ static inline uint16_t fls64(uint64_t value)
  * and return the index of that bit.
  *
  *  Bits are numbered starting at 0,the least significant bit.
- *  A return value of -1 means that the argument was zero.
+ *  A return value of INVALID_BIT_INDEX means that the return value is the inalid
+ *  bit index when the input argument was zero.
  *
  *  Examples:
- *	ffs64 (0x0) = -1
+ *	ffs64 (0x0) = INVALID_BIT_INDEX
  *	ffs64 (0x01) = 0
  *	ffs64 (0xf0) = 4
  *	ffs64 (0xf00) = 8
@@ -104,20 +105,24 @@ static inline uint16_t fls64(uint64_t value)
  *
  * @param value: 'unsigned long' type value
  *
- * @return value: zero-based bit index, -1 means 'value' was zero.
+ * @return value: zero-based bit index, INVALID_BIT_INDEX means
+ * when 'value' was zero, bit operations function can't find bit
+ * set and return the invalid bit index directly.
  *
  * **/
-static inline int ffs64(unsigned long value)
+static inline uint16_t ffs64(uint64_t value)
 {
-	int ret;
-	asm volatile("bsfq %1,%q0"
+	uint64_t ret = 0UL;
+	if (value == 0UL)
+		return (INVALID_BIT_INDEX);
+	asm volatile("bsfq %1,%0"
 			: "=r" (ret)
-			: "rm" (value), "0" (-1));
-	return ret;
+			: "rm" (value));
+	return (uint16_t)ret;
 }
 
 /*bit scan forward for the least significant bit '0'*/
-static inline int ffz64(unsigned long value)
+static inline uint16_t ffz64(uint64_t value)
 {
 	return ffs64(~value);
 }

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -31,6 +31,14 @@
 #define BITS_H
 
 #define	BUS_LOCK	"lock ; "
+/**
+ *
+ * INVALID_BIT_INDEX means when input paramter is zero,
+ * bit operations function can't find bit set and return
+ * the invalid bit index directly.
+ *
+ **/
+#define INVALID_BIT_INDEX  0xffffU
 
 /**
  *
@@ -38,28 +46,32 @@
  *       return the bit index of that bit.
  *
  *  Bits are numbered starting at 0,the least significant bit.
- *  A return value of -1 means that the argument was zero.
+ *  A return value of INVALID_BIT_INDEX means return value is
+ *  invalid bit index when the input argument was zero.
  *
  *  Examples:
- *	fls (0x0) = -1
+ *	fls (0x0) = INVALID_BIT_INDEX
  *	fls (0x01) = 0
- *	fls (0xf0) = 7
+ *	fls (0x80) = 7
  *	...
  *	fls (0x80000001) = 31
  *
- * @param value: 'unsigned int' type value
+ * @param value: 'uint32_t' type value
  *
- * @return value: zero-based bit index, -1 means 'value' was zero.
+ * @return value: zero-based bit index, INVALID_BIT_INDEX means
+ * when 'value' was zero, bit operations function can't find bit
+ * set and return the invalid bit index directly.
  *
  * **/
-static inline int fls(unsigned int value)
+static inline uint16_t fls(uint32_t value)
 {
-	int ret;
-
+	uint32_t ret = 0U;
+	if (value == 0U)
+		return (INVALID_BIT_INDEX);
 	asm volatile("bsrl %1,%0"
 			: "=r" (ret)
-			: "rm" (value), "0" (-1));
-	return ret;
+			: "rm" (value));
+	return (uint16_t)ret;
 }
 
 static inline int fls64(unsigned long value)
@@ -124,9 +136,13 @@ static inline int ffz64(unsigned long value)
  *
  * @return The number of leading zeros in 'value'.
  */
-static inline int clz(unsigned int value)
+static inline uint16_t clz(uint32_t value)
 {
-	return (31 - fls(value));
+	if (value == 0U)
+		return 32U;
+	else{
+		return (31U - fls(value));
+	}
 }
 
 /**

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -74,14 +74,15 @@ static inline uint16_t fls(uint32_t value)
 	return (uint16_t)ret;
 }
 
-static inline int fls64(unsigned long value)
+static inline uint16_t fls64(uint64_t value)
 {
-	int ret;
-
-	asm volatile("bsrq %1,%q0"
+	uint64_t ret = 0UL;
+	if (value == 0UL)
+		return (INVALID_BIT_INDEX);
+	asm volatile("bsrq %1,%0"
 			: "=r" (ret)
-			: "rm" (value), "0" (-1));
-	return ret;
+			: "rm" (value));
+	return (uint16_t)ret;
 }
 
 /**
@@ -152,9 +153,13 @@ static inline uint16_t clz(uint32_t value)
  *
  * @return The number of leading zeros in 'value'.
  */
-static inline int clz64(unsigned long value)
+static inline uint16_t clz64(uint64_t value)
 {
-	return (63 - fls64(value));
+	if (value == 0UL)
+		return 64U;
+	else{
+		return (63U - fls64(value));
+	}
 }
 
 /*

--- a/hypervisor/include/lib/mem_mgt.h
+++ b/hypervisor/include/lib/mem_mgt.h
@@ -8,7 +8,7 @@
 #define __MEM_MGT_H__
 
 /* Macros */
-#define BITMAP_WORD_SIZE         32
+#define BITMAP_WORD_SIZE         32U
 
 struct mem_pool {
 	void *start_addr;	/* Start Address of Memory Pool */

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -94,7 +94,7 @@ int udiv64(uint64_t dividend, uint64_t divisor, struct udiv_result *res)
 	 */
 
 	/* align divisor and dividend. */
-	bits = clz64(divisor) - clz64(dividend);
+	bits = (uint64_t)(clz64(divisor) - clz64(dividend));
 	divisor <<= bits;
 	mask = 1UL << bits;
 	/* division loop */

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -16,7 +16,7 @@ static int do_udiv32(uint32_t dividend, uint32_t divisor,
 	 * are valid * clz(dividend)<=clz(divisor)
 	 */
 
-	mask = clz(divisor) - clz(dividend);
+	mask = (uint32_t)(clz(divisor) - clz(dividend));
 	/* align divisor and dividend */
 	divisor <<= mask;
 	mask = 1U << mask;
@@ -26,8 +26,8 @@ static int do_udiv32(uint32_t dividend, uint32_t divisor,
 			dividend -= divisor;
 			res->q.dwords.low |= mask;
 		}
-		divisor >>= 1;
-	} while (((mask >>= 1) != 0) && (dividend != 0));
+		divisor >>= 1U;
+	} while (((mask >>= 1U) != 0U) && (dividend != 0U));
 	/* dividend now contains the reminder */
 	res->r.dwords.low = dividend;
 	return 0;

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -105,7 +105,7 @@ int udiv64(uint64_t dividend, uint64_t divisor, struct udiv_result *res)
 		}
 		divisor >>= 1;
 		mask >>= 1;
-	} while ((bits-- != 0) && (dividend != 0));
+	} while ((bits-- != 0UL) && (dividend != 0));
 
 	res->r.qword = dividend;
 	return 0;

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -58,9 +58,10 @@ struct mem_pool Paging_Memory_Pool = {
 static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
 {
 
-        void *memory = NULL;
-        uint32_t idx, bit_idx;
-        uint32_t requested_buffs;
+         void *memory = NULL;
+         uint32_t idx; 
+         uint16_t bit_idx;
+         uint32_t requested_buffs;
 
         /* Check if provided memory pool exists */
         if (pool == NULL)
@@ -85,9 +86,9 @@ static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
                         /* Declare temporary variables to be used locally in
                          * this block
                          */
-                        uint32_t i;
-                        uint32_t tmp_bit_idx = bit_idx;
-                        uint32_t tmp_idx = idx;
+			uint32_t i;
+			uint16_t tmp_bit_idx = bit_idx;
+			uint32_t tmp_idx = idx;
 
                         /* Check requested_buffs number of buffers availability
                          * in memory-pool right after selected buffer
@@ -101,7 +102,7 @@ static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
                                         if (++tmp_idx == pool->bmp_size)
                                                 break;
                                         /* Reset tmp_bit_idx */
-                                        tmp_bit_idx = 0;
+                                        tmp_bit_idx = 0U;
                                 }
 
                                 /* Break if selected buffer is not free */


### PR DESCRIPTION
Update return value type as unint16 for bit operations
Update the type of bit index, vcpu id, softirq id, 
event id as uint16_t to reduce type conversion, the 
following steps are doing:
(1) Update return value type for fls and clz;
(2) Update return value type for fls64 and clz64;
(3) Update return value type for ffs64 and ffz64.
For each step, for the related caller,the type of
variables which store return value is updated as
uint16_t and return value checking is updated.

V1-->V2:
        INVALID_BIT_INDEX instead of INVALID_NUMBER;
        INVALID_CPU_ID instead of INVALID_PCPU_ID or INVALID_VCPU_ID;
        "%hu" is used to print vcpu id (uint16_t);
        Add 'U/UL' for constant value as needed.
V2-->V3:
       Clean up extra updates, such as add "%hu";
       For bit operations, it return INVALID_BIT_INDEX
       directly when input parameter value is zero;
       Add 'U/UL' for constant value as needed.
V3-->V4:
        Clean up some comments.

Xiangyang Wu (3):
  HV:treewide:Update return type for bit operations fls and clz 
  HV:treewide:Update return type for function fls64 and clz64
  HV:treewide:Update return type of function ffs64 and ffz64

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
 Acked-by: Eddie Dong <eddie.dong@intel.com>