### PR TITLE
HV: Avoiding the chained assignment

### DIFF
--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -164,7 +164,8 @@ int set_vcpuid_entries(struct vm *vm)
 	result = set_vcpuid_entry(vm, &entry);
 	if (result != 0)
 		return result;
-	vm->vcpuid_level = limit = entry.eax;
+	limit = entry.eax;
+	vm->vcpuid_level = limit;
 
 	for (i = 1U; i <= limit; i++) {
 		/* cpuid 1/0xb is percpu related */
@@ -235,7 +236,8 @@ int set_vcpuid_entries(struct vm *vm)
 	if (result != 0)
 		return result;
 
-	vm->vcpuid_xlevel = limit = entry.eax;
+	limit = entry.eax;
+	vm->vcpuid_xlevel = limit;
 	for (i = 0x80000001U; i <= limit; i++) {
 		init_vcpuid_entry(vm, i, 0U, 0U, &entry);
 		result = set_vcpuid_entry(vm, &entry);

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -49,8 +49,8 @@ void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
 	data_page_num =
 		(data_size + CPU_PAGE_SIZE - 1) >> CPU_PAGE_SHIFT;
 
-	ptr = ucode_ptr = alloc_pages(data_page_num);
-	if (ptr == NULL)
+	ucode_ptr = alloc_pages(data_page_num);
+	if (ucode_ptr == NULL)
 		return;
 
 	err_code = 0U;
@@ -62,7 +62,7 @@ void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
 		return;
 
 	msr_write(MSR_IA32_BIOS_UPDT_TRIG,
-			(uint64_t)ptr + sizeof(struct ucode_header));
+			(uint64_t)ucode_ptr + sizeof(struct ucode_header));
 	get_microcode_version();
 
 	free(ucode_ptr);

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -327,11 +327,11 @@ vioapic_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 		else
 			lshift = 0;
 
-		last = new = vioapic->rtbl[pin].reg;
+		last = vioapic->rtbl[pin].reg;
 
 		data64 = (uint64_t)data << lshift;
 		mask64 = (uint64_t)0xffffffff << lshift;
-		new &= ~mask64 | RTBL_RO_BITS;
+		new = last & (~mask64 | RTBL_RO_BITS);
 		new |= data64 & ~RTBL_RO_BITS;
 
 		changed = last ^ new;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -101,7 +101,8 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 	for (id = 0U; id < (size_t)(sizeof(long) * 8U); id++)
 		if (!bitmap_test_and_set(id, &vmid_bitmap))
 			break;
-	vm->attr.id = vm->attr.boot_idx = id;
+	vm->attr.id = id;
+	vm->attr.boot_idx = id;
 
 	atomic_store(&vm->hw.created_vcpus, 0);
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -772,12 +772,20 @@ static void init_guest_state(struct vcpu *vcpu)
 	/***************************************************/
 	data32_idx = 0x10;
 	if (vcpu_mode == CPU_MODE_REAL) {
-		es = ss = ds = fs = gs = data32_idx;
+		es = data32_idx;
+		ss = data32_idx;
+		ds = data32_idx;
+		fs = data32_idx;
+		gs = data32_idx;
 		limit = 0xffff;
 
 	} else if (vcpu_mode == CPU_MODE_PROTECTED) {
 		/* Linear data segment in guest init gdt */
-		es = ss = ds = fs = gs = 0x18;
+		es = 0x18;
+		ss = 0x18;
+		ds = 0x18;
+		fs = 0x18;
+		gs = 0x18;
 		limit = 0xffffffffU;
 	} else if (vcpu_mode == CPU_MODE_64BIT) {
 		asm volatile ("movw %%es, %%ax":"=a" (es));

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -101,7 +101,8 @@ static void _get_req_info_(struct vhm_request *req, int *id, char *type,
 	char *state, char *dir, long *addr, long *val)
 {
 	(void)strcpy_s(dir, 16, "NONE");
-	*addr = *val = 0;
+	*addr = 0;
+	*val = 0;
 	*id = req->client;
 
 	switch (req->type) {


### PR DESCRIPTION
To follow the Misra C standard, doing one assignment per line to
make code is clearly readable and reduces the confusion of its
intetion or typo.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>