### PR TITLE
HV:treewide:Clean up vmread and vmwrite operations

### DIFF
--- a/hypervisor/arch/x86/cpu_primary.S
+++ b/hypervisor/arch/x86/cpu_primary.S
@@ -112,7 +112,8 @@ cpu_primary_start_32:
     lgdt    (%ebx)
 
     /* Perform a long jump based to start executing in 64-bit mode */
-    ljmp    $HOST_GDT_RING0_CODE_SEL, $primary_start_long_mode
+    /* 0x0008 = HOST_GDT_RING0_CODE_SEL */
+    ljmp    $0x0008, $primary_start_long_mode
 
     .code64
     .org 0x200
@@ -150,13 +151,15 @@ primary_start_long_mode:
     rex.w ljmp  *(%rax)
 .data
 jmpbuf: .quad 0
-        .word HOST_GDT_RING0_CODE_SEL
+	/* 0x0008 = HOST_GDT_RING0_CODE_SEL */
+        .word 0x0008
 .text
 after:
     // load all selector registers with appropriate values
     xor     %edx, %edx
     lldt    %dx
-    movl    $HOST_GDT_RING0_DATA_SEL,%eax
+    /* 0x10 = HOST_GDT_RING0_DATA_SEL*/
+    movl    $0x10,%eax
     mov     %eax,%ss  // Was 32bit POC Stack
     mov     %eax,%ds  // Was 32bit POC Data
     mov     %eax,%es  // Was 32bit POC Data

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -471,7 +471,7 @@ int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu)
 
 	/* TODO - EPT Violation handler */
 	pr_info("%s, Guest linear address: 0x%016llx ",
-			__func__, exec_vmread64(VMX_GUEST_LINEAR_ADDR));
+			__func__, exec_vmread(VMX_GUEST_LINEAR_ADDR));
 
 	pr_info("%s, Guest physical address: 0x%016llx ",
 			__func__, exec_vmread64(VMX_GUEST_PHYSICAL_ADDR_FULL));

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -286,7 +286,7 @@ int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa,
 	pw_info.level = pm;
 	pw_info.is_write_access = ((*err_code & PAGE_FAULT_WR_FLAG) != 0U);
 	pw_info.is_inst_fetch = ((*err_code & PAGE_FAULT_ID_FLAG) != 0U);
-	pw_info.is_user_mode = ((exec_vmread(VMX_GUEST_CS_SEL) & 0x3UL) == 3UL);
+	pw_info.is_user_mode = ((exec_vmread16(VMX_GUEST_CS_SEL) & 0x3U) == 3U);
 	pw_info.pse = true;
 	pw_info.nxe =
 		((cur_context->ia32_efer & MSR_IA32_EFER_NXE_BIT) != 0UL);

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -110,8 +110,8 @@ int vm_set_seg_desc(struct vcpu *vcpu, enum cpu_reg_name seg,
 	}
 
 	exec_vmwrite(base, ret_desc->base);
-	exec_vmwrite(limit, ret_desc->limit);
-	exec_vmwrite(access, ret_desc->access);
+	exec_vmwrite32(limit, ret_desc->limit);
+	exec_vmwrite32(access, ret_desc->access);
 
 	return 0;
 }
@@ -136,8 +136,8 @@ int vm_get_seg_desc(struct vcpu *vcpu, enum cpu_reg_name seg,
 	}
 
 	desc->base = exec_vmread(base);
-	desc->limit = (uint32_t)exec_vmread(limit);
-	desc->access = (uint32_t)exec_vmread(access);
+	desc->limit = exec_vmread32(limit);
+	desc->access = exec_vmread32(access);
 
 	return 0;
 }
@@ -351,7 +351,7 @@ int decode_instruction(struct vcpu *vcpu)
 		return retval;
 	}
 
