### PR TITLE
HV: Don't pass retval to vmm_emulate_instruction()

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -336,7 +336,7 @@ int emulate_instruction(struct vcpu *vcpu)
 	paging = &emul_cnx->paging;
 
 	retval = vmm_emulate_instruction(vcpu, gpa,
-			&emul_cnx->vie, paging, mread, mwrite, &retval);
+			&emul_cnx->vie, paging, mread, mwrite, NULL);
 
 	return retval;
 }


### PR DESCRIPTION
We pass retval to vmm_emulate_instruction and assign the return value to retval
at the same time. The retval will be passed to mmio_read/write finally as memarg
and the functions don't use the parameter actually. Apparently, we misused the
retval.

This patch fix it by passing 'NULL' to vmm_emulate_instruction.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>