### PR TITLE
doc: fix doc errors from acrn_vhm_mm.h API changes

### DIFF
--- a/doc/api/GVT-g_api.rst
+++ b/doc/api/GVT-g_api.rst
@@ -77,11 +77,9 @@ responses to user space modules, notified by vIRQ injections.
    :functions: acrn_hpa2gpa
                map_guest_phys
                unmap_guest_phys
-               set_mmio_map
-               unset_mmio_map
-
-.. kernel-doc:: include/linux/vhm/acrn_vhm_mm.h
-   :functions: update_memmap_attr
+               add_memory_region
+               del_memory_region
+               write_protect_page
 
 .. _MPT_interface:
 


### PR DESCRIPTION
API changes to acrn-kernel/include/linux/vhm/acrn_vhm_mm.h in
https://github.com/projectacrn/acrn-kernel/pull/48 renamed functions
that were referenced in the GTG-g_api.rst document, causing the
documentation build to fail.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>