### PR TITLE
HV: bug fix on emulating msi message from guest

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -200,9 +200,8 @@ static void ptdev_build_physical_msi(struct vm *vm, struct ptdev_msi_info *info,
 
 	/* get physical destination cpu mask */
 	dest = (info->vmsi_addr >> 12) & 0xffU;
-	phys = ((info->vmsi_addr &
-			(MSI_ADDR_RH | MSI_ADDR_LOG)) !=
-			(MSI_ADDR_RH | MSI_ADDR_LOG));
+	phys = ((info->vmsi_addr & MSI_ADDR_LOG) != MSI_ADDR_LOG);
+
 	calcvdest(vm, &vdmask, dest, phys);
 	pdmask = vcpumask2pcpumask(vm, vdmask);
 

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -93,7 +93,7 @@ vioapic_send_intr(struct vioapic *vioapic, uint8_t pin)
 
 	vector = rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC;
 	dest = (uint32_t)(rte.full >> IOAPIC_RTE_DEST_SHIFT);
-	vlapic_deliver_intr(vioapic->vm, level, dest, phys, delmode, vector);
+	vlapic_deliver_intr(vioapic->vm, level, dest, phys, delmode, vector, false);
 }
 
 static void

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -96,7 +96,7 @@ int vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id, uint32_t vector);
 int vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg);
 
 void vlapic_deliver_intr(struct vm *vm, bool level, uint32_t dest,
-		bool phys, uint32_t delmode, uint32_t vec);
+		bool phys, uint32_t delmode, uint32_t vec, bool rh);
 
 /* Reset the trigger-mode bits for all vectors to be edge-triggered */
 void vlapic_reset_tmr(struct vlapic *vlapic);


### PR DESCRIPTION
Current code has a mistake associating destination with
redirectionhint. So just use the destination mode to work out
destination mode.

When injecting the msi interrupt to vcpu in hypervisor layer,
current code ingnores the redirection hint(RH) bit of msi address
message from guest, and just use the destination mode and
destination ID. So correctly before injecting, check the RH bit,
if set, choose the vcpu that has lowest priority to inject msi.

Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Reviewed-by: Zhao, Yakui <yakui.zhao@intel.com>
Reviewed-by: Yin, Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>