### PR TITLE
HV: uart16550.c: check the denominator before use

### DIFF
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -89,6 +89,8 @@ static int uart16550_calc_baud_div(__unused struct tgt_uart *tgt_uart,
 {
 	uint32_t baud_multiplier = baud_rate < BAUD_460800 ? 16 : 13;
 
+	if (baud_rate == 0)
+		baud_rate = BAUD_115200;
 	*baud_div_ptr = ref_freq / (baud_multiplier * baud_rate);
 
 	return 0;


### PR DESCRIPTION
To prevent the value is devided by zero, checks the denominator
before the calculation. Adding the if statement to check before use.
If the baud_rate is equal to zero, using default baud_rate.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>