### PR TITLE
HV: instr_emul: integral type revisit

### DIFF
--- a/devicemodel/include/vmm.h
+++ b/devicemodel/include/vmm.h
@@ -67,47 +67,46 @@ enum vm_suspend_how {
 /*
  * Identifiers for architecturally defined registers.
  */
-enum vm_reg_name {
-	VM_REG_GUEST_RAX,
-	VM_REG_GUEST_RBX,
-	VM_REG_GUEST_RCX,
-	VM_REG_GUEST_RDX,
-	VM_REG_GUEST_RSI,
-	VM_REG_GUEST_RDI,
-	VM_REG_GUEST_RBP,
-	VM_REG_GUEST_R8,
-	VM_REG_GUEST_R9,
-	VM_REG_GUEST_R10,
-	VM_REG_GUEST_R11,
-	VM_REG_GUEST_R12,
-	VM_REG_GUEST_R13,
-	VM_REG_GUEST_R14,
-	VM_REG_GUEST_R15,
-	VM_REG_GUEST_CR0,
-	VM_REG_GUEST_CR3,
-	VM_REG_GUEST_CR4,
-	VM_REG_GUEST_DR7,
-	VM_REG_GUEST_RSP,
-	VM_REG_GUEST_RIP,
-	VM_REG_GUEST_RFLAGS,
-	VM_REG_GUEST_ES,
-	VM_REG_GUEST_CS,
-	VM_REG_GUEST_SS,
-	VM_REG_GUEST_DS,
-	VM_REG_GUEST_FS,
-	VM_REG_GUEST_GS,
-	VM_REG_GUEST_LDTR,
-	VM_REG_GUEST_TR,
-	VM_REG_GUEST_IDTR,
-	VM_REG_GUEST_GDTR,
-	VM_REG_GUEST_EFER,
-	VM_REG_GUEST_CR2,
-	VM_REG_GUEST_PDPTE0,
-	VM_REG_GUEST_PDPTE1,
-	VM_REG_GUEST_PDPTE2,
-	VM_REG_GUEST_PDPTE3,
-	VM_REG_GUEST_INTR_SHADOW,
-	VM_REG_LAST
+enum cpu_reg_name {
+	CPU_REG_RAX,
+	CPU_REG_RBX,
+	CPU_REG_RCX,
+	CPU_REG_RDX,
+	CPU_REG_RSI,
+	CPU_REG_RDI,
+	CPU_REG_RBP,
+	CPU_REG_R8,
+	CPU_REG_R9,
+	CPU_REG_R10,
+	CPU_REG_R11,
+	CPU_REG_R12,
+	CPU_REG_R13,
+	CPU_REG_R14,
+	CPU_REG_R15,
+	CPU_REG_CR0,
+	CPU_REG_CR3,
+	CPU_REG_CR4,
+	CPU_REG_DR7,
+	CPU_REG_RSP,
+	CPU_REG_RIP,
+	CPU_REG_RFLAGS,
+	CPU_REG_ES,
+	CPU_REG_CS,
+	CPU_REG_SS,
+	CPU_REG_DS,
+	CPU_REG_FS,
+	CPU_REG_GS,
+	CPU_REG_LDTR,
+	CPU_REG_TR,
+	CPU_REG_IDTR,
+	CPU_REG_GDTR,
+	CPU_REG_EFER,
+	CPU_REG_CR2,
+	CPU_REG_PDPTE0,
+	CPU_REG_PDPTE1,
+	CPU_REG_PDPTE2,
+	CPU_REG_PDPTE3,
+	CPU_REG_LAST
 };
 
 #define	VM_INTINFO_VECTOR(info)	((info) & 0xff)
@@ -220,9 +219,9 @@ struct vie {
 	uint8_t		imm_bytes;
 
 	uint8_t		scale;
-	int		base_register;		/* VM_REG_GUEST_xyz */
-	int		index_register;		/* VM_REG_GUEST_xyz */
-	int		segment_register;	/* VM_REG_GUEST_xyz */
+	int		base_register;		/* CPU_REG_xyz */
+	int		index_register;		/* CPU_REG_xyz */
+	int		segment_register;	/* CPU_REG_xyz */
 
 	int64_t		displacement;		/* optional addr displacement */
 	int64_t		immediate;		/* optional immediate operand */
@@ -268,7 +267,7 @@ struct vm_inout_str {
 	uint64_t	index;
 	uint64_t	count;		/* rep=1 (%rcx), rep=0 (1) */
 	int		addrsize;
-	enum vm_reg_name seg_name;
+	enum cpu_reg_name seg_name;
 	struct seg_desc seg_desc;
 };
 

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1527,13 +1527,13 @@ vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 int
-vie_alignment_check(int cpl, uint8_t size, uint64_t cr0, uint64_t rf, uint64_t gla)
+vie_alignment_check(uint8_t cpl, uint8_t size, uint64_t cr0, uint64_t rf, uint64_t gla)
 {
 	ASSERT(size == 1U || size == 2U || size == 4U || size == 8U,
 	    "%s: invalid size %hhu", __func__, size);
-	ASSERT(cpl >= 0 && cpl <= 3, "%s: invalid cpl %d", __func__, cpl);
+	ASSERT(cpl <= 3U, "%s: invalid cpl %d", __func__, cpl);
 
-	if (cpl != 3 || (cr0 & CR0_AM) == 0 || (rf & PSL_AC) == 0)
+	if (cpl != 3U || (cr0 & CR0_AM) == 0 || (rf & PSL_AC) == 0)
 		return 0;
 
 	return ((gla & (size - 1U)) != 0UL) ? 1 : 0;

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -671,8 +671,9 @@ emulate_movs(struct vcpu *vcpu, __unused uint64_t gpa, struct vie *vie,
 {
 	uint64_t dstaddr, srcaddr;
 	uint64_t rcx, rdi, rsi, rflags;
-	int error, fault, seg, repeat;
+	int error, fault, repeat;
 	uint8_t opsize;
+	enum vm_reg_name seg;
 
 	opsize = (vie->op.op_byte == 0xA4U) ? 1U : vie->opsize;
 	error = 0;
@@ -700,7 +701,7 @@ emulate_movs(struct vcpu *vcpu, __unused uint64_t gpa, struct vie *vie,
 		}
 	}
 
-	seg = (vie->segment_override != 0U) ? vie->segment_register : VM_REG_GUEST_DS;
+	seg = (vie->segment_override != 0U) ? (vie->segment_register) : VM_REG_GUEST_DS;
 	error = get_gla(vcpu, vie, paging, opsize, vie->addrsize,
 	    PROT_READ, seg, VM_REG_GUEST_RSI, &srcaddr, &fault);
 	if ((error != 0) || (fault != 0))
@@ -1735,7 +1736,7 @@ vie_advance(struct vie *vie)
 }
 
 static bool
-segment_override(uint8_t x, int *seg)
+segment_override(uint8_t x, enum vm_reg_name *seg)
 {
 
 	switch (x) {

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -34,25 +34,22 @@
 #include "instr_emul.h"
 
 /* struct vie_op.op_type */
-enum {
-	VIE_OP_TYPE_NONE = 0,
-	VIE_OP_TYPE_MOV,
-	VIE_OP_TYPE_MOVSX,
-	VIE_OP_TYPE_MOVZX,
-	VIE_OP_TYPE_AND,
-	VIE_OP_TYPE_OR,
-	VIE_OP_TYPE_SUB,
-	VIE_OP_TYPE_TWO_BYTE,
-	VIE_OP_TYPE_PUSH,
-	VIE_OP_TYPE_CMP,
-	VIE_OP_TYPE_POP,
-	VIE_OP_TYPE_MOVS,
-	VIE_OP_TYPE_GROUP1,
-	VIE_OP_TYPE_STOS,
-	VIE_OP_TYPE_BITTEST,
-	VIE_OP_TYPE_TEST,
-	VIE_OP_TYPE_LAST
-};
+#define VIE_OP_TYPE_NONE	0U
+#define VIE_OP_TYPE_MOV		1U
+#define VIE_OP_TYPE_MOVSX	2U
+#define VIE_OP_TYPE_MOVZX	3U
+#define VIE_OP_TYPE_AND		4U
+#define VIE_OP_TYPE_OR		5U
+#define VIE_OP_TYPE_SUB		6U
+#define VIE_OP_TYPE_TWO_BYTE	7U
+#define VIE_OP_TYPE_PUSH	8U
+#define VIE_OP_TYPE_CMP		9U
+#define VIE_OP_TYPE_POP		10U
+#define VIE_OP_TYPE_MOVS	11U
+#define VIE_OP_TYPE_GROUP1	12U
+#define VIE_OP_TYPE_STOS	13U
+#define VIE_OP_TYPE_BITTEST	14U
+#define VIE_OP_TYPE_TEST	15U
 
 /* struct vie_op.op_flags */
 #define	VIE_OP_F_IMM		(1U << 0)  /* 16/32-bit immediate operand */

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1270,7 +1270,7 @@ emulate_stack_op(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
 		error = vm_get_seg_desc(vcpu, CPU_REG_SS, &ss_desc);
 		ASSERT(error == 0, "%s: error %d getting SS descriptor",
 					__func__, error);
-		if ((_Bool)SEG_DESC_DEF32(ss_desc.access))
+		if (SEG_DESC_DEF32(ss_desc.access))
 			stackaddrsize = 4U;
 		else
 			stackaddrsize = 2U;
@@ -1595,7 +1595,7 @@ vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 		 * then the descriptor is unusable and attempting to use
 		 * it results in a #GP(0).
 		 */
-		if ((_Bool)SEG_DESC_UNUSABLE(desc->access))
+		if (SEG_DESC_UNUSABLE(desc->access))
 			return -1;
 
 		/*
@@ -1604,7 +1604,7 @@ vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 		 * descriptor that is not present. If this was the case then
 		 * it would have been checked before the VM-exit.
 		 */
-		ASSERT((_Bool)SEG_DESC_PRESENT(desc->access),
+		ASSERT(SEG_DESC_PRESENT(desc->access),
 		    "segment %d not present: %#x", seg, desc->access);
 
 		/*
@@ -1818,7 +1818,7 @@ decode_prefixes(struct vie *vie, enum vm_cpu_mode cpu_mode, int cs_d)
 			vie->opsize = 2U;
 		else
 			vie->opsize = 4U;
-	} else if (cs_d != 0) {
+	} else if (cs_d) {
 		/* Default address and operand sizes are 32-bits */
 		vie->addrsize = vie->addrsize_override != 0U ? 2U : 4U;
 		vie->opsize = vie->opsize_override != 0U ? 2U : 4U;
@@ -2137,7 +2137,7 @@ decode_moffset(struct vie *vie)
 }
 
 int
-__decode_instruction(enum vm_cpu_mode cpu_mode, int cs_d, struct vie *vie)
+__decode_instruction(enum vm_cpu_mode cpu_mode, bool cs_d, struct vie *vie)
 {
 	if (decode_prefixes(vie, cpu_mode, cs_d) != 0)
 		return -1;

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -361,10 +361,10 @@ vie_update_register(struct vcpu *vcpu, enum vm_reg_name reg,
  * Return the status flags that would result from doing (x - y).
  */
 #define	GETCC(sz)							\
-static u_long								\
+static uint64_t								\
 getcc##sz(uint##sz##_t x, uint##sz##_t y)				\
 {									\
-	u_long rflags;							\
+	uint64_t rflags;						\
 	\
 	__asm __volatile("sub %2,%1; pushfq; popq %0" :			\
 			"=r" (rflags), "+r" (x) : "m" (y));		\
@@ -376,7 +376,7 @@ GETCC(16);
 GETCC(32);
 GETCC(64);
 
-static u_long
+static uint64_t
 getcc(int opsize, uint64_t x, uint64_t y)
 {
 	ASSERT(opsize == 1 || opsize == 2 || opsize == 4 || opsize == 8,

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -30,6 +30,8 @@
 #ifndef	_VMM_INSTRUCTION_EMUL_H_
 #define	_VMM_INSTRUCTION_EMUL_H_
 
+#include "instr_emul_wrapper.h"
+
 /*
  * Callback functions to read and write memory regions.
  */
@@ -70,7 +72,7 @@ uint64_t vie_size2mask(uint8_t size);
 
 int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 	struct seg_desc *desc, uint64_t off, uint8_t length, uint8_t addrsize,
-	int prot, uint64_t *gla);
+	uint32_t prot, uint64_t *gla);
 
 int vie_init(struct vie *vie, struct vcpu *vcpu);
 

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -60,7 +60,7 @@ int vie_update_register(struct vcpu *vcpu, enum cpu_reg_name reg,
 /*
  * Returns 1 if an alignment check exception should be injected and 0 otherwise.
  */
-int vie_alignment_check(int cpl, uint8_t operand_size, uint64_t cr0,
+int vie_alignment_check(uint8_t cpl, uint8_t operand_size, uint64_t cr0,
 	uint64_t rflags, uint64_t gla);
 
 /* Returns 1 if the 'gla' is not canonical and 0 otherwise. */

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -87,7 +87,7 @@ int vie_init(struct vie *vie, struct vcpu *vcpu);
  */
 #define	VIE_INVALID_GLA		(1UL << 63)	/* a non-canonical address */
 int
-__decode_instruction(enum vm_cpu_mode cpu_mode, int cs_d, struct vie *vie);
+__decode_instruction(enum vm_cpu_mode cpu_mode, bool cs_d, struct vie *vie);
 
 int emulate_instruction(struct vcpu *vcpu);
 int decode_instruction(struct vcpu *vcpu);

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -54,7 +54,7 @@ int vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 		struct vm_guest_paging *paging, mem_region_read_t mrr,
 		mem_region_write_t mrw, void *mrarg);
 
-int vie_update_register(struct vcpu *vcpu, enum vm_reg_name reg,
+int vie_update_register(struct vcpu *vcpu, enum cpu_reg_name reg,
 		uint64_t val, uint8_t size);
 
 /*
@@ -68,7 +68,7 @@ int vie_canonical_check(enum vm_cpu_mode cpu_mode, uint64_t gla);
 
 uint64_t vie_size2mask(uint8_t size);
 
-int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum vm_reg_name seg,
+int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 	struct seg_desc *desc, uint64_t off, uint8_t length, uint8_t addrsize,
 	int prot, uint64_t *gla);
 

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -34,10 +34,10 @@
  * Callback functions to read and write memory regions.
  */
 typedef int (*mem_region_read_t)(struct vcpu *vcpu, uint64_t gpa,
-				 uint64_t *rval, int rsize, void *arg);
+				 uint64_t *rval, uint8_t rsize, void *arg);
 
 typedef int (*mem_region_write_t)(struct vcpu *vcpu, uint64_t gpa,
-				  uint64_t wval, int wsize, void *arg);
+				  uint64_t wval, uint8_t wsize, void *arg);
 
 /*
  * Emulate the decoded 'vie' instruction.
@@ -55,22 +55,22 @@ int vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 		mem_region_write_t mrw, void *mrarg);
 
 int vie_update_register(struct vcpu *vcpu, enum vm_reg_name reg,
-		uint64_t val, int size);
+		uint64_t val, uint8_t size);
 
 /*
  * Returns 1 if an alignment check exception should be injected and 0 otherwise.
  */
-int vie_alignment_check(int cpl, int operand_size, uint64_t cr0,
+int vie_alignment_check(int cpl, uint8_t operand_size, uint64_t cr0,
 	uint64_t rflags, uint64_t gla);
 
 /* Returns 1 if the 'gla' is not canonical and 0 otherwise. */
 int vie_canonical_check(enum vm_cpu_mode cpu_mode, uint64_t gla);
 
-uint64_t vie_size2mask(int size);
+uint64_t vie_size2mask(uint8_t size);
 
 int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum vm_reg_name seg,
-	struct seg_desc *desc, uint64_t off, int length, int addrsize, int prot,
-	uint64_t *gla);
+	struct seg_desc *desc, uint64_t off, uint8_t length, uint8_t addrsize,
+	int prot, uint64_t *gla);
 
 int vie_init(struct vie *vie, struct vcpu *vcpu);
 

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -268,7 +268,7 @@ static void get_guest_paging_info(struct vcpu *vcpu, struct emul_cnx *emul_cnx,
 }
 
 static int mmio_read(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t *rval,
-		__unused int size, __unused void *arg)
+		__unused uint8_t size, __unused void *arg)
 {
 	if (vcpu == NULL)
 		return -EINVAL;
@@ -278,7 +278,7 @@ static int mmio_read(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t *rval,
 }
 
 static int mmio_write(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t wval,
-		__unused int size, __unused void *arg)
+		__unused uint8_t size, __unused void *arg)
 {
 	if (vcpu == NULL)
 		return -EINVAL;

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -87,7 +87,7 @@ int vm_set_seg_desc(struct vcpu *vcpu, enum cpu_reg_name seg,
 		return -EINVAL;
 
 	error = encode_vmcs_seg_desc(seg, &base, &limit, &access);
-	if ((error != 0) || (access == 0xffffffff))
+	if ((error != 0) || (access == 0xffffffffU))
 		return -EINVAL;
 
 	exec_vmwrite(base, ret_desc->base);
@@ -110,7 +110,7 @@ int vm_get_seg_desc(struct vcpu *vcpu, enum cpu_reg_name seg,
 		return -EINVAL;
 
 	error = encode_vmcs_seg_desc(seg, &base, &limit, &access);
-	if ((error != 0) || (access == 0xffffffff))
+	if ((error != 0) || (access == 0xffffffffU))
 		return -EINVAL;
 
 	desc->base = exec_vmread(base);

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -261,11 +261,11 @@ static uint32_t get_vmcs_field(enum cpu_reg_name ident)
 static void get_guest_paging_info(struct vcpu *vcpu, struct emul_cnx *emul_cnx,
 						uint32_t csar)
 {
-	uint32_t cpl;
+	uint8_t cpl;
 
 	ASSERT(emul_cnx != NULL && vcpu != NULL, "Error in input arguments");
 
-	cpl = (csar >> 5) & 3U;
+	cpl = (uint8_t)((csar >> 5) & 3U);
 	emul_cnx->paging.cr3 =
 		vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].cr3;
 	emul_cnx->paging.cpl = cpl;

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -10,18 +10,19 @@
 #include "instr_emul.h"
 
 static int
-encode_vmcs_seg_desc(int seg, uint32_t *base, uint32_t *lim, uint32_t *acc);
+encode_vmcs_seg_desc(enum vm_reg_name seg,
+		uint32_t *base, uint32_t *lim, uint32_t *acc);
 
 static int32_t
-get_vmcs_field(int ident);
+get_vmcs_field(enum vm_reg_name ident);
 
 static bool
-is_segment_register(int reg);
+is_segment_register(enum vm_reg_name reg);
 
 static bool
-is_descriptor_table(int reg);
+is_descriptor_table(enum vm_reg_name reg);
 
-int vm_get_register(struct vcpu *vcpu, int reg, uint64_t *retval)
+int vm_get_register(struct vcpu *vcpu, enum vm_reg_name reg, uint64_t *retval)
 {
 	struct run_context *cur_context;
 
@@ -46,7 +47,7 @@ int vm_get_register(struct vcpu *vcpu, int reg, uint64_t *retval)
 	return 0;
 }
 
-int vm_set_register(struct vcpu *vcpu, int reg, uint64_t val)
+int vm_set_register(struct vcpu *vcpu, enum vm_reg_name reg, uint64_t val)
 {
 	struct run_context *cur_context;
 
@@ -71,7 +72,8 @@ int vm_set_register(struct vcpu *vcpu, int reg, uint64_t val)
 	return 0;
 }
 
-int vm_set_seg_desc(struct vcpu *vcpu, int seg, struct seg_desc *ret_desc)
+int vm_set_seg_desc(struct vcpu *vcpu, enum vm_reg_name seg,
+		struct seg_desc *ret_desc)
 {
 	int error;
 	uint32_t base, limit, access;
@@ -93,7 +95,8 @@ int vm_set_seg_desc(struct vcpu *vcpu, int seg, struct seg_desc *ret_desc)
 	return 0;
 }
 
-int vm_get_seg_desc(struct vcpu *vcpu, int seg, struct seg_desc *desc)
+int vm_get_seg_desc(struct vcpu *vcpu, enum vm_reg_name seg,
+		struct seg_desc *desc)
 {
 	int error;
 	uint32_t base, limit, access;
@@ -115,7 +118,7 @@ int vm_get_seg_desc(struct vcpu *vcpu, int seg, struct seg_desc *desc)
 	return 0;
 }
 
-static bool is_descriptor_table(int reg)
+static bool is_descriptor_table(enum vm_reg_name reg)
 {
 	switch (reg) {
 	case VM_REG_GUEST_IDTR:
@@ -126,7 +129,7 @@ static bool is_descriptor_table(int reg)
 	}
 }
 
-static bool is_segment_register(int reg)
+static bool is_segment_register(enum vm_reg_name reg)
 {
 	switch (reg) {
 	case VM_REG_GUEST_ES:
@@ -143,8 +146,9 @@ static bool is_segment_register(int reg)
 	}
 }
 
-static int encode_vmcs_seg_desc(int seg, uint32_t *base, uint32_t *lim,
-		uint32_t *acc)
+static int
+encode_vmcs_seg_desc(enum vm_reg_name seg,
+		uint32_t *base, uint32_t *lim, uint32_t *acc)
 {
 	switch (seg) {
 	case VM_REG_GUEST_ES:
@@ -204,7 +208,7 @@ static int encode_vmcs_seg_desc(int seg, uint32_t *base, uint32_t *lim,
 	return 0;
 }
 
-static int32_t get_vmcs_field(int ident)
+static int32_t get_vmcs_field(enum vm_reg_name ident)
 {
 	switch (ident) {
 	case VM_REG_GUEST_CR0:

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -114,8 +114,8 @@ int vm_get_seg_desc(struct vcpu *vcpu, enum cpu_reg_name seg,
 		return -EINVAL;
 
 	desc->base = exec_vmread(base);
-	desc->limit = exec_vmread(limit);
-	desc->access = exec_vmread(access);
+	desc->limit = (uint32_t)exec_vmread(limit);
+	desc->access = (uint32_t)exec_vmread(access);
 
 	return 0;
 }
@@ -313,7 +313,7 @@ int decode_instruction(struct vcpu *vcpu)
 		return retval;
 	}
 
-	csar = exec_vmread(VMX_GUEST_CS_ATTR);
+	csar = (uint32_t)exec_vmread(VMX_GUEST_CS_ATTR);
 	get_guest_paging_info(vcpu, emul_cnx, csar);
 	cpu_mode = get_vcpu_mode(vcpu);
 

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -34,47 +34,46 @@
 /*
  * Identifiers for architecturally defined registers.
  */
-enum vm_reg_name {
-	VM_REG_GUEST_RAX,
-	VM_REG_GUEST_RBX,
-	VM_REG_GUEST_RCX,
-	VM_REG_GUEST_RDX,
-	VM_REG_GUEST_RBP,
-	VM_REG_GUEST_RSI,
-	VM_REG_GUEST_R8,
-	VM_REG_GUEST_R9,
-	VM_REG_GUEST_R10,
-	VM_REG_GUEST_R11,
-	VM_REG_GUEST_R12,
-	VM_REG_GUEST_R13,
-	VM_REG_GUEST_R14,
-	VM_REG_GUEST_R15,
-	VM_REG_GUEST_RDI,
-	VM_REG_GUEST_CR0,
-	VM_REG_GUEST_CR3,
-	VM_REG_GUEST_CR4,
-	VM_REG_GUEST_DR7,
-	VM_REG_GUEST_RSP,
-	VM_REG_GUEST_RIP,
-	VM_REG_GUEST_RFLAGS,
-	VM_REG_GUEST_ES,
-	VM_REG_GUEST_CS,
-	VM_REG_GUEST_SS,
-	VM_REG_GUEST_DS,
-	VM_REG_GUEST_FS,
-	VM_REG_GUEST_GS,
-	VM_REG_GUEST_LDTR,
-	VM_REG_GUEST_TR,
-	VM_REG_GUEST_IDTR,
-	VM_REG_GUEST_GDTR,
-	VM_REG_GUEST_EFER,
-	VM_REG_GUEST_CR2,
-	VM_REG_GUEST_PDPTE0,
-	VM_REG_GUEST_PDPTE1,
-	VM_REG_GUEST_PDPTE2,
-	VM_REG_GUEST_PDPTE3,
-	VM_REG_GUEST_INTR_SHADOW,
-	VM_REG_LAST
+enum cpu_reg_name {
+	CPU_REG_RAX,
+	CPU_REG_RBX,
+	CPU_REG_RCX,
+	CPU_REG_RDX,
+	CPU_REG_RBP,
+	CPU_REG_RSI,
+	CPU_REG_R8,
+	CPU_REG_R9,
+	CPU_REG_R10,
+	CPU_REG_R11,
+	CPU_REG_R12,
+	CPU_REG_R13,
+	CPU_REG_R14,
+	CPU_REG_R15,
+	CPU_REG_RDI,
+	CPU_REG_CR0,
+	CPU_REG_CR3,
+	CPU_REG_CR4,
+	CPU_REG_DR7,
+	CPU_REG_RSP,
+	CPU_REG_RIP,
+	CPU_REG_RFLAGS,
+	CPU_REG_ES,
+	CPU_REG_CS,
+	CPU_REG_SS,
+	CPU_REG_DS,
+	CPU_REG_FS,
+	CPU_REG_GS,
+	CPU_REG_LDTR,
+	CPU_REG_TR,
+	CPU_REG_IDTR,
+	CPU_REG_GDTR,
+	CPU_REG_EFER,
+	CPU_REG_CR2,
+	CPU_REG_PDPTE0,
+	CPU_REG_PDPTE1,
+	CPU_REG_PDPTE2,
+	CPU_REG_PDPTE3,
+	CPU_REG_LAST
 };
 
 struct vie_op {
@@ -113,9 +112,9 @@ struct vie {
 	uint8_t		imm_bytes;
 
 	uint8_t		scale;
-	enum vm_reg_name base_register;		/* VM_REG_GUEST_xyz */
-	enum vm_reg_name index_register;	/* VM_REG_GUEST_xyz */
-	enum vm_reg_name segment_register;	/* VM_REG_GUEST_xyz */
+	enum cpu_reg_name base_register;		/* CPU_REG_xyz */
+	enum cpu_reg_name index_register;	/* CPU_REG_xyz */
+	enum cpu_reg_name segment_register;	/* CPU_REG_xyz */
 
 	int64_t		displacement;		/* optional addr displacement */
 	int64_t		immediate;		/* optional immediate operand */
@@ -185,10 +184,10 @@ struct emul_cnx {
 	struct vcpu *vcpu;
 };
 
-int vm_get_register(struct vcpu *vcpu, enum vm_reg_name reg, uint64_t *retval);
-int vm_set_register(struct vcpu *vcpu, enum vm_reg_name reg, uint64_t val);
-int vm_get_seg_desc(struct vcpu *vcpu, enum vm_reg_name reg,
+int vm_get_register(struct vcpu *vcpu, enum cpu_reg_name reg, uint64_t *retval);
+int vm_set_register(struct vcpu *vcpu, enum cpu_reg_name reg, uint64_t val);
+int vm_get_seg_desc(struct vcpu *vcpu, enum cpu_reg_name reg,
 		struct seg_desc *ret_desc);
-int vm_set_seg_desc(struct vcpu *vcpu, enum vm_reg_name reg,
+int vm_set_seg_desc(struct vcpu *vcpu, enum cpu_reg_name reg,
 		struct seg_desc *desc);
 #endif

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -31,6 +31,52 @@
 #define INSTR_EMUL_WRAPPER_H
 #include <cpu.h>
 
+/*
+ * Identifiers for architecturally defined registers.
+ */
+enum vm_reg_name {
+	VM_REG_GUEST_RAX,
+	VM_REG_GUEST_RBX,
+	VM_REG_GUEST_RCX,
+	VM_REG_GUEST_RDX,
+	VM_REG_GUEST_RBP,
+	VM_REG_GUEST_RSI,
+	VM_REG_GUEST_R8,
+	VM_REG_GUEST_R9,
+	VM_REG_GUEST_R10,
+	VM_REG_GUEST_R11,
+	VM_REG_GUEST_R12,
+	VM_REG_GUEST_R13,
+	VM_REG_GUEST_R14,
+	VM_REG_GUEST_R15,
+	VM_REG_GUEST_RDI,
+	VM_REG_GUEST_CR0,
+	VM_REG_GUEST_CR3,
+	VM_REG_GUEST_CR4,
+	VM_REG_GUEST_DR7,
+	VM_REG_GUEST_RSP,
+	VM_REG_GUEST_RIP,
+	VM_REG_GUEST_RFLAGS,
+	VM_REG_GUEST_ES,
+	VM_REG_GUEST_CS,
+	VM_REG_GUEST_SS,
+	VM_REG_GUEST_DS,
+	VM_REG_GUEST_FS,
+	VM_REG_GUEST_GS,
+	VM_REG_GUEST_LDTR,
+	VM_REG_GUEST_TR,
+	VM_REG_GUEST_IDTR,
+	VM_REG_GUEST_GDTR,
+	VM_REG_GUEST_EFER,
+	VM_REG_GUEST_CR2,
+	VM_REG_GUEST_PDPTE0,
+	VM_REG_GUEST_PDPTE1,
+	VM_REG_GUEST_PDPTE2,
+	VM_REG_GUEST_PDPTE3,
+	VM_REG_GUEST_INTR_SHADOW,
+	VM_REG_LAST
+};
+
 struct vie_op {
 	uint8_t		op_byte;	/* actual opcode byte */
 	uint8_t		op_type;	/* type of operation (e.g. MOV) */
@@ -67,9 +113,9 @@ struct vie {
 	uint8_t		imm_bytes;
 
 	uint8_t		scale;
-	int		base_register;		/* VM_REG_GUEST_xyz */
-	int		index_register;		/* VM_REG_GUEST_xyz */
-	int		segment_register;	/* VM_REG_GUEST_xyz */
+	enum vm_reg_name base_register;		/* VM_REG_GUEST_xyz */
+	enum vm_reg_name index_register;	/* VM_REG_GUEST_xyz */
+	enum vm_reg_name segment_register;	/* VM_REG_GUEST_xyz */
 
 	int64_t		displacement;		/* optional addr displacement */
 	int64_t		immediate;		/* optional immediate operand */
@@ -139,56 +185,10 @@ struct emul_cnx {
 	struct vcpu *vcpu;
 };
 
-/*
- * Identifiers for architecturally defined registers.
- */
-enum vm_reg_name {
-	VM_REG_GUEST_RAX,
-	VM_REG_GUEST_RBX,
-	VM_REG_GUEST_RCX,
-	VM_REG_GUEST_RDX,
-	VM_REG_GUEST_RBP,
-	VM_REG_GUEST_RSI,
-	VM_REG_GUEST_R8,
-	VM_REG_GUEST_R9,
-	VM_REG_GUEST_R10,
-	VM_REG_GUEST_R11,
-	VM_REG_GUEST_R12,
-	VM_REG_GUEST_R13,
-	VM_REG_GUEST_R14,
-	VM_REG_GUEST_R15,
-	VM_REG_GUEST_RDI,
-	VM_REG_GUEST_CR0,
-	VM_REG_GUEST_CR3,
-	VM_REG_GUEST_CR4,
-	VM_REG_GUEST_DR7,
-	VM_REG_GUEST_RSP,
-	VM_REG_GUEST_RIP,
-	VM_REG_GUEST_RFLAGS,
-	VM_REG_GUEST_ES,
-	VM_REG_GUEST_CS,
-	VM_REG_GUEST_SS,
-	VM_REG_GUEST_DS,
-	VM_REG_GUEST_FS,
-	VM_REG_GUEST_GS,
-	VM_REG_GUEST_LDTR,
-	VM_REG_GUEST_TR,
-	VM_REG_GUEST_IDTR,
-	VM_REG_GUEST_GDTR,
-	VM_REG_GUEST_EFER,
-	VM_REG_GUEST_CR2,
-	VM_REG_GUEST_PDPTE0,
-	VM_REG_GUEST_PDPTE1,
-	VM_REG_GUEST_PDPTE2,
-	VM_REG_GUEST_PDPTE3,
-	VM_REG_GUEST_INTR_SHADOW,
-	VM_REG_LAST
-};
-
-int vm_get_register(struct vcpu *vcpu, int reg, uint64_t *retval);
-int vm_set_register(struct vcpu *vcpu, int reg, uint64_t val);
-int vm_get_seg_desc(struct vcpu *vcpu, int reg,
+int vm_get_register(struct vcpu *vcpu, enum vm_reg_name reg, uint64_t *retval);
+int vm_set_register(struct vcpu *vcpu, enum vm_reg_name reg, uint64_t val);
+int vm_get_seg_desc(struct vcpu *vcpu, enum vm_reg_name reg,
 		struct seg_desc *ret_desc);
-int vm_set_seg_desc(struct vcpu *vcpu, int reg,
+int vm_set_seg_desc(struct vcpu *vcpu, enum vm_reg_name reg,
 		struct seg_desc *desc);
 #endif

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -185,8 +185,6 @@ enum vm_reg_name {
 	VM_REG_LAST
 };
 
-typedef unsigned long u_long;
-
 int vm_get_register(struct vcpu *vcpu, int reg, uint64_t *retval);
 int vm_set_register(struct vcpu *vcpu, int reg, uint64_t val);
 int vm_get_seg_desc(struct vcpu *vcpu, int reg,

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -166,10 +166,10 @@ struct seg_desc {
 
 #define	SEG_DESC_TYPE(access)		((access) & 0x001fU)
 #define	SEG_DESC_DPL(access)		(((access) >> 5) & 0x3U)
-#define	SEG_DESC_PRESENT(access)	((((access) & 0x0080U) != 0U) ? 1 : 0)
-#define	SEG_DESC_DEF32(access)		((((access) & 0x4000U) != 0U) ? 1 : 0)
-#define	SEG_DESC_GRANULARITY(access)	((((access) & 0x8000U) != 0U) ? 1 : 0)
-#define	SEG_DESC_UNUSABLE(access)	((((access) & 0x10000U) != 0U) ? 1 : 0)
+#define	SEG_DESC_PRESENT(access)	(((access) & 0x0080U) != 0U)
+#define	SEG_DESC_DEF32(access)		(((access) & 0x4000U) != 0U)
+#define	SEG_DESC_GRANULARITY(access)	(((access) & 0x8000U) != 0U)
+#define	SEG_DESC_UNUSABLE(access)	(((access) & 0x10000U) != 0U)
 
 struct vm_guest_paging {
 	uint64_t	cr3;

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -173,7 +173,7 @@ struct seg_desc {
 
 struct vm_guest_paging {
 	uint64_t	cr3;
-	int		cpl;
+	uint8_t		cpl;
 	enum vm_cpu_mode cpu_mode;
 	enum vm_paging_mode paging_mode;
 };

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -402,7 +402,18 @@
 
 /* External Interfaces */
 int exec_vmxon_instr(uint16_t pcpu_id);
+
+/**
+ * Read field from VMCS.
+ *
+ * Refer to Chapter 24, Vol. 3 in SDM for the width of VMCS fields.
+ *
+ * @return full contents in IA-32e mode for 64-bit fields.
+ * @return the lower 32-bit outside IA-32e mode for 64-bit fields.
+ * @return full contents for 32-bit fields, with higher 32-bit set to 0.
+ */
 uint64_t exec_vmread(uint32_t field);
+
 uint64_t exec_vmread64(uint32_t field_full);
 void exec_vmwrite(uint32_t field, uint64_t value);
 void exec_vmwrite64(uint32_t field_full, uint64_t value);


### PR DESCRIPTION
Though the fields in the structures used in the instruction emulator has                                                                                                                                            
well-defined signedness and width, plain 'int' is widely seen in the                                                                                                                                                
implementation, giving rise to lots of violations to MISRA C rules related to                                                                                                                                       
integral types.                                                                                                                                                                                                     
                                                                                                                                                                                                                    
Since the emulator is quite standalone with clearly defined interfaces, this                                                                                                                                        
series aims at cleaning up the usage of integral types inside this module.                                                                                                                                          
                                                                                                                                                                                                                    
v1 -> v2:                                                                                                                                                                                                           
                                                                                                                                                                                                                    
    * Rename vm_reg_* to cpu_reg_*.                                                                                                                                                                                 
    * Drop the fix to or'ed error code.                                                                                                                                                                             
    * Use a special value instead of a separate output parameter for reporting                                                                                                                                      
      errors in get_vmcs_field().