### PR TITLE
tools: acrntrace: save trace data file under current dir by default

### DIFF
--- a/tools/acrntrace/README.rst
+++ b/tools/acrntrace/README.rst
@@ -13,7 +13,7 @@ Usage
 *****
 
 The ``acrntrace`` tool runs on the Service OS (SOS) to capture trace data and
-output to trace file under ``/tmp/acrntrace`` with raw (binary) data format.
+output to trace file under ``./acrntrace`` with raw (binary) data format.
 
 Options:
 
@@ -96,7 +96,7 @@ data to your linux system, and running the analysis tool.
    will exit automatically when the free storage space on the disk is less than
    reserved space. Reserved space on the disk is configurable through '-r'.
 
-   Trace files are created under ``/tmp/acrntrace/``, with a
+   Trace files are created under ``./acrntrace/``, with a
    date-time-based directory name such as ``20171115-101605``
 
 #. When done, stop a running ``acrntrace``, with:
@@ -120,7 +120,7 @@ data to your linux system, and running the analysis tool.
 
    .. code-block:: none
 
-      # scp -r /tmp/acrntrace/20171115-101605/ \
+      # scp -r ./acrntrace/20171115-101605/ \
           username@hostname:/home/username/trace_data
 
    Replace username and hostname with appropriate values.

--- a/tools/acrntrace/acrntrace.h
+++ b/tools/acrntrace/acrntrace.h
@@ -17,9 +17,9 @@
 #define MMAP_SIZE 		((TRACE_ELEMENT_SIZE * TRACE_ELEMENT_NUM \
 				+ PAGE_SIZE - 1) & PAGE_MASK)
 */
-#define TRACE_FILE_NAME_LEN	36
-#define TRACE_FILE_DIR_LEN	(TRACE_FILE_NAME_LEN - 2)
-#define TRACE_FILE_ROOT		"/tmp/acrntrace/"
+#define TRACE_FILE_NAME_LEN	32
+#define TRACE_FILE_DIR_LEN	(TRACE_FILE_NAME_LEN - 3)
+#define TRACE_FILE_ROOT		"acrntrace/"
 #define DEV_PATH_LEN		18
 #define TIME_STR_LEN		16
 #define CMD_MAX_LEN		48

--- a/tools/acrntrace/sbuf.c
+++ b/tools/acrntrace/sbuf.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include "sbuf.h"
+#include <errno.h>
 
 static inline bool sbuf_is_empty(shared_buf_t *sbuf)
 {
@@ -59,9 +60,9 @@ int sbuf_write(int fd, shared_buf_t *sbuf)
 
 	start = (void *)sbuf + SBUF_HEAD_SIZE + sbuf->head;
         written = write(fd, start, sbuf->ele_size);
-	if ( written != sbuf->ele_size) {
-		printf("Failed to write. Expect written size %d, returned %d\n",
-				sbuf->ele_size, written);
+	if (written != sbuf->ele_size) {
+		printf("Failed to write: ret %d (ele_size %d), errno %d\n",
+			written, sbuf->ele_size, (written == -1) ? errno : 0);
 		return -1;
 	}
 


### PR DESCRIPTION
Current implementation save trace data files on tmpfs by default, acrntrace
would use up all the physical mem, which can affect system functioning.
This commit changes default location for trace data file to current dir, and
removes the codes for space reservation, which is not necessary.

Signed-off-by: Yan, Like <like.yan@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>