### PR TITLE
[REVERT-ME]: disable turbo mode

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -368,6 +368,7 @@ static void get_cpu_name(void)
 void bsp_boot_init(void)
 {
 	uint64_t rsp;
+	uint64_t misc_en;
 
 	start_tsc = rdtsc();
 
@@ -435,6 +436,10 @@ void bsp_boot_init(void)
 		"run_context ia32_spec_ctrl offset not match");
 
 	__bitmap_set(BOOT_CPU_ID, &pcpu_active_bitmap);
+
+	misc_en = msr_read(MSR_IA32_MISC_ENABLE);
+	if ((misc_en & TURBO_MODE_DISABLE) == 0)
+		msr_write(MSR_IA32_MISC_ENABLE, misc_en | TURBO_MODE_DISABLE);
 
 	/* Get CPU capabilities thru CPUID, including the physical address bit
 	 * limit which is required for initializing paging.
@@ -563,6 +568,7 @@ static void bsp_boot_post(void)
 void cpu_secondary_init(void)
 {
 	uint64_t rsp;
+	uint64_t misc_en;
 
 	/* Switch this CPU to use the same page tables set-up by the
 	 * primary/boot CPU
@@ -580,6 +586,10 @@ void cpu_secondary_init(void)
 			      CPU_STATE_INITIALIZING);
 
 	__bitmap_set(get_cpu_id(), &pcpu_active_bitmap);
+
+	misc_en = msr_read(MSR_IA32_MISC_ENABLE);
+	if ((misc_en & TURBO_MODE_DISABLE) == 0)
+		msr_write(MSR_IA32_MISC_ENABLE, misc_en | TURBO_MODE_DISABLE);
 
 	/* Switch to run-time stack */
 	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -554,4 +554,7 @@
 #define SPEC_ENABLE_STIBP		(1U<<1)
 #define PRED_SET_IBPB			(1U<<0)
 
+/* Turbo config bit */
+#define TURBO_MODE_DISABLE		(1UL<<38)
+
 #endif /* MSR_H */


### PR DESCRIPTION
there is a bug for system hang on SBL bootloader after we enabled turbo mode.
so add tmp patch to disable turbo mode as the work-around.
after SBL fixed it, we revert this patch.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>