### PR TITLE
hv: efi: remove multiple defined struct efi_ctx & dt_addr_t

### DIFF
--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -60,7 +60,7 @@ LDSCRIPT := $(GNUEFI_DIR)/elf_$(ARCH)_efi.lds
 
 INCDIR := /usr/include
 
-CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
+CFLAGS=-I. -I.. -I../../../include/common -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \
 		-Wall -I../fs/ -D$(ARCH) -O2 \
 		-include config.h

--- a/hypervisor/bsp/uefi/efi/boot.c
+++ b/hypervisor/bsp/uefi/efi/boot.c
@@ -36,6 +36,7 @@
 #include "efilinux.h"
 #include "stdlib.h"
 #include "boot.h"
+#include "acrn_efi.h"
 
 EFI_SYSTEM_TABLE *sys_table;
 EFI_BOOT_SERVICES *boot;

--- a/hypervisor/bsp/uefi/efi/boot.h
+++ b/hypervisor/bsp/uefi/efi/boot.h
@@ -80,55 +80,11 @@ struct efi_info {
 	UINT32 efi_memmap_hi;
 };
 
-typedef struct {
-	UINT16 limit;
-	UINT64 *base;
-} __attribute__((packed)) dt_addr_t;
-
 struct e820_entry {
 	UINT64 addr;		/* start of memory segment */
 	UINT64 size;		/* size of memory segment */
 	UINT32 type;		/* type of memory segment */
 } __attribute__((packed));
-
-
-struct efi_ctx {
-	uint64_t rip;
-	VOID *rsdp;
-	VOID *ap_trampoline_buf;
-	dt_addr_t  gdt;
-	dt_addr_t  idt;
-	uint16_t   tr_sel;
-	uint16_t   ldt_sel;
-	uint64_t   cr0;
-	uint64_t   cr3;
-	uint64_t   cr4;
-	uint64_t   rflags;
-	uint16_t   cs_sel;
-	uint32_t   cs_ar;
-	uint16_t   es_sel;
-	uint16_t   ss_sel;
-	uint16_t   ds_sel;
-	uint16_t   fs_sel;
-	uint16_t   gs_sel;
-	uint64_t   efer;
-	uint64_t   rax;
-	uint64_t   rbx;
-	uint64_t   rcx;
-	uint64_t   rdx;
-	uint64_t   rdi;
-	uint64_t   rsi;
-	uint64_t   rsp;
-	uint64_t   rbp;
-	uint64_t   r8;
-	uint64_t   r9;
-	uint64_t   r10;
-	uint64_t   r11;
-	uint64_t   r12;
-	uint64_t   r13;
-	uint64_t   r14;
-	uint64_t   r15;
-}__attribute__((packed));
 
 struct acpi_table_rsdp {
 	/* ACPI signature, contains "RSD PTR " */


### PR DESCRIPTION
In current code, struct efi_ctx and dt_addr_t are defined in two places.
This patch removes one copy of the definitions.

Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Jack Ren <jack.ren@intel.com>