### PR TITLE
add USB device sharing in GSG

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -373,7 +373,7 @@ two keyboards and mice connected to your device, one keyboard and
 mouse set for the SOS, and the other set for the UOS.  
 
 1. Boot the SOS and plug in the two keyboards and two mice
-   into four available USB ports on the device (the NUC we recommends has 4 USB ports).
+   into four available USB ports on the device (the NUC we recommend has 4 USB ports).
 
 #. Run ``dmesg`` to find the kernel messages logging the enumeration
    of the connected keyboards and mice.  For example::
@@ -408,18 +408,16 @@ mouse set for the SOS, and the other set for the UOS.
       [ 1008.519459] input: Logitech USB Optical Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-1/1-        1:1.0/0003:046D:C077.0008/input/input11
       [ 1008.519714] hid-generic 0003:046D:C077.0008: input,hidraw3: USB HID v1.11 Mouse [Logitech USB Optical Mouse] on usb-   0000:00:14.0-1/input0
 
-#. From ``dmesg`` info, you can easly find specific USB device info connected to certain port
+#. From ``dmesg`` info, you can easly find specific USB device info connected to certain port by pluging in 
+   USB device one by one 
    for example::
     
-      keyboard 1#: usb 1-3
-      mouse 1#: usb 1-4 
-      keyboard 2#: usb 1-2
-      mouse 2#: usb 1-1
-   
-   Now you can define which keyboard and mouse to be assigned for UOS, which for SOS. 
-   You'll need this device information in the next step.
+      mouse 1#: usb 1-1
+      keyboard 1#: usb 1-2 
+      keyboard 2#: usb 1-3
+      mouse 2#: usb 1-4
 
-#. Supposing you assign keyboard 2# and mouse 2# to the UOS. Use a text editor to modify
+#. Let's assign keyboard 1# and mouse 1# to the UOS. Use a text editor to modify
    ``/usr/share/acrn/samples/nuc/launch_uos.sh`` and add the line (using
    the keyboard and mouse identified in your dmesg output)::
 
@@ -428,23 +426,12 @@ mouse set for the SOS, and the other set for the UOS.
    Save the file, exit the editor, and run the ``sync`` command to ensure
    any pending write buffers are written to disk. 
   
-   by default, keyboard 1# and mouse 1# connected to Device be used for SOS without any additinoal configurartion
-   keyboard 2# and mouse 2# to UOS by modifying launch_uos.sh
-    
-   .. code-block:: none
-
-      # cd /usr/share/acrn/samples/nuc/
-      # vim lauch_uos.sh
-      # add below line into the file
-      # -s 9, xhci, 1-1:1-2 \
-      # sync
-  
+   by default, keyboard 2# and mouse 2# connected to Device be used for SOS without any additinoal configurartion
+   keyboard 1# and mouse 1# to UOS by modifying launch_uos.sh
+   
    .. note::
-     you can check and assign USB keyboard and USB mouse to UOS with modifying -s 9, xhci 1-x:1-y \
-     according to your USB device info
-     
-     there is an known issue to use USB keyboard and mouse in UOS, you have to unplug and plug back 
-     keyboard and mouse assigned to UOS after lauch UOS.  
+      You may have to unplug and plug in the keyboard and mouse
+      assigned to the UOS after launching the UOS.  
 
 
 Build ACRN from Source

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -408,7 +408,6 @@ mouse set for the SOS, and the other set for the UOS.
       [ 1008.519459] input: Logitech USB Optical Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-1/1-        1:1.0/0003:046D:C077.0008/input/input11
       [ 1008.519714] hid-generic 0003:046D:C077.0008: input,hidraw3: USB HID v1.11 Mouse [Logitech USB Optical Mouse] on usb-   0000:00:14.0-1/input0
 
-    
 #. From ``dmesg`` info, you can easly find specific USB device info connected to certain port
    for example::
     

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -58,7 +58,7 @@ complete this setup.
    this feature to have more control over when the updates happen. Use this command
    to disable the autoupdate feature:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # swupd autoupdate --disable
 
@@ -66,13 +66,13 @@ complete this setup.
    on your hardware, use this command to upgrade Clear Linux
    to version 23690 (or newer):
 
-   .. code-block:: none
+   .. code-block:: console
 
       # swupd update -m 23690     # or newer version
 
 #. Use the ``swupd bundle-add`` command and add these Clear Linux bundles:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # swupd bundle-add vim network-basic service-os kernel-pk \
         desktop openssh-server
