### PR TITLE
HV:vtd:fix all integer related violations

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -14,13 +14,13 @@
 #define ACRN_DBG_IOMMU LOG_INFO
 #define DMAR_FAULT_LOOP_MAX 10
 #else
-#define ACRN_DBG_IOMMU 6
+#define ACRN_DBG_IOMMU 6U
 #endif
 
 /* set an appropriate bus limitation when iommu init,
  * to reduce memory & time cost
  */
-#define IOMMU_INIT_BUS_LIMIT        (0xf)
+#define IOMMU_INIT_BUS_LIMIT        (0xfU)
 
 #define PAGE_MASK                   (0xFFFUL)
 #define LEVEL_WIDTH 9U
@@ -124,7 +124,7 @@ struct dmar_drhd_rt {
 
 	uint64_t cap;
 	uint64_t ecap;
-	uint64_t gcmd;  /* sw cache value of global cmd register */
+	uint32_t gcmd;  /* sw cache value of global cmd register */
 
 	uint32_t irq;
 	struct dev_handler_node *dmar_irq_node;
@@ -166,7 +166,7 @@ static uint32_t dmar_hdrh_unit_count;
  * domain id 0 is reserved,
  * bit0 --> domain id 0, ..., bit63 --> domain id 63
  */
-static uint32_t max_domain_id = 63;
+static uint32_t max_domain_id = 63U;
 static uint64_t domain_bitmap;
 static spinlock_t domain_lock;
 static struct iommu_domain *host_domain;
@@ -187,7 +187,7 @@ static int register_hrhd_units(void)
 	}
 
 	for (i = 0U; i < info->drhd_count; i++) {
-		drhd_rt = calloc(1, sizeof(struct dmar_drhd_rt));
+		drhd_rt = calloc(1U, sizeof(struct dmar_drhd_rt));
 		ASSERT(drhd_rt != NULL, "");
 		drhd_rt->drhd = &info->drhd_units[i];
 		dmar_register_hrhd(drhd_rt);
@@ -205,8 +205,8 @@ static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
 	uint64_t value;
 
-	value = mmio_read_long(HPA2HVA(dmar_uint->drhd->reg_base_addr + offset + 4));
-	value = value << 32;
+	value = mmio_read_long(HPA2HVA(dmar_uint->drhd->reg_base_addr + offset + 4U));
+	value = value << 32U;
 	value = value | mmio_read_long(HPA2HVA(dmar_uint->drhd->reg_base_addr +
 					offset));
 
@@ -224,11 +224,11 @@ static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 {
 	uint32_t temp;
 
-	temp = value;
+	temp = (uint32_t)value;
 	mmio_write_long(temp, HPA2HVA(dmar_uint->drhd->reg_base_addr + offset));
 
-	temp = value >> 32;
-	mmio_write_long(temp, HPA2HVA(dmar_uint->drhd->reg_base_addr + offset + 4));
+	temp = (uint32_t)(value >> 32U);
+	mmio_write_long(temp, HPA2HVA(dmar_uint->drhd->reg_base_addr + offset + 4U));
 }
 
 /* flush cache when root table, context table updated */
@@ -320,7 +320,7 @@ static void dmar_uint_show_capability(struct dmar_drhd_rt *dmar_uint)
 
 static inline uint8_t width_to_level(uint32_t width)
 {
-	return ((width - 12U) + (LEVEL_WIDTH)-1U) / (LEVEL_WIDTH);
+	return (uint8_t)(((width - 12U) + (LEVEL_WIDTH)-1U) / (LEVEL_WIDTH));
 }
 
 static inline uint8_t width_to_agaw(uint32_t width)
@@ -394,7 +394,7 @@ static void dmar_register_hrhd(struct dmar_drhd_rt *dmar_uint)
 
 	dmar_uint->cap = iommu_read64(dmar_uint, DMAR_CAP_REG);
 	dmar_uint->ecap = iommu_read64(dmar_uint, DMAR_ECAP_REG);
-	dmar_uint->gcmd = iommu_read64(dmar_uint, DMAR_GCMD_REG);
+	dmar_uint->gcmd = iommu_read32(dmar_uint, DMAR_GCMD_REG);
 
 	dmar_uint->cap_msagaw = dmar_uint_get_msagw(dmar_uint);
 
@@ -402,7 +402,7 @@ static void dmar_register_hrhd(struct dmar_drhd_rt *dmar_uint)
 		iommu_cap_num_fault_regs(dmar_uint->cap);
 	dmar_uint->cap_fault_reg_offset =
 		iommu_cap_fault_reg_offset(dmar_uint->cap);
-	dmar_uint->ecap_iotlb_offset = iommu_ecap_iro(dmar_uint->ecap) * 16;
+	dmar_uint->ecap_iotlb_offset = iommu_ecap_iro(dmar_uint->ecap) * 16U;
 
 #if DBG_IOMMU
 	pr_info("version:0x%x, cap:0x%llx, ecap:0x%llx",
@@ -418,11 +418,11 @@ static void dmar_register_hrhd(struct dmar_drhd_rt *dmar_uint)
 #endif
 
 	/* check capability */
-	if ((iommu_cap_super_page_val(dmar_uint->cap) & 0x1UL) == 0) {
+	if ((iommu_cap_super_page_val(dmar_uint->cap) & 0x1U) == 0U) {
 		dev_dbg(ACRN_DBG_IOMMU, "dmar uint doesn't support 2MB page!");
 	}
 
-	if ((iommu_cap_super_page_val(dmar_uint->cap) & 0x2UL) == 0) {
+	if ((iommu_cap_super_page_val(dmar_uint->cap) & 0x2U) == 0U) {
 		dev_dbg(ACRN_DBG_IOMMU, "dmar uint doesn't support 1GB page!");
 	}
 
@@ -457,7 +457,7 @@ static void dmar_register_hrhd(struct dmar_drhd_rt *dmar_uint)
 
 	dmar_hdrh_unit_count++;
 
-	if ((dmar_uint->gcmd & DMA_GCMD_TE) != 0) {
+	if ((dmar_uint->gcmd & DMA_GCMD_TE) != 0U) {
 		dmar_disable_translation(dmar_uint);
 	}
 }
@@ -505,7 +505,7 @@ static uint8_t alloc_domain_id(void)
 	 */
 	for (i = 1U; i < 64U; i++) {
 		mask = (1UL << i);
-		if ((domain_bitmap & mask) == 0) {
+		if ((domain_bitmap & mask) == 0UL) {
 			domain_bitmap |= mask;
 			break;
 		}
@@ -525,7 +525,7 @@ static void free_domain_id(uint16_t dom_id)
 
 static struct iommu_domain *create_host_domain(void)
 {
-	struct iommu_domain *domain = calloc(1, sizeof(struct iommu_domain));
+	struct iommu_domain *domain = calloc(1U, sizeof(struct iommu_domain));
 
 	ASSERT(domain != NULL, "");
 	domain->is_host = true;
@@ -546,7 +546,7 @@ static void dmar_write_buffer_flush(struct dmar_drhd_rt *dmar_uint)
 	}
 
 	IOMMU_LOCK(dmar_uint);
-	iommu_write64(dmar_uint, DMAR_GCMD_REG,
+	iommu_write32(dmar_uint, DMAR_GCMD_REG,
 			  dmar_uint->gcmd | DMA_GCMD_WBF);
 
 	/* read lower 32 bits to check */
@@ -596,7 +596,7 @@ static void dmar_invalid_context_cache(struct dmar_drhd_rt *dmar_uint,
 
 static void dmar_invalid_context_cache_global(struct dmar_drhd_rt *dmar_uint)
 {
-	dmar_invalid_context_cache(dmar_uint, 0, 0, 0, DMAR_CIRG_GLOBAL);
+	dmar_invalid_context_cache(dmar_uint, 0U, 0U, 0U, DMAR_CIRG_GLOBAL);
 }
 
 static void dmar_invalid_iotlb(struct dmar_drhd_rt *dmar_uint,
@@ -607,7 +607,7 @@ static void dmar_invalid_iotlb(struct dmar_drhd_rt *dmar_uint,
 	 * if hardware doesn't support it, will be ignored by hardware
 	 */
 	uint64_t cmd = DMA_IOTLB_IVT | DMA_IOTLB_DR | DMA_IOTLB_DW;
-	uint64_t addr = 0;
+	uint64_t addr = 0UL;
 	uint32_t status;
 
 	switch (iirg) {
@@ -633,9 +633,9 @@ static void dmar_invalid_iotlb(struct dmar_drhd_rt *dmar_uint,
 		iommu_write64(dmar_uint, dmar_uint->ecap_iotlb_offset, addr);
 	}
 
-	iommu_write64(dmar_uint, dmar_uint->ecap_iotlb_offset + 8, cmd);
+	iommu_write64(dmar_uint, dmar_uint->ecap_iotlb_offset + 8U, cmd);
 	/* read upper 32bits to check */
-	DMAR_WAIT_COMPLETION(dmar_uint->ecap_iotlb_offset + 12,
+	DMAR_WAIT_COMPLETION(dmar_uint->ecap_iotlb_offset + 12U,
 				 (status & DMA_IOTLB_IVT_32) == 0U, status);
 	IOMMU_UNLOCK(dmar_uint);
 
@@ -652,7 +652,7 @@ static void dmar_invalid_iotlb(struct dmar_drhd_rt *dmar_uint,
  */
 static void dmar_invalid_iotlb_global(struct dmar_drhd_rt *dmar_uint)
 {
-	dmar_invalid_iotlb(dmar_uint, 0, 0, 0, 0, DMAR_IIRG_GLOBAL);
+	dmar_invalid_iotlb(dmar_uint, 0U, 0UL, 0U, false, DMAR_IIRG_GLOBAL);
 }
 
 static void dmar_set_root_table(struct dmar_drhd_rt *dmar_uint)
@@ -685,12 +685,12 @@ static void dmar_fault_event_mask(struct dmar_drhd_rt *dmar_uint)
 static void dmar_fault_event_unmask(struct dmar_drhd_rt *dmar_uint)
 {
 	IOMMU_LOCK(dmar_uint);
-	iommu_write32(dmar_uint, DMAR_FECTL_REG, 0);
+	iommu_write32(dmar_uint, DMAR_FECTL_REG, 0U);
 	IOMMU_UNLOCK(dmar_uint);
 }
 
 static void dmar_fault_msi_write(struct dmar_drhd_rt *dmar_uint,
-			uint8_t vector)
+			uint32_t vector)
 {
 	uint32_t data;
 	uint32_t addr_low;
@@ -787,8 +787,8 @@ static int dmar_fault_handler(int irq, void *data)
 	while (dma_fsts_ppf(fsr)) {
 		loop++;
 		index = dma_fsts_fri(fsr);
-		record_reg_offset = dmar_uint->cap_fault_reg_offset
-				+ index * 16;
+		record_reg_offset = (uint32_t)dmar_uint->cap_fault_reg_offset
+				+ index * 16U;
 		if (index >= dmar_uint->cap_num_fault_regs) {
 			dev_dbg(ACRN_DBG_IOMMU, "%s: invalid FR Index",
 					__func__);
@@ -797,7 +797,7 @@ static int dmar_fault_handler(int irq, void *data)
 
 		/* read 128-bit fault recording register */
 		record[0] = iommu_read64(dmar_uint, record_reg_offset);
-		record[1] = iommu_read64(dmar_uint, record_reg_offset + 8);
+		record[1] = iommu_read64(dmar_uint, record_reg_offset + 8U);
 
 		dev_dbg(ACRN_DBG_IOMMU, "%s: record[%d] @0x%x:  0x%llx, 0x%llx",
 			__func__, index, record_reg_offset,
@@ -807,7 +807,7 @@ static int dmar_fault_handler(int irq, void *data)
 
 		/* write to clear */
 		iommu_write64(dmar_uint, record_reg_offset, record[0]);
-		iommu_write64(dmar_uint, record_reg_offset + 8, record[1]);
+		iommu_write64(dmar_uint, record_reg_offset + 8U, record[1]);
 
 #ifdef DMAR_FAULT_LOOP_MAX
 		if (loop > DMAR_FAULT_LOOP_MAX) {
@@ -1157,8 +1157,8 @@ int assign_iommu_device(struct iommu_domain *domain, uint8_t bus,
 
 	/* TODO: check if the device assigned */
 
-	remove_iommu_device(host_domain, 0, bus, devfun);
-	add_iommu_device(domain, 0, bus, devfun);
+	remove_iommu_device(host_domain, 0U, bus, devfun);
+	add_iommu_device(domain, 0U, bus, devfun);
 	return 0;
 }
 
@@ -1171,8 +1171,8 @@ int unassign_iommu_device(struct iommu_domain *domain, uint8_t bus,
 
 	/* TODO: check if the device assigned */
 
-	remove_iommu_device(domain, 0, bus, devfun);
-	add_iommu_device(host_domain, 0, bus, devfun);
+	remove_iommu_device(domain, 0U, bus, devfun);
+	add_iommu_device(host_domain, 0U, bus, devfun);
 	return 0;
 }
 
@@ -1307,7 +1307,7 @@ int init_iommu(void)
 
 	for (bus = 0U; bus <= IOMMU_INIT_BUS_LIMIT; bus++) {
 		for (devfun = 0U; devfun <= 255U; devfun++) {
-			add_iommu_device(host_domain, 0,
+			add_iommu_device(host_domain, 0U,
 					 (uint8_t)bus, (uint8_t)devfun);
 		}
 	}

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -49,12 +49,18 @@
 #define CTX_ENTRY_LOWER_SLPTPTR_MASK    \
 		(0xFFFFFFFFFFFFFUL <<  CTX_ENTRY_LOWER_SLPTPTR_POS)
 
-#define DMAR_GET_BITSLICE(var, bitname) \
-	((var & bitname ## _MASK) >> bitname ## _POS)
+static inline uint64_t
+dmar_get_bitslice(uint64_t var, uint64_t mask, uint32_t pos)
+{
+	return ((var & mask) >> pos);
+}
 
-#define DMAR_SET_BITSLICE(var, bitname, val) \
-	((var &	\
-	  ~bitname ## _MASK) | ((val << bitname ## _POS) & bitname ## _MASK))
+static inline uint64_t
+dmar_set_bitslice(uint64_t var, uint64_t mask,
+		  uint32_t pos, uint64_t val)
+{
+	return ((var & ~mask) | ((val << pos) & mask));
+}
 
 /* translation type */
 #define DMAR_CTX_TT_UNTRANSLATED    0x0UL
@@ -983,7 +989,9 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 
 	root_entry = (struct dmar_root_entry *)&root_table[bus * 2];
 
-	if (DMAR_GET_BITSLICE(root_entry->lower, ROOT_ENTRY_LOWER_PRESENT) == 0U) {
+	if (dmar_get_bitslice(root_entry->lower,
+	        ROOT_ENTRY_LOWER_PRESENT_MASK,
+		ROOT_ENTRY_LOWER_PRESENT_POS) == 0UL) {
 		void *vaddr = alloc_paging_struct();
 
 		if (vaddr != NULL) {
@@ -992,10 +1000,13 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 
 			context_table_addr = context_table_addr >> 12;
 
-			lower = DMAR_SET_BITSLICE(lower, ROOT_ENTRY_LOWER_CTP,
-					context_table_addr);
-			lower = DMAR_SET_BITSLICE(lower,
-					ROOT_ENTRY_LOWER_PRESENT, 1);
+			lower = dmar_set_bitslice(lower,
+				 ROOT_ENTRY_LOWER_CTP_MASK,
+			         ROOT_ENTRY_LOWER_CTP_POS,
+				 context_table_addr);
+			lower = dmar_set_bitslice(lower,
+				 ROOT_ENTRY_LOWER_PRESENT_MASK,
+				 ROOT_ENTRY_LOWER_PRESENT_POS, 1UL);
 
 			root_entry->upper = 0UL;
 			root_entry->lower = lower;
@@ -1006,8 +1017,9 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 			return 1;
 		}
 	} else {
-		context_table_addr = DMAR_GET_BITSLICE(root_entry->lower,
-				ROOT_ENTRY_LOWER_CTP);
+		context_table_addr = dmar_get_bitslice(root_entry->lower,
+				ROOT_ENTRY_LOWER_CTP_MASK,
+			        ROOT_ENTRY_LOWER_CTP_POS);
 	}
 
 	context_table_addr = context_table_addr << 12;
@@ -1016,7 +1028,9 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 	context_entry = (struct dmar_context_entry *)&context_table[devfun * 2];
 
 	/* the context entry should not be present */
-	if (DMAR_GET_BITSLICE(context_entry->lower, CTX_ENTRY_LOWER_P) != 0U) {
+	if (dmar_get_bitslice(context_entry->lower,
+	        CTX_ENTRY_LOWER_P_MASK,
+		CTX_ENTRY_LOWER_P_POS) != 0UL) {
 		pr_err("%s: context entry@0x%llx (Lower:%x) ",
 				__func__, context_entry, context_entry->lower);
 		pr_err("already present for %x:%x.%x",
@@ -1034,28 +1048,42 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 			 * programmed to indicate the largest AGAW value
 			 * supported by hardware.
 			 */
-			upper = DMAR_SET_BITSLICE(upper, CTX_ENTRY_UPPER_AW,
-						  dmar_uint->cap_msagaw);
-			lower = DMAR_SET_BITSLICE(lower, CTX_ENTRY_LOWER_TT,
-						  DMAR_CTX_TT_PASSTHROUGH);
+			upper = dmar_set_bitslice(upper,
+				  CTX_ENTRY_UPPER_AW_MASK,
+				  CTX_ENTRY_UPPER_AW_POS,
+				  dmar_uint->cap_msagaw);
+			lower = dmar_set_bitslice(lower,
+				  CTX_ENTRY_LOWER_TT_MASK,
+				  CTX_ENTRY_LOWER_TT_POS,
+			          DMAR_CTX_TT_PASSTHROUGH);
 		} else {
 			ASSERT(false,
 				  "dmaru doesn't support trans passthrough");
 		}
 	} else {
 		/* TODO: add Device TLB support */
-		upper =
-			DMAR_SET_BITSLICE(upper, CTX_ENTRY_UPPER_AW,
-					  width_to_agaw(
-						  domain->addr_width));
-		lower = DMAR_SET_BITSLICE(lower, CTX_ENTRY_LOWER_TT,
-					  DMAR_CTX_TT_UNTRANSLATED);
+		upper = dmar_set_bitslice(upper,
+		          CTX_ENTRY_UPPER_AW_MASK,
+		          CTX_ENTRY_UPPER_AW_POS,
+			  (uint64_t)width_to_agaw(domain->addr_width));
+		lower = dmar_set_bitslice(lower,
+		          CTX_ENTRY_LOWER_TT_MASK,
+			  CTX_ENTRY_LOWER_TT_POS,
+			  DMAR_CTX_TT_UNTRANSLATED);
 	}
 
-	upper = DMAR_SET_BITSLICE(upper, CTX_ENTRY_UPPER_DID, domain->dom_id);
-	lower = DMAR_SET_BITSLICE(lower, CTX_ENTRY_LOWER_SLPTPTR,
-				  domain->trans_table_ptr >> 12);
-	lower = DMAR_SET_BITSLICE(lower, CTX_ENTRY_LOWER_P, 1);
+	upper = dmar_set_bitslice(upper,
+	          CTX_ENTRY_UPPER_DID_MASK,
+		  CTX_ENTRY_UPPER_DID_POS,
+		  domain->dom_id);
+	lower = dmar_set_bitslice(lower,
+		  CTX_ENTRY_LOWER_SLPTPTR_MASK,
+		  CTX_ENTRY_LOWER_SLPTPTR_POS,
+		  domain->trans_table_ptr >> 12U);
+	lower = dmar_set_bitslice(lower,
+		  CTX_ENTRY_LOWER_P_MASK,
+		  CTX_ENTRY_LOWER_P_POS,
+		  1UL);
 
 	context_entry->upper = upper;
 	context_entry->lower = lower;
@@ -1075,6 +1103,7 @@ remove_iommu_device(struct iommu_domain *domain, uint16_t segment,
 	uint64_t *context_table;
 	struct dmar_root_entry *root_entry;
 	struct dmar_context_entry *context_entry;
+	uint16_t dom_id;
 
 	if (domain == NULL) {
 		return 1;
@@ -1090,15 +1119,17 @@ remove_iommu_device(struct iommu_domain *domain, uint16_t segment,
 	root_table = (uint64_t *)HPA2HVA(dmar_uint->root_table_addr);
 	root_entry = (struct dmar_root_entry *)&root_table[bus * 2];
 
-	context_table_addr = DMAR_GET_BITSLICE(root_entry->lower,
-						   ROOT_ENTRY_LOWER_CTP);
+	context_table_addr = dmar_get_bitslice(root_entry->lower,
+					       ROOT_ENTRY_LOWER_CTP_MASK,
+					       ROOT_ENTRY_LOWER_CTP_POS);
 	context_table_addr = context_table_addr << 12;
 	context_table = (uint64_t *)HPA2HVA(context_table_addr);
 
 	context_entry = (struct dmar_context_entry *)&context_table[devfun * 2];
 
-	if (DMAR_GET_BITSLICE(context_entry->upper,
-				  CTX_ENTRY_UPPER_DID) != domain->dom_id) {
+	dom_id = (uint16_t)dmar_get_bitslice(context_entry->upper,
+		        CTX_ENTRY_UPPER_DID_MASK, CTX_ENTRY_UPPER_DID_POS);
+	if (dom_id != domain->dom_id) {
 		pr_err("%s: domain id mismatch", __func__);
 		return 1;
 	}

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -137,7 +137,7 @@
 #include <cpu.h>
 
 /* Define cache line size (in bytes) */
-#define     CACHE_LINE_SIZE                 64
+#define     CACHE_LINE_SIZE                 64U
 
 /* Size of all page structures for IA-32e */
 #define     IA32E_STRUCT_SIZE               MEM_4K

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -37,12 +37,12 @@
 
 static inline uint8_t dmar_ver_major(uint64_t version)
 {
-	return ((version & 0xf0UL) >> 4U);
+	return (((uint8_t)version & 0xf0U) >> 4U);
 }
 
 static inline uint8_t dmar_ver_minor(uint64_t version)
 {
-	return (version & 0x0fUL);
+	return ((uint8_t)version & 0x0fU);
 }
 
 /*
@@ -50,42 +50,42 @@ static inline uint8_t dmar_ver_minor(uint64_t version)
  */
 static inline uint8_t iommu_cap_pi(uint64_t cap)
 {
-	return ((cap >> 59U) & 1UL);
+	return ((uint8_t)(cap >> 59U) & 1U);
 }
 
 static inline uint8_t iommu_cap_read_drain(uint64_t cap)
 {
-	return ((cap >> 55U) & 1UL);
+	return ((uint8_t)(cap >> 55U) & 1U);
 }
 
 static inline uint8_t iommu_cap_write_drain(uint64_t cap)
 {
-	return ((cap >> 54U) & 1UL);
+	return ((uint8_t)(cap >> 54U) & 1U);
 }
 
 static inline uint8_t iommu_cap_max_amask_val(uint64_t cap)
 {
-	return ((cap >> 48U) & 0x3fUL);
+	return ((uint8_t)(cap >> 48U) & 0x3fU);
 }
 
 static inline uint16_t iommu_cap_num_fault_regs(uint64_t cap)
 {
-	return (((cap >> 40U) & 0xffUL) + 1UL);
+	return (((uint16_t)(cap >> 40U) & 0xffU) + 1U);
 }
 
 static inline uint8_t iommu_cap_pgsel_inv(uint64_t cap)
 {
-	return ((cap >> 39U) & 1UL);
+	return ((uint8_t)(cap >> 39U) & 1U);
 }
 
 static inline uint8_t iommu_cap_super_page_val(uint64_t cap)
 {
-	return ((cap >> 34U) & 0xfUL);
+	return ((uint8_t)(cap >> 34U) & 0xfU);
 }
 
 static inline uint16_t iommu_cap_fault_reg_offset(uint64_t cap)
 {
-	return (((cap >> 24U) & 0x3ffUL) * 16U);
+	return (((uint16_t)(cap >> 24U) & 0x3ffU) * 16U);
 }
 
 static inline uint16_t iommu_cap_max_fault_reg_offset(uint64_t cap)
@@ -96,52 +96,52 @@ static inline uint16_t iommu_cap_max_fault_reg_offset(uint64_t cap)
 
 static inline uint8_t iommu_cap_zlr(uint64_t cap)
 {
-	return ((cap >> 22U) & 1UL);
+	return ((uint8_t)(cap >> 22U) & 1U);
 }
 
 static inline uint8_t iommu_cap_isoch(uint64_t cap)
 {
-	return ((cap >> 23U) & 1UL);
+	return ((uint8_t)(cap >> 23U) & 1U);
 }
 
 static inline uint8_t iommu_cap_mgaw(uint64_t cap)
 {
-	return (((cap >> 16U) & 0x3fUL) + 1UL);
+	return (((uint8_t)(cap >> 16U) & 0x3fU) + 1U);
 }
 
 static inline uint8_t iommu_cap_sagaw(uint64_t cap)
 {
-	return ((cap >> 8U) & 0x1fUL);
+	return ((uint8_t)(cap >> 8U) & 0x1fU);
 }
 
 static inline uint8_t iommu_cap_caching_mode(uint64_t cap)
 {
-	return ((cap >> 7U) & 1UL);
+	return ((uint8_t)(cap >> 7U) & 1U);
 }
 
 static inline uint8_t iommu_cap_phmr(uint64_t cap)
 {
-	return ((cap >> 6U) & 1UL);
+	return ((uint8_t)(cap >> 6U) & 1U);
 }
 
 static inline uint8_t iommu_cap_plmr(uint64_t cap)
 {
-	return ((cap >> 5U) & 1UL);
+	return ((uint8_t)(cap >> 5U) & 1U);
 }
 
 static inline uint8_t iommu_cap_rwbf(uint64_t cap)
 {
-	return ((cap >> 4U) & 1UL);
+	return ((uint8_t)(cap >> 4U) & 1U);
 }
 
 static inline uint8_t iommu_cap_afl(uint64_t cap)
 {
-	return ((cap >> 3U) & 1UL);
+	return ((uint8_t)(cap >> 3U) & 1U);
 }
 
 static inline uint32_t iommu_cap_ndoms(uint64_t cap)
 {
-	return ((1U) << (4UL + 2UL * (cap & 0x7UL)));
+	return ((1U) << (4U + 2U * ((uint8_t)cap & 0x7U)));
 }
 
 /*
@@ -149,146 +149,146 @@ static inline uint32_t iommu_cap_ndoms(uint64_t cap)
  */
 static inline uint8_t iommu_ecap_c(uint64_t ecap)
 {
-	return ((ecap >> 0U) & 1UL);
+	return ((uint8_t)(ecap >> 0U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_qi(uint64_t ecap)
 {
-	return ((ecap >> 1U) & 1UL);
+	return ((uint8_t)(ecap >> 1U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_dt(uint64_t ecap)
 {
-	return ((ecap >> 2U) & 1UL);
+	return ((uint8_t)(ecap >> 2U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_ir(uint64_t ecap)
 {
-	return ((ecap >> 3U) & 1UL);
+	return ((uint8_t)(ecap >> 3U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_eim(uint64_t ecap)
 {
-	return ((ecap >> 4U) & 1UL);
+	return ((uint8_t)(ecap >> 4U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_pt(uint64_t ecap)
 {
-	return ((ecap >> 6U) & 1UL);
+	return ((uint8_t)(ecap >> 6U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_sc(uint64_t ecap)
 {
-	return ((ecap >> 7U) & 1UL);
+	return ((uint8_t)(ecap >> 7U) & 1U);
 }
 
 static inline uint16_t iommu_ecap_iro(uint64_t ecap)
 {
-	return ((ecap >> 8U) & 0x3ffUL);
+	return ((uint16_t)(ecap >> 8U) & 0x3ffU);
 }
 
 static inline uint8_t iommu_ecap_mhmv(uint64_t ecap)
 {
-	return ((ecap >> 20U) & 0xfUL);
+	return ((uint8_t)(ecap >> 20U) & 0xfU);
 }
 
 static inline uint8_t iommu_ecap_ecs(uint64_t ecap)
 {
-	return ((ecap >> 24U) & 1UL);
+	return ((uint8_t)(ecap >> 24U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_mts(uint64_t ecap)
 {
-	return ((ecap >> 25U) & 1UL);
+	return ((uint8_t)(ecap >> 25U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_nest(uint64_t ecap)
 {
-	return ((ecap >> 26U) & 1UL);
+	return ((uint8_t)(ecap >> 26U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_dis(uint64_t ecap)
 {
-	return ((ecap >> 27U) & 1UL);
+	return ((uint8_t)(ecap >> 27U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_prs(uint64_t ecap)
 {
-	return ((ecap >> 29U) & 1UL);
+	return ((uint8_t)(ecap >> 29U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_ers(uint64_t ecap)
 {
-	return ((ecap >> 30U) & 1UL);
+	return ((uint8_t)(ecap >> 30U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_srs(uint64_t ecap)
 {
-	return ((ecap >> 31U) & 1UL);
+	return ((uint8_t)(ecap >> 31U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_nwfs(uint64_t ecap)
 {
-	return ((ecap >> 33U) & 1UL);
+	return ((uint8_t)(ecap >> 33U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_eafs(uint64_t ecap)
 {
-	return ((ecap >> 34U) & 1UL);
+	return ((uint8_t)(ecap >> 34U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_pss(uint64_t ecap)
 {
-	return ((ecap >> 35U) & 0x1fUL);
+	return ((uint8_t)(ecap >> 35U) & 0x1fU);
 }
 
 static inline uint8_t iommu_ecap_pasid(uint64_t ecap)
 {
-	return ((ecap >> 40U) & 1UL);
+	return ((uint8_t)(ecap >> 40U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_dit(uint64_t ecap)
 {
-	return ((ecap >> 41U) & 1UL);
+	return ((uint8_t)(ecap >> 41U) & 1U);
 }
 
 static inline uint8_t iommu_ecap_pds(uint64_t ecap)
 {
-	return ((ecap >> 42U) & 1UL);
+	return ((uint8_t)(ecap >> 42U) & 1U);
 }
 
 /* PMEN_REG */
-#define DMA_PMEN_EPM (((uint32_t)1)<<31)
-#define DMA_PMEN_PRS (((uint32_t)1)<<0)
+#define DMA_PMEN_EPM (1U << 31U)
+#define DMA_PMEN_PRS (1U << 0U)
 
 /* GCMD_REG */
-#define DMA_GCMD_TE (((uint32_t)1) << 31)
-#define DMA_GCMD_SRTP (((uint32_t)1) << 30)
-#define DMA_GCMD_SFL (((uint32_t)1) << 29)
-#define DMA_GCMD_EAFL (((uint32_t)1) << 28)
-#define DMA_GCMD_WBF (((uint32_t)1) << 27)
-#define DMA_GCMD_QIE (((uint32_t)1) << 26)
-#define DMA_GCMD_SIRTP (((uint32_t)1) << 24)
-#define DMA_GCMD_IRE (((uint32_t) 1) << 25)
-#define DMA_GCMD_CFI (((uint32_t) 1) << 23)
+#define DMA_GCMD_TE (1U << 31U)
+#define DMA_GCMD_SRTP (1U << 30U)
+#define DMA_GCMD_SFL (1U << 29U)
+#define DMA_GCMD_EAFL (1U << 28U)
+#define DMA_GCMD_WBF (1U << 27U)
+#define DMA_GCMD_QIE (1U << 26U)
+#define DMA_GCMD_SIRTP (1U << 24U)
+#define DMA_GCMD_IRE (1U << 25U)
+#define DMA_GCMD_CFI (1U << 23U)
 
 /* GSTS_REG */
-#define DMA_GSTS_TES (((uint32_t)1) << 31)
-#define DMA_GSTS_RTPS (((uint32_t)1) << 30)
-#define DMA_GSTS_FLS (((uint32_t)1) << 29)
-#define DMA_GSTS_AFLS (((uint32_t)1) << 28)
-#define DMA_GSTS_WBFS (((uint32_t)1) << 27)
-#define DMA_GSTS_QIES (((uint32_t)1) << 26)
-#define DMA_GSTS_IRTPS (((uint32_t)1) << 24)
-#define DMA_GSTS_IRES (((uint32_t)1) << 25)
-#define DMA_GSTS_CFIS (((uint32_t)1) << 23)
+#define DMA_GSTS_TES (1U << 31U)
+#define DMA_GSTS_RTPS (1U << 30U)
+#define DMA_GSTS_FLS (1U << 29U)
+#define DMA_GSTS_AFLS (1U << 28U)
+#define DMA_GSTS_WBFS (1U << 27U)
+#define DMA_GSTS_QIES (1U << 26U)
+#define DMA_GSTS_IRTPS (1U << 24U)
+#define DMA_GSTS_IRES (1U << 25U)
+#define DMA_GSTS_CFIS (1U << 23U)
 
 /* CCMD_REG */
-#define DMA_CCMD_ICC (((uint64_t)1UL) << 63)
-#define DMA_CCMD_ICC_32 (((uint32_t)1UL) << 31)
-#define DMA_CCMD_GLOBAL_INVL (((uint64_t)1UL) << 61)
-#define DMA_CCMD_DOMAIN_INVL (((uint64_t)2UL) << 61)
-#define DMA_CCMD_DEVICE_INVL (((uint64_t)3UL) << 61)
+#define DMA_CCMD_ICC (1UL << 63U)
+#define DMA_CCMD_ICC_32 (1U << 31U)
+#define DMA_CCMD_GLOBAL_INVL (1UL << 61U)
+#define DMA_CCMD_DOMAIN_INVL (2UL << 61U)
+#define DMA_CCMD_DEVICE_INVL (3UL << 61U)
 static inline uint64_t dma_ccmd_fm(uint8_t fm)
 {
 	return (((uint64_t)(fm & 0x3U)) << 32U);
@@ -310,7 +310,7 @@ static inline uint16_t dma_ccmd_did(uint16_t did)
 
 static inline uint8_t dma_ccmd_get_caig_32(uint32_t gaig)
 {
-	return ((gaig >> 27U) & 0x3U);
+	return ((uint8_t)(gaig >> 27U) & 0x3U);
 }
 
 
@@ -329,7 +329,7 @@ static inline uint64_t dma_iotlb_did(uint16_t did)
 
 static inline uint8_t dma_iotlb_get_iaig_32(uint32_t iai)
 {
-	return ((iai >> 25U) & 0x3U);
+	return ((uint8_t)(iai >> 25U) & 0x3U);
 }
 
 /* INVALIDATE_ADDRESS_REG */
@@ -344,95 +344,95 @@ static inline uint8_t dma_iotlb_invl_addr_am(uint8_t am)
 #define DMA_FECTL_IM				(((uint32_t)1U) << 31)
 
 /* FSTS_REG */
-static inline bool dma_fsts_pfo(uint32_t PFO)
+static inline bool dma_fsts_pfo(uint32_t pfo)
 {
-	return ((PFO >> 0U) & 1U) == 1U;
+	return (((pfo >> 0U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_ppf(uint32_t PPF)
+static inline bool dma_fsts_ppf(uint32_t ppf)
 {
-	return ((PPF >> 1U) & 1U) == 1U;
+	return (((ppf >> 1U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_afo(uint32_t AFO)
+static inline bool dma_fsts_afo(uint32_t afo)
 {
-	return ((AFO >> 2U) & 1U) == 1U;
+	return (((afo >> 2U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_apf(uint32_t APF)
+static inline bool dma_fsts_apf(uint32_t apf)
 {
-	return ((APF >> 3U) & 1U) == 1U;
+	return (((apf >> 3U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_iqe(uint32_t IQE)
+static inline bool dma_fsts_iqe(uint32_t iqe)
 {
-	return ((IQE >> 4U) & 1U) == 1U;
+	return (((iqe >> 4U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_ice(uint32_t ICE)
+static inline bool dma_fsts_ice(uint32_t ice)
 {
-	return ((ICE >> 5U) & 1U) == 1U;
+	return (((ice >> 5U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_ite(uint32_t ITE)
+static inline bool dma_fsts_ite(uint32_t ite)
 {
-	return ((ITE >> 6U) & 1U) == 1U;
+	return (((ite >> 6U) & 1U) == 1U);
 }
 
-static inline bool dma_fsts_pro(uint32_t PRO)
+static inline bool dma_fsts_pro(uint32_t pro)
 {
-	return ((PRO >> 7U) & 1U) == 1U;
+	return (((pro >> 7U) & 1U) == 1U);
 }
 
-static inline uint8_t dma_fsts_fri(uint32_t FRI)
+static inline uint8_t dma_fsts_fri(uint32_t fri)
 {
-	return ((FRI >> 8U) & 0xFFU);
+	return ((uint8_t)(fri >> 8U) & 0xFFU);
 }
 
 /* FRCD_REGs: upper 64 bits*/
-static inline bool dma_frcd_up_f(uint64_t UP_F)
+static inline bool dma_frcd_up_f(uint64_t up_f)
 {
-	return ((UP_F >> 63U) & 1UL) == 1UL;
+	return (((up_f >> 63U) & 1UL) == 1UL);
 }
 
-static inline uint8_t dma_frcd_up_t(uint64_t UP_T)
+static inline uint8_t dma_frcd_up_t(uint64_t up_t)
 {
-	return ((UP_T >> 62U) & 1UL);
+	return ((uint8_t)(up_t >> 62U) & 1U);
 }
 
-static inline uint8_t dma_frcd_up_at(uint64_t UP_AT)
+static inline uint8_t dma_frcd_up_at(uint64_t up_at)
 {
-	return ((UP_AT >> 60U) & 3UL);
+	return ((uint8_t)(up_at >> 60U) & 3U);
 }
 
-static inline uint32_t dma_frcd_up_pasid(uint64_t UP_PASID)
+static inline uint32_t dma_frcd_up_pasid(uint64_t up_pasid)
 {
-	return ((UP_PASID >> 40U) & 0xfffffUL);
+	return ((uint32_t)(up_pasid >> 40U) & 0xfffffU);
 }
 
-static inline uint8_t dma_frcd_up_fr(uint64_t UP_FR)
+static inline uint8_t dma_frcd_up_fr(uint64_t up_fr)
 {
-	return ((UP_FR >> 32U) & 0xffUL);
+	return ((uint8_t)(up_fr >> 32U) & 0xffU);
 }
 
-static inline bool dma_frcd_up_pp(uint64_t UP_PP)
+static inline bool dma_frcd_up_pp(uint64_t up_pp)
 {
-	return ((UP_PP >> 31U) & 1UL) == 1UL;
+	return (((up_pp >> 31U) & 1UL) == 1UL);
 }
 
-static inline bool dma_frcd_up_exe(uint64_t UP_EXE)
+static inline bool dma_frcd_up_exe(uint64_t up_exe)
 {
-	return ((UP_EXE >> 30U) & 1UL) == 1UL;
+	return (((up_exe >> 30U) & 1UL) == 1UL);
 }
 
-static inline bool dma_frcd_up_priv(uint64_t UP_PRIV)
+static inline bool dma_frcd_up_priv(uint64_t up_priv)
 {
-	return ((UP_PRIV >> 29U) & 1UL) == 1UL;
+	return (((up_priv >> 29U) & 1UL) == 1UL);
 }
 
-static inline uint32_t dma_frcd_up_sid(uint64_t UP_SID)
+static inline uint32_t dma_frcd_up_sid(uint64_t up_sid)
 {
-	return ((UP_SID >> 0U) & 0xffffUL);
+	return ((uint32_t)up_sid & 0xffffU);
 }
 
 #define DMAR_CONTEXT_TRANSLATION_TYPE_TRANSLATED 0x00U


### PR DESCRIPTION
HV:vtd:fix all integer related violations

Fix vtd.h and vtd.c all integer violations.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>