### PR TITLE
Enable basic UOS S3 support

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -104,6 +104,7 @@ SRCS += core/sw_load_vsbl.c
 SRCS += core/smbiostbl.c
 SRCS += core/mevent.c
 SRCS += core/gc.c
+SRCS += core/pm.c
 SRCS += core/console.c
 SRCS += core/inout.c
 SRCS += core/mem.c

--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -175,6 +175,15 @@ pm1_status_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 	return 0;
 }
 
+void
+pm_backto_wakeup(struct vmctx *ctx)
+{
+	/* According to ACPI 5.0 Table 4-16: bit 15, WAK_STS should be
+	 * set when system trasition to the working state
+	 */
+	pm1_status |= PM1_WAK_STS;
+}
+
 static int
 pm1_enable_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 		   uint32_t *eax, void *arg)

--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -33,6 +33,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <pthread.h>
 
 #include "vmmapi.h"
 #include "acpi.h"

--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -256,6 +256,11 @@ pm1_control_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 				error = vm_suspend(ctx, VM_SUSPEND_POWEROFF);
 				assert(error == 0 || errno == EALREADY);
 			}
+
+			if ((pm1_control & PM1_SLP_TYP) >> 10 == 3) {
+				error = vm_suspend(ctx, VM_SUSPEND_SUSPEND);
+				assert(error == 0 || errno == EALREADY);
+			}
 		}
 	}
 	return 0;

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -622,6 +622,7 @@ vm_suspend_resume(struct vmctx *ctx)
 	vm_stop_watchdog(ctx);
 	wait_for_resume(ctx);
 
+	pm_backto_wakeup(ctx);
 	vm_reset_watchdog(ctx);
 	vm_reset(ctx);
 }

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -59,6 +59,7 @@
 #include "sw_load.h"
 #include "monitor.h"
 #include "ioc.h"
+#include "pm.h"
 
 #define GUEST_NIO_PORT		0x488	/* guest upcalls via i/o port */
 
@@ -447,6 +448,22 @@ handle_vmexit(struct vmctx *ctx, struct vhm_request *vhm_req, int vcpu)
 	default:
 		exit(1);
 	}
+
+	/* If UOS is not in suspend or system reset mode, we don't
+	 * need to notify request done.
+	 *
+	 * But there is little difference between reset and suspend:
+	 *  - We don't need to notify request done for reset because reset
+	 *    doesn't care it.
+	 *  - We don't need to notify request done for suspend because
+	 *    guest will offline all APs, write PM register to trigger
+	 *    PM. Then the PM register writting will trigger the latest
+	 *    vmexit and it doesn't care request done either.
+	 */
+	if ((VM_SUSPEND_SYSTEM_RESET == vm_get_suspend_mode()) ||
+		(VM_SUSPEND_SUSPEND == vm_get_suspend_mode()))
+		return;
+
 	vm_notify_request_done(ctx, vcpu);
 }
 
@@ -577,6 +594,39 @@ vm_system_reset(struct vmctx *ctx)
 }
 
 static void
+vm_suspend_resume(struct vmctx *ctx)
+{
+	int vcpu_id = 0;
+
+	/*
+	 * If we get warm reboot request, we don't want to exit the
+	 * vcpu_loop/vm_loop/mevent_loop. So we do:
+	 *   1. pause VM
+	 *   2. notify request done to reset ioreq state in vhm
+	 *   3. stop vm watchdog
+	 *   4. wait for resume signal
+	 *   5. reset vm watchdog
+	 *   6. hypercall restart vm
+	 */
+	vm_pause(ctx);
+	for (vcpu_id = 0; vcpu_id < 4; vcpu_id++) {
+		struct vhm_request *vhm_req;
+
+		vhm_req = &vhm_req_buf[vcpu_id];
+		if (vhm_req->valid &&
+			(vhm_req->processed == REQ_STATE_PROCESSING) &&
+			(vhm_req->client == ctx->ioreq_client))
+			vm_notify_request_done(ctx, vcpu_id);
+	}
+
+	vm_stop_watchdog(ctx);
+	wait_for_resume(ctx);
+
+	vm_reset_watchdog(ctx);
+	vm_reset(ctx);
+}
+
+static void
 vm_loop(struct vmctx *ctx)
 {
 	int error;
@@ -605,6 +655,10 @@ vm_loop(struct vmctx *ctx)
 
 		if (VM_SUSPEND_SYSTEM_RESET == vm_get_suspend_mode()) {
 			vm_system_reset(ctx);
+		}
+
+		if (VM_SUSPEND_SUSPEND == vm_get_suspend_mode()) {
+			vm_suspend_resume(ctx);
 		}
 	}
 	quit_vm_loop = 0;

