### PR TITLE
IOC mediator: fix IOC mediator blocks acrn-dm shutdown flow

### DIFF
--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -659,7 +659,8 @@ enum ioc_event_type {
 	IOC_E_RAM_REFRESH,
 	IOC_E_HB_INACTIVE,
 	IOC_E_SHUTDOWN,
-	IOC_E_RESUME
+	IOC_E_RESUME,
+	IOC_E_KNOCK,
 };
 
 /*


### PR DESCRIPTION
This patch resolves IOC mediator deinit function is blocked due to IOC mediator
core thread enters into sleep by epoll_wait, then pthread_join cannot return.

Trigger an event to wakeup core thread when IOC mediator deinit is invoked.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>