### PR TITLE
cbc: fix the install issue when do make misc-install only

### DIFF
--- a/misc/cbc_attach/Makefile
+++ b/misc/cbc_attach/Makefile
@@ -6,7 +6,8 @@ all:
 clean:
 	rm -rf $(OUT_DIR)/cbc_attach
 
-install: $(OUT_DIR)/cbc_attach
+install: $(OUT_DIR)/cbc_attach cbc_attach.service
 	install -d $(DESTDIR)/usr/bin
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/cbc_attach
-	install -p -D -m 0644 cbc_attach.service $(DESTDIR)/usr/lib/systemd/system/
+	install -d $(DESTDIR)/usr/lib/systemd/system/
+	install -p -m 0644 cbc_attach.service $(DESTDIR)/usr/lib/systemd/system/

--- a/misc/cbc_lifecycle/Makefile
+++ b/misc/cbc_lifecycle/Makefile
@@ -10,4 +10,5 @@ clean:
 install: $(OUT_DIR)/cbc_lifecycle cbc_lifecycle.service
 	install -d $(DESTDIR)/usr/bin
 	install -t $(DESTDIR)/usr/bin $<
-	install -p -D -m 0644 cbc_lifecycle.service $(DESTDIR)/usr/lib/systemd/system/
+	install -d $(DESTDIR)/usr/lib/systemd/system/
+	install -p -m 0644 cbc_lifecycle.service $(DESTDIR)/usr/lib/systemd/system/


### PR DESCRIPTION
The install -D is misleading people since it only creates the leading
directories.

The problem was hidden due to we always call make install and the
destination folder was already created in previous install script.

Reviewed-by: Yu Wang <yu1.wang@intel.com>
Signed-off-by: Alek Du <alek.du@intel.com>