### PR TITLE
hv:fix "missing for discarded return value" for memset

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -368,7 +368,7 @@ void bsp_boot_init(void)
 	start_tsc = rdtsc();
 
 	/* Clear BSS */
-	memset(_ld_bss_start, 0, _ld_bss_end - _ld_bss_start);
+	(void)memset(_ld_bss_start, 0, _ld_bss_end - _ld_bss_start);
 
 	/* Build time sanity checks to make sure hard-coded offset
 	*  is matching the actual offset!

--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -113,7 +113,7 @@ void load_cpu_state_data(void)
 	int tbl_idx;
 	const struct cpu_state_info *state_info;
 
-	memset(&boot_cpu_data.state_info, 0,
+	(void)memset(&boot_cpu_data.state_info, 0,
 			sizeof(struct cpu_state_info));
 
 	tbl_idx = get_state_tbl_idx(boot_cpu_data.model_name);

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -425,7 +425,7 @@ int ept_violation_vmexit_handler(struct vcpu *vcpu)
 		 * instruction emulation. For MMIO read, ask DM to run MMIO
 		 * emulation at first.
 		 */
-		memset(&vcpu->req, 0, sizeof(struct vhm_request));
+		(void)memset(&vcpu->req, 0, sizeof(struct vhm_request));
 
 		if (dm_emulate_mmio_pre(vcpu, exit_qual) != 0)
 			goto out;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -726,7 +726,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 	 * number for it(without trusty) is GUEST_INIT_PT_PAGE_NUM-1.
 	 * here make sure they are init as 0 (page entry no present)
 	 */
-	memset(pml4_addr, 0, PAGE_SIZE_4K * GUEST_INIT_PT_PAGE_NUM-1);
+	(void)memset(pml4_addr, 0, PAGE_SIZE_4K * GUEST_INIT_PT_PAGE_NUM-1);
 
 	/* Write PML4E */
 	table_present = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT);
