### PR TITLE
HV: Add Partitioning mode option for ACRN

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -11,6 +11,18 @@ config PLATFORM_SBL
 
 endchoice
 
+choice
+	prompt "Hypervisor mode"
+	default SHARING_MODE
+
+config SHARING_MODE
+	bool "Sharing mode"
+
+config PARTITION_MODE
+	bool "Partition mode"
+	depends on PLATFORM_SBL
+endchoice
+
 config PLATFORM
 	string
 	default "uefi" if PLATFORM_UEFI


### PR DESCRIPTION
Adding Kconfig option to choose and compile partitioning mode for ACRN.
Current implementation does not allow ACRN to support sharing mode
and partitioning mode out of a single binary.