### PR TITLE
Doc: Refine hypervisor shell commands

### DIFF
--- a/doc/user-guides/acrn-shell.rst
+++ b/doc/user-guides/acrn-shell.rst
@@ -19,7 +19,7 @@ The ACRN hypervisor shell supports the following commands:
      - Lists all VCPUs in all VMs
    * - vcpu_dumpreg <vm_id, vcpu_id>
      - Dumps registers for a specific VCPU
-   * - dumpmem <hva, GVA, length>
+   * - dumpmem <hva, length>
      - Dumps host memory, starting a given address, and for
        a given length (in bytes)
    * - sos_console
@@ -36,8 +36,6 @@ The ACRN hypervisor shell supports the following commands:
      - Shows vmexit profiling
    * - logdump <pcpu_id>
      - Dumps the log buffer for the physical CPU
-   * - trace <cpumask, ms>
-     - Dumps a CPU's recent events within <ms> milliseconds
    * - loglevel [console_loglevel] [mem_loglevel]
      - Get (when paras is NULL)  or Set loglevel [0 (none) - 6 (verbose)] for the console and optionally
        for memory

--- a/doc/user-guides/acrn-shell.rst
+++ b/doc/user-guides/acrn-shell.rst
@@ -17,26 +17,20 @@ The ACRN hypervisor shell supports the following commands:
      - Lists all VMs, displaying VM Name, VM ID, and VM State (ON=running)
    * - vcpu_list
      - Lists all VCPUs in all VMs
-   * - vcpu_pause <vm_id, vcpu_id>
-     - Pauses a specific VCPU
-   * - vcpu_resume <vm_id, vcpu_id>
-     - Resumes a specific VCPU
    * - vcpu_dumpreg <vm_id, vcpu_id>
      - Dumps registers for a specific VCPU
-   * - vcpu_dumpmem <vm_id, vcpu_id, GVA, length>
-     - Dumps memory for a specific VCPU, starting a given address, and for
+   * - dumpmem <hva, GVA, length>
+     - Dumps host memory, starting a given address, and for
        a given length (in bytes)
-   * - vm_console
+   * - sos_console
      - Switches to the SOS's console
    * - int
      - Lists interrupt information per CPU
    * - pt
      - Shows pass-through device information
    * - reboot
-     - Triggers a system warm reboot (immediately)
-   * - lsreq
-     - Shows ioreq information
-   * - dump_ioapic
+     - Triggers a system reboot (immediately)
+    * - dump_ioapic
      - Shows native ioapic information
    * - vmexit
      - Shows vmexit profiling
@@ -44,12 +38,8 @@ The ACRN hypervisor shell supports the following commands:
      - Dumps the log buffer for the physical CPU
    * - trace <cpumask, ms>
      - Dumps a CPU's recent events within <ms> milliseconds
-   * - get_loglevel
-     - Get the loglevel
-   * - set_loglevel <console_loglevel> [mem_loglevel]
-     - Set loglevel [0 (none) - 6 (verbose)] for the console and optionally
+   * - loglevel [console_loglevel] [mem_loglevel]
+     - Get (when paras is NULL)  or Set loglevel [0 (none) - 6 (verbose)] for the console and optionally
        for memory
    * - cpuid <leaf> [subleaf]
      - Displays the CPUID leaf [subleaf], in hexadecimal
-   * - crash
-     - Triggers a system crash

--- a/doc/user-guides/acrn-shell.rst
+++ b/doc/user-guides/acrn-shell.rst
@@ -37,7 +37,7 @@ The ACRN hypervisor shell supports the following commands:
    * - logdump <pcpu_id>
      - Dumps the log buffer for the physical CPU
    * - loglevel [console_loglevel] [mem_loglevel]
-     - Get (when paras is NULL)  or Set loglevel [0 (none) - 6 (verbose)] for the console and optionally
+     - Get (when no parameters are given)  or Set loglevel [0 (none) - 6 (verbose)] for the console and optionally
        for memory
    * - cpuid <leaf> [subleaf]
      - Displays the CPUID leaf [subleaf], in hexadecimal


### PR DESCRIPTION
removed shell commands:
--vcpu_pause
--vcpu_resume
--lsreq
--(warm) reboot
--vcpu_dumpmem

updated shell commands:
--vm_console -> sos_console
--trigger crash -> reboot
--merge 'set_loglevel' & 'get_loglevel' to 'loglevel'

new adding shell commands:
--dumpmem --> dump host physical memory