### PR TITLE
doc: tweak logo href to projectacrn.org

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -208,6 +208,7 @@ html_static_path = ['static']
 
 def setup(app):
    app.add_stylesheet("acrn-custom.css")
+   app.add_javascript("acrn-custom.js")
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/doc/static/acrn-custom.js
+++ b/doc/static/acrn-custom.js
@@ -1,0 +1,5 @@
+/* tweak logo link */
+
+$(document).ready(function(){
+   $( ".icon-home" ).attr("href", "https://projectacrn.org/");
+});


### PR DESCRIPTION
Have the logo link to the project site rather than the doc site

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>