### PR TITLE
Dockerfile: remove security by-pass in Clear Linux Dockerfile

### DIFF
--- a/.travis-dockerfiles/Dockerfile.clearlinux
+++ b/.travis-dockerfiles/Dockerfile.clearlinux
@@ -5,9 +5,6 @@ RUN swupd bundle-add -b os-clr-on-clr python3-basic
 
 RUN pip3 install kconfiglib
 
-RUN mkdir -p /usr/local/bin
-RUN git config --global http.sslVerify false
-
 WORKDIR /root/acrn
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
"RUN git config --global http.sslVerify false" was needed with
a cloud-based CI system else it failed to clone the repository.

The project does not use that cloud-based CI system and hence
this workaround (security by-pass) is not needed.

Fix #654 

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>