### PR TITLE
HV:treewide:string assigned to const object

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -823,7 +823,7 @@ static void cpu_set_logical_id(uint16_t pcpu_id)
 
 static void print_hv_banner(void)
 {
-	char *boot_msg = "ACRN Hypervisor\n\r";
+	const char *boot_msg = "ACRN Hypervisor\n\r";
 
 	/* Print the boot message */
 	printf(boot_msg);

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -169,7 +169,7 @@ probe_table(uint64_t address, const char *sig)
 	return 1;
 }
 
-void *get_acpi_tbl(char *sig)
+void *get_acpi_tbl(const char *sig)
 {
 	struct acpi_table_rsdp *rsdp;
 	struct acpi_table_rsdt *rsdt;

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -228,7 +228,7 @@ static void show_host_call_trace(uint64_t rsp, uint64_t rbp, uint16_t pcpu_id)
 	printf("\r\n");
 }
 
-void __assert(uint32_t line, const char *file, char *txt)
+void __assert(uint32_t line, const char *file, const char *txt)
 {
 	uint16_t pcpu_id = get_cpu_id();
 	uint64_t rsp = cpu_rsp_get();

--- a/hypervisor/debug/serial.c
+++ b/hypervisor/debug/serial.c
@@ -10,7 +10,7 @@
 static struct uart *sio_ports[SERIAL_MAX_DEVS];
 static uint8_t sio_initialized[SERIAL_MAX_DEVS];
 
-static struct uart *get_uart_by_id(char *uart_id, uint32_t *index)
+static struct uart *get_uart_by_id(const char *uart_id, uint32_t *index)
 {
 	/* Initialize the index to the start of array. */
 	*index = 0U;
@@ -78,7 +78,7 @@ int serial_init(void)
 	return status;
 }
 
-uint32_t serial_open(char *uart_id)
+uint32_t serial_open(const char *uart_id)
 {
 	int status = SERIAL_DEV_NOT_FOUND;
 	struct uart *uart;

--- a/hypervisor/debug/serial_internal.h
+++ b/hypervisor/debug/serial_internal.h
@@ -175,7 +175,7 @@ struct uart {
 /* Null terminated array of target specific UART control blocks */
 extern struct tgt_uart Tgt_Uarts[SERIAL_MAX_DEVS];
 
-uint32_t serial_open(char *uart_id);
+uint32_t serial_open(const char *uart_id);
 int serial_getc(uint32_t uart_handle);
 int serial_gets(uint32_t uart_handle, char *buffer, uint32_t length);
 int serial_puts(uint32_t uart_handle, const char *s, uint32_t length);

--- a/hypervisor/debug/shell_internal.h
+++ b/hypervisor/debug/shell_internal.h
@@ -170,8 +170,8 @@ uint8_t shell_getc_serial(struct shell *p_shell);
 void shell_special_serial(struct shell *p_shell, uint8_t ch);
 void kick_shell(struct shell *p_shell);
 
-int shell_puts(struct shell *p_shell, char *str_ptr);
-int shell_set_name(struct shell *p_shell, char *name);
+int shell_puts(struct shell *p_shell, const char *str_ptr);
+int shell_set_name(struct shell *p_shell, const char *name);
 int shell_trigger_crash(struct shell *p_shell, int argc, char **argv);
 
 #endif /* SHELL_INTER_H */

--- a/hypervisor/debug/shell_public.c
+++ b/hypervisor/debug/shell_public.c
@@ -159,7 +159,7 @@ int shell_init(void)
 	return status;
 }
 
-int shell_puts(struct shell *p_shell, char *str_ptr)
+int shell_puts(struct shell *p_shell, const char *str_ptr)
 {
 	int status;
 
@@ -178,7 +178,7 @@ int shell_puts(struct shell *p_shell, char *str_ptr)
 	return status;
 }
 
-int shell_set_name(struct shell *p_shell, char *name)
+int shell_set_name(struct shell *p_shell, const char *name)
 {
 	int status;
 

--- a/hypervisor/include/debug/assert.h
+++ b/hypervisor/include/debug/assert.h
@@ -8,7 +8,7 @@
 #define ASSERT_H
 
 #ifdef HV_DEBUG
-void __assert(uint32_t line, const char *file, char *txt);
+void __assert(uint32_t line, const char *file, const char *txt);
 
 #define ASSERT(x, ...) \
 	if (!(x)) {\


### PR DESCRIPTION
In the hypervisor, some strings are assigned to non const
object, this violates MISRA C:2012.

Update the type of the object as const type since it always
points to string.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>