### PR TITLE
tools: replace payload[0] of struct mngr_msg with an union

### DIFF
--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -22,7 +22,7 @@ $(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h
 	ar -cr $@ $(OUT_DIR)/acrn_mngr.o
 
 ifneq ($(OUT_DIR),.)
-$(OUT_DIR)/acrn_mngr.h:
+$(OUT_DIR)/acrn_mngr.h: ./acrn_mngr.h
 	cp ./acrn_mngr.h $(OUT_DIR)/
 endif
 

--- a/tools/acrn-manager/acrn_mngr.c
+++ b/tools/acrn-manager/acrn_mngr.c
@@ -191,7 +191,7 @@ static int server_parse_buf(struct mngr_fd *mfd, struct mngr_client *client)
 		msg = client->buf + p;
 
 		/* do we out-of-boundary? */
-		if (p + msg->len > client->len) {
+		if (p + sizeof(struct mngr_msg) > client->len) {
 			pdebug();
 			break;
 		}
@@ -206,7 +206,7 @@ static int server_parse_buf(struct mngr_fd *mfd, struct mngr_client *client)
 			handled = 1;
 			break;
 		}
-		p += msg->len;
+		p += sizeof(struct mngr_msg);
 	} while (p < client->len);
 
 	if (!handled)
@@ -593,7 +593,7 @@ int mngr_add_handler(int server_fd, unsigned id,
 }
 
 int mngr_send_msg(int fd, struct mngr_msg *req, struct mngr_msg *ack,
-		  size_t ack_len, unsigned timeout)
+		  unsigned timeout)
 {
 	int socket_fd;
 	struct mngr_fd *mfd;
@@ -634,8 +634,8 @@ int mngr_send_msg(int fd, struct mngr_msg *req, struct mngr_msg *ack,
 		return -1;
 	}
 
-	ret = write(socket_fd, req, req->len);
-	if (ret != req->len) {
+	ret = write(socket_fd, req, sizeof(struct mngr_msg));
+	if (ret != sizeof(struct mngr_msg)) {
 		printf("%s %d\n", __FUNCTION__, __LINE__);
 		return -1;
 	}
@@ -651,7 +651,7 @@ int mngr_send_msg(int fd, struct mngr_msg *req, struct mngr_msg *ack,
 	if (!FD_ISSET(socket_fd, &rfd))
 		return 0;
 
-	ret = read(socket_fd, ack, ack_len);
+	ret = read(socket_fd, ack, sizeof(struct mngr_msg));
 
 	return ret;
 }

--- a/tools/acrn-manager/acrn_mngr.h
+++ b/tools/acrn-manager/acrn_mngr.h
@@ -34,23 +34,6 @@ enum msgid {
 	MSG_MAX,
 };
 
-/* For test, generate a message who carry a string
- * eg., VMM_MSG_STR(hello_msg, "Hello\n") will create hello_msg,
- * then you can write(sock_fd, hello_msg, sizeof(hello_msg))
- */
-#define MNGR_MSG_STR(var, str)   \
-struct mngr_msg_##var {          \
-struct mngr_msg msg;            \
-        char raw[sizeof(str)];          \
-} var = {                               \
-        .msg = {                       \
-                .magic = MNGR_MSG_MAGIC, \
-                .msgid = MSG_STR,       \
-                .len = sizeof(struct mngr_msg_##var),    \
-        },                                              \
-        .raw = str,                             \
-}
-
 /* DM handled message event types */
 enum dm_msgid {
 	DM_STOP = MSG_MAX + 1,	/* Stop this UOS */

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -60,29 +60,26 @@ struct vmmngr_struct *vmmngr_find(char *name)
 	return NULL;
 }
 
-static int send_msg(char *vmname, struct mngr_msg *req,
-                    struct mngr_msg *ack, size_t ack_len);
+static int send_msg(char *vmname, struct mngr_msg *req, struct mngr_msg *ack);
 
 static int query_state(const char *name)
 {
-	struct req_dm_query req;
-	struct ack_dm_query ack;
+	struct mngr_msg req;
+	struct mngr_msg ack;
 	int ret;
 
-	req.msg.magic = MNGR_MSG_MAGIC;
-	req.msg.msgid = DM_QUERY;
-	req.msg.timestamp = time(NULL);
-	req.msg.len = sizeof(req);
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_QUERY;
+	req.timestamp = time(NULL);
 
-	ret = send_msg(vmname, (struct mngr_msg *)&req,
-		(struct mngr_msg *)&ack, sizeof(ack));
+	ret = send_msg(vmname, &req, &ack);
 	if (ret)
 		return ret;
 
-	if (ack.state < 0)
+	if (ack.data.state < 0)
 		pdebug();
 
-	return ack.state;
+	return ack.data.state;
 }
 
 /* find all the running DM process, which has */
@@ -270,7 +267,7 @@ int shell_cmd(const char *cmd, char *outbuf, int len)
 }
 
 static int send_msg(char *vmname, struct mngr_msg *req,
-		    struct mngr_msg *ack, size_t ack_len)
+		    struct mngr_msg *ack)
 {
 	int fd, ret;
 
@@ -286,7 +283,7 @@ static int send_msg(char *vmname, struct mngr_msg *req,
 		return -1;
 	}
 
-	ret = mngr_send_msg(fd, req, ack, ack_len, 1);
+	ret = mngr_send_msg(fd, req, ack, 1);
 	if (ret < 0) {
 		printf("%s: Unable to send msg\n", __FUNCTION__);
 		mngr_close(fd);
@@ -326,99 +323,89 @@ int start_vm(char *vmname)
 
 int stop_vm(char *vmname)
 {
-	struct req_dm_stop req;
-	struct ack_dm_stop ack;
+	struct mngr_msg req;
+	struct mngr_msg ack;
 
-	req.msg.magic = MNGR_MSG_MAGIC;
-	req.msg.msgid = DM_STOP;
-	req.msg.timestamp = time(NULL);
-	req.msg.len = sizeof(req);
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_STOP;
+	req.timestamp = time(NULL);
 
-	send_msg(vmname, (struct mngr_msg *)&req,
-		 (struct mngr_msg *)&ack, sizeof(ack));
-	if (ack.err) {
+	send_msg(vmname, &req, &ack);
+	if (ack.data.err) {
 		printf("Error happens when try to stop vm. errno(%d)\n",
-		       ack.err);
+			ack.data.err);
 	}
 
-	return ack.err;
+	return ack.data.err;
 }
 
 int pause_vm(char *vmname)
 {
-	struct req_dm_pause req;
-	struct ack_dm_pause ack;
+	struct mngr_msg req;
+	struct mngr_msg ack;
 
-	req.msg.magic = MNGR_MSG_MAGIC;
-	req.msg.msgid = DM_PAUSE;
-	req.msg.timestamp = time(NULL);
-	req.msg.len = sizeof(req);
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_PAUSE;
+	req.timestamp = time(NULL);
 
-	send_msg(vmname, (struct mngr_msg *)&req,
-		 (struct mngr_msg *)&ack, sizeof(ack));
-	if (ack.err) {
-		printf("Unable to pause vm. errno(%d)\n", ack.err);
+	send_msg(vmname, &req, &ack);
+	if (ack.data.err) {
+		printf("Unable to pause vm. errno(%d)\n", ack.data.err);
 	}
 
-	return ack.err;
+	return ack.data.err;
 }
 
 int continue_vm(char *vmname)
 {
-	struct req_dm_continue req;
-	struct ack_dm_continue ack;
+	struct mngr_msg req;
+	struct mngr_msg ack;
 
-	req.msg.magic = MNGR_MSG_MAGIC;
-	req.msg.msgid = DM_CONTINUE;
-	req.msg.timestamp = time(NULL);
-	req.msg.len = sizeof(req);
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_CONTINUE;
+	req.timestamp = time(NULL);
 
-	send_msg(vmname, (struct mngr_msg *)&req,
-		 (struct mngr_msg *)&ack, sizeof(ack));
+	send_msg(vmname, &req, &ack);
 
-	if (ack.err) {
-		printf("Unable to continue vm. errno(%d)\n", ack.err);
+	if (ack.data.err) {
+		printf("Unable to continue vm. errno(%d)\n", ack.data.err);
 	}
 
-	return ack.err;
+	return ack.data.err;
 }
 
 int suspend_vm(char *vmname)
 {
-	struct req_dm_suspend req;
-	struct ack_dm_suspend ack;
+	struct mngr_msg req;
+	struct mngr_msg ack;
 
-	req.msg.magic = MNGR_MSG_MAGIC;
-	req.msg.msgid = DM_SUSPEND;
-	req.msg.timestamp = time(NULL);
-	req.msg.len = sizeof(req);
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_SUSPEND;
+	req.timestamp = time(NULL);
 
-	send_msg(vmname, (struct mngr_msg *)&req,
-		 (struct mngr_msg *)&ack, sizeof(ack));
+	send_msg(vmname, &req, &ack);
 
-	if (ack.err) {
-		printf("Unable to suspend vm. errno(%d)\n", ack.err);
+	if (ack.data.err) {
+		printf("Unable to suspend vm. errno(%d)\n", ack.data.err);
 	}
 
-	return ack.err;
+	return ack.data.err;
 }
 
 int resume_vm(char *vmname)
 {
-	struct req_dm_resume req;
-	struct ack_dm_resume ack;
+	struct mngr_msg req;
+	struct mngr_msg ack;
 
-	req.msg.magic = MNGR_MSG_MAGIC;
-	req.msg.msgid = DM_RESUME;
-	req.msg.timestamp = time(NULL);
-	req.msg.len = sizeof(req);
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_RESUME;
+	req.timestamp = time(NULL);
 
-	send_msg(vmname, (struct mngr_msg *)&req,
-		 (struct mngr_msg *)&ack, sizeof(ack));
+	send_msg(vmname, &req, &ack);
 
-	if (ack.err) {
-		printf("Unable to resume vm. errno(%d)\n", ack.err);
+	if (ack.data.err) {
+		printf("Unable to resume vm. errno(%d)\n", ack.data.err);
 	}
 
-	return ack.err;
+	return ack.data.err;
 }


### PR DESCRIPTION
We replace payload[0] of struct mngr_msg with an union, which contains all payload data. So that type cast for mngr_send_msg() is no longer needed. And we can avoid potential out-of-boundary memory accessing and using of uninitialized variable.
