### PR TITLE
hv: change several APIs to void type

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -544,10 +544,7 @@ static void bsp_boot_post(void)
 
 	ASSERT(get_cpu_id() == BOOT_CPU_ID, "");
 
-	if (init_iommu() != 0) {
-		pr_fatal("%s, init iommu failed\n", __func__);
-		return;
-	}
+	init_iommu();
 
 	console_setup_timer();
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -365,10 +365,10 @@ uint32_t dev_to_vector(struct dev_handler_node *node)
 	return node->desc->vector;
 }
 
-int init_default_irqs(uint16_t cpu_id)
+void init_default_irqs(uint16_t cpu_id)
 {
 	if (cpu_id != BOOT_CPU_ID) {
-		return 0;
+		return;
 	}
 
 	init_irq_desc();
@@ -377,8 +377,6 @@ int init_default_irqs(uint16_t cpu_id)
 	disable_pic_irq();
 	setup_ioapic_irq();
 	init_softirq();
-
-	return 0;
 }
 
 void dispatch_exception(struct intr_excp_ctx *ctx)
@@ -731,28 +729,14 @@ void get_cpu_interrupt_info(char *str, int str_max)
 }
 #endif /* HV_DEBUG */
 
-int interrupt_init(uint16_t pcpu_id)
+void interrupt_init(uint16_t pcpu_id)
 {
 	struct host_idt_descriptor *idtd = &HOST_IDTR;
-	int status;
 
 	set_idt(idtd);
-
-	status = init_lapic(pcpu_id);
-	ASSERT(status == 0, "lapic init failed");
-	if (status != 0) {
-		return -ENODEV;
-	}
-
-	status = init_default_irqs(pcpu_id);
-	ASSERT(status == 0, "irqs init failed");
-	if (status != 0) {
-		return -ENODEV;
-	}
-
+	init_lapic(pcpu_id);
+	init_default_irqs(pcpu_id);
 #ifndef CONFIG_EFI_STUB
 	CPU_IRQ_ENABLE();
 #endif
-
-	return status;
 }

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -180,7 +180,7 @@ static void map_lapic(void)
 	lapic_info.xapic.vaddr = HPA2HVA(lapic_info.xapic.paddr);
 }
 
-int early_init_lapic(void)
+void early_init_lapic(void)
 {
 	/* Get local APIC base address */
 	lapic_base_msr.value = msr_read(MSR_IA32_APIC_BASE);
@@ -207,11 +207,9 @@ int early_init_lapic(void)
 		ASSERT(lapic_base_msr.fields.x2APIC_enable == 0U,
 			"Disable X2APIC in BIOS");
 	}
-
-	return 0;
 }
 
-int init_lapic(uint16_t pcpu_id)
+void init_lapic(uint16_t pcpu_id)
 {
 	/* Set the Logical Destination Register */
 	write_lapic_reg32(LAPIC_LOGICAL_DESTINATION_REGISTER,
@@ -236,8 +234,6 @@ int init_lapic(uint16_t pcpu_id)
 
 	/* Ensure there are no ISR bits set. */
 	clear_lapic_isr();
-
-	return 0;
 }
 
 void save_lapic(struct lapic_regs *regs)

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -322,6 +322,9 @@ int parse_dmar_table(void)
 	return 0;
 }
 
+/**
+ * @post return != NULL
+ */
 struct dmar_info *get_dmar_info(void)
 {
 	parse_dmar_table();

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -70,7 +70,7 @@ int common_handler_edge(struct irq_desc *desc, void *handler_data);
 int common_dev_handler_level(struct irq_desc *desc, void *handler_data);
 int quick_handler_nolock(struct irq_desc *desc, void *handler_data);
 
-int init_default_irqs(uint16_t cpu);
+void init_default_irqs(uint16_t cpu);
 
 void dispatch_exception(struct intr_excp_ctx *ctx);
 void dispatch_interrupt(struct intr_excp_ctx *ctx);
@@ -106,7 +106,7 @@ int exception_vmexit_handler(struct vcpu *vcpu);
 int interrupt_window_vmexit_handler(struct vcpu *vcpu);
 int external_interrupt_vmexit_handler(struct vcpu *vcpu);
 int acrn_handle_pending_request(struct vcpu *vcpu);
-int interrupt_init(uint16_t pcpu_id);
+void interrupt_init(uint16_t pcpu_id);
 
 void cancel_event_injection(struct vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -134,8 +134,8 @@ union lapic_id {
 
 void write_lapic_reg32(uint32_t offset, uint32_t value);
 void save_lapic(struct lapic_regs *regs);
-int early_init_lapic(void);
-int init_lapic(uint16_t cpu_id);
+void early_init_lapic(void);
+void init_lapic(uint16_t cpu_id);
 void send_lapic_eoi(void);
 uint8_t get_cur_lapic_id(void);
 int send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -221,7 +221,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id,
 	uint64_t translation_table, uint32_t addr_width);
 
 /* Destroy the iommu domain */
-int destroy_iommu_domain(struct iommu_domain *domain);
+void destroy_iommu_domain(struct iommu_domain *domain);
 
 /* Enable translation of iommu*/
 void enable_iommu(void);
@@ -236,5 +236,5 @@ void suspend_iommu(void);
 void resume_iommu(void);
 
 /* iommu initialization */
-int init_iommu(void);
+void init_iommu(void);
 #endif


### PR DESCRIPTION
Change these 6 APIs to void type:
  init_default_irqs
  interrupt_init
  early_init_lapic
  init_lapic
  init_iommu
  destroy_iommu_domain
It has checked the argument of destroy_iommu_domain in shutdown_vm,
then no need to check it again inside destroy_iommu_domain.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>