### PR TITLE
hv:Replace 0(cpu_id) with BOOT_CPU_ID

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1606,7 +1606,7 @@ vlapic_init(struct acrn_vlapic *vlapic)
 	 */
 	vlapic->msr_apicbase = DEFAULT_APIC_BASE | APICBASE_ENABLED;
 
-	if (vlapic->vcpu->vcpu_id == 0U) {
+	if (vlapic->vcpu->vcpu_id == BOOT_CPU_ID) {
 		vlapic->msr_apicbase |= APICBASE_BSP;
 	}
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1685,7 +1685,7 @@ int init_vmcs(struct vcpu *vcpu)
 	init_exit_ctrl(vcpu);
 
 #ifdef CONFIG_EFI_STUB
-	if (is_vm0(vcpu->vm) && vcpu->pcpu_id == 0U) {
+	if (is_vm0(vcpu->vm) && vcpu->pcpu_id == BOOT_CPU_ID) {
 		override_uefi_vmcs(vcpu);
 	}
 #endif

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -38,7 +38,7 @@ int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid)
 	foreach_vcpu(i, vm, vcpu) {
 		if (vlapic_get_apicid(vcpu->arch_vcpu.vlapic) == lapicid) {
 			/* should not offline BSP */
-			if (vcpu->vcpu_id == 0U)
+			if (vcpu->vcpu_id == BOOT_CPU_ID)
 				return -1;
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
 			reset_vcpu(vcpu);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -265,7 +265,7 @@ struct vcpu {
 #endif
 };
 
-#define	is_vcpu_bsp(vcpu)	((vcpu)->vcpu_id == 0U)
+#define	is_vcpu_bsp(vcpu)	((vcpu)->vcpu_id == BOOT_CPU_ID)
 /* do not update Guest RIP for next VM Enter */
 static inline void vcpu_retain_rip(struct vcpu *vcpu)
 {


### PR DESCRIPTION
Replace 0(pcpu_id/vcpu_id) with BOOT_CPU_ID

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>