### PR TITLE
HV:CPU:Fix a mistake introduced by MARCO replacing patch

### DIFF
--- a/hypervisor/arch/x86/wakeup.S
+++ b/hypervisor/arch/x86/wakeup.S
@@ -121,8 +121,8 @@ restore_s3_context:
 	mov 0x88 + cpu_ctx(%rip), %rax
 	mov %rax, %cr3
 
-	/*144U=0x90=CPU_CONTEXT_OFFSET_CR4*/
-	mov 0x90 + cpu_ctx(%rip), %rax
+	/*120U=0x78=CPU_CONTEXT_OFFSET_CR0*/
+	mov 0x78 + cpu_ctx(%rip), %rax
 	mov %rax, %cr0
 
 	/*504U=0x1f8=CPU_CONTEXT_OFFSET_IDTR*/


### PR DESCRIPTION
Fixs: 7fd3c624 (HV:CPU:Constant values replace with
CPU MACRO)
There is a mistake in the previous MARCO replacing patch,
use CR4 value replaces CR0 MACRO.

Use CR0 value replaces CR0 MACRO.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>