### PR TITLE
HV: hypercall: revisit types in structure parameters

### DIFF
--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -50,16 +50,16 @@
 #define REQ_STATE_PROCESSING	2
 #define REQ_STATE_FAILED	-1
 
-#define REQ_PORTIO	0
-#define REQ_MMIO	1
-#define REQ_PCICFG	2
-#define REQ_WP		3
+#define REQ_PORTIO	0U
+#define REQ_MMIO	1U
+#define REQ_PCICFG	2U
+#define REQ_WP		3U
 
 #define REQUEST_READ	0U
 #define REQUEST_WRITE	1U
 
 /* IOAPIC device model info */
-#define VIOAPIC_RTE_NUM	48  /* vioapic pins */
+#define VIOAPIC_RTE_NUM	48U  /* vioapic pins */
 
 #if VIOAPIC_RTE_NUM < 24
 #error "VIOAPIC_RTE_NUM must be larger than 23"
@@ -78,17 +78,17 @@
 struct mmio_request {
 	uint32_t direction;
 	uint32_t reserved;
-	int64_t address;
-	int64_t size;
-	int64_t value;
+	uint64_t address;
+	uint64_t size;
+	uint64_t value;
 } __aligned(8);
 
 struct pio_request {
 	uint32_t direction;
 	uint32_t reserved;
-	int64_t address;
-	int64_t size;
-	int32_t value;
+	uint64_t address;
+	uint64_t size;
+	uint32_t value;
 } __aligned(8);
 
 struct pci_request {
@@ -105,10 +105,9 @@ struct pci_request {
 /* vhm_request are 256Bytes aligned */
 struct vhm_request {
 	/* offset: 0bytes - 63bytes */
-	union {
-		uint32_t type;
-		int32_t reserved0[16];
-	};
+	uint32_t type;
+	int32_t reserved0[15];
+
 	/* offset: 64bytes-127bytes */
 	union {
 		struct pio_request pio_request;
@@ -143,10 +142,16 @@ union vhm_request_buffer {
  */
 struct acrn_create_vm {
 	/** created vmid return to VHM. Keep it first field */
-	int16_t vmid;
+	uint16_t vmid;
+
+	/** Reserved */
+	uint16_t reserved0;
 
 	/** VCPU numbers this VM want to create */
-	uint32_t vcpu_num;
+	uint16_t vcpu_num;
+
+	/** Reserved */
+	uint16_t reserved1;
 
 	/** the GUID of this VM */
 	uint8_t	 GUID[16];
@@ -157,7 +162,7 @@ struct acrn_create_vm {
 	uint64_t vm_flag;
 
 	/** Reserved for future use*/
-	uint8_t  reserved[24];
+	uint8_t  reserved2[24];
 } __aligned(8);
 
 /**
@@ -203,12 +208,18 @@ struct acrn_irqline {
 	uint32_t reserved;
 
 	/** pic IRQ for ISA type */
-	uint64_t pic_irq;
+	uint32_t pic_irq;
+
+	/** Reserved */
+	uint32_t reserved0;
 
 	/** ioapic IRQ for IOAPIC & ISA TYPE,
-	 *  if ~0UL then this IRQ will not be injected
+	 *  if ~0U then this IRQ will not be injected
 	 */
-	uint64_t ioapic_irq;
+	uint32_t ioapic_irq;
+
+	/** Reserved */
+	uint32_t reserved1;
 } __aligned(8);
 
 /**
@@ -229,7 +240,13 @@ struct acrn_msi_entry {
  */
 struct acrn_nmi_entry {
 	/** virtual CPU ID to inject */
-	int64_t vcpu_id;
+	uint16_t vcpu_id;
+
+	/** Reserved */
+	uint16_t reserved0;
+
+	/** Reserved */
+	uint32_t reserved1;
 } __aligned(8);
 
 /**

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -59,17 +59,17 @@
 struct mmio_request {
 	uint32_t direction;
 	uint32_t reserved;
-	int64_t address;
-	int64_t size;
-	int64_t value;
+	uint64_t address;
+	uint64_t size;
+	uint64_t value;
 } __aligned(8);
 
 struct pio_request {
 	uint32_t direction;
 	uint32_t reserved;
-	int64_t address;
-	int64_t size;
-	int32_t value;
+	uint64_t address;
+	uint64_t size;
+	uint32_t value;
 } __aligned(8);
 
 struct pci_request {
@@ -123,10 +123,16 @@ union vhm_request_buffer {
  */
 struct acrn_create_vm {
 	/** created vmid return to VHM. Keep it first field */
-	int16_t vmid;
+	uint16_t vmid;
+
+	/** Reserved */
+	uint16_t reserved0;
 
 	/** VCPU numbers this VM want to create */
-	uint32_t vcpu_num;
+	uint16_t vcpu_num;
+
+	/** Reserved */
+	uint16_t reserved1;
 
 	/** the GUID of this VM */
 	uint8_t	 GUID[16];
@@ -137,7 +143,7 @@ struct acrn_create_vm {
 	uint64_t vm_flag;
 
 	/** Reserved for future use*/
-	uint8_t  reserved[24];
+	uint8_t  reserved2[24];
 } __aligned(8);
 
 /**
@@ -183,12 +189,18 @@ struct acrn_irqline {
 	uint32_t reserved;
 
 	/** pic IRQ for ISA type */
-	uint64_t pic_irq;
+	uint32_t pic_irq;
+
+	/** Reserved */
+	uint32_t reserved0;
 
 	/** ioapic IRQ for IOAPIC & ISA TYPE,
-	 *  if ~0UL then this IRQ will not be injected
+	 *  if ~0U then this IRQ will not be injected
 	 */
-	uint64_t ioapic_irq;
+	uint32_t ioapic_irq;
+
+	/** Reserved */
+	uint32_t reserved1;
 } __aligned(8);
 
 /**
@@ -209,7 +221,13 @@ struct acrn_msi_entry {
  */
 struct acrn_nmi_entry {
 	/** virtual CPU ID to inject */
-	int64_t vcpu_id;
+	uint16_t vcpu_id;
+
+	/** Reserved */
+	uint16_t reserved0;
+
+	/** Reserved */
+	uint32_t reserved1;
 } __aligned(8);
 
 /**

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -152,7 +152,13 @@ struct memory_map {
  */
 struct set_memmaps {
 	/** vmid for this hypercall */
-	uint64_t vmid;
+	uint16_t vmid;
+
+	/** Reserved */
+	uint16_t reserved0;
+
+	/** Reserved */
+	uint32_t reserved1;
 
 	/**  multi memmaps numbers */
 	uint32_t memmaps_num;
@@ -170,6 +176,9 @@ struct set_memmaps {
 struct sbuf_setup_param {
 	/** sbuf physical cpu id */
 	uint16_t pcpu_id;
+
+	/** Reserved */
+	uint16_t reserved;
 
 	/** sbuf id */
 	uint32_t sbuf_id;
@@ -210,13 +219,22 @@ struct hc_ptdev_irq {
 		/** INTX remapping info */
 		struct {
 			/** virtual IOAPIC/PIC pin */
-			uint32_t virt_pin;
+			uint8_t virt_pin;
+
+			/** Reserved */
+			uint32_t reserved0:24;
 
 			/** physical IOAPIC pin */
-			uint32_t phys_pin;
+			uint8_t phys_pin;
+
+			/** Reserved */
+			uint32_t reserved1:24;
 
 			/** is virtual pin from PIC */
-			uint32_t pic_pin;
+			bool pic_pin;
+
+			/** Reserved */
+			uint32_t reserved2:24;
 		} intx;
 
 		/** MSIx remapping info */


### PR DESCRIPTION
While fixing the MISRA C violations related to integral types, we have unified
the type of the following data:

    uint8_t:
        phys_pin, virt_pin, vpic_pin, ioapic_pin, vioapic_pin

    uint16_t:
        vm_id, pcpu_id, vcpu_id, vpid

    uint32_t:
        vector, irq

This patch revisits the types of the fields in vhm_request as well as the
structures used as parameters in the hypercalls, and make them aligned with the
types the hypervisor uses for such data. Reserved fields are added to keep the
size and layout of the structures. Implicit paddings are also made explicit as
reserved fields.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>