### PR TITLE
DM: extend i6300esb device to support watchdog timeout query

### DIFF
--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -99,7 +99,7 @@ struct vsbl_para {
 	uint64_t		bootargs_address;
 	uint32_t		trusty_enabled;
 	uint32_t		key_info_lock;
-	uint32_t		watchdog_reset;
+	uint32_t		reserved;
 	uint32_t		boot_device_address;
 };
 


### PR DESCRIPTION
6300esb has bit in its register to show whether the watchdog
timeout is hit.

This patch adds this bit support. So the guest could query
whether last reset is triggered by watchdog reset.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Cao Minggui <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
Tested-by: Binbin Wu <binbin.wu@intel.com>