### PR TITLE
hv: cpu: fix 'Pointer arithmetic is not on array'

### DIFF
--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -43,6 +43,9 @@
 #define CPU_PAGE_SIZE           0x1000U
 #define CPU_PAGE_MASK           0xFFFFFFFFFFFFF000UL
 
+/* Assume the max physcial cpu number is 128 */
+#define MAX_PCPU_NUM	128U
+
 #define MMU_PTE_PAGE_SHIFT	CPU_PAGE_SHIFT
 #define MMU_PDE_PAGE_SHIFT	21
 


### PR DESCRIPTION
Use the array for lapic_id directly to avoid the unnecessary pointer
arithmetic.

With current implementation,
  lapic_id_base is always a byte array with CPU_PAGE_SIZE elements

What this patch does:
 - replace 'uint8_t *lapic_id_base' with 'uint8_t
   lapic_id_array[CPU_PAGE_SIZE]' to make the boundary explicit
 - add a range check to ensure that there is no overflow

 v2 -> v3:
 * update the array size of lapic_id_array per discussion with Fengwei

 v1 -> v2:
 * remove the unnecessary range check in parse_madt in cpu.c

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>