### PR TITLE
hv:fix return value violation for vioapic_get_rte

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -629,17 +629,16 @@ int vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
 	return ret;
 }
 
-bool vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte)
+/**
+ * @pre vm->arch_vm.virt_ioapic != NULL
+ * @pre rte != NULL
+ */
+void vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte)
 {
 	struct vioapic *vioapic;
 
 	vioapic = vm_ioapic(vm);
-	if ((vioapic != NULL) && (rte != NULL)) {
-		*rte = vioapic->rtbl[pin];
-		return true;
-	} else {
-		return false;
-	}
+	*rte = vioapic->rtbl[pin];
 }
 
 #ifdef HV_DEBUG

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -51,7 +51,7 @@ void	vioapic_mmio_read(struct vm *vm, uint64_t gpa, uint32_t *rval);
 
 uint8_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
-bool	vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte);
+void	vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu,
 	struct io_request *io_req, __unused void *handler_private_data);
 


### PR DESCRIPTION
Change this API to void type
Add pre-condition, state the input parameters are not NULL.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>