### PR TITLE
hv: check eptp value before calling free_ept_mem()

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -98,8 +98,10 @@ static void free_ept_mem(void *pml4_addr)
 
 void destroy_ept(struct vm *vm)
 {
-	free_ept_mem(HPA2HVA(vm->arch_vm.nworld_eptp));
-	free_ept_mem(HPA2HVA(vm->arch_vm.m2p));
+	if (vm->arch_vm.nworld_eptp != 0U)
+		free_ept_mem(HPA2HVA(vm->arch_vm.nworld_eptp));
+	if (vm->arch_vm.m2p != 0U)
+		free_ept_mem(HPA2HVA(vm->arch_vm.m2p));
 
 	/*
 	 * If secure world is initialized, destroy Secure world ept.


### PR DESCRIPTION
There is chance to destroy vm whose ept table was not created, for
example, dm fails to setup mem for vm. In this case, it's better
to check the value of eptp before calling free_ept_mem() rather than
relying on assertion in the function.

Signed-off-by: Yan, Like <like.yan@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>