### PR TITLE
HV: io: I/O emulation path revisit (part 1)

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -243,7 +243,7 @@ encode_vmcs_seg_desc(enum cpu_reg_name seg,
  *
  *Post Condition:
  *In the non-general register names group (CPU_REG_CR0~CPU_REG_GDTR),
- *for register names CPU_REG_CR2, CPU_REG_IDTR and CPU_REG_GDTR, 
+ *for register names CPU_REG_CR2, CPU_REG_IDTR and CPU_REG_GDTR,
  *this function returns VMX_INVALID_VMCS_FIELD;
  *for other register names, it returns correspoding field index MACROs
  *in VMCS.
@@ -319,7 +319,7 @@ static int mmio_read(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t *rval,
 		return -EINVAL;
 	}
 
-	*rval = vcpu->mmio.value;
+	*rval = vcpu->req.reqs.mmio.value;
 	return 0;
 }
 
@@ -330,7 +330,7 @@ static int mmio_write(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t wval,
 		return -EINVAL;
 	}
 
-	vcpu->mmio.value = wval;
+	vcpu->req.reqs.mmio.value = wval;
 	return 0;
 }
 
@@ -375,7 +375,7 @@ int emulate_instruction(struct vcpu *vcpu)
 	struct emul_ctxt *emul_ctxt;
 	struct vm_guest_paging *paging;
 	int retval = 0;
-	uint64_t gpa = vcpu->mmio.paddr;
+	uint64_t gpa = vcpu->req.reqs.mmio.address;
 	mem_region_read_t mread = mmio_read;
 	mem_region_write_t mwrite = mmio_write;
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -122,6 +122,8 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	vcpu->pending_pre_work = 0U;
 	vcpu->state = VCPU_INIT;
 
+	(void)memset(&vcpu->req, 0U, sizeof(struct io_request));
+
 	return 0;
 }
 

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -32,10 +32,6 @@
 #define IDX_PAT		(IDX_TSC + 1U)
 #define IDX_MAX_MSR	(IDX_PAT + 1U)
 
-struct vhm_request;
-
-int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req);
-
 /*
  * VCPU related APIs
  */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -250,8 +250,7 @@ struct vcpu {
 	uint32_t running; /* vcpu is picked up and run? */
 	uint32_t ioreq_pending; /* ioreq is ongoing or not? */
 
-	struct vhm_request req; /* used by io/ept emulation */
-	struct mem_io mmio; /* used by io/ept emulation */
+	struct io_request req; /* used by io/ept emulation */
 
 	/* save guest msr tsc aux register.
 	 * Before VMENTRY, save guest MSR_TSC_AUX to this fields.

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -52,7 +52,7 @@ void	vioapic_mmio_read(struct vm *vm, uint64_t gpa, uint32_t *rval);
 uint8_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
 bool	vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte);
-int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
+int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
 		void *handler_private_data);
 
 #ifdef HV_DEBUG

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -111,7 +111,7 @@ void vlapic_set_tmr_one_vec(struct vlapic *vlapic, uint32_t delmode,
 void
 vlapic_apicv_batch_set_tmr(struct vlapic *vlapic);
 
-int vlapic_mmio_access_handler(struct vcpu *vcpu, struct mem_io *mmio,
+int vlapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
 		void *handler_private_data);
 
 uint32_t vlapic_get_id(struct vlapic *vlapic);

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -15,6 +15,7 @@
 #include <lapic.h>
 #include <msr.h>
 #include <io.h>
+#include <ioreq.h>
 #include <mtrr.h>
 #include <vcpu.h>
 #include <trusty.h>

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -9,13 +9,6 @@
 
 #include <types.h>
 
-/* Definition of a IO port range */
-struct vm_io_range {
-	uint16_t base;		/* IO port base */
-	uint16_t len;		/* IO port range */
-	uint32_t flags;		/* IO port attributes */
-};
-
 /* Write 1 byte to specified I/O port */
 static inline void io_write_byte(uint8_t value, uint16_t port)
 {
@@ -82,80 +75,6 @@ static inline uint32_t io_read(uint16_t addr, size_t sz)
 	}
 	return io_read_long(addr);
 }
