### PR TITLE
HV:treewide:Fix type conversion in VMX, timer and MTTR module

### DIFF
--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -7,14 +7,14 @@
 
 #ifdef CONFIG_MTRR_ENABLED
 
-#define MTRR_FIXED_RANGE_ALL_WB ((uint64_t)MTRR_MEM_TYPE_WB \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 8) \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 16) \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 24) \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 32) \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 40) \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 48) \
-					| (((uint64_t)MTRR_MEM_TYPE_WB) << 56))
+#define MTRR_FIXED_RANGE_ALL_WB (MTRR_MEM_TYPE_WB \
+					| (MTRR_MEM_TYPE_WB << 8U) \
+					| (MTRR_MEM_TYPE_WB << 16U) \
+					| (MTRR_MEM_TYPE_WB << 24U) \
+					| (MTRR_MEM_TYPE_WB << 32U) \
+					| (MTRR_MEM_TYPE_WB << 40U) \
+					| (MTRR_MEM_TYPE_WB << 48U) \
+					| (MTRR_MEM_TYPE_WB << 56U))
 
 struct fixed_range_mtrr_maps {
 	uint32_t msr;
@@ -22,53 +22,56 @@ struct fixed_range_mtrr_maps {
 	uint32_t sub_range_size;
 };
 
-#define MAX_FIXED_RANGE_ADDR	0x100000
+#define MAX_FIXED_RANGE_ADDR	0x100000UL
 static struct fixed_range_mtrr_maps fixed_mtrr_map[FIXED_RANGE_MTRR_NUM] = {
-	{ MSR_IA32_MTRR_FIX64K_00000, 0x0, 0x10000 },
-	{ MSR_IA32_MTRR_FIX16K_80000, 0x80000, 0x4000 },
-	{ MSR_IA32_MTRR_FIX16K_A0000, 0xA0000, 0x4000 },
-	{ MSR_IA32_MTRR_FIX4K_C0000, 0xC0000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_C8000, 0xC8000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_D0000, 0xD0000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_D8000, 0xD8000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_E0000, 0xE0000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_E8000, 0xE8000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_F0000, 0xF0000, 0x1000 },
-	{ MSR_IA32_MTRR_FIX4K_F8000, 0xF8000, 0x1000 },
+	{ MSR_IA32_MTRR_FIX64K_00000, 0x0U, 0x10000U },
+	{ MSR_IA32_MTRR_FIX16K_80000, 0x80000U, 0x4000U },
+	{ MSR_IA32_MTRR_FIX16K_A0000, 0xA0000U, 0x4000U },
+	{ MSR_IA32_MTRR_FIX4K_C0000, 0xC0000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_C8000, 0xC8000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_D0000, 0xD0000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_D8000, 0xD8000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_E0000, 0xE0000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_E8000, 0xE8000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_F0000, 0xF0000U, 0x1000U },
+	{ MSR_IA32_MTRR_FIX4K_F8000, 0xF8000U, 0x1000U },
 };
 
-int is_fixed_range_mtrr(uint32_t msr)
+static bool is_fixed_range_mtrr(uint32_t msr)
 {
 	return (msr >= fixed_mtrr_map[0].msr)
-		&& (msr <= fixed_mtrr_map[FIXED_RANGE_MTRR_NUM - 1].msr);
+		&& (msr <= fixed_mtrr_map[FIXED_RANGE_MTRR_NUM - 1U].msr);
 }
 
-static int get_index_of_fixed_mtrr(uint32_t msr)
+static uint32_t get_index_of_fixed_mtrr(uint32_t msr)
 {
-	int i;
+	uint32_t i;
 
-	for (i = 0; i < FIXED_RANGE_MTRR_NUM; i++) {
+	for (i = 0U; i < FIXED_RANGE_MTRR_NUM; i++) {
 		if (fixed_mtrr_map[i].msr == msr)
 			break;
 	}
 	return i;
 }
 
-int get_subrange_size_of_fixed_mtrr(int subrange_id)
+static uint32_t
+get_subrange_size_of_fixed_mtrr(uint32_t subrange_id)
 {
 	return fixed_mtrr_map[subrange_id].sub_range_size;
 }
 
-int get_subrange_start_of_fixed_mtrr(int index, int subrange_id)
+static uint32_t
+get_subrange_start_of_fixed_mtrr(uint32_t index, uint32_t subrange_id)
 {
 	return (fixed_mtrr_map[index].start + subrange_id *
 		get_subrange_size_of_fixed_mtrr(index));
 }
 
-int get_subrange_end_of_fixed_mtrr(int index, int subrange_id)
+static uint32_t
+get_subrange_end_of_fixed_mtrr(uint32_t index, uint32_t subrange_id)
 {
 	return (get_subrange_start_of_fixed_mtrr(index, subrange_id) +
-		get_subrange_size_of_fixed_mtrr(index) - 1);
+		get_subrange_size_of_fixed_mtrr(index) - 1U);
 }
 
 static inline bool is_mtrr_enabled(struct vcpu *vcpu)
@@ -90,23 +93,23 @@ static inline uint8_t get_default_memory_type(struct vcpu *vcpu)
 void init_mtrr(struct vcpu *vcpu)
 {
 	union mtrr_cap_reg cap = {0};
-	int i;
+	uint32_t i;
 
 	/*
 	 * We emulate fixed range MTRRs only
 	 * And expecting the guests won't write variable MTRRs
 	 * since MTRRCap.vcnt is 0
 	 */
-	vcpu->mtrr.cap.bits.vcnt = 0;
-	vcpu->mtrr.cap.bits.fix = 1;
-	vcpu->mtrr.def_type.bits.enable = 1;
-	vcpu->mtrr.def_type.bits.fixed_enable = 1;
+	vcpu->mtrr.cap.bits.vcnt = 0U;
+	vcpu->mtrr.cap.bits.fix = 1U;
+	vcpu->mtrr.def_type.bits.enable = 1U;
+	vcpu->mtrr.def_type.bits.fixed_enable = 1U;
 	vcpu->mtrr.def_type.bits.type = MTRR_MEM_TYPE_UC;
 
 	if (is_vm0(vcpu->vm))
 		cap.value = msr_read(MSR_IA32_MTRR_CAP);
 
-	for (i = 0; i < FIXED_RANGE_MTRR_NUM; i++) {
+	for (i = 0U; i < FIXED_RANGE_MTRR_NUM; i++) {
 		if (cap.bits.fix) {
 			/*
 			 * The system firmware runs in VMX non-root mode on VM0.
@@ -124,18 +127,18 @@ void init_mtrr(struct vcpu *vcpu)
 			vcpu->mtrr.fixed_range[i].value = MTRR_FIXED_RANGE_ALL_WB;
 		}
 
-		pr_dbg("vm%d vcpu%hu fixed-range MTRR[%d]: %16llx",
+		pr_dbg("vm%d vcpu%hu fixed-range MTRR[%u]: %16llx",
 			vcpu->vm->attr.id, vcpu->vcpu_id, i,
 			vcpu->mtrr.fixed_range[i].value);
 	}
 }
 
 static uint32_t update_ept(struct vm *vm, uint64_t start,
-	uint64_t size, uint32_t type)
+	uint64_t size, uint8_t type)
 {
 	uint64_t attr;
 
-	switch (type) {
+	switch ((uint64_t)type) {
 	case MTRR_MEM_TYPE_WC:
 		attr = IA32E_EPT_WC;
 		break;
@@ -159,9 +162,9 @@ static uint32_t update_ept(struct vm *vm, uint64_t start,
 
 static void update_ept_mem_type(struct vcpu *vcpu)
 {
-	uint32_t type;
+	uint8_t type;
 	uint64_t start, size;
-	int i, j;
+	uint32_t i, j;
 
 	/*
 	 * Intel SDM, Vol 3, 11.11.2.1 Section "IA32_MTRR_DEF_TYPE MSR":
@@ -169,18 +172,18 @@ static void update_ept_mem_type(struct vcpu *vcpu)
 	 * - when def_type.FE is clear, MTRRdefType.type is applied
 	 */
 	if (!is_mtrr_enabled(vcpu) || !is_fixed_range_mtrr_enabled(vcpu)) {
-		update_ept(vcpu->vm, 0, MAX_FIXED_RANGE_ADDR,
+		update_ept(vcpu->vm, 0U, MAX_FIXED_RANGE_ADDR,
 			get_default_memory_type(vcpu));
 		return;
 	}
 
 	/* Deal with fixed-range MTRRs only */
-	for (i = 0; i < FIXED_RANGE_MTRR_NUM; i++) {
+	for (i = 0U; i < FIXED_RANGE_MTRR_NUM; i++) {
 		type = vcpu->mtrr.fixed_range[i].type[0];
-		start = get_subrange_start_of_fixed_mtrr(i, 0);
+		start = get_subrange_start_of_fixed_mtrr(i, 0U);
 		size = get_subrange_size_of_fixed_mtrr(i);
 
-		for (j = 1; j < MTRR_SUB_RANGE_NUM; j++) {
+		for (j = 1U; j < MTRR_SUB_RANGE_NUM; j++) {
 			/* If it's same type, combine the subrange together */
 			if (type == vcpu->mtrr.fixed_range[i].type[j]) {
 				size += get_subrange_size_of_fixed_mtrr(i);
@@ -236,7 +239,7 @@ void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value)
 uint64_t mtrr_rdmsr(struct vcpu *vcpu, uint32_t msr)
 {
 	struct mtrr_state *mtrr = &vcpu->mtrr;
-	uint64_t ret = 0;
+	uint64_t ret = 0UL;
 
 	if (msr == MSR_IA32_MTRR_CAP)
 		ret = mtrr->cap.value;

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -6,10 +6,10 @@
 
 #include <hypervisor.h>
 
-#define MAX_TIMER_ACTIONS	32
-#define TIMER_IRQ		(NR_IRQS - 1)
-#define CAL_MS			10
-#define MIN_TIMER_PERIOD_US	500
+#define MAX_TIMER_ACTIONS	32U
+#define TIMER_IRQ		(NR_IRQS - 1U)
+#define CAL_MS			10U
+#define MIN_TIMER_PERIOD_US	500U
 
 uint32_t tsc_khz = 0U;
 
@@ -160,7 +160,7 @@ void timer_init(void)
 	char name[32] = {0};
 	uint16_t pcpu_id = get_cpu_id();
 
-	snprintf(name, 32, "timer_tick[%d]", pcpu_id);
+	snprintf(name, 32, "timer_tick[%hu]", pcpu_id);
 	if (request_timer_irq(pcpu_id, tsc_deadline_handler, NULL, name) < 0) {
 		pr_err("Timer setup failed");
 		return;
@@ -232,7 +232,7 @@ void check_tsc(void)
 
 static uint64_t pit_calibrate_tsc(uint16_t cal_ms)
 {
-#define PIT_TICK_RATE	1193182UL
+#define PIT_TICK_RATE	1193182U
 #define PIT_TARGET	0x3FFFU
 #define PIT_MAX_COUNT	0xFFFFU
 
@@ -254,9 +254,9 @@ static uint64_t pit_calibrate_tsc(uint16_t cal_ms)
 	 * Read/Write least significant byte first, mode 0, 16 bits.
 	 */
 
-	io_write_byte(0x30, 0x43);
-	io_write_byte(initial_pit & 0x00ffU, 0x40);	/* Write LSB */
-	io_write_byte(initial_pit >> 8, 0x40);		/* Write MSB */
+	io_write_byte(0x30U, 0x43U);
+	io_write_byte(initial_pit & 0x00ffU, 0x40U);	/* Write LSB */
+	io_write_byte(initial_pit >> 8U, 0x40U);		/* Write MSB */
 
 	current_tsc = rdtsc();
 
@@ -264,10 +264,10 @@ static uint64_t pit_calibrate_tsc(uint16_t cal_ms)
 		/* Port 0x43 ==> Control word write; 0x00 ==> Select
 		 * Counter 0, Counter Latch Command, Mode 0; 16 bits
 		 */
-		io_write_byte(0x00, 0x43);
+		io_write_byte(0x00U, 0x43U);
 
-		current_pit = io_read_byte(0x40);	/* Read LSB */
-		current_pit |= io_read_byte(0x40) << 8;	/* Read MSB */
+		current_pit = io_read_byte(0x40U);	/* Read LSB */
+		current_pit |= io_read_byte(0x40U) << 8U;	/* Read MSB */
 		/* Let the counter count down to PIT_TARGET */
 	} while (current_pit > PIT_TARGET);
 
@@ -284,7 +284,7 @@ static uint64_t native_calibrate_tsc(void)
 	if (boot_cpu_data.cpuid_level >= 0x15U) {
 		uint32_t eax_denominator, ebx_numerator, ecx_hz, reserved;
 
-		cpuid(0x15, &eax_denominator, &ebx_numerator,
+		cpuid(0x15U, &eax_denominator, &ebx_numerator,
 			&ecx_hz, &reserved);
 
 		if (eax_denominator != 0U && ebx_numerator != 0U) {

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -146,8 +146,8 @@ int vmexit_handler(struct vcpu *vcpu)
 	if ((vcpu->arch_vcpu.idt_vectoring_info & VMX_INT_INFO_VALID) != 0U) {
 		uint32_t vector_info = vcpu->arch_vcpu.idt_vectoring_info;
 		uint32_t vector = vector_info & 0xffU;
-		uint32_t type = (vector_info & VMX_INT_TYPE_MASK) >> 8;
-		uint32_t err_code = 0;
+		uint32_t type = (vector_info & VMX_INT_TYPE_MASK) >> 8U;
+		uint32_t err_code = 0U;
 
 		if (type == VMX_INT_TYPE_HW_EXP) {
 			if ((vector_info & VMX_INT_INFO_ERR_CODE_VALID) != 0U)
@@ -229,7 +229,7 @@ int cpuid_vmexit_handler(struct vcpu *vcpu)
 		(uint32_t *)&cur_context->guest_cpu_regs.regs.rcx,
 		(uint32_t *)&cur_context->guest_cpu_regs.regs.rdx);
 
-	TRACE_2L(TRACE_VMEXIT_CPUID, vcpu->vcpu_id, 0UL);
+	TRACE_2L(TRACE_VMEXIT_CPUID, (uint64_t)vcpu->vcpu_id, 0UL);
 
 	return 0;
 }
@@ -307,7 +307,7 @@ static int xsetbv_vmexit_handler(struct vcpu *vcpu)
 	struct run_context *ctx_ptr;
 
 	val64 = exec_vmread(VMX_GUEST_CR4);
-	if ((val64 & CR4_OSXSAVE) == 0U) {
+	if ((val64 & CR4_OSXSAVE) == 0UL) {
 		vcpu_inject_gp(vcpu, 0U);
 		return 0;
 	}
@@ -326,7 +326,7 @@ static int xsetbv_vmexit_handler(struct vcpu *vcpu)
 	}
 
 	val64 = ((ctx_ptr->guest_cpu_regs.regs.rax) & 0xffffffffUL) |
-			(ctx_ptr->guest_cpu_regs.regs.rdx << 32UL);
+			(ctx_ptr->guest_cpu_regs.regs.rdx << 32U);
 
 	/*bit 0(x87 state) of XCR0 can't be cleared*/
 	if ((val64 & 0x01UL) == 0UL) {
@@ -338,7 +338,7 @@ static int xsetbv_vmexit_handler(struct vcpu *vcpu)
 	 *set to 10b as it is necessary to set both bits
 	 *to use AVX instructions.
 	 **/
-	if (((val64 >> 1UL) & 0x3UL) == 0x2UL) {
+	if (((val64 >> 1U) & 0x3UL) == 0x2UL) {
 		vcpu_inject_gp(vcpu, 0U);
 		return 0;
 	}

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -53,21 +53,21 @@
 #define CPU_STACK_ALIGN         16UL
 
 /* CR0 register definitions */
-#define CR0_PG                  (1U<<31)	/* paging enable */
-#define CR0_CD                  (1U<<30)	/* cache disable */
-#define CR0_NW                  (1U<<29)	/* not write through */
-#define CR0_AM                  (1U<<18)	/* alignment mask */
-#define CR0_WP                  (1U<<16)	/* write protect */
-#define CR0_NE                  (1U<<5)	/* numeric error */
-#define CR0_ET                  (1U<<4)	/* extension type */
-#define CR0_TS                  (1U<<3)	/* task switched */
-#define CR0_EM                  (1U<<2)	/* emulation */
-#define CR0_MP                  (1U<<1)	/* monitor coprocessor */
-#define CR0_PE                  (1U<<0)	/* protected mode enabled */
+#define CR0_PG                  (1UL<<31U)	/* paging enable */
+#define CR0_CD                  (1UL<<30U)	/* cache disable */
+#define CR0_NW                  (1UL<<29U)	/* not write through */
+#define CR0_AM                  (1UL<<18U)	/* alignment mask */
+#define CR0_WP                  (1UL<<16U)	/* write protect */
+#define CR0_NE                  (1UL<<5U)	/* numeric error */
+#define CR0_ET                  (1UL<<4U)	/* extension type */
+#define CR0_TS                  (1UL<<3U)	/* task switched */
+#define CR0_EM                  (1UL<<2U)	/* emulation */
+#define CR0_MP                  (1UL<<1U)	/* monitor coprocessor */
+#define CR0_PE                  (1UL<<0U)	/* protected mode enabled */
 
 /* CR3 register definitions */
-#define CR3_PWT                 (1U<<3)	/* page-level write through */
-#define CR3_PCD                 (1U<<4)	/* page-level cache disable */
+#define CR3_PWT                 (1UL<<3U)	/* page-level write through */
+#define CR3_PCD                 (1UL<<4U)	/* page-level cache disable */
 
 /* CR4 register definitions */
 #define CR4_VME                 (1UL<<0)	/* virtual 8086 mode extensions */

--- a/hypervisor/include/arch/x86/gdt.h
+++ b/hypervisor/include/arch/x86/gdt.h
@@ -27,9 +27,9 @@
  * bytes.
  * Task State Segment (TSS) selectors are 16 bytes on x86-64 instead of 8 bytes.
  */
-#define X64_SEG_DESC_SIZE (0x8)	/* In long mode SEG Descriptors are 8 bytes */
-#define X64_LDT_DESC_SIZE (0x10)/* In long mode LDT Descriptors are 16 bytes */
-#define X64_TSS_DESC_SIZE (0x10)/* In long mode TSS Descriptors are 16 bytes */
+#define X64_SEG_DESC_SIZE (0x8U)	/* In long mode SEG Descriptors are 8 bytes */
+#define X64_LDT_DESC_SIZE (0x10U)/* In long mode LDT Descriptors are 16 bytes */
+#define X64_TSS_DESC_SIZE (0x10U)/* In long mode TSS Descriptors are 16 bytes */
 
 /*****************************************************************************
  *
@@ -41,13 +41,13 @@
  *
  *****************************************************************************/
 /* Number of global 8 byte segments descriptor(s) */
-#define    HOST_GDT_RING0_SEG_SELECTORS   (0x3)	/* rsvd, code, data */
+#define    HOST_GDT_RING0_SEG_SELECTORS   (0x3U)	/* rsvd, code, data */
 /* Offsets of global 8 byte segment descriptors */
-#define    HOST_GDT_RING0_RSVD_SEL        (0x0000)
-#define    HOST_GDT_RING0_CODE_SEL        (0x0008)
-#define    HOST_GDT_RING0_DATA_SEL        (0x0010)
+#define    HOST_GDT_RING0_RSVD_SEL        (0x0000U)
+#define    HOST_GDT_RING0_CODE_SEL        (0x0008U)
+#define    HOST_GDT_RING0_DATA_SEL        (0x0010U)
 /* Number of global 16 byte LDT descriptor(s) */
-#define    HOST_GDT_RING0_TSS_SELECTORS   (0x1)
+#define    HOST_GDT_RING0_TSS_SELECTORS   (0x1U)
 /* One for each CPU in the hypervisor. */
 
 /*****************************************************************************

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -492,10 +492,10 @@
 #define MSR_LNC_BIOS_CACHE_AS_RAM           0x000002E0U    /* Configure CAR */
 
 /* EFER bits */
-#define MSR_IA32_EFER_SCE_BIT                   (1U<<0)
-#define MSR_IA32_EFER_LME_BIT                   (1U<<8)    /* IA32e mode enable */
-#define MSR_IA32_EFER_LMA_BIT                   (1U<<10)   /* IA32e mode active */
-#define MSR_IA32_EFER_NXE_BIT                   (1U<<11)
+#define MSR_IA32_EFER_SCE_BIT                   (1UL<<0U)
+#define MSR_IA32_EFER_LME_BIT                   (1UL<<8U)    /* IA32e mode enable */
+#define MSR_IA32_EFER_LMA_BIT                   (1UL<<10U)   /* IA32e mode active */
+#define MSR_IA32_EFER_NXE_BIT                   (1UL<<11U)
 
 /* FEATURE CONTROL bits */
 #define MSR_IA32_FEATURE_CONTROL_LOCK           (1U<<0)
@@ -503,12 +503,12 @@
 #define MSR_IA32_FEATURE_CONTROL_VMX_NO_SMX     (1U<<2)
 
 /* PAT memory type definitions */
-#define PAT_MEM_TYPE_UC                     0x00U	/* uncached */
-#define PAT_MEM_TYPE_WC                     0x01U	/* write combining */
-#define PAT_MEM_TYPE_WT                     0x04U	/* write through */
-#define PAT_MEM_TYPE_WP                     0x05U	/* write protected */
-#define PAT_MEM_TYPE_WB                     0x06U	/* writeback */
-#define PAT_MEM_TYPE_UCM                    0x07U	/* uncached minus */
+#define PAT_MEM_TYPE_UC                     0x00UL	/* uncached */
+#define PAT_MEM_TYPE_WC                     0x01UL	/* write combining */
+#define PAT_MEM_TYPE_WT                     0x04UL	/* write through */
+#define PAT_MEM_TYPE_WP                     0x05UL	/* write protected */
+#define PAT_MEM_TYPE_WB                     0x06UL	/* writeback */
+#define PAT_MEM_TYPE_UCM                    0x07UL	/* uncached minus */
 #define PAT_MEM_TYPE_INVALID(x)             (((x) != PAT_MEM_TYPE_UC) && \
                                             ((x) != PAT_MEM_TYPE_WC) && \
                                             ((x) != PAT_MEM_TYPE_WT) && \
@@ -520,29 +520,29 @@
 #define PAT_FIELD_RSV_BITS                  (0xF8U)
 
 #define PAT_POWER_ON_VALUE     (PAT_MEM_TYPE_WB + \
-        ((uint64_t)PAT_MEM_TYPE_WT << 8) + \
-        ((uint64_t)PAT_MEM_TYPE_UCM << 16) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 24) + \
-        ((uint64_t)PAT_MEM_TYPE_WB << 32) + \
-        ((uint64_t)PAT_MEM_TYPE_WT << 40) + \
-        ((uint64_t)PAT_MEM_TYPE_UCM << 48) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 56))
+        (PAT_MEM_TYPE_WT << 8U) + \
+        (PAT_MEM_TYPE_UCM << 16U) + \
+        (PAT_MEM_TYPE_UC << 24U) + \
+        (PAT_MEM_TYPE_WB << 32U) + \
+        (PAT_MEM_TYPE_WT << 40U) + \
+        (PAT_MEM_TYPE_UCM << 48U) + \
+        (PAT_MEM_TYPE_UC << 56U))
 
 #define PAT_ALL_UC_VALUE (PAT_MEM_TYPE_UC + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 8) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 16) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 24) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 32) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 40) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 48) + \
-        ((uint64_t)PAT_MEM_TYPE_UC << 56))
+        (PAT_MEM_TYPE_UC << 8U) + \
+        (PAT_MEM_TYPE_UC << 16U) + \
+        (PAT_MEM_TYPE_UC << 24U) + \
+        (PAT_MEM_TYPE_UC << 32U) + \
+        (PAT_MEM_TYPE_UC << 40U) + \
+        (PAT_MEM_TYPE_UC << 48U) + \
+        (PAT_MEM_TYPE_UC << 56U))
 
 /* MTRR memory type definitions */
-#define MTRR_MEM_TYPE_UC             0x00U	/* uncached */
-#define MTRR_MEM_TYPE_WC             0x01U	/* write combining */
-#define MTRR_MEM_TYPE_WT             0x04U	/* write through */
-#define MTRR_MEM_TYPE_WP             0x05U	/* write protected */
-#define MTRR_MEM_TYPE_WB             0x06U	/* writeback */
+#define MTRR_MEM_TYPE_UC             0x00UL	/* uncached */
+#define MTRR_MEM_TYPE_WC             0x01UL	/* write combining */
+#define MTRR_MEM_TYPE_WT             0x04UL	/* write through */
+#define MTRR_MEM_TYPE_WP             0x05UL	/* write protected */
+#define MTRR_MEM_TYPE_WB             0x06UL	/* writeback */
 
 /* misc. MTRR flag definitions */
 #define MTRR_ENABLE                  0x800U	/* MTRR enable */

--- a/hypervisor/include/arch/x86/mtrr.h
+++ b/hypervisor/include/arch/x86/mtrr.h
@@ -6,8 +6,8 @@
 #ifndef MTRR_H
 #define MTRR_H
 
-#define FIXED_RANGE_MTRR_NUM	11
-#define MTRR_SUB_RANGE_NUM		8
+#define FIXED_RANGE_MTRR_NUM	11U
+#define MTRR_SUB_RANGE_NUM		8U
 
 union mtrr_cap_reg {
 	uint64_t value;


### PR DESCRIPTION
There are some integer type conversions in the VMX, timer
and MTTR module detected by static analysis tool.

Update related integer type in VMX, timer and MTTR
module.
Add related constant value with 'U/UL' suffix.

V1-->V2:
        Resolve few rebase conflicts.
V2-->V3:
        Add 'h' for uint16_t argument in log function;
	Update the type of temp variable 'type' as uint8_t
	in MTTR module to reduce type conversion.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>