### PR TITLE
HV: change wake vector address to accommodate sbl

### DIFF
--- a/hypervisor/bsp/sbl/platform_acpi_info.c
+++ b/hypervisor/bsp/sbl/platform_acpi_info.c
@@ -7,16 +7,48 @@
 #include <hypervisor.h>
 
 const struct acpi_info host_acpi_info = {
-	6,				/* x86 family: 6 */
-	0x5C,				/* x86 model: 0x5C, ApolloLake */
-	{
-		{SPACE_SYSTEM_IO, 32, 0, 3, 0x400},	/* PM1a EVT */
-		{SPACE_SYSTEM_IO,  0, 0, 0,     0},	/* PM1b EVT */
-		{SPACE_SYSTEM_IO, 16, 0, 2, 0x404},	/* PM1a CNT */
-		{SPACE_SYSTEM_IO,  0, 0, 0,     0},	/* PM1b CNT */
-		{0x05,	0,	0},			/* _S3 Package */
-		{0x07,	0,	0},			/* _S5 Package */
-		(uint32_t *)0x7A86BC9C,			/* Wake Vector 32 */
-		(uint64_t *)0x7A86BCA8			/* Wake Vector 64 */
+	.x86_family = 6U,
+	.x86_model = 0x5CU,			/* ApolloLake */
+	.pm_s_state = {
+		.pm1a_evt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0x20U,
+			.bit_offset = 0U,
+			.access_size = 3U,
+			.address = 0x400UL
+		},
+		.pm1b_evt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0U,
+			.bit_offset = 0U,
+			.access_size = 0U,
+			.address = 0UL
+		},
+		.pm1a_cnt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0x10U,
+			.bit_offset = 0U,
+			.access_size = 2U,
+			.address = 0x404UL
+		},
+		.pm1b_cnt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0U,
+			.bit_offset = 0U,
+			.access_size = 0U,
+			.address = 0UL
+		},
+		.s3_pkg = {
+			.val_pm1a = 0x05U,
+			.val_pm1b = 0U,
+			.reserved = 0U
+		},
+		.s5_pkg = {
+			.val_pm1a = 0x07U,
+			.val_pm1b = 0U,
+			.reserved = 0U
+		},
+		.wake_vector_32 = (uint32_t *)0x7A86BC9CUL,
+		.wake_vector_64 = (uint64_t *)0x7A86BCA8UL
 	}
 };

--- a/hypervisor/bsp/sbl/platform_acpi_info.c
+++ b/hypervisor/bsp/sbl/platform_acpi_info.c
@@ -10,13 +10,13 @@ const struct acpi_info host_acpi_info = {
 	6,				/* x86 family: 6 */
 	0x5C,				/* x86 model: 0x5C, ApolloLake */
 	{
-		{SPACE_SYSTEM_IO, 20, 0, 3, 0x400},	/* PM1a EVT */
+		{SPACE_SYSTEM_IO, 32, 0, 3, 0x400},	/* PM1a EVT */
 		{SPACE_SYSTEM_IO,  0, 0, 0,     0},	/* PM1b EVT */
-		{SPACE_SYSTEM_IO, 10, 0, 2, 0x404},	/* PM1a CNT */
+		{SPACE_SYSTEM_IO, 16, 0, 2, 0x404},	/* PM1a CNT */
 		{SPACE_SYSTEM_IO,  0, 0, 0,     0},	/* PM1b CNT */
 		{0x05,	0,	0},			/* _S3 Package */
 		{0x07,	0,	0},			/* _S5 Package */
-		(uint32_t *)0x7AEDCEFC,			/* Wake Vector 32 */
-		(uint64_t *)0x7AEDCF08			/* Wake Vector 64 */
+		(uint32_t *)0x7A86BC9C,			/* Wake Vector 32 */
+		(uint64_t *)0x7A86BCA8			/* Wake Vector 64 */
 	}
 };


### PR DESCRIPTION
- The previous wake vector address just work for ABL, need to change it
  to accommodate the latest SBL;

- Fix wrong bit width value in the pm1a gas;

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>