### PR TITLE
HV: rename functions in cpu.c

### DIFF
--- a/hypervisor/arch/x86/trampoline.S
+++ b/hypervisor/arch/x86/trampoline.S
@@ -38,7 +38,6 @@
  */
 
     .extern     cpu_secondary_init
-    .extern     cpu_logical_id
     .extern     _ld_bss_end
     .extern     HOST_GDTR
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -146,8 +146,6 @@
 
 #ifndef ASSEMBLER
 
-int cpu_find_logical_id(uint8_t lapic_id);
-
 /**********************************/
 /* EXTERNAL VARIABLES             */
 /**********************************/


### PR DESCRIPTION
- rename 'cpu_set_logical_id()' to 'set_current_cpu_id()'
- rename 'cpu_find_logical_id()' to 'get_cpu_id_from_lapic_id()'
- some clean up in cpu.c & trampolines.s

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>