### PR TITLE
hv: fix 'Recursion in procedure calls found'

### DIFF
--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -234,7 +234,7 @@ void __assert(uint32_t line, const char *file, const char *txt)
 	uint64_t rsp = cpu_rsp_get();
 	uint64_t rbp = cpu_rbp_get();
 
-	pr_fatal("Assertion failed in file %s,line %u : %s",
+	printf("Assertion failed in file %s,line %u : %s",
 			file, line, txt);
 	show_host_call_trace(rsp, rbp, pcpu_id);
 	dump_guest_context(pcpu_id);

--- a/hypervisor/include/debug/assert.h
+++ b/hypervisor/include/debug/assert.h
@@ -12,7 +12,6 @@ void __assert(uint32_t line, const char *file, const char *txt);
 
 #define ASSERT(x, ...) \
 	if (!(x)) {\
-		pr_fatal(__VA_ARGS__);\
 		__assert(__LINE__, __FILE__, "fatal error");\
 	}
 #else

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -344,14 +344,12 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
         uint8_t *src8;
 
         if (slen == 0U || dmax == 0U || dmax < slen) {
-                pr_err("%s: invalid src, dest buffer or length.", __func__);
-                return NULL;
+                ASSERT(false);
         }
 
         if ((d > s && d <= s + slen - 1)
                 || (d < s && s <= d + dmax - 1)) {
-                pr_err("%s: overlap happened.", __func__);
-                return NULL;
+                ASSERT(false);
         }
 
         /*same memory block, no need to copy*/


### PR DESCRIPTION
Here is how the recursion might happen:

                     when there is something wrong
                     |
sbuf_put -> memcpy_s -> pr_err -> do_logmsg
   |                                 |
   -----------------------------------

Replace 'pr_err' with 'ASSERT' in 'memcpy_s' to break this kind of
recursion.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>