--- a/devicemodel/core/mevent.c
+++ b/devicemodel/core/mevent.c
@@ -316,6 +316,8 @@ mevent_dispatch(void)
 	assert(pipev != NULL);
 
 	for (;;) {
+		int suspend_mode;
+
 		/*
 		 * Block awaiting events
 		 */
@@ -328,8 +330,11 @@ mevent_dispatch(void)
 		 */
 		mevent_handle(eventlist, ret);
 
-		if ((vm_get_suspend_mode() != VM_SUSPEND_NONE) &&
-			(vm_get_suspend_mode() != VM_SUSPEND_SYSTEM_RESET))
+		suspend_mode = vm_get_suspend_mode();
+
+		if ((suspend_mode != VM_SUSPEND_NONE) &&
+			(suspend_mode != VM_SUSPEND_SYSTEM_RESET) &&
+			(suspend_mode != VM_SUSPEND_SUSPEND))
 			break;
 	}
 }

--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -19,6 +19,7 @@
 #include "dm.h"
 #include "monitor.h"
 #include "acrn_mngr.h"
+#include "pm.h"
 
 /* helpers */
 /* Check if @path is a directory, and create if not exist */
@@ -205,6 +206,15 @@ static void handle_query(struct mngr_msg *msg, int client_fd, void *param)
 	mngr_send_msg(client_fd, &ack, NULL, ACK_TIMEOUT);
 }
 
+static struct monitor_vm_ops pmc_ops = {
+	.stop       = NULL,
+	.resume     = vm_monitor_resume,
+	.suspend    = NULL,
+	.pause      = NULL,
+	.unpause    = NULL,
+	.query      = vm_monitor_query,
+};
+
 int monitor_init(struct vmctx *ctx)
 {
 	int ret;
@@ -242,6 +252,8 @@ int monitor_init(struct vmctx *ctx)
 		fprintf(stderr, "%s %d\r\n", __FUNCTION__, __LINE__);
 		goto handlers_err;
 	}
+
+	monitor_register_vm_ops(&pmc_ops, ctx, "PMC_VM_OPs");
 
 	return 0;
 

--- a/devicemodel/core/pm.c
+++ b/devicemodel/core/pm.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include "vmmapi.h"
+
+static pthread_cond_t suspend_cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t suspend_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+int
+wait_for_resume(struct vmctx *ctx)
+{
+	pthread_mutex_lock(&suspend_mutex);
+	while (vm_get_suspend_mode() == VM_SUSPEND_SUSPEND) {
+		pthread_cond_wait(&suspend_cond, &suspend_mutex);
+	}
+	pthread_mutex_unlock(&suspend_mutex);
+
+	return 0;
+}
+
+int
+vm_resume(struct vmctx *ctx)
+{
+	pthread_mutex_lock(&suspend_mutex);
+	vm_set_suspend_mode(VM_SUSPEND_NONE);
+	pthread_cond_signal(&suspend_cond);
+	pthread_mutex_unlock(&suspend_mutex);
+
+	return 0;
+}
+
+int
+vm_monitor_resume(void *arg)
+{
+	struct vmctx *ctx = (struct vmctx *)arg;
+	vm_resume(ctx);
+
+	return 0;
+}
+
+int
+vm_monitor_query(void *arg)
+{
+	return vm_get_suspend_mode();
+}

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -744,6 +744,11 @@ basl_fwrite_dsdt(FILE *fp, struct vmctx *ctx)
 	dsdt_line("DefinitionBlock (\"dm_dsdt.aml\", \"DSDT\", 2,"
 			"\"DM \", \"DMDSDT  \", 0x00000001)");
 	dsdt_line("{");
+	dsdt_line("  Name (_S3, Package ()");
+	dsdt_line("  {");
+	dsdt_line("      0x03,");
+	dsdt_line("      Zero,");
+	dsdt_line("  })");
 	dsdt_line("  Name (_S5, Package ()");
 	dsdt_line("  {");
 	dsdt_line("      0x05,");

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -58,5 +58,6 @@ void	dsdt_indent(int levels);
 void	dsdt_unindent(int levels);
 void	sci_init(struct vmctx *ctx);
 void	pm_write_dsdt(struct vmctx *ctx, int ncpu);
+void	pm_backto_wakeup(struct vmctx *ctx);
 
 #endif /* _ACPI_H_ */

--- a/devicemodel/include/pm.h
+++ b/devicemodel/include/pm.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef	_DM_INCLUDE_PM_
+#define	_DM_INCLUDE_PM_
+
+int wait_for_resume(struct vmctx *ctx);
+int vm_resume(struct vmctx *ctx);
+int vm_monitor_resume(void *arg);
+int vm_monitor_query(void *arg);
+
+#endif

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -148,4 +148,6 @@ int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
 int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
+void	vm_stop_watchdog(struct vmctx *ctx);
+void	vm_reset_watchdog(struct vmctx *ctx);
 #endif	/* _VMMAPI_H_ */

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -65,6 +65,11 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_start_vm((uint16_t)param1);
 		break;
 
