### PR TITLE
hv: cpu state update should be moved just before halt.

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -750,13 +750,13 @@ void cpu_dead(uint16_t pcpu_id)
 		return;
 	}
 
-	/* Set state to show CPU is dead */
-	cpu_set_current_state(pcpu_id, CPU_STATE_DEAD);
-
 	/* clean up native stuff */
 	timer_cleanup();
 	vmx_off(pcpu_id);
 	CACHE_FLUSH_INVALIDATE_ALL();
+
+	/* Set state to show CPU is dead */
+	cpu_set_current_state(pcpu_id, CPU_STATE_DEAD);
 
 	/* Halt the CPU */
 	do {


### PR DESCRIPTION
The cpu offline requester monitor the target cpu state
to detect whether target cpu is put to offline already.

So we should only update the cpu state to offline after
all other operations are finished.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Eddie Dong <Eddie.dong@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>