### PR TITLE
Documentation: update to Clear Linux version 53210 for v0.1

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -36,13 +36,13 @@ on your platform. You'll need a network connection for your platform to
 complete this setup.
 
 .. note::
-   ACRN requires Clear Linux version 22140 or newer. The instructions below
-   have been validated with version 22140 and need some adjustment to work
+   ACRN requires Clear Linux version 23510 or newer. The instructions below
+   have been validated with version 23510 and need some adjustment to work
    with newer versions. You will see a note when the instruction needs to be
    adjusted.
 
 #. Download the compressed Clear installer image from
-   https://download.clearlinux.org/releases/22140/clear/clear-22140-installer.img.xz
+   https://download.clearlinux.org/releases/23510/clear/clear-23510-installer.img.xz
    and follow the `Clear Linux installation guide
    <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install>`__
    as a starting point for installing Clear Linux onto your platform.  Follow the recommended
@@ -99,9 +99,9 @@ partition. Follow these steps:
 
       # ls -1 /mnt/EFI/org.clearlinux
       bootloaderx64.efi
-      kernel-org.clearlinux.native.4.16.6-563
-      kernel-org.clearlinux.pk414-sos.4.14.34-28
-      kernel-org.clearlinux.pk414-standard.4.14.34-28
+      kernel-org.clearlinux.native.4.17.4-589
+      kernel-org.clearlinux.pk414-sos.4.14.51-60
+      kernel-org.clearlinux.pk414-standard.4.14.51-60
       loaderx64.efi
 
    .. note::
@@ -185,7 +185,7 @@ partition. Follow these steps:
 
    A starter acrn.conf configuration file is included in the Clear Linux release and is
    also available in the acrn-hypervisor/hypervisor GitHub repo as `acrn.conf
-   <https://github.com/projectacrn/acrn-hypervisor/hypervisor/tree/master/bsp/uefi/clearlinux/acrn.conf>`__
+   <https://github.com/projectacrn/acrn-hypervisor/blob/v0.1/hypervisor/bsp/uefi/clearlinux/acrn.conf>`_
    as shown here:
 
    .. literalinclude:: ../../hypervisor/bsp/uefi/clearlinux/acrn.conf
@@ -255,7 +255,7 @@ Set up Reference UOS
    .. code-block:: none
 
       # cd ~
-      # curl -O https://download.clearlinux.org/releases/22140/clear/clear-22140-kvm.img.xz
+      # curl -O https://download.clearlinux.org/releases/23510/clear/clear-23510-kvm.img.xz
 
    .. note::
       In case you want to use or try out a newer version of Clear Linux as the UOS, you can
@@ -266,16 +266,16 @@ Set up Reference UOS
 
    .. code-block:: none
 
-      # unxz clear-22140-kvm.img.xz
+      # unxz clear-23510-kvm.img.xz
 
 #. Deploy the UOS kernel modules to UOS virtual disk image (note: you'll need to use
    the same **standard** image version number noted in step 1 above):
 
    .. code-block:: none
 
-      # losetup -f -P --show /root/clear-22140-kvm.img
+      # losetup -f -P --show /root/clear-23510-kvm.img
       # mount /dev/loop0p3 /mnt
-      # cp -r /usr/lib/modules/4.14.34-28.pk414-standard /mnt/lib/modules/
+      # cp -r /usr/lib/modules/4.14.51-60.pk414-standard /mnt/lib/modules/
       # umount /mnt
       # sync
 
@@ -294,7 +294,7 @@ Set up Reference UOS
 
    .. note::
       In case you have downloaded a different Clear Linux image than the one above
-      (``clear-22140-kvm.img.xz``), you will need to modify the Clear Linux file name
+      (``clear-23510-kvm.img.xz``), you will need to modify the Clear Linux file name
       and version number highlighted above (the ``-s 3,virtio-blk`` argument) to match
       what you have downloaded above. Likewise, you may need to adjust the kernel file
       name on the second line highlighted (check the exact name to be used using:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,8 +12,8 @@ embedded development through an open source platform. Check out the
 :ref:`introduction` for more information.
 
 The project ACRN reference code can be found on GitHub in
-https://github.com/projectacrn.  It includes the ACRN hypervisor, the
-ACRN device model, and documentation.
+`https://github.com/projectacrn/acrn-hypervisor`_.  It includes the
+ACRN hypervisor, the ACRN device model, ACRN tools, and documentation.
 
 ACRN's key features include:
 
@@ -28,9 +28,15 @@ This version 0.1 release has the following software components:
 
 * The ACRN Hypervisor
 * The ACRN Device Model
+* The ACRN Graphics Sharing (GVT-g)
 * The ACRN Virtio framework
 * The ACRN Block, NIC, and console Virtio drivers
-* The ACRN Virtio Backend Service(VBS) and the Virtio and Hypervisor Service Module (VHM).
+* The ACRN Virtio Backend Service(VBS) and the Virtio and Hypervisor
+  Service Module (VHM)
+* The ACRN tools
+
+The Service OS and User OS are based on `Clear Linux <https://clearlinux.org/>`_
+version 23510.
 
 Version 0.1 features include:
 
@@ -50,21 +56,17 @@ Version 0.1 features include:
 - audio pass-thru
 - surface sharing
 - multi-plane, multi-pipe
-- HDMI
-- eDP
+- HDMI, eDP
 
 Known Issues
 ============
 
-* GPU - Preemption (Prioritized Rendering,
-* Batch Preemption, QoS Rendering)
+* GPU - Preemption (Prioritized Rendering, Batch Preemption, QoS Rendering)
 * Preemption feature works, but performance is not optimized yet.
 * Wifi not supported in guest OS
 * Audio pass-through to guest OS, but can only be validated on driver level
   using command line or alsa-player, and only supports limited formats
 * CSME pass-through to guest OS
 * GVT-g is available, need to perform features after configured properly
-* Camera works in Android guest. But camera app may crash after 5 mins
-* SD card works in Android guest, but does not support hot-plug.
 * Surface Sharing: Sometimes the window setup on Service OS takes up to 30 second
 * Sometimes system hangs, especially when workload is high (e.g. running benchmarks, playing videos)

--- a/hypervisor/bsp/uefi/clearlinux/acrn.conf
+++ b/hypervisor/bsp/uefi/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title The ACRN Service OS
-linux   /EFI/org.clearlinux/kernel-org.clearlinux.pk414-sos.4.14.23-19
+linux   /EFI/org.clearlinux/kernel-org.clearlinux.pk414-sos.4.14.51-60
 options pci_devices_ignore=(0:18:2) maxcpus=1 console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_initial_modeset=1 hvlog=2M@0x1FE00000


### PR DESCRIPTION
The Clear Linux version validated with ACRN v0.1 is 23510. This
updates the Getting Started Guide and Release Notes with the
relevant version numbers, both for the Clear Linux image and
kernels used.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>