### PR TITLE
HV: build: make relocation-related code configurable

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -63,12 +63,14 @@ LDFLAGS += -Wl,--gc-sections -nostartfiles -nostdlib
 LDFLAGS += -Wl,-n,-z,max-page-size=0x1000
 LDFLAGS += -Wl,-z,noexecstack
 
+ifeq (y, $(CONFIG_RELOC))
 # on X86_64, when build with "-pie", GCC fails on linking R_X86_64_32
 # relocations with "recompile with fPIC" error, because it may cause
 # run-time relocation overflow if it runs at address above 4GB.
 # We know it's safe because Hypervisor runs under 4GB. "noreloc-overflow"
 # is used to avoid the compile error
 LDFLAGS += -pie -z noreloc-overflow
+endif
 
 ARCH_CFLAGS += -gdwarf-2
 ARCH_ASFLAGS += -gdwarf-2 -DASSEMBLER=1

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -123,3 +123,7 @@ config UEFI_OS_LOADER_NAME
 config MTRR_ENABLED
 	bool
 	default y
+
+config RELOC
+	bool "Enable relocation"
+	default n

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -68,6 +68,7 @@ static uint64_t trampoline_relo_addr(void *addr)
 	return (uint64_t)addr - get_hv_image_delta();
 }
 
+#ifdef CONFIG_RELOC
 void _relocate(void)
 {
 	struct Elf64_Dyn *dyn;
@@ -136,6 +137,11 @@ void _relocate(void)
 		start = (struct Elf64_Rel *)((char *)start + size);
 	}
 }
+#else
+void _relocate(void)
+{
+}
+#endif
 
 uint64_t read_trampoline_sym(void *sym)
 {


### PR DESCRIPTION
The relocation feature relies on the ld option "-z noreloc-overflow" which is
only available for binutils >= 2.27, while on Ubuntu 16.04 or older the default
version of binutils is 2.26.

This patch wraps the relocation code with a configurable macro and make it
undefined by default to avoid default build failures.

NOTE: This is just a hotfix. The code dropped with undefined CONFIG_RELOC needs
to be reviewed by the original author of this feature. Checks to the binutils
version will also follow up.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>