### PR TITLE
dm: uart: fix acrn-dm crash issue when invoke uart_closetty function

### DIFF
--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -275,12 +275,15 @@ uart_opentty(struct uart_vdev *uart)
 static void
 uart_closetty(struct uart_vdev *uart)
 {
-	if (uart->tty.fd != STDIN_FILENO)
-		mevent_delete_close(uart->mev);
-	else
-		mevent_delete(uart->mev);
+	if (isatty(uart->tty.fd)) {
+		if (uart->tty.fd != STDIN_FILENO)
+			mevent_delete_close(uart->mev);
+		else
+			mevent_delete(uart->mev);
 
-	uart->mev = 0;
+		uart->mev = 0;
+	}
+
 	ttyclose();
 }
 


### PR DESCRIPTION
mevent is added only if uart backend fd refers TTY in uart_opentty.
So we should only delete mevent if uart backend fd refers TTY in uart_closetty.

This issue can be reproduced by below steps
1) acrnd starts UOS
2) run poweroff command in UOS
3) crash happens

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>