### PR TITLE
HV: rename resume_vm to start_vm in hypercall api

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -62,7 +62,7 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 
 	case HC_START_VM:
 		/* param1: vmid */
-		ret = hcall_resume_vm((uint16_t)param1);
+		ret = hcall_start_vm((uint16_t)param1);
 		break;
 
 	case HC_PAUSE_VM:

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -209,7 +209,7 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 	return ret;
 }
 
-int32_t hcall_resume_vm(uint16_t vmid)
+int32_t hcall_start_vm(uint16_t vmid)
 {
 	int32_t ret = 0;
 	struct vm *target_vm = get_vm_from_vmid(vmid);

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -77,9 +77,9 @@ int32_t hcall_create_vm(struct vm *vm, uint64_t param);
 int32_t hcall_destroy_vm(uint16_t vmid);
 
 /**
- * @brief resume virtual machine
+ * @brief start virtual machine
  *
- * Resume a virtual machine, it will schedule target VM's vcpu to run.
+ * Start a virtual machine, it will schedule target VM's vcpu to run.
  * The function will return -1 if the target VM does not exist or the
  * IOReq buffer page for the VM is not ready.
  *
@@ -87,7 +87,7 @@ int32_t hcall_destroy_vm(uint16_t vmid);
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_resume_vm(uint16_t vmid);
+int32_t hcall_start_vm(uint16_t vmid);
 
 /**
  * @brief pause virtual machine


### PR DESCRIPTION
Currently we don't support resume VM in HC API, the real meaning
of the code is to start VM.

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>