@@ -766,7 +766,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 	 */
 	if (vm->sworld_control.sworld_enabled && !is_vm0(vm)) {
 		/* clear page entry for trusty */
-		memset(pml4_addr + 6 * PAGE_SIZE_4K, 0, PAGE_SIZE_4K);
+		(void)memset(pml4_addr + 6 * PAGE_SIZE_4K, 0, PAGE_SIZE_4K);
 
 		/* Write PDPTE for trusy memory, PD will use 7th page */
 		pd_base_paddr = GUEST_INIT_PAGE_TABLE_START +

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1241,7 +1241,7 @@ emulate_stack_op(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
 	uint8_t size, stackaddrsize;
 	uint32_t err_code = 0U;
 
-	memset(&ss_desc, 0U, sizeof(ss_desc));
+	(void)memset(&ss_desc, 0U, sizeof(ss_desc));
 
 	val = 0UL;
 	size = vie->opsize;
@@ -1690,7 +1690,7 @@ vie_init(struct vie *vie, struct vcpu *vcpu)
 		return -EINVAL;
 	}
 
-	memset(vie, 0U, sizeof(struct vie));
+	(void)memset(vie, 0U, sizeof(struct vie));
 
 	vie->base_register = CPU_REG_LAST;
 	vie->index_register = CPU_REG_LAST;

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -36,7 +36,8 @@ static void vm_setup_cpu_px(struct vm *vm)
 	uint32_t px_data_size;
 
 	vm->pm.px_cnt = 0U;
-	memset(vm->pm.px_data, 0, MAX_PSTATE * sizeof(struct cpu_px_data));
+	(void)memset(vm->pm.px_data, 0,
+			MAX_PSTATE * sizeof(struct cpu_px_data));
 
 	if ((boot_cpu_data.state_info.px_cnt == 0U)
 		|| (boot_cpu_data.state_info.px_data == NULL)) {
@@ -60,7 +61,8 @@ static void vm_setup_cpu_cx(struct vm *vm)
 	uint32_t cx_data_size;
 
 	vm->pm.cx_cnt = 0U;
-	memset(vm->pm.cx_data, 0, MAX_CSTATE * sizeof(struct cpu_cx_data));
+	(void)memset(vm->pm.cx_data, 0,
+			MAX_CSTATE * sizeof(struct cpu_cx_data));
 
 	if ((boot_cpu_data.state_info.cx_cnt == 0U)
 		|| (boot_cpu_data.state_info.cx_data == NULL)) {

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -96,7 +96,7 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	ASSERT(vcpu->arch_vcpu.vmcs != NULL, "");
 
 	/* Memset VMCS region for this VCPU */
-	memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
+	(void)memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
 
 	/* Initialize exception field in VCPU context */
 	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
@@ -283,7 +283,7 @@ void reset_vcpu(struct vcpu *vcpu)
 	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
 	vcpu->arch_vcpu.irq_window_enabled = 0;
 	vcpu->arch_vcpu.inject_event_pending = false;
-	memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
+	(void)memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
 
 	vlapic = vcpu->arch_vcpu.vlapic;
 	vlapic_reset(vlapic);

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -262,7 +262,7 @@ static void vlapic_create_timer(struct vlapic *vlapic)
 		return;
 
 	vlapic_timer = &vlapic->vlapic_timer;
-	memset(vlapic_timer, 0, sizeof(struct vlapic_timer));
+	(void)memset(vlapic_timer, 0, sizeof(struct vlapic_timer));
 
 	initialize_timer(&vlapic_timer->timer,
 			vlapic_timer_expired, vlapic->vcpu,
@@ -1491,9 +1491,9 @@ vlapic_reset(struct vlapic *vlapic)
 
 	lapic = vlapic->apic_page;
 	apic_page = (void *)vlapic->apic_page;
-	memset(apic_page, 0, CPU_PAGE_SIZE);
+	(void)memset(apic_page, 0, CPU_PAGE_SIZE);
 	if (vlapic->pir_desc)
-		memset(vlapic->pir_desc, 0, sizeof(struct pir_desc));
+		(void)memset(vlapic->pir_desc, 0, sizeof(struct pir_desc));
 
 	lapic->id = vlapic_build_id(vlapic);
 	lapic->version = VLAPIC_VERSION;
@@ -1992,7 +1992,7 @@ int vlapic_create(struct vcpu *vcpu)
 	ASSERT(vlapic != NULL, "vlapic allocate failed");
 	ASSERT(apic_page != NULL, "apic reg page allocate failed");
 
-	memset((void *)apic_page, 0, CPU_PAGE_SIZE);
+	(void)memset((void *)apic_page, 0, CPU_PAGE_SIZE);
 	vlapic->vm = vcpu->vm;
 	vlapic->vcpu = vcpu;
 	vlapic->apic_page = (struct lapic_regs *)apic_page;
@@ -2169,7 +2169,7 @@ apicv_get_apic_access_addr(__unused struct vm *vm)
 		ASSERT(apicv_apic_access_addr != NULL,
 					"apicv allocate failed.");
 
-		memset((void *)apicv_apic_access_addr, 0, CPU_PAGE_SIZE);
+		(void)memset((void *)apicv_apic_access_addr, 0, CPU_PAGE_SIZE);
 	}
 	return HVA2HPA(apicv_apic_access_addr);
 }

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -92,7 +92,7 @@ void init_msr_emulation(struct vcpu *vcpu)
 		/* Allocate and initialize memory for MSR bitmap region*/
 		vcpu->vm->arch_vm.msr_bitmap = alloc_page();
 		ASSERT(vcpu->vm->arch_vm.msr_bitmap != NULL, "");
-		memset(vcpu->vm->arch_vm.msr_bitmap, 0x0, CPU_PAGE_SIZE);
+		(void)memset(vcpu->vm->arch_vm.msr_bitmap, 0x0, CPU_PAGE_SIZE);
 
 		msr_bitmap = vcpu->vm->arch_vm.msr_bitmap;
 
@@ -135,7 +135,7 @@ void init_msr_emulation(struct vcpu *vcpu)
 			(uint64_t *)calloc(msrs_count, sizeof(uint64_t));
 
 	ASSERT(vcpu->guest_msrs != NULL, "");
-	memset(vcpu->guest_msrs, 0, msrs_count * sizeof(uint64_t));
+	(void)memset(vcpu->guest_msrs, 0, msrs_count * sizeof(uint64_t));
 }
 
 int rdmsr_vmexit_handler(struct vcpu *vcpu)

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -113,7 +113,7 @@ int io_instr_vmexit_handler(struct vcpu *vcpu)
 	if (status != 0) {
 		uint64_t *rax = &cur_context->guest_cpu_regs.regs.rax;
 
-		memset(&vcpu->req, 0, sizeof(struct vhm_request));
+		(void)memset(&vcpu->req, 0, sizeof(struct vhm_request));
 		dm_emulate_pio_pre(vcpu, exit_qual, sz, *rax);
 		status = acrn_insert_request_wait(vcpu, &vcpu->req);
 	}
@@ -220,12 +220,12 @@ void setup_io_bitmap(struct vm *vm)
 	       (vm->arch_vm.iobitmap[1] != NULL), "");
 
 	if (is_vm0(vm)) {
-		memset(vm->arch_vm.iobitmap[0], 0x00, CPU_PAGE_SIZE);
-		memset(vm->arch_vm.iobitmap[1], 0x00, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[0], 0x00, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[1], 0x00, CPU_PAGE_SIZE);
 	} else {
 		/* block all IO port access from Guest */
-		memset(vm->arch_vm.iobitmap[0], 0xFF, CPU_PAGE_SIZE);
-		memset(vm->arch_vm.iobitmap[1], 0xFF, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[0], 0xFF, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[1], 0xFF, CPU_PAGE_SIZE);
 	}
 }
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -23,7 +23,7 @@ static void init_irq_desc(void)
 	irq_desc_base = alloc_pages(page_num);
 
 	ASSERT(irq_desc_base != NULL, "page alloc failed!");
