### PR TITLE
hv: treewide: fix 'Function prototype/defn param type mismatch'

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -82,7 +82,7 @@ static int
 apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
 
 static int
-apicv_pending_intr(struct acrn_vlapic *vlapic, uint32_t *vecptr);
+apicv_pending_intr(struct acrn_vlapic *vlapic, __unused uint32_t *vecptr);
 
 static void
 apicv_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level);

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -28,7 +28,7 @@ struct acpi_table_header {
 	uint32_t                asl_compiler_revision;
 };
 
-uint16_t parse_madt(uint8_t *lapic_id_base);
+uint16_t parse_madt(uint8_t lapic_id_array[MAX_PCPU_NUM]);
 
 void *get_dmar_table(void);
 #endif /* !ACPI_H */

--- a/hypervisor/debug/shell_internal.h
+++ b/hypervisor/debug/shell_internal.h
@@ -127,23 +127,23 @@ struct shell_cmd {
 #define SHELL_CMD_TRIGGER_CRASH_HELP	"trigger crash"
 
 /* Global function prototypes */
-int shell_show_req_info(int argc, char **argv);
-int shell_cmd_help(int argc, char **argv);
-int shell_list_vm(int argc, char **argv);
-int shell_list_vcpu(int argc, char **argv);
+int shell_show_req_info(__unused int argc, __unused char **argv);
+int shell_cmd_help(__unused int argc, __unused char **argv);
+int shell_list_vm(__unused int argc, __unused char **argv);
+int shell_list_vcpu(__unused int argc, __unused char **argv);
 int shell_pause_vcpu(int argc, char **argv);
 int shell_resume_vcpu(int argc, char **argv);
 int shell_vcpu_dumpreg(int argc, char **argv);
 int shell_vcpu_dumpmem(int argc, char **argv);
 int shell_to_sos_console(int argc, char **argv);
-int shell_show_cpu_int(int argc, char **argv);
-int shell_show_ptdev_info(int argc, char **argv);
-int shell_reboot(int argc, char **argv);
+int shell_show_cpu_int(__unused int argc, __unused char **argv);
+int shell_show_ptdev_info(__unused int argc, __unused char **argv);
+int shell_reboot(__unused int argc, __unused char **argv);
 int shell_show_vioapic_info(int argc, char **argv);
-int shell_show_ioapic_info(int argc, char **argv);
-int shell_show_vmexit_profile(int argc, char **argv);
+int shell_show_ioapic_info(__unused int argc, __unused char **argv);
+int shell_show_vmexit_profile(__unused int argc, __unused char **argv);
 int shell_dump_logbuf(int argc, char **argv);
-int shell_get_loglevel(int argc, char **argv);
+int shell_get_loglevel(__unused int argc, __unused char **argv);
 int shell_set_loglevel(int argc, char **argv);
 int shell_cpuid(int argc, char **argv);
 struct shell_cmd *shell_find_cmd(const char *cmd);

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -17,8 +17,8 @@ int ptdev_intx_pin_remap(struct vm *vm, struct ptdev_intx_info *info);
 int ptdev_add_intx_remapping(struct vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin, bool pic_pin);
 void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin);
-int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
-	uint16_t phys_bdf, uint32_t vector_count);
+int ptdev_add_msix_remapping(struct vm *vm, __unused uint16_t virt_bdf,
+	__unused uint16_t phys_bdf, uint32_t vector_count);
 void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 		uint32_t vector_count);
 

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -52,8 +52,8 @@ void	vioapic_mmio_read(struct vm *vm, uint64_t gpa, uint32_t *rval);
 uint8_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
 bool	vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte);
-int	vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
-		void *handler_private_data);
+int	vioapic_mmio_access_handler(struct vcpu *vcpu,
+	struct io_request *io_req, __unused void *handler_private_data);
 
 #ifdef HV_DEBUG
 void get_vioapic_info(char *str_arg, int str_max, uint16_t vmid);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -112,7 +112,7 @@ void
 vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
 
 int vlapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
-		void *handler_private_data);
+		__unused void *handler_private_data);
 
 uint32_t vlapic_get_id(struct acrn_vlapic *vlapic);
 uint8_t vlapic_get_apicid(struct acrn_vlapic *vlapic);
@@ -123,13 +123,13 @@ void vlapic_init(struct acrn_vlapic *vlapic);
 void vlapic_reset(struct acrn_vlapic *vlapic);
 void vlapic_restore(struct acrn_vlapic *vlapic, struct lapic_regs *regs);
 bool vlapic_enabled(struct acrn_vlapic *vlapic);
-uint64_t apicv_get_apic_access_addr(struct vm *vm);
+uint64_t apicv_get_apic_access_addr(__unused struct vm *vm);
 uint64_t apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);
 void apicv_inject_pir(struct acrn_vlapic *vlapic);
 int apic_access_vmexit_handler(struct vcpu *vcpu);
 int apic_write_vmexit_handler(struct vcpu *vcpu);
 int veoi_vmexit_handler(struct vcpu *vcpu);
-int tpr_below_threshold_vmexit_handler(struct vcpu *vcpu);
+int tpr_below_threshold_vmexit_handler(__unused struct vcpu *vcpu);
 
 void calcvdest(struct vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 #endif	/* _VLAPIC_H_ */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -48,10 +48,12 @@ struct intr_excp_ctx {
 	uint64_t ss;
 };
 
-int handle_level_interrupt_common(struct irq_desc *desc, void *handler_data);
-int common_handler_edge(struct irq_desc *desc, void *handler_data);
-int common_dev_handler_level(struct irq_desc *desc, void *handler_data);
-int quick_handler_nolock(struct irq_desc *desc, void *handler_data);
+int handle_level_interrupt_common(struct irq_desc *desc,
+	__unused void *handler_data);
+int common_handler_edge(struct irq_desc *desc, __unused void *handler_data);
+int common_dev_handler_level(struct irq_desc *desc,
+	__unused void *handler_data);
+int quick_handler_nolock(struct irq_desc *desc, __unused void *handler_data);
 
 void init_default_irqs(uint16_t cpu);
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -391,7 +391,7 @@ int ept_mr_del(struct vm *vm, uint64_t *pml4_page,
 	uint64_t gpa, uint64_t size);
 
 int     ept_violation_vmexit_handler(struct vcpu *vcpu);
-int     ept_misconfig_vmexit_handler(struct vcpu *vcpu);
+int     ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu);
 
 #endif /* ASSEMBLER not defined */
 

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -29,7 +29,7 @@
 
 extern uint32_t console_loglevel;
 extern uint32_t mem_loglevel;
-void init_logmsg(uint32_t mem_size, uint32_t flags);
+void init_logmsg(__unused uint32_t mem_size, uint32_t flags);
 void print_logmsg_buffer(uint16_t pcpu_id);
 void do_logmsg(uint32_t severity, const char *fmt, ...);
 


### PR DESCRIPTION
Fix the parameter type mismatch between API declaration and definition.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>