### PR TITLE
HV:treewide:fix rest of violations related parameter changed

### DIFF
--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -177,8 +177,9 @@ void free_io_emulation_resource(struct vm *vm)
 	free(vm->arch_vm.iobitmap[1]);
 }
 
-void allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes)
+void allow_guest_io_access(struct vm *vm, uint32_t address_arg, uint32_t nbytes)
 {
+	uint32_t address = address_arg;
 	uint32_t *b;
 	uint32_t i;
 	uint32_t a;
@@ -194,8 +195,9 @@ void allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes)
 	}
 }
 
-static void deny_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes)
+static void deny_guest_io_access(struct vm *vm, uint32_t address_arg, uint32_t nbytes)
 {
+	uint32_t address = address_arg;
 	uint32_t *b;
 	uint32_t i;
 	uint32_t a;

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -230,12 +230,13 @@ void check_tsc(void)
 	CPU_CR_WRITE(cr4, (temp64 & ~CR4_TSD));
 }
 
-static uint64_t pit_calibrate_tsc(uint16_t cal_ms)
+static uint64_t pit_calibrate_tsc(uint16_t cal_ms_arg)
 {
 #define PIT_TICK_RATE	1193182U
 #define PIT_TARGET	0x3FFFU
 #define PIT_MAX_COUNT	0xFFFFU
 
+	uint16_t cal_ms = cal_ms_arg;
 	uint32_t initial_pit;
 	uint16_t current_pit;
 	uint16_t max_cal_ms;

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -180,8 +180,9 @@ static void dump_guest_context(uint16_t pcpu_id)
 	}
 }
 
-static void show_host_call_trace(uint64_t rsp, uint64_t rbp, uint16_t pcpu_id)
+static void show_host_call_trace(uint64_t rsp, uint64_t rbp_arg, uint16_t pcpu_id)
 {
+	uint64_t rbp = rbp_arg;
 	uint32_t i = 0U;
 	uint32_t cb_hierarchy = 0U;
 	uint64_t *sp = (uint64_t *)rsp;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -152,9 +152,10 @@ static void uart_toggle_intr(struct vuart *vu)
 }
 
 static void uart_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t offset,
+		struct vm *vm, uint16_t offset_arg,
 		__unused size_t width, uint32_t value)
 {
+	uint16_t offset = offset_arg;
 	struct vuart *vu = vm_vuart(vm);
 	offset -= vu->base;
 	vuart_lock(vu);
@@ -231,9 +232,10 @@ done:
 }
 
 static uint32_t uart_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t offset,