-
-struct vm_io_handler;
-struct vm;
-struct vcpu;
-
-typedef
-uint32_t (*io_read_fn_t)(struct vm_io_handler *, struct vm *,
-				uint16_t, size_t);
-
-typedef
-void (*io_write_fn_t)(struct vm_io_handler *, struct vm *,
-				uint16_t, size_t, uint32_t);
-
-/* Describes a single IO handler description entry. */
-struct vm_io_handler_desc {
-
-	/** The base address of the IO range for this description. */
-	uint16_t addr;
-	/** The number of bytes covered by this description. */
-	size_t len;
-
-	/** A pointer to the "read" function.
-	 *
-	 * The read function is called from the hypervisor whenever
-	 * a read access to a range described in "ranges" occur.
-	 * The arguments to the callback are:
-	 *
-	 *    - The address of the port to read from.
-	 *    - The width of the read operation (1,2 or 4).
-	 *
-	 * The implementation must return the ports content as
-	 * byte, word or doubleword (depending on the width).
-	 *
-	 * If the pointer is null, a read of 1's is assumed.
-	 */
-
-	io_read_fn_t io_read;
-	/** A pointer to the "write" function.
-	 *
-	 * The write function is called from the hypervisor code
-	 * whenever a write access to a range described in "ranges"
-	 * occur. The arguments to the callback are:
-	 *
-	 *   - The address of the port to write to.
-	 *   - The width of the write operation (1,2 or 4).
-	 *   - The value to write as byte, word or doubleword
-	 *     (depending on the width)
-	 *
-	 * The implementation must write the value to the port.
-	 *
-	 * If the pointer is null, the write access is ignored.
-    */
-
-	io_write_fn_t io_write;
-};
-
-struct vm_io_handler {
-	struct vm_io_handler *next;
-	struct vm_io_handler_desc desc;
-};
-
-#define IO_ATTR_R               0U
-#define IO_ATTR_RW              1U
-#define IO_ATTR_NO_ACCESS       2U
-
-/* External Interfaces */
-int io_instr_vmexit_handler(struct vcpu *vcpu);
-void   setup_io_bitmap(struct vm *vm);
-void   free_io_emulation_resource(struct vm *vm);
-void   allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes);
-void   register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
-		io_read_fn_t io_read_fn_ptr,
-		io_write_fn_t io_write_fn_ptr);
-int dm_emulate_pio_post(struct vcpu *vcpu);
 
 /** Writes a 32 bit value to a memory mapped IO device.
  *
@@ -326,25 +245,5 @@ static inline void setb(void *addr, uint8_t mask, uint8_t value)
 {
 	mmio_write_byte((mmio_read_byte(addr) & ~mask) | value, addr);
 }
-
-/* MMIO memory access types */
-enum mem_io_type {
-	HV_MEM_IO_READ = 0,
-	HV_MEM_IO_WRITE,
-};
-
-/* MMIO emulation related structures */
-#define MMIO_TRANS_VALID        1U
-#define MMIO_TRANS_INVALID      0U
-struct mem_io {
-	uint64_t paddr;      /* Physical address being accessed */
-	enum mem_io_type read_write;   /* 0 = read / 1 = write operation */
-	uint8_t access_size; /* Access size being emulated */
-	uint8_t sign_extend_read; /* 1 if sign extension required for read */
-	uint64_t value;      /* Value read or value to write */
-	uint8_t mmio_status; /* Indicates if this MMIO transaction is valid */
-	/* Used to store emulation context for this mmio transaction */
-	void *private_data;
-};
 
 #endif /* _IO_H defined */

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef IOREQ_H
+#define IOREQ_H
+
+#include <types.h>
+
+/* Definition of a IO port range */
+struct vm_io_range {
+	uint16_t base;		/* IO port base */
+	uint16_t len;		/* IO port range */
+	uint32_t flags;		/* IO port attributes */
+};
+
+struct vm_io_handler;
+struct vm;
+struct vcpu;
+
+typedef
+uint32_t (*io_read_fn_t)(struct vm_io_handler *, struct vm *,
+				uint16_t, size_t);
+
+typedef
+void (*io_write_fn_t)(struct vm_io_handler *, struct vm *,
+				uint16_t, size_t, uint32_t);
+
+/* Describes a single IO handler description entry. */
+struct vm_io_handler_desc {
+
+	/** The base address of the IO range for this description. */
+	uint16_t addr;
+	/** The number of bytes covered by this description. */
+	size_t len;
+
+	/** A pointer to the "read" function.
+	 *
+	 * The read function is called from the hypervisor whenever
+	 * a read access to a range described in "ranges" occur.
+	 * The arguments to the callback are:
+	 *
+	 *    - The address of the port to read from.
+	 *    - The width of the read operation (1,2 or 4).
+	 *
+	 * The implementation must return the ports content as
+	 * byte, word or doubleword (depending on the width).
+	 *
+	 * If the pointer is null, a read of 1's is assumed.
+	 */
+
+	io_read_fn_t io_read;
+	/** A pointer to the "write" function.
+	 *
+	 * The write function is called from the hypervisor code
+	 * whenever a write access to a range described in "ranges"
+	 * occur. The arguments to the callback are:
+	 *
+	 *   - The address of the port to write to.
+	 *   - The width of the write operation (1,2 or 4).
+	 *   - The value to write as byte, word or doubleword
+	 *     (depending on the width)
+	 *
+	 * The implementation must write the value to the port.
+	 *
+	 * If the pointer is null, the write access is ignored.
+    */
+
+	io_write_fn_t io_write;
+};
+
+struct vm_io_handler {
+	struct vm_io_handler *next;
+	struct vm_io_handler_desc desc;
+};
+
+#define IO_ATTR_R               0U
+#define IO_ATTR_RW              1U
+#define IO_ATTR_NO_ACCESS       2U
+
+/* MMIO memory access types */
+enum mem_io_type {
+    HV_MEM_IO_READ = 0,
+    HV_MEM_IO_WRITE,
+};
+
+/* MMIO emulation related structures */
+#define MMIO_TRANS_VALID        1U
+#define MMIO_TRANS_INVALID      0U
+struct mem_io {
+    uint64_t paddr;      /* Physical address being accessed */
+    enum mem_io_type read_write;   /* 0 = read / 1 = write operation */
+    uint8_t access_size; /* Access size being emulated */
+    uint8_t sign_extend_read; /* 1 if sign extension required for read */
+    uint64_t value;      /* Value read or value to write */
+    uint8_t mmio_status; /* Indicates if this MMIO transaction is valid */
+    /* Used to store emulation context for this mmio transaction */
+    void *private_data;
+};
+
+/* Typedef for MMIO handler and range check routine */
+struct mmio_request;
+typedef int (*hv_mem_io_handler_t)(struct vcpu *, struct mem_io *, void *);
+
+/* Structure for MMIO handler node */
+struct mem_io_node {
+	hv_mem_io_handler_t read_write;
+	void *handler_private_data;
+	struct list_head list;
+	uint64_t range_start;
+	uint64_t range_end;
+};
+
+/* External Interfaces */
+int io_instr_vmexit_handler(struct vcpu *vcpu);
+void   setup_io_bitmap(struct vm *vm);
+void   free_io_emulation_resource(struct vm *vm);
+void   allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes);
+void   register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
+		io_read_fn_t io_read_fn_ptr,
+		io_write_fn_t io_write_fn_ptr);
+int dm_emulate_pio_post(struct vcpu *vcpu);
+
+int register_mmio_emulation_handler(struct vm *vm,
+	hv_mem_io_handler_t read_write, uint64_t start,
+	uint64_t end, void *handler_private_data);
+void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
+        uint64_t end);
+int dm_emulate_mmio_post(struct vcpu *vcpu);
+
+int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req);
+
+#endif /* IOREQ_H */

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -8,6 +8,20 @@
 #define IOREQ_H
 
 #include <types.h>
