### PR TITLE
HV:treewide:add suffix or prefix to data structure name

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -375,7 +375,7 @@ void bsp_boot_init(void)
 	*  is matching the actual offset!
 	*/
 	ASSERT((sizeof(struct trusty_startup_param)
-			+ sizeof(struct key_info)) < 0x1000U,
+			+ sizeof(struct trusty_key_info)) < 0x1000U,
 		"trusty_startup_param + key_info > 1Page size(4KB)!");
 
 	ASSERT(NR_WORLD == 2, "Only 2 Worlds supported!");

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -469,7 +469,7 @@ int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu)
 int ept_mr_add(struct vm *vm, uint64_t hpa_arg,
 	uint64_t gpa_arg, uint64_t size, uint32_t prot_arg)
 {
-	struct map_params map_params;
+	struct mem_map_params map_params;
 	uint16_t i;
 	struct vcpu *vcpu;
 	uint64_t hpa = hpa_arg;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1563,7 +1563,7 @@ vlapic_reset(struct acrn_vlapic *vlapic)
 	apic_page = (void *)vlapic->apic_page;
 	(void)memset(apic_page, 0U, CPU_PAGE_SIZE);
 	if (vlapic->pir_desc) {
-		(void)memset(vlapic->pir_desc, 0U, sizeof(struct pir_desc));
+		(void)memset(vlapic->pir_desc, 0U, sizeof(struct vlapic_pir_desc));
 	}
 
 	lapic->id = vlapic_build_id(vlapic);
@@ -2108,7 +2108,7 @@ int vlapic_create(struct vcpu *vcpu)
 			vlapic->ops.apicv_batch_set_tmr =
 					apicv_batch_set_tmr;
 
-			vlapic->pir_desc = (struct pir_desc *)(&(vlapic->pir));
+			vlapic->pir_desc = (struct vlapic_pir_desc *)(&(vlapic->pir));
 		}
 
 		if (is_vcpu_bsp(vcpu)) {
@@ -2174,7 +2174,7 @@ void vlapic_free(struct vcpu *vcpu)
 static int
 apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, __unused bool level)
 {
-	struct pir_desc *pir_desc;
+	struct vlapic_pir_desc *pir_desc;
 	uint64_t mask;
 	uint32_t idx;
 	int32_t notify;
@@ -2192,7 +2192,7 @@ apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, __unused bool 
 static int
 apicv_pending_intr(struct acrn_vlapic *vlapic, __unused uint32_t *vecptr)
 {
-	struct pir_desc *pir_desc;
+	struct vlapic_pir_desc *pir_desc;
 	struct lapic_regs *lapic;
 	uint64_t pending, pirval;
 	uint32_t i, ppr, vpr;
@@ -2301,7 +2301,7 @@ apicv_get_apic_page_addr(struct acrn_vlapic *vlapic)
 void
 apicv_inject_pir(struct acrn_vlapic *vlapic)
 {
-	struct pir_desc *pir_desc;
+	struct vlapic_pir_desc *pir_desc;
 	struct lapic_regs *lapic;
 	uint64_t val, pirval;
 	uint16_t rvi, pirbase = 0U, i;

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -91,7 +91,7 @@
 
 struct acrn_vlapic;
 
-struct pir_desc {
+struct vlapic_pir_desc {
 	uint64_t pir[4];
 	uint64_t pending;
 	uint64_t unused[3];
@@ -119,7 +119,7 @@ struct acrn_vlapic {
 	struct vm		*vm;
 	struct vcpu		*vcpu;
 	struct lapic_regs	*apic_page;
-	struct pir_desc		*pir_desc;
+	struct vlapic_pir_desc		*pir_desc;
 	struct vlapic_ops	ops;
 
 	uint32_t		esr_pending;
@@ -154,7 +154,7 @@ struct acrn_vlapic {
 	 */
 	uint32_t	svr_last;
 	uint32_t	lvt_last[VLAPIC_MAXLVT_INDEX + 1];
-	struct pir_desc	pir;
+	struct vlapic_pir_desc	pir;
 };
 
 #endif	/* _VLAPIC_PRIV_H_ */

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -424,7 +424,7 @@ static int get_table_entry(void *addr, void *table_base,
 }
 
 static void *walk_paging_struct(void *addr, void *table_base,
-		uint32_t table_level, struct map_params *map_params,
+		uint32_t table_level, struct mem_map_params *map_params,
 		uint64_t attr)
 {
 	uint32_t table_offset;
@@ -608,7 +608,7 @@ bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg)
 
 }
 
-int obtain_last_page_table_entry(struct map_params *map_params,
+int obtain_last_page_table_entry(struct mem_map_params *map_params,
 		struct entry_params *entry, void *addr, bool direct)
 {
 	uint64_t table_entry;
@@ -732,7 +732,7 @@ int obtain_last_page_table_entry(struct map_params *map_params,
 	return 0;
 }
 
-static uint64_t update_page_table_entry(struct map_params *map_params,
+static uint64_t update_page_table_entry(struct mem_map_params *map_params,
 		void *paddr, void *vaddr, uint64_t size, uint64_t attr,
 		bool direct)
 {
@@ -792,7 +792,7 @@ static uint64_t update_page_table_entry(struct map_params *map_params,
 	return adjustment_size;
 }
 
-static uint64_t break_page_table(struct map_params *map_params, void *paddr,
+static uint64_t break_page_table(struct mem_map_params *map_params, void *paddr,
 		void *vaddr, uint64_t page_size, bool direct)
 {
 	uint32_t i = 0U;
@@ -889,7 +889,7 @@ static uint64_t break_page_table(struct map_params *map_params, void *paddr,
 	return next_page_size;
 }
 
-static int modify_paging(struct map_params *map_params, void *paddr_arg,
+static int modify_paging(struct mem_map_params *map_params, void *paddr_arg,
 		void *vaddr_arg, uint64_t size, uint32_t flags, bool direct)
 {
 	void *vaddr = vaddr_arg;
@@ -978,7 +978,7 @@ static int modify_paging(struct map_params *map_params, void *paddr_arg,
 	return 0;
 }
 
-int map_mem(struct map_params *map_params, void *paddr, void *vaddr,
+int map_mem(struct mem_map_params *map_params, void *paddr, void *vaddr,
 		    uint64_t size, uint32_t flags)
 {
 	int ret = 0;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -16,7 +16,7 @@ struct trusty_mem {
 	 */
 	union {
 		struct {
-			struct key_info key_info;
+			struct trusty_key_info key_info;
 			struct trusty_startup_param startup_param;
 		} data;
 		uint8_t page[CPU_PAGE_SIZE];
@@ -27,7 +27,7 @@ struct trusty_mem {
 	uint8_t left_mem[0];
 };
 
-static struct key_info g_key_info = {
+static struct trusty_key_info g_key_info = {
 	.size_of_this_struct = sizeof(g_key_info),
 	.version = 0U,
 	.platform = 3U,
@@ -78,7 +78,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 {
 	uint64_t nworld_pml4e = 0UL;
 	uint64_t sworld_pml4e = 0UL;
-	struct map_params map_params;
+	struct mem_map_params map_params;
 	uint64_t gpa = 0UL;
 	uint64_t hpa = gpa2hpa(vm, gpa_orig);
 	uint64_t table_present = (IA32E_EPT_R_BIT |
@@ -179,7 +179,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 
 void  destroy_secure_world(struct vm *vm)
 {
-	struct map_params  map_params;
+	struct mem_map_params  map_params;
 	struct vm *vm0 = get_vm_from_vmid(0U);
 
 	if (vm0 == NULL) {
@@ -347,7 +347,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 {
 	uint32_t i;
 	struct trusty_mem *mem;
-	struct key_info *key_info;
+	struct trusty_key_info *key_info;
 
 	mem = (struct trusty_mem *)(HPA2HVA(mem_base_hpa));
 
@@ -366,7 +366,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 				BUP_MKHI_BOOTLOADER_SEED_LEN,
 				NULL, 0U,
 				vcpu->vm->GUID, sizeof(vcpu->vm->GUID)) == 0) {
-			(void)memset(key_info, 0U, sizeof(struct key_info));
+			(void)memset(key_info, 0U, sizeof(struct trusty_key_info));
 			pr_err("%s: derive dvseed failed!", __func__);
 			return false;
 		}
@@ -385,7 +385,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
 	 * is put in the first page of trusty memory just followed by key_info.
 	 */
 	vcpu->arch_vcpu.contexts[SECURE_WORLD].guest_cpu_regs.regs.rdi
-		= (uint64_t)TRUSTY_EPT_REBASE_GPA + sizeof(struct key_info);
+		= (uint64_t)TRUSTY_EPT_REBASE_GPA + sizeof(struct trusty_key_info);
 
 	return true;
 }

--- a/hypervisor/arch/x86/trusty2.c
+++ b/hypervisor/arch/x86/trusty2.c
@@ -13,7 +13,7 @@ uint64_t gpa2hpa_for_trusty(struct vm *vm, uint64_t gpa)
 {
 	uint64_t hpa = 0UL;
 	struct entry_params entry;
-	struct map_params map_params;
+	struct mem_map_params map_params;
 
 	map_params.page_table_type = PTT_EPT;
 	map_params.pml4_base = vm->arch_vm.sworld_eptp;
@@ -58,7 +58,7 @@ void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	uint64_t nworld_pml4e = 0UL;
 	uint64_t sworld_pml4e = 0UL;
 	struct entry_params entry;
-	struct map_params map_params;
+	struct mem_map_params map_params;
 	uint64_t gpa_uos = gpa_orig;
 	uint64_t gpa_sos;
 	uint64_t adjust_size;
@@ -158,7 +158,7 @@ void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 void  destroy_secure_world(struct vm *vm)
 {
 
-	struct map_params  map_params;
+	struct mem_map_params  map_params;
 	struct entry_params entry;
 	struct vm *vm0 = get_vm_from_vmid(0);
 	uint64_t hpa;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -100,7 +100,7 @@ struct cpu_gp_regs {
 	uint64_t r15;
 };
 
-struct segment {
+struct segment_sel {
 	uint16_t selector;
 	uint64_t base;
 	uint32_t limit;
@@ -155,16 +155,16 @@ struct run_context {
 	uint64_t vmx_cr4;
 
 	/* segment registers */
-	struct segment cs;
-	struct segment ss;
-	struct segment ds;
-	struct segment es;
-	struct segment fs;
-	struct segment gs;
-	struct segment tr;
-	struct segment idtr;
-	struct segment ldtr;
-	struct segment gdtr;
+	struct segment_sel cs;
+	struct segment_sel ss;
+	struct segment_sel ds;
+	struct segment_sel es;
+	struct segment_sel fs;
+	struct segment_sel gs;
+	struct segment_sel tr;
+	struct segment_sel idtr;
+	struct segment_sel ldtr;
+	struct segment_sel gdtr;
 
 	/* The 512 bytes area to save the FPU/MMX/SSE states for the guest */
 	uint64_t

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -112,7 +112,7 @@ enum intr_cpu_startup_shorthand {
 	INTR_CPU_STARTUP_UNKNOWN,
 };
 
-union lapic_id {
+union lapic_id_reg {
 	uint32_t value;
 	struct {
 		uint8_t xapic_id;

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -220,7 +220,7 @@ enum _page_table_type {
 	PAGETABLE_TYPE_UNKNOWN,
 };
 
-struct map_params {
+struct mem_map_params {
 	/* enum _page_table_type: HOST or EPT*/
 	enum _page_table_type page_table_type;
 	/* used HVA->HPA for HOST, used GPA->HPA for EPT */
@@ -310,7 +310,7 @@ void free_paging_struct(void *ptr);
 void enable_paging(uint64_t pml4_base_addr);
 void enable_smep(void);
 void init_paging(void);
-int map_mem(struct map_params *map_params, void *paddr, void *vaddr,
+int map_mem(struct mem_map_params *map_params, void *paddr, void *vaddr,
 		    uint64_t size, uint32_t flags);
 int mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
 		uint64_t vaddr_base, uint64_t size,
@@ -325,7 +325,7 @@ void flush_vpid_single(uint16_t vpid);
 void flush_vpid_global(void);
 void invept(struct vcpu *vcpu);
 bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg);
-int obtain_last_page_table_entry(struct map_params *map_params,
+int obtain_last_page_table_entry(struct mem_map_params *map_params,
 		struct entry_params *entry, void *addr, bool direct);
 uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, enum _page_table_type ptt);

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -29,7 +29,7 @@ struct seed_info {
 };
 
 /* Structure of key info */
-struct key_info {
+struct trusty_key_info {
 	uint32_t size_of_this_struct;
 
 	/* version info:


### PR DESCRIPTION
For data structure types "struct key_info, struct pir_desc,
struct map_params, union lapic_id, struct segment",
its name is identical with variable name in the same scope.
This MISRA C  violation is detected by static analysis tool.
Naming convention rule:If the data structure type is used by only one 
module and its name meaning is simplistic, its name needs prefix
shorten module name.


The following udpates are made:
struct key_info-->struct trusty_key_info
struct pir_desc-->struct vlapic_pir_desc
struct map_params-->struct mem_map_params
union lapic_id-->union lapic_id_reg
struct segment-->struct segment_sel

Reviewed-by: Junjie Mao <junjie.mao@intel.com>