### PR TITLE
Dm lanuch

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -122,7 +122,8 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   -B "root=/dev/vda2 rw rootwait maxcpus=$2 nohpet console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 i915.enable_guc_loading=0 \
-  i915.enable_hangcheck=0 i915.nuclear_pageflip=1" $vm_name
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 \
+  i915.enable_guc_submission=0" $vm_name
 }
 
 function launch_android()
@@ -242,7 +243,7 @@ fi
 kernel_cmdline_generic="maxcpus=$2 nohpet tsc=reliable intel_iommu=off \
    androidboot.serialno=$ser \
    i915.enable_rc6=1 i915.enable_fbc=1 i915.enable_guc_loading=0 i915.avail_planes_per_pipe=$4 \
-   i915.enable_hangcheck=0 use_nuclear_flip=1"
+   i915.enable_hangcheck=0 use_nuclear_flip=1 i915.enable_guc_submission=0"
 
 boot_dev_flag=",b"
 if [ $6 == 1 ];then

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -29,7 +29,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \
-  i915.enable_hangcheck=0 i915.nuclear_pageflip=1" $vm_name
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0" $vm_name
 }
 
 launch_clear 2 1 "64 448 8" 0x070F00 clear

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -29,7 +29,8 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \
-  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0" $vm_name
+  i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0 \
+  i915.enable_guc_submission=0" $vm_name
 }
 
 launch_clear 2 1 "64 448 8" 0x070F00 clear


### PR DESCRIPTION
Add the boot option if i915 guc for UOS. 
One is to fix the incorrect memory allocation on UOS
Another is to disable the guc_submission explicitly so that it is aligned with SOS.