### PR TITLE
HV:treewide:fix "Reference parameter to procedure is reassigned"

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -1009,8 +1009,9 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 	}
 }
 
-void get_ptdev_info(char *str, int str_max)
+void get_ptdev_info(char *str_arg, int str_max)
 {
+	char *str = str_arg;
 	struct ptdev_remapping_info *entry;
 	int len, size = str_max;
 	uint32_t irq, vector;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -352,9 +352,10 @@ static inline uint32_t _copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
 	return len;
 }
 
-static inline int copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa_arg,
+static inline int copy_gpa(struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
 	uint32_t size_arg, bool cp_from_vm)
 {
+	void *h_ptr = h_ptr_arg;
 	uint32_t len;
 	uint64_t gpa = gpa_arg;
 	uint32_t size = size_arg;
@@ -378,9 +379,10 @@ static inline int copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa_arg,
 	return 0;
 }
 
-static inline int copy_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva_arg,
+static inline int copy_gva(struct vcpu *vcpu, void *h_ptr_arg, uint64_t gva_arg,
 	uint32_t size_arg, uint32_t *err_code, bool cp_from_vm)
 {
+	void *h_ptr = h_ptr_arg;
 	uint64_t gpa = 0UL;
 	int32_t ret;
 	uint32_t len;

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -644,8 +644,9 @@ bool vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte)
 }
 
 #ifdef HV_DEBUG
