### PR TITLE
lpc: resolve UOS boot-up issue caused by lpc.

### DIFF
--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <sys/errno.h>
 
 #include "vmmapi.h"
 #include "acpi.h"
@@ -214,7 +215,12 @@ lpc_init(struct vmctx *ctx)
 			goto init_failed;
 		}
 
-		if (uart_set_backend(lpc_uart->uart, lpc_uart->opts) != 0) {
+		error = uart_set_backend(lpc_uart->uart, lpc_uart->opts);
+		/*
+		 * Continue to initialize LPC UART device if opts is invalid,
+		 * and the data will be dropped by uart_write in UART DM.
+		 */
+		if (error && error != -EINVAL) {
 			fprintf(stderr, "Unable to initialize backend '%s' "
 			    "for LPC device %s\n", lpc_uart->opts, name);
 			uart_deinit(lpc_uart->uart);

--- a/devicemodel/hw/pci/uart.c
+++ b/devicemodel/hw/pci/uart.c
@@ -27,6 +27,7 @@
  */
 
 #include <stdio.h>
+#include <sys/errno.h>
 
 #include "pci_core.h"
 #include "uart_core.h"
@@ -82,6 +83,7 @@ static int
 pci_uart_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
 	struct uart_vdev *uart;
+	int ret;
 
 	pci_emul_alloc_bar(dev, 0, PCIBAR_IO, UART_IO_BAR_SIZE);
 	pci_lintr_request(dev);
@@ -94,7 +96,8 @@ pci_uart_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	uart = uart_init(pci_uart_intr_assert, pci_uart_intr_deassert, dev);
 	dev->arg = uart;
 
-	if (uart_set_backend(uart, opts) != 0) {
+	ret = uart_set_backend(uart, opts);
+	if (ret && ret != -EINVAL) {
 		fprintf(stderr, "Unable to initialize backend '%s' for "
 		    "pci uart at %d:%d\n", opts, dev->slot, dev->func);
 		return -1;

--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -36,6 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <pthread.h>
+#include <sys/errno.h>
 
 #include "types.h"
 #include "mevent.h"
@@ -679,7 +680,7 @@ uart_set_backend(struct uart_vdev *uart, const char *opts)
 	retval = -1;
 
 	if (opts == NULL)
-		return 0;
+		return -EINVAL;
 
 	if (strcmp("stdio", opts) == 0) {
 		if (!stdio_in_use) {
@@ -691,6 +692,9 @@ uart_set_backend(struct uart_vdev *uart, const char *opts)
 	} else if (uart_tty_backend(uart, opts) == 0) {
 		retval = 0;
 	}
+
+	if (retval)
+		return -EINVAL;
 
 	/* Make the backend file descriptor non-blocking */
 	if (retval == 0)


### PR DESCRIPTION
The lpc dm causes that UOS can't boot if the parameters are set incorrectly,
it is not friendly to users.

This patch optimizes the lpc error handle flow. UOS always can boot successfully
whatever the lpc settings are.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>