### PR TITLE
hv: treewide: fix 'Array has no bounds specified'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -369,7 +369,8 @@ void bsp_boot_init(void)
 	start_tsc = rdtsc();
 
 	/* Clear BSS */
-	(void)memset(_ld_bss_start, 0U, (size_t)(_ld_bss_end - _ld_bss_start));
+	(void)memset(&_ld_bss_start, 0U,
+			(size_t)(&_ld_bss_end - &_ld_bss_start));
 
 	/* Build time sanity checks to make sure hard-coded offset
 	*  is matching the actual offset!

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -14,25 +14,25 @@ extern void write_trampoline_sym(void *sym, uint64_t val);
 extern uint64_t prepare_trampoline(void);
 
 /* external symbols that are helpful for relocation */
-extern uint8_t         _DYNAMIC[];
-extern const uint8_t   _ld_trampoline_load[];
-extern uint8_t         _ld_trampoline_start[];
-extern uint8_t         _ld_trampoline_end[];
-extern const uint64_t  _ld_trampoline_size;
+extern uint8_t		_DYNAMIC[1];
+extern const uint8_t	_ld_trampoline_load;
+extern uint8_t		_ld_trampoline_start;
+extern uint8_t		_ld_trampoline_end;
+extern const uint64_t	_ld_trampoline_size;
 
-extern uint8_t         cpu_primary_start_32[];
-extern uint8_t         cpu_primary_start_64[];
+extern uint8_t		cpu_primary_start_32;
+extern uint8_t		cpu_primary_start_64;
 
-extern uint8_t         trampoline_fixup_cs[];
-extern uint8_t         trampoline_fixup_ip[];
-extern uint8_t         trampoline_fixup_target[];
-extern uint8_t         CPU_Boot_Page_Tables_Start[];
-extern uint8_t         CPU_Boot_Page_Tables_ptr[];
-extern uint8_t         trampoline_pdpt_addr[];
-extern uint8_t         trampoline_gdt_ptr[];
-extern uint8_t         trampoline_start64_fixup[];
-extern uint8_t         trampoline_spinlock_ptr[];
+extern uint8_t		trampoline_fixup_cs;
+extern uint8_t		trampoline_fixup_ip;
+extern uint8_t		trampoline_fixup_target;
+extern uint8_t		CPU_Boot_Page_Tables_Start;
+extern uint8_t		CPU_Boot_Page_Tables_ptr;
+extern uint8_t		trampoline_pdpt_addr;
+extern uint8_t		trampoline_gdt_ptr;
+extern uint8_t		trampoline_start64_fixup;
+extern uint8_t		trampoline_spinlock_ptr;
 
-extern uint64_t        trampoline_start16_paddr;
+extern uint64_t		trampoline_start16_paddr;
 
 #endif /* RELOCATE_H */

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -155,8 +155,8 @@
 /**********************************/
 /* EXTERNAL VARIABLES             */
 /**********************************/
-extern uint8_t                _ld_bss_start[];
-extern uint8_t                _ld_bss_end[];
+extern uint8_t		_ld_bss_start;
+extern uint8_t		_ld_bss_end;
 
 /* In trampoline range, hold the jump target which trampline will jump to */
 extern uint64_t               main_entry[1];

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -93,14 +93,14 @@ void init_e820(void);
 void obtain_e820_mem_info(void);
 extern uint32_t e820_entries;
 extern struct e820_entry e820[E820_MAX_ENTRIES];
-extern uint32_t boot_regs[];
+extern uint32_t boot_regs[2];
 extern struct e820_mem_params e820_mem;
 
 int rdmsr_vmexit_handler(struct vcpu *vcpu);
 int wrmsr_vmexit_handler(struct vcpu *vcpu);
 void init_msr_emulation(struct vcpu *vcpu);
 
-extern const char vm_exit[];
+extern const char vm_exit;
 struct run_context;
 int vmx_vmrun(struct run_context *context, int ops, int ibrs);
 


### PR DESCRIPTION
MISRAC requires that the array size should be declared explicitly.

This patch fixes the issues caused by the arrays that are defined in
link_ram.ld.in or assembly file.

v1 -> v2:
 * Update the solution based on the info from the following link.
   https://sourceware.org/binutils/docs/ld/Source-Code-Reference.html

   Fix pattern is like below:
   extern char start_of_ROM, end_of_ROM, start_of_FLASH;
   memcpy (& start_of_FLASH, & start_of_ROM, & end_of_ROM - &
start_of_ROM);

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>