### PR TITLE
HV:misc:fix "signed/unsigned conversion with cast"

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -23,31 +23,31 @@
 #define IOMMU_INIT_BUS_LIMIT        (0xf)
 
 #define PAGE_MASK                   (0xFFFUL)
-#define LEVEL_WIDTH 9
+#define LEVEL_WIDTH 9U
 
-#define ROOT_ENTRY_LOWER_PRESENT_POS        (0)
-#define ROOT_ENTRY_LOWER_PRESENT_MASK       ((uint64_t)1)
-#define ROOT_ENTRY_LOWER_CTP_POS            (12)
-#define ROOT_ENTRY_LOWER_CTP_MASK           ((uint64_t)0xFFFFFFFFFFFFF)
+#define ROOT_ENTRY_LOWER_PRESENT_POS        (0U)
+#define ROOT_ENTRY_LOWER_PRESENT_MASK       (1UL)
+#define ROOT_ENTRY_LOWER_CTP_POS            (12U)
+#define ROOT_ENTRY_LOWER_CTP_MASK           (0xFFFFFFFFFFFFFUL)
 
-#define CTX_ENTRY_UPPER_AW_POS          (0)
+#define CTX_ENTRY_UPPER_AW_POS          (0U)
 #define CTX_ENTRY_UPPER_AW_MASK         \
-		((uint64_t)0x7 << CTX_ENTRY_UPPER_AW_POS)
-#define CTX_ENTRY_UPPER_DID_POS         (8)
+		(0x7UL << CTX_ENTRY_UPPER_AW_POS)
+#define CTX_ENTRY_UPPER_DID_POS         (8U)
 #define CTX_ENTRY_UPPER_DID_MASK        \
-		((uint64_t)0x3F << CTX_ENTRY_UPPER_DID_POS)
-#define CTX_ENTRY_LOWER_P_POS           (0)
+		(0x3FUL << CTX_ENTRY_UPPER_DID_POS)
+#define CTX_ENTRY_LOWER_P_POS           (0U)
 #define CTX_ENTRY_LOWER_P_MASK          \
-		((uint64_t)0x1 << CTX_ENTRY_LOWER_P_POS)
-#define CTX_ENTRY_LOWER_FPD_POS         (1)
+		(0x1UL << CTX_ENTRY_LOWER_P_POS)
+#define CTX_ENTRY_LOWER_FPD_POS         (1U)
 #define CTX_ENTRY_LOWER_FPD_MASK        \
-		((uint64_t)0x1 << CTX_ENTRY_LOWER_FPD_POS)
-#define CTX_ENTRY_LOWER_TT_POS          (2)
+		(0x1UL << CTX_ENTRY_LOWER_FPD_POS)
+#define CTX_ENTRY_LOWER_TT_POS          (2U)
 #define CTX_ENTRY_LOWER_TT_MASK         \
-		((uint64_t)0x3 << CTX_ENTRY_LOWER_TT_POS)
-#define CTX_ENTRY_LOWER_SLPTPTR_POS     (12)
+		(0x3UL << CTX_ENTRY_LOWER_TT_POS)
+#define CTX_ENTRY_LOWER_SLPTPTR_POS     (12U)
 #define CTX_ENTRY_LOWER_SLPTPTR_MASK    \
