### PR TITLE
DM: add service to support auot boot UOS

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -184,6 +184,7 @@ install-samples-nuc: $(SAMPLES_NUC)
 
 install-samples-mrb: $(SAMPLES_MRB)
 	install -D -t $(DESTDIR)/usr/share/acrn/samples/apl-mrb $^
+	install -p -D -m 0644 ./samples/apl-mrb/acrn_guest.service $(DESTDIR)/usr/lib/systemd/system
 
 install-bios: $(BIOS_BIN)
 	install -d $(DESTDIR)/usr/share/acrn/bios

--- a/devicemodel/samples/apl-mrb/acrn_guest.service
+++ b/devicemodel/samples/apl-mrb/acrn_guest.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Start ACRN UOS
+After=systemd-networkd.service
+
+ConditionPathExists=/sys/kernel/gvt
+
+[Service]
+Type=simple
+RemainAfterExit=false
+ExecStart=/bin/sh /usr/share/acrn/samples/apl-mrb/launch_uos.sh -V 5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
add acrn_guest.service, and modify makefile to install it
into root fs.

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Like Yan <like.yan@intel.com>