+#include <acrn_common.h>
+
+/* Internal representation of a I/O request. */
+struct io_request {
+	/** Type of the request (PIO, MMIO, etc). Refer to vhm_request. */
+	uint32_t type;
+
+	/** Status of request handling. Written by request handlers and read by
+	 * the I/O emulation framework. Refer to vhm_request. */
+	int32_t processed;
+
+	/** Details of this request in the same format as vhm_request. */
+	union vhm_io_request reqs;
+};
 
 /* Definition of a IO port range */
 struct vm_io_range {
@@ -80,29 +94,9 @@ struct vm_io_handler {
 #define IO_ATTR_RW              1U
 #define IO_ATTR_NO_ACCESS       2U
 
-/* MMIO memory access types */
-enum mem_io_type {
-    HV_MEM_IO_READ = 0,
-    HV_MEM_IO_WRITE,
-};
-
-/* MMIO emulation related structures */
-#define MMIO_TRANS_VALID        1U
-#define MMIO_TRANS_INVALID      0U
-struct mem_io {
-    uint64_t paddr;      /* Physical address being accessed */
-    enum mem_io_type read_write;   /* 0 = read / 1 = write operation */
-    uint8_t access_size; /* Access size being emulated */
-    uint8_t sign_extend_read; /* 1 if sign extension required for read */
-    uint64_t value;      /* Value read or value to write */
-    uint8_t mmio_status; /* Indicates if this MMIO transaction is valid */
-    /* Used to store emulation context for this mmio transaction */
-    void *private_data;
-};
-
 /* Typedef for MMIO handler and range check routine */
 struct mmio_request;
-typedef int (*hv_mem_io_handler_t)(struct vcpu *, struct mem_io *, void *);
+typedef int (*hv_mem_io_handler_t)(struct vcpu *, struct io_request *, void *);
 
 /* Structure for MMIO handler node */
 struct mem_io_node {
@@ -130,6 +124,6 @@ void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
         uint64_t end);
 int dm_emulate_mmio_post(struct vcpu *vcpu);
 
-int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct vhm_request *req);
+int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct io_request *req);
 
 #endif /* IOREQ_H */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -303,18 +303,6 @@ static inline void mem_write64(void *addr, uint64_t data)
 	*addr64 = data;
 }
 
