### PR TITLE
HV: Refine 'hv_main()' function usage

### DIFF
--- a/hypervisor/arch/x86/idt.S
+++ b/hypervisor/arch/x86/idt.S
@@ -393,7 +393,7 @@ external_interrupt_save_frame:
 
     /*
      * We disable softirq path from interrupt IRET, since right now all IRQ
-     * are for Guest, and we can execute softirq in hv_main() loop
+     * are for Guest.
      */
 
     popq    %rax

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -107,48 +107,6 @@ void vcpu_thread(struct vcpu *vcpu)
 	} while (1);
 }
 
-static bool is_vm0_bsp(uint16_t pcpu_id)
-{
-#ifdef CONFIG_VM0_DESC
-	return pcpu_id == vm0_desc.vm_pcpu_ids[0];
-#else
-	return pcpu_id == BOOT_CPU_ID;
-#endif
-}
-
-int32_t hv_main(uint16_t pcpu_id)
-{
-	int32_t ret;
-
-	pr_info("%s, Starting common entry point for CPU %hu",
-			__func__, pcpu_id);
-
-	if (pcpu_id != get_cpu_id()) {
-		pr_err("%s, cpu_id %hu mismatch\n", __func__, pcpu_id);
-		return -EINVAL;
-	}
-
-	/* Enable virtualization extensions */
-	ret = exec_vmxon_instr(pcpu_id);
-	if (ret != 0) {
-		return ret;
-	}
-
-	/* X2APIC mode is disabled by default. */
-	x2apic_enabled = false;
-
-	if (is_vm0_bsp(pcpu_id)) {
-		ret = prepare_vm0();
-		if (ret != 0) {
-			return ret;
-		}
-	}
-
-	default_idle();
-
-	return 0;
-}
-
 #ifdef HV_DEBUG
 void get_vmexit_profile(char *str_arg, int str_max)
 {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -161,9 +161,6 @@ int32_t hcall_create_vm(struct vm *vm, uint64_t param)
 {
 	int32_t ret = 0;
 	struct vm *target_vm = NULL;
-	/* VM are created from hv_main() directly
-	 * Here we just return the vmid for DM
-	 */
 	struct acrn_create_vm cv;
 	struct vm_description vm_desc;
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -261,7 +261,6 @@ extern struct cpuinfo_x86 boot_cpu_data;
 /* Function prototypes */
 void cpu_dead(uint16_t pcpu_id);
 void trampoline_start16(void);
-int32_t hv_main(uint16_t cpu_id);
 bool is_vapic_supported(void);
 bool is_vapic_intr_delivery_supported(void);
 bool is_vapic_virt_reg_supported(void);


### PR DESCRIPTION
  'hv_main()' wraps several logic which has no dependencies
   each other(enable VMX, prepare to create service os VM..),
   in this case, split this function to make code logic clear.
   remove 'is_vm0_bsp()' & 'hv_main()'

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>