-		((uint64_t)0xFFFFFFFFFFFFF <<  CTX_ENTRY_LOWER_SLPTPTR_POS)
+		(0xFFFFFFFFFFFFFUL <<  CTX_ENTRY_LOWER_SLPTPTR_POS)
 
 #define DMAR_GET_BITSLICE(var, bitname) \
 	((var & bitname ## _MASK) >> bitname ## _POS)
@@ -57,14 +57,14 @@
 	  ~bitname ## _MASK) | ((val << bitname ## _POS) & bitname ## _MASK))
 
 /* translation type */
-#define DMAR_CTX_TT_UNTRANSLATED    0x0
-#define DMAR_CTX_TT_ALL             0x1
-#define DMAR_CTX_TT_PASSTHROUGH     0x2
+#define DMAR_CTX_TT_UNTRANSLATED    0x0UL
+#define DMAR_CTX_TT_ALL             0x1UL
+#define DMAR_CTX_TT_PASSTHROUGH     0x2UL
 
 /* Fault event MSI data register */
-#define DMAR_MSI_DELIVERY_MODE_SHIFT     (8)
-#define DMAR_MSI_DELIVERY_FIXED          (0 << DMAR_MSI_DELIVERY_MODE_SHIFT)
-#define DMAR_MSI_DELIVERY_LOWPRI         (1 << DMAR_MSI_DELIVERY_MODE_SHIFT)
+#define DMAR_MSI_DELIVERY_MODE_SHIFT     (8U)
+#define DMAR_MSI_DELIVERY_FIXED          (0U << DMAR_MSI_DELIVERY_MODE_SHIFT)
+#define DMAR_MSI_DELIVERY_LOWPRI         (1U << DMAR_MSI_DELIVERY_MODE_SHIFT)
 
 /* Fault event MSI address register */
 #define DMAR_MSI_DEST_MODE_SHIFT         (2)
@@ -312,27 +312,28 @@ static void dmar_uint_show_capability(struct dmar_drhd_rt *dmar_uint)
 }
 #endif
 
-static inline uint8_t width_to_level(int width)
+static inline uint8_t width_to_level(uint32_t width)
 {
-	return ((width - 12) + (LEVEL_WIDTH)-1) / (LEVEL_WIDTH);
+	return ((width - 12U) + (LEVEL_WIDTH)-1U) / (LEVEL_WIDTH);
 }
 
-static inline uint8_t width_to_agaw(int width)
+static inline uint8_t width_to_agaw(uint32_t width)
 {
-	return width_to_level(width) - 2;
+	return width_to_level(width) - 2U;
 }
 
 static uint8_t dmar_uint_get_msagw(struct dmar_drhd_rt *dmar_uint)
 {
-	int i;
+	uint8_t i;
 	uint8_t sgaw = iommu_cap_sagaw(dmar_uint->cap);
 
-	for (i = 4; i >= 0; i--) {
-		if (((1 << i) & sgaw) != 0) {
+	for (i = 5U; i > 0U;) {
+		i--;
+		if (((1U << i) & sgaw) != 0U) {
 			break;
 		}
 	}
-	return (uint8_t)i;
+	return i;
 }
 
 static bool
@@ -340,9 +341,9 @@ dmar_unit_support_aw(struct dmar_drhd_rt *dmar_uint, uint32_t addr_width)
 {
 	uint8_t aw;
 
-	aw = (uint8_t)width_to_agaw(addr_width);
+	aw = width_to_agaw(addr_width);
 
-	return ((1U << aw) & iommu_cap_sagaw(dmar_uint->cap)) != 0;
+	return (((1U << aw) & iommu_cap_sagaw(dmar_uint->cap)) != 0U);
 }
 
 static void dmar_enable_translation(struct dmar_drhd_rt *dmar_uint)
@@ -390,6 +391,7 @@ static void dmar_register_hrhd(struct dmar_drhd_rt *dmar_uint)
 	dmar_uint->gcmd = iommu_read64(dmar_uint, DMAR_GCMD_REG);
 
 	dmar_uint->cap_msagaw = dmar_uint_get_msagw(dmar_uint);
+
 	dmar_uint->cap_num_fault_regs =
 		iommu_cap_num_fault_regs(dmar_uint->cap);
 	dmar_uint->cap_fault_reg_offset =
@@ -508,7 +510,7 @@ static uint8_t alloc_domain_id(void)
 
 static void free_domain_id(uint16_t dom_id)
 {
-	uint64_t mask = (1 << dom_id);
+	uint64_t mask = (1UL << dom_id);
 
 	spinlock_obtain(&domain_lock);
 	domain_bitmap &= ~mask;
@@ -577,7 +579,7 @@ static void dmar_invalid_context_cache(struct dmar_drhd_rt *dmar_uint,
 	IOMMU_LOCK(dmar_uint);
 	iommu_write64(dmar_uint, DMAR_CCMD_REG, cmd);
 	/* read upper 32bits to check */
-	DMAR_WAIT_COMPLETION(DMAR_CCMD_REG + 4, (status & DMA_CCMD_ICC_32) == 0U,
+	DMAR_WAIT_COMPLETION(DMAR_CCMD_REG + 4U, (status & DMA_CCMD_ICC_32) == 0U,
 				 status);
 
 	IOMMU_UNLOCK(dmar_uint);
@@ -867,7 +869,7 @@ static void dmar_disable(struct dmar_drhd_rt *dmar_uint)
 }
 
 struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_table,
-		int addr_width)
+		uint32_t addr_width)
 {
 	struct iommu_domain *domain;
 	uint16_t domain_id;
@@ -1172,7 +1174,7 @@ void disable_iommu(void)
 }
 
 /* 4 iommu fault register state */
-#define	IOMMU_FAULT_REGISTER_STATE_NUM	4
+#define	IOMMU_FAULT_REGISTER_STATE_NUM	4U
 static uint32_t
 iommu_fault_state[CONFIG_MAX_IOMMU_NUM][IOMMU_FAULT_REGISTER_STATE_NUM];
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -20,9 +20,9 @@ static void run_vcpu_pre_work(struct vcpu *vcpu)
 
 void vcpu_thread(struct vcpu *vcpu)
 {
-	uint64_t vmexit_begin = 0, vmexit_end = 0;
-	uint16_t basic_exit_reason = 0;
-	uint64_t tsc_aux_hyp_cpu = vcpu->pcpu_id;
+	uint64_t vmexit_begin = 0UL, vmexit_end = 0UL;
+	uint16_t basic_exit_reason = 0U;
+	uint64_t tsc_aux_hyp_cpu = (uint64_t) vcpu->pcpu_id;
 	int32_t ret = 0;
 
 	/* If vcpu is not launched, we need to do init_vmcs first */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -623,7 +623,7 @@ int64_t hcall_assign_ptdev(struct vm *vm, uint64_t vmid, uint64_t param)
 		}
 		/* TODO: how to get vm's address width? */
 		target_vm->iommu_domain = create_iommu_domain(vmid,
-				target_vm->arch_vm.nworld_eptp, 48);
+				target_vm->arch_vm.nworld_eptp, 48U);
 		if (target_vm->iommu_domain == NULL) {
 			return -ENODEV;
 		}

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -60,7 +60,7 @@ int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req)
 	union vhm_request_buffer *req_buf = NULL;
 	uint16_t cur;
 
-	ASSERT(sizeof(*req) == (4096/VHM_REQUEST_MAX),
+	ASSERT(sizeof(*req) == (4096U/VHM_REQUEST_MAX),
 			"vhm_request page broken!");
 
 
@@ -99,7 +99,7 @@ int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req)
 
 #ifdef HV_DEBUG
 static void _get_req_info_(struct vhm_request *req, int *id, char *type,
-	char *state, char *dir, long *addr, long *val)
+	char *state, char *dir, int64_t *addr, long *val)
 {
 	(void)strcpy_s(dir, 16, "NONE");
 	*addr = 0;

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -128,7 +128,7 @@ static int ptdev_interrupt_handler(__unused int irq, void *data)
 
 /* active intr with irq registering */
 void
-ptdev_activate_entry(struct ptdev_remapping_info *entry, int phys_irq,
+ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq,
 		bool lowpri)
 {
 	struct dev_handler_node *node;

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -56,8 +56,8 @@ static uint64_t create_zero_page(struct vm *vm)
 		(uint32_t)(uint64_t)sw_linux->bootargs_load_addr;
 
 	/* set constant arguments in zero page */
-	zeropage->hdr.loader_type = 0xff;
-	zeropage->hdr.load_flags |= (1U << 5);	/* quiet */
+	zeropage->hdr.loader_type = 0xffU;
+	zeropage->hdr.load_flags |= (1U << 5U);	/* quiet */
 
 	/* Create/add e820 table entries in zeropage */
 	zeropage->e820_nentries = create_e820_table(zeropage->e820);
@@ -82,7 +82,7 @@ int load_guest(struct vm *vm, struct vcpu *vcpu)
 
 	/* hardcode vcpu entry addr(kernel entry) & rsi (zeropage)*/
 	(void)memset(cur_context->guest_cpu_regs.longs,
-			0, sizeof(uint64_t)*NUM_GPRS);
+			0U, sizeof(uint64_t)*NUM_GPRS);
 
 	hva  = GPA2HVA(vm, lowmem_gpa_top -
 			MEM_4K - MEM_2K);
@@ -122,10 +122,10 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	/* calculate the kernel entry point */
 	zeropage = (struct zero_page *)
 			vm->sw.kernel_info.kernel_src_addr;
-	kernel_entry_offset = (zeropage->hdr.setup_sects + 1) * 512;
+	kernel_entry_offset = (zeropage->hdr.setup_sects + 1U) * 512U;
 	if (vcpu->arch_vcpu.cpu_mode == CPU_MODE_64BIT) {
 		/* 64bit entry is the 512bytes after the start */
-		kernel_entry_offset += 512;
+		kernel_entry_offset += 512U;
 	}
 
 	vm->sw.kernel_info.kernel_entry_addr =
@@ -152,7 +152,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 		 * zeropage
 		 */
 		(void)memset(cur_context->guest_cpu_regs.longs,
-			0, sizeof(uint64_t) * NUM_GPRS);
+			0U, sizeof(uint64_t) * NUM_GPRS);
 
 		/* Get host-physical address for guest bootargs */
 		hva = GPA2HVA(vm,

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -9,7 +9,7 @@
 
 #include <ptdev.h>
 
-void ptdev_intx_ack(struct vm *vm, int virt_pin,
+void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
 int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
 		struct ptdev_msi_info *info);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -13,7 +13,7 @@
 #define REG_SIZE                            8
 
 /* Number of GPRs saved / restored for guest in VCPU structure */
-#define NUM_GPRS                            15
+#define NUM_GPRS                            15U
 #define GUEST_STATE_AREA_SIZE               512
 
 #define	CPU_CONTEXT_INDEX_RAX			0

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -41,31 +41,31 @@
 /*
  * Decoding Capability Register
  */
-#define iommu_cap_pi(c)			(((c) >> 59) & 1UL)
-#define iommu_cap_read_drain(c)   (((c) >> 55) & 1UL)
-#define iommu_cap_write_drain(c)  (((c) >> 54) & 1UL)
-#define iommu_cap_max_amask_val(c)    (((c) >> 48) & 0x3fUL)
-#define iommu_cap_num_fault_regs(c)   ((((c) >> 40) & 0xffUL) + 1)
-#define iommu_cap_pgsel_inv(c)    (((c) >> 39) & 1UL)
+#define iommu_cap_pi(c)			(((c) >> 59U) & 1UL)
+#define iommu_cap_read_drain(c)   (((c) >> 55U) & 1UL)
+#define iommu_cap_write_drain(c)  (((c) >> 54U) & 1UL)
+#define iommu_cap_max_amask_val(c)    (((c) >> 48U) & 0x3fUL)
+#define iommu_cap_num_fault_regs(c)   ((((c) >> 40U) & 0xffUL) + 1UL)
+#define iommu_cap_pgsel_inv(c)    (((c) >> 39U) & 1UL)
 
-#define iommu_cap_super_page_val(c)   (((c) >> 34) & 0xfUL)
+#define iommu_cap_super_page_val(c)   (((c) >> 34U) & 0xfUL)
 #define iommu_cap_super_offset(c) \
 	(((find_first_bit(&iommu_cap_super_page_val(c), 4)) \
 	* OFFSET_STRIDE) + 21)
 
-#define iommu_cap_fault_reg_offset(c) ((((c) >> 24) & 0x3ffUL) * 16)
+#define iommu_cap_fault_reg_offset(c) ((((c) >> 24U) & 0x3ffUL) * 16UL)
 #define iommu_cap_max_fault_reg_offset(c) \
-	(iommu_cap_fault_reg_offset(c) + iommu_cap_num_fault_regs(c) * 16)
+	(iommu_cap_fault_reg_offset(c) + iommu_cap_num_fault_regs(c) * 16UL)
 
-#define iommu_cap_zlr(c)      (((c) >> 22) & 1UL)
-#define iommu_cap_isoch(c)        (((c) >> 23) & 1UL)
-#define iommu_cap_mgaw(c)     ((((c) >> 16) & 0x3f) + 1UL)
-#define iommu_cap_sagaw(c)        (((c) >> 8) & 0x1fUL)
-#define iommu_cap_caching_mode(c) (((c) >> 7) & 1UL)
-#define iommu_cap_phmr(c)     (((c) >> 6) & 1UL)
-#define iommu_cap_plmr(c)     (((c) >> 5) & 1UL)
-#define iommu_cap_rwbf(c)     (((c) >> 4) & 1UL)
-#define iommu_cap_afl(c)      (((c) >> 3) & 1UL)
+#define iommu_cap_zlr(c)      (((c) >> 22U) & 1UL)
+#define iommu_cap_isoch(c)        (((c) >> 23U) & 1UL)
+#define iommu_cap_mgaw(c)     ((((c) >> 16U) & 0x3f) + 1UL)
+#define iommu_cap_sagaw(c)        (((c) >> 8U) & 0x1fUL)
+#define iommu_cap_caching_mode(c) (((c) >> 7U) & 1UL)
+#define iommu_cap_phmr(c)     (((c) >> 6U) & 1UL)
+#define iommu_cap_plmr(c)     (((c) >> 5U) & 1UL)
+#define iommu_cap_rwbf(c)     (((c) >> 4U) & 1UL)
+#define iommu_cap_afl(c)      (((c) >> 3U) & 1UL)
 #define iommu_cap_ndoms(c)        ((1U) << (4U + 2U * ((c) & 0x7U)))
 
 /*
@@ -218,7 +218,7 @@ int unassign_iommu_device(struct iommu_domain *domain,
 
 /* Create a iommu domain for a VM specified by vm_id */
 struct iommu_domain *create_iommu_domain(uint16_t vm_id,
-	uint64_t translation_table, int addr_width);
+	uint64_t translation_table, uint32_t addr_width);
 
 /* Destroy the iommu domain */
 int destroy_iommu_domain(struct iommu_domain *domain);

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -77,7 +77,7 @@ struct ptdev_remapping_info *alloc_entry(struct vm *vm,
 void release_entry(struct ptdev_remapping_info *entry);
 void ptdev_activate_entry(
 		struct ptdev_remapping_info *entry,
-		int phys_irq, bool lowpri);
+		uint32_t phys_irq, bool lowpri);
 void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
 
 #ifdef HV_DEBUG

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -24,7 +24,7 @@
 /*
  * IO request
  */
-#define VHM_REQUEST_MAX 16
+#define VHM_REQUEST_MAX 16U
 
 #define REQ_STATE_PENDING	0
 #define REQ_STATE_SUCCESS	1
@@ -36,8 +36,8 @@
 #define REQ_PCICFG	2U
 #define REQ_WP		3U
 
-#define REQUEST_READ	0
-#define REQUEST_WRITE	1
+#define REQUEST_READ	0U
+#define REQUEST_WRITE	1U
 
 /* IOAPIC device model info */
 #define VIOAPIC_RTE_NUM	48U  /* vioapic pins */


### PR DESCRIPTION
Signed/unsigned conversion should add cast explicitily
or change the type of them to the same.

V1->V2:Fixed the 0U to 0UL because of the mistakes.
V2->V3:remove unsed macro

Signed-off-by: HuiHuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>