@@ -109,7 +109,7 @@ partition. Follow these steps:
 
 #. Mount the EFI partition and verify you have the following files:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # mount /dev/sda1 /mnt
 
@@ -136,7 +136,7 @@ partition. Follow these steps:
 #. Put the ``acrn.efi`` hypervisor application (included in the Clear
    Linux release) on the EFI partition with:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # mkdir /mnt/EFI/acrn
       # cp /usr/lib/acrn/acrn.efi /mnt/EFI/acrn/
@@ -148,7 +148,7 @@ partition. Follow these steps:
    Service OS bootloader. Use the ``efibootmgr`` utility to configure the EFI
    firmware and add a new entry that loads the ACRN hypervisor.
 
-   .. code-block:: none
+   .. code-block:: console
 
       # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN"
 
@@ -179,7 +179,7 @@ partition. Follow these steps:
    Here is a more complete example of how to configure the EFI firmware to load the ACRN
    hypervisor and set these parameters.
 
-   .. code-block:: none
+   .. code-block:: console
 
       # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN NUC Hypervisor" \
             -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=disabled"
@@ -209,7 +209,7 @@ partition. Follow these steps:
 
    On the platform, copy the ``acrn.conf`` file to the EFI partition we mounted earlier:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # cp /usr/share/acrn/samples/nuc/acrn.conf /mnt/loader/entries/
 
@@ -226,14 +226,14 @@ partition. Follow these steps:
 #. Add a timeout period for Systemd-Boot to wait, otherwise it will not
    present the boot menu and will always boot the base Clear Linux
 
-   .. code-block:: none
+   .. code-block:: console
 
       # clr-boot-manager set-timeout 20
       # clr-boot-manager update
 
 #. Add new user
 
-   .. code-block:: none
+   .. code-block:: console
 
       # useradd cl-sos
       # passwd cl-sos
@@ -241,7 +241,7 @@ partition. Follow these steps:
 
 #. Enable weston service
 
-   .. code-block:: none
+   .. code-block:: console
 
       # systemctl enable weston@cl-sos
 
@@ -302,14 +302,14 @@ Set up Reference UOS
 
 #. Uncompress it:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # unxz clear-23690-kvm.img.xz
 
 #. Deploy the UOS kernel modules to UOS virtual disk image (note: you'll need to use
    the same **standard** image version number noted in step 1 above):
 
-   .. code-block:: none
+   .. code-block:: console
 
       # losetup -f -P --show /root/clear-23690-kvm.img
       # mount /dev/loop0p3 /mnt
@@ -341,7 +341,7 @@ Set up Reference UOS
    By default, the script is located in the ``/usr/share/acrn/samples/nuc/``
    directory. You can edit it there, and then run it to launch the User OS:
 
-   .. code-block:: none
+   .. code-block:: console
 
       # cd /usr/share/acrn/samples/nuc/
       # ./launch_uos.sh
@@ -442,7 +442,7 @@ each with their own way to install development tools:
 * On a Clear Linux development system, install the ``os-clr-on-clr`` bundle to get
   the necessary tools:
 
-  .. code-block:: none
+  .. code-block:: console
 
      $ sudo swupd bundle-add os-clr-on-clr
      $ sudo swupd bundle-add python3-basic
@@ -450,7 +450,7 @@ each with their own way to install development tools:
 
 * On a Ubuntu/Debian development system:
 
-  .. code-block:: none
+  .. code-block:: console
 
      $ sudo apt install gcc \
           git \
@@ -475,7 +475,7 @@ each with their own way to install development tools:
 
 * On a Fedora/Redhat development system:
 
-  .. code-block:: none
+  .. code-block:: console
 
      $ sudo dnf install gcc \
           git \
@@ -498,7 +498,7 @@ each with their own way to install development tools:
 
 * On a CentOS development system:
 
-  .. code-block:: none
+  .. code-block:: console
 
      $ sudo yum install gcc \
              git \
@@ -536,7 +536,7 @@ repository has three main components in it:
 
 You can build all these components in one go as follows:
 
-.. code-block:: none
+.. code-block:: console
 
    $ git clone https://github.com/projectacrn/acrn-hypervisor
    $ cd acrn-hypervisor
@@ -555,7 +555,7 @@ and are using it as the current working directory.
 
 #. Build the ACRN hypervisor.
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ cd hypervisor
       $ make PLATFORM=uefi
