### PR TITLE
hv: further fix to configurable relocatoin

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -39,10 +39,15 @@ CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -fshort-wchar -ffreestanding
 CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
-CFLAGS += -static -nostdinc -nostdlib -fno-common
+CFLAGS += -nostdinc -nostdlib -fno-common
 CFLAGS += -O2 -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security
+ifeq (y, $(CONFIG_RELOC))
 CFLAGS += -fpie
+else
+CFLAGS += -static
+endif
+
 
 ifdef STACK_PROTECTOR
 ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
@@ -70,6 +75,8 @@ ifeq (y, $(CONFIG_RELOC))
 # We know it's safe because Hypervisor runs under 4GB. "noreloc-overflow"
 # is used to avoid the compile error
 LDFLAGS += -pie -z noreloc-overflow
+else
+LDFLAGS += -static
 endif
 
 ARCH_CFLAGS += -gdwarf-2

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -68,9 +68,9 @@ static uint64_t trampoline_relo_addr(void *addr)
 	return (uint64_t)addr - get_hv_image_delta();
 }
 
-#ifdef CONFIG_RELOC
 void _relocate(void)
 {
+#ifdef CONFIG_RELOC
 	struct Elf64_Dyn *dyn;
 	struct Elf64_Rel *start = NULL, *end = NULL;
 	uint64_t delta, size = 0;
@@ -136,12 +136,8 @@ void _relocate(void)
 		}
 		start = (struct Elf64_Rel *)((char *)start + size);
 	}
-}
-#else
-void _relocate(void)
-{
-}
 #endif
+}
 
 uint64_t read_trampoline_sym(void *sym)
 {

--- a/hypervisor/bsp/uefi/efi/malloc.c
+++ b/hypervisor/bsp/uefi/efi/malloc.c
@@ -268,7 +268,11 @@ EFI_STATUS __emalloc(UINTN size, UINTN min_addr, EFI_PHYSICAL_ADDRESS *addr,
 			continue;
 		}
 
+#ifndef CONFIG_RELOC
 		aligned = start;
+#else
+		aligned = min_addr;
+#endif
 		err = allocate_pages(AllocateAddress, mem_type,
 					 nr_pages, &aligned);
 		if (err == EFI_SUCCESS) {


### PR DESCRIPTION
commit ia23549aa915e7dc2c ("build: make relocation-related code
configurable") adds CONFIG_RELOC to make relocation configurable

This patch corrects the behavior when CONFIG_RELOC is disabled
- Don't use "CFLAGS += -fpie" and put back "LDFLAGS += -static"
- __emalloc(): forced to allocate exactly the asked address, which is
  CONFIG_RAM_START