### PR TITLE
hv:rename several APIs in vlapic.c

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1815,7 +1815,7 @@ vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg)
 }
 
 static bool
-x2apic_msr(uint32_t msr)
+is_x2apic_msr(uint32_t msr)
 {
 	if (msr >= 0x800 && msr <= 0xBFF)
 		return true;
@@ -1831,10 +1831,10 @@ x2apic_msr_to_regoff(uint32_t msr)
 }
 
 bool
-vlapic_msr(uint32_t msr)
+is_vlapic_msr(uint32_t msr)
 {
 
-	if (x2apic_msr(msr) || (msr == MSR_IA32_APIC_BASE))
+	if (is_x2apic_msr(msr) || (msr == MSR_IA32_APIC_BASE))
 		return true;
 	else
 		return false;
@@ -1918,7 +1918,7 @@ vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t val)
 }
 
 int
-vlapic_mmio_write(struct vcpu *vcpu, uint64_t gpa, uint64_t wval, int size)
+vlapic_write_mmio_reg(struct vcpu *vcpu, uint64_t gpa, uint64_t wval, int size)
 {
 	int error;
 	uint64_t off;
@@ -1939,7 +1939,7 @@ vlapic_mmio_write(struct vcpu *vcpu, uint64_t gpa, uint64_t wval, int size)
 }
 
 int
-vlapic_mmio_read(struct vcpu *vcpu, uint64_t gpa, uint64_t *rval,
+vlapic_read_mmio_reg(struct vcpu *vcpu, uint64_t gpa, uint64_t *rval,
 			__unused int size)
 {
 	int error;
@@ -1973,14 +1973,14 @@ int vlapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 			"All RW to LAPIC must be 32-bits in size");
 
 	if (mmio->read_write == HV_MEM_IO_READ) {
-		ret = vlapic_mmio_read(vcpu,
+		ret = vlapic_read_mmio_reg(vcpu,
 				gpa,
 				&mmio->value,
 				mmio->access_size);
 		mmio->mmio_status = MMIO_TRANS_VALID;
 
 	} else if (mmio->read_write == HV_MEM_IO_WRITE) {
-		ret = vlapic_mmio_write(vcpu,
+		ret = vlapic_write_mmio_reg(vcpu,
 				gpa,
 				mmio->value,
 				mmio->access_size);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -58,12 +58,14 @@ void vlapic_intr_accepted(struct vlapic *vlapic, uint32_t vector);
 
 struct vlapic *vm_lapic_from_vcpuid(struct vm *vm, uint16_t vcpu_id);
 struct vlapic *vm_lapic_from_pcpuid(struct vm *vm, uint16_t pcpu_id);
-bool vlapic_msr(uint32_t num);
+bool is_vlapic_msr(uint32_t num);
 int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
 int vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t wval);
 
-int vlapic_mmio_read(struct vcpu *vcpu, uint64_t gpa, uint64_t *rval, int size);
-int vlapic_mmio_write(struct vcpu *vcpu, uint64_t gpa, uint64_t wval, int size);
+int vlapic_read_mmio_reg(struct vcpu *vcpu, uint64_t gpa,
+		uint64_t *rval, int size);
+int vlapic_write_mmio_reg(struct vcpu *vcpu, uint64_t gpa,
+		uint64_t wval, int size);
 
 /*
  * Signals to the LAPIC that an interrupt at 'vector' needs to be generated


### PR DESCRIPTION
rename 4 APIs:
  x2apic_msr -> is_ x2apic_msr
  vlapic_msr -> is_vlapic_msr
  vlapic_mmio_write -> vlapic_write_mmio_reg
  vlapic_mmio_read -> vlapic_read_mmio_reg

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>