+	case HC_RESET_VM:
+		/* param1: vmid */
+		ret = hcall_reset_vm((uint16_t)param1);
+		break;
+
 	case HC_PAUSE_VM:
 		/* param1: vmid */
 		ret = hcall_pause_vm((uint16_t)param1);

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -55,12 +55,12 @@ static inline int exec_vmxon(void *addr)
 	/* Ensure previous operations successful */
 	if (status == 0) {
 		/* Turn VMX on */
-		asm volatile ("mov %1, %%rax\n"
+		asm volatile (
 			      "vmxon (%%rax)\n"
 			      "pushfq\n"
 			      "pop %0\n":"=r" (rflags)
-			      : "r"(addr)
-			      : "%rax", "cc", "memory");
+			      : "a"(addr)
+			      : "cc", "memory");
 
 		/* if carry and zero flags are clear operation success */
 		if ((rflags & (RFLAGS_C | RFLAGS_Z)) != 0U) {
@@ -153,12 +153,12 @@ int exec_vmclear(void *addr)
 	ASSERT(status == 0, "Incorrect arguments");
 
 	asm volatile (
-		"mov %1, %%rax\n"
 		"vmclear (%%rax)\n"
 		"pushfq\n"
-		"pop %0\n":"=r" (rflags)
-		: "r"(addr)
-		: "%rax", "cc", "memory");
+		"pop %0\n"
+		:"=r" (rflags)
+		: "a"(addr)
+		: "cc", "memory");
 
 	/* if carry and zero flags are clear operation success */
 	if ((rflags & (RFLAGS_C | RFLAGS_Z)) != 0U) {
@@ -179,13 +179,12 @@ int exec_vmptrld(void *addr)
 	ASSERT(status == 0, "Incorrect arguments");
 
 	asm volatile (
-		"mov %1, %%rax\n"
 		"vmptrld (%%rax)\n"
 		"pushfq\n"
 		"pop %0\n"
 		: "=r" (rflags)
-		: "r"(addr)
-		: "%rax", "cc");
+		: "a"(addr)
+		: "cc", "memory");
 
 	/* if carry and zero flags are clear operation success */
 	if ((rflags & (RFLAGS_C | RFLAGS_Z)) != 0U) {
@@ -1153,7 +1152,7 @@ static void init_host_state(__unused struct vcpu *vcpu)
 	    (((trbase_lo >> 56U) & 0xffUL) << 24U);
 
 	/* SS segment override for upper32 bits of base in ia32e mode */
-	asm volatile ("mov %0,%%rax\n"
+	asm volatile (
 		      ".byte 0x36\n"
 		      "movq 8(%%rax),%%rax\n":"=a" (trbase_hi):"0"(trbase));
 	realtrbase = realtrbase | (trbase_hi << 32U);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -266,6 +266,17 @@ int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param)
 	return ret;
 }
 
+int32_t hcall_reset_vm(uint16_t vmid)
+{
+	struct vm *target_vm = get_vm_from_vmid(vmid);
+
+	if ((target_vm == NULL) || is_vm0(target_vm))
+		return -1;
+
+	reset_vm(target_vm);
+	return 0;
+}
+
 int32_t hcall_assert_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret = 0;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -173,6 +173,7 @@ void pause_vm(struct vm *vm);
 void resume_vm(struct vm *vm);
 void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec);
 int start_vm(struct vm *vm);
+int reset_vm(struct vm *vm);
 int create_vm(struct vm_description *vm_desc, struct vm **vm);
 int prepare_vm0(void);
 #ifdef CONFIG_VM0_DESC

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -77,6 +77,20 @@ int32_t hcall_create_vm(struct vm *vm, uint64_t param);
 int32_t hcall_destroy_vm(uint16_t vmid);
 
 /**
+ * @brief reset virtual machine
+ *
+ * Reset a virtual machine, it will make target VM rerun from
+ * pre-defined entry. Comparing to start vm, this function reset
+ * each vcpu state and do some initialization for guest.
+ * The function will return -1 if the target VM does not exist.
+ *
+ * @param vmid ID of the VM
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_reset_vm(uint16_t vmid);
+
+/**
  * @brief start virtual machine
  *
  * Start a virtual machine, it will schedule target VM's vcpu to run.

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -35,6 +35,7 @@
 #define HC_START_VM                 BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x02UL)
 #define HC_PAUSE_VM                 BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x03UL)
 #define HC_CREATE_VCPU              BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x04UL)
+#define HC_RESET_VM                 BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x05UL)
 
 /* IRQ and Interrupts */
 #define HC_ID_IRQ_BASE              0x20UL


### PR DESCRIPTION
This patch series enable the UOS S3 support. And with patch [2/6],
the system reset also could work.

For most virtio and emulated virtual devices, we don't need to do
anything in BE side for S3. There is only 1 exception: watchdog.
We have to move watchdog reset out of guest to make sure watchdog
always takes effect for guest to handle guest hang.

Now, there are some issues related with S3 we are still working
on:
1. PT dev issue for S3. Some PT dev can't work after UOS and UOS
   enter/exit S3.
2. Trusy S3 handling. We are waiting for dependency patch in. Then
   we will submit the trusty S3 handling patches.
3. Some mediator may have issue with UOS S3. We need to enable
   the basic UOS S3 first. So mediator owner could test/debug
   the mediator for UOS S3.

ChangeLog:
v1 -> v2:
  - Remove the suspend/resume callback added in v1 because most
    virtual devices don't need it.
  - Add global function to handle watchdog for S3.
    NOTE:
    We now only have one watchdog virtual device now. If we will
    have multi watchdog virtual devices in the future, we should
    move the global watchdog function to specific files.
