### PR TITLE
fix assign.c interger violations

### DIFF
--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -285,7 +285,7 @@ struct acrn_vm_pci_msix_remap {
 	/** if the pass-through PCI device is MSI-X, this field contains
 	 *  the MSI-X entry table index
 	 */
-	int32_t msix_entry_index;
+	uint32_t msix_entry_index;
 
 	/** if the pass-through PCI device is MSI-X, this field contains
 	 *  Vector Control for MSI-X Entry, field defined in MSI-X spec

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -28,7 +28,7 @@ struct ptdev_msi_info {
 	uint32_t pmsi_addr; /* phys msi_addr */
 	uint32_t pmsi_data; /* phys msi_data */
 	int msix;	/* 0-MSI, 1-MSIX */
-	int msix_entry_index; /* MSI: 0, MSIX: index of vector table*/
+	uint32_t msix_entry_index; /* MSI: 0, MSIX: index of vector table*/
 	uint32_t virt_vector;
 	uint32_t phys_vector;
 };

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -266,7 +266,7 @@ struct acrn_vm_pci_msix_remap {
 	/** if the pass-through PCI device is MSI-X, this field contains
 	 *  the MSI-X entry table index
 	 */
-	int32_t msix_entry_index;
+	uint32_t msix_entry_index;
 
 	/** if the pass-through PCI device is MSI-X, this field contains
 	 *  Vector Control for MSI-X Entry, field defined in MSI-X spec


### PR DESCRIPTION
fix all assign.c integer violations except related
"Implicit conversion: actual to formal param".

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>