### PR TITLE
hv: treewide: fix 'Procedure parameter has a type but no identifier'

### DIFF
--- a/hypervisor/debug/shell_internal.h
+++ b/hypervisor/debug/shell_internal.h
@@ -30,7 +30,7 @@ struct shell {
 };
 
 /* Shell Command Function */
-typedef int (*shell_cmd_fn_t)(int, char **);
+typedef int (*shell_cmd_fn_t)(int argc, char **argv);
 
 /* Shell Command */
 struct shell_cmd {

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -107,7 +107,7 @@ int vmx_vmrun(struct run_context *context, int ops, int ibrs);
 int load_guest(struct vm *vm, struct vcpu *vcpu);
 int general_sw_loader(struct vm *vm, struct vcpu *vcpu);
 
-typedef int (*vm_sw_loader_t)(struct vm *, struct vcpu *);
+typedef int (*vm_sw_loader_t)(struct vm *vm, struct vcpu *vcpu);
 extern vm_sw_loader_t vm_sw_loader;
 
 int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -35,12 +35,12 @@ struct vm;
 struct vcpu;
 
 typedef
-uint32_t (*io_read_fn_t)(struct vm_io_handler *, struct vm *,
-				uint16_t, size_t);
+uint32_t (*io_read_fn_t)(struct vm_io_handler *handler, struct vm *vm,
+				uint16_t port, size_t size);
 
 typedef
-void (*io_write_fn_t)(struct vm_io_handler *, struct vm *,
-				uint16_t, size_t, uint32_t);
+void (*io_write_fn_t)(struct vm_io_handler *handler, struct vm *vm,
+				uint16_t port, size_t size, uint32_t val);
 
 /* Describes a single IO handler description entry. */
 struct vm_io_handler_desc {
@@ -96,7 +96,8 @@ struct vm_io_handler {
 
 /* Typedef for MMIO handler and range check routine */
 struct mmio_request;
-typedef int (*hv_mem_io_handler_t)(struct vcpu *, struct io_request *, void *);
+typedef int (*hv_mem_io_handler_t)(struct vcpu *vcpu, struct io_request *io_req,
+					void *handler_private_data);
 
 /* Structure for MMIO handler node */
 struct mem_io_node {

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -7,7 +7,7 @@
 #ifndef TIMER_H
 #define TIMER_H
 
-typedef int (*timer_handle_t)(void *);
+typedef int (*timer_handle_t)(void *data);
 
 enum tick_mode {
 	TICK_MODE_ONESHOT = 0,

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -24,7 +24,7 @@ enum irq_desc_state {
 	IRQ_DESC_IN_PROCESS,
 };
 
-typedef int (*dev_handler_t)(int irq, void*);
+typedef int (*dev_handler_t)(int irq, void *dev_data);
 struct irq_request_info {
 	/* vector set to 0xE0 ~ 0xFF for pri_register_handler
 	 * and set to VECTOR_INVALID for normal_register_handler
@@ -84,7 +84,7 @@ normal_register_handler(uint32_t irq,
 		const char *name);
 void unregister_handler_common(struct dev_handler_node *node);
 
-typedef int (*irq_handler_t)(struct irq_desc*, void*);
+typedef int (*irq_handler_t)(struct irq_desc *desc, void *handler_data);
 void update_irq_handler(uint32_t irq, irq_handler_t func);
 
 #endif /* COMMON_IRQ_H */


### PR DESCRIPTION
Add the parameter identifier for typedef function pointer.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>