### PR TITLE
vioapic.c: Using suffix rather than casting

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -330,7 +330,7 @@ vioapic_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 		last = vioapic->rtbl[pin].reg;
 
 		data64 = (uint64_t)data << lshift;
-		mask64 = (uint64_t)0xffffffff << lshift;
+		mask64 = 0xffffffffUL << lshift;
 		new = last & (~mask64 | RTBL_RO_BITS);
 		new |= data64 & ~RTBL_RO_BITS;
 


### PR DESCRIPTION
Using suffix "UL" rather than type casting 0xffffffff.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>