### PR TITLE
HV:transfer vm_hw_logical_core_ids's type and rename it

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -356,7 +356,7 @@ static inline bool vcpu_in_vm_desc(struct vcpu *vcpu,
 	int i;
 
 	for (i = 0; i < vm_desc->vm_hw_num_cores; i++) {
-		if (vcpu->pcpu_id == vm_desc->vm_hw_logical_core_ids[i]) {
+		if (vcpu->pcpu_id == vm_desc->vm_pcpu_ids[i]) {
 			return true;
 		}
 	}

--- a/hypervisor/bsp/sbl/vm_description.c
+++ b/hypervisor/bsp/sbl/vm_description.c
@@ -10,9 +10,9 @@
 #define VM0_NUM_CPUS    1
 
 /* Logical CPU IDs assigned to VM0 */
-int VM0_CPUS[VM0_NUM_CPUS] = {0};
+uint16_t VM0_CPUS[VM0_NUM_CPUS] = {0U};
 
 struct vm_description vm0_desc = {
 	.vm_hw_num_cores = VM0_NUM_CPUS,
-	.vm_hw_logical_core_ids = &VM0_CPUS[0],
+	.vm_pcpu_ids = &VM0_CPUS[0],
 };

--- a/hypervisor/bsp/uefi/vm_description.c
+++ b/hypervisor/bsp/uefi/vm_description.c
@@ -10,9 +10,9 @@
 #define VM0_NUM_CPUS    1
 
 /* Logical CPU IDs assigned to VM0 */
-int VM0_CPUS[VM0_NUM_CPUS] = {0};
+uint16_t VM0_CPUS[VM0_NUM_CPUS] = {0U};
 
 struct vm_description vm0_desc = {
 	.vm_hw_num_cores = VM0_NUM_CPUS,
-	.vm_hw_logical_core_ids = &VM0_CPUS[0],
+	.vm_pcpu_ids = &VM0_CPUS[0],
 };

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -104,7 +104,7 @@ void vcpu_thread(struct vcpu *vcpu)
 
 static bool is_vm0_bsp(uint16_t pcpu_id)
 {
-	return pcpu_id == vm0_desc.vm_hw_logical_core_ids[0];
+	return pcpu_id == vm0_desc.vm_pcpu_ids[0];
 }
 
 int32_t hv_main(uint16_t pcpu_id)

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -158,10 +158,10 @@ struct vm {
 };
 
 struct vm_description {
-	/* The logical CPU IDs associated with this VM - The first CPU listed
+	/* The physical CPU IDs associated with this VM - The first CPU listed
 	 * will be the VM's BSP
 	 */
-	int                    *vm_hw_logical_core_ids;
+	uint16_t               *vm_pcpu_ids;
 	unsigned char          GUID[16]; /* GUID of the vm will be created */
 	uint16_t               vm_hw_num_cores;   /* Number of virtual cores */
 	/* Whether secure world is enabled for current VM. */


### PR DESCRIPTION
rename vm_hw_logical_core_ids to vm_pcpu_ids
and changed the type to uint16_t.

V1->V2:rename the vm_hw_logical_core_ids

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>