### PR TITLE
doc: add v0.1 doc choice

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -64,6 +64,7 @@ clean:
 # along with a README
 
 publish:
+	mkdir -p $(PUBLISHDIR)
 	rm -fr $(PUBLISHDIR)/*
 	cp -r $(BUILDDIR)/html/* $(PUBLISHDIR)
 	cp scripts/publish-README.md $(PUBLISHDIR)/../README.md

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,8 +102,10 @@ try:
 except:
     pass
 finally:
-    if version_major and version_minor and version_rc :
-        version = release = "v " + version_major + '.' + version_minor + version_rc
+    if version_major and version_minor :
+        version = release = "v " + version_major + '.' + version_minor
+        if version_rc :
+          version = release = version + version_rc
     else:
         sys.stderr.write('Warning: Could not extract hypervisor version from VERSION file\n')
         version = release = "unknown"
@@ -181,7 +183,7 @@ else:
 html_context = {
    'current_version': current_version,
    'versions': ( ("latest", "/latest/"),
-#                 ("0.1-rc4", "/0.1-rc4/"),
+                 ("0.1", "/0.1/"),
                )
     }
 


### PR DESCRIPTION
Normal publication is to the /latest/ folder.  With the tagged 0.1
release, we now have an alternative frozen version of the docs.

Also, tweaked the code for collecting version information from the
VERSION file to create document version number, and Makefile needed to
create the publish directory for a new tagged version.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>