### PR TITLE
doc: fix a formatting issue in the virtio-hld

### DIFF
--- a/doc/developer-guides/virtio-hld.rst
+++ b/doc/developer-guides/virtio-hld.rst
@@ -610,7 +610,9 @@ To use the virtio-console device, use the following virtio command::
 
 .. note::
 
-   - '@' : marks the port as a console port, otherwise it is a normal
+   Here are some notes about the virtio-console device:
+
+   - ``@`` : marks the port as a console port, otherwise it is a normal
      virtio serial port
    - stdio/tty/pty: tty capable, which means :kbd:`TAB` and :kbd:`BACKSPACE`
      are supported as in regular terminals


### PR DESCRIPTION
Layout of note at the end of the doc had a CSS formatting problem solved
by adding a leading sentence before the bullet list.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>