### PR TITLE
HV:Treewide:Update the type of vcpu id as uint16_t

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -275,7 +275,7 @@ void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
 int dm_emulate_mmio_post(struct vcpu *vcpu)
 {
 	int ret = 0;
-	int cur = vcpu->vcpu_id;
+	uint16_t cur = vcpu->vcpu_id;
 	union vhm_request_buffer *req_buf;
 
 	req_buf = (union vhm_request_buffer *)(vcpu->vm->sw.io_shared_page);

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -34,7 +34,7 @@ is_vm0(struct vm *vm)
 	return (vm->attr.boot_idx & 0x7FU) == 0;
 }
 
-inline struct vcpu *vcpu_from_vid(struct vm *vm, int vcpu_id)
+inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 {
 	int i;
 	struct vcpu *vcpu;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -83,7 +83,7 @@ int create_vcpu(uint16_t cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	if (is_vcpu_bsp(vcpu) && is_vm0(vcpu->vm)) {
 		/* Set up temporary guest page tables */
 		vm->arch_vm.guest_init_pml4 = create_guest_initial_paging(vm);
-		pr_info("VM %d VCPU %d CR3: 0x%016llx ",
+		pr_info("VM %d VCPU %hu CR3: 0x%016llx ",
 			vm->attr.id, vcpu->vcpu_id,
 			vm->arch_vm.guest_init_pml4);
 	}
@@ -154,7 +154,7 @@ int start_vcpu(struct vcpu *vcpu)
 
 	/* If this VCPU is not already launched, launch it */
 	if (!vcpu->launched) {
-		pr_info("VM %d Starting VCPU %d",
+		pr_info("VM %d Starting VCPU %hu",
 				vcpu->vm->attr.id, vcpu->vcpu_id);
 
 		if (vcpu->arch_vcpu.vpid)
@@ -183,7 +183,7 @@ int start_vcpu(struct vcpu *vcpu)
 		/* See if VM launched successfully */
 		if (status == 0) {
 			if (is_vcpu_bsp(vcpu)) {
-				pr_info("VM %d VCPU %d successfully launched",
+				pr_info("VM %d VCPU %hu successfully launched",
 					vcpu->vm->attr.id, vcpu->vcpu_id);
 			}
 		}
@@ -263,7 +263,7 @@ void reset_vcpu(struct vcpu *vcpu)
 {
 	struct vlapic *vlapic;
 
-	pr_dbg("vcpu%d reset", vcpu->vcpu_id);
+	pr_dbg("vcpu%hu reset", vcpu->vcpu_id);
 	ASSERT(vcpu->state != VCPU_RUNNING,
 			"reset vcpu when it's running");
 
@@ -293,7 +293,7 @@ void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state)
 {
 	uint16_t pcpu_id = get_cpu_id();
 
-	pr_dbg("vcpu%d paused, new state: %d",
+	pr_dbg("vcpu%hu paused, new state: %d",
 		vcpu->vcpu_id, new_state);
 
 	get_schedule_lock(vcpu->pcpu_id);
@@ -317,7 +317,7 @@ void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state)
 
 void resume_vcpu(struct vcpu *vcpu)
 {
-	pr_dbg("vcpu%d resumed", vcpu->vcpu_id);
+	pr_dbg("vcpu%hu resumed", vcpu->vcpu_id);
 
 	get_schedule_lock(vcpu->pcpu_id);
 	vcpu->state = vcpu->prev_state;
@@ -332,7 +332,7 @@ void resume_vcpu(struct vcpu *vcpu)
 void schedule_vcpu(struct vcpu *vcpu)
 {
 	vcpu->state = VCPU_RUNNING;
-	pr_dbg("vcpu%d scheduled", vcpu->vcpu_id);
+	pr_dbg("vcpu%hu scheduled", vcpu->vcpu_id);
 
 	get_schedule_lock(vcpu->pcpu_id);
 	add_vcpu_to_runqueue(vcpu);

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -104,12 +104,12 @@ static void vlapic_set_error(struct vlapic *vlapic, uint32_t mask);
 static int vlapic_timer_expired(void *data);
 
 static struct vlapic *
-vm_lapic_from_vcpu_id(struct vm *vm, int vcpu_id)
+vm_lapic_from_vcpu_id(struct vm *vm, uint16_t vcpu_id)
 {
 	struct vcpu *vcpu;
 
 	vcpu = vcpu_from_vid(vm, vcpu_id);
-	ASSERT(vcpu != NULL, "vm%d, vcpu%d", vm->attr.id, vcpu_id);
+	ASSERT(vcpu != NULL, "vm%d, vcpu%hu", vm->attr.id, vcpu_id);
 
 	return vcpu->arch_vcpu.vlapic;
 }
@@ -170,7 +170,7 @@ static inline uint32_t
 vlapic_build_id(struct vlapic *vlapic)
 {
 	struct vcpu *vcpu = vlapic->vcpu;
-	uint32_t id;
+	uint16_t id;
 
 	if (is_vm0(vcpu->vm)) {
 		/* Get APIC ID sequence format from cpu_storage */
@@ -1528,7 +1528,7 @@ void
 vlapic_init(struct vlapic *vlapic)
 {
 	ASSERT(vlapic->vm != NULL, "%s: vm is not initialized", __func__);
-	ASSERT(vlapic->vcpu->vcpu_id >= 0 &&
+	ASSERT(vlapic->vcpu->vcpu_id >= 0U &&
 		vlapic->vcpu->vcpu_id < phys_cpu_num,
 		"%s: vcpu_id is not initialized", __func__);
 	ASSERT(vlapic->apic_page != NULL,
@@ -1540,7 +1540,7 @@ vlapic_init(struct vlapic *vlapic)
 	 */
 	vlapic->msr_apicbase = DEFAULT_APIC_BASE | APICBASE_ENABLED;
 
-	if (vlapic->vcpu->vcpu_id == 0)
+	if (vlapic->vcpu->vcpu_id == 0U)
 		vlapic->msr_apicbase |= APICBASE_BSP;
 
 	vlapic_create_timer(vlapic);
@@ -1867,7 +1867,7 @@ vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval)
 	uint32_t offset;
 	struct vlapic *vlapic;
 
-	dev_dbg(ACRN_DBG_LAPIC, "cpu[%d] rdmsr: %x", vcpu->vcpu_id, msr);
+	dev_dbg(ACRN_DBG_LAPIC, "cpu[%hu] rdmsr: %x", vcpu->vcpu_id, msr);
 	vlapic = vcpu->arch_vcpu.vlapic;
 
 	switch (msr) {
@@ -1912,7 +1912,7 @@ vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t val)
 		break;
 	}
 
-	dev_dbg(ACRN_DBG_LAPIC, "cpu[%d] wrmsr: %x val=%#x",
+	dev_dbg(ACRN_DBG_LAPIC, "cpu[%hu] wrmsr: %x val=%#x",
 		vcpu->vcpu_id, msr, val);
 	return error;
 }

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -8,7 +8,7 @@
 
 int dm_emulate_pio_post(struct vcpu *vcpu)
 {
-	int cur = vcpu->vcpu_id;
+	uint16_t cur = vcpu->vcpu_id;
 	int cur_context = vcpu->arch_vcpu.cur_context;
 	union vhm_request_buffer *req_buf = NULL;
 	uint32_t mask =

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -124,7 +124,7 @@ void init_mtrr(struct vcpu *vcpu)
 			vcpu->mtrr.fixed_range[i].value = MTRR_FIXED_RANGE_ALL_WB;
 		}
 
-		pr_dbg("vm%d vcpu%d fixed-range MTRR[%d]: %16llx",
+		pr_dbg("vm%d vcpu%hu fixed-range MTRR[%d]: %16llx",
 			vcpu->vm->attr.id, vcpu->vcpu_id, i,
 			vcpu->mtrr.fixed_range[i].value);
 	}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -372,7 +372,7 @@ int64_t hcall_notify_req_finish(uint64_t vmid, uint64_t vcpu_id)
 	dev_dbg(ACRN_DBG_HYCALL, "[%d] NOTIFY_FINISH for vcpu %d",
 			vmid, vcpu_id);
 
-	vcpu = vcpu_from_vid(target_vm, vcpu_id);
+	vcpu = vcpu_from_vid(target_vm, (uint16_t)vcpu_id);
 	if (vcpu == NULL) {
 		pr_err("%s, failed to get VCPU %d context from VM %d\n",
 			__func__, vcpu_id, target_vm->attr.id);

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -25,11 +25,11 @@ static void fire_vhm_interrupt(void)
 	vlapic_intr_edge(vcpu, VECTOR_VIRT_IRQ_VHM);
 }
 
-static void acrn_print_request(int vcpu_id, struct vhm_request *req)
+static void acrn_print_request(uint16_t vcpu_id, struct vhm_request *req)
 {
 	switch (req->type) {
 	case REQ_MMIO:
-		dev_dbg(ACRN_DBG_IOREQUEST, "[vcpu_id=%d type=MMIO]", vcpu_id);
+		dev_dbg(ACRN_DBG_IOREQUEST, "[vcpu_id=%hu type=MMIO]", vcpu_id);
 		dev_dbg(ACRN_DBG_IOREQUEST,
 			"gpa=0x%lx, R/W=%d, size=%ld value=0x%lx processed=%lx",
 			req->reqs.mmio_request.address,
@@ -39,7 +39,7 @@ static void acrn_print_request(int vcpu_id, struct vhm_request *req)
 			req->processed);
 		break;
 	case REQ_PORTIO:
-		dev_dbg(ACRN_DBG_IOREQUEST, "[vcpu_id=%d type=PORTIO]", vcpu_id);
+		dev_dbg(ACRN_DBG_IOREQUEST, "[vcpu_id=%hu type=PORTIO]", vcpu_id);
 		dev_dbg(ACRN_DBG_IOREQUEST,
 			"IO=0x%lx, R/W=%d, size=%ld value=0x%lx processed=%lx",
 			req->reqs.pio_request.address,
@@ -49,7 +49,7 @@ static void acrn_print_request(int vcpu_id, struct vhm_request *req)
 			req->processed);
 		break;
 	default:
-		dev_dbg(ACRN_DBG_IOREQUEST, "[vcpu_id=%d type=%d] NOT support type",
+		dev_dbg(ACRN_DBG_IOREQUEST, "[vcpu_id=%hu type=%d] NOT support type",
 			vcpu_id, req->type);
 		break;
 	}

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -92,7 +92,7 @@ int load_guest(struct vm *vm, struct vcpu *vcpu)
 
 	pr_info("%s, Set config according to predefined offset:",
 			__func__);
-	pr_info("VCPU%d Entry: 0x%llx, RSI: 0x%016llx, cr3: 0x%016llx",
+	pr_info("VCPU%hu Entry: 0x%llx, RSI: 0x%016llx, cr3: 0x%016llx",
 			vcpu->vcpu_id, vcpu->entry_addr,
 			cur_context->guest_cpu_regs.regs.rsi,
 			vm->arch_vm.guest_init_pml4);
@@ -132,7 +132,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	if (is_vcpu_bsp(vcpu)) {
 		/* Set VCPU entry point to kernel entry */
 		vcpu->entry_addr = vm->sw.kernel_info.kernel_entry_addr;
-		pr_info("%s, VM *d VCPU %d Entry: 0x%016llx ",
+		pr_info("%s, VM *d VCPU %hu Entry: 0x%016llx ",
 			__func__, vm->attr.id, vcpu->vcpu_id, vcpu->entry_addr);
 	}
 

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -55,7 +55,7 @@ static void dump_guest_reg(struct vcpu *vcpu)
 	printf("\n\n================================================");
 	printf("================================\n\n");
 	printf("Guest Registers:\r\n");
-	printf("=	VM ID %d ==== vCPU ID %d ===  pCPU ID %d ===="
+	printf("=	VM ID %d ==== vCPU ID %hu ===  pCPU ID %d ===="
 			"world %d =============\r\n",
 			vcpu->vm->attr.id, vcpu->vcpu_id, vcpu->pcpu_id,
 			vcpu->arch_vcpu.cur_context);
@@ -112,7 +112,7 @@ static void dump_guest_stack(struct vcpu *vcpu)
 	}
 
 	printf("\r\nGuest Stack:\r\n");
-	printf("Dump stack for vcpu %d, from gva 0x%016llx\r\n",
+	printf("Dump stack for vcpu %hu, from gva 0x%016llx\r\n",
 			vcpu->vcpu_id, cur_context->rsp);
 	for (i = 0U; i < DUMP_STACK_SIZE/32U; i++) {
 		printf("guest_rsp(0x%llx):  0x%016llx  0x%016llx  "

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -522,7 +522,7 @@ int shell_list_vcpu(struct shell *p_shell,
 			 * and VM id
 			 */
 			snprintf(temp_str, MAX_STR_SIZE,
-					"  %-9d %-10d %-7d %-12s %-16s\r\n",
+					"  %-9d %-10d %-7hu %-12s %-16s\r\n",
 					vm->attr.id,
 					vcpu->pcpu_id,
 					vcpu->vcpu_id,
@@ -542,7 +542,8 @@ int shell_pause_vcpu(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id, vcpu_id;
+	uint32_t vm_id;
+	uint16_t vcpu_id;
 	struct vm *vm;
 	struct vcpu *vcpu;
 
@@ -553,8 +554,9 @@ int shell_pause_vcpu(struct shell *p_shell,
 			"Please enter correct cmd with <vm_id, vcpu_id>\r\n");
 	} else {
 		vm_id = atoi(argv[1]);
-		vcpu_id = atoi(argv[2]);
-
+		vcpu_id = (uint16_t)atoi(argv[2]);
+		if (vcpu_id >= phys_cpu_num)
+			return (-EINVAL);
 		vm = get_vm_from_vmid(vm_id);
 		if (vm != NULL) {
 			vcpu = vcpu_from_vid(vm, vcpu_id);
@@ -591,7 +593,8 @@ int shell_resume_vcpu(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id, vcpu_id;
+	uint32_t vm_id;
+	uint16_t vcpu_id;
 	struct vm *vm;
 	struct vcpu *vcpu;
 
@@ -602,7 +605,9 @@ int shell_resume_vcpu(struct shell *p_shell,
 			"Please enter correct cmd with <vm_id, vcpu_id>\r\n");
 	} else {
 		vm_id = atoi(argv[1]);
-		vcpu_id = atoi(argv[2]);
+		vcpu_id = (uint16_t)atoi(argv[2]);
+		if (vcpu_id >= phys_cpu_num)
+			return (-EINVAL);
 		vm = get_vm_from_vmid(vm_id);
 		if (vm != NULL) {
 			vcpu = vcpu_from_vid(vm, vcpu_id);
@@ -638,7 +643,8 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id, vcpu_id;
+	uint32_t vm_id;
+	uint16_t vcpu_id;
 	char temp_str[MAX_STR_SIZE];
 	struct vm *vm;
 	struct vcpu *vcpu;
@@ -655,8 +661,9 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 	}
 
 	vm_id = atoi(argv[1]);
-	vcpu_id = atoi(argv[2]);
-
+	vcpu_id = (uint16_t)atoi(argv[2]);
+	if (vcpu_id >= phys_cpu_num)
+		return (-EINVAL);
 	vm = get_vm_from_vmid(vm_id);
 	if (vm == NULL) {
 		shell_puts(p_shell, "No vm found in the input "
@@ -679,7 +686,7 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 	}
 
 	snprintf(temp_str, MAX_STR_SIZE,
-		"=  VM ID %d ==== CPU ID %d========================\r\n",
+		"=  VM ID %d ==== CPU ID %hu========================\r\n",
 		vm->attr.id, vcpu->vcpu_id);
 	shell_puts(p_shell, temp_str);
 	snprintf(temp_str, MAX_STR_SIZE, "=  RIP=0x%016llx  RSP=0x%016llx "
@@ -752,7 +759,8 @@ int shell_vcpu_dumpmem(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id, vcpu_id;
+	uint32_t vm_id;
+	uint16_t vcpu_id;
 	uint64_t gva;
 	uint64_t tmp[MAX_MEMDUMP_LEN/8];
 	uint32_t i, length = 32U;
@@ -771,8 +779,9 @@ int shell_vcpu_dumpmem(struct shell *p_shell,
 	}
 
 	vm_id = atoi(argv[1]);
-	vcpu_id = atoi(argv[2]);
-
+	vcpu_id = (uint16_t)atoi(argv[2]);
+	if (vcpu_id >= phys_cpu_num)
+		return (-EINVAL);
 	vm = get_vm_from_vmid(vm_id);
 	if (vm == NULL) {
 		status = -EINVAL;
@@ -799,7 +808,7 @@ int shell_vcpu_dumpmem(struct shell *p_shell,
 				"Cannot handle user gva yet!\r\n");
 		} else {
 			snprintf(temp_str, MAX_STR_SIZE,
-				"Dump memory for vcpu %d, from gva 0x%016llx, "
+				"Dump memory for vcpu %hu, from gva 0x%016llx, "
 				"length %d:\r\n", vcpu_id, gva, length);
 			shell_puts(p_shell, temp_str);
 

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -96,7 +96,7 @@ uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
 int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
 
 struct vcpu *get_primary_vcpu(struct vm *vm);
-struct vcpu *vcpu_from_vid(struct vm *vm, int vcpu_id);
+struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id);
 struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id);
 
 enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -232,8 +232,8 @@ struct vcpu_arch {
 
 struct vm;
 struct vcpu {
-	int pcpu_id;	/* Physical CPU ID of this VCPU */
-	int vcpu_id;	/* virtual identifier for VCPU */
+	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */
+	uint16_t vcpu_id;	/* virtual identifier for VCPU */
 	struct vcpu_arch arch_vcpu;
 		/* Architecture specific definitions for this VCPU */
 	struct vm *vm;		/* Reference to the VM this VCPU belongs to */

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -56,7 +56,7 @@ int vlapic_pending_intr(struct vlapic *vlapic, uint32_t *vecptr);
  */
 void vlapic_intr_accepted(struct vlapic *vlapic, uint32_t vector);
 
-struct vlapic *vm_lapic_from_vcpuid(struct vm *vm, int vcpu_id);
+struct vlapic *vm_lapic_from_vcpuid(struct vm *vm, uint16_t vcpu_id);
 struct vlapic *vm_lapic_from_pcpuid(struct vm *vm, uint16_t pcpu_id);
 bool vlapic_msr(uint32_t num);
 int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);


### PR DESCRIPTION
In the hypervisor, virtual cpu id is defined as "int" or "uint32_t"
type in the hypervisor. So there are some sign conversion issues
about virtual cpu id (vcpu_id) reported by static analysis tool.
Sign conversion violates the rules of MISRA C:2012.

BTW, virtual cpu id has different names (vcpu_id, cpu_id, logical_id)
 for different modules of HV, its type is defined as "int" or "uint32_t"
in the HV. cpu_id type and logical_id type clean up will be done in
other patchs.

V1-->V2:
         More clean up the type of vcpu id;
         "%hu" is for vcpu id in the print function.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>