### PR TITLE
hv: sprintf: fix 'Declaration does not specify an array'

### DIFF
--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -10,7 +10,9 @@
 #define NULL ((void *) 0)
 #endif
 
-#define PRINT_STRING_MAX_LEN 4096
+#define PRINT_STRING_MAX_LEN		4096U
+
+#define HEX_DIGITS_LEN			17U
 
 /** Use upper case letters for hexadecimal format. */
 #define PRINT_FLAG_UPPER		0x00000001U
@@ -292,7 +294,7 @@ static int print_pow2(struct print_param *param,
 	/* buffer for the 0/0x/0X prefix */
 	char prefix[2];
 	/* pointer to the digits translation table */
-	const char *digits;
+	const char (*digits)[HEX_DIGITS_LEN];
 	/* mask to extract next character */
 	uint64_t mask;
 	int ret;
@@ -302,7 +304,7 @@ static int print_pow2(struct print_param *param,
 
 	/* determine digit translation table */
 	digits = ((param->vars.flags & PRINT_FLAG_UPPER) != 0) ?
-			upper_hex_digits : lower_hex_digits;
+			&upper_hex_digits : &lower_hex_digits;
 
 	/* apply mask for short/char */
 	v &= param->vars.mask;
@@ -315,14 +317,14 @@ static int print_pow2(struct print_param *param,
 
 		if (shift == 4U) {
 			param->vars.prefixlen = 2U;
-			prefix[1] = digits[16];
+			prefix[1] = (*digits)[16];
 		}
 	}
 
 	/* determine digits from right to left */
 	do {
 		pos--;
-		*pos = digits[(v & mask)];
+		*pos = (*digits)[(v & mask)];
 		v >>= shift;
 	} while (v != 0UL);
 


### PR DESCRIPTION
The array size of upper_hex_digits and lower_hex_digits are same and
constant.
Use an array rather than a pointer to fix the violation - 'Declaration
does not specify an array'

v3 -> v4:
 * Update the array size of 'digits'
 * Update the usage of 'digits'

v2 -> v3:
 * Update the usage of 'digits'

v1 -> v2:
 * Define a MACRO for the array size of 'digits'
 * Simplify the declaration of 'digits'

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>