### PR TITLE
HV:fix rest integer violations

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -760,7 +760,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 	 * number for it(without trusty) is GUEST_INIT_PT_PAGE_NUM-1.
 	 * here make sure they are init as 0 (page entry no present)
 	 */
-	(void)memset(pml4_addr, 0, PAGE_SIZE_4K * GUEST_INIT_PT_PAGE_NUM-1);
+	(void)memset(pml4_addr, 0U, PAGE_SIZE_4K * GUEST_INIT_PT_PAGE_NUM-1);
 
 	/* Write PML4E */
 	table_present = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT);
@@ -800,7 +800,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 	 */
 	if (vm->sworld_control.sworld_enabled && !is_vm0(vm)) {
 		/* clear page entry for trusty */
-		(void)memset(pml4_addr + 6 * PAGE_SIZE_4K, 0, PAGE_SIZE_4K);
+		(void)memset(pml4_addr + 6U * PAGE_SIZE_4K, 0U, PAGE_SIZE_4K);
 
 		/* Write PDPTE for trusy memory, PD will use 7th page */
 		pd_base_paddr = GUEST_INIT_PAGE_TABLE_START +

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -41,7 +41,7 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	pr_info("Creating VCPU %hu", pcpu_id);
 
 	/* Allocate memory for VCPU */
-	vcpu = calloc(1, sizeof(struct vcpu));
+	vcpu = calloc(1U, sizeof(struct vcpu));
 	ASSERT(vcpu != NULL, "");
 
 	/* Initialize the physical CPU ID for this VCPU */
@@ -96,7 +96,7 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	ASSERT(vcpu->arch_vcpu.vmcs != NULL, "");
 
 	/* Memset VMCS region for this VCPU */
-	(void)memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
+	(void)memset(vcpu->arch_vcpu.vmcs, 0U, CPU_PAGE_SIZE);
 
 	/* Initialize exception field in VCPU context */
 	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
@@ -283,7 +283,7 @@ void reset_vcpu(struct vcpu *vcpu)
 	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
 	vcpu->arch_vcpu.irq_window_enabled = 0;
 	vcpu->arch_vcpu.inject_event_pending = false;
-	(void)memset(vcpu->arch_vcpu.vmcs, 0, CPU_PAGE_SIZE);
+	(void)memset(vcpu->arch_vcpu.vmcs, 0U, CPU_PAGE_SIZE);
 
 	vlapic = vcpu->arch_vcpu.vlapic;
 	vlapic_reset(vlapic);

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -407,7 +407,7 @@ void allow_guest_io_access(struct vm *vm, uint32_t address_arg, uint32_t nbytes)
 			b = vm->arch_vm.iobitmap[1];
 		}
 		a = address & 0x7fffU;
-		b[a >> 5] &= ~(1 << (a & 0x1fU));
+		b[a >> 5U] &= ~(1U << (a & 0x1fU));
 		address++;
 	}
 }
@@ -437,7 +437,7 @@ static struct vm_io_handler *create_io_handler(uint32_t port, uint32_t len,
 
 	struct vm_io_handler *handler;
 
-	handler = calloc(1, sizeof(struct vm_io_handler));
+	handler = calloc(1U, sizeof(struct vm_io_handler));
 
 	if (handler != NULL) {
 		handler->desc.addr = port;
@@ -461,12 +461,12 @@ void setup_io_bitmap(struct vm *vm)
 	       (vm->arch_vm.iobitmap[1] != NULL), "");
 
 	if (is_vm0(vm)) {
-		(void)memset(vm->arch_vm.iobitmap[0], 0x00, CPU_PAGE_SIZE);
-		(void)memset(vm->arch_vm.iobitmap[1], 0x00, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[0], 0x00U, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[1], 0x00U, CPU_PAGE_SIZE);
 	} else {
 		/* block all IO port access from Guest */
-		(void)memset(vm->arch_vm.iobitmap[0], 0xFF, CPU_PAGE_SIZE);
-		(void)memset(vm->arch_vm.iobitmap[1], 0xFF, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[0], 0xFFU, CPU_PAGE_SIZE);
+		(void)memset(vm->arch_vm.iobitmap[1], 0xFFU, CPU_PAGE_SIZE);
 	}
 }
 
