### PR TITLE
HV: Moving operators out from conditions

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1107,7 +1107,8 @@ vlapic_icrlo_write_handler(struct vlapic *vlapic)
 				"Sending SIPI from VCPU %d to %hu with vector %d",
 				vlapic->vcpu->vcpu_id, vcpu_id, vec);
 
-			if (--target_vcpu->arch_vcpu.nr_sipi > 0)
+			target_vcpu->arch_vcpu.nr_sipi--;
+			if (target_vcpu->arch_vcpu.nr_sipi > 0)
 				continue;
 
 			target_vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -620,9 +620,8 @@ void init_paging(void)
 			attr_uc);
 
 	/* Modify WB attribute for E820_TYPE_RAM */
-	for (i = 0U, entry = &e820[0];
-			i < e820_entries;
-			i++, entry = &e820[i]) {
+	for (i = 0U; i < e820_entries; i++) {
+		entry = &e820[i];
 		if (entry->type == E820_TYPE_RAM) {
 			modify_mem(&map_params, (void *)entry->baseaddr,
 					(void *)entry->baseaddr,

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -191,7 +191,8 @@ void timer_softirq(uint16_t pcpu_id)
 	list_for_each_safe(pos, n, &cpu_timer->timer_list) {
 		timer = list_entry(pos, struct timer, node);
 		/* timer expried */
-		if (timer->fire_tsc <= current_tsc && --tries > 0) {
+		tries--;
+		if (timer->fire_tsc <= current_tsc && tries > 0) {
 			del_timer(timer);
 
 			run_timer(timer);

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1167,10 +1167,11 @@ void suspend_iommu(void)
 		/* If the number of real iommu devices is larger than we
 		 * defined in kconfig.
 		 */
-		if (iommu_idx++ > CONFIG_MAX_IOMMU_NUM) {
+		if (iommu_idx > CONFIG_MAX_IOMMU_NUM) {
 			pr_err("iommu dev number is larger than pre-defined");
 			break;
 		}
+		iommu_idx++;
 	}
 }
 
@@ -1206,10 +1207,11 @@ void resume_iommu(void)
 		/* If the number of real iommu devices is larger than we
 		 * defined in kconfig.
 		 */
-		if (iommu_idx++ > CONFIG_MAX_IOMMU_NUM) {
+		if (iommu_idx > CONFIG_MAX_IOMMU_NUM) {
 			pr_err("iommu dev number is larger than pre-defined");
 			break;
 		}
+		iommu_idx++;
 	}
 }
 

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -28,8 +28,10 @@ static int charout(int cmd, const char *s, int sz, void *hnd)
 	/* fill mode */
 	else {
 		*nchars += sz;
-		while ((sz--) != 0)
+		while (sz != 0) {
 			console_putc(*s);
+			sz--;
+		}
 	}
 
 	return *nchars;

--- a/hypervisor/debug/serial.c
+++ b/hypervisor/debug/serial.c
@@ -22,7 +22,8 @@ static struct uart *get_uart_by_id(const char *uart_id, uint32_t *index)
 			break;
 
 		/* No device is found if index reaches end of array. */
-		if (++(*index) == SERIAL_MAX_DEVS)
+		(*index)++;
+		if (*index == SERIAL_MAX_DEVS)
 			return NULL;
 
 	}

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -79,8 +79,9 @@ static int string_to_argv(char *argv_str, void *p_argv_mem,
 			 */
 			*p_ch = 0;
 			/* Remove all space in middile of cmdline */
-			while (*++p_ch == ' ')
-				;
+			p_ch++;
+			while (*p_ch == ' ')
+				p_ch++;
 		}
 	}
 

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -27,7 +27,8 @@ static int do_udiv32(uint32_t dividend, uint32_t divisor,
 			res->q.dwords.low |= mask;
 		}
 		divisor >>= 1U;
-	} while (((mask >>= 1U) != 0U) && (dividend != 0U));
+		mask >>= 1U;
+	} while ((mask != 0U) && (dividend != 0U));
 	/* dividend now contains the reminder */
 	res->r.dwords.low = dividend;
 	return 0;

--- a/hypervisor/lib/mdelay.c
+++ b/hypervisor/lib/mdelay.c
@@ -9,8 +9,9 @@
 void mdelay(uint32_t loop_count)
 {
 	/* Loop until done */
-	while (loop_count-- != 0) {
+	while (loop_count != 0) {
 		/* Delay for 1 ms */
 		udelay(1000);
+		loop_count--;
 	}
 }

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -95,11 +95,13 @@ static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
                          */
                         for (i = 1; i < requested_buffs; i++) {
                                 /* Check if tmp_bit_idx is out-of-range */
-                                if (++tmp_bit_idx == BITMAP_WORD_SIZE) {
+                                tmp_bit_idx++;
+                                if (tmp_bit_idx == BITMAP_WORD_SIZE) {
                                         /* Break the loop if tmp_idx is
                                          * out-of-range
                                          */
-                                        if (++tmp_idx == pool->bmp_size)
+                                        tmp_idx++;
+                                        if (tmp_idx == pool->bmp_size)
                                                 break;
                                         /* Reset tmp_bit_idx */
                                         tmp_bit_idx = 0U;
@@ -153,7 +155,8 @@ static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
                                         }
 
                                         /* Check if bit_idx is out-of-range */
-                                        if (++bit_idx == BITMAP_WORD_SIZE) {
+                                        bit_idx++;
+                                        if (bit_idx == BITMAP_WORD_SIZE) {
                                                 /* Increment idx */
                                                 idx++;
                                                 /* Reset bit_idx */
@@ -306,8 +309,9 @@ void *memchr(const void *void_s, int c, size_t n)
 
         while (ptr < end) {
 
-                if (*ptr++ == val)
-                        return ((void *)(ptr - 1));
+                if (*ptr == val)
+                        return ((void *)ptr);
+                ptr++;
         }
 
         return NULL;

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -147,7 +147,8 @@ static const char *get_length_modifier(const char *s,
 {
 	/* check for h[h] (char/short) */
 	if (*s == 'h') {
-		if (*++s == 'h') {
+		s++;
+		if (*s == 'h') {
 			*flags |= PRINT_FLAG_CHAR;
 			*mask = 0x000000FF;
 			++s;
@@ -158,7 +159,8 @@ static const char *get_length_modifier(const char *s,
 	}
 	/* check for l[l] (long/long long) */
 	else if (*s == 'l') {
-		if (*++s == 'l') {
+		s++;
+		if (*s == 'l') {
 			*flags |= PRINT_FLAG_LONG_LONG;
 			++s;
 		} else
@@ -297,8 +299,10 @@ static int print_pow2(struct print_param *param,
 
 	/* determine digits from right to left */
 	do {
-		*--pos = digits[(v & mask)];
-	} while ((v >>= shift) != 0UL);
+		pos--;
+		*pos = digits[(v & mask)];
+		v >>= shift;
+	} while (v != 0UL);
 
 	/* assign parameter and apply width and precision */
 	param->vars.value = pos;
@@ -365,8 +369,10 @@ static int print_decimal(struct print_param *param, int64_t value)
 		 * 10.
 		 */
 		nv.dwords.low = v.dwords.low / 10;
-		*--pos = (v.dwords.low - (10 * nv.dwords.low)) + '0';
-	} while ((v.dwords.low = nv.dwords.low) != 0);
+		pos--;
+		*pos = (v.dwords.low - (10 * nv.dwords.low)) + '0';
+		v.dwords.low = nv.dwords.low;
+	} while (v.dwords.low != 0);
 
 	/* assign parameter and apply width and precision */
 	param->vars.value = pos;


### PR DESCRIPTION
To follow the Misra-c standard, any operators should be done outside
the conditions. Removed the prefix, postfix and bitwise shift from
conditions.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>