### PR TITLE
HV:common:fix "integer type violations"

### DIFF
--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -43,7 +43,7 @@
 /*
  * IO request
  */
-#define VHM_REQUEST_MAX 16
+#define VHM_REQUEST_MAX 16U
 
 #define REQ_STATE_PENDING	0
 #define REQ_STATE_SUCCESS	1
@@ -55,8 +55,8 @@
 #define REQ_PCICFG	2
 #define REQ_WP		3
 
-#define REQUEST_READ	0
-#define REQUEST_WRITE	1
+#define REQUEST_READ	0U
+#define REQUEST_WRITE	1U
 
 /* IOAPIC device model info */
 #define VIOAPIC_RTE_NUM	48  /* vioapic pins */
@@ -143,7 +143,7 @@ union vhm_request_buffer {
  */
 struct acrn_create_vm {
 	/** created vmid return to VHM. Keep it first field */
-	int32_t vmid;
+	int16_t vmid;
 
 	/** VCPU numbers this VM want to create */
 	uint32_t vcpu_num;
@@ -184,10 +184,10 @@ struct acrn_set_ioreq_buffer {
 } __aligned(8);
 
 /** Interrupt type for acrn_irqline: inject interrupt to IOAPIC */
-#define	ACRN_INTR_TYPE_ISA	0
+#define	ACRN_INTR_TYPE_ISA	0U
 
 /** Interrupt type for acrn_irqline: inject interrupt to both PIC and IOAPIC */
-#define	ACRN_INTR_TYPE_IOAPIC	1
+#define	ACRN_INTR_TYPE_IOAPIC	1U
 
 /**
  * @brief Info to assert/deassert/pulse a virtual IRQ line for a VM
@@ -286,7 +286,7 @@ struct acrn_vm_pci_msix_remap {
  * layout below 1M, DM add this address to E280 reserved range to make sure
  * there is no overlap for the address 0xef000 usage.
  */
-#define GUEST_CFG_OFFSET	0xef000
+#define GUEST_CFG_OFFSET	0xef000UL
 
 /**
  * @brief Info The power state data of a VCPU.
@@ -333,10 +333,10 @@ struct cpu_px_data {
  * For Px, PMCMD_STATE_NUM means Px number from 0 to (MAX_PSTATE - 1),
  * For Cx, PMCMD_STATE_NUM means Cx entry index from 1 to MAX_CX_ENTRY.
  */
-#define PMCMD_VMID_MASK		0xff000000
-#define PMCMD_VCPUID_MASK	0x00ff0000
-#define PMCMD_STATE_NUM_MASK	0x0000ff00
-#define PMCMD_TYPE_MASK		0x000000ff
+#define PMCMD_VMID_MASK		0xff000000U
+#define PMCMD_VCPUID_MASK	0x00ff0000U
+#define PMCMD_STATE_NUM_MASK	0x0000ff00U
+#define PMCMD_TYPE_MASK		0x000000ffU
 
 #define PMCMD_VMID_SHIFT	24
 #define PMCMD_VCPUID_SHIFT	16

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -271,8 +271,8 @@ $(VERSION):
 	echo "#define HV_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION);\
 	echo "#define HV_EXTRA_VERSION "\"$(EXTRA_VERSION)\""" >> $(VERSION);\
 	echo "#define HV_FULL_VERSION "\"$(FULL_VERSION)\""" >> $(VERSION);\
-	echo "#define HV_API_MAJOR_VERSION $(API_MAJOR_VERSION)" >> $(VERSION);\
-	echo "#define HV_API_MINOR_VERSION $(API_MINOR_VERSION)" >> $(VERSION);\
+	echo "#define HV_API_MAJOR_VERSION $(API_MAJOR_VERSION)U" >> $(VERSION);\
+	echo "#define HV_API_MINOR_VERSION $(API_MINOR_VERSION)U" >> $(VERSION);\
 	echo "#define HV_DAILY_TAG "\""$$DAILY_TAG"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_VERSION "\""$$PATCH"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TYPE "\""$$BUILD_TYPE"\""" >> $(VERSION);\

--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -902,7 +902,7 @@ void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin)
  *   one entry vs. one phys_bdf:msi_idx
  */
 int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
-		uint16_t phys_bdf, int vector_count)
+		uint16_t phys_bdf, uint32_t vector_count)
 {
 	struct ptdev_remapping_info *entry;
 	int i;
@@ -918,7 +918,7 @@ int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 }
 
 void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
