### PR TITLE
HV: Assignment should not mix with operator

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -255,8 +255,10 @@ uint16_t __attribute__((weak)) parse_madt(uint8_t *lapic_id_base)
 	static const uint8_t lapic_id[] = {0U, 2U, 4U, 6U};
 	uint32_t i;
 
-	for (i = 0U; i < ARRAY_SIZE(lapic_id); i++)
-		*lapic_id_base++ = lapic_id[i];
+	for (i = 0U; i < ARRAY_SIZE(lapic_id); i++) {
+		*lapic_id_base = lapic_id[i];
+		lapic_id_base++;
+	}
 
 	return ((uint16_t)ARRAY_SIZE(lapic_id));
 }
@@ -279,8 +281,10 @@ static void init_phy_cpu_storage(void)
 	pcpu_num = parse_madt(lapic_id_base);
 	alloc_phy_cpu_data(pcpu_num);
 
-	for (i = 0U; i < pcpu_num; i++)
-		per_cpu(lapic_id, i) = *lapic_id_base++;
+	for (i = 0U; i < pcpu_num; i++) {
+		per_cpu(lapic_id, i) = *lapic_id_base;
+		lapic_id_base++;
+	}
 
 	/* free memory after lapic_id are saved in per_cpu data */
 	free((void *)lapic_id_base);

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -68,7 +68,8 @@ static inline int set_vcpuid_entry(struct vm *vm,
 		return -ENOMEM;
 	}
 
-	tmp = &vm->vcpuid_entries[vm->vcpuid_entry_nr++];
+	tmp = &vm->vcpuid_entries[vm->vcpuid_entry_nr];
+	vm->vcpuid_entry_nr++;
 	(void)memcpy_s(tmp, entry_size, entry, entry_size);
 	return 0;
 }

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -236,7 +236,8 @@ static uint16_t _parse_madt(void *madt, uint8_t *lapic_id_base)
 		if (entry->type == ACPI_MADT_TYPE_LOCAL_APIC) {
 			processor = (struct acpi_madt_local_apic *)entry;
 			if ((processor->lapic_flags & ACPI_MADT_ENABLED) != 0U) {
-				*lapic_id_base++ = processor->id;
+				*lapic_id_base = processor->id;
+				lapic_id_base++;
 				pcpu_id++;
 			}
 		}

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -358,8 +358,10 @@ void vuart_console_rx_chars(uint32_t serial_handle)
 		}
 		if (vu->active != false) {
 			buf_idx = 0;
-			while (buf_idx < vbuf_len)
-				fifo_putchar(&vu->rxfifo, buffer[buf_idx++]);
+			while (buf_idx < vbuf_len) {
+				fifo_putchar(&vu->rxfifo, buffer[buf_idx]);
+				buf_idx++;
+			}
 
 			uart_toggle_intr(vu);
 		}

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -366,7 +366,9 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
         /*small data block*/
         if (slen < 8U) {
                 while (slen != 0U) {
-                        *dest8++ = *src8++;
+                        *dest8 = *src8;
+                        dest8++;
+                        src8++;
                         slen--;
                 }
 
@@ -375,8 +377,11 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
 
         /*make sure 8bytes-aligned for at least one addr.*/
         if ((!MEM_ALIGNED_CHECK(src8, 8)) && (!MEM_ALIGNED_CHECK(dest8, 8))) {
-                for (; slen != 0U && (((uint64_t)src8) & 7UL) != 0UL; slen--)
-                        *dest8++ = *src8++;
+                for (; slen != 0U && (((uint64_t)src8) & 7UL) != 0UL; slen--) {
+                        *dest8 = *src8;
+                        dest8++;
+                        src8++;
+                }
         }
 
         /*copy main data blocks, with rep prefix*/
@@ -393,7 +398,9 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
 
         /*tail bytes*/
         while (slen != 0U) {
-                *dest8++ = *src8++;
+                *dest8 = *src8;
+                dest8++;
+                src8++;
                 slen--;
         }
 
@@ -413,8 +420,10 @@ void *memset(void *base, uint8_t v, size_t n)
 
         /*do the few bytes to get uint64_t alignment*/
         count = n;
-        for (; count != 0U && ((uint64_t)dest_p & 7UL) != 0UL; count--)
-                *dest_p++ = v;
+        for (; count != 0U && ((uint64_t)dest_p & 7UL) != 0UL; count--) {
+                *dest_p = v;
+                dest_p++;
+        }
 
         /*64-bit mode*/
         n_q = count >> 3U;

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -93,8 +93,10 @@ static const char *get_int(const char *s, int *x)
 	}
 
 	/* parse uint32_teger */
-	while ((*s >= '0') && (*s <= '9'))
-		*x = *x * 10 + (*s++ - '0');
+	while ((*s >= '0') && (*s <= '9')) {
+		*x = *x * 10 + (*s - '0');
+		s++;
+	}
 
 	/* apply sign to result */
 	if (negative != 0)
@@ -358,7 +360,8 @@ static int print_decimal(struct print_param *param, int64_t value)
 	while (v.dwords.high != 0U) {
 		/* determine digits from right to left */
 		udiv64(v.qword, 10, &d);
-		*--pos = d.r.dwords.low + '0';
+		pos--;
+		*pos = d.r.dwords.low + '0';
 		v.qword = d.q.qword;
 	}
 
@@ -472,7 +475,8 @@ int do_print(const char *fmt, struct print_param *param,
 		/* continue only if the '%' character was found */
 		if (*fmt == '%') {
 			/* mark current position in the format string */
-			start = fmt++;
+			start = fmt;
+			fmt++;
 
 			/* initialize the variables for the next argument */
 			(void)memset(&(param->vars), 0, sizeof(param->vars));
@@ -497,7 +501,8 @@ int do_print(const char *fmt, struct print_param *param,
 
 			fmt = get_length_modifier(fmt, &(param->vars.flags),
 						&(param->vars.mask));
-			ch = *fmt++;
+			ch = *fmt;
+			fmt++;
 
 			/* a single '%'? => print out a single '%' */
 			if (ch == '%') {

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -101,7 +101,8 @@ uint64_t strtoul_hex(const char *nptr)
 	 * See strtol for comments as to the logic used.
 	 */
 	do {
-		c = *s++;
+		c = *s;
+		s++;
 	} while (ISSPACE(c));
 
 	if (c == '0' && (*s == 'x' || *s == 'X')) {


### PR DESCRIPTION
Removed the postfix and prefix operation in assignment expression.
Noncompliant code example:
1) *a++ = *b ++;
2) a = arr[--b];

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>