### PR TITLE
HV:transfer vmid's type to uint16_t

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -651,7 +651,7 @@ bool vioapic_get_rte(struct vm *vm, uint8_t pin, void *rte)
 }
 
 #ifdef HV_DEBUG
-void get_vioapic_info(char *str, int str_max, int vmid)
+void get_vioapic_info(char *str, int str_max, uint16_t vmid)
 {
 	int len, size = str_max, delmode;
 	uint64_t rte;
@@ -662,7 +662,7 @@ void get_vioapic_info(char *str, int str_max, int vmid)
 
 	if (vm == NULL) {
 		len = snprintf(str, size,
-			"\r\nvm is not exist for vmid %d", vmid);
+			"\r\nvm is not exist for vmid %hu", vmid);
 		size -= len;
 		str += len;
 		goto END;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -42,7 +42,7 @@ static void init_vm(struct vm_description *vm_desc,
 /* return a pointer to the virtual machine structure associated with
  * this VM ID
  */
-struct vm *get_vm_from_vmid(int vm_id)
+struct vm *get_vm_from_vmid(uint16_t vm_id)
 {
 	struct vm *vm = NULL;
 	struct list_head *pos;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -86,7 +86,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 				IA32E_EPT_X_BIT);
 	uint64_t pdpte = 0, *dest_pdpte_p = NULL, *src_pdpte_p = NULL;
 	void *sub_table_addr = NULL, *pml4_base = NULL;
-	struct vm *vm0 = get_vm_from_vmid(0);
+	struct vm *vm0 = get_vm_from_vmid(0U);
 	uint16_t i;
 	struct vcpu *vcpu;
 
@@ -186,7 +186,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 void  destroy_secure_world(struct vm *vm)
 {
 	struct map_params  map_params;
-	struct vm *vm0 = get_vm_from_vmid(0);
+	struct vm *vm0 = get_vm_from_vmid(0U);
 
 	if (vm0 == NULL) {
 		pr_err("Parse vm0 context failed.");

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -147,7 +147,7 @@ struct iommu_domain {
 	bool is_host;
 	bool is_tt_ept;     /* if reuse EPT of the domain */
 	uint16_t dom_id;
-	int vm_id;
+	uint16_t vm_id;
 	uint32_t addr_width;   /* address width of the domain */
 	uint64_t trans_table_ptr;
 };
@@ -862,7 +862,7 @@ static void dmar_disable(struct dmar_drhd_rt *dmar_uint)
 	dmar_fault_event_mask(dmar_uint);
 }
 
-struct iommu_domain *create_iommu_domain(int vm_id, uint64_t translation_table,
+struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_table,
 		int addr_width)
 {
 	struct iommu_domain *domain;
@@ -896,7 +896,7 @@ struct iommu_domain *create_iommu_domain(int vm_id, uint64_t translation_table,
 	list_add(&domain->list, &iommu_domains);
 	spinlock_release(&domain_lock);
 
-	dev_dbg(ACRN_DBG_IOMMU, "create domain [%d]: vm_id = %d, ept@0x%x",
+	dev_dbg(ACRN_DBG_IOMMU, "create domain [%d]: vm_id = %hu, ept@0x%x",
 		domain->dom_id,
 		domain->vm_id,
 		domain->trans_table_ptr);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -93,7 +93,7 @@ handle_vioapic_irqline(struct vm *vm, int irq, enum irq_mode mode)
 	return ret;
 }
 
-static int handle_virt_irqline(struct vm *vm, uint64_t target_vmid,
+static int handle_virt_irqline(struct vm *vm, uint16_t target_vmid,
 		struct acrn_irqline *param, enum irq_mode mode)
 {
 	int32_t ret = 0;
@@ -218,7 +218,6 @@ int64_t hcall_create_vcpu(struct vm *vm, uint64_t vmid, uint64_t param)
 	int32_t ret;
 	uint16_t pcpu_id;
 	struct acrn_create_vcpu cv;
-
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
 	if ((target_vm == NULL) || (param == 0U)) {
@@ -250,7 +249,7 @@ int64_t hcall_assert_irqline(struct vm *vm, uint64_t vmid, uint64_t param)
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
 	}
-	ret = handle_virt_irqline(vm, vmid, &irqline, IRQ_ASSERT);
+	ret = handle_virt_irqline(vm, (uint16_t)vmid, &irqline, IRQ_ASSERT);
 
 	return ret;
 }
@@ -264,7 +263,7 @@ int64_t hcall_deassert_irqline(struct vm *vm, uint64_t vmid, uint64_t param)
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
 	}
-	ret = handle_virt_irqline(vm, vmid, &irqline, IRQ_DEASSERT);
+	ret = handle_virt_irqline(vm, (uint16_t)vmid, &irqline, IRQ_DEASSERT);
 
 	return ret;
 }
@@ -278,7 +277,7 @@ int64_t hcall_pulse_irqline(struct vm *vm, uint64_t vmid, uint64_t param)
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
 	}
-	ret = handle_virt_irqline(vm, vmid, &irqline, IRQ_PULSE);
+	ret = handle_virt_irqline(vm, (uint16_t)vmid, &irqline, IRQ_PULSE);
 
 	return ret;
 }
@@ -741,7 +740,7 @@ int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
 
 int64_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param)
 {
-	int32_t target_vm_id;
+	uint16_t target_vm_id;
 	struct vm *target_vm;
 
 	target_vm_id = (cmd & PMCMD_VMID_MASK) >> PMCMD_VMID_SHIFT;

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -16,7 +16,7 @@ static void fire_vhm_interrupt(void)
 	struct vm *vm0;
 	struct vcpu *vcpu;
 
-	vm0 = get_vm_from_vmid(0);
+	vm0 = get_vm_from_vmid(0U);
 	ASSERT(vm0 != NULL, "VM Pointer is NULL");
 
 	vcpu = vcpu_from_vid(vm0, 0);

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -549,7 +549,7 @@ int shell_pause_vcpu(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id;
+	uint16_t vm_id;
 	uint16_t vcpu_id;
 	struct vm *vm;
 	struct vcpu *vcpu;
@@ -560,7 +560,12 @@ int shell_pause_vcpu(struct shell *p_shell,
 		shell_puts(p_shell,
 			"Please enter correct cmd with <vm_id, vcpu_id>\r\n");
 	} else {
-		vm_id = atoi(argv[1]);
+		status = atoi(argv[1]);
+		if (status < 0) {
+			return -EINVAL;
+		} else {
+			vm_id = (uint16_t)status;
+		}
 		vcpu_id = (uint16_t)atoi(argv[2]);
 		if (vcpu_id >= phys_cpu_num)
 			return (-EINVAL);
@@ -600,7 +605,7 @@ int shell_resume_vcpu(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id;
+	uint16_t vm_id;
 	uint16_t vcpu_id;
 	struct vm *vm;
 	struct vcpu *vcpu;
@@ -611,7 +616,11 @@ int shell_resume_vcpu(struct shell *p_shell,
 		shell_puts(p_shell,
 			"Please enter correct cmd with <vm_id, vcpu_id>\r\n");
 	} else {
-		vm_id = atoi(argv[1]);
+		status = atoi(argv[1]);
+		if (status < 0) {
+			return -EINVAL;
+		}
+		vm_id = (uint16_t)status;
 		vcpu_id = (uint16_t)atoi(argv[2]);
 		if (vcpu_id >= phys_cpu_num)
 			return (-EINVAL);
@@ -650,7 +659,7 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id;
+	uint16_t vm_id;
 	uint16_t vcpu_id;
 	char temp_str[MAX_STR_SIZE];
 	struct vm *vm;
@@ -667,7 +676,11 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 		return -EINVAL;
 	}
 
-	vm_id = atoi(argv[1]);
+	status = atoi(argv[1]);
+	if (status < 0) {
+		return -EINVAL;
+	}
+	vm_id = (uint16_t)status;
 	vcpu_id = (uint16_t)atoi(argv[2]);
 	if (vcpu_id >= phys_cpu_num)
 		return (-EINVAL);
@@ -743,7 +756,7 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 		shell_puts(p_shell, "Cannot handle user gva yet!\r\n");
 	} else {
 		snprintf(temp_str, MAX_STR_SIZE,
-				"\r\nDump RSP for vm %d, from "
+				"\r\nDump RSP for vm %hu, from "
 				"gva 0x%016llx\r\n",
 				vm_id, cur_context->rsp);
 		shell_puts(p_shell, temp_str);
@@ -766,7 +779,7 @@ int shell_vcpu_dumpmem(struct shell *p_shell,
 		int argc, char **argv)
 {
 	int status = 0;
-	uint32_t vm_id;
+	uint16_t vm_id;
 	uint16_t vcpu_id;
 	uint64_t gva;
 	uint64_t tmp[MAX_MEMDUMP_LEN/8];
@@ -785,7 +798,11 @@ int shell_vcpu_dumpmem(struct shell *p_shell,
 		return status;
 	}
 
-	vm_id = atoi(argv[1]);
+	status = atoi(argv[1]);
+	if (status < 0) {
+		return -EINVAL;
+	}
+	vm_id = (uint16_t)status;
 	vcpu_id = (uint16_t)atoi(argv[2]);
 	if (vcpu_id >= phys_cpu_num)
 		return (-EINVAL);
@@ -848,7 +865,7 @@ int shell_to_sos_console(struct shell *p_shell,
 		__unused int argc, __unused char **argv)
 {
 	char temp_str[TEMP_STR_SIZE];
-	int guest_no = 0;
+	uint16_t guest_no = 0U;
 
 	struct vm *vm;
 	struct vuart *vuart;
@@ -944,7 +961,8 @@ int shell_show_req_info(struct shell *p_shell,
 int shell_show_vioapic_info(struct shell *p_shell, int argc, char **argv)
 {
 	char *temp_str = alloc_page();
-	uint32_t vmid;
+	uint16_t vmid;
+	int32_t ret;
 
 	if (temp_str == NULL) {
 		return -ENOMEM;
@@ -955,7 +973,12 @@ int shell_show_vioapic_info(struct shell *p_shell, int argc, char **argv)
 		snprintf(temp_str, CPU_PAGE_SIZE, "\r\nvmid param needed\r\n");
 		goto END;
 	} else {
-		vmid = atoi(argv[1]);
+		ret = atoi(argv[1]);
+		if (ret >= 0) {
+			vmid = (uint16_t) ret;
+		} else {
+			return -EINVAL;
+		}
 	}
 
 	get_vioapic_info(temp_str, CPU_PAGE_SIZE, vmid);

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -381,7 +381,7 @@ void vuart_console_rx_chars(uint32_t serial_handle)
 
 struct vuart *vuart_console_active(void)
 {
-	struct vm *vm = get_vm_from_vmid(0);
+	struct vm *vm = get_vm_from_vmid(0U);
 
 	if ((vm != NULL) && (vm->vuart != NULL)) {
 		struct vuart *vu = vm->vuart;

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -55,7 +55,7 @@ int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 		void *handler_private_data);
 
 #ifdef HV_DEBUG
-void get_vioapic_info(char *str, int str_max, int vmid);
+void get_vioapic_info(char *str, int str_max, uint16_t vmid);
 #endif /* HV_DEBUG */
 
 #endif

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -16,8 +16,8 @@ enum vm_privilege_level {
 
 #define	MAX_VM_NAME_LEN		16
 struct vm_attr {
-	int id;		/* Virtual machine identifier */
-	int boot_idx;	/* Index indicating the boot sequence for this VM */
+	uint16_t id;		/* Virtual machine identifier */
+	uint16_t boot_idx;	/* Index indicating the boot sequence for this VM */
 };
 
 struct vm_hw_info {
@@ -177,7 +177,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **vm);
 int prepare_vm0(void);
 void vm_fixup(struct vm *vm);
 
-struct vm *get_vm_from_vmid(int vm_id);
+struct vm *get_vm_from_vmid(uint16_t vm_id);
 
 extern struct list_head vm_list;
 extern spinlock_t vm_list_lock;

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -217,7 +217,7 @@ int unassign_iommu_device(struct iommu_domain *domain,
 	uint8_t bus, uint8_t devfun);
 
 /* Create a iommu domain for a VM specified by vm_id */
-struct iommu_domain *create_iommu_domain(int vm_id,
+struct iommu_domain *create_iommu_domain(uint16_t vm_id,
 	uint64_t translation_table, int addr_width);
 
 /* Destroy the iommu domain */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -123,7 +123,7 @@ union vhm_request_buffer {
  */
 struct acrn_create_vm {
 	/** created vmid return to VHM. Keep it first field */
-	int32_t vmid;
+	int16_t vmid;
 
 	/** VCPU numbers this VM want to create */
 	uint32_t vcpu_num;

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -76,7 +76,7 @@
 #define HC_PM_GET_CPU_STATE         _HC_ID(HC_ID, HC_ID_PM_BASE + 0x00UL)
 
 #define ACRN_DOM0_VMID (0UL)
-#define ACRN_INVALID_VMID (-1)
+#define ACRN_INVALID_VMID (0xffffU)
 #define ACRN_INVALID_HPA (~0UL)
 
 /* Generic memory attributes */


### PR DESCRIPTION
vmid's type prefered to be uint16_t.

V1->V2:vmid from uint32_t transfer to uint16_t
V2->V3:add range check to hcall's vmid parameter
V3->V4:seperate the declaration and actual code.
V4->V5:remove range check from hcall's vmid parameter

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>