-		int vector_count)
+		uint32_t vector_count)
 {
 	int i;
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -503,7 +503,7 @@ static void bsp_boot_post(void)
 			HV_DAILY_TAG,
 			HV_BUILD_USER, ticks_to_us(start_tsc));
 
-	pr_acrnlog("API version %d.%d",
+	pr_acrnlog("API version %u.%u",
 			HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
 
 	pr_acrnlog("Detect processor: %s", boot_cpu_data.model_name);

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -21,7 +21,7 @@ static void run_vcpu_pre_work(struct vcpu *vcpu)
 void vcpu_thread(struct vcpu *vcpu)
 {
 	uint64_t vmexit_begin = 0UL, vmexit_end = 0UL;
-	uint16_t basic_exit_reason = 0U;
+	uint32_t basic_exit_reason = 0U;
 	uint64_t tsc_aux_hyp_cpu = (uint64_t) vcpu->pcpu_id;
 	int32_t ret = 0;
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -10,7 +10,7 @@
 #include <version.h>
 #include <reloc.h>
 
-#define ACRN_DBG_HYCALL	6
+#define ACRN_DBG_HYCALL	6U
 
 bool is_hypercall_from_ring0(void)
 {
@@ -44,7 +44,7 @@ int64_t hcall_get_api_version(struct vm *vm, uint64_t param)
 	return 0;
 }
 
-static int handle_vpic_irqline(struct vm *vm, int irq, enum irq_mode mode)
+static int handle_vpic_irqline(struct vm *vm, uint32_t irq, enum irq_mode mode)
 {
 	int32_t ret = -1;
 
@@ -69,7 +69,7 @@ static int handle_vpic_irqline(struct vm *vm, int irq, enum irq_mode mode)
 }
 
 static int
-handle_vioapic_irqline(struct vm *vm, int irq, enum irq_mode mode)
+handle_vioapic_irqline(struct vm *vm, uint32_t irq, enum irq_mode mode)
 {
 	int32_t ret = -1;
 
@@ -141,16 +141,16 @@ int64_t hcall_create_vm(struct vm *vm, uint64_t param)
 	struct acrn_create_vm cv;
 	struct vm_description vm_desc;
 
-	(void)memset((void *)&cv, 0, sizeof(cv));
+	(void)memset((void *)&cv, 0U, sizeof(cv));
 	if (copy_from_gpa(vm, &cv, param, sizeof(cv)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
 	}
 
-	(void)memset(&vm_desc, 0, sizeof(vm_desc));
+	(void)memset(&vm_desc, 0U, sizeof(vm_desc));
 	vm_desc.sworld_enabled =
-		(!!(cv.vm_flag & (SECURE_WORLD_ENABLED)));
-	(void)memcpy_s(&vm_desc.GUID[0], 16, &cv.GUID[0], 16);
+		((cv.vm_flag & (SECURE_WORLD_ENABLED)) != 0U);
+	(void)memcpy_s(&vm_desc.GUID[0], 16U, &cv.GUID[0], 16U);
 	ret = create_vm(&vm_desc, &target_vm);
 
 	if (ret != 0) {
@@ -292,7 +292,7 @@ int64_t hcall_inject_msi(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&msi, 0, sizeof(msi));
+	(void)memset((void *)&msi, 0U, sizeof(msi));
 	if (copy_from_gpa(vm, &msi, param, sizeof(msi)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
@@ -313,7 +313,7 @@ int64_t hcall_set_ioreq_buffer(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&iobuf, 0, sizeof(iobuf));
+	(void)memset((void *)&iobuf, 0U, sizeof(iobuf));
 
 	if (copy_from_gpa(vm, &iobuf, param, sizeof(iobuf)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -468,7 +468,7 @@ int64_t hcall_set_vm_memmap(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&memmap, 0, sizeof(memmap));
+	(void)memset((void *)&memmap, 0U, sizeof(memmap));
 
 	if (copy_from_gpa(vm, &memmap, param, sizeof(memmap)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -501,7 +501,7 @@ int64_t hcall_set_vm_memmaps(struct vm *vm, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&set_memmaps, 0, sizeof(set_memmaps));
+	(void)memset((void *)&set_memmaps, 0U, sizeof(set_memmaps));
 
 	if (copy_from_gpa(vm, &set_memmaps, param, sizeof(set_memmaps)) != 0) {
 		pr_err("%s: Unable copy param from vm\n", __func__);
@@ -542,7 +542,7 @@ int64_t hcall_remap_pci_msix(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&remap, 0, sizeof(remap));
+	(void)memset((void *)&remap, 0U, sizeof(remap));
 
 	if (copy_from_gpa(vm, &remap, param, sizeof(remap)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -582,7 +582,7 @@ int64_t hcall_gpa_to_hpa(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&v_gpa2hpa, 0, sizeof(v_gpa2hpa));
+	(void)memset((void *)&v_gpa2hpa, 0U, sizeof(v_gpa2hpa));
 
 	if (copy_from_gpa(vm, &v_gpa2hpa, param, sizeof(v_gpa2hpa)) != 0) {
 		pr_err("HCALL gpa2hpa: Unable copy param from vm\n");
@@ -665,7 +665,7 @@ int64_t hcall_set_ptdev_intr_info(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&irq, 0, sizeof(irq));
+	(void)memset((void *)&irq, 0U, sizeof(irq));
 
 	if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -697,7 +697,7 @@ hcall_reset_ptdev_intr_info(struct vm *vm, uint64_t vmid, uint64_t param)
 		return -1;
 	}
 
-	(void)memset((void *)&irq, 0, sizeof(irq));
+	(void)memset((void *)&irq, 0U, sizeof(irq));
 
 	if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -722,7 +722,7 @@ int64_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
 	struct sbuf_setup_param ssp;
 	uint64_t *hva;
 
-	(void)memset((void *)&ssp, 0, sizeof(ssp));
+	(void)memset((void *)&ssp, 0U, sizeof(ssp));
 
 	if (copy_from_gpa(vm, &ssp, param, sizeof(ssp)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -5,7 +5,7 @@
 
 #include <hypervisor.h>
 
-#define ACRN_DBG_IOREQUEST	6
+#define ACRN_DBG_IOREQUEST	6U
 
 static void fire_vhm_interrupt(void)
 {
@@ -19,7 +19,7 @@ static void fire_vhm_interrupt(void)
 	vm0 = get_vm_from_vmid(0U);
 	ASSERT(vm0 != NULL, "VM Pointer is NULL");
 
-	vcpu = vcpu_from_vid(vm0, 0);
+	vcpu = vcpu_from_vid(vm0, 0U);
 	ASSERT(vcpu != NULL, "vcpu_from_vid failed");
 
 	vlapic_intr_edge(vcpu, VECTOR_VIRT_IRQ_VHM);
@@ -101,53 +101,53 @@ int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req)
 static void _get_req_info_(struct vhm_request *req, int *id, char *type,
 	char *state, char *dir, int64_t *addr, long *val)
 {
-	(void)strcpy_s(dir, 16, "NONE");
+	(void)strcpy_s(dir, 16U, "NONE");
 	*addr = 0;
 	*val = 0;
 	*id = req->client;
 
 	switch (req->type) {
 	case REQ_PORTIO:
-		(void)strcpy_s(type, 16, "PORTIO");
+		(void)strcpy_s(type, 16U, "PORTIO");
 		if (req->reqs.pio_request.direction == REQUEST_READ) {
-			(void)strcpy_s(dir, 16, "READ");
+			(void)strcpy_s(dir, 16U, "READ");
 		} else {
-			(void)strcpy_s(dir, 16, "WRITE");
+			(void)strcpy_s(dir, 16U, "WRITE");
 		}
 		*addr = req->reqs.pio_request.address;
 		*val = req->reqs.pio_request.value;
 		break;
 	case REQ_MMIO:
 	case REQ_WP:
-		(void)strcpy_s(type, 16, "MMIO/WP");
+		(void)strcpy_s(type, 16U, "MMIO/WP");
 		if (req->reqs.mmio_request.direction == REQUEST_READ) {
-			(void)strcpy_s(dir, 16, "READ");
+			(void)strcpy_s(dir, 16U, "READ");
 		} else {
-			(void)strcpy_s(dir, 16, "WRITE");
+			(void)strcpy_s(dir, 16U, "WRITE");
 		}
 		*addr = req->reqs.mmio_request.address;
 		*val = req->reqs.mmio_request.value;
 		break;
 		break;
 	default:
-		(void)strcpy_s(type, 16, "UNKNOWN");
+		(void)strcpy_s(type, 16U, "UNKNOWN");
 	}
 
 	switch (req->processed) {
 	case REQ_STATE_SUCCESS:
-		(void)strcpy_s(state, 16, "SUCCESS");
+		(void)strcpy_s(state, 16U, "SUCCESS");
 		break;
 	case REQ_STATE_PENDING:
-		(void)strcpy_s(state, 16, "PENDING");
+		(void)strcpy_s(state, 16U, "PENDING");
 		break;
 	case REQ_STATE_PROCESSING:
-		(void)strcpy_s(state, 16, "PROCESS");
+		(void)strcpy_s(state, 16U, "PROCESS");
 		break;
 	case REQ_STATE_FAILED:
-		(void)strcpy_s(state, 16, "FAILED");
+		(void)strcpy_s(state, 16U, "FAILED");
 		break;
 	default:
-		(void)strcpy_s(state, 16,  "UNKNOWN");
+		(void)strcpy_s(state, 16U,  "UNKNOWN");
 	}
 }
 

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -35,7 +35,7 @@ static uint64_t create_zero_page(struct vm *vm)
 	zeropage = (struct zero_page *)((char *)hva + MEM_4K);
 
 	/* clear the zeropage */
-	(void)memset(zeropage, 0, MEM_2K);
+	(void)memset(zeropage, 0U, MEM_2K);
 
 	/* copy part of the header into the zero page */
 	hva = GPA2HVA(vm, (uint64_t)vm->sw.kernel_info.kernel_load_addr);
@@ -122,7 +122,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	/* calculate the kernel entry point */
 	zeropage = (struct zero_page *)
 			vm->sw.kernel_info.kernel_src_addr;
-	kernel_entry_offset = (zeropage->hdr.setup_sects + 1U) * 512U;
+	kernel_entry_offset = (uint32_t)(zeropage->hdr.setup_sects + 1U) * 512U;
 	if (vcpu->arch_vcpu.cpu_mode == CPU_MODE_64BIT) {
 		/* 64bit entry is the 512bytes after the start */
 		kernel_entry_offset += 512U;
@@ -193,7 +193,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 					reserving_1g_pages);
 				(void)strcpy_s((char *)hva
 					+vm->sw.linux_info.bootargs_size,
-					100, dyn_bootargs);
+					100U, dyn_bootargs);
 			}
 		}
 #endif

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -18,8 +18,8 @@ int ptdev_add_intx_remapping(struct vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin, bool pic_pin);
 void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin);
 int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
-	uint16_t phys_bdf, int vector_count);
+	uint16_t phys_bdf, uint32_t vector_count);
 void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
-		int vector_count);
+		uint32_t vector_count);
 
 #endif /* ASSIGN_H */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -7,7 +7,7 @@
 #ifndef _VCPU_H_
 #define	_VCPU_H_
 
-#define	ACRN_VCPU_MMIO_COMPLETE		(0)
+#define	ACRN_VCPU_MMIO_COMPLETE		(0U)
 
 /* Size of various elements within the VCPU structure */
 #define REG_SIZE                            8

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -164,10 +164,10 @@ struct acrn_set_ioreq_buffer {
 } __aligned(8);
 
 /** Interrupt type for acrn_irqline: inject interrupt to IOAPIC */
-#define	ACRN_INTR_TYPE_ISA	0
+#define	ACRN_INTR_TYPE_ISA	0U
 
 /** Interrupt type for acrn_irqline: inject interrupt to both PIC and IOAPIC */
-#define	ACRN_INTR_TYPE_IOAPIC	1
+#define	ACRN_INTR_TYPE_IOAPIC	1U
 
 /**
  * @brief Info to assert/deassert/pulse a virtual IRQ line for a VM
@@ -266,7 +266,7 @@ struct acrn_vm_pci_msix_remap {
  * layout below 1M, DM add this address to E280 reserved range to make sure
  * there is no overlap for the address 0xef000 usage.
  */
-#define GUEST_CFG_OFFSET	0xef000
+#define GUEST_CFG_OFFSET	0xef000UL
 
 /**
  * @brief Info The power state data of a VCPU.

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -194,9 +194,9 @@ struct vm_gpa2hpa {
  * hypercall
  */
 struct hc_ptdev_irq {
-#define IRQ_INTX 0
-#define IRQ_MSI 1
-#define IRQ_MSIX 2
+#define IRQ_INTX 0U
+#define IRQ_MSI 1U
+#define IRQ_MSIX 2U
 	/** irq mapping type: INTX or MSI */
 	uint32_t type;
 


### PR DESCRIPTION
fix integer type violations,keep some violations which
related to hypcall and msix_entry_index.

V1->V2:1.modified API_MAJOR_VERSION from Makefile
       2.sync acrn_common.h changed to device model

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>