### PR TITLE
Rename struct timer, vie, vie_op, emul_ctxt

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -58,7 +58,7 @@
 #define	VIE_OP_F_NO_MODRM	(1U << 3)
 #define	VIE_OP_F_NO_GLA_VERIFICATION (1U << 4)
 
-static const struct vie_op two_byte_opcodes[256] = {
+static const struct instr_emul_vie_op two_byte_opcodes[256] = {
 	[0xB6] = {
 		.op_byte = 0xB6,
 		.op_type = VIE_OP_TYPE_MOVZX,
@@ -78,7 +78,7 @@ static const struct vie_op two_byte_opcodes[256] = {
 	},
 };
 
-static const struct vie_op one_byte_opcodes[256] = {
+static const struct instr_emul_vie_op one_byte_opcodes[256] = {
 	[0x0F] = {
 		.op_byte = 0x0FU,
 		.op_type = VIE_OP_TYPE_TWO_BYTE
@@ -234,7 +234,7 @@ vie_read_register(struct vcpu *vcpu, enum cpu_reg_name reg, uint64_t *rval)
 }
 
 static void
-vie_calc_bytereg(struct vie *vie, enum cpu_reg_name *reg, int *lhbr)
+vie_calc_bytereg(struct instr_emul_vie *vie, enum cpu_reg_name *reg, int *lhbr)
 {
 	*lhbr = 0;
 	*reg = vie->reg;
@@ -260,7 +260,7 @@ vie_calc_bytereg(struct vie *vie, enum cpu_reg_name *reg, int *lhbr)
 }
 
 static int
-vie_read_bytereg(struct vcpu *vcpu, struct vie *vie, uint8_t *rval)
+vie_read_bytereg(struct vcpu *vcpu, struct instr_emul_vie *vie, uint8_t *rval)
 {
 	uint64_t val;
 	int error, lhbr;
@@ -282,7 +282,7 @@ vie_read_bytereg(struct vcpu *vcpu, struct vie *vie, uint8_t *rval)
 }
 
 static int
-vie_write_bytereg(struct vcpu *vcpu, struct vie *vie, uint8_t byte)
+vie_write_bytereg(struct vcpu *vcpu, struct instr_emul_vie *vie, uint8_t byte)
 {
 	uint64_t origval, val, mask;
 	int error, lhbr;
@@ -400,7 +400,7 @@ getcc(uint8_t opsize, uint64_t x, uint64_t y)
 }
 
 static int
-emulate_mov(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_mov(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, mem_region_write_t memwrite,
 		void *arg)
 {
@@ -526,7 +526,7 @@ emulate_mov(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_movx(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_movx(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, __unused mem_region_write_t memwrite,
 		void *arg)
 {
@@ -619,7 +619,7 @@ emulate_movx(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
  * Helper function to calculate and validate a linear address.
  */
 static int
-get_gla(struct vcpu *vcpu, __unused struct vie *vie,
+get_gla(struct vcpu *vcpu, __unused struct instr_emul_vie *vie,
 	struct vm_guest_paging *paging,
 	uint8_t opsize, uint8_t addrsize, uint32_t prot, enum cpu_reg_name seg,
 	enum cpu_reg_name gpr, uint64_t *gla, int *fault)
@@ -677,7 +677,7 @@ guest_fault:
 }
 
 static int
-emulate_movs(struct vcpu *vcpu, __unused uint64_t gpa, struct vie *vie,
+emulate_movs(struct vcpu *vcpu, __unused uint64_t gpa, struct instr_emul_vie *vie,
 		struct vm_guest_paging *paging,
 		__unused mem_region_read_t memread,
 		__unused mem_region_write_t memwrite,
@@ -766,7 +766,7 @@ done:
 }
 
 static int
-emulate_stos(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_stos(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		__unused struct vm_guest_paging *paging,
 		__unused mem_region_read_t memread,
 		mem_region_write_t memwrite, void *arg)
@@ -827,7 +827,7 @@ emulate_stos(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_test(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_test(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, __unused mem_region_write_t memwrite,
 		void *arg)
 {
@@ -893,7 +893,7 @@ emulate_test(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_and(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_and(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, mem_region_write_t memwrite,
 		void *arg)
 {
@@ -982,7 +982,7 @@ emulate_and(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_or(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_or(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, mem_region_write_t memwrite,
 		void *arg)
 {
@@ -1074,7 +1074,7 @@ emulate_or(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_cmp(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_cmp(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, __unused mem_region_write_t memwrite,
 		void *arg)
 {
@@ -1172,7 +1172,7 @@ emulate_cmp(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_sub(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_sub(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, __unused mem_region_write_t memwrite,
 		void *arg)
 {
@@ -1227,7 +1227,7 @@ emulate_sub(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_stack_op(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
+emulate_stack_op(struct vcpu *vcpu, uint64_t mmio_gpa, struct instr_emul_vie *vie,
 		struct vm_guest_paging *paging, mem_region_read_t memread,
 		mem_region_write_t memwrite, void *arg)
 {
@@ -1338,7 +1338,7 @@ emulate_stack_op(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
 }
 
 static int
-emulate_push(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
+emulate_push(struct vcpu *vcpu, uint64_t mmio_gpa, struct instr_emul_vie *vie,
 		struct vm_guest_paging *paging, mem_region_read_t memread,
 		mem_region_write_t memwrite, void *arg)
 {
@@ -1360,7 +1360,7 @@ emulate_push(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
 }
 
 static int
-emulate_pop(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
+emulate_pop(struct vcpu *vcpu, uint64_t mmio_gpa, struct instr_emul_vie *vie,
 		struct vm_guest_paging *paging, mem_region_read_t memread,
 		mem_region_write_t memwrite, void *arg)
 {
@@ -1382,7 +1382,7 @@ emulate_pop(struct vcpu *vcpu, uint64_t mmio_gpa, struct vie *vie,
 }
 
 static int
-emulate_group1(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_group1(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		__unused struct vm_guest_paging *paging,
 		mem_region_read_t memread,
 		mem_region_write_t memwrite, void *memarg)
@@ -1411,7 +1411,7 @@ emulate_group1(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 static int
-emulate_bittest(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+emulate_bittest(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		mem_region_read_t memread, __unused mem_region_write_t memwrite,
 		void *memarg)
 {
@@ -1457,7 +1457,7 @@ emulate_bittest(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
 }
 
 int
-vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		struct vm_guest_paging *paging, mem_region_read_t memread,
 		mem_region_write_t memwrite, void *memarg)
 {
@@ -1693,7 +1693,7 @@ vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 }
 
 int
-vie_init(struct vie *vie, struct vcpu *vcpu)
+vie_init(struct instr_emul_vie *vie, struct vcpu *vcpu)
 {
 	uint64_t guest_rip_gva =
 		vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].rip;
@@ -1707,7 +1707,7 @@ vie_init(struct vie *vie, struct vcpu *vcpu)
 		return -EINVAL;
 	}
 
-	(void)memset(vie, 0U, sizeof(struct vie));
+	(void)memset(vie, 0U, sizeof(struct instr_emul_vie));
 
 	err_code = PAGE_FAULT_ID_FLAG;
 	ret = copy_from_gva(vcpu, vie->inst, guest_rip_gva,
@@ -1725,7 +1725,7 @@ vie_init(struct vie *vie, struct vcpu *vcpu)
 }
 
 static int
-vie_peek(struct vie *vie, uint8_t *x)
+vie_peek(struct instr_emul_vie *vie, uint8_t *x)
 {
 
 	if (vie->num_processed < vie->num_valid) {
@@ -1737,7 +1737,7 @@ vie_peek(struct vie *vie, uint8_t *x)
 }
 
 static void
-vie_advance(struct vie *vie)
+vie_advance(struct instr_emul_vie *vie)
 {
 
 	vie->num_processed++;
@@ -1773,7 +1773,7 @@ segment_override(uint8_t x, enum cpu_reg_name *seg)
 }
 
 static int
-decode_prefixes(struct vie *vie, enum vm_cpu_mode cpu_mode, bool cs_d)
+decode_prefixes(struct instr_emul_vie *vie, enum vm_cpu_mode cpu_mode, bool cs_d)
 {
 	uint8_t x;
 
@@ -1845,7 +1845,7 @@ decode_prefixes(struct vie *vie, enum vm_cpu_mode cpu_mode, bool cs_d)
 }
 
 static int
-decode_two_byte_opcode(struct vie *vie)
+decode_two_byte_opcode(struct instr_emul_vie *vie)
 {
 	uint8_t x;
 
@@ -1864,7 +1864,7 @@ decode_two_byte_opcode(struct vie *vie)
 }
 
 static int
-decode_opcode(struct vie *vie)
+decode_opcode(struct instr_emul_vie *vie)
 {
 	uint8_t x;
 
@@ -1888,7 +1888,7 @@ decode_opcode(struct vie *vie)
 }
 
 static int
-decode_modrm(struct vie *vie, enum vm_cpu_mode cpu_mode)
+decode_modrm(struct instr_emul_vie *vie, enum vm_cpu_mode cpu_mode)
 {
 	uint8_t x;
 
@@ -1943,7 +1943,7 @@ decode_modrm(struct vie *vie, enum vm_cpu_mode cpu_mode)
 }
 
 static int
-decode_sib(struct vie *vie)
+decode_sib(struct instr_emul_vie *vie)
 {
 	uint8_t x;
 
@@ -2011,7 +2011,7 @@ decode_sib(struct vie *vie)
 }
 
 static int
-decode_displacement(struct vie *vie)
+decode_displacement(struct instr_emul_vie *vie)
 {
 	int n, i;
 	uint8_t x;
@@ -2052,7 +2052,7 @@ decode_displacement(struct vie *vie)
 }
 
 static int
-decode_immediate(struct vie *vie)
+decode_immediate(struct instr_emul_vie *vie)
 {
 	int i, n;
 	uint8_t x;
@@ -2117,7 +2117,7 @@ decode_immediate(struct vie *vie)
 }
 
 static int
-decode_moffset(struct vie *vie)
+decode_moffset(struct instr_emul_vie *vie)
 {
 	uint8_t i, n, x;
 	union {
@@ -2153,7 +2153,7 @@ decode_moffset(struct vie *vie)
 }
 
 int
-__decode_instruction(enum vm_cpu_mode cpu_mode, bool cs_d, struct vie *vie)
+__decode_instruction(enum vm_cpu_mode cpu_mode, bool cs_d, struct instr_emul_vie *vie)
 {
 	if (decode_prefixes(vie, cpu_mode, cs_d) != 0) {
 		return -1;

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -52,7 +52,7 @@ typedef int (*mem_region_write_t)(struct vcpu *vcpu, uint64_t gpa,
  * 'struct vmctx *' when called from user context.
  * s
  */
-int vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct vie *vie,
+int vmm_emulate_instruction(struct vcpu *vcpu, uint64_t gpa, struct instr_emul_vie *vie,
 		struct vm_guest_paging *paging, mem_region_read_t mrr,
 		mem_region_write_t mrw, void *mrarg);
 
@@ -74,7 +74,7 @@ int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 	struct seg_desc *desc, uint64_t offset_arg, uint8_t length_arg,
 	uint8_t addrsize, uint32_t prot, uint64_t *gla);
 
-int vie_init(struct vie *vie, struct vcpu *vcpu);
+int vie_init(struct instr_emul_vie *vie, struct vcpu *vcpu);
 
 /*
  * Decode the instruction fetched into 'vie' so it can be emulated.
@@ -89,7 +89,7 @@ int vie_init(struct vie *vie, struct vcpu *vcpu);
  */
 #define	VIE_INVALID_GLA		(1UL << 63)	/* a non-canonical address */
 int
-__decode_instruction(enum vm_cpu_mode cpu_mode, bool cs_d, struct vie *vie);
+__decode_instruction(enum vm_cpu_mode cpu_mode, bool cs_d, struct instr_emul_vie *vie);
 
 int emulate_instruction(struct vcpu *vcpu);
 int decode_instruction(struct vcpu *vcpu);

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.c
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.c
@@ -297,7 +297,7 @@ static uint32_t get_vmcs_field(enum cpu_reg_name ident)
 	}
 }
 
-static void get_guest_paging_info(struct vcpu *vcpu, struct emul_ctxt *emul_ctxt,
+static void get_guest_paging_info(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
 						uint32_t csar)
 {
 	uint8_t cpl;
@@ -336,7 +336,7 @@ static int mmio_write(struct vcpu *vcpu, __unused uint64_t gpa, uint64_t wval,
 
 int decode_instruction(struct vcpu *vcpu)
 {
-	struct emul_ctxt *emul_ctxt;
+	struct instr_emul_ctxt *emul_ctxt;
 	uint32_t csar;
 	int retval = 0;
 	enum vm_cpu_mode cpu_mode;
@@ -372,7 +372,7 @@ int decode_instruction(struct vcpu *vcpu)
 
 int emulate_instruction(struct vcpu *vcpu)
 {
-	struct emul_ctxt *emul_ctxt;
+	struct instr_emul_ctxt *emul_ctxt;
 	struct vm_guest_paging *paging;
 	int retval = 0;
 	uint64_t gpa = vcpu->req.reqs.mmio.address;

--- a/hypervisor/arch/x86/guest/instr_emul_wrapper.h
+++ b/hypervisor/arch/x86/guest/instr_emul_wrapper.h
@@ -141,14 +141,14 @@ enum cpu_reg_name {
 #define CPU_REG_SEG_FIRST		CPU_REG_ES
 #define CPU_REG_SEG_LAST		CPU_REG_GS
 
-struct vie_op {
+struct instr_emul_vie_op {
 	uint8_t		op_byte;	/* actual opcode byte */
 	uint8_t		op_type;	/* type of operation (e.g. MOV) */
 	uint16_t	op_flags;
 };
 
 #define	VIE_INST_SIZE	15U
-struct vie {
+struct instr_emul_vie {
 	uint8_t		inst[VIE_INST_SIZE];	/* instruction bytes */
 	uint8_t		num_valid;		/* size of the instruction */
 	uint8_t		num_processed;
@@ -186,7 +186,7 @@ struct vie {
 
 	uint8_t		decoded;	/* set to 1 if successfully decoded */
 
-	struct vie_op	op;			/* opcode description */
+	struct instr_emul_vie_op	op;			/* opcode description */
 };
 
 #define	PSL_C		0x00000001U	/* carry bit */
@@ -243,8 +243,8 @@ struct vm_guest_paging {
 	enum vm_paging_mode paging_mode;
 };
 
-struct emul_ctxt {
-	struct vie vie;
+struct instr_emul_ctxt {
+	struct instr_emul_vie vie;
 	struct vm_guest_paging paging;
 	struct vcpu *vcpu;
 };

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -280,7 +280,7 @@ static void vlapic_create_timer(struct acrn_vlapic *vlapic)
 
 static void vlapic_reset_timer(struct acrn_vlapic *vlapic)
 {
-	struct timer *timer;
+	struct hv_timer *timer;
 
 	if (vlapic == NULL) {
 		return;
@@ -299,7 +299,7 @@ set_expiration(struct acrn_vlapic *vlapic)
 	uint64_t now = rdtsc();
 	uint64_t delta;
 	struct vlapic_timer *vtimer;
-	struct timer *timer;
+	struct hv_timer *timer;
 	uint32_t tmicr, divisor_shift;
 
 	vtimer = &vlapic->vtimer;
@@ -328,7 +328,7 @@ static void vlapic_update_lvtt(struct acrn_vlapic *vlapic,
 	struct vlapic_timer *vtimer = &vlapic->vtimer;
 
 	if (vtimer->mode != timer_mode) {
-		struct timer *timer = &vtimer->timer;
+		struct hv_timer *timer = &vtimer->timer;
 
 		/*
 		 * A write to the LVT Timer Register that changes
@@ -411,7 +411,7 @@ static uint64_t vlapic_get_tsc_deadline_msr(struct acrn_vlapic *vlapic)
 static void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic,
 			uint64_t val_arg)
 {
-	struct timer *timer;
+	struct hv_timer *timer;
 	uint64_t val = val_arg;
 
 	if (!vlapic_lvtt_tsc_deadline(vlapic)) {

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -109,7 +109,7 @@ struct vlapic_ops {
 };
 
 struct vlapic_timer {
-	struct timer timer;
+	struct hv_timer timer;
 	uint32_t mode;
 	uint32_t tmicr;
 	uint32_t divisor_shift;

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -10,7 +10,7 @@
 static spinlock_t lock;
 
 static uint32_t serial_handle = SERIAL_INVALID_HANDLE;
-struct timer console_timer;
+struct hv_timer console_timer;
 
 #define CONSOLE_KICK_TIMER_TIMEOUT  40 /* timeout is 40ms*/
 

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -35,7 +35,7 @@ struct per_cpu_region {
 #endif
 	struct per_cpu_timers cpu_timers;
 	struct sched_context sched_ctx;
-	struct emul_ctxt g_inst_ctxt;
+	struct instr_emul_ctxt g_inst_ctxt;
 	struct host_gdt gdt;
 	struct tss_64 tss;
 	enum cpu_state cpu_state;

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -18,7 +18,7 @@ struct per_cpu_timers {
 	struct list_head timer_list;	/* it's for runtime active timer list */
 };
 
-struct timer {
+struct hv_timer {
 	struct list_head node;		/* link all timers */
 	int mode;			/* timer mode: one-shot or periodic */
 	uint64_t fire_tsc;		/* tsc deadline to interrupt */
@@ -31,7 +31,7 @@ struct timer {
  * Don't initialize a timer twice if it has been add to the timer list
  * after call add_timer. If u want, delete the timer from the list first.
  */
-static inline void initialize_timer(struct timer *timer,
+static inline void initialize_timer(struct hv_timer *timer,
 				timer_handle_t func,
 				void *priv_data,
 				uint64_t fire_tsc,
@@ -51,8 +51,8 @@ static inline void initialize_timer(struct timer *timer,
 /*
  * Don't call add_timer/del_timer in the timer callback function.
  */
-int add_timer(struct timer *timer);
-void del_timer(struct timer *timer);
+int add_timer(struct hv_timer *timer);
+void del_timer(struct hv_timer *timer);
 
 void timer_softirq(uint16_t pcpu_id);
 void timer_init(void);

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -8,7 +8,7 @@
 #define CONSOLE_H
 
 #ifdef HV_DEBUG
-extern struct timer console_timer;
+extern struct hv_timer console_timer;
 
 /** Initializes the console module.
  *


### PR DESCRIPTION
For data structure types "struct timer, struct vie", "struct emul_ctxt",
its name is identical with variable name in the same scope. This MISRA C 
violation is detected by static analysis tool.

Naming convention rule:If the data structure type is used by multi modules, 
its corresponding logic resource is only used by hypervisor/host and isn't 
exposed to external components (such as SOS, UOS), its name meaning is  
simplistic (such as timer), its name needs prefix "hv_". 

Naming convention rule:If the data structure type is used by only one 
module and its name meaning is simplistic, its name needs prefix 
shorten module name.

Follow naming convention rule to udpate data structure type "struct vie_op".

The following udpates are made:
struct timer-->struct hv_timer
struct vie-->struct instr_emul_vie
struct vie_op-->struct instr_emul_vie_op
struct emul_ctxt-->struct instr_emul_ctxt

Acked-by: Eddie Dong <eddie.dong@intel.com>