+		struct vm *vm, uint16_t offset_arg,
 		__unused size_t width)
 {
+	uint16_t offset = offset_arg;
 	char iir, reg;
 	uint8_t intr_reason;
 	struct vuart *vu = vm_vuart(vm);

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -111,7 +111,7 @@ struct mem_io_node {
 int io_instr_vmexit_handler(struct vcpu *vcpu);
 void   setup_io_bitmap(struct vm *vm);
 void   free_io_emulation_resource(struct vm *vm);
-void   allow_guest_io_access(struct vm *vm, uint32_t address, uint32_t nbytes);
+void   allow_guest_io_access(struct vm *vm, uint32_t address_arg, uint32_t nbytes);
 void   register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr);

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -176,9 +176,10 @@ static inline uint16_t clz64(uint64_t value)
  * If nr>=64, it will be truncated.
  */
 #define build_bitmap_set(name, op_len, op_type, lock, nr, addr)	\
-static inline void name(uint16_t nr, volatile op_type *addr)	\
+static inline void name(uint16_t nr_arg, volatile op_type *addr)	\
 {								\
-	nr = nr & ((8U * sizeof(op_type)) - 1U);		\
+	uint16_t nr;					\
+	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);	        \
 	asm volatile(lock "or" op_len " %1,%0"			\
 			:  "+m" (*addr)				\
 			:  "r" ((op_type)(1UL<<nr))		\
@@ -195,9 +196,10 @@ build_bitmap_set(bitmap32_set, "l", uint32_t, BUS_LOCK, nr, addr)
  * If nr>=64, it will be truncated.
  */
 #define build_bitmap_clear(name, op_len, op_type, lock, nr, addr)	\
-static inline void name(uint16_t nr, volatile op_type *addr) 		\
+static inline void name(uint16_t nr_arg, volatile op_type *addr)        \
 {									\
-	nr = nr & ((8U * sizeof(op_type)) - 1U);			\
+	uint16_t nr;					        \
+	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "and" op_len " %1,%0"				\
 			:  "+m" (*addr)					\
 			:  "r" ((op_type)(~(1UL<<(nr))))		\
@@ -213,10 +215,11 @@ build_bitmap_clear(bitmap32_clear, "l", uint32_t, BUS_LOCK, nr, addr)
  * Note:Input parameter nr shall be less than 64. If nr>=64, it will
  * be truncated.
  */
-static inline bool bitmap_test(uint16_t nr, volatile uint64_t *addr)
+static inline bool bitmap_test(uint16_t nr_arg, volatile uint64_t *addr)
 {
+	uint16_t nr;
 	int32_t ret=0;
-	nr = nr & 0x3fU;
+	nr = nr_arg & 0x3fU;
 	asm volatile("btq %q2,%1\n\tsbbl %0, %0"
 			: "=r" (ret), "=m" (*addr)
 			: "r" ((uint64_t)nr)
@@ -224,10 +227,11 @@ static inline bool bitmap_test(uint16_t nr, volatile uint64_t *addr)
 	return (ret != 0);
 }
 
-static inline bool bitmap32_test(uint16_t nr, volatile uint32_t *addr)
+static inline bool bitmap32_test(uint16_t nr_arg, volatile uint32_t *addr)
 {
+	uint16_t nr;
 	int32_t ret=0;
-	nr = nr & 0x1fU;
+	nr = nr_arg & 0x1fU;
 	asm volatile("btl %2,%1\n\tsbbl %0, %0"
 			: "=r" (ret), "=m" (*addr)
 			: "r" ((uint32_t)nr)
@@ -243,10 +247,11 @@ static inline bool bitmap32_test(uint16_t nr, volatile uint32_t *addr)
  * will be truncated.
  */
 #define build_bitmap_testandset(name, op_len, op_type, lock, nr, addr)	\
-static inline bool name(uint16_t nr, volatile op_type *addr)		\
+static inline bool name(uint16_t nr_arg, volatile op_type *addr)        \
 {									\
+	uint16_t nr;						\
 	int32_t ret=0;							\
-	nr = nr & ((8U * sizeof(op_type)) - 1U);			\
+	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "bts" op_len " %2,%1\n\tsbbl %0,%0"		\
 			: "=r" (ret), "=m" (*addr)			\
 			: "r" ((op_type)nr)				\
@@ -266,10 +271,11 @@ build_bitmap_testandset(bitmap32_test_and_set, "l", uint32_t, BUS_LOCK, nr, addr
  * it will be truncated.
  */
 #define build_bitmap_testandclear(name, op_len, op_type, lock, nr, addr)\
-static inline bool name(uint16_t nr, volatile op_type *addr)		\
+static inline bool name(uint16_t nr_arg, volatile op_type *addr)        \
 {									\
+	uint16_t nr;						\
 	int32_t ret=0;							\
-	nr = nr & ((8U * sizeof(op_type)) - 1U);			\
+	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "btr" op_len " %2,%1\n\tsbbl %0,%0"		\
 			: "=r" (ret), "=m" (*addr)			\
 			: "r" ((op_type)nr)				\

--- a/hypervisor/lib/div.c
+++ b/hypervisor/lib/div.c
@@ -6,10 +6,11 @@
 
 #include <hv_lib.h>
 
-static int do_udiv32(uint32_t dividend_arg, uint32_t divisor,
+static int do_udiv32(uint32_t dividend_arg, uint32_t divisor_arg,
 	struct udiv_result *res)
 {
 	uint32_t dividend = dividend_arg;
+	uint32_t divisor = divisor_arg;
 	uint32_t mask;
 	/* dividend is always greater than or equal to the divisor. Neither
 	 * divisor nor dividend are 0. Thus: * clz(dividend) and clz(divisor)

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -281,8 +281,9 @@ static int format_number(struct print_param *param)
 }
 
 static int print_pow2(struct print_param *param,
-		uint64_t v, uint32_t shift)
+		uint64_t v_arg, uint32_t shift)
 {
+	uint64_t v = v_arg;
 	/* max buffer required for octal representation of unsigned long long */
 	char digitbuff[22];
 	/* Insert position for the next character+1 */


### PR DESCRIPTION
Misra c required parameter should not changed in the scope
of function,use local variable to replace it.

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>