### PR TITLE
hv: treewide: fix 'No definition in system for prototyped procedure'

### DIFF
--- a/hypervisor/debug/shell_internal.h
+++ b/hypervisor/debug/shell_internal.h
@@ -141,15 +141,12 @@ struct shell_cmd {
 int shell_show_req_info(struct shell *p_shell, int argc, char **argv);
 int shell_construct(struct shell **p_shell);
 int shell_cmd_help(struct shell *p_shell, int argc, char **argv);
-int shell_reset_cmd(struct shell *p_shell, int argc, char **argv);
 int shell_list_vm(struct shell *p_shell, int argc, char **argv);
 int shell_list_vcpu(struct shell *p_shell, int argc, char **argv);
 int shell_pause_vcpu(struct shell *p_shell, int argc, char **argv);
 int shell_resume_vcpu(struct shell *p_shell, int argc, char **argv);
 int shell_vcpu_dumpreg(struct shell *p_shell, int argc, char **argv);
 int shell_vcpu_dumpmem(struct shell *p_shell, int argc, char **argv);
-int shell_boot_vm(struct shell *p_shell, int argc, char **argv);
-int shell_trace_cmd(struct shell *p_shell, int argc, char **argv);
 int shell_to_sos_console(struct shell *p_shell, int argc, char **argv);
 int shell_show_cpu_int(struct shell *p_shell, int argc, char **argv);
 int shell_show_ptdev_info(struct shell *p_shell, int argc, char **argv);

--- a/hypervisor/include/arch/x86/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/guest/guest_pm.h
@@ -10,7 +10,6 @@
 void vm_setup_cpu_state(struct vm *vm);
 int vm_load_pm_s_state(struct vm *vm);
 int validate_pstate(struct vm *vm, uint64_t perf_ctl);
-struct cpu_cx_data* get_target_cx(struct vm *vm, uint8_t cn);
 void register_pm1ab_handler(struct vm *vm);
 
 #endif /* PM_H */

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -56,7 +56,6 @@ int vlapic_pending_intr(struct vlapic *vlapic, uint32_t *vecptr);
  */
 void vlapic_intr_accepted(struct vlapic *vlapic, uint32_t vector);
 
-struct vlapic *vm_lapic_from_vcpuid(struct vm *vm, uint16_t vcpu_id);
 struct vlapic *vm_lapic_from_pcpuid(struct vm *vm, uint16_t pcpu_id);
 bool is_vlapic_msr(uint32_t num);
 int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
@@ -126,7 +125,6 @@ void vlapic_restore(struct vlapic *vlapic, struct lapic_regs *regs);
 bool vlapic_enabled(struct vlapic *vlapic);
 uint64_t apicv_get_apic_access_addr(struct vm *vm);
 uint64_t apicv_get_apic_page_addr(struct vlapic *vlapic);
-bool vlapic_apicv_enabled(struct vcpu *vcpu);
 void apicv_inject_pir(struct vlapic *vlapic);
 int apic_access_vmexit_handler(struct vcpu *vcpu);
 int apic_write_vmexit_handler(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -99,11 +99,10 @@ int vpic_pulse_irq(struct vm *vm, uint32_t irq);
 
 void vpic_pending_intr(struct vm *vm, uint32_t *vecptr);
 void vpic_intr_accepted(struct vm *vm, uint32_t vector);
-int vpic_set_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger trigger);
-int vpic_get_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger *trigger);
-
-struct vm_io_handler *vpic_create_io_handler(int flags, uint32_t port,
-	uint32_t len);
+int vpic_set_irq_trigger(struct vm *vm, uint32_t irq,
+	enum vpic_trigger trigger);
+int vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
+	enum vpic_trigger *trigger);
 
 bool vpic_is_pin_mask(struct vpic *vpic, uint8_t virt_pin);
 

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -425,7 +425,6 @@ void exec_vmwrite64(uint32_t field_full, uint64_t value);
 int init_vmcs(struct vcpu *vcpu);
 
 int vmx_off(uint16_t pcpu_id);
-int vmx_restart(uint16_t pcpu_id);
 
 int exec_vmclear(void *addr);
 int exec_vmptrld(void *addr);
@@ -444,7 +443,8 @@ static inline enum vm_cpu_mode get_vcpu_mode(struct vcpu *vcpu)
 
 static inline bool cpu_has_vmx_unrestricted_guest_cap(void)
 {
-       return ((msr_read(MSR_IA32_VMX_MISC) & VMX_SUPPORT_UNRESTRICTED_GUEST) != 0UL);
+	return ((msr_read(MSR_IA32_VMX_MISC) & VMX_SUPPORT_UNRESTRICTED_GUEST)
+									!= 0UL);
 }
 
 typedef struct _descriptor_table_{

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -17,8 +17,6 @@ struct vhm_request;
 
 bool is_hypercall_from_ring0(void);
 
-int acrn_vpic_inject_irq(struct vm *vm, int irq, enum irq_mode mode);
-
 /**
  * @brief Hypercall
  *

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -28,7 +28,6 @@ struct udiv_result {
 /* Function prototypes */
 void udelay(uint32_t us);
 void *memchr(const void *void_s, int c, size_t n);
-void *memmove(void *s1, const void *s2, size_t n);
 int strcmp(const char *s1, const char *s2);
 int strncmp(const char *s1, const char *s2, size_t n);
 char *strcpy_s(char *d, size_t dmax, const char *s);


### PR DESCRIPTION
- Remove those APIs without definition

- Minor changes to make sure the line length is less than 80

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>