### PR TITLE
tools: acrn-crashlog: replace ldconfig with pkg-config in Makefile

### DIFF
--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -20,16 +20,27 @@ export BUILDDIR
 export CC
 export RM
 
-EXTRA_LIBS = -lsystemd
-LDCNF := $(shell ldconfig -p)
-LIB_EXIST = $(findstring libsystemd-journal.so, $(LDCNF))
-ifeq ($(strip $(LIB_EXIST)),libsystemd-journal.so)
-	EXTRA_LIBS = -lsystemd-journal
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/lib/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/share/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/local/lib/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/local/share/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/lib32/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/lib64/pkgconfig
+
+EXTRA_LIBS = -lsystemd-journal
+PKG_CONFIG := $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH); \
+	pkg-config --libs libsystemd)
+LIB_EXIST := $(findstring lsystemd, $(PKG_CONFIG))
+ifeq ($(strip $(LIB_EXIST)),lsystemd)
+	EXTRA_LIBS := -lsystemd
 endif
-LIB_EXIST = $(findstring libtelemetry.so, $(LDCNF))
-ifeq ($(strip $(LIB_EXIST)),libtelemetry.so)
-	CFLAGS	+= -DHAVE_TELEMETRICS_CLIENT
-	EXTRA_LIBS += -ltelemetry
+
+PKG_CONFIG := $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH); \
+	pkg-config --libs libtelemetry)
+LIB_EXIST := $(findstring ltelemetry, $(PKG_CONFIG))
+ifeq ($(strip $(LIB_EXIST)),ltelemetry)
+        CFLAGS  += -DHAVE_TELEMETRICS_CLIENT
+        EXTRA_LIBS += -ltelemetry
 endif
 export CFLAGS
 export EXTRA_LIBS


### PR DESCRIPTION
This patch is to fix the dependency issue with autospec.

Using ldconfig in the autospec build environment is not
going to work as the packages do not have the cache
generate after a rpm install. This patch replaces ldconfig
with pkg-config to check the existance of the libraries.

Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Jin Zhi <zhi.jin@intel.com>
Reviewed-by: Liu Xinwu <xinwu.liu@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>