### PR TITLE
HV: No assignment inside while loop condition

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -79,7 +79,8 @@ inline uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 	uint64_t dmask = 0;
 	struct vcpu *vcpu;
 
-	while ((vcpu_id = ffs64(vdmask)) != INVALID_BIT_INDEX) {
+	for (vcpu_id = ffs64(vdmask); vcpu_id != INVALID_BIT_INDEX;
+		vcpu_id = ffs64(vdmask)) {
 		bitmap_clear(vcpu_id, &vdmask);
 		vcpu = vcpu_from_vid(vm, vcpu_id);
 		ASSERT(vcpu != NULL, "vcpu_from_vid failed");

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -912,7 +912,8 @@ vlapic_calcdest(struct vm *vm, uint64_t *dmask, uint32_t dest,
 		 */
 		*dmask = 0UL;
 		amask = vm_active_cpus(vm);
-		while ((vcpu_id = ffs64(amask)) != INVALID_BIT_INDEX) {
+		for (vcpu_id = ffs64(amask); vcpu_id != INVALID_BIT_INDEX;
+			vcpu_id = ffs64(amask)) {
 			bitmap_clear(vcpu_id, &amask);
 
 			vlapic = vm_lapic_from_vcpu_id(vm, vcpu_id);
@@ -1613,7 +1614,8 @@ vlapic_deliver_intr(struct vm *vm, bool level, uint32_t dest, bool phys,
 	 */
 	vlapic_calcdest(vm, &dmask, dest, phys, lowprio);
 
-	while ((vcpu_id = ffs64(dmask)) != INVALID_BIT_INDEX) {
+	for (vcpu_id = ffs64(dmask); vcpu_id != INVALID_BIT_INDEX;
+		vcpu_id = ffs64(dmask)) {
 		bitmap_clear(vcpu_id, &dmask);
 		target_vcpu = vcpu_from_vid(vm, vcpu_id);
 		if (target_vcpu == NULL)
@@ -1759,7 +1761,8 @@ vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id, uint32_t vector)
 	else
 		bitmap_set(vcpu_id, &dmask);
 	error = 0;
-	while ((vcpu_id = ffs64(dmask)) != INVALID_BIT_INDEX) {
+	for (vcpu_id = ffs64(dmask); vcpu_id != INVALID_BIT_INDEX;
+		vcpu_id = ffs64(dmask)) {
 		bitmap_clear(vcpu_id, &dmask);
 		vlapic = vm_lapic_from_vcpu_id(vm, vcpu_id);
 		error = vlapic_trigger_lvt(vlapic, vector);

--- a/hypervisor/debug/serial.c
+++ b/hypervisor/debug/serial.c
@@ -143,8 +143,9 @@ uint32_t serial_get_rx_data(uint32_t uart_handle)
 		return 0U;
 
 	/* Place all the data available in RX FIFO, in circular buffer */
-	while ((data_avail = uart->tgt_uart->rx_data_is_avail(
-				uart->tgt_uart, &lsr_reg)) != 0) {
+	data_avail = uart->tgt_uart->rx_data_is_avail(
+				uart->tgt_uart, &lsr_reg);
+	while (data_avail != 0) {
 
 		/* Read the byte */
 		uart->tgt_uart->read(uart->tgt_uart, (void *)&ch, &bytes_read);
@@ -178,6 +179,8 @@ uint32_t serial_get_rx_data(uint32_t uart_handle)
 		}
 		/* Update the total bytes read */
 		total_bytes_read += bytes_read;
+		data_avail = uart->tgt_uart->rx_data_is_avail(
+				uart->tgt_uart, &lsr_reg);
 	}
 	return total_bytes_read;
 }


### PR DESCRIPTION
The assigment should be done outside while loop condition. To fix
it, one assigment initializaion and update statement of for loop
have been applied. The only while loop reminds to avoid very long
for loop expression.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>