### PR TITLE
hv: treewide: fix 'Array has no bounds specified'

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -15,7 +15,7 @@
 #define EXCEPTION_CLASS_CONT	2
 #define EXCEPTION_CLASS_PF	3
 
-static const uint16_t exception_type[] = {
+static const uint16_t exception_type[32] = {
 	[0] = VMX_INT_TYPE_HW_EXP,
 	[1] = VMX_INT_TYPE_HW_EXP,
 	[2] = VMX_INT_TYPE_HW_EXP,

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -6,10 +6,17 @@
 
 #include <hypervisor.h>
 
+/*
+ * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
+ * there are 65 Basic Exit Reasons.
+ */
+#define NR_VMX_EXIT_REASONS	65U
+
 static int unhandled_vmexit_handler(struct vcpu *vcpu);
 static int xsetbv_vmexit_handler(struct vcpu *vcpu);
+
 /* VM Dispatch table for Exit condition handling */
-static const struct vm_exit_dispatch dispatch_table[] = {
+static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 	[VMX_EXIT_REASON_EXCEPTION_OR_NMI] = {
 		.handler = exception_vmexit_handler},
 	[VMX_EXIT_REASON_EXTERNAL_INTERRUPT] = {
@@ -125,7 +132,23 @@ static const struct vm_exit_dispatch dispatch_table[] = {
 		.handler = xsetbv_vmexit_handler},
 	[VMX_EXIT_REASON_APIC_WRITE] = {
 		.handler = apic_write_vmexit_handler,
-		.need_exit_qualification = 1}
+		.need_exit_qualification = 1},
+	[VMX_EXIT_REASON_RDRAND] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_INVPCID] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_VMFUNC] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_ENCLS] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_RDSEED] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_PAGE_MODIFICATION_LOG_FULL] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_XSAVES] = {
+		.handler = unhandled_vmexit_handler},
+	[VMX_EXIT_REASON_XRSTORS] = {
+		.handler = unhandled_vmexit_handler}
 };
 
 int vmexit_handler(struct vcpu *vcpu)
@@ -242,7 +265,7 @@ int cr_access_vmexit_handler(struct vcpu *vcpu)
 	uint64_t *regptr;
 	struct run_context *cur_context =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
-	static const int reg_trans_tab[] = {
+	static const int reg_trans_tab[16] = {
 		[0] = CPU_CONTEXT_INDEX_RAX,
 		[1] = CPU_CONTEXT_INDEX_RCX,
 		[2] = CPU_CONTEXT_INDEX_RDX,

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -9,7 +9,7 @@
 /*
  * readable exception descriptors.
  */
-static const char *const excp_names[] = {
+static const char *const excp_names[32] = {
 	[0] = "Divide Error",
 	[1] = "RESERVED",
 	[2] = "NMI",

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -7,13 +7,14 @@
 #ifndef IOAPIC_H
 #define IOAPIC_H
 
-/* IOAPIC_MAX_LINES is architecturally defined.
+/*
+ * IOAPIC_MAX_LINES is architecturally defined.
  * The usable RTEs may be a subset of the total on a per IO APIC basis.
  */
 #define IOAPIC_MAX_LINES	120U
 #define NR_LEGACY_IRQ		16U
-#define NR_LEGACY_PIN	NR_LEGACY_IRQ
-#define NR_MAX_GSI	(CONFIG_NR_IOAPICS*IOAPIC_MAX_LINES)
+#define NR_LEGACY_PIN		NR_LEGACY_IRQ
+#define NR_MAX_GSI		(CONFIG_NR_IOAPICS * IOAPIC_MAX_LINES)
 
 #define GSI_MASK_IRQ(irq) irq_gsi_mask_unmask((irq), true)
 #define GSI_UNMASK_IRQ(irq) irq_gsi_mask_unmask((irq), false)
@@ -28,12 +29,11 @@ void irq_gsi_mask_unmask(uint32_t irq, bool mask);
 void ioapic_set_rte(uint32_t irq, union ioapic_rte rte);
 void ioapic_get_rte(uint32_t irq, union ioapic_rte *rte);
 
-
 void suspend_ioapic(void);
 void resume_ioapic(void);
 
-extern uint8_t legacy_irq_to_pin[];
-extern uint8_t pic_ioapic_pin_map[];
+extern uint8_t legacy_irq_to_pin[NR_LEGACY_IRQ];
+extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
 
 #ifdef HV_DEBUG
 int get_ioapic_info(char *str, int str_max_len);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -390,9 +390,6 @@ static inline void clflush(volatile void *p)
 	asm volatile ("clflush (%0)" :: "r"(p));
 }
 
-/* External variable declarations */
-extern uint8_t CPU_Boot_Page_Tables_Start_VM[];
-
 /* External Interfaces */
 bool is_ept_supported(void);
 uint64_t create_guest_initial_paging(struct vm *vm);

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -252,6 +252,14 @@
 #define VMX_EXIT_REASON_WBINVD                                       0x00000036U
 #define VMX_EXIT_REASON_XSETBV                                       0x00000037U
 #define VMX_EXIT_REASON_APIC_WRITE                                   0x00000038U
+#define VMX_EXIT_REASON_RDRAND                                       0x00000039U
+#define VMX_EXIT_REASON_INVPCID                                      0x0000003AU
+#define VMX_EXIT_REASON_VMFUNC                                       0x0000003BU
+#define VMX_EXIT_REASON_ENCLS                                        0x0000003CU
+#define VMX_EXIT_REASON_RDSEED                                       0x0000003DU
+#define VMX_EXIT_REASON_PAGE_MODIFICATION_LOG_FULL                   0x0000003EU
+#define VMX_EXIT_REASON_XSAVES                                       0x0000003FU
+#define VMX_EXIT_REASON_XRSTORS                                      0x00000040U
 
 /* VMX execution control bits (pin based) */
 #define VMX_PINBASED_CTLS_IRQ_EXIT     (1U<<0)


### PR DESCRIPTION
- explicitly declare the array size to fix the violation 'Array has no
  bounds specified'

- minor changes for comments style

v1 -> v2:
 * add the definition for exit reasons from 0x39 to 0x40 based on "SDM
    APPENDIX C VMX BASIC EXIT REASONS"

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>