### PR TITLE
doc: fix doc error filter patterns

### DIFF
--- a/doc/.known-issues/doc/hypercall.conf
+++ b/doc/.known-issues/doc/hypercall.conf
@@ -17,10 +17,12 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^[ \t]*
 ^[ \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+#
+^(?P<filename>[-._/\w]+/api/hypercall_api.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*vhm_request.reqs
 ^[- \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+#
+^(?P<filename>[-._/\w]+/api/hypercall_api.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^.*union hc_ptdev_irq::\@1  hc_ptdev_irq::is
 ^[- \t]*\^
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
@@ -29,7 +31,8 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^[ \t]*
 ^[ \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+#
+^(?P<filename>[-._/\w]+/api/hypercall_api.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*hc_ptdev_irq.is
 ^[- \t]*\^
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
@@ -41,13 +44,24 @@
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^[ \t]*
 ^[ \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
+^[ \t]*
+^[ \t]*\^
+#
+^(?P<filename>[-._/\w]+/api/hypercall_api.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*hc_ptdev_irq.is.intx
 ^[- \t]*\^
 ^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected identifier in nested name. \[error at [0-9]+]
 ^[ \t]*
 ^[ \t]*\^
-^(?P=filename):(?P=lineno): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
+#
+^(?P<filename>[-._/\w]+/api/hypercall_api.rst):(?P<lineno>[0-9]+): WARNING: Invalid definition: Expected end of definition. \[error at [0-9]+]
 ^.*hc_ptdev_irq.is.msix
 ^[- \t]*\^
 #


### PR DESCRIPTION
Changes to hypercall.h altered the error pattern match used to decide if
doxygen errors are "expected".  Update the pattern match.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>