### PR TITLE
hv:fix MISRA-C return value violation

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -296,7 +296,7 @@ void vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code)
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
 }
 
-int vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code)
+void vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code)
 {
 	struct run_context *cur_context =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
@@ -304,7 +304,6 @@ int vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code)
 	cur_context->cr2 = addr;
 	vcpu_queue_exception(vcpu, IDT_PF, err_code);
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
-	return 0;
 }
 
 int interrupt_window_vmexit_handler(struct vcpu *vcpu)

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -127,7 +127,7 @@ static int ptdev_interrupt_handler(__unused int irq, void *data)
 }
 
 /* active intr with irq registering */
-struct ptdev_remapping_info *
+void
 ptdev_activate_entry(struct ptdev_remapping_info *entry, int phys_irq,
 		bool lowpri)
 {
@@ -141,7 +141,6 @@ ptdev_activate_entry(struct ptdev_remapping_info *entry, int phys_irq,
 	entry->node = node;
 
 	atomic_set_int(&entry->active, ACTIVE_FLAG);
-	return entry;
 }
 
 void

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -21,20 +21,18 @@ uint32_t get_serial_handle(void)
 
 static void print_char(char x)
 {
-	serial_puts(serial_handle, &x, 1);
+	(void)serial_puts(serial_handle, &x, 1);
 
 	if (x == '\n') {
-		serial_puts(serial_handle, "\r", 1);
+		(void)serial_puts(serial_handle, "\r", 1);
 	}
 }
 
-int console_init(void)
+void console_init(void)
 {
 	spinlock_init(&lock);
 
 	serial_handle = serial_open("STDIO");
-
-	return 0;
 }
 
 int console_putc(int ch)
@@ -73,7 +71,7 @@ int console_puts(const char *s)
 			}
 
 			/* write all characters up to p */
-			serial_puts(serial_handle, s, p - s);
+			(void)serial_puts(serial_handle, s, p - s);
 
 			res += p - s;
 
@@ -116,7 +114,7 @@ int console_write(const char *s, size_t len)
 			}
 
 			/* write all characters processed so far */
-			serial_puts(serial_handle, s, p - s);
+			(void)serial_puts(serial_handle, s, p - s);
 
 			res += p - s;
 
@@ -156,14 +154,14 @@ void console_dump_bytes(const void *p, unsigned int len)
 		/* print one row as ASCII characters (if possible) */
 		for (i = 0; i < 16; i++) {
 			if ((x[i] < ' ') || (x[i] >= 127)) {
-				console_putc('.');
+				(void)console_putc('.');
 			}
 			else {
-				console_putc(x[i]);
+				(void)console_putc(x[i]);
 			}
 		}
 		/* continue with next row */
-		console_putc('\n');
+		(void)console_putc('\n');
 		/* set pointer one row ahead */
 		x += 16;
 	}
@@ -175,7 +173,7 @@ static void console_read(void)
 
 	if (serial_handle != SERIAL_INVALID_HANDLE) {
 		/* Get all the data available in the RX FIFO */
-		serial_get_rx_data(serial_handle);
+		(void)serial_get_rx_data(serial_handle);
 	}
 
 	spinlock_release(&lock);

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -159,7 +159,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 
 			for (i = 0; i < (msg_len - 1) / LOG_ENTRY_SIZE + 1;
 					i++) {
-				sbuf_put(sbuf, (uint8_t *)buffer +
+				(void)sbuf_put(sbuf, (uint8_t *)buffer +
 							i * LOG_ENTRY_SIZE);
 			}
 		}

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -28,7 +28,7 @@ static int charout(int cmd, const char *s, int sz, void *hnd)
 	/* fill mode */
 		*nchars += sz;
 		while (sz != 0) {
-			console_putc(*s);
+			(void)console_putc(*s);
 			sz--;
 		}
 	}

--- a/hypervisor/debug/serial.c
+++ b/hypervisor/debug/serial.c
@@ -178,7 +178,7 @@ uint32_t serial_get_rx_data(uint32_t uart_handle)
 			spinlock_obtain(&uart->buffer_lock);
 
 			/* Put the item on circular buffer */
-			sbuf_put(uart->rx_sio_queue, &ch);
+			(void)sbuf_put(uart->rx_sio_queue, &ch);
 
 			/* Exit Critical Section */
 			spinlock_release(&uart->buffer_lock);

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -1107,7 +1107,7 @@ void shell_puts_serial(struct shell *p_shell, char *string_ptr)
 		(uint32_t)(uint64_t)p_shell->session_io.io_session_info;
 
 	/* Output the string */
-	serial_puts(serial_handle, string_ptr,
+	(void)serial_puts(serial_handle, string_ptr,
 				strnlen_s(string_ptr, SHELL_STRING_MAX_LEN));
 }
 

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -97,7 +97,7 @@ extern spurious_handler_t spurious_handler;
 void vcpu_inject_extint(struct vcpu *vcpu);
 void vcpu_inject_nmi(struct vcpu *vcpu);
 void vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code);
-int vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code);
+void vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code);
 void vcpu_make_request(struct vcpu *vcpu, int eventid);
 int vcpu_queue_exception(struct vcpu *vcpu, uint32_t vector, uint32_t err_code);
 

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -75,7 +75,7 @@ struct ptdev_remapping_info *ptdev_dequeue_softirq(void);
 struct ptdev_remapping_info *alloc_entry(struct vm *vm,
 		enum ptdev_intr_type type);
 void release_entry(struct ptdev_remapping_info *entry);
-struct ptdev_remapping_info *ptdev_activate_entry(
+void ptdev_activate_entry(
 		struct ptdev_remapping_info *entry,
 		int phys_irq, bool lowpri);
 void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -12,12 +12,9 @@ extern struct timer console_timer;
 
 /** Initializes the console module.
  *
- *  @param cdev A pointer to the character device to use for the console.
- *
- *  @return '0' on success. Any other value indicates an error.
  */
 
-int console_init(void);
+void console_init(void);
 
 /** Writes a NUL terminated string to the console.
  *
@@ -76,9 +73,8 @@ static inline void resume_console(void)
 }
 
 #else
-static inline int console_init(void)
+static inline void console_init(void)
 {
-	return 0;
 }
 static inline int console_puts(__unused const char *str)
 {

--- a/hypervisor/include/debug/trace.h
+++ b/hypervisor/include/debug/trace.h
@@ -100,7 +100,7 @@ _trace_put(uint16_t cpu_id, uint32_t evid,
 	entry->id = evid;
 	entry->n_data = (uint8_t)n_data;
 	entry->cpu = (uint8_t)cpu_id;
-	sbuf_put(sbuf, (uint8_t *)entry);
+	(void)sbuf_put(sbuf, (uint8_t *)entry);
 }
 
 static inline void


### PR DESCRIPTION
Change these 4 APIs to void type:
   vcpu_inject_pf
   uart16550_calc_baud_div
   uart16550_set_baud_rate
   ptdev_activate_entry
No need to return 'entry' for ptdev_activate_entry
since the input parameter is 'entry'.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>