-/* Typedef for MMIO handler and range check routine */
-typedef int(*hv_mem_io_handler_t)(struct vcpu *, struct mem_io *, void *);
-
-/* Structure for MMIO handler node */
-struct mem_io_node {
-	hv_mem_io_handler_t read_write;
-	void *handler_private_data;
-	struct list_head list;
-	uint64_t range_start;
-	uint64_t range_end;
-};
-
 uint64_t get_paging_pml4(void);
 bool check_mmu_1gb_support(enum _page_table_type page_table_type);
 void *alloc_paging_struct(void);
@@ -341,13 +329,6 @@ int obtain_last_page_table_entry(struct map_params *map_params,
 		struct entry_params *entry, void *addr, bool direct);
 uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, enum _page_table_type ptt);
-
-int register_mmio_emulation_handler(struct vm *vm,
-	hv_mem_io_handler_t read_write, uint64_t start,
-	uint64_t end, void *handler_private_data);
-
-void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
-        uint64_t end);
 
 #pragma pack(1)
 
@@ -411,7 +392,6 @@ int ept_mr_del(struct vm *vm, uint64_t *pml4_page,
 
 int     ept_violation_vmexit_handler(struct vcpu *vcpu);
 int     ept_misconfig_vmexit_handler(struct vcpu *vcpu);
-int     dm_emulate_mmio_post(struct vcpu *vcpu);
 
 #endif /* ASSEMBLER not defined */
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -83,6 +83,13 @@ struct pci_request {
 	int32_t reg;
 } __aligned(8);
 
+union vhm_io_request {
+	struct pio_request pio;
+	struct pci_request pci;
+	struct mmio_request mmio;
+	int64_t reserved1[8];
+};
+
 /* vhm_request are 256Bytes aligned */
 struct vhm_request {
 	/* offset: 0bytes - 63bytes */
@@ -90,12 +97,7 @@ struct vhm_request {
 	int32_t reserved0[15];
 
 	/* offset: 64bytes-127bytes */
-	union {
-		struct pio_request pio_request;
-		struct pci_request pci_request;
-		struct mmio_request mmio_request;
-		int64_t reserved1[8];
-	} reqs;
+	union vhm_io_request reqs;
 
 	/* True: valid req which need VHM to process.
 	 * ACRN write, VHM read only


### PR DESCRIPTION
This series moves I/O emulation related declarations to a separate ioreq.h and cleans up the duplication of I/O request-related structures in vcpu.

Next steps:
* Name cleanup ('pio' for port I/O, 'mmio' for memory mapped I/O, and 'io' for both)
* I/O emulation code cleanup
* Simplification of VHM request states
* Cleanup emulation under abnormal cases.