### PR TITLE
acrn-manager: create acrn-hypervisor-dev package

### DIFF
--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -47,9 +47,13 @@ endif
 	rm -f $(OUT_DIR)/acrnd
 
 .PHONY: install
-install: $(OUT_DIR)/acrnctl
+install: $(OUT_DIR)/acrnctl $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/libacrn-mngr.a
 	install -d $(DESTDIR)/usr/bin
 	install -d $(DESTDIR)/usr/lib/systemd/system
+	install -d $(DESTDIR)/usr/lib64/
+	install -d $(DESTDIR)/usr/include/acrn
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnctl
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnd
+	install -t $(DESTDIR)/usr/lib64/ $(OUT_DIR)/libacrn-mngr.a
+	install -t $(DESTDIR)/usr/include/acrn $(OUT_DIR)/acrn_mngr.h
 	install -p -D -m 0644 $(OUT_DIR)/acrnd.service $(DESTDIR)/usr/lib/systemd/system


### PR DESCRIPTION
As first step to separate misc folder into github/intel/ioc-cbc-tools we
need let acrn create devel package. This package will let ioc-cbc-tools
use acrn manager interface API to control lifecycle.

The Clear Linux autospec script will *detect* /usr/include/acrn/*.h and
thus help us create the devel package. This devel pacakge will be in the
build_req for ioc-cbc-tools autospec.

Signed-off-by: Alek Du <alek.du@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>
Reviewed-by: Like Yan <like.yan@intel.com>