### PR TITLE
HV:treewide:Fixing pointer castings

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -140,7 +140,7 @@ static int _gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_info,
 	uint32_t i;
 	uint64_t index;
 	uint32_t shift;
-	uint8_t *base;
+	void *base;
 	uint64_t entry;
 	uint64_t addr, page_size;
 	int ret = 0;
@@ -167,10 +167,12 @@ static int _gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_info,
 		page_size = 1UL << shift;
 
 		if (pw_info->width == 10U) {
+			uint32_t *base32 = (uint32_t *)base;
 			/* 32bit entry */
-			entry = *((uint32_t *)(base + (4U * index)));
+			entry = (uint64_t)(*(base32 + index));
 		} else {
-			entry = *((uint64_t *)(base + (8U * index)));
+			uint64_t *base64 = (uint64_t *)base;
+			entry = *(base64 + index);
 		}
 
 		/* check if the entry present */

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -746,7 +746,7 @@ emulate_movs(struct vcpu *vcpu, __unused uint64_t gpa, struct vie *vie,
 		goto done;
 	}
 
-	(void)memcpy_s((char *)dstaddr, 16U, (char *)srcaddr, opsize);
+	(void)memcpy_s((void *)dstaddr, 16U, (void *)srcaddr, opsize);
 
 	error = vie_read_register(vcpu, CPU_REG_RSI, &rsi);
 	error = vie_read_register(vcpu, CPU_REG_RDI, &rdi);

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1205,7 +1205,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 {
 	uint32_t value32;
 	uint64_t value64;
-	struct vm *vm = (struct vm *) vcpu->vm;
+	struct vm *vm = vcpu->vm;
 
 	/* Log messages to show initializing VMX execution controls */
 	pr_dbg("*****************************");

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -933,9 +933,9 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 		uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_uint;
-	uint64_t *root_table;
+	struct dmar_root_entry *root_table;
 	uint64_t context_table_addr;
-	uint64_t *context_table;
+	struct dmar_context_entry *context_table;
 	struct dmar_root_entry *root_entry;
 	struct dmar_context_entry *context_entry;
 	uint64_t upper = 0UL;
@@ -975,9 +975,9 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 		}
 	}
 
-	root_table = (uint64_t *)HPA2HVA(dmar_uint->root_table_addr);
+	root_table = (struct dmar_root_entry *)HPA2HVA(dmar_uint->root_table_addr);
 
-	root_entry = (struct dmar_root_entry *)&root_table[bus * 2];
+	root_entry = root_table + bus;
 
 	if (dmar_get_bitslice(root_entry->lower,
 	        ROOT_ENTRY_LOWER_PRESENT_MASK,
@@ -1014,8 +1014,8 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 
 	context_table_addr = context_table_addr << 12;
 
-	context_table = (uint64_t *)HPA2HVA(context_table_addr);
-	context_entry = (struct dmar_context_entry *)&context_table[devfun * 2];
+	context_table = (struct dmar_context_entry *)HPA2HVA(context_table_addr);
+	context_entry = context_table + devfun;
 
 	/* the context entry should not be present */
 	if (dmar_get_bitslice(context_entry->lower,
@@ -1088,9 +1088,9 @@ remove_iommu_device(struct iommu_domain *domain, uint16_t segment,
 		uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_uint;
-	uint64_t *root_table;
+	struct dmar_root_entry *root_table;
 	uint64_t context_table_addr;
-	uint64_t *context_table;
+	struct dmar_context_entry *context_table;
 	struct dmar_root_entry *root_entry;
 	struct dmar_context_entry *context_entry;
 	uint16_t dom_id;
@@ -1106,16 +1106,16 @@ remove_iommu_device(struct iommu_domain *domain, uint16_t segment,
 		return 1;
 	}
 
-	root_table = (uint64_t *)HPA2HVA(dmar_uint->root_table_addr);
-	root_entry = (struct dmar_root_entry *)&root_table[bus * 2];
+	root_table = (struct dmar_root_entry *)HPA2HVA(dmar_uint->root_table_addr);
+	root_entry = root_table + bus;
 
 	context_table_addr = dmar_get_bitslice(root_entry->lower,
 					       ROOT_ENTRY_LOWER_CTP_MASK,
 					       ROOT_ENTRY_LOWER_CTP_POS);
 	context_table_addr = context_table_addr << 12;
-	context_table = (uint64_t *)HPA2HVA(context_table_addr);
+	context_table = (struct dmar_context_entry *)HPA2HVA(context_table_addr);
 
-	context_entry = (struct dmar_context_entry *)&context_table[devfun * 2];
+	context_entry = context_table + devfun;
 
 	dom_id = (uint16_t)dmar_get_bitslice(context_entry->upper,
 		        CTX_ENTRY_UPPER_DID_MASK, CTX_ENTRY_UPPER_DID_POS);


### PR DESCRIPTION
In the hypervisor, there are many casts from
an void pointer to integer pointer, then from
integer pointer to structure pointer.
These pointer castings are detected by static analysis
tool. All pointer casts are violations, There are
some duplicated pointer cast. This will make deviation
analysis complex.
BTW, there are one useless pointer casting and one
wrong pointer casting in the hypervisor.

Remvoe duplicated pointer casts to make deviation analysis
simple;
Remove one useless pointer casting;
Update one wrong pointer casting.

Note: There are many void type pointer casts, non-void type
pointer is casted to void type pointer, char type pointer casts,
non-char type pointer is casted to char type pointer. These pointer
casting is need by the memory management module, IO moudle etc.
Deviation analysis will be made and recoded in the analysis report.

V1-->V2:
	Fix mixing pointer and array voilation.
V2-->V3:
	Remvoe pointer casting from integer pointer into
	non-void/non-char pointer directly;
	Remove redundant type conversion.

Signed-off-by: Xiangyang Wu <xiangyang.wu@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>