### PR TITLE
HV:treewide:Update cpu_id type as uint_16 and rename related cpu_id

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -31,22 +31,22 @@ struct vcpu *get_ever_run_vcpu(uint16_t pcpu_id)
  *     for physical CPU 1 : vcpu->pcpu_id = 1, vcpu->vcpu_id = 1, vmid = 1;
  *
  ***********************************************************************/
-int create_vcpu(uint16_t cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
+int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 {
 	struct vcpu *vcpu;
 
 	ASSERT(vm != NULL, "");
 	ASSERT(rtn_vcpu_handle != NULL, "");
 
-	pr_info("Creating VCPU %d", cpu_id);
+	pr_info("Creating VCPU %hu", pcpu_id);
 
 	/* Allocate memory for VCPU */
 	vcpu = calloc(1, sizeof(struct vcpu));
 	ASSERT(vcpu != NULL, "");
 
 	/* Initialize the physical CPU ID for this VCPU */
-	vcpu->pcpu_id = cpu_id;
-	per_cpu(ever_run_vcpu, cpu_id) = vcpu;
+	vcpu->pcpu_id = pcpu_id;
+	per_cpu(ever_run_vcpu, pcpu_id) = vcpu;
 
 	/* Initialize the parent VM reference */
 	vcpu->vm = vm;
@@ -72,7 +72,7 @@ int create_vcpu(uint16_t cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	ASSERT(vcpu->vcpu_id < vm->hw.num_vcpus,
 			"Allocated vcpu_id is out of range!");
 
-	per_cpu(vcpu, cpu_id) = vcpu;
+	per_cpu(vcpu, pcpu_id) = vcpu;
 
 	pr_info("PCPU%d is working as VM%d VCPU%d, Role: %s",
 			vcpu->pcpu_id, vcpu->vm->attr.id, vcpu->vcpu_id,

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -376,19 +376,19 @@ int init_default_irqs(uint16_t cpu_id)
 
 void dispatch_exception(struct intr_excp_ctx *ctx)
 {
-	unsigned int cpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_cpu_id();
 
 	/* Obtain lock to ensure exception dump doesn't get corrupted */
 	spinlock_obtain(&exception_spinlock);
 
 	/* Dump exception context */
-	dump_exception(ctx, cpu_id);
+	dump_exception(ctx, pcpu_id);
 
 	/* Release lock to let other CPUs handle exception */
 	spinlock_release(&exception_spinlock);
 
 	/* Halt the CPU */
-	cpu_dead(cpu_id);
+	cpu_dead(pcpu_id);
 }
 
 void handle_spurious_interrupt(uint32_t vector)
@@ -710,19 +710,19 @@ void get_cpu_interrupt_info(char *str, int str_max)
 }
 #endif /* HV_DEBUG */
 
-int interrupt_init(uint32_t cpu_id)
+int interrupt_init(uint16_t pcpu_id)
 {
 	struct host_idt_descriptor *idtd = &HOST_IDTR;
 	int status;
 
 	set_idt(idtd);
 
-	status = init_lapic(cpu_id);
+	status = init_lapic(pcpu_id);
 	ASSERT(status == 0, "lapic init failed");
 	if (status != 0)
 		return -ENODEV;
 
-	status = init_default_irqs(cpu_id);
+	status = init_default_irqs(pcpu_id);
 	ASSERT(status == 0, "irqs init failed");
 	if (status != 0)
 		return -ENODEV;

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -211,11 +211,11 @@ int early_init_lapic(void)
 	return 0;
 }
 
-int init_lapic(uint16_t cpu_id)
+int init_lapic(uint16_t pcpu_id)
 {
 	/* Set the Logical Destination Register */
 	write_lapic_reg32(LAPIC_LOGICAL_DESTINATION_REGISTER,
-		((1U << cpu_id) << 24));
+		((1U << pcpu_id) << 24U));
 
 	/* Set the Destination Format Register */
 	write_lapic_reg32(LAPIC_DESTINATION_FORMAT_REGISTER, 0xf << 28);

--- a/hypervisor/arch/x86/softirq.c
+++ b/hypervisor/arch/x86/softirq.c
@@ -18,11 +18,11 @@ void enable_softirq(uint16_t cpu_id)
 
 void init_softirq(void)
 {
-	uint16_t cpu_id;
+	uint16_t pcpu_id;
 
-	for (cpu_id = 0; cpu_id < phys_cpu_num; cpu_id++) {
-		per_cpu(softirq_pending, cpu_id) = 0;
-		bitmap_set(SOFTIRQ_ATOMIC, &per_cpu(softirq_pending, cpu_id));
+	for (pcpu_id = 0U; pcpu_id < phys_cpu_num; pcpu_id++) {
+		per_cpu(softirq_pending, pcpu_id) = 0;
+		bitmap_set(SOFTIRQ_ATOMIC, &per_cpu(softirq_pending, pcpu_id));
 	}
 }
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -104,33 +104,33 @@ static bool is_vm0_bsp(uint16_t pcpu_id)
 	return pcpu_id == vm0_desc.vm_hw_logical_core_ids[0];
 }
 
-int32_t hv_main(uint16_t cpu_id)
+int32_t hv_main(uint16_t pcpu_id)
 {
 	int32_t ret;
 
-	pr_info("%s, Starting common entry point for CPU %d",
-			__func__, cpu_id);
+	pr_info("%s, Starting common entry point for CPU %hu",
+			__func__, pcpu_id);
 
-	if (cpu_id >= phys_cpu_num) {
-		pr_err("%s, cpu_id %d out of range %d\n",
-			__func__, cpu_id, phys_cpu_num);
+	if (pcpu_id >= phys_cpu_num) {
+		pr_err("%s, cpu_id %hu out of range %d\n",
+			__func__, pcpu_id, phys_cpu_num);
 		return -EINVAL;
 	}
 
-	if (cpu_id != get_cpu_id()) {
-		pr_err("%s, cpu_id %d mismatch\n", __func__, cpu_id);
+	if (pcpu_id != get_cpu_id()) {
+		pr_err("%s, cpu_id %hu mismatch\n", __func__, pcpu_id);
 		return -EINVAL;
 	}
 
 	/* Enable virtualization extensions */
-	ret = exec_vmxon_instr(cpu_id);
+	ret = exec_vmxon_instr(pcpu_id);
 	if (ret != 0)
 		return ret;
 
 	/* X2APIC mode is disabled by default. */
 	x2apic_enabled = false;
 
-	if (is_vm0_bsp(cpu_id)) {
+	if (is_vm0_bsp(pcpu_id)) {
 		ret = prepare_vm0();
 		if (ret != 0)
 			return ret;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -277,7 +277,7 @@ struct vcpu {
 
 /* External Interfaces */
 struct vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
-int create_vcpu(uint16_t cpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle);
+int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle);
 int start_vcpu(struct vcpu *vcpu);
 int shutdown_vcpu(struct vcpu *vcpu);
 void destroy_vcpu(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -105,7 +105,7 @@ int exception_vmexit_handler(struct vcpu *vcpu);
 int interrupt_window_vmexit_handler(struct vcpu *vcpu);
 int external_interrupt_vmexit_handler(struct vcpu *vcpu);
 int acrn_handle_pending_request(struct vcpu *vcpu);
-int interrupt_init(uint32_t logical_id);
+int interrupt_init(uint16_t pcpu_id);
 
 void cancel_event_injection(struct vcpu *vcpu);
 

--- a/hypervisor/include/debug/dump.h
+++ b/hypervisor/include/debug/dump.h
@@ -14,7 +14,7 @@ struct intr_excp_ctx;
 #define DUMP_STACK_SIZE 0x200U
 
 void dump_intr_excp_frame(struct intr_excp_ctx *ctx);
-void dump_exception(struct intr_excp_ctx *ctx, uint32_t cpu_id);
+void dump_exception(struct intr_excp_ctx *ctx, uint16_t pcpu_id);
 
 #else
 static inline void dump_intr_excp_frame(__unused struct intr_excp_ctx *ctx)
@@ -22,7 +22,7 @@ static inline void dump_intr_excp_frame(__unused struct intr_excp_ctx *ctx)
 }
 
 static inline void dump_exception(__unused struct intr_excp_ctx *ctx,
-		__unused uint32_t cpu_id)
+		__unused uint16_t pcpu_id)
 {
 }
 

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -30,7 +30,7 @@
 extern uint32_t console_loglevel;
 extern uint32_t mem_loglevel;
 void init_logmsg(uint32_t mem_size, uint32_t flags);
-void print_logmsg_buffer(uint32_t cpu_id);
+void print_logmsg_buffer(uint16_t pcpu_id);
 void do_logmsg(uint32_t severity, const char *fmt, ...);
 
 #else /* HV_DEBUG */
@@ -45,7 +45,7 @@ static inline void do_logmsg(__unused uint32_t severity,
 {
 }
 
-static inline void print_logmsg_buffer(__unused uint32_t cpu_id)
+static inline void print_logmsg_buffer(__unused uint16_t pcpu_id)
 {
 }
 


### PR DESCRIPTION
There are extra type conversion in the HV since cpu_id
type is uint32_t and the return value type of get_cpu_id
is uint16_t. BTW, the name of cpu_id is not clear enough
to express its usage.

So the following updates are made in this patch:
Update cpu_id type as unit_16 to reduce type casting;
Update related temporary variables type;
Update related print argument;
Change the input parameter name of interrupt_init as
cpu_id to keep align with function implement;
Rename related cpu_id as pcpu_id as needed.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>