-void get_vioapic_info(char *str, int str_max, uint16_t vmid)
+void get_vioapic_info(char *str_arg, int str_max, uint16_t vmid)
 {
+	char *str = str_arg;
 	int len, size = str_max;
 	union ioapic_rte rte;
 	uint32_t delmode, vector, dest;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -454,8 +454,9 @@ static void get_rte_info(union ioapic_rte rte, bool *mask, bool *irr,
 	*dest = (uint32_t)(rte.full >> APIC_ID_SHIFT);
 }
 
-int get_ioapic_info(char *str, int str_max_len)
+int get_ioapic_info(char *str_arg, int str_max_len)
 {
+	char *str = str_arg;
 	uint32_t irq;
 	int len, size = str_max_len;
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -685,8 +685,9 @@ pri_register_handler(uint32_t irq,
 }
 
 #ifdef HV_DEBUG
-void get_cpu_interrupt_info(char *str, int str_max)
+void get_cpu_interrupt_info(char *str_arg, int str_max)
 {
+	char *str = str_arg;
 	uint16_t pcpu_id;
 	uint32_t irq, vector;
 	int len, size = str_max;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -889,9 +889,11 @@ static uint64_t break_page_table(struct map_params *map_params, void *paddr,
 	return next_page_size;
 }
 
-static int modify_paging(struct map_params *map_params, void *paddr,
-		void *vaddr, uint64_t size, uint32_t flags, bool direct)
+static int modify_paging(struct map_params *map_params, void *paddr_arg,
+		void *vaddr_arg, uint64_t size, uint32_t flags, bool direct)
 {
+	void *vaddr = vaddr_arg;
+	void *paddr = paddr_arg;
 	int64_t  remaining_size;
 	uint64_t adjust_size;
 	uint64_t attr = flags;

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -151,8 +151,9 @@ int32_t hv_main(uint16_t pcpu_id)
 }
 
 #ifdef HV_DEBUG
-void get_vmexit_profile(char *str, int str_max)
+void get_vmexit_profile(char *str_arg, int str_max)
 {
+	char *str = str_arg;
 	uint16_t cpu, i;
 	int len, size = str_max;
 

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -157,8 +157,9 @@ static void _get_req_info_(struct vhm_request *req, int *id, char *type,
 	}
 }
 
-void get_req_info(char *str, int str_max)
+void get_req_info(char *str_arg, int str_max)
 {
+	char *str = str_arg;
 	uint32_t i;
 	int32_t len, size = str_max, client_id;
 	union vhm_request_buffer *req_buf;

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -51,8 +51,9 @@ int console_putc(int ch)
 	return res;
 }
 
-int console_puts(const char *s)
+int console_puts(const char *s_arg)
 {
+	const char *s = s_arg;
 	int res = -1;
 	const char *p;
 
@@ -91,8 +92,9 @@ int console_puts(const char *s)
 	return res;
 }
 
-int console_write(const char *s, size_t len)
+int console_write(const char *s_arg, size_t len)
 {
+	const char *s = s_arg;
 	int res = -1;
 	const char *e;
 	const char *p;

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -6,8 +6,10 @@
 
 #include <hypervisor.h>
 
-static int charout(int cmd, const char *s, uint32_t sz, void *hnd)
+static int charout(int cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
 {
+	const char *s = s_arg;
+	uint32_t sz = sz_arg;
 	/* pointer to an integer to store the number of characters */
 	int *nchars = (int *)hnd;
 	/* working pointer */

--- a/hypervisor/debug/serial.c
+++ b/hypervisor/debug/serial.c
@@ -317,8 +317,9 @@ static int serial_putc(uint32_t uart_handle, int c)
 	return ((bytes_written > 0U) ? c : (SERIAL_EOF));
 }
 
-int serial_puts(uint32_t uart_handle, const char *s, uint32_t length_arg)
+int serial_puts(uint32_t uart_handle, const char *s_arg, uint32_t length_arg)
 {
+	const char *s = s_arg;
 	const char *old_data = s;
 	uint32_t index;
 	struct uart *port;

--- a/hypervisor/debug/serial_internal.h
+++ b/hypervisor/debug/serial_internal.h
@@ -178,7 +178,7 @@ extern struct tgt_uart Tgt_Uarts[SERIAL_MAX_DEVS];
 uint32_t serial_open(const char *uart_id);
 int serial_getc(uint32_t uart_handle);
 int serial_gets(uint32_t uart_handle, char *buffer, uint32_t length_arg);
-int serial_puts(uint32_t uart_handle, const char *s, uint32_t length_arg);
+int serial_puts(uint32_t uart_handle, const char *s_arg, uint32_t length_arg);
 uint32_t serial_get_rx_data(uint32_t uart_handle);
 
 #endif /* !SERIAL_INTER_H */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -120,7 +120,7 @@ int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 uint64_t create_guest_init_gdt(struct vm *vm, uint32_t *limit);
 
 #ifdef HV_DEBUG
-void get_req_info(char *str, int str_max);
+void get_req_info(char *str_arg, int str_max);
 #endif /* HV_DEBUG */
 
 #endif	/* !ASSEMBLER */

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -56,7 +56,7 @@ int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
 		void *handler_private_data);
 
 #ifdef HV_DEBUG
-void get_vioapic_info(char *str, int str_max, uint16_t vmid);
+void get_vioapic_info(char *str_arg, int str_max, uint16_t vmid);
 #endif /* HV_DEBUG */
 
 #endif

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -36,7 +36,7 @@ extern uint8_t legacy_irq_to_pin[NR_LEGACY_IRQ];
 extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
 
 #ifdef HV_DEBUG
-int get_ioapic_info(char *str, int str_max_len);
+int get_ioapic_info(char *str_arg, int str_max_len);
 #endif /* HV_DEBUG */
 
 #endif /* IOAPIC_H */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -94,7 +94,7 @@ void interrupt_init(uint16_t pcpu_id);
 void cancel_event_injection(struct vcpu *vcpu);
 
 #ifdef HV_DEBUG
-void get_cpu_interrupt_info(char *str, int str_max);
+void get_cpu_interrupt_info(char *str_arg, int str_max);
 #endif /* HV_DEBUG */
 
 #endif /* ARCH_IRQ_H */

--- a/hypervisor/include/arch/x86/vmexit.h
+++ b/hypervisor/include/arch/x86/vmexit.h
@@ -48,7 +48,7 @@ int cr_access_vmexit_handler(struct vcpu *vcpu);
 	(VM_EXIT_QUALIFICATION_BIT_MASK(exit_qual, 31U, 16U) >> 16U)
 
 #ifdef HV_DEBUG
-void get_vmexit_profile(char *str, int str_max);
+void get_vmexit_profile(char *str_arg, int str_max);
 #endif /* HV_DEBUG */
 
 #endif /* VMEXIT_H_ */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -81,7 +81,7 @@ void ptdev_activate_entry(
 void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
 
 #ifdef HV_DEBUG
-void get_ptdev_info(char *str, int str_max);
+void get_ptdev_info(char *str_arg, int str_max);
 #endif /* HV_DEBUG */
 
 #endif /* PTDEV_H */

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -24,7 +24,7 @@ void console_init(void);
  *          and no character was written.
  */
 
-int console_puts(const char *str);
+int console_puts(const char *s_arg);
 
 /** Writes a given number of characters to the console.
  *
@@ -35,7 +35,7 @@ int console_puts(const char *str);
  *          and no character was written.
  */
 
-int console_write(const char *str, size_t len);
+int console_write(const char *s_arg, size_t len);
 
 /** Writes a single character to the console.
  *

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -28,13 +28,13 @@ struct udiv_result {
 /* Function prototypes */
 void udelay(uint32_t us);
 void *memchr(const void *void_s, int c, size_t n);
-int strcmp(const char *s1, const char *s2);
-int strncmp(const char *s1, const char *s2, size_t n);
-char *strcpy_s(char *d, size_t dmax, const char *s_arg);
-char *strncpy_s(char *d, size_t dmax, const char *s, size_t slen_arg);
-char *strchr(const char *s, int ch);
+int strcmp(const char *s1_arg, const char *s2_arg);
+int strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg);
+char *strcpy_s(char *d_arg, size_t dmax, const char *s_arg);
+char *strncpy_s(char *d_arg, size_t dmax, const char *s, size_t slen_arg);
+char *strchr(const char *s_arg, int ch);
 void mdelay(uint32_t loop_count_arg);
-size_t strnlen_s(const char *str, size_t maxlen_arg);
+size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
 void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg);
 int udiv64(uint64_t dividend_arg, uint64_t divisor_arg, struct udiv_result *res);

--- a/hypervisor/include/lib/sprintf.h
+++ b/hypervisor/include/lib/sprintf.h
@@ -42,7 +42,7 @@ struct print_param {
 	} vars;
 };
 
-int do_print(const char *fmt, struct print_param *param,
+int do_print(const char *fmt_arg, struct print_param *param,
 		__builtin_va_list args);
 
 /**  The well known vsnprintf() function.
@@ -56,7 +56,7 @@ int do_print(const char *fmt, struct print_param *param,
  * @return The number of bytes which would be written, even if the destination
  *         is smaller. On error a negative number is returned.
  */
-int vsnprintf(char *dst, size_t sz, const char *fmt, va_list args);
+int vsnprintf(char *dst_arg, size_t sz_arg, const char *fmt, va_list args);
 
 /** The well known snprintf() function.
  *

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -83,8 +83,9 @@ static const char lower_hex_digits[] = {
 	'a', 'b', 'c', 'd', 'e', 'f', 'x'
 };
 
-static const char *get_param(const char *s, uint32_t *x)
+static const char *get_param(const char *s_arg, uint32_t *x)
 {
+	const char *s = s_arg;
 	*x = 0U;
 
 	/* ignore '-' for negative numbers, it will be handled in flags*/
@@ -102,8 +103,9 @@ static const char *get_param(const char *s, uint32_t *x)
 	return s;
 }
 
-static const char *get_flags(const char *s, uint32_t *flags)
+static const char *get_flags(const char *s_arg, uint32_t *flags)
 {
+	const char *s = s_arg;
 	/* contains the flag characters */
 	static const char flagchars[] = "#0- +";
 	/* contains the numeric flags for the characters above */
@@ -152,9 +154,10 @@ static const char *get_flags(const char *s, uint32_t *flags)
 	return s;
 }
 
-static const char *get_length_modifier(const char *s,
+static const char *get_length_modifier(const char *s_arg,
 			uint32_t *flags, uint64_t *mask)
 {
+	const char *s = s_arg;
 	if (*s == 'h') {
 		/* check for h[h] (char/short) */
 		s++;
@@ -460,9 +463,10 @@ static int print_string(struct print_param *param, const char *s)
 	return res;
 }
 
-int do_print(const char *fmt, struct print_param *param,
+int do_print(const char *fmt_arg, struct print_param *param,
 		__builtin_va_list args)
 {
+	const char *fmt = fmt_arg;
 	/* the result of this function */
 	int res = 0;
 	/* temp. storage for the next character */
@@ -616,8 +620,9 @@ int do_print(const char *fmt, struct print_param *param,
 	return res;
 }
 
-static int charmem(int cmd, const char *s, uint32_t sz, void *hnd)
+static int charmem(int cmd, const char *s_arg, uint32_t sz, void *hnd)
 {
+	const char *s = s_arg;
 	/* pointer to the snprint parameter list */
 	struct snprint_param *param = (struct snprint_param *) hnd;
 	/* pointer to the destination */
@@ -650,8 +655,10 @@ static int charmem(int cmd, const char *s, uint32_t sz, void *hnd)
 	return (int)n;
 }
 
-int vsnprintf(char *dst, size_t sz, const char *fmt, va_list args)
+int vsnprintf(char *dst_arg, size_t sz_arg, const char *fmt, va_list args)
 {
+	char *dst = dst_arg;
+	int32_t sz = sz_arg;
 	int res = 0;
 
 	if (sz == 0U || (dst == NULL)) {

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -153,8 +153,9 @@ int atoi(const char *str)
 	return (int)strtol_deci(str);
 }
 
-char *strchr(const char *s, int ch)
+char *strchr(const char *s_arg, int ch)
 {
+	const char *s = s_arg;
 	while ((*s != '\0') && (*s != ch)) {
 		++s;
 	}
@@ -184,13 +185,13 @@ char *strchr(const char *s, int ch)
  *    1) both d and s shall not be null pointers.
  *    2) dmax shall not 0.
  */
-char *strcpy_s(char *d, size_t dmax, const char *s_arg)
+char *strcpy_s(char *d_arg, size_t dmax, const char *s_arg)
 {
-
+	char *d = d_arg;
+	const char *s = s_arg;
 	char *dest_base;
 	size_t dest_avail;
 	uint64_t overlap_guard;
-	const char *s = s_arg;
 
 	if (s == NULL || d == NULL || dmax == 0U) {
 		pr_err("%s: invalid src, dest buffer or length.", __func__);
@@ -261,8 +262,10 @@ char *strcpy_s(char *d, size_t dmax, const char *s_arg)
  *    3) will assert() if overlap happens or dest buffer has no
  *       enough space.
  */
-char *strncpy_s(char *d, size_t dmax, const char *s, size_t slen_arg)
+char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg)
 {
+	const char *s = s_arg;
+	char *d = d_arg;
 	char *dest_base;
 	size_t dest_avail;
 	uint64_t overlap_guard;
@@ -339,10 +342,11 @@ char *strncpy_s(char *d, size_t dmax, const char *s, size_t slen_arg)
  *    string length, excluding the null character.
  *    will return 0 if str is null.
  */
-size_t strnlen_s(const char *str, size_t maxlen_arg)
+size_t strnlen_s(const char *str_arg, size_t maxlen_arg)
 {
-	size_t count;
+	const char *str = str_arg;
 	size_t maxlen = maxlen_arg;
+	size_t count;
 
 	if (str == NULL) {
 		return 0;
@@ -371,8 +375,10 @@ static char hexdigit(uint8_t decimal_val)
 	return hexdigits[decimal_val & 0x0FU];
 }
 
-int strcmp(const char *s1, const char *s2)
+int strcmp(const char *s1_arg, const char *s2_arg)
 {
+	const char *s1 = s1_arg;
+	const char *s2 = s2_arg;
 	while (((*s1) != '\0') && ((*s2) != '\0') && ((*s1) == (*s2))) {
 		s1++;
 		s2++;
@@ -381,8 +387,10 @@ int strcmp(const char *s1, const char *s2)
 	return *s1 - *s2;
 }
 
-int strncmp(const char *s1, const char *s2, size_t n_arg)
+int strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg)
 {
+	const char *s1 = s1_arg;
+	const char *s2 = s2_arg;
 	size_t n = n_arg;
 	while (((n - 1) != 0U) && ((*s1) != '\0') && ((*s2) != '\0')
 		&& ((*s1) == (*s2))) {


### PR DESCRIPTION
Parameter's type which is pointer should not be changed in the
scope of function,assign it's value to local variable to fixed
it out.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>