-	memset(irq_desc_base, 0, page_num * CPU_PAGE_SIZE);
+	(void)memset(irq_desc_base, 0, page_num * CPU_PAGE_SIZE);
 
 	for (i = 0U; i < NR_MAX_IRQS; i++) {
 		irq_desc_base[i].irq = i;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -651,7 +651,7 @@ void *alloc_paging_struct(void)
 	ptr = alloc_page();
 
 	ASSERT(ptr != NULL, "page alloc failed!");
-	memset(ptr, 0, CPU_PAGE_SIZE);
+	(void)memset(ptr, 0, CPU_PAGE_SIZE);
 
 	return ptr;
 }
@@ -659,7 +659,7 @@ void *alloc_paging_struct(void)
 void free_paging_struct(void *ptr)
 {
 	if (ptr != NULL) {
-		memset(ptr, 0, CPU_PAGE_SIZE);
+		(void)memset(ptr, 0, CPU_PAGE_SIZE);
 		free(ptr);
 	}
 }

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -155,7 +155,7 @@ void  destroy_secure_world(struct vm *vm)
 	}
 
 	/* clear trusty memory space */
-	memset(HPA2HVA(vm->sworld_control.sworld_memory.base_hpa),
+	(void)memset(HPA2HVA(vm->sworld_control.sworld_memory.base_hpa),
 			0, vm->sworld_control.sworld_memory.length);
 
 	/* restore memory to SOS ept mapping */
@@ -319,7 +319,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 	memcpy_s(&mem->first_page.data.key_info, sizeof(g_key_info),
 			&g_key_info, sizeof(g_key_info));
 
-	memset(mem->first_page.data.key_info.dseed_list, 0,
+	(void)memset(mem->first_page.data.key_info.dseed_list, 0,
 			sizeof(mem->first_page.data.key_info.dseed_list));
 	/* Derive dvseed from dseed for Trusty */
 	key_info = &mem->first_page.data.key_info;
@@ -330,7 +330,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 				BUP_MKHI_BOOTLOADER_SEED_LEN,
 				NULL, 0,
 				vcpu->vm->GUID, sizeof(vcpu->vm->GUID)) == 0) {
-			memset(key_info, 0, sizeof(struct key_info));
+			(void)memset(key_info, 0, sizeof(struct key_info));
 			pr_err("%s: derive dvseed failed!", __func__);
 			return false;
 		}
@@ -455,7 +455,7 @@ void trusty_set_dseed(void *dseed, uint8_t dseed_num)
 		(dseed_num > BOOTLOADER_SEED_MAX_ENTRIES)) {
 
 		g_key_info.num_seeds = 1;
-		memset(g_key_info.dseed_list[0].seed, 0xA5,
+		(void)memset(g_key_info.dseed_list[0].seed, 0xA5,
 			sizeof(g_key_info.dseed_list[0].seed));
 		return;
 	}

--- a/hypervisor/boot/sbl/hob_parse.c
+++ b/hypervisor/boot/sbl/hob_parse.c
@@ -52,7 +52,7 @@ void parse_seed_list(struct seed_list_hob *seed_hob)
 			dseed_index++;
 
 			/* erase original seed in seed entry */
-			memset(entry->seed, 0, sizeof(struct seed_info));
+			(void)memset(entry->seed, 0, sizeof(struct seed_info));
 		}
 
 		entry = (struct seed_entry *)((uint8_t *)entry +
@@ -60,10 +60,10 @@ void parse_seed_list(struct seed_list_hob *seed_hob)
 	}
 
 	trusty_set_dseed(dseed_list, dseed_index);
