### PR TITLE
DM: fix make install issue in auto boot UOS service

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -184,6 +184,7 @@ install-samples-nuc: $(SAMPLES_NUC)
 
 install-samples-mrb: $(SAMPLES_MRB)
 	install -D -t $(DESTDIR)/usr/share/acrn/samples/apl-mrb $^
+	install -d $(DESTDIR)/usr/lib/systemd/system/
 	install -p -D -m 0644 ./samples/apl-mrb/acrn_guest.service $(DESTDIR)/usr/lib/systemd/system
 
 install-bios: $(BIOS_BIN)


### PR DESCRIPTION
We need create system directory before we copy into $(DESTDIR)/usr/lib/systemd/system/, otherwise it will fail in clearlinux make build.

Signed-off-by: Nanlin Xie <nanlin.xie@intel.com>