### PR TITLE
store virtual address of EPT PML4 table

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -495,10 +495,6 @@ int ept_mmap(struct vm *vm, uint64_t hpa,
 
 	/* Setup memory map parameters */
 	map_params.page_table_type = PTT_EPT;
-	if (vm->arch_vm.nworld_eptp == NULL) {
-		vm->arch_vm.nworld_eptp = alloc_paging_struct();
-		vm->arch_vm.m2p = alloc_paging_struct();
-	}
 	map_params.pml4_base = vm->arch_vm.nworld_eptp;
 	map_params.pml4_inverted = vm->arch_vm.m2p;
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -110,6 +110,15 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 
 	/* gpa_lowtop are used for system start up */
 	vm->hw.gpa_lowtop = 0UL;
+
+	vm->arch_vm.nworld_eptp = alloc_paging_struct();
+	vm->arch_vm.m2p = alloc_paging_struct();
+	if ((vm->arch_vm.nworld_eptp == NULL) ||
+			(vm->arch_vm.m2p == NULL)) {
+		pr_fatal("%s, alloc memory for EPTP failed\n", __func__);
+		return -ENOMEM;
+	}
+
 	/* Only for SOS: Configure VM software information */
 	/* For UOS: This VM software information is configure in DM */
 	if (is_vm0(vm)) {

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -178,11 +178,12 @@ void invept(struct vcpu *vcpu)
 	struct invept_desc desc = {0};
 
 	if (cpu_has_vmx_ept_cap(VMX_EPT_INVEPT_SINGLE_CONTEXT)) {
-		desc.eptp = vcpu->vm->arch_vm.nworld_eptp | (3UL << 3U) | 6UL;
+		desc.eptp = HVA2HPA(vcpu->vm->arch_vm.nworld_eptp) |
+				(3UL << 3U) | 6UL;
 		_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
 		if (vcpu->vm->sworld_control.sworld_enabled &&
-			vcpu->vm->arch_vm.sworld_eptp) {
-			desc.eptp = vcpu->vm->arch_vm.sworld_eptp
+			vcpu->vm->arch_vm.sworld_eptp != NULL) {
+			desc.eptp = HVA2HPA(vcpu->vm->arch_vm.sworld_eptp)
 				| (3UL << 3U) | 6UL;
 			_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
 		}

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1344,7 +1344,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	 * TODO: introduce API to make this data driven based
 	 * on VMX_EPT_VPID_CAP
 	 */
-	value64 = vm->arch_vm.nworld_eptp | (3UL << 3U) | 6UL;
+	value64 = HVA2HPA(vm->arch_vm.nworld_eptp) | (3UL << 3U) | 6UL;
 	exec_vmwrite64(VMX_EPT_POINTER_FULL, value64);
 	pr_dbg("VMX_EPT_POINTER: 0x%016llx ", value64);
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -616,14 +616,14 @@ int64_t hcall_assign_ptdev(struct vm *vm, uint64_t vmid, uint64_t param)
 
 	/* create a iommu domain for target VM if not created */
 	if (target_vm->iommu_domain == NULL) {
-		if (target_vm->arch_vm.nworld_eptp == 0UL) {
+		if (target_vm->arch_vm.nworld_eptp == NULL) {
 			pr_err("%s, EPT of VM not set!\n",
 				__func__, target_vm->attr.id);
 			return -EPERM;
 		}
 		/* TODO: how to get vm's address width? */
 		target_vm->iommu_domain = create_iommu_domain(vmid,
-				target_vm->arch_vm.nworld_eptp, 48U);
+				HVA2HPA(target_vm->arch_vm.nworld_eptp), 48U);
 		if (target_vm->iommu_domain == NULL) {
 			return -ENODEV;
 		}

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -25,7 +25,7 @@ int64_t hcall_world_switch(struct vcpu *vcpu)
 		return -EPERM;
 	}
 
-	if (vcpu->vm->arch_vm.sworld_eptp == 0U) {
+	if (vcpu->vm->arch_vm.sworld_eptp == NULL) {
 		pr_err("%s, Trusty is not initialized!\n", __func__);
 		return -EPERM;
 	}
@@ -44,7 +44,7 @@ int64_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param)
 		return -EPERM;
 	}
 
-	if (vcpu->vm->arch_vm.sworld_eptp != 0U) {
+	if (vcpu->vm->arch_vm.sworld_eptp != NULL) {
 		pr_err("%s, Trusty already initialized!\n", __func__);
 		return -EPERM;
 	}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -87,13 +87,13 @@ enum vm_state {
 struct vm_arch {
 	uint64_t guest_init_pml4;/* Guest init pml4 */
 	/* EPT hierarchy for Normal World */
-	uint64_t nworld_eptp;
+	void *nworld_eptp;
 	/* EPT hierarchy for Secure World
 	 * Secure world can access Normal World's memory,
 	 * but Normal World can not access Secure World's memory.
 	 */
-	uint64_t sworld_eptp;
-	uint64_t m2p;		/* machine address to guest physical address */
+	void *sworld_eptp;
+	void *m2p;		/* machine address to guest physical address */
 	void *tmp_pg_array;	/* Page array for tmp guest paging struct */
 	void *iobitmap[2];/* IO bitmap page array base address for this VM */
 	void *msr_bitmap;	/* MSR bitmap page base address for this VM */


### PR DESCRIPTION
Most of the time, we use the virtual address of EPT PMl4 table, not physical address.