### PR TITLE
 tools: this patch set resolves acrnd and acrnctl S3 issues

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -141,7 +141,7 @@ static void _scan_alive_vm(void)
 			case VM_SUSPEND_NONE:
 				vm->state = VM_STARTED;
 				break;
-			case VM_SUSPEND_HALT:
+			case VM_SUSPEND_SUSPEND:
 				vm->state = VM_PAUSED;
 				break;
 			default:

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -72,7 +72,7 @@ static int query_state(const char *name)
 	req.msgid = DM_QUERY;
 	req.timestamp = time(NULL);
 
-	ret = send_msg(vmname, &req, &ack);
+	ret = send_msg(name, &req, &ack);
 	if (ret)
 		return ret;
 

--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -475,12 +475,8 @@ static int acrnctl_do_resume(int argc, char *argv[])
 			continue;
 		}
 
-		/* Per current implemention, we can't know if vm is in suspended
-		   state. Send reume cmd to acrn-dm when VM_STARTED and will
-		   correct it later when we have a way to check if vm has been
-		   suspended */
 		switch (s->state) {
-			case VM_STARTED:
+			case VM_PAUSED:
 				resume_vm(argv[i]);
 				break;
 			default:


### PR DESCRIPTION
this patch set resolves acrnd and acrnctl S3 issues.
    -fix S3 flow between acrnd and cbc lifecycle service.
    -fix issues that S3 cannot work in acrnd.
    -fix an issue that acrnctl tool can not resume paused vm.

v2:
    1) Use pthread_mutex_lock to ensure only one acrnd stop thread at a time.
    2) Remove the acrnd shutdown patch from the patchset, because rootcause of
       the acrnd shutdown issue is acrn-dm happen crash, and will fix this with
       an independent patch.

Yuan Liu (4):
  tools: fix an invalid parameter of send_msg in query_state
  tools: fix an issue acrnd does not notify the vm stop state to cbc
    lifecycle service
  tools: fix resuming vm issue in acrnd
  tools: fix resuming vm issue in acrnctl

 tools/acrn-manager/acrn_vm_ops.c |  4 +-
 tools/acrn-manager/acrnctl.c     |  6 +--
 tools/acrn-manager/acrnd.c       | 95 +++++++++++++++++++++++++++++++++++++---
 3 files changed, 92 insertions(+), 13 deletions(-)