### PR TITLE
HV: make: check CONFIG_RELEASE=y for release build

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -199,7 +199,7 @@ endif
 endif
 
 C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(C_SRCS))
-ifeq ($(CONFIG_RELEASE),n)
+ifneq ($(CONFIG_RELEASE),y)
 C_OBJS += $(patsubst %.c,$(HV_OBJDIR)/%.o,$(D_SRCS))
 CFLAGS += -DHV_DEBUG
 endif
@@ -263,7 +263,7 @@ $(VERSION):
 	DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
 	TIME=`date "+%F %T"`;\
 	USER=`id -u -n`; \
-	if [ $(CONFIG_RELEASE) = "n" ];then BUILD_TYPE="DBG";else BUILD_TYPE="REL";fi;\
+	if [ x$(CONFIG_RELEASE) = "xy" ];then BUILD_TYPE="REL";else BUILD_TYPE="DBG";fi;\
 	echo "/*" > $(VERSION); \
 	sed 's/^/ * /' ../LICENSE >> $(VERSION); \
 	echo " */" >> $(VERSION); \


### PR DESCRIPTION
Currently we reply on CONFIG_RELEASE=n to determine if a debug version should be
built. Though this holds due to the configuration overriding in kconfig.mk, this
only applies to make >= 3.82. For make 3.81, $(eval $(call xxx)) does not work
as expected, and thus CONFIG_RELEASE is undefined for debug builds.

Instead of checking CONFIG_RELEASE=n, this patch checks CONFIG_RELEASE=y
instead, which is guaranteed without relying on the behavior of $(eval $(call
xxx)).

Signed-off-by: Junjie Mao <junjie.mao@intel.com>