-	csar = (uint32_t)exec_vmread(VMX_GUEST_CS_ATTR);
+	csar = exec_vmread32(VMX_GUEST_CS_ATTR);
 	get_guest_paging_info(vcpu, emul_ctxt, csar);
 	cpu_mode = get_vcpu_mode(vcpu);
 

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -44,8 +44,10 @@ int vm_get_register(struct vcpu *vcpu, enum cpu_reg_name reg, uint64_t *retval)
 		uint32_t field = get_vmcs_field(reg);
 
 		if (field != VMX_INVALID_VMCS_FIELD) {
-			if (reg < CPU_REG_64BIT_LAST) {
+			if (reg < CPU_REG_NATURAL_LAST) {
 				*retval = exec_vmread(field);
+			} else if (reg < CPU_REG_64BIT_LAST) {
+				*retval = exec_vmread64(field);
 			} else {
 				*retval = (uint64_t)exec_vmread16(field);
 			}
@@ -77,8 +79,10 @@ int vm_set_register(struct vcpu *vcpu, enum cpu_reg_name reg, uint64_t val)
 		uint32_t field = get_vmcs_field(reg);
 
 		if (field != VMX_INVALID_VMCS_FIELD) {
-			if (reg < CPU_REG_64BIT_LAST) {
+			if (reg < CPU_REG_NATURAL_LAST) {
 				exec_vmwrite(field, val);
+			} else if (reg <= CPU_REG_64BIT_LAST) {
+				exec_vmwrite64(field, val);
 			} else {
 				exec_vmwrite16(field, (uint16_t)val);
 			}

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -31,8 +31,27 @@
 #define INSTR_EMUL_WRAPPER_H
 #include <cpu.h>
 
-/*
+/**
+ *
  * Identifiers for architecturally defined registers.
+ *
+ * These register names is used in condition statement.
+ * Within the following groups,register name need to be 
+ * kept in order:
+ * General register names group (CPU_REG_RAX~CPU_REG_RDI);
+ * Non general register names group (CPU_REG_CR0~CPU_REG_LAST);
+ * Segement register names group (CPU_REG_ES~CPU_REG_GS).
+ *
+ * CPU_REG_NATURAL_LAST indicates in the non general register names
+ * group the register name (less than CPU_REG_NATURAL_last) is 
+ * corresponds to the natural width field in VMCS;
+ *
+ * CPU_REG_64BIT_LAST indicates in the non general register names
+ * group the register name (less than CPU_REG_64BIT_LAST and more than
+ * CPU_REG_NATURAL_last) corresponds to the 64-bit field in VMCS.
+ *
+ * CPU_REG_LAST indicates the last register name.
+ *
  */
 enum cpu_reg_name {
 	CPU_REG_RAX,
@@ -51,12 +70,20 @@ enum cpu_reg_name {
 	CPU_REG_R15,
 	CPU_REG_RDI,
 	CPU_REG_CR0,
+	CPU_REG_CR2,
 	CPU_REG_CR3,
 	CPU_REG_CR4,
 	CPU_REG_DR7,
 	CPU_REG_RSP,
 	CPU_REG_RIP,
 	CPU_REG_RFLAGS,
+	CPU_REG_NATURAL_LAST,
+	CPU_REG_EFER,
+	CPU_REG_PDPTE0,
+	CPU_REG_PDPTE1,
+	CPU_REG_PDPTE2,
+	CPU_REG_PDPTE3,
+	CPU_REG_64BIT_LAST,
 	CPU_REG_ES,
 	CPU_REG_CS,
 	CPU_REG_SS,
@@ -67,12 +94,6 @@ enum cpu_reg_name {
 	CPU_REG_TR,
 	CPU_REG_IDTR,
 	CPU_REG_GDTR,
-	CPU_REG_EFER,
-	CPU_REG_CR2,
-	CPU_REG_PDPTE0,
-	CPU_REG_PDPTE1,
-	CPU_REG_PDPTE2,
-	CPU_REG_PDPTE3,
 	CPU_REG_LAST
 };
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -193,8 +193,8 @@ int start_vcpu(struct vcpu *vcpu)
 		 */
 		instlen = vcpu->arch_vcpu.inst_len;
 		rip = cur_context->rip;
-		exec_vmwrite(VMX_GUEST_RIP, ((rip + instlen) &
-				0xFFFFFFFFFFFFFFFF));
+		exec_vmwrite(VMX_GUEST_RIP, ((rip +(uint64_t)instlen) &
+				0xFFFFFFFFFFFFFFFFUL));
 
 		/* Resume the VM */
 		status = vmx_vmrun(cur_context, VM_RESUME, ibrs_type);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -205,24 +205,24 @@ int start_vcpu(struct vcpu *vcpu)
 
 	/* Save guest IA32_EFER register */
 	cur_context->ia32_efer = exec_vmread64(VMX_GUEST_IA32_EFER_FULL);
-	set_vcpu_mode(vcpu, exec_vmread(VMX_GUEST_CS_ATTR));
+	set_vcpu_mode(vcpu, exec_vmread32(VMX_GUEST_CS_ATTR));
 
 	/* Obtain current VCPU instruction pointer and length */
 	cur_context->rip = exec_vmread(VMX_GUEST_RIP);
-	vcpu->arch_vcpu.inst_len = exec_vmread(VMX_EXIT_INSTR_LEN);
+	vcpu->arch_vcpu.inst_len = exec_vmread32(VMX_EXIT_INSTR_LEN);
 
 	cur_context->rsp = exec_vmread(VMX_GUEST_RSP);
 	cur_context->rflags = exec_vmread(VMX_GUEST_RFLAGS);
 
 	/* Obtain VM exit reason */
-	vcpu->arch_vcpu.exit_reason = exec_vmread(VMX_EXIT_REASON);
+	vcpu->arch_vcpu.exit_reason = exec_vmread32(VMX_EXIT_REASON);
 
 	if (status != 0) {
 		/* refer to 64-ia32 spec section 24.9.1 volume#3 */
 		if (vcpu->arch_vcpu.exit_reason & VMX_VMENTRY_FAIL)
 			pr_fatal("vmentry fail reason=%lx", vcpu->arch_vcpu.exit_reason);
 		else
-			pr_fatal("vmexit fail err_inst=%lx", exec_vmread(VMX_INSTR_ERROR));
+			pr_fatal("vmexit fail err_inst=%x", exec_vmread32(VMX_INSTR_ERROR));
 
 		ASSERT(status == 0, "vm fail");
 	}

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -158,7 +158,7 @@ int start_vcpu(struct vcpu *vcpu)
 				vcpu->vm->attr.id, vcpu->vcpu_id);
 
 		if (vcpu->arch_vcpu.vpid)
-			exec_vmwrite(VMX_VPID, vcpu->arch_vcpu.vpid);
+			exec_vmwrite16(VMX_VPID, vcpu->arch_vcpu.vpid);
 
 		/*
 		 * A power-up or a reset invalidates all linear mappings,

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2221,14 +2221,14 @@ apicv_set_tmr(__unused struct vlapic *vlapic, uint32_t vector, bool level)
 	mask = 1UL << (vector % 64U);
 	field = VMX_EOI_EXIT(vector);
 
-	val = exec_vmread(field);
+	val = exec_vmread64(field);
 	if (level) {
 		val |= mask;
 	} else {
 		val &= ~mask;
 	}
 
-	exec_vmwrite(field, val);
+	exec_vmwrite64(field, val);
 }
 
 /* Update the VMX_EOI_EXIT according to related tmr */

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2340,13 +2340,12 @@ apicv_inject_pir(struct vlapic *vlapic)
 	if (pirval != 0UL) {
 		rvi = pirbase + fls64(pirval);
 
-		intr_status_old = (uint16_t)
-				(0xFFFFUL &
-				exec_vmread(VMX_GUEST_INTR_STATUS));
+		intr_status_old = 0xFFFFU & 
+				exec_vmread16(VMX_GUEST_INTR_STATUS);
 
 		intr_status_new = (intr_status_old & 0xFF00U) | rvi;
 		if (intr_status_new > intr_status_old) {
-			exec_vmwrite(VMX_GUEST_INTR_STATUS,
+			exec_vmwrite16(VMX_GUEST_INTR_STATUS,
 					intr_status_new);
 		}
 	}

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -198,7 +198,7 @@ int rdmsr_vmexit_handler(struct vcpu *vcpu)
 	/* following MSR not emulated now just left for future */
 	case MSR_IA32_SYSENTER_CS:
 	{
-		v = exec_vmread(VMX_GUEST_IA32_SYSENTER_CS);
+		v = (uint64_t)exec_vmread32(VMX_GUEST_IA32_SYSENTER_CS);
 		break;
 	}
 	case MSR_IA32_SYSENTER_ESP:
@@ -331,7 +331,7 @@ int wrmsr_vmexit_handler(struct vcpu *vcpu)
 	/* following MSR not emulated now just left for future */
 	case MSR_IA32_SYSENTER_CS:
 	{
-		exec_vmwrite(VMX_GUEST_IA32_SYSENTER_CS, v);
+		exec_vmwrite32(VMX_GUEST_IA32_SYSENTER_CS, (uint32_t)v);
 		break;
 	}
 	case MSR_IA32_SYSENTER_ESP:

--- a/hypervisor/arch/x86/idt.S
+++ b/hypervisor/arch/x86/idt.S
@@ -24,13 +24,15 @@ HOST_IDTR:
  * We'll rearrange and fix up the descriptors at runtime
  */
 .macro interrupt_descriptor entry, dpl=0 ist=0
-	.long	HOST_GDT_RING0_CODE_SEL << 16
+	/* 0x0008 = HOST_GDT_RING0_CODE_SEL */
+	.long	0x0008 << 16
 	.long	0x00008e00 + (dpl << 13) + ist
 	.quad	entry
 .endm
 
 .macro	trap_descriptor entry, dpl=0, ist=0
-	.long	HOST_GDT_RING0_CODE_SEL << 16
+        /* 0x0008 = HOST_GDT_RING0_CODE_SEL */
+	.long	0x0008 << 16
 	.long	0x00008f00 + (dpl <<13) + ist
 	.quad	entry
 .endm

--- a/hypervisor/arch/x86/trampoline.S
+++ b/hypervisor/arch/x86/trampoline.S
@@ -133,14 +133,15 @@ trampoline_fixup_target:
     .global trampoline_start64_fixup
 trampoline_start64_fixup:
     .long   trampoline_start64
-    .word   HOST_GDT_RING0_CODE_SEL
+    /* 0x0008 = HOST_GDT_RING0_CODE_SEL */
+    .word   0x0008
 
     .code64
 trampoline_start64:
 
     /* Set up all other data segment registers */
-
-    movl    $HOST_GDT_RING0_DATA_SEL, %eax
+    /* 0x0010 = HOST_GDT_RING0_DATA_SEL */
+    movl    $0x0010, %eax
     mov     %eax, %ss
     mov     %eax, %ds
     mov     %eax, %es

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -38,16 +38,16 @@ static struct key_info g_key_info = {
 { \
 	seg.selector = exec_vmread16(VMX_GUEST_##SEG_NAME##_SEL); \
 	seg.base = exec_vmread(VMX_GUEST_##SEG_NAME##_BASE); \
-	seg.limit = exec_vmread(VMX_GUEST_##SEG_NAME##_LIMIT); \
-	seg.attr = exec_vmread(VMX_GUEST_##SEG_NAME##_ATTR); \
+	seg.limit = exec_vmread32(VMX_GUEST_##SEG_NAME##_LIMIT); \
+	seg.attr = exec_vmread32(VMX_GUEST_##SEG_NAME##_ATTR); \
 }
 
 #define load_segment(seg, SEG_NAME) \
 { \
 	exec_vmwrite16(VMX_GUEST_##SEG_NAME##_SEL, seg.selector); \
 	exec_vmwrite(VMX_GUEST_##SEG_NAME##_BASE, seg.base); \
-	exec_vmwrite(VMX_GUEST_##SEG_NAME##_LIMIT, seg.limit); \
-	exec_vmwrite(VMX_GUEST_##SEG_NAME##_ATTR, seg.attr); \
+	exec_vmwrite32(VMX_GUEST_##SEG_NAME##_LIMIT, seg.limit); \
+	exec_vmwrite32(VMX_GUEST_##SEG_NAME##_ATTR, seg.attr); \
 }
 
 #ifndef WORKAROUND_FOR_TRUSTY_4G_MEM
@@ -234,9 +234,9 @@ static void save_world_ctx(struct run_context *context)
 	 */
 	context->vmx_ia32_pat = exec_vmread(VMX_GUEST_IA32_PAT_FULL);
 	context->ia32_efer = exec_vmread64(VMX_GUEST_IA32_EFER_FULL);
-	context->ia32_sysenter_cs = exec_vmread(VMX_GUEST_IA32_SYSENTER_CS);
 	context->ia32_sysenter_esp = exec_vmread(VMX_GUEST_IA32_SYSENTER_ESP);
 	context->ia32_sysenter_eip = exec_vmread(VMX_GUEST_IA32_SYSENTER_EIP);
+	context->ia32_sysenter_cs = exec_vmread32(VMX_GUEST_IA32_SYSENTER_CS);
 	save_segment(context->cs, CS);
 	save_segment(context->ss, SS);
 	save_segment(context->ds, DS);
@@ -247,9 +247,9 @@ static void save_world_ctx(struct run_context *context)
 	save_segment(context->ldtr, LDTR);
 	/* Only base and limit for IDTR and GDTR */
 	context->idtr.base = exec_vmread(VMX_GUEST_IDTR_BASE);
-	context->idtr.limit = exec_vmread(VMX_GUEST_IDTR_LIMIT);
 	context->gdtr.base = exec_vmread(VMX_GUEST_GDTR_BASE);
-	context->gdtr.limit = exec_vmread(VMX_GUEST_GDTR_LIMIT);
+	context->idtr.limit = exec_vmread32(VMX_GUEST_IDTR_LIMIT);
+	context->gdtr.limit = exec_vmread32(VMX_GUEST_GDTR_LIMIT);
 
 	/* MSRs which not in the VMCS */
 	context->ia32_star = msr_read(MSR_IA32_STAR);
@@ -280,7 +280,7 @@ static void load_world_ctx(struct run_context *context)
 	exec_vmwrite64(VMX_GUEST_IA32_DEBUGCTL_FULL, context->ia32_debugctl);
 	exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, context->vmx_ia32_pat);
 	exec_vmwrite64(VMX_GUEST_IA32_EFER_FULL, context->ia32_efer);
-	exec_vmwrite(VMX_GUEST_IA32_SYSENTER_CS, context->ia32_sysenter_cs);
+	exec_vmwrite32(VMX_GUEST_IA32_SYSENTER_CS, context->ia32_sysenter_cs);
 	exec_vmwrite(VMX_GUEST_IA32_SYSENTER_ESP, context->ia32_sysenter_esp);
 	exec_vmwrite(VMX_GUEST_IA32_SYSENTER_EIP, context->ia32_sysenter_eip);
 	load_segment(context->cs, CS);
@@ -293,9 +293,9 @@ static void load_world_ctx(struct run_context *context)
 	load_segment(context->ldtr, LDTR);
 	/* Only base and limit for IDTR and GDTR */
 	exec_vmwrite(VMX_GUEST_IDTR_BASE, context->idtr.base);
-	exec_vmwrite(VMX_GUEST_IDTR_LIMIT, context->idtr.limit);
 	exec_vmwrite(VMX_GUEST_GDTR_BASE, context->gdtr.base);
-	exec_vmwrite(VMX_GUEST_GDTR_LIMIT, context->gdtr.limit);
+	exec_vmwrite32(VMX_GUEST_IDTR_LIMIT, context->idtr.limit);
+	exec_vmwrite32(VMX_GUEST_GDTR_LIMIT, context->gdtr.limit);
 
 	/* MSRs which not in the VMCS */
 	msr_write(MSR_IA32_STAR, context->ia32_star);

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -232,7 +232,7 @@ static void save_world_ctx(struct run_context *context)
 	 * the wrmsr handler keeps track of 'ia32_pat', and we only
 	 * need to load 'vmx_ia32_pat' here.
 	 */
-	context->vmx_ia32_pat = exec_vmread(VMX_GUEST_IA32_PAT_FULL);
+	context->vmx_ia32_pat = exec_vmread64(VMX_GUEST_IA32_PAT_FULL);
 	context->ia32_efer = exec_vmread64(VMX_GUEST_IA32_EFER_FULL);
 	context->ia32_sysenter_esp = exec_vmread(VMX_GUEST_IA32_SYSENTER_ESP);
 	context->ia32_sysenter_eip = exec_vmread(VMX_GUEST_IA32_SYSENTER_EIP);
@@ -426,7 +426,7 @@ static bool init_secure_world_env(struct vcpu *vcpu,
 
 	exec_vmwrite(VMX_GUEST_RSP,
 		TRUSTY_EPT_REBASE_GPA + size);
-	exec_vmwrite(VMX_TSC_OFFSET_FULL,
+	exec_vmwrite64(VMX_TSC_OFFSET_FULL,
 		vcpu->arch_vcpu.contexts[SECURE_WORLD].tsc_offset);
 
 	return setup_trusty_info(vcpu, size, base_hpa);

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -36,7 +36,7 @@ static struct key_info g_key_info = {
 
 #define save_segment(seg, SEG_NAME) \
 { \
-	seg.selector = exec_vmread(VMX_GUEST_##SEG_NAME##_SEL); \
+	seg.selector = exec_vmread16(VMX_GUEST_##SEG_NAME##_SEL); \
 	seg.base = exec_vmread(VMX_GUEST_##SEG_NAME##_BASE); \
 	seg.limit = exec_vmread(VMX_GUEST_##SEG_NAME##_LIMIT); \
 	seg.attr = exec_vmread(VMX_GUEST_##SEG_NAME##_ATTR); \
@@ -44,7 +44,7 @@ static struct key_info g_key_info = {
 
 #define load_segment(seg, SEG_NAME) \
 { \
-	exec_vmwrite(VMX_GUEST_##SEG_NAME##_SEL, seg.selector); \
+	exec_vmwrite16(VMX_GUEST_##SEG_NAME##_SEL, seg.selector); \
 	exec_vmwrite(VMX_GUEST_##SEG_NAME##_BASE, seg.base); \
 	exec_vmwrite(VMX_GUEST_##SEG_NAME##_LIMIT, seg.limit); \
 	exec_vmwrite(VMX_GUEST_##SEG_NAME##_ATTR, seg.attr); \

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -141,7 +141,7 @@ int vmexit_handler(struct vcpu *vcpu)
 
 	/* Obtain interrupt info */
 	vcpu->arch_vcpu.idt_vectoring_info =
-	    exec_vmread(VMX_IDT_VEC_INFO_FIELD);
+	    exec_vmread32(VMX_IDT_VEC_INFO_FIELD);
 	/* Filter out HW exception & NMI */
 	if ((vcpu->arch_vcpu.idt_vectoring_info & VMX_INT_INFO_VALID) != 0U) {
 		uint32_t vector_info = vcpu->arch_vcpu.idt_vectoring_info;
@@ -151,7 +151,7 @@ int vmexit_handler(struct vcpu *vcpu)
 
 		if (type == VMX_INT_TYPE_HW_EXP) {
 			if ((vector_info & VMX_INT_INFO_ERR_CODE_VALID) != 0U)
-				err_code = exec_vmread(VMX_IDT_VEC_ERROR_CODE);
+				err_code = exec_vmread32(VMX_IDT_VEC_ERROR_CODE);
 			vcpu_queue_exception(vcpu, vector, err_code);
 			vcpu->arch_vcpu.idt_vectoring_info = 0U;
 		} else if (type == VMX_INT_TYPE_NMI) {

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -220,6 +220,15 @@ uint64_t exec_vmread64(uint32_t field_full)
 	return low;
 }
 
+uint32_t exec_vmread32(uint32_t field)
+{
+	uint64_t value;
+
+	value = exec_vmread64(field);
+
+	return (uint32_t)value;
+}
+
 uint16_t exec_vmread16(uint32_t field)
 {
         uint64_t value;
@@ -248,6 +257,11 @@ void exec_vmwrite64(unsigned int field_full, uint64_t value)
 #else
 	exec_vmwrite(field_full, value);
 #endif
+}
+
+void exec_vmwrite32(uint32_t field, uint32_t value)
+{
+	exec_vmwrite64(field, (uint64_t)value);
 }
 
 void exec_vmwrite16(uint32_t field, uint16_t value)
@@ -402,9 +416,9 @@ int vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0)
 		}
 		/* Enable long mode */
 		pr_dbg("VMM: Enable long mode");
-		entry_ctrls = exec_vmread(VMX_ENTRY_CONTROLS);
+		entry_ctrls = exec_vmread32(VMX_ENTRY_CONTROLS);
 		entry_ctrls |= VMX_ENTRY_CTLS_IA32E_MODE;
-		exec_vmwrite(VMX_ENTRY_CONTROLS, entry_ctrls);
+		exec_vmwrite32(VMX_ENTRY_CONTROLS, entry_ctrls);
 
 		context->ia32_efer |= MSR_IA32_EFER_LMA_BIT;
 		exec_vmwrite64(VMX_GUEST_IA32_EFER_FULL, context->ia32_efer);
@@ -412,9 +426,9 @@ int vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0)
 		   paging_enabled && ((cr0 & CR0_PG) == 0U)){
 		/* Disable long mode */
 		pr_dbg("VMM: Disable long mode");
-		entry_ctrls = exec_vmread(VMX_ENTRY_CONTROLS);
+		entry_ctrls = exec_vmread32(VMX_ENTRY_CONTROLS);
 		entry_ctrls &= ~VMX_ENTRY_CTLS_IA32E_MODE;
-		exec_vmwrite(VMX_ENTRY_CONTROLS, entry_ctrls);
+		exec_vmwrite32(VMX_ENTRY_CONTROLS, entry_ctrls);
 
 		context->ia32_efer &= ~MSR_IA32_EFER_LMA_BIT;
 		exec_vmwrite64(VMX_GUEST_IA32_EFER_FULL, context->ia32_efer);
@@ -666,12 +680,12 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* Limit */
 	field = VMX_GUEST_CS_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_CS_LIMIT: 0x%x ", limit);
 
 	/* Access */
 	field = VMX_GUEST_CS_ATTR;
-	exec_vmwrite(field, access);
+	exec_vmwrite32(field, access);
 	pr_dbg("VMX_GUEST_CS_ATTR: 0x%x ", access);
 
 	/* Base */
@@ -750,7 +764,7 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* GDTR Limit */
 	field = VMX_GUEST_GDTR_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_GDTR_LIMIT: 0x%x ", limit);
 
 	/* IDTR - Interrupt Descriptor Table */
@@ -784,7 +798,7 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* IDTR Limit */
 	field = VMX_GUEST_IDTR_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_IDTR_LIMIT: 0x%x ", limit);
 
 	/***************************************************/
@@ -848,19 +862,19 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* Limit */
 	field = VMX_GUEST_ES_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_ES_LIMIT: 0x%x ", limit);
 	field = VMX_GUEST_SS_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_SS_LIMIT: 0x%x ", limit);
 	field = VMX_GUEST_DS_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_DS_LIMIT: 0x%x ", limit);
 	field = VMX_GUEST_FS_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_FS_LIMIT: 0x%x ", limit);
 	field = VMX_GUEST_GS_LIMIT;
-	exec_vmwrite(field, limit);
+	exec_vmwrite32(field, limit);
 	pr_dbg("VMX_GUEST_GS_LIMIT: 0x%x ", limit);
 
 	/* Access */
@@ -872,19 +886,19 @@ static void init_guest_state(struct vcpu *vcpu)
 	}
 
 	field = VMX_GUEST_ES_ATTR;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_ES_ATTR: 0x%x ", value32);
 	field = VMX_GUEST_SS_ATTR;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_SS_ATTR: 0x%x ", value32);
 	field = VMX_GUEST_DS_ATTR;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_DS_ATTR: 0x%x ", value32);
 	field = VMX_GUEST_FS_ATTR;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_FS_ATTR: 0x%x ", value32);
 	field = VMX_GUEST_GS_ATTR;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_GS_ATTR: 0x%x ", value32);
 
 	/* Base */
@@ -920,12 +934,12 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	field = VMX_GUEST_LDTR_LIMIT;
 	value32 = 0xffffffffU;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_LDTR_LIMIT: 0x%x ", value32);
 
 	field = VMX_GUEST_LDTR_ATTR;
 	value32 = 0x10000U;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_LDTR_ATTR: 0x%x ", value32);
 
 	field = VMX_GUEST_LDTR_BASE;
@@ -941,12 +955,12 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	field = VMX_GUEST_TR_LIMIT;
 	value32 = 0xffU;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_TR_LIMIT: 0x%x ", value32);
 
 	field = VMX_GUEST_TR_ATTR;
 	value32 = 0x8bU;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_TR_ATTR: 0x%x ", value32);
 
 	field = VMX_GUEST_TR_BASE;
@@ -956,24 +970,24 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	field = VMX_GUEST_INTERRUPTIBILITY_INFO;
 	value32 = 0U;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_INTERRUPTIBILITY_INFO: 0x%x ",
 		  value32);
 
 	field = VMX_GUEST_ACTIVITY_STATE;
 	value32 = 0U;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_ACTIVITY_STATE: 0x%x ",
 		  value32);
 
 	field = VMX_GUEST_SMBASE;
 	value32 = 0U;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_SMBASE: 0x%x ", value32);
 
 	value32 = msr_read(MSR_IA32_SYSENTER_CS) & 0xFFFFFFFFU;
 	field = VMX_GUEST_IA32_SYSENTER_CS;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_GUEST_IA32_SYSENTER_CS: 0x%x ",
 		  value32);
 
@@ -1130,7 +1144,7 @@ static void init_host_state(__unused struct vcpu *vcpu)
 
 	value32 = msr_read(MSR_IA32_SYSENTER_CS) & 0xFFFFFFFFU;
 	field = VMX_HOST_IA32_SYSENTER_CS;
-	exec_vmwrite(field, value32);
+	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_HOST_IA32_SYSENTER_CS: 0x%x ",
 			value32);
 
@@ -1223,7 +1237,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	/* enable external interrupt VM Exit */
 	value32 |= VMX_PINBASED_CTLS_IRQ_EXIT;
 
-	exec_vmwrite(VMX_PIN_VM_EXEC_CONTROLS, value32);
+	exec_vmwrite32(VMX_PIN_VM_EXEC_CONTROLS, value32);
 	pr_dbg("VMX_PIN_VM_EXEC_CONTROLS: 0x%x ", value32);
 
 	/* Set up primary processor based VM execution controls - pg 2900
@@ -1262,7 +1276,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 			VMX_PROCBASED_CTLS_CR8_STORE);
 	}
 
-	exec_vmwrite(VMX_PROC_VM_EXEC_CONTROLS, value32);
+	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
 	pr_dbg("VMX_PROC_VM_EXEC_CONTROLS: 0x%x ", value32);
 
 	/* Set up secondary processor based VM execution controls - pg 2901
@@ -1299,7 +1313,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 			 * Set up TPR threshold for virtual interrupt delivery
 			 * - pg 2904 24.6.8
 			 */
-			exec_vmwrite(VMX_TPR_THRESHOLD, 0);
+			exec_vmwrite32(VMX_TPR_THRESHOLD, 0U);
 		}
 	}
 
@@ -1308,7 +1322,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 		value32 |= VMX_PROCBASED_CTLS2_XSVE_XRSTR;
 	}
 
-	exec_vmwrite(VMX_PROC_VM_EXEC_CONTROLS2, value32);
+	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS2, value32);
 	pr_dbg("VMX_PROC_VM_EXEC_CONTROLS2: 0x%x ", value32);
 
 	if (is_vapic_supported()) {
@@ -1355,26 +1369,26 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	 * enable VM exit on MC only
 	 */
 	value32 = (1U << IDT_MC);
-	exec_vmwrite(VMX_EXCEPTION_BITMAP, value32);
+	exec_vmwrite32(VMX_EXCEPTION_BITMAP, value32);
 
 	/* Set up page fault error code mask - second paragraph * pg 2902
 	 * 24.6.3 - guest page fault exception causing * vmexit is governed by
 	 * both VMX_EXCEPTION_BITMAP and * VMX_PF_ERROR_CODE_MASK
 	 */
-	exec_vmwrite(VMX_PF_ERROR_CODE_MASK, 0);
+	exec_vmwrite32(VMX_PF_ERROR_CODE_MASK, 0U);
 
 	/* Set up page fault error code match - second paragraph * pg 2902
 	 * 24.6.3 - guest page fault exception causing * vmexit is governed by
 	 * both VMX_EXCEPTION_BITMAP and * VMX_PF_ERROR_CODE_MATCH
 	 */
-	exec_vmwrite(VMX_PF_ERROR_CODE_MATCH, 0);
+	exec_vmwrite32(VMX_PF_ERROR_CODE_MATCH, 0U);
 
 	/* Set up CR3 target count - An execution of mov to CR3 * by guest
 	 * causes HW to evaluate operand match with * one of N CR3-Target Value
 	 * registers. The CR3 target * count values tells the number of
 	 * target-value regs to evaluate
 	 */
-	exec_vmwrite(VMX_CR3_TARGET_COUNT, 0);
+	exec_vmwrite32(VMX_CR3_TARGET_COUNT, 0U);
 
 	/* Set up IO bitmap register A and B - pg 2902 24.6.4 */
 	value64 = HVA2HPA(vm->arch_vm.iobitmap[0]);
@@ -1432,23 +1446,23 @@ static void init_entry_ctrl(__unused struct vcpu *vcpu)
 	value32 |= (VMX_ENTRY_CTLS_LOAD_EFER |
 		    VMX_ENTRY_CTLS_LOAD_PAT);
 
-	exec_vmwrite(VMX_ENTRY_CONTROLS, value32);
+	exec_vmwrite32(VMX_ENTRY_CONTROLS, value32);
 	pr_dbg("VMX_ENTRY_CONTROLS: 0x%x ", value32);
 
 	/* Set up VMX entry MSR load count - pg 2908 24.8.2 Tells the number of
 	 * MSRs on load from memory on VM entry from mem address provided by
 	 * VM-entry MSR load address field
 	 */
-	exec_vmwrite(VMX_ENTRY_MSR_LOAD_COUNT, 0);
+	exec_vmwrite32(VMX_ENTRY_MSR_LOAD_COUNT, 0U);
 
 	/* Set up VM entry interrupt information field pg 2909 24.8.3 */
-	exec_vmwrite(VMX_ENTRY_INT_INFO_FIELD, 0);
+	exec_vmwrite32(VMX_ENTRY_INT_INFO_FIELD, 0U);
 
 	/* Set up VM entry exception error code - pg 2910 24.8.3 */
-	exec_vmwrite(VMX_ENTRY_EXCEPTION_ERROR_CODE, 0);
+	exec_vmwrite32(VMX_ENTRY_EXCEPTION_ERROR_CODE, 0U);
 
 	/* Set up VM entry instruction length - pg 2910 24.8.3 */
-	exec_vmwrite(VMX_ENTRY_INSTR_LENGTH, 0);
+	exec_vmwrite32(VMX_ENTRY_INSTR_LENGTH, 0U);
 }
 
 static void init_exit_ctrl(__unused struct vcpu *vcpu)
@@ -1475,7 +1489,7 @@ static void init_exit_ctrl(__unused struct vcpu *vcpu)
 		    VMX_EXIT_CTLS_SAVE_EFER |
 		    VMX_EXIT_CTLS_HOST_ADDR64);
 
-	exec_vmwrite(VMX_EXIT_CONTROLS, value32);
+	exec_vmwrite32(VMX_EXIT_CONTROLS, value32);
 	pr_dbg("VMX_EXIT_CONTROL: 0x%x ", value32);
 
 	/* Set up VM exit MSR store and load counts pg 2908 24.7.2 - tells the
@@ -1483,8 +1497,8 @@ static void init_exit_ctrl(__unused struct vcpu *vcpu)
 	 * The 64 bit VM-exit MSR store and load address fields provide the
 	 * corresponding addresses
 	 */
-	exec_vmwrite(VMX_EXIT_MSR_STORE_COUNT, 0);
-	exec_vmwrite(VMX_EXIT_MSR_LOAD_COUNT, 0);
+	exec_vmwrite32(VMX_EXIT_MSR_STORE_COUNT, 0U);
+	exec_vmwrite32(VMX_EXIT_MSR_LOAD_COUNT, 0U);
 }
 
 #ifdef CONFIG_EFI_STUB
@@ -1510,7 +1524,7 @@ static void override_uefi_vmcs(struct vcpu *vcpu)
 
 		/* Access */
 		field = VMX_GUEST_CS_ATTR;
-		exec_vmwrite(field, efi_ctx->cs_ar);
+		exec_vmwrite32(field, efi_ctx->cs_ar);
 		pr_dbg("VMX_GUEST_CS_ATTR: 0x%x ", efi_ctx->cs_ar);
 
 		field = VMX_GUEST_ES_SEL;
@@ -1557,7 +1571,7 @@ static void override_uefi_vmcs(struct vcpu *vcpu)
 
 		/* GDTR Limit */
 		field = VMX_GUEST_GDTR_LIMIT;
-		exec_vmwrite(field, efi_ctx->gdt.limit);
+		exec_vmwrite32(field, efi_ctx->gdt.limit);
 		pr_dbg("VMX_GUEST_GDTR_LIMIT: 0x%x ", efi_ctx->gdt.limit);
 
 		/* IDTR Base */
@@ -1567,7 +1581,7 @@ static void override_uefi_vmcs(struct vcpu *vcpu)
 
 		/* IDTR Limit */
 		field = VMX_GUEST_IDTR_LIMIT;
-		exec_vmwrite(field, efi_ctx->idt.limit);
+		exec_vmwrite32(field, efi_ctx->idt.limit);
 		pr_dbg("VMX_GUEST_IDTR_LIMIT: 0x%x ", efi_ctx->idt.limit);
 	}
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -220,6 +220,15 @@ uint64_t exec_vmread64(uint32_t field_full)
 	return low;
 }
 
+uint16_t exec_vmread16(uint32_t field)
+{
+        uint64_t value;
+
+        value = exec_vmread64(field);
+
+        return (uint16_t)value;
+}
+
 void exec_vmwrite(uint32_t field, uint64_t value)
 {
 	asm volatile (
@@ -239,6 +248,11 @@ void exec_vmwrite64(unsigned int field_full, uint64_t value)
 #else
 	exec_vmwrite(field_full, value);
 #endif
+}
+
+void exec_vmwrite16(uint32_t field, uint16_t value)
+{
+	exec_vmwrite64(field, (uint64_t)value);
 }
 
 #define HV_ARCH_VMX_GET_CS(SEL)				\
@@ -534,6 +548,7 @@ static void init_guest_state(struct vcpu *vcpu)
 {
 	uint32_t field;
 	uint64_t value;
+	uint16_t value16;
 	uint32_t value32;
 	uint64_t value64;
 	uint16_t sel;
@@ -646,7 +661,7 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* Selector */
 	field = VMX_GUEST_CS_SEL;
-	exec_vmwrite(field, sel);
+	exec_vmwrite16(field, sel);
 	pr_dbg("VMX_GUEST_CS_SEL: 0x%x ", sel);
 
 	/* Limit */
@@ -812,23 +827,23 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* Selector */
 	field = VMX_GUEST_ES_SEL;
-	exec_vmwrite(field, es);
+	exec_vmwrite16(field, es);
 	pr_dbg("VMX_GUEST_ES_SEL: 0x%x ", es);
 
 	field = VMX_GUEST_SS_SEL;
-	exec_vmwrite(field, ss);
+	exec_vmwrite16(field, ss);
 	pr_dbg("VMX_GUEST_SS_SEL: 0x%x ", ss);
 
 	field = VMX_GUEST_DS_SEL;
-	exec_vmwrite(field, ds);
+	exec_vmwrite16(field, ds);
 	pr_dbg("VMX_GUEST_DS_SEL: 0x%x ", ds);
 
 	field = VMX_GUEST_FS_SEL;
-	exec_vmwrite(field, fs);
+	exec_vmwrite16(field, fs);
 	pr_dbg("VMX_GUEST_FS_SEL: 0x%x ", fs);
 
 	field = VMX_GUEST_GS_SEL;
-	exec_vmwrite(field, gs);
+	exec_vmwrite16(field, gs);
 	pr_dbg("VMX_GUEST_GS_SEL: 0x%x ", gs);
 
 	/* Limit */
@@ -899,9 +914,9 @@ static void init_guest_state(struct vcpu *vcpu)
 	/* LDT and TR (dummy) */
 	/***************************************************/
 	field = VMX_GUEST_LDTR_SEL;
-	value32 = ldt_idx;
-	exec_vmwrite(field, value32);
-	pr_dbg("VMX_GUEST_LDTR_SEL: 0x%x ", value32);
+	value16 = ldt_idx;
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_GUEST_LDTR_SEL: 0x%hu ", value16);
 
 	field = VMX_GUEST_LDTR_LIMIT;
 	value32 = 0xffffffffU;
@@ -920,9 +935,9 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	/* Task Register */
 	field = VMX_GUEST_TR_SEL;
-	value32 = lssd32_idx;
-	exec_vmwrite(field, value32);
-	pr_dbg("VMX_GUEST_TR_SEL: 0x%x ", value32);
+	value16 = lssd32_idx;
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_GUEST_TR_SEL: 0x%hu ", value16);
 
 	field = VMX_GUEST_TR_LIMIT;
 	value32 = 0xffU;
@@ -1023,37 +1038,37 @@ static void init_host_state(__unused struct vcpu *vcpu)
 	 ***************************************************/
 	field = VMX_HOST_ES_SEL;
 	asm volatile ("movw %%es, %%ax":"=a" (value16));
-	exec_vmwrite(field, value16);
-	pr_dbg("VMX_HOST_ES_SEL: 0x%x ", value16);
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_HOST_ES_SEL: 0x%hu ", value16);
 
 	field = VMX_HOST_CS_SEL;
 	asm volatile ("movw %%cs, %%ax":"=a" (value16));
-	exec_vmwrite(field, value16);
-	pr_dbg("VMX_HOST_CS_SEL: 0x%x ", value16);
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_HOST_CS_SEL: 0x%hu ", value16);
 
 	field = VMX_HOST_SS_SEL;
 	asm volatile ("movw %%ss, %%ax":"=a" (value16));
-	exec_vmwrite(field, value16);
-	pr_dbg("VMX_HOST_SS_SEL: 0x%x ", value16);
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_HOST_SS_SEL: 0x%hu ", value16);
 
 	field = VMX_HOST_DS_SEL;
 	asm volatile ("movw %%ds, %%ax":"=a" (value16));
-	exec_vmwrite(field, value16);
-	pr_dbg("VMX_HOST_DS_SEL: 0x%x ", value16);
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_HOST_DS_SEL: 0x%hu ", value16);
 
 	field = VMX_HOST_FS_SEL;
 	asm volatile ("movw %%fs, %%ax":"=a" (value16));
-	exec_vmwrite(field, value16);
-	pr_dbg("VMX_HOST_FS_SEL: 0x%x ", value16);
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_HOST_FS_SEL: 0x%hu ", value16);
 
 	field = VMX_HOST_GS_SEL;
 	asm volatile ("movw %%gs, %%ax":"=a" (value16));
-	exec_vmwrite(field, value16);
-	pr_dbg("VMX_HOST_GS_SEL: 0x%x ", value16);
+	exec_vmwrite16(field, value16);
+	pr_dbg("VMX_HOST_GS_SEL: 0x%hu ", value16);
 
 	field = VMX_HOST_TR_SEL;
 	asm volatile ("str %%ax":"=a" (tr_sel));
-	exec_vmwrite(field, tr_sel);
+	exec_vmwrite16(field, tr_sel);
 	pr_dbg("VMX_HOST_TR_SEL: 0x%x ", tr_sel);
 
 	/******************************************************
@@ -1490,7 +1505,7 @@ static void override_uefi_vmcs(struct vcpu *vcpu)
 
 		/* Selector */
 		field = VMX_GUEST_CS_SEL;
-		exec_vmwrite(field, efi_ctx->cs_sel);
+		exec_vmwrite16(field, efi_ctx->cs_sel);
 		pr_dbg("VMX_GUEST_CS_SEL: 0x%x ", efi_ctx->cs_sel);
 
 		/* Access */
@@ -1499,23 +1514,23 @@ static void override_uefi_vmcs(struct vcpu *vcpu)
 		pr_dbg("VMX_GUEST_CS_ATTR: 0x%x ", efi_ctx->cs_ar);
 
 		field = VMX_GUEST_ES_SEL;
-		exec_vmwrite(field, efi_ctx->es_sel);
+		exec_vmwrite16(field, efi_ctx->es_sel);
 		pr_dbg("VMX_GUEST_ES_SEL: 0x%x ", efi_ctx->es_sel);
 
 		field = VMX_GUEST_SS_SEL;
-		exec_vmwrite(field, efi_ctx->ss_sel);
+		exec_vmwrite16(field, efi_ctx->ss_sel);
 		pr_dbg("VMX_GUEST_SS_SEL: 0x%x ", efi_ctx->ss_sel);
 
 		field = VMX_GUEST_DS_SEL;
-		exec_vmwrite(field, efi_ctx->ds_sel);
+		exec_vmwrite16(field, efi_ctx->ds_sel);
 		pr_dbg("VMX_GUEST_DS_SEL: 0x%x ", efi_ctx->ds_sel);
 
 		field = VMX_GUEST_FS_SEL;
-		exec_vmwrite(field, efi_ctx->fs_sel);
+		exec_vmwrite16(field, efi_ctx->fs_sel);
 		pr_dbg("VMX_GUEST_FS_SEL: 0x%x ", efi_ctx->fs_sel);
 
 		field = VMX_GUEST_GS_SEL;
-		exec_vmwrite(field, efi_ctx->gs_sel);
+		exec_vmwrite16(field, efi_ctx->gs_sel);
 		pr_dbg("VMX_GUEST_GS_SEL: 0x%x ", efi_ctx->gs_sel);
 
 		/* Base */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -14,11 +14,11 @@
 
 bool is_hypercall_from_ring0(void)
 {
-	uint64_t cs_sel;
+	uint16_t cs_sel;
 
-	cs_sel = exec_vmread(VMX_GUEST_CS_SEL);
+	cs_sel = exec_vmread16(VMX_GUEST_CS_SEL);
 	/* cs_selector[1:0] is CPL */
-	if ((cs_sel & 0x3UL) == 0) {
+	if ((cs_sel & 0x3U) == 0U) {
 		return true;
 	}
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -113,10 +113,10 @@ struct cpu_regs {
 };
 
 struct segment {
-	uint64_t selector;
+	uint16_t selector;
 	uint64_t base;
-	uint64_t limit;
-	uint64_t attr;
+	uint32_t limit;
+	uint32_t attr;
 };
 
 struct run_context {
@@ -159,7 +159,7 @@ struct run_context {
 	uint64_t ia32_pat;
 	uint64_t vmx_ia32_pat;
 	uint64_t ia32_efer;
-	uint64_t ia32_sysenter_cs;
+	uint32_t ia32_sysenter_cs;
 	uint64_t ia32_sysenter_esp;
 	uint64_t ia32_sysenter_eip;
 	uint64_t ia32_debugctl;

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -415,9 +415,11 @@ int exec_vmxon_instr(uint16_t pcpu_id);
 uint64_t exec_vmread(uint32_t field);
 
 uint16_t exec_vmread16(uint32_t field);
+uint32_t exec_vmread32(uint32_t field);
 uint64_t exec_vmread64(uint32_t field_full);
 void exec_vmwrite(uint32_t field, uint64_t value);
 void exec_vmwrite16(uint32_t field, uint16_t value);
+void exec_vmwrite32(uint32_t field, uint32_t value);
 void exec_vmwrite64(uint32_t field_full, uint64_t value);
 int init_vmcs(struct vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -414,8 +414,10 @@ int exec_vmxon_instr(uint16_t pcpu_id);
  */
 uint64_t exec_vmread(uint32_t field);
 
+uint16_t exec_vmread16(uint32_t field);
 uint64_t exec_vmread64(uint32_t field_full);
 void exec_vmwrite(uint32_t field, uint64_t value);
+void exec_vmwrite16(uint32_t field, uint16_t value);
 void exec_vmwrite64(uint32_t field_full, uint64_t value);
 int init_vmcs(struct vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -412,15 +412,16 @@ int exec_vmxon_instr(uint16_t pcpu_id);
  * @return the lower 32-bit outside IA-32e mode for 64-bit fields.
  * @return full contents for 32-bit fields, with higher 32-bit set to 0.
  */
-uint64_t exec_vmread(uint32_t field);
-
 uint16_t exec_vmread16(uint32_t field);
 uint32_t exec_vmread32(uint32_t field);
 uint64_t exec_vmread64(uint32_t field_full);
-void exec_vmwrite(uint32_t field, uint64_t value);
+#define exec_vmread exec_vmread64
+
 void exec_vmwrite16(uint32_t field, uint16_t value);
 void exec_vmwrite32(uint32_t field, uint32_t value);
 void exec_vmwrite64(uint32_t field_full, uint64_t value);
+#define exec_vmwrite exec_vmwrite64
+
 int init_vmcs(struct vcpu *vcpu);
 
 int vmx_off(uint16_t pcpu_id);


### PR DESCRIPTION
There are many integer type conversions in VMX, timer
and MTTR module detected by static analysis tool, these
integer type conversions voilate MISRA C:2012.

The following steps are taken to fix above integer type
conversions:
Replace SEL MARCO with constant value in assembly code;
Update vmread and vmwrite operations to access 16 bit,
32 bit, 64 bit, and natural width VMCS fields;

Update related variables type for vmread/vmwrite operations;
Update related caller according to VMCS fields size.

V1-->V2:
        Split patch as six part;
        Update vmread/vmwrite operations and related caller;
V2-->V3:
        Update code comments;
        Update related variables type for vmread/vmwrite;
        Add "hu" for uint16_t argument in log function.
V3-->V4:
         Few updates for coding style;
          Remove useless type conversion.
Reviewed-by: Junjie Mao <junjie.mao@intel.com>