### PR TITLE
hv: timer: request timer irq once only

### DIFF
--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -26,7 +26,6 @@ struct per_cpu_region {
 	uint64_t softirq_pending;
 	uint64_t spurious;
 	uint64_t vmxon_region_pa;
-	struct dev_handler_node *timer_node;
 	struct shared_buf *earlylog_sbuf;
 	void *vcpu;
 	void *ever_run_vcpu;


### PR DESCRIPTION
Since global vector table is being used on all pcpus, it's not necessary to request timer irq
at each cpu init. With this change, per_cpu timer nodes are removed, and only BSP registers
and unregisters timer irq.

Signed-off-by: Yan, Like <like.yan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>