### PR TITLE
HV: cleanup coding style violation

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -536,7 +536,6 @@ vioapic_reset(struct vioapic *vioapic)
 struct vioapic *
 vioapic_init(struct vm *vm)
 {
-	int i;
 	struct vioapic *vioapic;
 
 	vioapic = calloc(1, sizeof(struct vioapic));

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -310,9 +310,9 @@ void setup_ioapic_irq(void)
 
 	for (ioapic_id = 0U;
 	     ioapic_id < CONFIG_NR_IOAPICS; ioapic_id++) {
-		int pin;
-		int max_pins;
-		int version;
+		uint32_t pin;
+		uint32_t max_pins;
+		uint32_t version;
 		void *addr;
 
 		addr = map_ioapic(get_ioapic_base(ioapic_id));

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -74,7 +74,6 @@ int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 	uint32_t pm1b_cnt_val)
 {
 	uint32_t pcpu_id;
-	int ret;
 	uint64_t pmain_entry_saved;
 	uint32_t guest_wakeup_vec32;
 	uint64_t *pmain_entry;

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -317,7 +317,7 @@ int shell_process_cmd(struct shell *p_shell, char *p_input_line)
 
 	(void) string_to_argv(&cmd_argv_str[0],
 			(void *) &cmd_argv_mem[0],
-			sizeof(cmd_argv_mem), &cmd_argc, &cmd_argv);
+			sizeof(cmd_argv_mem), (void *)&cmd_argc, &cmd_argv);
 
 	/* Determine if there is a command to process. */
 	if (cmd_argc != 0) {
@@ -1068,6 +1068,8 @@ int shell_trigger_crash(struct shell *p_shell, int argc, char **argv)
 {
 	char str[MAX_STR_SIZE] = {0};
 
+	(void)argc;
+	(void)argv;
 	snprintf(str, MAX_STR_SIZE, "trigger crash, divide by 0 ...\r\n");
 	shell_puts(p_shell, str);
 	snprintf(str, MAX_STR_SIZE, "%d\r", 1/0);


### PR DESCRIPTION
 - replace MACROs with inline functions
 - remove unused local viarbles
 - fix build errors

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>