### PR TITLE
HV: vioapic: fixes to integral-type-related violations

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -6,11 +6,7 @@
 
 #include <hypervisor.h>
 
-/* Register offsets */
-#define IOAPIC_REGSEL_OFFSET   0
-#define IOAPIC_WINSWL_OFFSET   0x10
-
-#define IOAPIC_MAX_PIN          240U
+#define	IOAPIC_MAX_PIN		240U
 #define IOAPIC_INVALID_PIN      0xffU
 
 struct gsi_table {
@@ -103,9 +99,9 @@ ioapic_read_reg32(const void *ioapic_base, const uint32_t offset)
 	spinlock_irqsave_obtain(&ioapic_lock);
 
 	/* Write IOREGSEL */
-	mmio_write_long(offset, (void *)ioapic_base + IOAPIC_REGSEL_OFFSET);
+	mmio_write_long(offset, (void *)ioapic_base + IOAPIC_REGSEL);
 	/* Read  IOWIN */
-	v = mmio_read_long((void *)ioapic_base + IOAPIC_WINSWL_OFFSET);
+	v = mmio_read_long((void *)ioapic_base + IOAPIC_WINDOW);
 
 	spinlock_irqrestore_release(&ioapic_lock);
 	return v;
@@ -120,9 +116,9 @@ ioapic_write_reg32(const void *ioapic_base,
 	spinlock_irqsave_obtain(&ioapic_lock);
 
 	/* Write IOREGSEL */
-	mmio_write_long(offset, (void *)ioapic_base + IOAPIC_REGSEL_OFFSET);
+	mmio_write_long(offset, (void *)ioapic_base + IOAPIC_REGSEL);
 	/* Write IOWIN */
-	mmio_write_long(value, (void *)ioapic_base + IOAPIC_WINSWL_OFFSET);
+	mmio_write_long(value, (void *)ioapic_base + IOAPIC_WINDOW);
 
 	spinlock_irqrestore_release(&ioapic_lock);
 }

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -253,6 +253,15 @@ struct ioapic {
 	uint32_t iowin;	PAD3;
 };
 
+/* IOAPIC Redirection Table (RTE) Entry structure */
+union ioapic_rte {
+	uint64_t full;
+	struct {
+		uint32_t lo_32;
+		uint32_t hi_32;
+	} u;
+};
+
 #undef PAD4
 #undef PAD3
 
@@ -480,7 +489,9 @@ struct ioapic {
 /*
  * fields in the IO APIC's redirection table entries
  */
-#define IOAPIC_RTE_DEST	APIC_ID_MASK	/* broadcast addr: all APICs */
+#define IOAPIC_RTE_DEST_SHIFT  	56U
+/* broadcast addr: all APICs */
+#define IOAPIC_RTE_DEST_MASK	0xff00000000000000UL
 
 #define IOAPIC_RTE_RESV	0x00fe0000UL	/* reserved */
 

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -449,6 +449,7 @@ union ioapic_rte {
 #define DEFAULT_IO_APIC_BASE	0xfec00000UL
 
 /* window register offset */
+#define IOAPIC_REGSEL		0x00U
 #define IOAPIC_WINDOW		0x10U
 #define IOAPIC_EOIR		0x40U
 

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -46,10 +46,8 @@ int	vioapic_deassert_irq(struct vm *vm, uint32_t irq);
 int	vioapic_pulse_irq(struct vm *vm, uint32_t irq);
 void	vioapic_update_tmr(struct vcpu *vcpu);
 
-int	vioapic_mmio_write(void *vm, uint64_t gpa,
-	    uint64_t wval, int size);
-int	vioapic_mmio_read(void *vm, uint64_t gpa,
-	    uint64_t *rval, int size);
+void	vioapic_mmio_write(struct vm *vm, uint64_t gpa, uint32_t wval);
+void	vioapic_mmio_read(struct vm *vm, uint64_t gpa, uint32_t *rval);
 
 uint8_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -31,6 +31,9 @@
 #ifndef _VIOAPIC_H_
 #define	_VIOAPIC_H_
 
+#include <apicreg.h>
+#include <vm.h>
+
 #define	VIOAPIC_BASE	0xFEC00000UL
 #define	VIOAPIC_SIZE	4096UL
 
@@ -50,7 +53,7 @@ int	vioapic_mmio_read(void *vm, uint64_t gpa,
 
 uint8_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
-bool	vioapic_get_rte(struct vm *vm, uint8_t pin, void *rte);
+bool	vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
 		void *handler_private_data);
 

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -17,7 +17,6 @@
 
 #define GSI_MASK_IRQ(irq) irq_gsi_mask_unmask((irq), true)
 #define GSI_UNMASK_IRQ(irq) irq_gsi_mask_unmask((irq), false)
-#define GSI_SET_RTE(irq, rte) ioapic_set_rte((irq), (rte))
 
 void setup_ioapic_irq(void);
 
@@ -26,8 +25,8 @@ uint32_t irq_gsi_num(void);
 uint8_t irq_to_pin(uint32_t irq);
 uint32_t pin_to_irq(uint8_t pin);
 void irq_gsi_mask_unmask(uint32_t irq, bool mask);
-void ioapic_set_rte(uint32_t irq, uint64_t rte);
-void ioapic_get_rte(uint32_t irq, uint64_t *rte);
+void ioapic_set_rte(uint32_t irq, union ioapic_rte rte);
+void ioapic_get_rte(uint32_t irq, union ioapic_rte *rte);
 
 
 void suspend_ioapic(void);


### PR DESCRIPTION
This patch series fix MISRA C violations related to integral types, with:

    * the first unifying access patterns to ioapic/vioapic RTEs to avoid
      implicit narrowing, and

    * the second fixing rest of the violations that can be fixed locally.

v1 -> v2:

    * Instead of two 32-bit ''low'' and ''high'', define a union that allows
      either 32-bit or 64-bit accesses to RTEs.
    * Drop duplicated definitions to IOAPIC register offsets.
    * Drop the ''size'' parameter of vioapic_mmio_[read|write] and
      vioapic_mmio_rw since vioapic_mmio_access_handler() ensures that size is
      always 4.