### PR TITLE
tools: acrn-crashlog: fix potential buffer overflow issues

### DIFF
--- a/tools/acrn-crashlog/common/log_sys.c
+++ b/tools/acrn-crashlog/common/log_sys.c
@@ -17,7 +17,9 @@ void do_log(const int level,
 	va_list args;
 	char *fmt;
 	char log[MAX_LOG_LEN];
+	char *msg_log;
 	int n = 0;
+	int msg_len = 0;
 #ifdef DEBUG_ACRN_CRASHLOG
 	const char header_fmt[] = "<%-20s%5d>: ";
 #endif
@@ -40,8 +42,10 @@ void do_log(const int level,
 	if (n < 0 || (size_t)n >= sizeof(log))
 		n = 0;
 #endif
+	msg_log = log + n;
+	msg_len = sizeof(log) - n;
 	/* msg */
-	vsnprintf(log + n, sizeof(log) - n, fmt, args);
+	vsnprintf(msg_log, msg_len, fmt, args);
 	log[sizeof(log) - 1] = 0;
 	va_end(args);
 

--- a/tools/acrn-crashlog/usercrash/protocol.c
+++ b/tools/acrn-crashlog/usercrash/protocol.c
@@ -44,7 +44,7 @@ static int socket_make_sockaddr_un(const char *name,
 	name_len = strlen(name);
 	if (name_len >= (SUN_PATH_MAX - socket_len))
 		return -1;
-	strcat(p_addr->sun_path, name);
+	strncat(p_addr->sun_path, name, SUN_PATH_MAX - socket_len);
 
 	p_addr->sun_family = AF_LOCAL;
 	*alen = name_len + socket_len +
@@ -111,7 +111,7 @@ static int socket_bind(int fd, const char *name)
 	name_len = strlen(name);
 	if (name_len >= SUN_PATH_MAX)
 		return -1;
-	strcpy(addr.sun_path, name);
+	strncpy(addr.sun_path, name, SUN_PATH_MAX);
 	unlink(addr.sun_path);
 	alen = strlen(addr.sun_path) + sizeof(addr.sun_family);
 


### PR DESCRIPTION
This patch is to fix the potential buffer overflow issues.

Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: xiaojin2 <xiaojing.liu@intel.com>