### PR TITLE
doc: CSS tweak for table caption location

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -91,6 +91,11 @@ table.align-center {
    display: table !important;
 }
 
+/* put the table caption at the bottom, as done for figures */
+table {
+   caption-side: bottom;
+}
+
 
 .code-block-caption {
     color: #000;


### PR DESCRIPTION
Default behavior is for figure captions below the figure, but table
captions above the table.  Tweak the CSS for tables to put the caption
below instead.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>