@@ -564,7 +564,7 @@ and are using it as the current working directory.
 
 #. Build the ACRN device model (included in the acrn-hypervisor repo):
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ cd ../devicemodel
       $ make
@@ -573,7 +573,7 @@ and are using it as the current working directory.
 
 #. Build the ACRN tools (included in the acrn-hypervisor repo):
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ cd ../tools
       $ for d in */; do make -C "$d"; done
@@ -596,7 +596,7 @@ based on the platform selected, assuming that you are under the top-level
 directory of acrn-hypervisor. The configuration file, named ``.config``, can be
 found under the target folder of your build.
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ cd hypervisor
       $ make defconfig PLATFORM=uefi
@@ -615,7 +615,7 @@ are under the top-level directory of acrn-hypervisor, generate a default
 configuration file for UEFI, allow you to modify some configurations and build
 the hypervisor using the updated ``.config``.
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ cd hypervisor
       $ make defconfig PLATFORM=uefi
@@ -627,7 +627,7 @@ the hypervisor using the updated ``.config``.
 
 Refer to the help on menuconfig for a detailed guide on the interface.
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ pydoc3 menuconfig
 
@@ -639,7 +639,7 @@ Currently the ACRN hypervisor looks for default configurations under
 specified platform. The following steps allow you to create a defconfig for
 another platform based on a current one.
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ cd hypervisor
       $ make defconfig PLATFORM=uefi
@@ -650,6 +650,6 @@ another platform based on a current one.
 Then you can re-use that configuration by passing the name (``xxx`` in the
 example above) to 'PLATFORM=':
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ make defconfig PLATFORM=xxx

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -364,6 +364,46 @@ For hugeTLB to work, you'll need to reserve huge pages:
      by using a 2M page, but make sure your huge page reservation size is
      large enough for your usage.
 
+USB Device Sharing
+==========================================
+
+The ACRN hypervisor is able to support USB device sharing
+supposing you have 2 sets of USB keyboard and mouse, 1 set is for SOS, another for UOS
+
+For SOS, boot up SOS and plug 2 sets USB keyboard and USB mouse into USB ports of device:
+
+  - run "dmesg" to check the kernel log
+
+  - record keyboard and mouse device info: 
+    
+    for example: 
+                 keyboard 1#: USB/1-3/1-3
+    
+                 mouse 1#: USB/1-4/1-4
+
+                 keyboard 2#: USB/1-2/1-2
+                 
+                 mouse #2: USB/1-1/1-1
+  
+  now let's assign keyboard 1# and mouse 1# to SOS, keyboard 2# and mouse 2# to UOS by modifying 
+  launch_uos.sh
+  
+  
+   .. code-block:: none
+
+      # cd /usr/share/acrn/samples/nuc/
+      # vim lauch_uos.sh
+      # add below line into the file
+      # -s 9, xhci, 1-1:1-2 \
+      # sync
+  
+  .. note::
+     you can check and assign USB keyboard and USB mouse to UOS with modifying -s 9, xhci 1-x:1-y \
+     according to your USB device info
+     
+     there is an known issue to use USB keyboard and mouse in UOS, you have to unplug and plug back 
+     keyboard and mouse for UOS after lauch UOS.  
+
 Build ACRN from Source
 **********************
 

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -231,6 +231,20 @@ partition. Follow these steps:
       # clr-boot-manager set-timeout 20
       # clr-boot-manager update
 
+#. Add new user
+
+   .. code-block:: none
+
+      # useradd cl-sos
+      # passwd cl-sos
+      # usermod -G wheel -a cl-sos
+
+#. Enable weston service
+
+   .. code-block:: none
+
+      # systemctl enable weston@cl-sos
+
 #. Reboot and select "The ACRN Service OS" to boot, as shown below:
 
 
@@ -340,31 +354,6 @@ Set up Reference UOS
       :name: gsg-successful-boot
 
 
