### PR TITLE
HV: Clean up commented out code and add brackets of same level precedence expression 

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -374,8 +374,8 @@ void bsp_boot_init(void)
 	/* Build time sanity checks to make sure hard-coded offset
 	*  is matching the actual offset!
 	*/
-	ASSERT(sizeof(struct trusty_startup_param)
-			+ sizeof(struct key_info) < 0x1000U,
+	ASSERT((sizeof(struct trusty_startup_param)
+			+ sizeof(struct key_info)) < 0x1000U,
 		"trusty_startup_param + key_info > 1Page size(4KB)!");
 
 	ASSERT(NR_WORLD == 2, "Only 2 Worlds supported!");

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -400,13 +400,13 @@ int ept_violation_vmexit_handler(struct vcpu *vcpu)
 
 	list_for_each(pos, &vcpu->vm->mmio_list) {
 		mmio_handler = list_entry(pos, struct mem_io_node, list);
-		if ((mmio->paddr + mmio->access_size <=
+		if (((mmio->paddr + mmio->access_size) <=
 			mmio_handler->range_start) ||
 			(mmio->paddr >= mmio_handler->range_end)) {
 			continue;
 		}
 		else if (!((mmio->paddr >= mmio_handler->range_start) &&
-			(mmio->paddr + mmio->access_size <=
+			((mmio->paddr + mmio->access_size) <=
 			mmio_handler->range_end))) {
 			pr_fatal("Err MMIO, addr:0x%llx, size:%x",
 					mmio->paddr, mmio->access_size);

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -649,7 +649,7 @@ uint64_t e820_alloc_low_memory(uint32_t size)
 	struct e820_entry *entry, *new_entry;
 
 	/* We want memory in page boundary and integral multiple of pages */
-	size = ((size + CPU_PAGE_SIZE - 1U) >> CPU_PAGE_SHIFT)
+	size = (((size + CPU_PAGE_SIZE) - 1U) >> CPU_PAGE_SHIFT)
 		<< CPU_PAGE_SHIFT;
 
 	for (i = 0U; i < e820_entries; i++) {
@@ -682,8 +682,8 @@ uint64_t e820_alloc_low_memory(uint32_t size)
 		new_entry = &e820[e820_entries];
 		new_entry->type = E820_TYPE_RESERVED;
 		new_entry->baseaddr = end - size;
-		new_entry->length = entry->baseaddr +
-			entry->length - new_entry->baseaddr;
+		new_entry->length = (entry->baseaddr +
+			entry->length) - new_entry->baseaddr;
 
 		/* Shrink the existing entry and total available memory */
 		entry->length -= new_entry->length;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -162,15 +162,15 @@ static int _gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_info,
 			goto out;
 		}
 
-		shift = i * pw_info->width + 12U;
+		shift = (i * pw_info->width) + 12U;
 		index = (gva >> shift) & ((1UL << pw_info->width) - 1UL);
 		page_size = 1UL << shift;
 
 		if (pw_info->width == 10U) {
 			/* 32bit entry */
-			entry = *((uint32_t *)(base + 4U * index));
+			entry = *((uint32_t *)(base + (4U * index)));
 		} else {
-			entry = *((uint64_t *)(base + 8U * index));
+			entry = *((uint64_t *)(base + (8U * index)));
 		}
 
 		/* check if the entry present */
@@ -501,7 +501,7 @@ void obtain_e820_mem_info(void)
 			e820_mem.mem_bottom = entry->baseaddr;
 		}
 
-		if (entry->baseaddr + entry->length
+		if ((entry->baseaddr + entry->length)
 				> e820_mem.mem_top) {
 			e820_mem.mem_top = entry->baseaddr
 				+ entry->length;
@@ -664,7 +664,7 @@ uint64_t e820_alloc_low_memory(uint32_t size)
 		/* Search for available low memory */
 		if ((entry->type != E820_TYPE_RAM)
 			|| (length < size)
-			|| (start + size > MEM_1M)) {
+			|| ((start + size) > MEM_1M)) {
 			continue;
 		}
 

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1459,7 +1459,7 @@ emulate_bittest(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 	 * Intel SDM, Vol 2, Table 3-2:
 	 * "Range of Bit Positions Specified by Bit Offset Operands"
 	 */
-	bitmask = (uint64_t)vie->opsize * 8UL - 1UL;
+	bitmask = ((uint64_t)vie->opsize * 8UL) - 1UL;
 	bitoff = (uint64_t)vie->immediate & bitmask;
 
 	/* Copy the bit into the Carry flag in %rflags */

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -48,7 +48,7 @@ void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
 
 	data_size = UCODE_GET_DATA_SIZE(uhdr) + sizeof(struct ucode_header);
 	data_page_num =
-		(data_size + CPU_PAGE_SIZE - 1U) >> CPU_PAGE_SHIFT;
+		((data_size + CPU_PAGE_SIZE) - 1U) >> CPU_PAGE_SHIFT;
 
 	ucode_ptr = alloc_pages(data_page_num);
 	if (ucode_ptr == NULL) {

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -248,8 +248,8 @@ vioapic_read(struct vioapic *vioapic, uint32_t addr)
 	}
 
 	/* redirection table entries */
-	if (regnum >= IOAPIC_REDTBL &&
-	    (regnum < IOAPIC_REDTBL + (uint32_t)pincount * 2U) != 0) {
+	if ((regnum >= IOAPIC_REDTBL) &&
+	    (regnum < (IOAPIC_REDTBL + ((uint32_t)pincount * 2U)))) {
 		uint32_t addr_offset = regnum - IOAPIC_REDTBL;
 		uint32_t rte_offset = addr_offset / 2U;
 		pin = (uint8_t)rte_offset;
@@ -323,8 +323,8 @@ vioapic_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 	}
 
 	/* redirection table entries */
-	if (regnum >= IOAPIC_REDTBL &&
-	    (regnum < IOAPIC_REDTBL + (uint32_t)pincount * 2U) != 0U) {
+	if ((regnum >= IOAPIC_REDTBL) &&
+	    (regnum < (IOAPIC_REDTBL + ((uint32_t)pincount * 2U)))) {
 		uint32_t addr_offset = regnum - IOAPIC_REDTBL;
 		uint32_t rte_offset = addr_offset / 2U;
 		pin = (uint8_t)rte_offset;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -814,7 +814,7 @@ vlapic_process_eoi(struct vlapic *vlapic)
 					vlapic->isrvec_stk_top);
 			}
 			isrptr[i].val &= ~(1U << bitpos);
-			vector = i * 32U + bitpos;
+			vector = (i * 32U) + bitpos;
 			dev_dbg(ACRN_DBG_LAPIC, "EOI vector %u", vector);
 			vlapic_dump_isr(vlapic, "vlapic_process_eoi");
 			vlapic->isrvec_stk_top--;
@@ -1201,7 +1201,7 @@ vlapic_pending_intr(struct vlapic *vlapic, uint32_t *vecptr)
 		val = atomic_load32(&irrptr[i].val);
 		bitpos = (uint32_t)fls32(val);
 		if (bitpos != INVALID_BIT_INDEX) {
-			vector = i * 32U + bitpos;
+			vector = (i * 32U) + bitpos;
 			if (PRIO(vector) > PRIO(lapic->ppr)) {
 				if (vecptr != NULL) {
 					*vecptr = vector;
@@ -1578,7 +1578,7 @@ vlapic_reset(struct vlapic *vlapic)
 
 	vlapic->svr_last = lapic->svr;
 
-	for (i = 0U; i < VLAPIC_MAXLVT_INDEX + 1U; i++) {
+	for (i = 0U; i < (VLAPIC_MAXLVT_INDEX + 1U); i++) {
 		vlapic->lvt_last[i] = 0U;
 	}
 
@@ -2258,7 +2258,7 @@ apicv_batch_set_tmr(struct vlapic *vlapic)
 	e = 256U;
 
 	while (s < e) {
-		val = ptr[s/TMR_STEP_LEN + 1].val;
+		val = ptr[(s/TMR_STEP_LEN) + 1].val;
 		val <<= TMR_STEP_LEN;
 		val |= ptr[s/TMR_STEP_LEN].val;
 		exec_vmwrite64(VMX_EOI_EXIT(s), val);

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -24,10 +24,6 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 	uint64_t param1 = cur_context->guest_cpu_regs.regs.rdi;
 	/* hypercall param2 from guest*/
 	uint64_t param2 = cur_context->guest_cpu_regs.regs.rsi;
-	/* hypercall param3 from guest, reserved*/
-	/* uint64_t param3 = cur_context->guest_cpu_regs.regs.rdx; */
-	/* hypercall param4 from guest, reserved*/
-	/* uint64_t param4 = cur_context->guest_cpu_regs.regs.rcx; */
 
 	if (!is_hypercall_from_ring0()) {
 		pr_err("hypercall is only allowed from RING-0!\n");

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -12,7 +12,7 @@ int dm_emulate_pio_post(struct vcpu *vcpu)
 	int cur_context = vcpu->arch_vcpu.cur_context;
 	union vhm_request_buffer *req_buf = NULL;
 	uint32_t mask =
-		0xFFFFFFFFUL >> (32 - 8 * vcpu->req.reqs.pio_request.size);
+		0xFFFFFFFFUL >> (32U - (8U * vcpu->req.reqs.pio_request.size));
 	uint64_t *rax;
 
 	req_buf = (union vhm_request_buffer *)(vcpu->vm->sw.io_shared_page);
@@ -71,7 +71,7 @@ int io_instr_vmexit_handler(struct vcpu *vcpu)
 	sz = VM_EXIT_IO_INSTRUCTION_SIZE(exit_qual) + 1;
 	port = VM_EXIT_IO_INSTRUCTION_PORT_NUMBER(exit_qual);
 	direction = VM_EXIT_IO_INSTRUCTION_ACCESS_DIRECTION(exit_qual);
-	mask = 0xfffffffful >> (32 - 8 * sz);
+	mask = 0xfffffffful >> (32U - (8U * sz));
 
 	TRACE_4I(TRACE_VMEXIT_IO_INSTRUCTION, port, (uint32_t)direction, sz,
 		(uint32_t)cur_context_idx);
@@ -87,8 +87,8 @@ int io_instr_vmexit_handler(struct vcpu *vcpu)
 	for (handler = vm->arch_vm.io_handler;
 			handler; handler = handler->next) {
 
-		if ((port >= handler->desc.addr + handler->desc.len) ||
-				(port + sz <= handler->desc.addr)) {
+		if ((port >= (handler->desc.addr + handler->desc.len)) ||
+				((port + sz) <= handler->desc.addr)) {
 			continue;
 		} else if (!((port >= handler->desc.addr) && ((port + sz)
 				<= (handler->desc.addr + handler->desc.len)))) {

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -146,7 +146,7 @@ static inline void
 ioapic_get_rte_entry(void *ioapic_addr,
 		uint8_t pin, union ioapic_rte *rte)
 {
-	uint32_t rte_addr = (uint32_t)pin * 2U + 0x10U;
+	uint32_t rte_addr = ((uint32_t)pin * 2U) + 0x10U;
 	rte->u.lo_32 = ioapic_read_reg32(ioapic_addr, rte_addr);
 	rte->u.hi_32 = ioapic_read_reg32(ioapic_addr, rte_addr + 1U);
 }
@@ -155,7 +155,7 @@ static inline void
 ioapic_set_rte_entry(void *ioapic_addr,
 		uint8_t pin, union ioapic_rte rte)
 {
-	uint32_t rte_addr = (uint32_t)pin * 2U + 0x10U;
+	uint32_t rte_addr = ((uint32_t)pin * 2U) + 0x10U;
 	ioapic_write_reg32(ioapic_addr, rte_addr, rte.u.lo_32);
 	ioapic_write_reg32(ioapic_addr, rte_addr + 1U, rte.u.hi_32);
 }

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -241,13 +241,13 @@ static uint64_t pit_calibrate_tsc(uint16_t cal_ms)
 	uint16_t max_cal_ms;
 	uint64_t current_tsc;
 
-	max_cal_ms = (PIT_MAX_COUNT - PIT_TARGET) * 1000U / PIT_TICK_RATE;
+	max_cal_ms = ((PIT_MAX_COUNT - PIT_TARGET) * 1000U) / PIT_TICK_RATE;
 	cal_ms = min(cal_ms, max_cal_ms);
 
 	/* Assume the 8254 delivers 18.2 ticks per second when 16 bits fully
 	 * wrap.  This is about 1.193MHz or a clock period of 0.8384uSec
 	 */
-	initial_pit = (uint16_t)(cal_ms * PIT_TICK_RATE / 1000U);
+	initial_pit = (uint16_t)((cal_ms * PIT_TICK_RATE) / 1000U);
 	initial_pit += PIT_TARGET;
 
 	/* Port 0x43 ==> Control word write; Data 0x30 ==> Select Counter 0,
@@ -273,7 +273,7 @@ static uint64_t pit_calibrate_tsc(uint16_t cal_ms)
 
 	current_tsc = rdtsc() - current_tsc;
 
-	return current_tsc / cal_ms * 1000U;
+	return (current_tsc / cal_ms) * 1000U;
 }
 
 /*
@@ -288,8 +288,8 @@ static uint64_t native_calibrate_tsc(void)
 			&ecx_hz, &reserved);
 
 		if (eax_denominator != 0U && ebx_numerator != 0U) {
-			return (uint64_t) ecx_hz *
-				ebx_numerator / eax_denominator;
+			return ((uint64_t) ecx_hz *
+				ebx_numerator) / eax_denominator;
 		}
 	}
 

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -481,7 +481,7 @@ bool initialize_trusty(struct vcpu *vcpu, uint64_t param)
 
 	/* init secure world environment */
 	if (init_secure_world_env(vcpu,
-		trusty_entry_gpa - trusty_base_gpa + TRUSTY_EPT_REBASE_GPA,
+		(trusty_entry_gpa - trusty_base_gpa) + TRUSTY_EPT_REBASE_GPA,
 		trusty_base_hpa, trusty_mem_size)) {
 
 		/* switch to Secure World */

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -236,8 +236,6 @@ static int unhandled_vmexit_handler(struct vcpu *vcpu)
 	pr_err("Exit qualification: 0x%016llx ",
 			exec_vmread(VMX_EXIT_QUALIFICATION));
 
-	/* while(1); */
-
 	TRACE_2L(TRACE_VMEXIT_UNHANDLED, vcpu->arch_vcpu.exit_reason, 0UL);
 
 	return 0;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -635,7 +635,7 @@ static void init_guest_state(struct vcpu *vcpu)
 			}
 		} else {
 			/* AP is initialized with real mode
-			 * and CS value is left shift 8 bits from sipi vector;
+			 * and CS value is left shift 8 bits from sipi vector.
 			 */
 			sel = vcpu->arch_vcpu.sipi_vector << 8U;
 			base = sel << 4U;

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -93,7 +93,7 @@ dmar_set_bitslice(uint64_t var, uint64_t mask,
 			status = iommu_read32(dmar_uint, offset);   \
 			if (condition)                              \
 				break;                                  \
-			ASSERT((rdtsc() - start < CYCLES_PER_MS),        \
+			ASSERT(((rdtsc() - start) < CYCLES_PER_MS),        \
 				"DMAR OP Timeout!");   \
 			asm volatile ("pause" ::: "memory");        \
 		}                                               \
@@ -781,7 +781,7 @@ static int dmar_fault_handler(int irq, void *data)
 		loop++;
 		index = dma_fsts_fri(fsr);
 		record_reg_offset = (uint32_t)dmar_uint->cap_fault_reg_offset
-				+ index * 16U;
+				+ (index * 16U);
 		if (index >= dmar_uint->cap_num_fault_regs) {
 			dev_dbg(ACRN_DBG_IOMMU, "%s: invalid FR Index",
 					__func__);
@@ -1221,7 +1221,7 @@ void suspend_iommu(void)
 		for (i = 0U; i < IOMMU_FAULT_REGISTER_STATE_NUM; i++) {
 			iommu_fault_state[iommu_idx][i] =
 				iommu_read32(dmar_unit, DMAR_FECTL_REG +
-					i * IOMMU_FAULT_REGISTER_STATE_NUM);
+					(i * IOMMU_FAULT_REGISTER_STATE_NUM));
 		}
 		/* disable translation */
 		dmar_disable_translation(dmar_unit);
@@ -1262,7 +1262,7 @@ void resume_iommu(void)
 		/* restore IOMMU fault register state */
 		for (i = 0U; i < IOMMU_FAULT_REGISTER_STATE_NUM; i++) {
 			iommu_write32(dmar_unit, DMAR_FECTL_REG +
-				i * IOMMU_FAULT_REGISTER_STATE_NUM,
+				(i * IOMMU_FAULT_REGISTER_STATE_NUM),
 				iommu_fault_state[iommu_idx][i]);
 		}
 		/* enable translation */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -424,9 +424,9 @@ _set_vm_memmap(struct vm *vm, struct vm *target_vm,
 
 	base_paddr = get_hv_image_base();
 	if (((hpa <= base_paddr) &&
-		(hpa + memmap->length > base_paddr)) ||
+		((hpa + memmap->length) > base_paddr)) ||
 		((hpa >= base_paddr) &&
-		(hpa < base_paddr + CONFIG_RAM_SIZE))) {
+		(hpa < (base_paddr + CONFIG_RAM_SIZE)))) {
 		pr_err("%s: ERROR! overlap the HV memory region.", __func__);
 		return -1;
 	}

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -23,7 +23,7 @@ static struct logmsg logmsg;
 static inline void alloc_earlylog_sbuf(uint16_t pcpu_id)
 {
 	uint32_t ele_size = LOG_ENTRY_SIZE;
-	uint32_t ele_num = ((HVLOG_BUF_SIZE >> 1) / phys_cpu_num
+	uint32_t ele_num = (((HVLOG_BUF_SIZE >> 1U) / phys_cpu_num)
 			   - SBUF_HEAD_SIZE) / ele_size;
 
 	per_cpu(earlylog_sbuf, pcpu_id) = sbuf_allocate(ele_num, ele_size);
@@ -158,10 +158,10 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 		if (sbuf != NULL) {
 			msg_len = strnlen_s(buffer, LOG_MESSAGE_MAX_SIZE);
 
-			for (i = 0; i < (msg_len - 1) / LOG_ENTRY_SIZE + 1;
+			for (i = 0; i < (((msg_len - 1) / LOG_ENTRY_SIZE) + 1);
 					i++) {
 				(void)sbuf_put(sbuf, (uint8_t *)buffer +
-							i * LOG_ENTRY_SIZE);
+							(i * LOG_ENTRY_SIZE));
 			}
 		}
 	}

--- a/hypervisor/debug/shell_internal.c
+++ b/hypervisor/debug/shell_internal.c
@@ -768,8 +768,8 @@ int shell_vcpu_dumpreg(struct shell *p_shell,
 			snprintf(temp_str, MAX_STR_SIZE,
 					"=  0x%016llx  0x%016llx  "
 					"0x%016llx  0x%016llx\r\n",
-					tmp[i*4UL], tmp[i*4UL+1UL],
-					tmp[i*4UL+2UL], tmp[i*4UL+3UL]);
+					tmp[i*4UL], tmp[(i*4UL)+1UL],
+					tmp[(i*4UL)+2UL], tmp[(i*4UL)+3UL]);
 			shell_puts(p_shell, temp_str);
 		}
 	}
@@ -841,18 +841,18 @@ int shell_vcpu_dumpmem(struct shell *p_shell,
 				"length %d:\r\n", vcpu_id, gva, length);
 			shell_puts(p_shell, temp_str);
 
-			for (i = 0U; i < length/32U; i++) {
+			for (i = 0U; i < (length/32U); i++) {
 				snprintf(temp_str, MAX_STR_SIZE,
 					"=  0x%016llx  0x%016llx  0x%016llx  "
-					"0x%016llx\r\n", tmp[i*4], tmp[i*4+1],
-					tmp[i*4+2], tmp[i*4+3]);
+					"0x%016llx\r\n", tmp[i*4], tmp[(i*4)+1],
+					tmp[(i*4)+2], tmp[(i*4)+3]);
 				shell_puts(p_shell, temp_str);
 			}
 			if ((length % 32U) != 0) {
 				snprintf(temp_str, MAX_STR_SIZE,
 					"=  0x%016llx  0x%016llx  0x%016llx  "
-					"0x%016llx\r\n", tmp[i*4], tmp[i*4+1],
-					tmp[i*4+2], tmp[i*4+3]);
+					"0x%016llx\r\n", tmp[i*4], tmp[(i*4)+1],
+					tmp[(i*4)+2], tmp[(i*4)+3]);
 				shell_puts(p_shell, temp_str);
 			}
 		}

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -210,7 +210,8 @@
 #define     MMU_MEM_ATTR_TYPE_MASK \
 		(IA32E_PDPTE_PAT_BIT | IA32E_COMM_PCD_BIT | IA32E_COMM_PWT_BIT)
 
-#define ROUND_PAGE_UP(addr)  (((addr) + (uint64_t)CPU_PAGE_SIZE - 1UL) & CPU_PAGE_MASK)
+#define ROUND_PAGE_UP(addr)  \
+		((((addr) + (uint64_t)CPU_PAGE_SIZE) - 1UL) & CPU_PAGE_MASK)
 #define ROUND_PAGE_DOWN(addr) ((addr) & CPU_PAGE_MASK)
 
 enum _page_table_type {

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -377,7 +377,7 @@ struct e820_entry {
  */
 static inline void *mmu_pt_for_pde(uint32_t *pd, uint32_t vaddr)
 {
-	return pd + ((vaddr >> 22U) + 1U) * 1024U;
+	return pd + (((vaddr >> 22U) + 1U) * 1024U);
 }
 
 #define CACHE_FLUSH_INVALIDATE_ALL()			\

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -58,7 +58,7 @@
 #define	VMX_EOI_EXIT2_HIGH			0x00002021U
 #define	VMX_EOI_EXIT3_FULL			0x00002022U
 #define	VMX_EOI_EXIT3_HIGH			0x00002023U
-#define	VMX_EOI_EXIT(vector)	(VMX_EOI_EXIT0_FULL + ((vector) / 64U) * 2U)
+#define	VMX_EOI_EXIT(vector)	(VMX_EOI_EXIT0_FULL + (((vector) / 64U) * 2U))
 #define VMX_XSS_EXITING_BITMAP_FULL		0x0000202CU
 #define VMX_XSS_EXITING_BITMAP_HIGH		0x0000202DU
 /* 64-bit read-only data fields */

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -91,7 +91,7 @@ static inline uint16_t iommu_cap_fault_reg_offset(uint64_t cap)
 static inline uint16_t iommu_cap_max_fault_reg_offset(uint64_t cap)
 {
 	return (iommu_cap_fault_reg_offset(cap) +
-		iommu_cap_num_fault_regs(cap) * 16U);
+		(iommu_cap_num_fault_regs(cap) * 16U));
 }
 
 static inline uint8_t iommu_cap_zlr(uint64_t cap)
@@ -141,7 +141,7 @@ static inline uint8_t iommu_cap_afl(uint64_t cap)
 
 static inline uint32_t iommu_cap_ndoms(uint64_t cap)
 {
-	return ((1U) << (4U + 2U * ((uint8_t)cap & 0x7U)));
+	return ((1U) << (4U + (2U * ((uint8_t)cap & 0x7U))));
 }
 
 /*

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -178,7 +178,7 @@ static inline uint16_t clz64(uint64_t value)
 #define build_bitmap_set(name, op_len, op_type, lock, nr, addr)	\
 static inline void name(uint16_t nr, volatile op_type *addr)	\
 {								\
-	nr = nr & (8U * sizeof(op_type) - 1U);			\
+	nr = nr & ((8U * sizeof(op_type)) - 1U);		\
 	asm volatile(lock "or" op_len " %1,%0"			\
 			:  "+m" (*addr)				\
 			:  "r" ((op_type)(1UL<<nr))		\
@@ -197,7 +197,7 @@ build_bitmap_set(bitmap32_set, "l", uint32_t, BUS_LOCK, nr, addr)
 #define build_bitmap_clear(name, op_len, op_type, lock, nr, addr)	\
 static inline void name(uint16_t nr, volatile op_type *addr) 		\
 {									\
-	nr = nr & (8U * sizeof(op_type) - 1U);				\
+	nr = nr & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "and" op_len " %1,%0"				\
 			:  "+m" (*addr)					\
 			:  "r" ((op_type)(~(1UL<<(nr))))		\
@@ -246,7 +246,7 @@ static inline bool bitmap32_test(uint16_t nr, volatile uint32_t *addr)
 static inline bool name(uint16_t nr, volatile op_type *addr)		\
 {									\
 	int32_t ret=0;							\
-	nr = nr & (8U * sizeof(op_type) - 1U);				\
+	nr = nr & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "bts" op_len " %2,%1\n\tsbbl %0,%0"		\
 			: "=r" (ret), "=m" (*addr)			\
 			: "r" ((op_type)nr)				\
@@ -269,7 +269,7 @@ build_bitmap_testandset(bitmap32_test_and_set, "l", uint32_t, BUS_LOCK, nr, addr
 static inline bool name(uint16_t nr, volatile op_type *addr)		\
 {									\
 	int32_t ret=0;							\
-	nr = nr & (8U * sizeof(op_type) - 1U);				\
+	nr = nr & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "btr" op_len " %2,%1\n\tsbbl %0,%0"		\
 			: "=r" (ret), "=m" (*addr)			\
 			: "r" ((op_type)nr)				\

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -51,7 +51,7 @@ extern uint32_t tsc_khz;
 
 static inline uint64_t us_to_ticks(uint32_t us)
 {
-	return ((uint64_t)us * (uint64_t)tsc_khz / 1000UL);
+	return (((uint64_t)us * (uint64_t)tsc_khz) / 1000UL);
 }
 
 #define CYCLES_PER_MS	us_to_ticks(1000U)

--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -18,7 +18,7 @@
 #define offsetof(st, m) __builtin_offsetof(st, m)
 
 /** Roundup (x/y) to ( x/y + (x%y) ? 1 : 0) **/
-#define INT_DIV_ROUNDUP(x, y)	(((x)+(y)-1)/(y))
+#define INT_DIV_ROUNDUP(x, y)	((((x)+(y))-1)/(y))
 
 #define min(x, y)	((x) < (y)) ? (x) : (y)
 

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -109,7 +109,7 @@ int udiv64(uint64_t dividend, uint64_t divisor, struct udiv_result *res)
 		}
 		divisor >>= 1UL;
 		mask >>= 1UL;
-	} while ((bits-- != 0UL) && (dividend != 0UL));
+	} while (((bits--) != 0UL) && (dividend != 0UL));
 
 	res->r.qword = dividend;
 	return 0;

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -245,7 +245,7 @@ void *malloc(unsigned int num_bytes)
 		memory = allocate_mem(&Memory_Pool, num_bytes);
 	} else {
 		uint32_t page_num =
-			(num_bytes + CPU_PAGE_SIZE - 1U) >> CPU_PAGE_SHIFT;
+			((num_bytes + CPU_PAGE_SIZE) - 1U) >> CPU_PAGE_SHIFT;
 		/* Request memory allocation through alloc_page */
 		memory = alloc_pages(page_num);
 	}
@@ -361,8 +361,8 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
 		ASSERT(false);
 	}
 
-	if (((d > s) && (d <= (s + slen - 1U)))
-			|| ((d < s) && (s <= (d + dmax - 1U)))) {
+	if (((d > s) && (d <= ((s + slen) - 1U)))
+			|| ((d < s) && (s <= ((d + dmax) - 1U)))) {
 		ASSERT(false);
 	}
 

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -126,9 +126,9 @@ static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
 				 * memory pool
 				 */
 				memory = (char *)pool->start_addr +
-					pool->buff_size *
-					(idx * BITMAP_WORD_SIZE +
-							bit_idx);
+					(pool->buff_size *
+					((idx * BITMAP_WORD_SIZE) +
+							bit_idx));
 
 				/* Update allocation bitmaps information for
 				 * selected buffers
@@ -361,8 +361,8 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
 		ASSERT(false);
 	}
 
-	if ((d > s && d <= s + slen - 1)
-			|| (d < s && s <= d + dmax - 1)) {
+	if (((d > s) && (d <= (s + slen - 1U)))
+			|| ((d < s) && (s <= (d + dmax - 1U)))) {
 		ASSERT(false);
 	}
 

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -608,10 +608,6 @@ int do_print(const char *fmt, struct print_param *param,
 			/* pointer argument */
 			else if (ch == 'p') {
 				param->vars.flags |= PRINT_FLAG_ALTERNATE_FORM;
-				/* XXXCRG res=print_pow2(param,
-				 * (uint32_t) __builtin_va_arg(args,
-				 * void *),4);
-				 */
 				res = print_pow2(param, (uint64_t)
 					__builtin_va_arg(args, void *), 4U);
 			}

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -335,7 +335,7 @@ static int print_pow2(struct print_param *param,
 
 	/* assign parameter and apply width and precision */
 	param->vars.value = pos;
-	param->vars.valuelen = digitbuff + sizeof(digitbuff) - pos;
+	param->vars.valuelen = (digitbuff + sizeof(digitbuff)) - pos;
 
 	ret = format_number(param);
 
@@ -408,7 +408,7 @@ static int print_decimal(struct print_param *param, int64_t value)
 
 	/* assign parameter and apply width and precision */
 	param->vars.value = pos;
-	param->vars.valuelen = digitbuff + sizeof(digitbuff) - pos;
+	param->vars.valuelen = (digitbuff + sizeof(digitbuff)) - pos;
 
 	ret = format_number(param);
 

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -96,7 +96,7 @@ static const char *get_int(const char *s, int *x)
 
 	/* parse uint32_teger */
 	while ((*s >= '0') && (*s <= '9')) {
-		*x = *x * 10 + (*s - '0');
+		*x = (*x * 10) + (*s - '0');
 		s++;
 	}
 
@@ -648,7 +648,7 @@ static int charmem(int cmd, const char *s, int sz, void *hnd)
 	if (cmd == PRINT_CMD_COPY) {
 		if (sz < 0) {
 			while ((*s) != '\0') {
-				if (n < param->sz - param->wrtn) {
+				if (n < (param->sz - param->wrtn)) {
 					*p = *s;
 				}
 				p++;
@@ -658,7 +658,7 @@ static int charmem(int cmd, const char *s, int sz, void *hnd)
 
 		} else if (sz > 0) {
 			while (((*s) != '\0') && n < sz) {
-				if (n < param->sz - param->wrtn) {
+				if (n < (param->sz - param->wrtn)) {
 					*p = *s;
 				}
 				p++;
@@ -674,7 +674,7 @@ static int charmem(int cmd, const char *s, int sz, void *hnd)
 	}
 	/* fill mode */
 	else {
-		n = (sz < param->sz - param->wrtn) ? sz : 0;
+		n = (sz < (param->sz - param->wrtn)) ? sz : 0;
 		param->wrtn += sz;
 		(void)memset(p, *s, n);
 	}


### PR DESCRIPTION
Series patches of misra-c violation fix. It is for clean up legacy and add brackets in  expression when there is same level of precedence operators.