### PR TITLE
 HV:vtd change the macro to the inline function

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -754,7 +754,7 @@ static void fault_record_analysis(__unused uint64_t low, uint64_t high)
 		DMA_FRCD_UP_SID(high) & 0x7UL,
 		low);
 #if DBG_IOMMU
-	if (iommu_ecap_dt(dmar_uint->ecap)) {
+	if (iommu_ecap_dt(dmar_uint->ecap)i != 0U) {
 		pr_info("Address Type: 0x%x",
 				DMA_FRCD_UP_AT(high));
 	}

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -35,8 +35,15 @@
 #define DMAR_ICS_REG    0x9cU    /* Invalidation complete status register */
 #define DMAR_IRTA_REG   0xb8U    /* Interrupt remapping table addr register */
 
-#define DMAR_VER_MAJOR(v)       (((v) & 0xf0U) >> 4)
-#define DMAR_VER_MINOR(v)       ((v) & 0x0fU)
+static inline uint8_t dmar_ver_major(uint64_t version)
+{
+	return ((version & 0xf0UL) >> 4U);
+}
+
+static inline uint8_t dmar_ver_minor(uint64_t version)
+{
+	return (version & 0x0fUL);
+}
 
 /*
  * Decoding Capability Register
@@ -282,14 +289,30 @@ static inline uint8_t iommu_ecap_pds(uint64_t ecap)
 #define DMA_CCMD_GLOBAL_INVL (((uint64_t)1UL) << 61)
 #define DMA_CCMD_DOMAIN_INVL (((uint64_t)2UL) << 61)
 #define DMA_CCMD_DEVICE_INVL (((uint64_t)3UL) << 61)
-#define DMA_CCMD_FM(m) (((uint64_t)((m) & 0x3UL)) << 32)
+static inline uint64_t dma_ccmd_fm(uint8_t fm)
+{
+	return (((uint64_t)(fm & 0x3U)) << 32U);
+}
+
 #define DMA_CCMD_MASK_NOBIT 0UL
 #define DMA_CCMD_MASK_1BIT 1UL
 #define DMA_CCMD_MASK_2BIT 2UL
 #define DMA_CCMD_MASK_3BIT 3UL
-#define DMA_CCMD_SID(s) (((uint64_t)((s) & 0xffffUL)) << 16)
-#define DMA_CCMD_DID(d) ((uint64_t)((d) & 0xffffUL))
-#define DMA_CCMD_GET_CAIG_32(v) (((uint32_t)(v) >> 27) & 0x3U)
+static inline uint64_t dma_ccmd_sid(uint16_t sid)
+{
+	return (((uint64_t)(sid & 0xffffU)) << 16U);
+}
+
+static inline uint16_t dma_ccmd_did(uint16_t did)
+{
+	return (did & 0xffffU);
+}
+
+static inline uint8_t dma_ccmd_get_caig_32(uint32_t gaig)
+{
+	return ((gaig >> 27U) & 0x3U);
+}
+
 
 /* IOTLB_REG */
 #define DMA_IOTLB_IVT				(((uint64_t)1UL) << 63)
@@ -299,38 +322,118 @@ static inline uint8_t iommu_ecap_pds(uint64_t ecap)
 #define DMA_IOTLB_PAGE_INVL			(((uint64_t)3UL) << 60)
 #define DMA_IOTLB_DR				(((uint64_t)1UL) << 49)
 #define DMA_IOTLB_DW				(((uint64_t)1UL) << 48)
-#define DMA_IOTLB_DID(d)			 \
-	(((uint64_t)((d) & 0xffffUL)) << 32)
-#define DMA_IOTLB_GET_IAIG_32(v)	(((uint32_t)(v) >> 25) & 0x3U)
+static inline uint64_t dma_iotlb_did(uint16_t did)
+{
+	return (((uint64_t)(did & 0xffffU)) << 32U);
+}
+
+static inline uint8_t dma_iotlb_get_iaig_32(uint32_t iai)
+{
+	return ((iai >> 25U) & 0x3U);
+}
 
 /* INVALIDATE_ADDRESS_REG */
-#define DMA_IOTLB_INVL_ADDR_AM(m)			((uint64_t)((m) & 0x3fUL))
+static inline uint8_t dma_iotlb_invl_addr_am(uint8_t am)
+{
+	return (am & 0x3fU);
+}
+
 #define DMA_IOTLB_INVL_ADDR_IH_UNMODIFIED	(((uint64_t)1UL) << 6)
 
 /* FECTL_REG */
 #define DMA_FECTL_IM				(((uint32_t)1U) << 31)
 
 /* FSTS_REG */
-#define DMA_FSTS_PFO(s)				(((s) >> 0) & 1U)
-#define DMA_FSTS_PPF(s)				(((s) >> 1) & 1U)
-#define DMA_FSTS_AFO(s)				(((s) >> 2) & 1U)
-#define DMA_FSTS_APF(s)				(((s) >> 3) & 1U)
-#define DMA_FSTS_IQE(s)				(((s) >> 4) & 1U)
-#define DMA_FSTS_ICE(s)				(((s) >> 5) & 1U)
-#define DMA_FSTS_ITE(s)				(((s) >> 6) & 1U)
-#define DMA_FSTS_PRO(s)				(((s) >> 7) & 1U)
-#define DMA_FSTS_FRI(s)				(((s) >> 8) & 0xFFU)
+static inline bool dma_fsts_pfo(uint32_t PFO)
+{
+	return ((PFO >> 0U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_ppf(uint32_t PPF)
+{
+	return ((PPF >> 1U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_afo(uint32_t AFO)
+{
+	return ((AFO >> 2U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_apf(uint32_t APF)
+{
+	return ((APF >> 3U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_iqe(uint32_t IQE)
+{
+	return ((IQE >> 4U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_ice(uint32_t ICE)
+{
+	return ((ICE >> 5U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_ite(uint32_t ITE)
+{
+	return ((ITE >> 6U) & 1U) == 1U;
+}
+
+static inline bool dma_fsts_pro(uint32_t PRO)
+{
+	return ((PRO >> 7U) & 1U) == 1U;
+}
+
+static inline uint8_t dma_fsts_fri(uint32_t FRI)
+{
+	return ((FRI >> 8U) & 0xFFU);
+}
 
 /* FRCD_REGs: upper 64 bits*/
-#define DMA_FRCD_UP_F(r)				(((r) >> 63) & 1UL)
-#define DMA_FRCD_UP_T(r)				(((r) >> 62) & 1UL)
-#define DMA_FRCD_UP_AT(r)				(((r) >> 60) & 3UL)
-#define DMA_FRCD_UP_PASID(r)			(((r) >> 40) & 0xfffffUL)
-#define DMA_FRCD_UP_FR(r)				(((r) >> 32) & 0xffUL)
-#define DMA_FRCD_UP_PP(r)				(((r) >> 31) & 1UL)
-#define DMA_FRCD_UP_EXE(r)				(((r) >> 30) & 1UL)
-#define DMA_FRCD_UP_PRIV(r)				(((r) >> 29) & 1UL)
-#define DMA_FRCD_UP_SID(r)				(((r) >> 0) & 0xffffUL)
+static inline bool dma_frcd_up_f(uint64_t UP_F)
+{
+	return ((UP_F >> 63U) & 1UL) == 1UL;
+}
+
+static inline uint8_t dma_frcd_up_t(uint64_t UP_T)
+{
+	return ((UP_T >> 62U) & 1UL);
+}
+
+static inline uint8_t dma_frcd_up_at(uint64_t UP_AT)
+{
+	return ((UP_AT >> 60U) & 3UL);
+}
+
+static inline uint32_t dma_frcd_up_pasid(uint64_t UP_PASID)
+{
+	return ((UP_PASID >> 40U) & 0xfffffUL);
+}
+
+static inline uint8_t dma_frcd_up_fr(uint64_t UP_FR)
+{
+	return ((UP_FR >> 32U) & 0xffUL);
+}
+
+static inline bool dma_frcd_up_pp(uint64_t UP_PP)
+{
+	return ((UP_PP >> 31U) & 1UL) == 1UL;
+}
+
+static inline bool dma_frcd_up_exe(uint64_t UP_EXE)
+{
+	return ((UP_EXE >> 30U) & 1UL) == 1UL;
+}
+
+static inline bool dma_frcd_up_priv(uint64_t UP_PRIV)
+{
+	return ((UP_PRIV >> 29U) & 1UL) == 1UL;
+}
+
+static inline uint32_t dma_frcd_up_sid(uint64_t UP_SID)
+{
+	return ((UP_SID >> 0U) & 0xffffUL);
+}
 
 #define DMAR_CONTEXT_TRANSLATION_TYPE_TRANSLATED 0x00U
 #define DMAR_CONTEXT_TRANSLATION_TYPE_RESERVED 0x01U

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -41,58 +41,214 @@
 /*
  * Decoding Capability Register
  */
-#define iommu_cap_pi(c)			(((c) >> 59U) & 1UL)
-#define iommu_cap_read_drain(c)   (((c) >> 55U) & 1UL)
-#define iommu_cap_write_drain(c)  (((c) >> 54U) & 1UL)
-#define iommu_cap_max_amask_val(c)    (((c) >> 48U) & 0x3fUL)
-#define iommu_cap_num_fault_regs(c)   ((((c) >> 40U) & 0xffUL) + 1UL)
-#define iommu_cap_pgsel_inv(c)    (((c) >> 39U) & 1UL)
+static inline uint8_t iommu_cap_pi(uint64_t cap)
+{
+	return ((cap >> 59U) & 1UL);
+}
 
-#define iommu_cap_super_page_val(c)   (((c) >> 34U) & 0xfUL)
-#define iommu_cap_super_offset(c) \
-	(((find_first_bit(&iommu_cap_super_page_val(c), 4)) \
-	* OFFSET_STRIDE) + 21)
+static inline uint8_t iommu_cap_read_drain(uint64_t cap)
+{
+	return ((cap >> 55U) & 1UL);
+}
 
-#define iommu_cap_fault_reg_offset(c) ((((c) >> 24U) & 0x3ffUL) * 16UL)
-#define iommu_cap_max_fault_reg_offset(c) \
-	(iommu_cap_fault_reg_offset(c) + iommu_cap_num_fault_regs(c) * 16UL)
+static inline uint8_t iommu_cap_write_drain(uint64_t cap)
+{
+	return ((cap >> 54U) & 1UL);
+}
 
-#define iommu_cap_zlr(c)      (((c) >> 22U) & 1UL)
-#define iommu_cap_isoch(c)        (((c) >> 23U) & 1UL)
-#define iommu_cap_mgaw(c)     ((((c) >> 16U) & 0x3f) + 1UL)
-#define iommu_cap_sagaw(c)        (((c) >> 8U) & 0x1fUL)
-#define iommu_cap_caching_mode(c) (((c) >> 7U) & 1UL)
-#define iommu_cap_phmr(c)     (((c) >> 6U) & 1UL)
-#define iommu_cap_plmr(c)     (((c) >> 5U) & 1UL)
-#define iommu_cap_rwbf(c)     (((c) >> 4U) & 1UL)
-#define iommu_cap_afl(c)      (((c) >> 3U) & 1UL)
-#define iommu_cap_ndoms(c)        ((1U) << (4U + 2U * ((c) & 0x7U)))
+static inline uint8_t iommu_cap_max_amask_val(uint64_t cap)
+{
+	return ((cap >> 48U) & 0x3fUL);
+}
+
+static inline uint16_t iommu_cap_num_fault_regs(uint64_t cap)
+{
+	return (((cap >> 40U) & 0xffUL) + 1UL);
+}
+
+static inline uint8_t iommu_cap_pgsel_inv(uint64_t cap)
+{
+	return ((cap >> 39U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_super_page_val(uint64_t cap)
+{
+	return ((cap >> 34U) & 0xfUL);
+}
+
+static inline uint16_t iommu_cap_fault_reg_offset(uint64_t cap)
+{
+	return (((cap >> 24U) & 0x3ffUL) * 16U);
+}
+
+static inline uint16_t iommu_cap_max_fault_reg_offset(uint64_t cap)
+{
+	return (iommu_cap_fault_reg_offset(cap) +
+		iommu_cap_num_fault_regs(cap) * 16U);
+}
+
+static inline uint8_t iommu_cap_zlr(uint64_t cap)
+{
+	return ((cap >> 22U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_isoch(uint64_t cap)
+{
+	return ((cap >> 23U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_mgaw(uint64_t cap)
+{
+	return (((cap >> 16U) & 0x3fUL) + 1UL);
+}
+
+static inline uint8_t iommu_cap_sagaw(uint64_t cap)
+{
+	return ((cap >> 8U) & 0x1fUL);
+}
+
+static inline uint8_t iommu_cap_caching_mode(uint64_t cap)
+{
+	return ((cap >> 7U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_phmr(uint64_t cap)
+{
+	return ((cap >> 6U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_plmr(uint64_t cap)
+{
+	return ((cap >> 5U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_rwbf(uint64_t cap)
+{
+	return ((cap >> 4U) & 1UL);
+}
+
+static inline uint8_t iommu_cap_afl(uint64_t cap)
+{
+	return ((cap >> 3U) & 1UL);
+}
+
+static inline uint32_t iommu_cap_ndoms(uint64_t cap)
+{
+	return ((1U) << (4UL + 2UL * (cap & 0x7UL)));
+}
 
 /*
  * Decoding Extended Capability Register
  */
-#define iommu_ecap_c(c)		(((c) >> 0) & 1UL)
-#define iommu_ecap_qi(c)		(((c) >> 1) & 1UL)
-#define iommu_ecap_dt(c)		(((c) >> 2) & 1UL)
-#define iommu_ecap_ir(c)		(((c) >> 3) & 1UL)
-#define iommu_ecap_eim(c)		(((c) >> 4) & 1UL)
-#define iommu_ecap_pt(c)		(((c) >> 6) & 1UL)
-#define iommu_ecap_sc(c)		(((c) >> 7) & 1UL)
-#define iommu_ecap_iro(c)		(((c) >> 8) & 0x3ffUL)
-#define iommu_ecap_mhmv(c)	(((c) >> 20) & 0xfUL)
-#define iommu_ecap_ecs(c)		(((c) >> 24) & 1UL)
-#define iommu_ecap_mts(c)		(((c) >> 25) & 1UL)
-#define iommu_ecap_nest(c)	(((c) >> 26) & 1UL)
-#define iommu_ecap_dis(c)		(((c) >> 27) & 1UL)
-#define iommu_ecap_prs(c)		(((c) >> 29) & 1UL)
-#define iommu_ecap_ers(c)		(((c) >> 30) & 1UL)
-#define iommu_ecap_srs(c)		(((c) >> 31) & 1UL)
-#define iommu_ecap_nwfs(c)	(((c) >> 33) & 1UL)
-#define iommu_ecap_eafs(c)	(((c) >> 34) & 1UL)
-#define iommu_ecap_pss(c)		(((c) >> 35) & 0x1fUL)
-#define iommu_ecap_pasid(c)	(((c) >> 40) & 1UL)
-#define iommu_ecap_dit(c)		(((c) >> 41) & 1UL)
-#define iommu_ecap_pds(c)		(((c) >> 42) & 1UL)
+static inline uint8_t iommu_ecap_c(uint64_t ecap)
+{
+	return ((ecap >> 0U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_qi(uint64_t ecap)
+{
+	return ((ecap >> 1U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_dt(uint64_t ecap)
+{
+	return ((ecap >> 2U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_ir(uint64_t ecap)
+{
+	return ((ecap >> 3U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_eim(uint64_t ecap)
+{
+	return ((ecap >> 4U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_pt(uint64_t ecap)
+{
+	return ((ecap >> 6U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_sc(uint64_t ecap)
+{
+	return ((ecap >> 7U) & 1UL);
+}
+
+static inline uint16_t iommu_ecap_iro(uint64_t ecap)
+{
+	return ((ecap >> 8U) & 0x3ffUL);
+}
+
+static inline uint8_t iommu_ecap_mhmv(uint64_t ecap)
+{
+	return ((ecap >> 20U) & 0xfUL);
+}
+
+static inline uint8_t iommu_ecap_ecs(uint64_t ecap)
+{
+	return ((ecap >> 24U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_mts(uint64_t ecap)
+{
+	return ((ecap >> 25U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_nest(uint64_t ecap)
+{
+	return ((ecap >> 26U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_dis(uint64_t ecap)
+{
+	return ((ecap >> 27U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_prs(uint64_t ecap)
+{
+	return ((ecap >> 29U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_ers(uint64_t ecap)
+{
+	return ((ecap >> 30U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_srs(uint64_t ecap)
+{
+	return ((ecap >> 31U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_nwfs(uint64_t ecap)
+{
+	return ((ecap >> 33U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_eafs(uint64_t ecap)
+{
+	return ((ecap >> 34U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_pss(uint64_t ecap)
+{
+	return ((ecap >> 35U) & 0x1fUL);
+}
+
+static inline uint8_t iommu_ecap_pasid(uint64_t ecap)
+{
+	return ((ecap >> 40U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_dit(uint64_t ecap)
+{
+	return ((ecap >> 41U) & 1UL);
+}
+
+static inline uint8_t iommu_ecap_pds(uint64_t ecap)
+{
+	return ((ecap >> 42U) & 1UL);
+}
 
 /* PMEN_REG */
 #define DMA_PMEN_EPM (((uint32_t)1)<<31)


### PR DESCRIPTION
Function like macro changed to be inline function to limit
the return type and parameter type.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>