### PR TITLE
hv: fix the potential dead loop in _parse_madt

### DIFF
--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -237,7 +237,7 @@ static uint16_t _parse_madt(void *madt, uint8_t lapic_id_array[MAX_PCPU_NUM])
 
 	for (entry = first; (void *)entry < end; ) {
 		if (entry->length < sizeof(struct acpi_subtable_header)) {
-			continue;
+			break;
 		}
 
 		if (entry->type == ACPI_MADT_TYPE_LOCAL_APIC) {


### PR DESCRIPTION
With current implementation:
If the case 'entry->length < sizeof(struct acpi_subtable_header)' is
triggered, it will lead to a dead loop.

What this patch does:
Gracefully return when this case is triggered.

Why:
If 'entry->length < sizeof(struct acpi_subtable_header)', it means that
there is no valid 'struct acpi_subtable_header' starting from the entry.
There must be something wrong. It should not happen in normal case.

v1 -> v2:
 * Remove the unacceptable ASSERT, just gracefully return

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>