### PR TITLE
HV: vioapic: use uint8_t for pins

### DIFF
--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -48,9 +48,9 @@ int	vioapic_mmio_write(void *vm, uint64_t gpa,
 int	vioapic_mmio_read(void *vm, uint64_t gpa,
 	    uint64_t *rval, int size);
 
-int	vioapic_pincount(struct vm *vm);
+uint8_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
-bool	vioapic_get_rte(struct vm *vm, int pin, void *rte);
+bool	vioapic_get_rte(struct vm *vm, uint8_t pin, void *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 		void *handler_private_data);
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -40,7 +40,7 @@
 #define REQUEST_WRITE	1
 
 /* IOAPIC device model info */
-#define VIOAPIC_RTE_NUM	48  /* vioapic pins */
+#define VIOAPIC_RTE_NUM	48U  /* vioapic pins */
 
 #if VIOAPIC_RTE_NUM < 24
 #error "VIOAPIC_RTE_NUM must be larger than 23"


### PR DESCRIPTION
IOAPIC pins always fit in 8-bit and we already use uint8_t for virt_pins. This
patch converts pins in vioapic to uint8_t.

This is based on Arindam's previous patch ("was: hv: Cleanup and optimise
vioapic.c"), with SOS boot failure resolved, format string updated, complex
arithmetic expression with implicit type conversion decoupled. Also make some
local variables representing interrupt vectors uint32_t.

Signed-off-by: Arindam Roy <arindam.roy@intel.com>
Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>