### PR TITLE
DOC:GSG: Fix few mistakes about updating acrn.conf and efibootmgr opt…

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -150,7 +150,7 @@ partition. Follow these steps:
 
    .. code-block:: none
 
-      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L ACRN
+      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN"
 
    .. note::
 
@@ -181,8 +181,8 @@ partition. Follow these steps:
 
    .. code-block:: none
 
-      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN Hypervisor" \
-            -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=mmio@0x9141e000"
+      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN NUC Hypervisor" \
+            -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=disabled"
 
 #. Create a boot entry for the ACRN Service OS by copying a provided ``acrn.conf``
    and editing it to account for the kernel versions noted in a previous step.
@@ -213,9 +213,10 @@ partition. Follow these steps:
 
       # cp /usr/share/acrn/samples/nuc/acrn.conf /mnt/loader/entries/
 
-   You will need to edit this file to adjust the kernel version (``linux`` section)
-   and also insert the ``PARTUUID`` of your ``/dev/sda3`` partition
-   (``root=PARTUUID=<><UUID of rootfs partition>``) in the ``options`` section.
+   You will need to edit this file to adjust the kernel version (``linux`` section),
+   insert the ``PARTUUID`` of your ``/dev/sda3`` partition
+   (``root=PARTUUID=<><UUID of rootfs partition>``) in the ``options`` section, and
+   add the ``hugepagesz=1G hugepages=2`` at end of the ``options`` section.
 
    Use ``blkid`` to find out what your ``/dev/sda3`` ``PARTUUID`` value is.
 


### PR DESCRIPTION
…ions

During setting up ACRN hypervisor, SOS and UOC on the
intel® NUC (NUC6CAYH) board, there are few mistakes
about updating acrn.conf and efibootmgr options, this
will lead to fail to set up ACRN hypervisor, SOS and UOS
on the NUC.

About updating acrn.conf, add "hugepagesz=1G hugepages=2"
About efibootmgr options, string parameter of option "-L"
needs to add double quotation marks; "uart=disabled" in
the option "-u" since there is no serial port on NUC.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>