### PR TITLE
1st patch set for vioapic/vlapic/vpic reshuffle

### DIFF
--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -284,10 +284,8 @@ vioapic_write_eoi(struct vioapic *vioapic, uint32_t vector)
 	for (pin = 0U; pin < pincount; pin++) {
 		rte = vioapic->rtbl[pin];
 
-		if ((rte.full & IOAPIC_RTE_REM_IRR) == 0UL) {
-			continue;
-		}
-		if ((rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC) != vector) {
+		if (((rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC) != vector) ||
+			((rte.full & IOAPIC_RTE_REM_IRR) == 0UL)) {
 			continue;
 		}
 
@@ -492,12 +490,11 @@ vioapic_process_eoi(struct vm *vm, uint32_t vector)
 	/* notify device to ack if assigned pin */
 	for (pin = 0U; pin < pincount; pin++) {
 		rte = vioapic->rtbl[pin];
-		if ((rte.full & IOAPIC_RTE_REM_IRR) == 0UL) {
+		if (((rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC) != vector) ||
+			((rte.full & IOAPIC_RTE_REM_IRR) == 0UL)) {
 			continue;
 		}
-		if ((rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC) != vector) {
-			continue;
-		}
+
 		ptdev_intx_ack(vm, pin, PTDEV_VPIN_IOAPIC);
 	}
 
@@ -508,10 +505,8 @@ vioapic_process_eoi(struct vm *vm, uint32_t vector)
 	VIOAPIC_LOCK(vioapic);
 	for (pin = 0U; pin < pincount; pin++) {
 		rte = vioapic->rtbl[pin];
-		if ((rte.full & IOAPIC_RTE_REM_IRR) == 0UL) {
-			continue;
-		}
-		if ((rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC) != vector) {
+		if (((rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC) != vector) ||
+			((rte.full & IOAPIC_RTE_REM_IRR) == 0UL)) {
 			continue;
 		}
 

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -51,6 +51,7 @@ struct vioapic {
 #define	VIOAPIC_LOCK(vioapic)	spinlock_obtain(&((vioapic)->mtx))
 #define	VIOAPIC_UNLOCK(vioapic)	 spinlock_release(&((vioapic)->mtx))
 
+#define IOAPIC_ID_MASK		0x0f000000U
 #define MASK_ALL_INTERRUPTS   0x0001000000010000UL
 #define IOAPIC_RTE_LOW_INTVEC    ((uint32_t)IOAPIC_RTE_INTVEC)
 
@@ -320,7 +321,7 @@ vioapic_indirect_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 	regnum = addr & 0xffUL;
 	switch (regnum) {
 	case IOAPIC_ID:
-		vioapic->id = data & APIC_ID_MASK;
+		vioapic->id = data & IOAPIC_ID_MASK;
 		break;
 	case IOAPIC_VER:
 	case IOAPIC_ARB:

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -540,6 +540,8 @@ vioapic_reset(struct vioapic *vioapic)
 	for (pin = 0U; pin < pincount; pin++) {
 		vioapic->rtbl[pin].full = MASK_ALL_INTERRUPTS;
 	}
+	vioapic->id = 0U;
+	vioapic->ioregsel = 0U;
 }
 
 struct vioapic *

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1391,14 +1391,15 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 						value64);
 
 		if (is_vapic_intr_delivery_supported()) {
-			/* these fields are supported only on processors
-			 * that support the 1-setting of the "virtual-interrupt
-			 * delivery" VM-execution control
+			/* Disable all EOI VMEXIT by default and
+			 * clear RVI and SVI.
 			 */
-			exec_vmwrite64(VMX_EOI_EXIT0_FULL, ~0UL);
-			exec_vmwrite64(VMX_EOI_EXIT1_FULL, ~0UL);
-			exec_vmwrite64(VMX_EOI_EXIT2_FULL, ~0UL);
-			exec_vmwrite64(VMX_EOI_EXIT3_FULL, ~0UL);
+			exec_vmwrite64(VMX_EOI_EXIT0_FULL, 0UL);
+			exec_vmwrite64(VMX_EOI_EXIT1_FULL, 0UL);
+			exec_vmwrite64(VMX_EOI_EXIT2_FULL, 0UL);
+			exec_vmwrite64(VMX_EOI_EXIT3_FULL, 0UL);
+
+			exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0);
 		}
 	}
 

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -451,7 +451,6 @@ union ioapic_rte {
 /* window register offset */
 #define IOAPIC_REGSEL		0x00U
 #define IOAPIC_WINDOW		0x10U
-#define IOAPIC_EOIR		0x40U
 
 /* indexes into IO APIC */
 #define IOAPIC_ID		0x00U

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -49,9 +49,9 @@ void	vioapic_update_tmr(struct vcpu *vcpu);
 void	vioapic_mmio_write(struct vm *vm, uint64_t gpa, uint32_t wval);
 void	vioapic_mmio_read(struct vm *vm, uint64_t gpa, uint32_t *rval);
 
-uint8_t	vioapic_pincount(struct vm *vm);
+uint32_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
-void	vioapic_get_rte(struct vm *vm, uint8_t pin, union ioapic_rte *rte);
+void	vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu,
 	struct io_request *io_req, __unused void *handler_private_data);
 


### PR DESCRIPTION
This is the first set patches for vioapic/vlapic/vpic reshuffle. It majorly for vioapic, the subsequent patch sets will cover vlapic/vpic which plan to submit soon.

-refines the coding style for some key vioapic functions.
-fix several bugs.
-remove 0x20 ioapic support related code.
-the 0012 patch is for apicv, others are for vioapic.

v2:
-drop the two patches:
	hv: vioapic: support non-32-bits aligned access for vioapic
		Assume all access are 32bits aligned.
	hv: vioapic: change the vioapic->acnt to vioapic->state
		acnt is used for irq sharing. So keep it.
-to create new macro for ioapic id mask, avoid impact lapic id mask.
-provide more detail description for the reason to clear remote irr when switch to edge trigger mode.
-to keep original apicv support check conditions.
-fix 4 MISRA C warnings


Yu Wang (10):
  hv: vioapic: refine vioapic mmio access related code
  hv: vioapic: check vector prior to irr in EOI write emulation
  hv: vioapic: refine vioapic_mmio_rw function
  hv: vioapic: avoid deliver unnecessary interrupt for level trigger
  hv: vioapic: correct the ioapic id mask
  hv: vioapic: improve the vioapic reset flow
  hv: vioapic: change the variable type of pin to uint32_t
  hv: vioapic: remove EOI register support
  hv: vioapic: set remote IRR to zero once trigger mode switch to edge
  hv: apicv: improve the default apicv reset flow

 hypervisor/arch/x86/guest/vioapic.c         | 200 ++++++++------------
 hypervisor/arch/x86/vmx.c                   |  15 +-
 hypervisor/include/arch/x86/apicreg.h       |   1 -
 hypervisor/include/arch/x86/guest/vioapic.h |   4 +-
 4 files changed, 89 insertions(+), 131 deletions(-)

--
2.17.0


-=-=-=-=-=-=-=-=-=-=-=-
Links: You receive all messages sent to this group.

View/Reply Online (#9591): https://lists.projectacrn.org/g/acrn-dev/message/9591
Mute This Topic: https://lists.projectacrn.org/mt/24152615/767576
Group Owner: acrn-dev+owner@lists.projectacrn.org
Unsubscribe: https://lists.projectacrn.org/g/acrn-dev/leave/1700551/1532397164/xyzzy  [yu1.wang@intel.com]
-=-=-=-=-=-=-=-=-=-=-=-
