### PR TITLE
hv: fix typo in relocation code

### DIFF
--- a/hypervisor/bsp/uefi/efi/malloc.c
+++ b/hypervisor/bsp/uefi/efi/malloc.c
@@ -268,7 +268,7 @@ EFI_STATUS __emalloc(UINTN size, UINTN min_addr, EFI_PHYSICAL_ADDRESS *addr,
 			continue;
 		}
 
-#ifndef CONFIG_RELOC
+#ifdef CONFIG_RELOC
 		aligned = start;
 #else
 		aligned = min_addr;


### PR DESCRIPTION
Fixed a typo in 621425da20d0 ("hv: further fix to configurable
relocation"). It shoud allocate fixed address if CONFIG_RELOC is
not defined.