### PR TITLE
update launch_uos.sh to align with ACRN v0.1

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -23,14 +23,14 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
-  -s 3,virtio-blk,/root/clear-21260-kvm.img \
+  -s 3,virtio-blk,/root/clear-23690-kvm.img \
   -s 4,virtio-net,tap0 \
-  -k /usr/lib/kernel/org.clearlinux.pk414-standard.4.14.23-19 \
+  -k /usr/lib/kernel/org.clearlinux.pk414-standard.4.14.52-63 \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \
   i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0 \
-  i915.enable_guc_submission=0" $vm_name
+  i915.enable_guc_submission=0 i915.enable_initial_modeset=1" $vm_name
 }
 
 launch_clear 2 1 "64 448 8" 0x070F00 clear

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -30,7 +30,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \
   i915.enable_hangcheck=0 i915.nuclear_pageflip=1 i915.enable_guc_loading=0 \
-  i915.enable_guc_submission=0 i915.enable_initial_modeset=1" $vm_name
+  i915.enable_guc_submission=0 " $vm_name
 }
 
 launch_clear 2 1 "64 448 8" 0x070F00 clear


### PR DESCRIPTION
update the kernel version to align with ACRN v0.1 and fix a graphic display issue with i915.enable_initial_modeset=1 for UOS

Signed-off-by: ailun258 <ailin.yang@intel.com>