### PR TITLE
doc: fix acrntrace parameter documentation

### DIFF
--- a/tools/acrntrace/README.rst
+++ b/tools/acrntrace/README.rst
@@ -17,12 +17,12 @@ output to trace file under ``/tmp/acrntrace`` with raw (binary) data format.
 
 Options:
 
--h			print this message
--i period		specify polling interval in milliseconds [1-999]
--t			max time to capture trace data (in second)
--c			clear the buffered old data
--r			minimal amount (in MB) of free space kept on the disk
-			before acrntrace stops
+-h                      print this message
+-i period               specify polling interval in milliseconds [1-999]
+-t max_time             max time to capture trace data (in second)
+-c                      clear the buffered old data
+-r free_space           amount of free space (in MB) remaining on the disk
+                        before acrntrace stops
 
 The ``acrntrace_format.py`` is a offline tool for parsing trace data (as output
 by acrntrace) to human-readable formats based on given format.
@@ -56,7 +56,7 @@ An example *formats_file* is available in the acrn_hypervisor repo in
 ``hypervisor/tools/acrntrace/scripts/formats``.
 
 The ``acrnalyze.py`` is a offline tool to analyze trace data (as output by
-acrntrace) based on given analyser, such as ``vm_exit`` or ``irq``.
+acrntrace) based on given analyzer, such as ``vm_exit`` or ``irq``.
 
 Options:
 


### PR DESCRIPTION
Fix missing parameter documentation, and a misspelling

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>