### PR TITLE
HV: Rename 'CPU_BOOT_ID' to 'BOOT_CPU_ID'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -430,7 +430,7 @@ void bsp_boot_init(void)
 		CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL,
 		"run_context ia32_spec_ctrl offset not match");
 
-	__bitmap_set(CPU_BOOT_ID, &pcpu_active_bitmap);
+	__bitmap_set(BOOT_CPU_ID, &pcpu_active_bitmap);
 
 	/* Get CPU capabilities thru CPUID, including the physical address bit
 	 * limit which is required for initializing paging.
@@ -467,7 +467,7 @@ static void bsp_boot_post(void)
 	cpu_xsave_init();
 
 	/* Set state for this CPU to initializing */
-	cpu_set_current_state(CPU_BOOT_ID, CPU_STATE_INITIALIZING);
+	cpu_set_current_state(BOOT_CPU_ID, CPU_STATE_INITIALIZING);
 
 	/* Perform any necessary BSP initialization */
 	init_bsp();
@@ -507,7 +507,7 @@ static void bsp_boot_post(void)
 
 	pr_acrnlog("Detect processor: %s", boot_cpu_data.model_name);
 
-	pr_dbg("Core %hu is up", CPU_BOOT_ID);
+	pr_dbg("Core %hu is up", BOOT_CPU_ID);
 
 	if (hardware_detect_support() != 0) {
 		pr_fatal("hardware not support!\n");
@@ -527,7 +527,7 @@ static void bsp_boot_post(void)
 	shell_init();
 
 	/* Initialize interrupts */
-	interrupt_init(CPU_BOOT_ID);
+	interrupt_init(BOOT_CPU_ID);
 
 	timer_init();
 	setup_notification();
@@ -541,7 +541,7 @@ static void bsp_boot_post(void)
 	/* Trigger event to allow secondary CPUs to continue */
 	__bitmap_set(0U, &pcpu_sync);
 
-	ASSERT(get_cpu_id() == CPU_BOOT_ID, "");
+	ASSERT(get_cpu_id() == BOOT_CPU_ID, "");
 
 	if (init_iommu() != 0) {
 		pr_fatal("%s, init iommu failed\n", __func__);
@@ -551,11 +551,11 @@ static void bsp_boot_post(void)
 	console_setup_timer();
 
 	/* Start initializing the VM for this CPU */
-	if (hv_main(CPU_BOOT_ID) != 0)
+	if (hv_main(BOOT_CPU_ID) != 0)
 		panic("failed to start VM for bsp\n");
 
 	/* Control should not come here */
-	cpu_dead(CPU_BOOT_ID);
+	cpu_dead(BOOT_CPU_ID);
 }
 
 /* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
@@ -930,7 +930,7 @@ static void cpu_xsave_init(void)
 		val64 |= CR4_OSXSAVE;
 		CPU_CR_WRITE(cr4, val64);
 
-		if (get_cpu_id() == CPU_BOOT_ID) {
+		if (get_cpu_id() == BOOT_CPU_ID) {
 			uint32_t ecx, unused;
 			cpuid(CPUID_FEATURES, &unused, &unused, &ecx, &unused);
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -361,7 +361,7 @@ uint32_t dev_to_vector(struct dev_handler_node *node)
 
 int init_default_irqs(uint16_t cpu_id)
 {
-	if (cpu_id != CPU_BOOT_ID)
+	if (cpu_id != BOOT_CPU_ID)
 		return 0;
 
 	init_irq_desc();

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -418,7 +418,7 @@ static uint32_t map_mem_region(void *vaddr, void *paddr,
 			if ((phys_cpu_num != 0U) &&
 				((pcpu_active_bitmap &
 				((1UL << phys_cpu_num) - 1))
-				!= (1UL << CPU_BOOT_ID))) {
+				!= (1UL << BOOT_CPU_ID))) {
 				panic("need shootdown for invlpg");
 			}
 			inv_tlb_one_page(vaddr);

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -11,7 +11,7 @@ static void fire_vhm_interrupt(void)
 {
 	/*
 	 * use vLAPIC to inject vector to SOS vcpu 0 if vlapic is enabled
-	 * otherwise, send IPI hardcoded to CPU_BOOT_ID
+	 * otherwise, send IPI hardcoded to BOOT_CPU_ID
 	 */
 	struct vm *vm0;
 	struct vcpu *vcpu;

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -130,7 +130,7 @@
 #define CPU_MHZ_TO_KHZ          1000
 
 /* Boot CPU ID */
-#define CPU_BOOT_ID             0U
+#define BOOT_CPU_ID             0U
 
 /* hypervisor stack bottom magic('intl') */
 #define SP_BOTTOM_MAGIC    0x696e746cUL


### PR DESCRIPTION
 - code cleanup to set a more smooth name

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>