### PR TITLE
HV: instr_emul: Replace ASSERT/panic with pr_err

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -2046,7 +2046,9 @@ decode_displacement(struct vie *vie)
 	}
 
 	if (n != 1 && n != 4) {
-		panic("decode_displacement: invalid disp_bytes %d", n);
+		pr_err("%s: decode_displacement: invalid disp_bytes %d",
+			__func__, n);
+		return -EINVAL;
 	}
 
 	for (i = 0; i < n; i++) {
@@ -2103,8 +2105,11 @@ decode_immediate(struct vie *vie)
 		return 0;
 	}
 
-	ASSERT(n == 1 || n == 2 || n == 4,
-		"%s: invalid number of immediate bytes: %d", __func__, n);
+	if ( n != 1 && n != 2 && n != 4) {
+		pr_err("%s: invalid number of immediate bytes: %d",
+			__func__, n);
+		return -EINVAL;
+	}
 
 	for (i = 0; i < n; i++) {
 		if (vie_peek(vie, &x) != 0) {
@@ -2145,7 +2150,10 @@ decode_moffset(struct vie *vie)
 	 * The memory offset size follows the address-size of the instruction.
 	 */
 	n = vie->addrsize;
-	ASSERT(n == 2U || n == 4U || n == 8U, "invalid moffset bytes: %hhu", n);
+	if ( n != 2U && n != 4U && n != 8U) {
+		pr_err("%s: invalid moffset bytes: %hhu", __func__, n);
+		return -EINVAL;
+	}
 
 	u.u64 = 0UL;
 	for (i = 0U; i < n; i++) {


### PR DESCRIPTION
ASSERT/panic are called when we get invalid values. It is a little bit strict.
This patch replaces ASSERT/panic with pr_err and return -EINVAL.

v1 -> v2:
  - v1 patch name (HV: instr_emul: Remove unnecessary check in decode_xxx)
  - keep the check and replace ASSERT/panic with pr_err.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>