### PR TITLE
Refine Intel Apollo Lake xHCI DRD emulation.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -366,6 +366,8 @@ struct pci_xhci_vdev {
 	struct pci_xhci_dev_emu  **devices; /* XHCI[port] = device */
 	struct pci_xhci_dev_emu  **slots;   /* slots assigned from 1 */
 	int		ndevices;
+	uint16_t	pid;
+	uint16_t	vid;
 
 	void		*excap_ptr;
 	int (*excap_write)(struct pci_xhci_vdev *, uint64_t, uint64_t);
@@ -3447,6 +3449,8 @@ pci_xhci_parse_extcap(struct pci_xhci_vdev *xdev, char *opts)
 	if (!strncmp(cap, "apl", 3)) {
 		xdev->excap_write = pci_xhci_apl_drdregs_write;
 		xdev->excap_ptr = excap_group_apl;
+		xdev->vid = XHCI_PCI_VENDOR_ID_INTEL;
+		xdev->pid = XHCI_PCI_DEVICE_ID_INTEL_APL;
 	} else
 		rc = -2;
 
@@ -3575,6 +3579,9 @@ pci_xhci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 	xdev->excap_ptr = excap_group_dft;
 
+	xdev->vid = XHCI_PCI_DEVICE_ID_DFLT;
+	xdev->pid = XHCI_PCI_VENDOR_ID_DFLT;
+
 	/* discover devices */
 	error = pci_xhci_parse_opts(xdev, opts);
 	if (error < 0)
@@ -3639,8 +3646,8 @@ pci_xhci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	 */
 	xdev->hccparams1 |= XHCI_SET_HCCP1_XECP(XHCI_EXCAP_PTR);
 
-	pci_set_cfgdata16(dev, PCIR_DEVICE, 0x1E31);
-	pci_set_cfgdata16(dev, PCIR_VENDOR, 0x8086);
+	pci_set_cfgdata16(dev, PCIR_DEVICE, xdev->pid);
+	pci_set_cfgdata16(dev, PCIR_VENDOR, xdev->vid);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_SERIALBUS);
 	pci_set_cfgdata8(dev, PCIR_SUBCLASS, PCIS_SERIALBUS_USB);
 	pci_set_cfgdata8(dev, PCIR_PROGIF, PCIP_SERIALBUS_USB_XHCI);

--- a/devicemodel/include/xhcireg.h
+++ b/devicemodel/include/xhcireg.h
@@ -253,12 +253,6 @@
 /* Intel APL xHCI DRD Configuration registers */
 #define	XHCI_DRD_MUX_CFG0		0x0000
 #define	XHCI_DRD_MUX_CFG1		0x0004
-#define	XCHI_DRD_CFG0_MODE_MASK		0x0003
-#define	XHCI_DRD_CFG0_DYN		0
-#define	XHCI_DRD_CFG0_HOST_MODE		1
-#define	XHCI_DRD_CFG0_DEV_MODE		2
-#define	XHCI_DRD_CFG0_SYNC		(1 << 2)
-#define	XHCI_DRD_CFG0_SWITCH_EN		(1 << 16)
 #define	XHCI_DRD_CFG0_IDPIN		(1 << 20)
 #define	XHCI_DRD_CFG0_IDPIN_EN		(1 << 21)
 #define	XHCI_DRD_CFG0_VBUS_VALID	(1 << 24)
@@ -269,15 +263,16 @@
 #define	XHCI_APL_DRDREGS_BASE		0x80D8
 
 /* setting drd for host mode */
-#define	XHCI_NATIVE_DRD_DEV_MODE	"D"
+#define	XHCI_NATIVE_DRD_DEV_MODE	"device"
 
 /* setting drd for device mode */
-#define	XHCI_NATIVE_DRD_HOST_MODE	"H"
+#define	XHCI_NATIVE_DRD_HOST_MODE	"host"
 #define	XHCI_NATIVE_DRD_SWITCH_PATH	\
-	"/sys/devices/platform/intel_usb_dr_phy.0/mux_state"
+	"/sys/class/usb_role/intel_xhci_usb_sw-role-switch/role"
 
 /* return value after setting drd device node */
-#define	XHCI_NATIVE_DRD_WRITE_SZ	2
+#define	XHCI_NATIVE_DRD_WRITE_DEV_SZ	(sizeof(XHCI_NATIVE_DRD_DEV_MODE) - 1)
+#define	XHCI_NATIVE_DRD_WRITE_HOST_SZ	(sizeof(XHCI_NATIVE_DRD_HOST_MODE) - 1)
 
 /* XHCI register R/W wrappers */
 #define	XREAD1(sc, what, a) \

--- a/devicemodel/include/xhcireg.h
+++ b/devicemodel/include/xhcireg.h
@@ -240,6 +240,16 @@
 #define	EXCAP_GROUP_END		0xFFFF
 #define	EXCAP_GROUP_NULL	NULL
 
+/* xHCI PCI Vendor IDs */
+#define	XHCI_PCI_VENDOR_ID_INTEL	0x8086
+
+/* xHCI PCI Device IDs */
+#define	XHCI_PCI_DEVICE_ID_INTEL_APL	0x5aa8
+
+/* Default xHCI PCI VID/PID */
+#define	XHCI_PCI_VENDOR_ID_DFLT		XHCI_PCI_VENDOR_ID_INTEL
+#define	XHCI_PCI_DEVICE_ID_DFLT		0x1e31
+
 /* Intel APL xHCI DRD Configuration registers */
 #define	XHCI_DRD_MUX_CFG0		0x0000
 #define	XHCI_DRD_MUX_CFG1		0x0004


### PR DESCRIPTION
Change xHCI DRD mode switch path and operational model in DRD emulation
followed with DRD driver change in linux kernel. And make xHCI VID and
PID parameters scalable with different platforms.

Liang Yang (2):
  DM USB: xHCI: Set correct PCI VID/PID for APL DRD cap.
  DM USB: xHCI: Update the native DRD interfaces.