-	memset(dseed_list, 0, sizeof(dseed_list));
+	(void)memset(dseed_list, 0, sizeof(dseed_list));
 	return;
 
 fail:
 	trusty_set_dseed(NULL, 0);
-	memset(dseed_list, 0, sizeof(dseed_list));
+	(void)memset(dseed_list, 0, sizeof(dseed_list));
 }

--- a/hypervisor/bsp/uefi/efi/boot.c
+++ b/hypervisor/bsp/uefi/efi/boot.c
@@ -83,14 +83,14 @@ construct_mbi(struct multiboot_info **mbi_ret, struct efi_ctx *efi_ctx)
 		goto out;
 
 	mbi = (struct multiboot_info *)(UINTN)addr;
-	memset((void *)mbi, 0x0, sizeof(*mbi));
+	(void)memset((void *)mbi, 0x0, sizeof(*mbi));
 
 	/* allocate mmap[] */
 	err = emalloc(sizeof(struct multiboot_mmap)*128, 8, &addr);
 	if (err != EFI_SUCCESS)
 		goto out;
 	mmap = (struct multiboot_mmap *)(UINTN)addr;
-	memset((void *)mmap, 0x0, sizeof(*mmap)*128);
+	(void)memset((void *)mmap, 0x0, sizeof(*mmap)*128);
 
 	/* We're just interested in the map's size for now */
 	map_size = 0;

--- a/hypervisor/bsp/uefi/efi/malloc.c
+++ b/hypervisor/bsp/uefi/efi/malloc.c
@@ -354,7 +354,7 @@ void *calloc(UINTN nmemb, UINTN size)
 
 	buffer = malloc(bytes);
 	if (buffer)
-		memset(buffer, 0, bytes);
+		(void)memset(buffer, 0, bytes);
 	return buffer;
 }
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -135,13 +135,13 @@ int64_t hcall_create_vm(struct vm *vm, uint64_t param)
 	struct acrn_create_vm cv;
 	struct vm_description vm_desc;
 