-Device Manager memory allocation mechanism
-==========================================
-
-The ACRN Device Manager (DM) virtual memory allocation uses the HugeTLB mechanism.
-(You can read more about `HugeTLB in the linux kernel <https://linuxgazette.net/155/krishnakumar.html>`_
-for more information about how this mechanism works.)
-
-For hugeTLB to work, you'll need to reserve huge pages:
-
-  - For a (large) 1GB huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
-    (for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in
-    ``acrn.conf`` (for EFI)
-
-  - For a (smaller) 2MB huge page reservation, after the SOS starts up, run the
-    command::
-
-       echo reserved_pg_num > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
-
-  .. note::
-     You can use 2M reserving method to do reservation for 1G page size, but it
-     may fail.  For an EFI platform, you may skip 1G page reservation
-     by using a 2M page, but make sure your huge page reservation size is
-     large enough for your usage.
-
-
 USB Device Sharing
 ==========================================
 
@@ -378,7 +367,7 @@ mouse set for the SOS, and the other set for the UOS.
 #. Run ``dmesg`` to find the kernel messages logging the enumeration
    of the connected keyboards and mice.  For example::
 
-  .. code-block:: none
+  .. code-block:: console
 
       # dmesg
       [  560.469525] usb 1-4: Product: USB Optical Mouse
@@ -412,12 +401,12 @@ mouse set for the SOS, and the other set for the UOS.
    USB device one by one 
    for example::
     
-      mouse 1#: usb 1-1
-      keyboard 1#: usb 1-2 
-      keyboard 2#: usb 1-3
-      mouse 2#: usb 1-4
+      mouse #1: usb 1-1
+      keyboard #1: usb 1-2 
+      keyboard #2: usb 1-3
+      mouse #2: usb 1-4
 
-#. Let's assign keyboard 1# and mouse 1# to the UOS. Use a text editor to modify
+#. Let's assign keyboard #1 and mouse #1 to the UOS. Use a text editor to modify
    ``/usr/share/acrn/samples/nuc/launch_uos.sh`` and add the line (using
    the keyboard and mouse identified in your dmesg output)::
 
@@ -426,11 +415,11 @@ mouse set for the SOS, and the other set for the UOS.
    Save the file, exit the editor, and run the ``sync`` command to ensure
    any pending write buffers are written to disk. 
   
-   by default, keyboard 2# and mouse 2# connected to Device be used for SOS without any additinoal configurartion
-   keyboard 1# and mouse 1# to UOS by modifying launch_uos.sh
+   In our example, keyboard #2 and mouse #2 will be used to interact with the Service OS (SOS) 
+   and the keyboard #1 and mouse #1 will be used for the User OS (UOS).
    
    .. note::
-      You may have to unplug and plug in the keyboard and mouse
+      You may have to unplug and plug the keyboard and mouse back in (same connectors!)
       assigned to the UOS after launching the UOS.  
 
 

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -244,6 +244,7 @@ partition. Follow these steps:
    .. code-block:: console
 
       # systemctl enable weston@cl-sos
+      # systemctl start weston@cl-sos
 
 #. Reboot and select "The ACRN Service OS" to boot, as shown below:
 

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -364,31 +364,74 @@ For hugeTLB to work, you'll need to reserve huge pages:
      by using a 2M page, but make sure your huge page reservation size is
      large enough for your usage.
 
+
 USB Device Sharing
 ==========================================
 
-The ACRN hypervisor is able to support USB device sharing
-supposing you have 2 sets of USB keyboard and mouse, 1 set is for SOS, another for UOS
+The ACRN hypervisor supports USB device sharing.  Suppose you have
+two keyboards and mice connected to your device, one keyboard and 
+mouse set for the SOS, and the other set for the UOS.  
 
-For SOS, boot up SOS and plug 2 sets USB keyboard and USB mouse into USB ports of device:
+1. Boot the SOS and plug in the two keyboards and two mice
+   into four available USB ports on the device (the NUC we recommends has 4 USB ports).
 
-  - run "dmesg" to check the kernel log
+#. Run ``dmesg`` to find the kernel messages logging the enumeration
+   of the connected keyboards and mice.  For example::
 
-  - record keyboard and mouse device info: 
+  .. code-block:: none
+
+      # dmesg
+      [  560.469525] usb 1-4: Product: USB Optical Mouse
+      [  560.469600] usb 1-4: Manufacturer: Logitech
+      [  560.472238] input: Logitech USB Optical Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-4/1- 4:1.0/0003:046D:C018.0005/input/input8
+      [  560.472673] hid-generic 0003:046D:C018.0005: input,hidraw1: USB HID v1.11 Mouse [Logitech USB Optical Mouse] on usb-   0000:00:14.0-4/input0
+      [  561.743470] usb 1-3: USB disconnect, device number 6
+      [  565.504044] usb 1-3: new low-speed USB device number 8 using xhci_hcd
+      [  565.639056] usb 1-3: New USB device found, idVendor=03f0, idProduct=0024
+      [  565.639167] usb 1-3: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+      [  565.639282] usb 1-3: Product: HP Basic USB Keyboard
+      [  565.639362] usb 1-3: Manufacturer: CHICONY
+      [  565.644013] input: CHICONY HP Basic USB Keyboard as /devices/pci0000:00/0000:00:14.0/usb1/1-3/1- 3:1.0/0003:03F0:0024.0006/input/input9
+      [  565.696139] hid-generic 0003:03F0:0024.0006: input,hidraw0: USB HID v1.10 Keyboard [CHICONY HP Basic USB Keyboard] on usb-0000:00:14.0-3/input0
+      [ 1000.587071] usb 1-2: new low-speed USB device number 9 using xhci_hcd
+      [ 1000.719824] usb 1-2: New USB device found, idVendor=046d, idProduct=c315
+      [ 1000.719934] usb 1-2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+      [ 1000.720048] usb 1-2: Product: Logitech USB Keyboard
+      [ 1000.720143] usb 1-2: Manufacturer: Logitech
+      [ 1000.724286] input: Logitech Logitech USB Keyboard as /devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/0003:046D:C315.0007/input/input10
+      [ 1000.776433] hid-generic 0003:046D:C315.0007: input,hidraw2: USB HID v1.10 Keyboard [Logitech Logitech USB Keyboard] on usb-0000:00:14.0-2/input0
+      [ 1008.387071] usb 1-1: new low-speed USB device number 10 using xhci_hcd
+      [ 1008.516312] usb 1-1: New USB device found, idVendor=046d, idProduct=c077
+      [ 1008.516421] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+      [ 1008.516536] usb 1-1: Product: USB Optical Mouse
+      [ 1008.516610] usb 1-1: Manufacturer: Logitech
+      [ 1008.519459] input: Logitech USB Optical Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-1/1-        1:1.0/0003:046D:C077.0008/input/input11
+      [ 1008.519714] hid-generic 0003:046D:C077.0008: input,hidraw3: USB HID v1.11 Mouse [Logitech USB Optical Mouse] on usb-   0000:00:14.0-1/input0
+
     
-    for example: 
-                 keyboard 1#: USB/1-3/1-3
+#. From ``dmesg`` info, you can easly find specific USB device info connected to certain port
+   for example::
     
-                 mouse 1#: USB/1-4/1-4
+      keyboard 1#: usb 1-3
+      mouse 1#: usb 1-4 
+      keyboard 2#: usb 1-2
+      mouse 2#: usb 1-1
+   
+   Now you can define which keyboard and mouse to be assigned for UOS, which for SOS. 
+   You'll need this device information in the next step.
 
-                 keyboard 2#: USB/1-2/1-2
-                 
-                 mouse #2: USB/1-1/1-1
+#. Supposing you assign keyboard 2# and mouse 2# to the UOS. Use a text editor to modify
+   ``/usr/share/acrn/samples/nuc/launch_uos.sh`` and add the line (using
+   the keyboard and mouse identified in your dmesg output)::
+
+      -s 9, xhci, 1-1:1-2 \
+
+   Save the file, exit the editor, and run the ``sync`` command to ensure
+   any pending write buffers are written to disk. 
   
-  now let's assign keyboard 1# and mouse 1# to SOS, keyboard 2# and mouse 2# to UOS by modifying 
-  launch_uos.sh
-  
-  
+   by default, keyboard 1# and mouse 1# connected to Device be used for SOS without any additinoal configurartion
+   keyboard 2# and mouse 2# to UOS by modifying launch_uos.sh
+    
    .. code-block:: none
 
       # cd /usr/share/acrn/samples/nuc/
@@ -397,12 +440,13 @@ For SOS, boot up SOS and plug 2 sets USB keyboard and USB mouse into USB ports o
       # -s 9, xhci, 1-1:1-2 \
       # sync
   
-  .. note::
+   .. note::
      you can check and assign USB keyboard and USB mouse to UOS with modifying -s 9, xhci 1-x:1-y \
      according to your USB device info
      
      there is an known issue to use USB keyboard and mouse in UOS, you have to unplug and plug back 
-     keyboard and mouse for UOS after lauch UOS.  
+     keyboard and mouse assigned to UOS after lauch UOS.  
+
 
 Build ACRN from Source
 **********************


### PR DESCRIPTION
currently, ACRN supports USB device sharing, like USB keyboard and USB mouse for UOS, 
this patch is to share USB keyboard and USB mouse to UOS with modifying script

Signed-off-by: ailun258 <ailin.yang@intel.com>