### PR TITLE
 tools:acrn-crashlog: Detect and classify the crash in ACRN and kernel

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/android_events.c
+++ b/tools/acrn-crashlog/acrnprobe/android_events.c
@@ -400,6 +400,7 @@ static void get_last_line_synced(const struct sender_t *sender)
 	int sid;
 	int ret;
 	struct vm_t *vm;
+	char *p;
 	char vmkey[ANDROID_WORD_LEN];
 	char vm_name[32];
 
@@ -438,6 +439,9 @@ static void get_last_line_synced(const struct sender_t *sender)
 			     strerror(errno));
 			continue;
 		}
+		p = strchr(vmkey, ' ');
+		if (p)
+			*p = 0;
 
 		ret = refresh_key_synced_stage1(sender, vm, vmkey, MM_ONLY);
 		if (ret < 0) {

--- a/tools/acrn-crashlog/acrnprobe/history.c
+++ b/tools/acrn-crashlog/acrnprobe/history.c
@@ -118,7 +118,7 @@ void hist_raise_event(char *event, char *type, char *log, char *lastuptime,
 		char *key)
 {
 	char line[MAXLINESIZE];
-	char eventtime[32];
+	char eventtime[LONG_TIME_SIZE];
 	struct sender_t *crashlog;
 	int maxlines;
 	int ret;
@@ -158,7 +158,7 @@ void hist_raise_event(char *event, char *type, char *log, char *lastuptime,
 
 void hist_raise_uptime(char *lastuptime)
 {
-	char boot_time[24];
+	char boot_time[UPTIME_SIZE];
 	char firstline[MAXLINESIZE];
 	int hours;
 	int ret;

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -65,8 +65,8 @@ struct crash_t {
 
 	int wd;
 	int level;
-	struct crash_t *(*reclassify)(struct crash_t *, char*, char**, char**,
-				char**);
+	struct crash_t *(*reclassify)(const struct crash_t *, const char*,
+					char**, char**, char**);
 };
 
 struct info_t {

--- a/tools/acrn-crashlog/acrnprobe/include/probeutils.h
+++ b/tools/acrn-crashlog/acrnprobe/include/probeutils.h
@@ -22,6 +22,9 @@
 #ifndef __PROBEUTILS_H__
 #define __PROBEUTILS_H__
 
+#define UPTIME_SIZE 24
+#define LONG_TIME_SIZE 32
+
 enum e_dir_mode {
 	MODE_CRASH = 0,
 	MODE_STATS,

--- a/tools/acrn-crashlog/acrnprobe/include/probeutils.h
+++ b/tools/acrn-crashlog/acrnprobe/include/probeutils.h
@@ -40,5 +40,6 @@ void generate_crashfile(char *dir, char *event, char *hashkey,
 			char *type, char *data0,
 			char *data1, char *data2);
 char *generate_log_dir(enum e_dir_mode mode, char *hashkey);
+int is_boot_id_changed(void);
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/startupreason.h
+++ b/tools/acrn-crashlog/acrnprobe/include/startupreason.h
@@ -19,4 +19,6 @@
  * limitations under the License.
  */
 
-extern void read_startupreason(char *startupreason);
+#define REBOOT_REASON_SIZE 32
+
+extern void read_startupreason(char *startupreason, const size_t limit);

--- a/tools/acrn-crashlog/acrnprobe/probeutils.c
+++ b/tools/acrn-crashlog/acrnprobe/probeutils.c
@@ -50,7 +50,7 @@ unsigned long long get_uptime(void)
 	return time_ns;
 }
 
-int get_uptime_string(char newuptime[24], int *hours)
+int get_uptime_string(char *newuptime, int *hours)
 {
 	long long tm;
 	int seconds, minutes;
@@ -68,11 +68,11 @@ int get_uptime_string(char newuptime[24], int *hours)
 	/* hours */
 	*hours /= 60;
 
-	return snprintf(newuptime, 24, "%04d:%02d:%02d", *hours,
+	return snprintf(newuptime, UPTIME_SIZE, "%04d:%02d:%02d", *hours,
 			minutes, seconds);
 }
 
-int get_current_time_long(char buf[32])
+int get_current_time_long(char *buf)
 {
 	time_t t;
 	struct tm *time_val;
@@ -82,7 +82,7 @@ int get_current_time_long(char buf[32])
 	if (!time_val)
 		return -1;
 
-	return strftime(buf, 32, "%Y-%m-%d/%H:%M:%S  ", time_val);
+	return strftime(buf, LONG_TIME_SIZE, "%Y-%m-%d/%H:%M:%S  ", time_val);
 }
 
 /**
@@ -348,16 +348,18 @@ void generate_crashfile(char *dir, char *event, char *hashkey,
 {
 	char *buf;
 	char *path;
-	char datetime[32];
-	char uptime[32];
+	char datetime[LONG_TIME_SIZE];
+	char uptime[UPTIME_SIZE];
 	int hours;
 	int ret;
 	const int fmtsize = 128;
 	int filesize;
 
+	datetime[0] = 0;
 	ret = get_current_time_long(datetime);
 	if (ret <= 0)
 		return;
+	uptime[0] = 0;
 	get_uptime_string(uptime, &hours);
 
 	filesize = fmtsize + strlen(event) +

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -601,7 +601,7 @@ static void telemd_send_reboot(void)
 {
 	struct sender_t *telemd;
 	char *class;
-	char reason[MAXLINESIZE];
+	char reason[REBOOT_REASON_SIZE];
 	int ret;
 
 	telemd = get_sender_by_name("telemd");
@@ -627,7 +627,7 @@ static void telemd_send_reboot(void)
 		free(content);
 	}
 
-	read_startupreason(reason);
+	read_startupreason(reason, sizeof(reason));
 	ret = asprintf(&class, "clearlinux/reboot/%s", reason);
 	if (ret < 0) {
 		LOGE("compute string failed, out of memory\n");
@@ -952,7 +952,7 @@ static void crashlog_send_uptime(void)
 
 static void crashlog_send_reboot(void)
 {
-	char reason[MAXLINESIZE];
+	char reason[REBOOT_REASON_SIZE];
 	char *key;
 	struct sender_t *crashlog;
 
@@ -972,7 +972,7 @@ static void crashlog_send_reboot(void)
 		free(key);
 	}
 
-	read_startupreason(reason);
+	read_startupreason(reason, sizeof(reason));
 	key = generate_event_id("REBOOT", reason);
 	if (key == NULL) {
 		LOGE("generate event id failed, error (%s)\n",

--- a/tools/acrn-crashlog/common/cmdutils.c
+++ b/tools/acrn-crashlog/common/cmdutils.c
@@ -35,7 +35,7 @@
  *	   If all system calls succeed, then the return value is the
  *	   termination status of the child process used to execute command.
  */
-int execv_out2file(char *argv[], char *outfile)
+int execv_out2file(char * const argv[], const char *outfile)
 {
 	pid_t pid;
 
@@ -103,13 +103,13 @@ int execv_out2file(char *argv[], char *outfile)
 	return -1;
 }
 
-int debugfs_cmd(char *loop_dev, char *cmd, char *outfile)
+int debugfs_cmd(const char *loop_dev, const char *cmd, const char *outfile)
 {
-	char *argv[5] = {"debugfs", "-R", NULL, NULL, 0};
+	const char *argv[5] = {"debugfs", "-R", NULL, NULL, 0};
 
 	argv[2] = cmd;
 	argv[3] = loop_dev;
-	return  execv_out2file(argv, outfile);
+	return  execv_out2file((char * const *)argv, outfile);
 }
 
 /**
@@ -128,7 +128,7 @@ int debugfs_cmd(char *loop_dev, char *cmd, char *outfile)
  *	   If all system calls succeed, then the return value is the
  *	   termination status of the child process used to execute command.
  */
-int exec_out2file(char *outfile, char *fmt, ...)
+int exec_out2file(const char *outfile, const char *fmt, ...)
 {
 	va_list args;
 	char *cmd;
@@ -184,7 +184,7 @@ int exec_out2file(char *outfile, char *fmt, ...)
  *
  * @return a pointer to command's output if successful, or NULL if not.
  */
-char *exec_out2mem(char *fmt, ...)
+char *exec_out2mem(const char *fmt, ...)
 {
 	va_list args;
 	char *cmd;

--- a/tools/acrn-crashlog/common/include/cmdutils.h
+++ b/tools/acrn-crashlog/common/include/cmdutils.h
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-int execv_out2file(char *argv[], char *outfile);
-int debugfs_cmd(char *loop_dev, char *cmd, char *outfile);
-int exec_out2file(char *outfile, char *fmt, ...);
-char *exec_out2mem(char *fmt, ...);
+int execv_out2file(char * const argv[], const char *outfile);
+int debugfs_cmd(const char *loop_dev, const char *cmd, const char *outfile);
+int exec_out2file(const char *outfile, const char *fmt, ...);
+char *exec_out2mem(const char *fmt, ...);

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -75,7 +75,7 @@ int mkdir_p(char *path);
 int mm_count_lines(struct mm_file_t *mfile);
 struct mm_file_t *mmap_file(const char *path);
 void unmap_file(struct mm_file_t *mfile);
-int do_copy_tail(char *src, char *dest, int limit);
+int do_copy_tail(const char *src, const char *dest, int limit);
 int do_mv(char *src, char *dest);
 int append_file(char *filename, char *text);
 int mm_replace_str_line(struct mm_file_t *mfile, char *replace,
@@ -97,10 +97,20 @@ int file_read_key_value(const char *path, const char *key,
 			const size_t limit, char *value);
 int file_read_key_value_r(const char *path, const char *key,
 			const size_t limit, char *value);
-int dir_contains(const char *dir, const char *filename, int exact,
-		char *fullname);
+int ac_scandir(const char *dirp, struct dirent ***namelist,
+		int (*filter)(const struct dirent *, const void *),
+		const void *farg,
+		int (*compar)(const struct dirent **,
+				const struct dirent **));
+int filter_filename_substr(const struct dirent *entry, const void *arg);
+int filter_filename_exactly(const struct dirent *entry, const void *arg);
+int filter_filename_startswith(const struct dirent *entry,
+					const void *arg);
+int dir_contains(const char *dir, const char *filename, int exact);
 int lsdir(const char *dir, char *fullname[], int limit);
 int find_file(char *dir, char *target_file, int depth, char *path[], int limit);
 int read_file(const char *path, unsigned long *size, void **data);
+int is_ac_filefmt(const char *file_fmt);
+int config_fmt_to_files(const char *file_fmt, char ***out);
 
 #endif

--- a/tools/acrn-crashlog/data/acrnprobe.service
+++ b/tools/acrn-crashlog/data/acrnprobe.service
@@ -2,6 +2,7 @@
 Description=ACRN crashlog probe
 Requires=telemd.socket
 Requires=usercrash_s
+After=acrnlog.service
 After=usercrash.service
 After=prepare.service
 

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -77,14 +77,14 @@
 		</log>
 		<log id='5' enable='true'>
 			<name>acrnlog_cur</name>
-			<type>file_rotation</type>
-			<path>/tmp/acrnlog/acrnlog_cur.[biggest]</path>
+			<type>file</type>
+			<path>/tmp/acrnlog/acrnlog_cur.[-1]</path>
 			<lines>500</lines>
 		</log>
 		<log id='6' enable='true'>
 			<name>acrnlog_last</name>
-			<type>file_rotation</type>
-			<path>/tmp/acrnlog/acrnlog_last.[all]</path>
+			<type>file</type>
+			<path>/tmp/acrnlog/acrnlog_last.[*]</path>
 		</log>
 	</logs>
 

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -27,8 +27,8 @@
 	<triggers>
 		<trigger id="1" enable="true">
 			<name>t_pstore</name>
-			<type>file</type>
-			<path>/sys/fs/pstore/console-ramoops</path>
+			<type>node</type>
+			<path>/sys/fs/pstore/console-ramoops-0</path>
 		</trigger>
 		<trigger id="2" enable="true">
 			<name>t_boot</name>
@@ -39,6 +39,15 @@
 			<name>t_usercrash</name>
 			<type>dir</type>
 			<path>/var/log/usercrashes</path>
+		</trigger>
+		<trigger id="4" enable="true">
+			<name>t_rebootreason</name>
+			<type>rebootreason</type>
+		</trigger>
+		<trigger id="5" enable="true">
+			<name>t_acrnlog_last</name>
+			<type>file</type>
+			<path>/tmp/acrnlog/acrnlog_last.[*]</path>
 		</trigger>
 	</triggers>
 
@@ -57,8 +66,8 @@
 	<logs>
 		<log id="1" enable="true">
 			<name>pstore</name>
-			<type>file</type>
-			<path>/sys/fs/pstore/console-ramoops</path>
+			<type>node</type>
+			<path>/sys/fs/pstore/console-ramoops-0</path>
 		</log>
 		<log id='2' enable='true'>
 			<name>kmsg</name>
@@ -90,33 +99,65 @@
 
 	<crashes>
 		<crash id='1' inherit='0' enable='true'>
+			<name>UNKNOWN</name>
+			<trigger>t_rebootreason</trigger>
+			<channel>oneshot</channel>
+			<content id='1'>WARM</content>
+			<log id='1'>pstore</log>
+			<log id='2'>acrnlog_last</log>
+		</crash>
+		<crash id='2' inherit='0' enable='true'>
+			<name>SWWDT_UNHANDLE</name>
+			<trigger>t_rebootreason</trigger>
+			<channel>oneshot</channel>
+			<content id='1'>WATCHDOG</content>
+			<log id='1'>pstore</log>
+			<log id='2'>acrnlog_last</log>
+		</crash>
+		<crash id='3' inherit='0' enable='true'>
+			<name>HWWDT_UNHANDLE</name>
+			<trigger>t_rebootreason</trigger>
+			<channel>oneshot</channel>
+			<content id='1'>GLOBAL</content>
+			<log id='1'>pstore</log>
+			<log id='2'>acrnlog_last</log>
+		</crash>
+		<crash id='4' inherit='1' enable='true'>
+			<name>ACRNCRASH</name>
+			<trigger>t_acrnlog_last</trigger>
+			<content id='1'>= Unhandled exception:</content>
+		</crash>
+		<crash id='5' inherit='1' enable='true'>
 			<name>IPANIC</name>
 			<trigger>t_pstore</trigger>
-			<channel>oneshot</channel>
-			<log id='1'>pstore</log>
+			<content id='1'> </content>
+			<mightcontent expression='1' id='1'>Kernel panic - not syncing:</mightcontent>
+			<mightcontent expression='1' id='2'>BUG: unable to handle kernel</mightcontent>
 			<data id='1'>kernel BUG at</data>
 			<data id='2'>EIP is at</data>
 			<data id='3'>Comm:</data>
 		</crash>
-		<crash id='2' inherit='1' enable='true'>
-			<name>IPANIC_SWWDT</name>
-			<content id='1'>BUG: soft lockup - CPU#</content>
+		<crash id='6' inherit='2' enable='true'>
+			<name>ACRNCRASH</name>
+			<trigger>t_acrnlog_last</trigger>
+			<content id='1'>= Unhandled exception:</content>
 		</crash>
-		<crash id='3' inherit='2' enable='true'>
-			<name>IPANIC_SWWDT_FAKE</name>
-			<mightcontent expression='1' id='1'>EIP: panic_dbg_set</mightcontent>
-			<mightcontent expression='1' id='2'>RIP: panic_dbg_set</mightcontent>
+		<crash id='7' inherit='2' enable='true'>
+			<name>SWWDT_IPANIC</name>
+			<trigger>t_pstore</trigger>
+			<content id='1'> </content>
+			<mightcontent expression='1' id='1'>Kernel panic - not syncing:</mightcontent>
+			<mightcontent expression='1' id='2'>BUG: unable to handle kernel</mightcontent>
+			<data id='1'>kernel BUG at</data>
+			<data id='2'>EIP is at</data>
+			<data id='3'>Comm:</data>
 		</crash>
-		<crash id='4' inherit='0' enable='true'>
+		<crash id='8' inherit='0' enable='true'>
 			<name>USERCRASH</name>
 			<trigger>t_usercrash</trigger>
 			<channel>inotify</channel>
 			<log id='1'>kmsg</log>
 			<log id='2'>syslog</log>
-		</crash>
-		<crash id='5' inherit='1' enable='true'>
-			<name>IPANIC_HWWDT</name>
-			<content id='1'>Watchdog detected hard LOCKUP on cpu</content>
 		</crash>
 	</crashes>
 
@@ -131,7 +172,5 @@
 			<log id='4'>acrnlog_last</log>
 		</info>
 	</infos>
-
-
 
 </conf>


### PR DESCRIPTION
Since ACRN has the capability to reboot and reboot reason is available
in SOS, acrnprobe could detect the crash of acrn and SOS kernel.

List of added crash types:

1. ACRNCRASH		- crashed in hypervisor, this detection depends on
 			  files in /tmp/acrnlog_last(provided by acrnlog).
2. IPANIC		- crashed in SOS kernel, this detection depends on
			  pstore.
3. SWWDT_IPANIC		- crashed in SOS kernel and reboot reason is wdt.
4. HWWDT_UNHANDLE	- only recognize reboot reason is global, there is no
 			  further clues that it's a SOS kernel crash or a
			  hypervisor crash.
5. SWWDT_UNHANDLE	- only recognize reboot reason is wdt, there is no
			  further clues that it's a SOS kernel crash or a
			  hypervisor crash.
 6. UNKNOWN		- only recognize reboot reason is warm, there is no
			  further clues that it's a SOS kernel crash or a
			  hypervisor crash.