-	memset((void *)&cv, 0, sizeof(cv));
+	(void)memset((void *)&cv, 0, sizeof(cv));
 	if (copy_from_gpa(vm, &cv, param, sizeof(cv)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
 	}
 
-	memset(&vm_desc, 0, sizeof(vm_desc));
+	(void)memset(&vm_desc, 0, sizeof(vm_desc));
 	vm_desc.sworld_enabled =
 		(!!(cv.vm_flag & (SECURE_WORLD_ENABLED)));
 	memcpy_s(&vm_desc.GUID[0], 16, &cv.GUID[0], 16);
@@ -281,7 +281,7 @@ int64_t hcall_inject_msi(struct vm *vm, uint64_t vmid, uint64_t param)
 	if (target_vm == NULL)
 		return -1;
 
-	memset((void *)&msi, 0, sizeof(msi));
+	(void)memset((void *)&msi, 0, sizeof(msi));
 	if (copy_from_gpa(vm, &msi, param, sizeof(msi)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
@@ -301,7 +301,7 @@ int64_t hcall_set_ioreq_buffer(struct vm *vm, uint64_t vmid, uint64_t param)
 	if (target_vm == NULL)
 		return -1;
 
-	memset((void *)&iobuf, 0, sizeof(iobuf));
+	(void)memset((void *)&iobuf, 0, sizeof(iobuf));
 
 	if (copy_from_gpa(vm, &iobuf, param, sizeof(iobuf)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -449,7 +449,7 @@ int64_t hcall_set_vm_memmap(struct vm *vm, uint64_t vmid, uint64_t param)
 	if ((vm == NULL) || (target_vm == NULL))
 		return -1;
 
-	memset((void *)&memmap, 0, sizeof(memmap));
+	(void)memset((void *)&memmap, 0, sizeof(memmap));
 
 	if (copy_from_gpa(vm, &memmap, param, sizeof(memmap)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -482,7 +482,7 @@ int64_t hcall_set_vm_memmaps(struct vm *vm, uint64_t param)
 		return -1;
 	}
 
-	memset((void *)&set_memmaps, 0, sizeof(set_memmaps));
+	(void)memset((void *)&set_memmaps, 0, sizeof(set_memmaps));
 
 	if (copy_from_gpa(vm, &set_memmaps, param, sizeof(set_memmaps)) != 0) {
 		pr_err("%s: Unable copy param from vm\n", __func__);
@@ -521,7 +521,7 @@ int64_t hcall_remap_pci_msix(struct vm *vm, uint64_t vmid, uint64_t param)
 	if (target_vm == NULL)
 		return -1;
 
-	memset((void *)&remap, 0, sizeof(remap));
+	(void)memset((void *)&remap, 0, sizeof(remap));
 
 	if (copy_from_gpa(vm, &remap, param, sizeof(remap)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -560,7 +560,7 @@ int64_t hcall_gpa_to_hpa(struct vm *vm, uint64_t vmid, uint64_t param)
 	if (target_vm == NULL)
 		return -1;
 
-	memset((void *)&v_gpa2hpa, 0, sizeof(v_gpa2hpa));
+	(void)memset((void *)&v_gpa2hpa, 0, sizeof(v_gpa2hpa));
 
 	if (copy_from_gpa(vm, &v_gpa2hpa, param, sizeof(v_gpa2hpa)) != 0) {
 		pr_err("HCALL gpa2hpa: Unable copy param from vm\n");
@@ -640,7 +640,7 @@ int64_t hcall_set_ptdev_intr_info(struct vm *vm, uint64_t vmid, uint64_t param)
 	if (target_vm == NULL)
 		return -1;
 
-	memset((void *)&irq, 0, sizeof(irq));
+	(void)memset((void *)&irq, 0, sizeof(irq));
 
 	if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -670,7 +670,7 @@ hcall_reset_ptdev_intr_info(struct vm *vm, uint64_t vmid, uint64_t param)
 	if (target_vm == NULL)
 		return -1;
 
-	memset((void *)&irq, 0, sizeof(irq));
+	(void)memset((void *)&irq, 0, sizeof(irq));
 
 	if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -694,7 +694,7 @@ int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
 	struct sbuf_setup_param ssp;
 	uint64_t *hva;
 
-	memset((void *)&ssp, 0, sizeof(ssp));
+	(void)memset((void *)&ssp, 0, sizeof(ssp));
 
 	if (copy_from_gpa(vm, &ssp, param, sizeof(ssp)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -35,7 +35,7 @@ static uint64_t create_zero_page(struct vm *vm)
 	zeropage = (struct zero_page *)((char *)hva + MEM_4K);
 
 	/* clear the zeropage */
-	memset(zeropage, 0, MEM_2K);
+	(void)memset(zeropage, 0, MEM_2K);
 
 	/* copy part of the header into the zero page */
 	hva = GPA2HVA(vm, (uint64_t)vm->sw.kernel_info.kernel_load_addr);
@@ -81,7 +81,7 @@ int load_guest(struct vm *vm, struct vcpu *vcpu)
 	lowmem_gpa_top = *(uint64_t *)hva;
 
 	/* hardcode vcpu entry addr(kernel entry) & rsi (zeropage)*/
-	memset(cur_context->guest_cpu_regs.longs,
+	(void)memset(cur_context->guest_cpu_regs.longs,
 			0, sizeof(uint64_t)*NUM_GPRS);
 
 	hva  = GPA2HVA(vm, lowmem_gpa_top -
@@ -149,7 +149,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 		/* Documentation states: ebx=0, edi=0, ebp=0, esi=ptr to
 		 * zeropage
 		 */
-		memset(cur_context->guest_cpu_regs.longs,
+		(void)memset(cur_context->guest_cpu_regs.longs,
 			0, sizeof(uint64_t) * NUM_GPRS);
 
 		/* Get host-physical address for guest bootargs */

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -107,7 +107,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	pcpu_id = get_cpu_id();
 	buffer = per_cpu(logbuf, pcpu_id);
 
-	memset(buffer, 0, LOG_MESSAGE_MAX_SIZE);
+	(void)memset(buffer, 0, LOG_MESSAGE_MAX_SIZE);
 	/* Put time-stamp, CPU ID and severity into buffer */
 	snprintf(buffer, LOG_MESSAGE_MAX_SIZE,
 			"[%lluus][cpu=%hu][sev=%u][seq=%u]:",
@@ -187,7 +187,7 @@ void print_logmsg_buffer(uint16_t pcpu_id)
 
 	do {
 		uint32_t idx;
-		memset(buffer, 0, LOG_ENTRY_SIZE + 1);
+		(void)memset(buffer, 0, LOG_ENTRY_SIZE + 1);
 
 		if (*sbuf == NULL)
 			return;

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -45,7 +45,7 @@ int vprintf(const char *fmt, va_list args)
 	int nchars = 0;
 
 	/* initialize parameters */
-	memset(&param, 0, sizeof(param));
+	(void)memset(&param, 0, sizeof(param));
 	param.emit = charout;
 	param.data = &nchars;
 

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -225,8 +225,8 @@ static int shell_process(struct shell *p_shell)
 	status = shell_process_cmd(p_shell, p_input_line);
 
 	/* Now that the command is processed, zero fill the input buffer */
-	memset((void *) p_shell->input_line[p_shell->input_line_active], 0,
-		SHELL_CMD_MAX_LEN + 1U);
+	(void)memset((void *) p_shell->input_line[p_shell->input_line_active],
+			0, SHELL_CMD_MAX_LEN + 1U);
 
 	/* Process command and return result to caller */
 	return status;
@@ -360,7 +360,7 @@ int shell_init_serial(struct shell *p_shell)
 	}
 
 	/* Zero fill the input buffer */
-	memset((void *)p_shell->input_line[p_shell->input_line_active], 0,
+	(void)memset((void *)p_shell->input_line[p_shell->input_line_active], 0,
 			SHELL_CMD_MAX_LEN + 1U);
 
 	return status;
@@ -382,7 +382,7 @@ int shell_cmd_help(struct shell *p_shell,
 	pr_dbg("shell: Number of registered commands = %u in %s\n",
 		p_shell->cmd_count, __func__);
 
-	memset(space_buf, ' ', sizeof(space_buf));
+	(void)memset(space_buf, ' ', sizeof(space_buf));
 	/* Proceed based on the number of registered commands. */
 	if (p_shell->cmd_count == 0U) {
 		/* No registered commands */

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -272,7 +272,7 @@ void *calloc(unsigned int num_elements, unsigned int element_size)
         /* Determine if memory was allocated */
         if (memory != NULL) {
                 /* Zero all the memory */
-                memset(memory, 0, num_elements * element_size);
+		(void)memset(memory, 0, num_elements * element_size);
         }
 
         /* Return pointer to memory */

--- a/hypervisor/lib/spinlock.c
+++ b/hypervisor/lib/spinlock.c
@@ -8,7 +8,7 @@
 
 inline void spinlock_init(spinlock_t *lock)
 {
-	memset(lock, 0, sizeof(spinlock_t));
+	(void)memset(lock, 0, sizeof(spinlock_t));
 }
 void spinlock_obtain(spinlock_t *lock)
 {

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -469,7 +469,7 @@ int do_print(const char *fmt, struct print_param *param,
 			start = fmt++;
 
 			/* initialize the variables for the next argument */
-			memset(&(param->vars), 0, sizeof(param->vars));
+			(void)memset(&(param->vars), 0, sizeof(param->vars));
 			param->vars.mask = 0xFFFFFFFFFFFFFFFFUL;
 
 			/*
@@ -625,7 +625,7 @@ static int charmem(int cmd, const char *s, int sz, void *hnd)
 	else {
 		n = (sz < param->sz - param->wrtn) ? sz : 0;
 		param->wrtn += sz;
-		memset(p, *s, n);
+		(void)memset(p, *s, n);
 	}
 
 	return n;
@@ -649,10 +649,10 @@ int vsnprintf(char *dst, int sz, const char *fmt, va_list args)
 	struct snprint_param snparam;
 
 	/* initialize parameters */
-	memset(&snparam, 0, sizeof(snparam));
+	(void)memset(&snparam, 0, sizeof(snparam));
 	snparam.dst = dst;
 	snparam.sz = sz;
-	memset(&param, 0, sizeof(param));
+	(void)memset(&param, 0, sizeof(param));
 	param.emit = charmem;
 	param.data = &snparam;
 


### PR DESCRIPTION
No need to check the return value for memset
code like this:
int a(void) {
	return 0;
}
int b(void){
	a();
}
fix as follow:
int a(void) {
	return 0;
}
int b(void){
	(void)a();
}

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>