### PR TITLE
HV: consider header depenencies when rebuilding

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -272,10 +272,13 @@ $(VERSION):
 	echo "#define HV_BUILD_TIME "\""$$TIME"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_USER "\""$$USER"\""" >> $(VERSION)
 
+-include $(C_OBJS:.o=.d)
+-include $(S_OBJS:.o=.d)
+
 $(HV_OBJDIR)/%.o: %.c $(HV_OBJDIR)/$(HV_CONFIG_H)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \
-	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@
+	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@ -MMD -MT $@
 
 $(HV_OBJDIR)/%.o: %.S $(HV_OBJDIR)/$(HV_CONFIG_H)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \
-	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. $(ASFLAGS) $(ARCH_ASFLAGS) -c $< -o $@
+	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. $(ASFLAGS) $(ARCH_ASFLAGS) -c $< -o $@ -MMD -MT $@

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -1,9 +1,15 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 #ifndef PER_CPU_H
 #define PER_CPU_H
+
 #include <hypervisor.h>
 #include <bsp_extern.h>
 #include <schedule.h>
-#include <version.h>
 #include <common/irq.h>
 #include <arch/x86/irq.h>
 #include <sbuf.h>
@@ -52,4 +58,5 @@ extern uint64_t pcpu_active_bitmap;
 
 /* get percpu data for current pcpu */
 #define get_cpu_var(name)	per_cpu(name, get_cpu_id())
+
 #endif


### PR DESCRIPTION
With Kconfig, it would be common to rebuild the hypervisor with a few
configuration symbols changed. But for a proper rebuild, users are required to
execute ''make clean'' first, which deletes the configuration file at all.

This patch leverages the compiler to generate a target that add involved headers
as dependencies to a specific file. The inclusion of version.h is dropped in
per_cpu.h to avoid forcefully rebuild of all files since version.h is created on
build.