### PR TITLE
Ensure we have MMC device as in GP2.0

### DIFF
--- a/devicemodel/samples/apl-mrb/acrn_guest.service
+++ b/devicemodel/samples/apl-mrb/acrn_guest.service
@@ -3,6 +3,7 @@ Description=Start ACRN UOS
 After=systemd-networkd.service
 
 ConditionPathExists=/sys/kernel/gvt
+ConditionPathExists=/dev/mmcblk1p3
 
 [Service]
 Type=simple


### PR DESCRIPTION
Ensure we have a /dev/mmcblk1p3 device before we can launch
the guest OS service.

This will be help to not launch the acrn guest service on devices
which don't have MMC.

Exmaples are NUC with sata devices or installation on non APL MRB.