### PR TITLE
HV:CPU:Update logical_id type as uint_16 and rename logical_id

### DIFF
--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -271,7 +271,7 @@ extern struct cpuinfo_x86 boot_cpu_data;
 #define MAX_CX_ENTRY	(MAX_CSTATE - 1U)
 
 /* Function prototypes */
-void cpu_dead(uint32_t logical_id);
+void cpu_dead(uint16_t pcpu_id);
 void trampoline_start16(void);
 int32_t hv_main(uint16_t cpu_id);
 bool is_vapic_supported(void);


### PR DESCRIPTION
There are extra type conversion in the HV since logical_id
type is uint32_t and the input argument of bitmap operations
is uint16_t. BTW, the name of logical_id is not clear enough
to express its usage.

So the following updates are made in this patch:
Update logical_id type as unit_16 to reduce type casting;
Update related print argument;
Rename related logical_id as pcpu_id as needed.

Note: logical_id in the interrupt_init definition have been
updated in cpu_id cleanup patch.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>