### PR TITLE
HV: vlapic: integral type cleanup

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -85,7 +85,7 @@
 /*
  * 16 priority levels with at most one vector injected per level.
  */
-#define	ISRVEC_STK_SIZE		(16 + 1)
+#define	ISRVEC_STK_SIZE		(16U + 1U)
 
 #define VLAPIC_MAXLVT_INDEX	APIC_LVT_CMCI
 
@@ -132,9 +132,17 @@ struct vlapic {
 	 * A vector is popped from the stack when the processor does an EOI.
 	 * The vector on the top of the stack is used to compute the
 	 * Processor Priority in conjunction with the TPR.
+	 *
+	 * Note: isrvec_stk_top is unsigned and always equal to the number of
+	 * vectors in the stack.
+	 *
+	 * Operations:
+	 *     init: isrvec_stk_top = 0;
+	 *     push: isrvec_stk_top++; isrvec_stk[isrvec_stk_top] = x;
+	 *     pop : isrvec_stk_top--;
 	 */
 	uint8_t		isrvec_stk[ISRVEC_STK_SIZE];
-	int		isrvec_stk_top;
+	uint32_t	isrvec_stk_top;
 
 	uint64_t	msr_apicbase;
 

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -33,54 +33,54 @@
 /*
  * APIC Register:		Offset	Description
  */
-#define APIC_OFFSET_ID		0x20	/* Local APIC ID		*/
-#define APIC_OFFSET_VER		0x30	/* Local APIC Version		*/
-#define APIC_OFFSET_TPR		0x80	/* Task Priority Register	*/
-#define APIC_OFFSET_APR		0x90	/* Arbitration Priority		*/
-#define APIC_OFFSET_PPR		0xA0	/* Processor Priority Register	*/
-#define APIC_OFFSET_EOI		0xB0	/* EOI Register			*/
-#define APIC_OFFSET_RRR		0xC0	/* Remote read			*/
-#define APIC_OFFSET_LDR		0xD0	/* Logical Destination		*/
-#define APIC_OFFSET_DFR		0xE0	/* Destination Format Register	*/
-#define APIC_OFFSET_SVR		0xF0	/* Spurious Vector Register	*/
-#define APIC_OFFSET_ISR0	0x100	/* In Service Register		*/
-#define APIC_OFFSET_ISR1	0x110
-#define APIC_OFFSET_ISR2	0x120
-#define APIC_OFFSET_ISR3	0x130
-#define APIC_OFFSET_ISR4	0x140
-#define APIC_OFFSET_ISR5	0x150
-#define APIC_OFFSET_ISR6	0x160
-#define APIC_OFFSET_ISR7	0x170
-#define APIC_OFFSET_TMR0	0x180	/* Trigger Mode Register	*/
-#define APIC_OFFSET_TMR1	0x190
-#define APIC_OFFSET_TMR2	0x1A0
-#define APIC_OFFSET_TMR3	0x1B0
-#define APIC_OFFSET_TMR4	0x1C0
-#define APIC_OFFSET_TMR5	0x1D0
-#define APIC_OFFSET_TMR6	0x1E0
-#define APIC_OFFSET_TMR7	0x1F0
-#define APIC_OFFSET_IRR0	0x200	/* Interrupt Request Register	*/
-#define APIC_OFFSET_IRR1	0x210
-#define APIC_OFFSET_IRR2	0x220
-#define APIC_OFFSET_IRR3	0x230
-#define APIC_OFFSET_IRR4	0x240
-#define APIC_OFFSET_IRR5	0x250
-#define APIC_OFFSET_IRR6	0x260
-#define APIC_OFFSET_IRR7	0x270
-#define APIC_OFFSET_ESR		0x280	/* Error Status Register	*/
-#define APIC_OFFSET_CMCI_LVT	0x2F0	/* Local Vector Table (CMCI)	*/
-#define APIC_OFFSET_ICR_LOW	0x300	/* Interrupt Command Register	*/
-#define APIC_OFFSET_ICR_HI	0x310
-#define APIC_OFFSET_TIMER_LVT	0x320	/* Local Vector Table (Timer)	*/
-#define APIC_OFFSET_THERM_LVT	0x330	/* Local Vector Table (Thermal)	*/
-#define APIC_OFFSET_PERF_LVT	0x340	/* Local Vector Table (PMC)	*/
-#define APIC_OFFSET_LINT0_LVT	0x350	/* Local Vector Table (LINT0)	*/
-#define APIC_OFFSET_LINT1_LVT	0x360	/* Local Vector Table (LINT1)	*/
-#define APIC_OFFSET_ERROR_LVT	0x370	/* Local Vector Table (ERROR)	*/
-#define APIC_OFFSET_TIMER_ICR	0x380	/* Timer's Initial Count	*/
-#define APIC_OFFSET_TIMER_CCR	0x390	/* Timer's Current Count	*/
-#define APIC_OFFSET_TIMER_DCR	0x3E0	/* Timer's Divide Configuration	*/
-#define	APIC_OFFSET_SELF_IPI	0x3F0	/* Self IPI register */
+#define APIC_OFFSET_ID		0x20U	/* Local APIC ID		*/
+#define APIC_OFFSET_VER		0x30U	/* Local APIC Version		*/
+#define APIC_OFFSET_TPR		0x80U	/* Task Priority Register	*/
+#define APIC_OFFSET_APR		0x90U	/* Arbitration Priority		*/
+#define APIC_OFFSET_PPR		0xA0U	/* Processor Priority Register	*/
+#define APIC_OFFSET_EOI		0xB0U	/* EOI Register			*/
+#define APIC_OFFSET_RRR		0xC0U	/* Remote read			*/
+#define APIC_OFFSET_LDR		0xD0U	/* Logical Destination		*/
+#define APIC_OFFSET_DFR		0xE0U	/* Destination Format Register	*/
+#define APIC_OFFSET_SVR		0xF0U	/* Spurious Vector Register	*/
+#define APIC_OFFSET_ISR0	0x100U	/* In Service Register		*/
+#define APIC_OFFSET_ISR1	0x110U
+#define APIC_OFFSET_ISR2	0x120U
+#define APIC_OFFSET_ISR3	0x130U
+#define APIC_OFFSET_ISR4	0x140U
+#define APIC_OFFSET_ISR5	0x150U
+#define APIC_OFFSET_ISR6	0x160U
+#define APIC_OFFSET_ISR7	0x170U
+#define APIC_OFFSET_TMR0	0x180U	/* Trigger Mode Register	*/
+#define APIC_OFFSET_TMR1	0x190U
+#define APIC_OFFSET_TMR2	0x1A0U
+#define APIC_OFFSET_TMR3	0x1B0U
+#define APIC_OFFSET_TMR4	0x1C0U
+#define APIC_OFFSET_TMR5	0x1D0U
+#define APIC_OFFSET_TMR6	0x1E0U
+#define APIC_OFFSET_TMR7	0x1F0U
+#define APIC_OFFSET_IRR0	0x200U	/* Interrupt Request Register	*/
+#define APIC_OFFSET_IRR1	0x210U
+#define APIC_OFFSET_IRR2	0x220U
+#define APIC_OFFSET_IRR3	0x230U
+#define APIC_OFFSET_IRR4	0x240U
+#define APIC_OFFSET_IRR5	0x250U
+#define APIC_OFFSET_IRR6	0x260U
+#define APIC_OFFSET_IRR7	0x270U
+#define APIC_OFFSET_ESR		0x280U	/* Error Status Register	*/
+#define APIC_OFFSET_CMCI_LVT	0x2F0U	/* Local Vector Table (CMCI)	*/
+#define APIC_OFFSET_ICR_LOW	0x300U	/* Interrupt Command Register	*/
+#define APIC_OFFSET_ICR_HI	0x310U
+#define APIC_OFFSET_TIMER_LVT	0x320U	/* Local Vector Table (Timer)	*/
+#define APIC_OFFSET_THERM_LVT	0x330U	/* Local Vector Table (Thermal)	*/
+#define APIC_OFFSET_PERF_LVT	0x340U	/* Local Vector Table (PMC)	*/
+#define APIC_OFFSET_LINT0_LVT	0x350U	/* Local Vector Table (LINT0)	*/
+#define APIC_OFFSET_LINT1_LVT	0x360U	/* Local Vector Table (LINT1)	*/
+#define APIC_OFFSET_ERROR_LVT	0x370U	/* Local Vector Table (ERROR)	*/
+#define APIC_OFFSET_TIMER_ICR	0x380U	/* Timer's Initial Count	*/
+#define APIC_OFFSET_TIMER_CCR	0x390U	/* Timer's Current Count	*/
+#define APIC_OFFSET_TIMER_DCR	0x3E0U	/* Timer's Divide Configuration	*/
+#define APIC_OFFSET_SELF_IPI	0x3F0U	/* Self IPI register */
 
 /*
  * 16 priority levels with at most one vector injected per level.

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -272,7 +272,7 @@ struct ioapic {
 
 /* constants relating to APIC ID registers */
 #define APIC_ID_MASK		0xff000000U
-#define	APIC_ID_SHIFT		24
+#define	APIC_ID_SHIFT		24U
 #define	APIC_ID_CLUSTER		0xf0U
 #define	APIC_ID_CLUSTER_ID	0x0fU
 #define	APIC_MAX_CLUSTER	0xeU
@@ -282,7 +282,7 @@ struct ioapic {
 /* fields in VER */
 #define APIC_VER_VERSION	0x000000ffU
 #define APIC_VER_MAXLVT		0x00ff0000U
-#define MAXLVTSHIFT		16
+#define MAXLVTSHIFT		16U
 #define APIC_VER_EOI_SUPPRESSION 0x01000000U
 #define APIC_VER_AMD_EXT_SPACE	0x80000000U
 

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -16,6 +16,8 @@
 
 #ifndef ASSEMBLER
 
+#include <mmu.h>
+
 #define foreach_vcpu(idx, vm, vcpu)				\
 	for (idx = 0U, vcpu = vm->hw.vcpu_array[idx];		\
 		(idx < vm->hw.num_vcpus) && (vcpu != NULL);	\
@@ -110,6 +112,7 @@ int wrmsr_vmexit_handler(struct vcpu *vcpu);
 void init_msr_emulation(struct vcpu *vcpu);
 
 extern const char vm_exit[];
+struct run_context;
 int vmx_vmrun(struct run_context *context, int ops, int ibrs);
 
 int load_guest(struct vm *vm, struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -77,6 +77,8 @@
 
 #ifndef ASSEMBLER
 
+#include <guest.h>
+
 enum vcpu_state {
 	VCPU_INIT,
 	VCPU_RUNNING,
@@ -217,7 +219,7 @@ struct vcpu_arch {
 	uint32_t inst_len;
 
 	/* Information related to secondary / AP VCPU start-up */
-	uint8_t cpu_mode;
+	enum vm_cpu_mode cpu_mode;
 	uint8_t nr_sipi;
 	uint32_t sipi_vector;
 

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -63,9 +63,9 @@ int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
 int vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t wval);
 
 int vlapic_read_mmio_reg(struct vcpu *vcpu, uint64_t gpa,
-		uint64_t *rval, int size);
+		uint64_t *rval, uint8_t size);
 int vlapic_write_mmio_reg(struct vcpu *vcpu, uint64_t gpa,
-		uint64_t wval, int size);
+		uint64_t wval, uint8_t size);
 
 /*
  * Signals to the LAPIC that an interrupt at 'vector' needs to be generated
@@ -96,7 +96,7 @@ int vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id, uint32_t vector);
 int vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg);
 
 void vlapic_deliver_intr(struct vm *vm, bool level, uint32_t dest,
-		bool phys, int delmode, int vec);
+		bool phys, uint32_t delmode, uint32_t vec);
 
 /* Reset the trigger-mode bits for all vectors to be edge-triggered */
 void vlapic_reset_tmr(struct vlapic *vlapic);
@@ -106,7 +106,7 @@ void vlapic_reset_tmr(struct vlapic *vlapic);
  * the (dest,phys,delmode) tuple resolves to an interrupt being delivered to
  * this 'vlapic'.
  */
-void vlapic_set_tmr_one_vec(struct vlapic *vlapic, int delmode,
+void vlapic_set_tmr_one_vec(struct vlapic *vlapic, uint32_t delmode,
 		uint32_t vector, bool level);
 
 void

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -134,7 +134,7 @@ struct vm {
 	enum vm_state state;	/* VM state */
 	void *vuart;		/* Virtual UART */
 	struct vpic *vpic;      /* Virtual PIC */
-	uint32_t vpic_wire_mode;
+	enum vpic_wire_mode vpic_wire_mode;
 	struct iommu_domain *iommu_domain;	/* iommu domain of this VM */
 	struct list_head list; /* list of VM */
 	spinlock_t spinlock;	/* Spin-lock used to protect VM modifications */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -280,22 +280,26 @@ static inline uint64_t mem_read64(void *addr)
 
 static inline void mem_write8(void *addr, uint8_t data)
 {
-	*(volatile uint8_t *)(addr) = (uint8_t)(data);
+	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
+	*addr8 = data;
 }
 
 static inline void mem_write16(void *addr, uint16_t data)
 {
-	*(volatile uint16_t *)(addr) = (uint16_t)(data);
+	volatile uint16_t *addr16 = (volatile uint16_t *)addr;
+	*addr16 = data;
 }
 
 static inline void mem_write32(void *addr, uint32_t data)
 {
-	*(volatile uint32_t *)(addr) = (uint32_t)(data);
+	volatile uint32_t *addr32 = (volatile uint32_t *)addr;
+	*addr32 = data;
 }
 
 static inline void mem_write64(void *addr, uint64_t data)
 {
-	*(volatile uint64_t *)(addr) = (uint64_t)(data);
+	volatile uint64_t *addr64 = (volatile uint64_t *)addr;
+	*addr64 = data;
 }
 
 /* Typedef for MMIO handler and range check routine */

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -58,7 +58,7 @@
 #define	VMX_EOI_EXIT2_HIGH			0x00002021U
 #define	VMX_EOI_EXIT3_FULL			0x00002022U
 #define	VMX_EOI_EXIT3_HIGH			0x00002023U
-#define	VMX_EOI_EXIT(vector)	(VMX_EOI_EXIT0_FULL + ((vector) / 64) * 2)
+#define	VMX_EOI_EXIT(vector)	(VMX_EOI_EXIT0_FULL + ((vector) / 64U) * 2U)
 #define VMX_XSS_EXITING_BITMAP_FULL		0x0000202CU
 #define VMX_XSS_EXITING_BITMAP_HIGH		0x0000202DU
 /* 64-bit read-only data fields */
@@ -376,7 +376,7 @@
  *  15 = guest-physical access for an instructon fetch or during
  *       instruction execution
  */
-#define APIC_ACCESS_TYPE(qual)		(((qual) >> 12) & 0xFU)
+#define APIC_ACCESS_TYPE(qual)		(((qual) >> 12U) & 0xFUL)
 #define APIC_ACCESS_OFFSET(qual)	((qual) & 0xFFFU)
 
 

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -432,7 +432,7 @@ int vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0);
 int vmx_write_cr3(struct vcpu *vcpu, uint64_t cr3);
 int vmx_write_cr4(struct vcpu *vcpu, uint64_t cr4);
 
-static inline uint8_t get_vcpu_mode(struct vcpu *vcpu)
+static inline enum vm_cpu_mode get_vcpu_mode(struct vcpu *vcpu)
 {
 	return vcpu->arch_vcpu.cpu_mode;
 }


### PR DESCRIPTION
A summary of changes made in this patch:

* Use uint32_t for register offsets.
* Use uint32_t for isrvec_stk_top which equals to the number of vectors in the
  stack.
* Use local variables to hold struct members before using them, to avoid
  confusions from static checkers.
* Use uint32_t for tpr, though the higher 24 bits are reserved.
* For-loops with loop variables counting down to 0 are converted to while-loops
  to make the loop variable unsigned when necessary.
* 'U' suffix for constants in unsigned contexts.
* Local variables are typed so that explicit casts are minimized.

Issues yet to be closed include

* Conversions due to atomic APIs taking/returning signed values.
* Conversions due to exec_[vmread|vmwrite] always work on 64-bit integers.
* IOAPIC RTE constants are 64-bit instead of 32-bit.