### PR TITLE
hv:fix "missing for discarded return value" for memcpy_s and strcpy_s

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -909,7 +909,7 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 {
 	if (is_entry_active(entry)) {
 		if (entry->type == PTDEV_INTR_MSI) {
-			strcpy_s(type, 16, "MSI");
+			(void)strcpy_s(type, 16, "MSI");
 			*dest = (entry->ptdev_intr_info.msi.pmsi_addr & 0xFF000U)
 				>> 12;
 			if ((entry->ptdev_intr_info.msi.pmsi_data &
@@ -928,9 +928,9 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 
 			if (entry->ptdev_intr_info.intx.vpin_src
 				== PTDEV_VPIN_IOAPIC)
-				strcpy_s(type, 16, "IOAPIC");
+				(void)strcpy_s(type, 16, "IOAPIC");
 			else
-				strcpy_s(type, 16, "PIC");
+				(void)strcpy_s(type, 16, "PIC");
 			ioapic_get_rte(phys_irq, &rte);
 			*dest = ((rte >> 32) & IOAPIC_RTE_DEST) >> 24;
 			if ((rte & IOAPIC_RTE_TRGRLVL) != 0U)
@@ -945,7 +945,7 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 		*irq = dev_to_irq(entry->node);
 		*vector = dev_to_vector(entry->node);
 	} else {
-		strcpy_s(type, 16, "NONE");
+		(void)strcpy_s(type, 16, "NONE");
 		*irq = IRQ_INVALID;
 		*vector = 0U;
 		*dest = 0UL;

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -695,7 +695,7 @@ static uint64_t prepare_trampoline(void)
 	pr_dbg("trampoline code: %llx size %x", dest_pa, size);
 
 	/* Copy segment for AP initialization code below 1MB */
-	memcpy_s(HPA2HVA(dest_pa), size, _ld_trampoline_load, size);
+	(void)memcpy_s(HPA2HVA(dest_pa), size, _ld_trampoline_load, size);
 	update_trampoline_code_refs(dest_pa);
 	trampoline_start16_paddr = dest_pa;
 

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -69,7 +69,7 @@ static inline int set_vcpuid_entry(struct vm *vm,
 	}
 
 	tmp = &vm->vcpuid_entries[vm->vcpuid_entry_nr++];
-	memcpy_s(tmp, entry_size, entry, entry_size);
+	(void)memcpy_s(tmp, entry_size, entry, entry_size);
 	return 0;
 }
 

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -317,9 +317,9 @@ static inline int32_t _copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
 	g_ptr = HPA2HVA(hpa);
 
 	if (cp_from_vm)
-		memcpy_s(h_ptr, len, g_ptr, len);
+		(void)memcpy_s(h_ptr, len, g_ptr, len);
 	else
-		memcpy_s(g_ptr, len, h_ptr, len);
+		(void)memcpy_s(g_ptr, len, h_ptr, len);
 
 	return len;
 }
@@ -825,7 +825,7 @@ uint32_t create_guest_init_gdt(struct vm *vm, uint32_t *limit)
 	void *gtd_addr = GPA2HVA(vm, GUEST_INIT_GDT_START);
 
 	*limit = sizeof(guest_init_gdt) - 1;
-	memcpy_s(gtd_addr, 64, guest_init_gdt, sizeof(guest_init_gdt));
+	(void)memcpy_s(gtd_addr, 64, guest_init_gdt, sizeof(guest_init_gdt));
 
 	return GUEST_INIT_GDT_START;
 };

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -710,7 +710,7 @@ emulate_movs(struct vcpu *vcpu, __unused uint64_t gpa, struct vie *vie,
 	if ((error != 0) || (fault != 0))
 		goto done;
 
-	memcpy_s((char *)dstaddr, 16U, (char *)srcaddr, opsize);
+	(void)memcpy_s((char *)dstaddr, 16U, (char *)srcaddr, opsize);
 
 	error = vie_read_register(vcpu, CPU_REG_RSI, &rsi);
 	ASSERT(error == 0, "%s: error %d getting rsi", __func__, error);

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -51,7 +51,7 @@ static void vm_setup_cpu_px(struct vm *vm)
 
 	px_data_size = vm->pm.px_cnt * sizeof(struct cpu_px_data);
 
-	memcpy_s(vm->pm.px_data, px_data_size,
+	(void)memcpy_s(vm->pm.px_data, px_data_size,
 			boot_cpu_data.state_info.px_data, px_data_size);
 
 }
@@ -79,7 +79,7 @@ static void vm_setup_cpu_cx(struct vm *vm)
 	/* please note pm.cx_data[0] is a empty space holder,
 	 * pm.cx_data[1...MAX_CX_ENTRY] would be used to store cx entry datas.
 	 */
-	memcpy_s(vm->pm.cx_data + 1, cx_data_size,
+	(void)memcpy_s(vm->pm.cx_data + 1, cx_data_size,
 			boot_cpu_data.state_info.cx_data, cx_data_size);
 
 }

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -122,7 +122,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 		/* populate UOS vm fields according to vm_desc */
 		vm->sworld_control.sworld_enabled =
 			vm_desc->sworld_enabled;
-		memcpy_s(&vm->GUID[0], sizeof(vm->GUID),
+		(void)memcpy_s(&vm->GUID[0], sizeof(vm->GUID),
 					&vm_desc->GUID[0],
 					sizeof(vm_desc->GUID));
 	}

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -283,7 +283,7 @@ OUT:
 		/* we are okay using strcpy_s here even with spinlock
 		 * since no #PG in HV right now
 		 */
-		strcpy_s(node->name, 32, info->name);
+		(void)strcpy_s(node->name, 32, info->name);
 		dev_dbg(ACRN_DBG_IRQ, "[%s] %s irq%d vr:0x%x",
 			__func__, node->name, irq, desc->vector);
 	}

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -108,7 +108,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 
 
 	nworld_pml4e = MEM_READ64(HPA2HVA(vm->arch_vm.nworld_eptp));
-	memcpy_s(HPA2HVA(sworld_pml4e & IA32E_REF_MASK), CPU_PAGE_SIZE,
+	(void)memcpy_s(HPA2HVA(sworld_pml4e & IA32E_REF_MASK), CPU_PAGE_SIZE,
 			HPA2HVA(nworld_pml4e & IA32E_REF_MASK), CPU_PAGE_SIZE);
 
 	/* Map gpa_rebased~gpa_rebased+size
@@ -316,7 +316,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 	mem = (struct trusty_mem *)(HPA2HVA(mem_base_hpa));
 
 	/* copy key_info to the first page of trusty memory */
-	memcpy_s(&mem->first_page.data.key_info, sizeof(g_key_info),
+	(void)memcpy_s(&mem->first_page.data.key_info, sizeof(g_key_info),
 			&g_key_info, sizeof(g_key_info));
 
 	(void)memset(mem->first_page.data.key_info.dseed_list, 0,
@@ -461,6 +461,7 @@ void trusty_set_dseed(void *dseed, uint8_t dseed_num)
 	}
 
 	g_key_info.num_seeds = dseed_num;
-	memcpy_s(&g_key_info.dseed_list, sizeof(struct seed_info) * dseed_num,
+	(void)memcpy_s(&g_key_info.dseed_list,
+			sizeof(struct seed_info) * dseed_num,
 			dseed, sizeof(struct seed_info) * dseed_num);
 }

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -96,7 +96,7 @@ int exec_vmxon_instr(uint16_t pcpu_id)
 		 * MSR
 		 */
 		tmp32 = msr_read(MSR_IA32_VMX_BASIC);
-		memcpy_s((uint32_t *) vmxon_region_va, 4, &tmp32, 4);
+		(void)memcpy_s((uint32_t *) vmxon_region_va, 4, &tmp32, 4);
 
 		/* Turn on CR0.NE and CR4.VMXE */
 		CPU_CR_READ(cr0, &tmp64);
@@ -1545,7 +1545,7 @@ int init_vmcs(struct vcpu *vcpu)
 
 	/* Obtain the VM Rev ID from HW and populate VMCS page with it */
 	vmx_rev_id = msr_read(MSR_IA32_VMX_BASIC);
-	memcpy_s((void *) vcpu->arch_vcpu.vmcs, 4, &vmx_rev_id, 4);
+	(void)memcpy_s((void *) vcpu->arch_vcpu.vmcs, 4, &vmx_rev_id, 4);
 
 	/* Execute VMCLEAR on current VMCS */
 	vmcs_pa = HVA2HPA(vcpu->arch_vcpu.vmcs);

--- a/hypervisor/boot/sbl/hob_parse.c
+++ b/hypervisor/boot/sbl/hob_parse.c
@@ -45,7 +45,7 @@ void parse_seed_list(struct seed_list_hob *seed_hob)
 				goto fail;
 			}
 
-			memcpy_s(&dseed_list[dseed_index],
+			(void)memcpy_s(&dseed_list[dseed_index],
 					sizeof(struct seed_info),
 					entry->seed,
 					sizeof(struct seed_info));

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -61,12 +61,12 @@ static void parse_other_modules(struct vm *vm,
 			/*copy boot args to load addr, set src=load addr*/
 			if (copy_once != 0) {
 				copy_once = 0;
-				strcpy_s(load_addr, MEM_2K,
+				(void)strcpy_s(load_addr, MEM_2K,
 					vm->sw.linux_info.bootargs_src_addr);
 				vm->sw.linux_info.bootargs_src_addr = load_addr;
 			}
 
-			strcpy_s(load_addr + args_size,
+			(void)strcpy_s(load_addr + args_size,
 				100, dyn_bootargs);
 			vm->sw.linux_info.bootargs_size =
 				strnlen_s(load_addr, MEM_2K);
@@ -159,7 +159,7 @@ int init_vm0_boot_info(struct vm *vm)
 
 		cmd_dst = kernel_cmdline;
 		cmd_src = HPA2HVA((uint64_t)mbi->mi_cmdline);
-		strncpy_s(cmd_dst, MEM_2K, cmd_src,
+		(void)strncpy_s(cmd_dst, MEM_2K, cmd_src,
 			strnlen_s(cmd_src, MEM_2K));
 		off = strnlen_s(cmd_dst, MEM_2K);
 		cmd_dst[off] = ' ';	/* insert space */
@@ -167,7 +167,7 @@ int init_vm0_boot_info(struct vm *vm)
 
 		cmd_dst += off;
 		cmd_src = HPA2HVA((uint64_t)mods[0].mm_string);
-		strncpy_s(cmd_dst, MEM_2K - off, cmd_src,
+		(void)strncpy_s(cmd_dst, MEM_2K - off, cmd_src,
 				strnlen_s(cmd_src, MEM_2K - off));
 
 		vm->sw.linux_info.bootargs_src_addr = kernel_cmdline;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -144,7 +144,7 @@ int64_t hcall_create_vm(struct vm *vm, uint64_t param)
 	(void)memset(&vm_desc, 0, sizeof(vm_desc));
 	vm_desc.sworld_enabled =
 		(!!(cv.vm_flag & (SECURE_WORLD_ENABLED)));
-	memcpy_s(&vm_desc.GUID[0], 16, &cv.GUID[0], 16);
+	(void)memcpy_s(&vm_desc.GUID[0], 16, &cv.GUID[0], 16);
 	ret = create_vm(&vm_desc, &target_vm);
 
 	if (ret != 0) {

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -71,7 +71,7 @@ int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req)
 
 	/* ACRN insert request to VHM and inject upcall */
 	cur = vcpu->vcpu_id;
-	memcpy_s(&req_buf->req_queue[cur], sizeof(struct vhm_request),
+	(void)memcpy_s(&req_buf->req_queue[cur], sizeof(struct vhm_request),
 		 req, sizeof(struct vhm_request));
 
 	/* pause vcpu, wait for VHM to handle the MMIO request.
@@ -100,50 +100,50 @@ int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req)
 static void _get_req_info_(struct vhm_request *req, int *id, char *type,
 	char *state, char *dir, long *addr, long *val)
 {
-	strcpy_s(dir, 16, "NONE");
+	(void)strcpy_s(dir, 16, "NONE");
 	*addr = *val = 0;
 	*id = req->client;
 
 	switch (req->type) {
 	case REQ_PORTIO:
-		strcpy_s(type, 16, "PORTIO");
+		(void)strcpy_s(type, 16, "PORTIO");
 		if (req->reqs.pio_request.direction == REQUEST_READ)
-			strcpy_s(dir, 16, "READ");
+			(void)strcpy_s(dir, 16, "READ");
 		else
-			strcpy_s(dir, 16, "WRITE");
+			(void)strcpy_s(dir, 16, "WRITE");
 		*addr = req->reqs.pio_request.address;
 		*val = req->reqs.pio_request.value;
 		break;
 	case REQ_MMIO:
 	case REQ_WP:
-		strcpy_s(type, 16, "MMIO/WP");
+		(void)strcpy_s(type, 16, "MMIO/WP");
 		if (req->reqs.mmio_request.direction == REQUEST_READ)
-			strcpy_s(dir, 16, "READ");
+			(void)strcpy_s(dir, 16, "READ");
 		else
-			strcpy_s(dir, 16, "WRITE");
+			(void)strcpy_s(dir, 16, "WRITE");
 		*addr = req->reqs.mmio_request.address;
 		*val = req->reqs.mmio_request.value;
 		break;
 		break;
 	default:
-		strcpy_s(type, 16, "UNKNOWN");
+		(void)strcpy_s(type, 16, "UNKNOWN");
 	}
 
 	switch (req->processed) {
 	case REQ_STATE_SUCCESS:
-		strcpy_s(state, 16, "SUCCESS");
+		(void)strcpy_s(state, 16, "SUCCESS");
 		break;
 	case REQ_STATE_PENDING:
-		strcpy_s(state, 16, "PENDING");
+		(void)strcpy_s(state, 16, "PENDING");
 		break;
 	case REQ_STATE_PROCESSING:
-		strcpy_s(state, 16, "PROCESS");
+		(void)strcpy_s(state, 16, "PROCESS");
 		break;
 	case REQ_STATE_FAILED:
-		strcpy_s(state, 16, "FAILED");
+		(void)strcpy_s(state, 16, "FAILED");
 		break;
 	default:
-		strcpy_s(state, 16,  "UNKNOWN");
+		(void)strcpy_s(state, 16,  "UNKNOWN");
 	}
 }
 

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -39,7 +39,7 @@ static uint64_t create_zero_page(struct vm *vm)
 
 	/* copy part of the header into the zero page */
 	hva = GPA2HVA(vm, (uint64_t)vm->sw.kernel_info.kernel_load_addr);
-	memcpy_s(&(zeropage->hdr), sizeof(zeropage->hdr),
+	(void)memcpy_s(&(zeropage->hdr), sizeof(zeropage->hdr),
 				&(hva->hdr), sizeof(hva->hdr));
 
 	/* See if kernel has a RAM disk */
@@ -140,7 +140,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	hva = GPA2HVA(vm, (uint64_t)vm->sw.kernel_info.kernel_load_addr);
 
 	/* Copy the guest kernel image to its run-time location */
-	memcpy_s((void *)hva, vm->sw.kernel_info.kernel_size,
+	(void)memcpy_s((void *)hva, vm->sw.kernel_info.kernel_size,
 				vm->sw.kernel_info.kernel_src_addr,
 				vm->sw.kernel_info.kernel_size);
 
@@ -157,7 +157,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 			(uint64_t)vm->sw.linux_info.bootargs_load_addr);
 
 		/* Copy Guest OS bootargs to its load location */
-		strcpy_s((char *)hva, MEM_2K,
+		(void)strcpy_s((char *)hva, MEM_2K,
 				vm->sw.linux_info.bootargs_src_addr);
 
 #ifdef CONFIG_CMA
@@ -166,7 +166,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 			snprintf(dyn_bootargs, 100, " cma=%dM@0x%llx",
 					(e820_mem.max_ram_blk_size >> 20),
 					e820_mem.max_ram_blk_base);
-			strcpy_s((char *)hva
+			(void)strcpy_s((char *)hva
 					+vm->sw.linux_info.bootargs_size,
 					100, dyn_bootargs);
 		}
@@ -189,7 +189,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 				snprintf(dyn_bootargs, 100,
 					" hugepagesz=1G hugepages=%d",
 					reserving_1g_pages);
-				strcpy_s((char *)hva
+				(void)strcpy_s((char *)hva
 					+vm->sw.linux_info.bootargs_size,
 					100, dyn_bootargs);
 			}
@@ -203,7 +203,8 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 				(uint64_t)vm->sw.linux_info.ramdisk_load_addr);
 
 			/* Copy RAM disk to its load location */
-			memcpy_s((void *)hva, vm->sw.linux_info.ramdisk_size,
+			(void)memcpy_s((void *)hva,
+					vm->sw.linux_info.ramdisk_size,
 					vm->sw.linux_info.ramdisk_src_addr,
 					vm->sw.linux_info.ramdisk_size);
 

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -59,7 +59,8 @@ static int do_copy_earlylog(struct shared_buf *dst_sbuf,
 	buf_size = SBUF_HEAD_SIZE + dst_sbuf->size;
 	valid_size = SBUF_HEAD_SIZE + cur_tail;
 
-	memcpy_s((void *)dst_sbuf, buf_size, (void *)src_sbuf, valid_size);
+	(void)memcpy_s((void *)dst_sbuf, buf_size,
+			(void *)src_sbuf, valid_size);
 	if (dst_sbuf->tail != cur_tail)
 		/* there is chance to lose new log from certain pcpu */
 		dst_sbuf->tail = cur_tail;

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -94,7 +94,7 @@ int sbuf_get(struct shared_buf *sbuf, uint8_t *data)
 
 	from = (void *)sbuf + SBUF_HEAD_SIZE + sbuf->head;
 
-	memcpy_s((void *)data, sbuf->ele_size, from, sbuf->ele_size);
+	(void)memcpy_s((void *)data, sbuf->ele_size, from, sbuf->ele_size);
 
 	sbuf->head = sbuf_next_ptr(sbuf->head, sbuf->ele_size, sbuf->size);
 
@@ -142,7 +142,7 @@ int sbuf_put(struct shared_buf *sbuf, uint8_t *data)
 
 	to = (void *)sbuf + SBUF_HEAD_SIZE + sbuf->tail;
 
-	memcpy_s(to, sbuf->ele_size, data, sbuf->ele_size);
+	(void)memcpy_s(to, sbuf->ele_size, data, sbuf->ele_size);
 
 	if (trigger_overwrite) {
 		sbuf->head = sbuf_next_ptr(sbuf->head,

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -306,7 +306,7 @@ int shell_process_cmd(struct shell *p_shell, char *p_input_line)
 	/* Copy the input line INTo an argument string to become part of the
 	 * argument vector.
 	 */
-	(void) strcpy_s(&cmd_argv_str[0], SHELL_CMD_MAX_LEN, p_input_line);
+	(void)strcpy_s(&cmd_argv_str[0], SHELL_CMD_MAX_LEN, p_input_line);
 	cmd_argv_str[SHELL_CMD_MAX_LEN] = 0;
 
 	/* Build the argv vector from the string. The first argument in the
@@ -464,13 +464,13 @@ int shell_list_vm(struct shell *p_shell,
 		vm = list_entry(pos, struct vm, list);
 		switch (vm->state) {
 		case VM_CREATED:
-			strcpy_s(state, 32, "Created"); break;
+			(void)strcpy_s(state, 32, "Created"); break;
 		case VM_STARTED:
-			strcpy_s(state, 32, "Started"); break;
+			(void)strcpy_s(state, 32, "Started"); break;
 		case VM_PAUSED:
-			strcpy_s(state, 32, "Paused"); break;
+			(void)strcpy_s(state, 32, "Paused"); break;
 		default:
-			strcpy_s(state, 32, "Unknown"); break;
+			(void)strcpy_s(state, 32, "Unknown"); break;
 		}
 		/* Create output string consisting of VM name and VM id
 		 */
@@ -508,15 +508,15 @@ int shell_list_vcpu(struct shell *p_shell,
 		foreach_vcpu(i, vm, vcpu) {
 			switch (vcpu->state) {
 			case VCPU_INIT:
-				strcpy_s(state, 32, "Init"); break;
+				(void)strcpy_s(state, 32, "Init"); break;
 			case VCPU_PAUSED:
-				strcpy_s(state, 32, "Paused"); break;
+				(void)strcpy_s(state, 32, "Paused"); break;
 			case VCPU_RUNNING:
-				strcpy_s(state, 32, "Running"); break;
+				(void)strcpy_s(state, 32, "Running"); break;
 			case VCPU_ZOMBIE:
-				strcpy_s(state, 32, "Zombie"); break;
+				(void)strcpy_s(state, 32, "Zombie"); break;
 			default:
-				strcpy_s(state, 32, "Unknown");
+				(void)strcpy_s(state, 32, "Unknown");
 			}
 			/* Create output string consisting of VM name
 			 * and VM id

--- a/hypervisor/debug/shell_public.c
+++ b/hypervisor/debug/shell_public.c
@@ -183,7 +183,7 @@ int shell_set_name(struct shell *p_shell, const char *name)
 	int status;
 
 	if ((p_shell != NULL) && (name != NULL)) {
-		strncpy_s((void *) p_shell->name, SHELL_NAME_MAX_LEN,
+		(void)strncpy_s((void *) p_shell->name, SHELL_NAME_MAX_LEN,
 			(void *) name, SHELL_NAME_MAX_LEN - 1);
 
 		/* Ensure null terminated string */

--- a/hypervisor/lib/crypto/hkdf.c
+++ b/hypervisor/lib/crypto/hkdf.c
@@ -17,7 +17,7 @@ int hkdf_sha256(uint8_t *out_key, size_t out_len,
 	 * to derive multiple seeds in order to support multiple
 	 * AaaG/Trusty instances.
 	 */
-	memcpy_s(out_key, out_len, secret, secret_len);
+	(void)memcpy_s(out_key, out_len, secret, secret_len);
 
 	return 1;
 }


### PR DESCRIPTION
It will print error information inside memcpy_s/strcpy_s/strncpy_s if
the parameter is invalid, then no need to check
the return value of memcpy_s/strcpy_s/strncpy_s for the caller
code like this:
int a(void) {
return 0;
}
int b(void){
a();
}
fix as follow:
int a(void) {
return 0;
}
int b(void){
(void)a();
}

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>