### PR TITLE
HV: instr_emul: Rename emul_cnx to emul_ctxt

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -178,7 +178,7 @@ struct vm_guest_paging {
 	enum vm_paging_mode paging_mode;
 };
 
-struct emul_cnx {
+struct emul_ctxt {
 	struct vie vie;
 	struct vm_guest_paging paging;
 	struct vcpu *vcpu;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -29,7 +29,7 @@ struct per_cpu_region {
 #endif
 	struct per_cpu_timers cpu_timers;
 	struct sched_context sched_ctx;
-	struct emul_cnx g_inst_ctxt;
+	struct emul_ctxt g_inst_ctxt;
 	struct host_gdt gdt;
 	struct tss_64 tss;
 	enum cpu_state state;


### PR DESCRIPTION
ctxt is a more general abbreviation of context.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>