### PR TITLE
HV: printf.c: Do not return expression contains subexpression

### DIFF
--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -23,7 +23,8 @@ static int charout(int cmd, const char *s, int sz, void *hnd)
 		else
 			s += console_write(s, sz);
 
-		return (*nchars += (s - p));
+		*nchars += (s - p);
+		return *nchars;
 	}
 	/* fill mode */
 	else {


### PR DESCRIPTION
Operation should be done outside return expression. Moved the assignment out from return expression.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>