### PR TITLE
doc: use code-block:: none for command examples

### DIFF
--- a/tools/acrn-crashlog/README.rst
+++ b/tools/acrn-crashlog/README.rst
@@ -35,14 +35,14 @@ Build
 
 To build the ``ACRN-Crashlog``, run below command under ``acrn-crashlog/``:
 
-.. code-block:: console
+.. code-block:: none
 
    $ make
 
 To remove all generated files and return the folder to its clean state, use
 below command under ``acrn-crashlog/``:
 
-.. code-block:: console
+.. code-block:: none
 
    $ make clean
 
@@ -51,7 +51,7 @@ Installing
 
 To install the build
 
-.. code-block:: console
+.. code-block:: none
 
    $ sudo make install
 
@@ -81,7 +81,7 @@ telemetrics-client on the system:
 
 Crashlog can be retrieved with ``telem_journal`` command:
 
-.. code-block:: console
+.. code-block:: none
 
    $ telem_journal -i
 
@@ -93,7 +93,7 @@ Crashlog can be retrieved with ``telem_journal`` command:
 ``ACRN-Crashlog`` also provides a tool ``debugger`` to dump the specific
 process information:
 
-.. code-block:: console
+.. code-block:: none
 
    $ debugger <pid>
 
@@ -106,7 +106,7 @@ Source Code
 
 The source code structure:
 
-.. code-block:: console
+.. code-block:: none
 
    acrn-crashlog/
    ├── acrnprobe

--- a/tools/acrn-crashlog/acrnprobe/README.rst
+++ b/tools/acrn-crashlog/acrnprobe/README.rst
@@ -26,13 +26,13 @@ Specify a configuration file for ``acrnprobe``. If this option is unused,
 ``acrnprobe`` will use the configuration file located in CUSTOM CONFIGURATION
 PATH or INSTALLATION PATH (see `CONFIGURATION FILES`_).
 
-.. code-block:: console
+.. code-block:: none
 
    $ acrnprobe -c [configuration_path]
 
 To see the version of ``acrnprobe``.
 
-.. code-block:: console
+.. code-block:: none
 
    $ acrnprobe -V
 

--- a/tools/acrn-crashlog/usercrash/README.rst
+++ b/tools/acrn-crashlog/usercrash/README.rst
@@ -56,7 +56,7 @@ Usage
   ``core_pattern``. The content of ``core_pattern`` is configured as
   ``usercrash_c`` while booting up:
 
-.. code-block:: console
+.. code-block:: none
 
    $ echo "|/usr/bin/usercrash_c %p %e %s" > /proc/sys/kernel/core_pattern
 
@@ -67,7 +67,7 @@ event will be sent to server from client.
   specific process, including backtrace, stack, opened files, registers value,
   memory content around registers, and etc.
 
-.. code-block:: console
+.. code-block:: none
 
    $ debugger <pid>
 


### PR DESCRIPTION
The ``.. code-block::`` directive can specify a highlight language for
the body of the directive.  Previously the languages "none" and
"console" were the same, but we're now using "console" for creating
terminal-looking output (rather than doing images of terminal windows)
with a black background and white text.

This PR replaces unintended uses of the "console" highlighting language
with "none".

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>