@@ -498,7 +498,7 @@ int register_mmio_emulation_handler(struct vm *vm,
 	int status = -EINVAL;
 	struct mem_io_node *mmio_node;
 
-	if (vm->hw.created_vcpus > 0 && vm->hw.vcpu_array[0]->launched) {
+	if (vm->hw.created_vcpus > 0U && vm->hw.vcpu_array[0]->launched) {
 		ASSERT(false, "register mmio handler after vm launched");
 		return status;
 	}

--- a/hypervisor/arch/x86/trusty2.c
+++ b/hypervisor/arch/x86/trusty2.c
@@ -187,7 +187,7 @@ void  destroy_secure_world(struct vm *vm)
 		if ((uint64_t)size < entry.page_size)
 			adjust_size = size;
 
-		(void)memset(HPA2HVA(hpa), 0, adjust_size);
+		(void)memset(HPA2HVA(hpa), 0U, adjust_size);
 		/* restore memory to SOS ept mapping */
 		map_params.pml4_base = vm0->arch_vm.nworld_eptp;
 		map_params.pml4_inverted = vm0->arch_vm.m2p;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -38,7 +38,7 @@ int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid)
 	foreach_vcpu(i, vm, vcpu) {
 		if (vlapic_get_apicid(vcpu->arch_vcpu.vlapic) == lapicid) {
 			/* should not offline BSP */
-			if (vcpu->vcpu_id == 0)
+			if (vcpu->vcpu_id == 0U)
 				return -1;
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
 			reset_vcpu(vcpu);

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -68,7 +68,7 @@ alloc_entry(struct vm *vm, enum ptdev_intr_type type)
 	struct ptdev_remapping_info *entry;
 
 	/* allocate */
-	entry = calloc(1, sizeof(*entry));
+	entry = calloc(1U, sizeof(*entry));
 	ASSERT(entry != NULL, "alloc memory failed");
 	entry->type = type;
 	entry->vm = vm;

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -113,7 +113,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	pcpu_id = get_cpu_id();
 	buffer = per_cpu(logbuf, pcpu_id);
 
-	(void)memset(buffer, 0, LOG_MESSAGE_MAX_SIZE);
+	(void)memset(buffer, 0U, LOG_MESSAGE_MAX_SIZE);
 	/* Put time-stamp, CPU ID and severity into buffer */
 	snprintf(buffer, LOG_MESSAGE_MAX_SIZE,
 			"[%lluus][cpu=%hu][sev=%u][seq=%u]:",
@@ -197,7 +197,7 @@ void print_logmsg_buffer(uint16_t pcpu_id)
 
 	do {
 		uint32_t idx;
-		(void)memset(buffer, 0, LOG_ENTRY_SIZE + 1);
+		(void)memset(buffer, 0U, LOG_ENTRY_SIZE + 1);
 
 		if (*sbuf == NULL) {
 			return;

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -44,7 +44,7 @@ int vprintf(const char *fmt, va_list args)
 	int nchars = 0;
 
 	/* initialize parameters */
-	(void)memset(&param, 0, sizeof(param));
+	(void)memset(&param, 0U, sizeof(param));
 	param.emit = charout;
 	param.data = &nchars;
 

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -56,7 +56,7 @@ struct shared_buf *sbuf_allocate(uint32_t ele_num, uint32_t ele_size)
 		return NULL;
 	}
 
-	sbuf = calloc(1, sbuf_allocate_size);
+	sbuf = calloc(1U, sbuf_allocate_size);
 	if (sbuf == NULL) {
 		pr_err("%s no memory!", __func__);
 		return NULL;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -450,7 +450,7 @@ void shell_init(void)
 	(void)strcpy_s((void *)p_shell->name, SHELL_NAME_MAX_LEN, "Serial");
 
 	/* Zero fill the input buffer */
-	(void)memset((void *)p_shell->input_line[p_shell->input_line_active], 0,
+	(void)memset((void *)p_shell->input_line[p_shell->input_line_active], 0U,
 			SHELL_CMD_MAX_LEN + 1U);
 }
 
@@ -1045,7 +1045,7 @@ END:
 
 int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 {
-	char *temp_str = alloc_pages(2);
+	char *temp_str = alloc_pages(2U);
 
 	if (temp_str == NULL) {
 		return -ENOMEM;
@@ -1061,7 +1061,7 @@ int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 
 int shell_show_vmexit_profile(__unused int argc, __unused char **argv)
 {
-	char *temp_str = alloc_pages(2);
+	char *temp_str = alloc_pages(2U);
 
 	if (temp_str == NULL) {
 		return -ENOMEM;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -52,7 +52,7 @@ static void fifo_reset(struct fifo *fifo)
 
 static void fifo_init(struct fifo *fifo, int sz)
 {
-	fifo->buf = calloc(1, sz);
+	fifo->buf = calloc(1U, sz);
 	ASSERT(fifo->buf != NULL, "");
 	fifo->size = sz;
 	fifo_reset(fifo);
@@ -360,7 +360,7 @@ void *vuart_init(struct vm *vm)
 	struct vuart *vu;
 	uint16_t divisor;
 
-	vu = calloc(1, sizeof(struct vuart));
+	vu = calloc(1U, sizeof(struct vuart));
 	ASSERT(vu != NULL, "");
 
 	/* Set baud rate*/


### PR DESCRIPTION
Fix integer related violations.
V1->V2:
  clean all memset/calloc integer violations excpet bsp/boot directory

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>