### PR TITLE
HV:treewide: Clean up -1U or -1UL

### DIFF
--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -206,7 +206,7 @@ struct acrn_irqline {
 	uint64_t pic_irq;
 
 	/** ioapic IRQ for IOAPIC & ISA TYPE,
-	 *  if -1 then this IRQ will not be injected
+	 *  if ~0UL then this IRQ will not be injected
 	 */
 	uint64_t ioapic_irq;
 } __aligned(8);

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -718,9 +718,12 @@ void start_cpus()
 	 */
 	expected_up = phys_cpu_num;
 
-	/* Broadcast IPIs to all other CPUs */
+	/* Broadcast IPIs to all other CPUs,
+	 * In this case, INTR_CPU_STARTUP_ALL_EX_SELF decides broadcasting
+	 * IPIs, INVALID_CPU_ID is parameter value to destination pcpu_id.
+	 */
 	send_startup_ipi(INTR_CPU_STARTUP_ALL_EX_SELF,
-			-1U, startup_paddr);
+			INVALID_CPU_ID, startup_paddr);
 
 	/* Wait until global count is equal to expected CPU up count or
 	 * configured time-out has expired

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -483,7 +483,7 @@ vlapic_set_intr_ready(struct vlapic *vlapic, uint32_t vector, bool level)
 static inline int
 lvt_off_to_idx(uint32_t offset)
 {
-	uint32_t index = -1U;
+	uint32_t index = ~0U;
 
 	switch (offset) {
 	case APIC_OFFSET_CMCI_LVT:

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -352,7 +352,7 @@ uint8_t get_cur_lapic_id(void)
 
 int
 send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
-	uint32_t cpu_startup_dest, uint64_t cpu_startup_start_address)
+	uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
 {
 	union apic_icr icr;
 	uint8_t shorthand;
@@ -368,7 +368,7 @@ send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 
 	if (cpu_startup_shorthand == INTR_CPU_STARTUP_USE_DEST) {
 		shorthand = INTR_LAPIC_ICR_USE_DEST_ARRAY;
-		icr.x_bits.dest_field = per_cpu(lapic_id, cpu_startup_dest);
+		icr.x_bits.dest_field = per_cpu(lapic_id, dest_pcpu_id);
 	} else {		/* Use destination shorthand */
 		shorthand = INTR_LAPIC_ICR_ALL_EX_SELF;
 		icr.value_32.hi_32 = 0;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1280,10 +1280,10 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 			 * that support the 1-setting of the "virtual-interrupt
 			 * delivery" VM-execution control
 			 */
-			exec_vmwrite64(VMX_EOI_EXIT0_FULL, -1UL);
-			exec_vmwrite64(VMX_EOI_EXIT1_FULL, -1UL);
-			exec_vmwrite64(VMX_EOI_EXIT2_FULL, -1UL);
-			exec_vmwrite64(VMX_EOI_EXIT3_FULL, -1UL);
+			exec_vmwrite64(VMX_EOI_EXIT0_FULL, ~0UL);
+			exec_vmwrite64(VMX_EOI_EXIT1_FULL, ~0UL);
+			exec_vmwrite64(VMX_EOI_EXIT2_FULL, ~0UL);
+			exec_vmwrite64(VMX_EOI_EXIT3_FULL, ~0UL);
 		}
 	}
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -105,8 +105,8 @@ static int handle_virt_irqline(struct vm *vm, uint64_t target_vmid,
 		/* Call vpic for pic injection */
 		ret = handle_vpic_irqline(target_vm, param->pic_irq, mode);
 
-		/* call vioapic for ioapic injection if ioapic_irq != -1*/
-		if (param->ioapic_irq != -1UL) {
+		/* call vioapic for ioapic injection if ioapic_irq != ~0UL*/
+		if (param->ioapic_irq != (~0UL)) {
 			/* handle IOAPIC irqline */
 			ret = handle_vioapic_irqline(target_vm,
 				param->ioapic_irq, mode);

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -144,7 +144,7 @@ int init_lapic(uint16_t cpu_id);
 void send_lapic_eoi(void);
 uint8_t get_cur_lapic_id(void);
 int send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
-		uint32_t cpu_startup_dest,
+		uint16_t dest_pcpu_id,
 		uint64_t cpu_startup_start_address);
 /* API to send an IPI to a single guest */
 void send_single_ipi(uint16_t pcpu_id, uint32_t vector);

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -186,7 +186,7 @@ struct acrn_irqline {
 	uint64_t pic_irq;
 
 	/** ioapic IRQ for IOAPIC & ISA TYPE,
-	 *  if -1 then this IRQ will not be injected
+	 *  if ~0UL then this IRQ will not be injected
 	 */
 	uint64_t ioapic_irq;
 } __aligned(8);

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -77,7 +77,7 @@
 
 #define ACRN_DOM0_VMID (0UL)
 #define ACRN_INVALID_VMID (-1)
-#define ACRN_INVALID_HPA (-1UL)
+#define ACRN_INVALID_HPA (~0UL)
 
 /* Generic memory attributes */
 #define	MEM_ACCESS_READ                 0x00000001U


### PR DESCRIPTION
According to C99 standard, -1 integer constant with 'U/UL'
suffix has no type.

To explicit the integer constant:
Update -1U or -1UL as ~0U or ~0UL, or invalid number according
to usage case.

V1-->V2:
	Update parameter name and type of send_startup_ipi since
	the second parameter is used as pcpu_id;
	Update related comments for code clearity.
V2-->V3:
	Update comments of struct acrn_irqline;
	rename  cpu_startup_dest as dest_pcpu_id in the second
	parameter of send_startup_ipi.

Tracked-on: ccm0001001-247033
Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>