### PR TITLE
HV:treewide: Rename bit operation function fls as fls32

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -774,7 +774,7 @@ vlapic_process_eoi(struct vlapic *vlapic)
 	tmrptr = &lapic->tmr[0];
 
 	for (i = 7; i >= 0; i--) {
-		bitpos = fls(isrptr[i].val);
+		bitpos = fls32(isrptr[i].val);
 		if (bitpos != INVALID_BIT_INDEX) {
 			if (vlapic->isrvec_stk_top <= 0) {
 				panic("invalid vlapic isrvec_stk_top %d",
@@ -1145,7 +1145,7 @@ vlapic_pending_intr(struct vlapic *vlapic, uint32_t *vecptr)
 
 	for (i = 7; i >= 0; i--) {
 		val = atomic_load((int *)&irrptr[i].val);
-		bitpos = fls(val);
+		bitpos = fls32(val);
 		if (bitpos != INVALID_BIT_INDEX) {
 			vector = (uint32_t)(i * 32) + (uint32_t)bitpos;
 			if (PRIO(vector) > PRIO(lapic->ppr)) {

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -42,7 +42,7 @@
 
 /**
  *
- * fls - Find the Last (most significant) bit Set in value and
+ * fls32 - Find the Last (most significant) bit Set in value and
  *       return the bit index of that bit.
  *
  *  Bits are numbered starting at 0,the least significant bit.
@@ -50,11 +50,11 @@
  *  invalid bit index when the input argument was zero.
  *
  *  Examples:
- *	fls (0x0) = INVALID_BIT_INDEX
- *	fls (0x01) = 0
- *	fls (0x80) = 7
+ *	fls32 (0x0) = INVALID_BIT_INDEX
+ *	fls32 (0x01) = 0
+ *	fls32 (0x80) = 7
  *	...
- *	fls (0x80000001) = 31
+ *	fls32 (0x80000001) = 31
  *
  * @param value: 'uint32_t' type value
  *
@@ -63,7 +63,7 @@
  * set and return the invalid bit index directly.
  *
  * **/
-static inline uint16_t fls(uint32_t value)
+static inline uint16_t fls32(uint32_t value)
 {
 	uint32_t ret = 0U;
 	if (value == 0U)
@@ -147,7 +147,7 @@ static inline uint16_t clz(uint32_t value)
 	if (value == 0U)
 		return 32U;
 	else{
-		return (31U - fls(value));
+		return (31U - fls32(value));
 	}
 }
 


### PR DESCRIPTION
Rename bit operation function fls as fls32, keep name
style with other bit operation function.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>