### PR TITLE
HV:treewide:rename struct pic, iommu_domain and function pointer

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -475,8 +475,8 @@ vlapic_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 		return 1;
 	}
 
-	if (vlapic->ops.apicv_set_intr_ready != NULL) {
-		return (*vlapic->ops.apicv_set_intr_ready)
+	if (vlapic->ops.apicv_set_intr_ready_fn != NULL) {
+		return vlapic->ops.apicv_set_intr_ready_fn
 			(vlapic, vector, level);
 	}
 
@@ -1190,8 +1190,8 @@ vlapic_pending_intr(struct acrn_vlapic *vlapic, uint32_t *vecptr)
 	uint32_t i, vector, val, bitpos;
 	struct lapic_reg *irrptr;
 
-	if (vlapic->ops.apicv_pending_intr != NULL) {
-		return (*vlapic->ops.apicv_pending_intr)(vlapic, vecptr);
+	if (vlapic->ops.apicv_pending_intr_fn != NULL) {
+		return vlapic->ops.apicv_pending_intr_fn(vlapic, vecptr);
 	}
 
 	irrptr = &lapic->irr[0];
@@ -1222,8 +1222,8 @@ vlapic_intr_accepted(struct acrn_vlapic *vlapic, uint32_t vector)
 	struct lapic_reg *irrptr, *isrptr;
 	uint32_t idx, stk_top;
 
-	if (vlapic->ops.apicv_intr_accepted != NULL) {
-		vlapic->ops.apicv_intr_accepted(vlapic, vector);
+	if (vlapic->ops.apicv_intr_accepted_fn != NULL) {
+		vlapic->ops.apicv_intr_accepted_fn(vlapic, vector);
 		return;
 	}
 
@@ -1746,16 +1746,16 @@ vlapic_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 void
 vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic)
 {
-	if (vlapic->ops.apicv_batch_set_tmr != NULL) {
-		vlapic->ops.apicv_batch_set_tmr(vlapic);
+	if (vlapic->ops.apicv_batch_set_tmr_fn != NULL) {
+		vlapic->ops.apicv_batch_set_tmr_fn(vlapic);
 	}
 }
 
 static void
 vlapic_apicv_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 {
-	if (vlapic->ops.apicv_set_tmr != NULL) {
-		vlapic->ops.apicv_set_tmr(vlapic, vector, level);
+	if (vlapic->ops.apicv_set_tmr_fn != NULL) {
+		vlapic->ops.apicv_set_tmr_fn(vlapic, vector, level);
 	}
 }
 
@@ -2098,14 +2098,14 @@ int vlapic_create(struct vcpu *vcpu)
 
 	if (is_vapic_supported()) {
 		if (is_vapic_intr_delivery_supported()) {
-			vlapic->ops.apicv_set_intr_ready =
+			vlapic->ops.apicv_set_intr_ready_fn =
 					apicv_set_intr_ready;
 
-			vlapic->ops.apicv_pending_intr =
+			vlapic->ops.apicv_pending_intr_fn =
 					apicv_pending_intr;
 
-			vlapic->ops.apicv_set_tmr = apicv_set_tmr;
-			vlapic->ops.apicv_batch_set_tmr =
+			vlapic->ops.apicv_set_tmr_fn = apicv_set_tmr;
+			vlapic->ops.apicv_batch_set_tmr_fn =
 					apicv_batch_set_tmr;
 
 			vlapic->pir_desc = (struct vlapic_pir_desc *)(&(vlapic->pir));

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -98,14 +98,14 @@ struct vlapic_pir_desc {
 } __aligned(64);
 
 struct vlapic_ops {
-	int (*apicv_set_intr_ready)
+	int (*apicv_set_intr_ready_fn)
 		(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
-	int (*apicv_pending_intr)(struct acrn_vlapic *vlapic, uint32_t *vecptr);
-	void (*apicv_intr_accepted)(struct acrn_vlapic *vlapic, uint32_t vector);
-	void (*apicv_post_intr)(struct acrn_vlapic *vlapic, int hostcpu);
-	void (*apicv_set_tmr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
-	void (*apicv_batch_set_tmr)(struct acrn_vlapic *vlapic);
-	void (*enable_x2apic_mode)(struct acrn_vlapic *vlapic);
+	int (*apicv_pending_intr_fn)(struct acrn_vlapic *vlapic, uint32_t *vecptr);
+	void (*apicv_intr_accepted_fn)(struct acrn_vlapic *vlapic, uint32_t vector);
+	void (*apicv_post_intr_fn)(struct acrn_vlapic *vlapic, int hostcpu);
+	void (*apicv_set_tmr_fn)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
+	void (*apicv_batch_set_tmr_fn)(struct acrn_vlapic *vlapic);
+	void (*enable_x2apic_mode_fn)(struct acrn_vlapic *vlapic);
 };
 
 struct vlapic_timer {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -268,9 +268,9 @@ int shutdown_vm(struct vm *vm)
 	/* TODO: De-initialize I/O Emulation */
 	free_io_emulation_resource(vm);
 
-	/* Free iommu_domain */
-	if (vm->iommu_domain != NULL) {
-		destroy_iommu_domain(vm->iommu_domain);
+	/* Free iommu */
+	if (vm->iommu != NULL) {
+		destroy_iommu_domain(vm->iommu);
 	}
 
 	bitmap_clear_lock(vm->attr.id, &vmid_bitmap);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -697,21 +697,21 @@ int32_t hcall_assign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
 	}
 
 	/* create a iommu domain for target VM if not created */
-	if (target_vm->iommu_domain == NULL) {
+	if (target_vm->iommu == NULL) {
 		if (target_vm->arch_vm.nworld_eptp == NULL) {
 			pr_err("%s, EPT of VM not set!\n",
 				__func__, target_vm->attr.id);
 			return -EPERM;
 		}
 		/* TODO: how to get vm's address width? */
-		target_vm->iommu_domain = create_iommu_domain(vmid,
+		target_vm->iommu = create_iommu_domain(vmid,
 				HVA2HPA(target_vm->arch_vm.nworld_eptp), 48U);
-		if (target_vm->iommu_domain == NULL) {
+		if (target_vm->iommu == NULL) {
 			return -ENODEV;
 		}
 
 	}
-	ret = assign_iommu_device(target_vm->iommu_domain,
+	ret = assign_iommu_device(target_vm->iommu,
 			(uint8_t)(bdf >> 8), (uint8_t)(bdf & 0xffU));
 
 	return ret;
@@ -731,7 +731,7 @@ int32_t hcall_deassign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
 		pr_err("%s: Unable copy param to vm\n", __func__);
 		return -1;
 	}
-	ret = unassign_iommu_device(target_vm->iommu_domain,
+	ret = unassign_iommu_device(target_vm->iommu,
 			(uint8_t)(bdf >> 8), (uint8_t)(bdf & 0xffU));
 
 	return ret;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -135,7 +135,7 @@ struct vm {
 	void *vuart;		/* Virtual UART */
 	struct acrn_vpic *vpic;      /* Virtual PIC */
 	enum vpic_wire_mode vpic_wire_mode;
-	struct iommu_domain *iommu_domain;	/* iommu domain of this VM */
+	struct iommu_domain *iommu;	/* iommu domain of this VM */
 	struct list_head list; /* list of VM */
 	spinlock_t spinlock;	/* Spin-lock used to protect VM modifications */
 


### PR DESCRIPTION
Naming convention rule:If the data structure type is used by only one 
module and its name meaning is simplistic, its name needs prefix
shorten module name.
Naming convention rule:Variable name can be shortened from its 
data structure type name.
Naming convention rule:If the type is function
pointer, its name needs suffix "_fn".

The following udpates are made:
struct pic pic-->struct i8259_reg_state i8259
struct iommu_domain-->struct vm_iommu_domain
*apicv_set_intr_ready-->*apicv_set_intr_ready_fn
*apicv_pending_intr-->*apicv_pending_intr_fn
*apicv_set_tmr-->*apicv_set_tmr_fn
*apicv_batch_set_tmr-->*apicv_batch_set_tmr_fn
*apicv_intr_accepted-->*apicv_intr_accepted_fn
*apicv_post_intr-->*apicv_post_intr_fn
*enable_x2apic_mode-->*enable_x2apic_mode_fn

V1-->V2:
        Update function pointer when it is used
        for calling.