### PR TITLE
DM: add tag info while no repo in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ DM_OUT := $(ROOT_OUT)/devicemodel
 TOOLS_OUT := $(ROOT_OUT)/tools
 MISC_OUT := $(ROOT_OUT)/misc
 DOC_OUT := $(ROOT_OUT)/doc
+BUILD_VERSION ?=
+BUILD_TAG ?=
 export TOOLS_OUT
 
 .PHONY: all hypervisor devicemodel tools misc doc
@@ -27,7 +29,7 @@ sbl-hypervisor:
 
 devicemodel: tools
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
-	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT)
+	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG)
 
 tools:
 	mkdir -p $(TOOLS_OUT)

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -5,6 +5,8 @@ include ../VERSION
 FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)
 BASEDIR := $(shell pwd)
 DM_OBJDIR ?= $(CURDIR)/build
+DM_BUILD_VERSION ?=
+DM_BUILD_TAG ?=
 
 CC ?= gcc
 
@@ -154,16 +156,21 @@ distclean:
 
 include/version.h:
 	touch include/version.h
-	@COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
-	DIRTY=`git diff-index --name-only HEAD`;\
-	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-	DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
+	if [ "$(DM_BUILD_VERSION)"x = x -o "$(DM_BUILD_TAG)"x = x ];then\
+		COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
+		DIRTY=`git diff-index --name-only HEAD`;\
+		if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+		DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
+	else\
+		PATCH=$(DM_BUILD_VERSION);\
+		DAILY_TAG=$(DM_BUILD_TAG);\
+	fi;\
 	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
 	USER=`id -u -n`; \
 	echo "/*" > include/version.h; \
-	sed 's/^/ * /' ../LICENSE >> include/version.h; \
-	echo " */" >> include/version.h; \
-	echo "" >> include/version.h; \
+	sed 's/^/ * /' ../LICENSE >> include/version.h;\
+	echo " */" >> include/version.h;\
+	echo "" >> include/version.h;\
 	echo "#define DM_MAJOR_VERSION $(MAJOR_VERSION)" >> include/version.h;\
 	echo "#define DM_MINOR_VERSION $(MINOR_VERSION)" >> include/version.h;\
 	echo "#define DM_EXTRA_VERSION "\"$(EXTRA_VERSION)\""" >> include/version.h;\


### PR DESCRIPTION
there is no git repo, which download from github release,
however, acrn-dm -v will get tag info from this repo, in
such case, the tag info was null.
this patch will fix nul tag, which get it from CL mock build.

Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>