### PR TITLE
HV: clear memory region used by UOS before it exit

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -339,6 +339,20 @@ vm_setup_memory(struct vmctx *ctx, size_t memsize)
 void
 vm_unsetup_memory(struct vmctx *ctx)
 {
+	/*
+	 * For security reason, clean the VM's memory region
+	 * to avoid secret information leaking in below case:
+	 * After a UOS is destroyed, the memory will be reclaimed,
+	 * then if the new UOS starts, that memory region may be
+	 * allocated the new UOS, the previous UOS sensitive data
+	 * may be leaked to the new UOS if the memory is not cleared.
+	 *
+	 */
+	bzero((void *)ctx->baseaddr, ctx->lowmem);
+	if (ctx->highmem > 0) {
+		bzero((void *)(ctx->baseaddr + 4 * GB), ctx->highmem);
+	}
+
 	hugetlb_unsetup_memory(ctx);
 }
 


### PR DESCRIPTION
 this patch fixes such an information leaking issue:
   in case that after a UOS is destroyed, its memroy
   will be reclaimed and maybe re-allocated for a new UOS,
   then the previous UOS sensitive data in memory may
   be leaked to the new UOS.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>