### PR TITLE
tools: acrn-crashlog: fix build warnings with gcc8.1.1

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/history.c
+++ b/tools/acrn-crashlog/acrnprobe/history.c
@@ -56,10 +56,10 @@ static void entry_to_history_line(struct history_entry *entry,
 	newline[0] = 0;
 	if (entry->log != NULL) {
 		char *ptr;
-		char tmp[MAXLINESIZE];
+		char tmp[PATH_MAX];
 
-		strncpy(tmp, entry->log, MAXLINESIZE);
-		tmp[MAXLINESIZE-1] = 0;
+		strncpy(tmp, entry->log, PATH_MAX);
+		tmp[PATH_MAX - 1] = 0;
 		ptr = strrchr(tmp, '/');
 		if (ptr && ptr[1] == 0)
 			ptr[0] = 0;

--- a/tools/acrn-crashlog/acrnprobe/include/property.h
+++ b/tools/acrn-crashlog/acrnprobe/include/property.h
@@ -23,10 +23,14 @@
 #define __PROPERTY_H__
 #include "load_conf.h"
 
-#define VERSION_SIZE       256
+#define VERSION_SIZE		256
+/* UUID_SIZE contains the UUID number, dashes and some buffer*/
+#define UUID_SIZE		48
+/* General BUILD_VERSION like 23690 */
+#define BUILD_VERSION_SIZE	16
 
-char guuid[VERSION_SIZE];
-char gbuildversion[VERSION_SIZE];
+char guuid[UUID_SIZE];
+char gbuildversion[BUILD_VERSION_SIZE];
 
 int init_properties(struct sender_t *sender);
 int swupdated(struct sender_t *sender);

--- a/tools/acrn-crashlog/acrnprobe/property.c
+++ b/tools/acrn-crashlog/acrnprobe/property.c
@@ -47,7 +47,7 @@ static void get_device_id(struct sender_t *sender)
 		return;
 	}
 
-	ret = file_read_string(MACHINE_ID, guuid, VERSION_SIZE);
+	ret = file_read_string(MACHINE_ID, guuid, BUILD_VERSION_SIZE);
 	if (ret <= 0)
 		LOGE("Could not get mmc id: %d (%s)\n",
 		     ret, strerror(-ret));
@@ -56,7 +56,8 @@ static void get_device_id(struct sender_t *sender)
 
 	LOGE("Could not find DeviceId, set it to '%s'\n",
 	     DEVICE_ID_UNKNOWN);
-	strncpy(guuid, DEVICE_ID_UNKNOWN, strlen(DEVICE_ID_UNKNOWN));
+	strncpy(guuid, DEVICE_ID_UNKNOWN, UUID_SIZE);
+	guuid[UUID_SIZE - 1] = '\0';
 
 write:
 	overwrite_file(loguuid, guuid);
@@ -66,7 +67,7 @@ write:
 static int get_buildversion(struct sender_t *sender)
 {
 	int ret;
-	char lastbuild[VERSION_SIZE];
+	char lastbuild[BUILD_VERSION_SIZE];
 	char *logbuildid;
 	char *currentbuild = gbuildversion;
 
@@ -84,7 +85,7 @@ static int get_buildversion(struct sender_t *sender)
 		return ret;
 	}
 
-	ret = file_read_string(logbuildid, lastbuild, VERSION_SIZE);
+	ret = file_read_string(logbuildid, lastbuild, BUILD_VERSION_SIZE);
 	if (ret == -ENOENT ||
 	    !ret ||
 	    (ret > 0 && strcmp(currentbuild, lastbuild))) {

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -32,7 +32,7 @@
 
 #define KB                      (1024)
 #define MB                      (KB * KB)
-#define MAXLINESIZE             (4 * KB)
+#define MAXLINESIZE             (PATH_MAX + 128)
 #define CPBUFFERSIZE            (4 * KB)
 #define PAGE_SIZE               (4 * KB)
 

--- a/tools/acrn-crashlog/usercrash/crash_dump.c
+++ b/tools/acrn-crashlog/usercrash/crash_dump.c
@@ -24,6 +24,8 @@
 #define DUMP_FILE "/tmp/core"
 #define BUFFER_SIZE 8196
 #define LINK_LEN 512
+/* 128 means the length of the DUMP_FILE */
+#define FORMAT_LENGTH (LINK_LEN + 128)
 
 static void loginfo(int fd, const char *fmt, ...)
 {
@@ -110,7 +112,7 @@ static int save_coredump(const char *filename)
 static int get_backtrace(int pid, int fd, int sig, const char *comm)
 {
 	char *membkt;
-	char format[512];
+	char format[FORMAT_LENGTH];
 
 	loginfo(fd, "\nBackTrace:\n\n");
 	memset(format, 0, sizeof(format));

--- a/tools/acrn-crashlog/usercrash/protocol.c
+++ b/tools/acrn-crashlog/usercrash/protocol.c
@@ -112,6 +112,7 @@ static int socket_bind(int fd, const char *name)
 	if (name_len >= SUN_PATH_MAX)
 		return -1;
 	strncpy(addr.sun_path, name, SUN_PATH_MAX);
+	addr.sun_path[SUN_PATH_MAX - 1] = '\0';
 	unlink(addr.sun_path);
 	alen = strlen(addr.sun_path) + sizeof(addr.sun_family);
 


### PR DESCRIPTION
This patch is to fix the build warning with gcc8.1.1. Most of them are
warnings for buffer overflow from snprintf and strncpy.

Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: xiaojin2 <xiaojing.liu@intel.com>