### PR TITLE
Improve acrn-bridge 

### DIFF
--- a/tools/acrnbridge/Makefile
+++ b/tools/acrnbridge/Makefile
@@ -10,7 +10,7 @@ all:
 
 install:
 	install -d $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
-	install -p -D -m 0644 $(OUT_DIR)/acrn.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
-	install -p -D -m 0644 $(OUT_DIR)/acrn.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
-	install -p -D -m 0644 $(OUT_DIR)/acrn_tap0.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
-	install -p -D -m 0644 $(OUT_DIR)/eth.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
+	install -p -D -m 0644 $(OUT_DIR)/acrn.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn.netdev
+	install -p -D -m 0644 $(OUT_DIR)/acrn.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn.network
+	install -p -D -m 0644 $(OUT_DIR)/acrn_tap0.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn_tap0.netdev
+	install -p -D -m 0644 $(OUT_DIR)/eth.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-eth.network

--- a/tools/acrnbridge/Makefile
+++ b/tools/acrnbridge/Makefile
@@ -14,5 +14,3 @@ install:
 	install -p -D -m 0644 $(OUT_DIR)/acrn.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
 	install -p -D -m 0644 $(OUT_DIR)/acrn_tap0.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
 	install -p -D -m 0644 $(OUT_DIR)/eth.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
-	ln -sf /dev/null $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/80-dhcp.network
-	ln -sf /dev/null $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/80-virtual.network


### PR DESCRIPTION
This patch set improves and fixes the systemd network units used                                                                                   
in the acrn-bridge.                                                                                                                                
                                                                                                                                                   
It fixed the install target and rename the installed files to add                                                                                  
a 50- prefix, this allow the units to be processed before the others                                                                               
units in Clear Linux, and add a constrain to be processed in a virtual                                                                             
machine environment.                                                                                                                               
                                                                                                                                                   
You can find a copy of this patch set at                                                                                                           
https://github.com/miguelinux/acrn-hypervisor/tree/fix-acrn-bridge                                                                                 
                                                                                                                                                   
Currently this settings is used in Clear Linux package and need to be                                                                              
upstreammed.

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>
Acked-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com> 