### PR TITLE
HV:treewide:fix value outside range of underlying type

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -951,9 +951,10 @@ void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 }
 
 #ifdef HV_DEBUG
+#define PTDEV_INVALID_PIN 0xffU
 static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 		uint32_t *irq, uint32_t *vector, uint64_t *dest, bool *lvl_tm,
-		int *pin, int *vpin, uint32_t *bdf, uint32_t *vbdf)
+		uint8_t *pin, uint8_t *vpin, uint32_t *bdf, uint32_t *vbdf)
 {
 	struct ptdev_intx_info *intx = &entry->ptdev_intr_info.intx;
 	if (is_entry_active(entry)) {
@@ -967,8 +968,8 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 			} else {
 				*lvl_tm = false;
 			}
-			*pin = IRQ_INVALID;
-			*vpin = -1;
+			*pin = PTDEV_INVALID_PIN;
+			*vpin = PTDEV_INVALID_PIN;
 			*bdf = entry->phys_bdf;
 			*vbdf = entry->virt_bdf;
 		} else {
@@ -1018,7 +1019,7 @@ void get_ptdev_info(char *str_arg, int str_max)
 	char type[16];
 	uint64_t dest;
 	bool lvl_tm;
-	int32_t pin, vpin;
+	uint8_t pin, vpin;
 	uint32_t bdf, vbdf;
 	struct list_head *pos;
 
@@ -1043,14 +1044,14 @@ void get_ptdev_info(char *str_arg, int str_max)
 			str += len;
 
 			len = snprintf(str, size,
-					"\t%s\t%d\t%d\t%x:%x.%x\t%x:%x.%x",
+					"\t%s\t%hhu\t%hhu\t%x:%x.%x\t%x:%x.%x",
 					is_entry_active(entry) ?
 					(lvl_tm ? "level" : "edge") : "none",
 					pin, vpin,
-					(bdf & 0xff00U) >> 8,
-					(bdf & 0xf8U) >> 3, bdf & 0x7U,
-					(vbdf & 0xff00U) >> 8,
-					(vbdf & 0xf8U) >> 3, vbdf & 0x7U);
+					(bdf & 0xff00U) >> 8U,
+					(bdf & 0xf8U) >> 3U, bdf & 0x7U,
+					(vbdf & 0xff00U) >> 8U,
+					(vbdf & 0xf8U) >> 3U, vbdf & 0x7U);
 			size -= len;
 			str += len;
 		}

--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -7,18 +7,20 @@
 #include <hypervisor.h>
 
 static void set_tss_desc(union tss_64_descriptor *desc,
-		uint64_t tss, size_t tss_limit, int type)
+		uint64_t tss, size_t tss_limit, uint32_t type)
 {
 	uint32_t u1, u2, u3;
+	uint32_t tss_hi_32 = (uint32_t)(tss >> 32U);
+	uint32_t tss_lo_32 = (uint32_t)tss;
 
-	u1 = (uint32_t)((tss << 16U) & 0xFFFFFFFFUL);
-	u2 = (uint32_t)(tss & 0xFF000000UL);
-	u3 = (uint32_t)((tss & 0x00FF0000UL) >> 16U);
+	u1 = tss_lo_32 << 16U;
+	u2 = tss_lo_32 & 0xFF000000U;
+	u3 = (tss_lo_32 & 0x00FF0000U) >> 16U;
 
 
 	desc->fields.low32.value = u1 | (tss_limit & 0xFFFFU);
-	desc->fields.base_addr_63_32 = (uint32_t)(tss >> 32U);
-	desc->fields.high32.value = (u2 | ((uint32_t)type << 8U) | 0x8000U | u3);
+	desc->fields.base_addr_63_32 = tss_hi_32;
+	desc->fields.high32.value = u2 | (type << 8U) | 0x8000U | u3;
 }
 
 void load_gdtr_and_tr(void)

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -229,16 +229,16 @@ void check_tsc(void)
 	CPU_CR_WRITE(cr4, (temp64 & ~CR4_TSD));
 }
 
-static uint64_t pit_calibrate_tsc(uint16_t cal_ms_arg)
+static uint64_t pit_calibrate_tsc(uint32_t cal_ms_arg)
 {
 #define PIT_TICK_RATE	1193182U
 #define PIT_TARGET	0x3FFFU
 #define PIT_MAX_COUNT	0xFFFFU
 
-	uint16_t cal_ms = cal_ms_arg;
+	uint32_t cal_ms = cal_ms_arg;
 	uint32_t initial_pit;
 	uint16_t current_pit;
-	uint16_t max_cal_ms;
+	uint32_t max_cal_ms;
 	uint64_t current_tsc;
 	uint8_t initial_pit_high, initial_pit_low;
 
@@ -248,7 +248,7 @@ static uint64_t pit_calibrate_tsc(uint16_t cal_ms_arg)
 	/* Assume the 8254 delivers 18.2 ticks per second when 16 bits fully
 	 * wrap.  This is about 1.193MHz or a clock period of 0.8384uSec
 	 */
-	initial_pit = ((uint32_t)cal_ms * PIT_TICK_RATE) / 1000U;
+	initial_pit = (cal_ms * PIT_TICK_RATE) / 1000U;
 	initial_pit += PIT_TARGET;
 	initial_pit_high = (uint8_t)(initial_pit >> 8U);
 	initial_pit_low = (uint8_t)initial_pit;
@@ -269,8 +269,8 @@ static uint64_t pit_calibrate_tsc(uint16_t cal_ms_arg)
 		 */
 		pio_write8(0x00U, 0x43U);
 
-		current_pit = pio_read8(0x40U);	/* Read LSB */
-		current_pit |= pio_read8(0x40U) << 8U;	/* Read MSB */
+		current_pit = (uint16_t)pio_read8(0x40U);	/* Read LSB */
+		current_pit |= (uint16_t)pio_read8(0x40U) << 8U;	/* Read MSB */
 		/* Let the counter count down to PIT_TARGET */
 	} while (current_pit > PIT_TARGET);
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1173,7 +1173,7 @@ static void init_host_state(__unused struct vcpu *vcpu)
 	exec_vmwrite(field, idtb.base);
 	pr_dbg("VMX_HOST_IDTR_BASE: 0x%x ", idtb.base);
 
-	value32 = (uint32_t)(msr_read(MSR_IA32_SYSENTER_CS) & 0xFFFFFFFFUL);
+	value32 = (uint32_t)msr_read(MSR_IA32_SYSENTER_CS);
 	field = VMX_HOST_IA32_SYSENTER_CS;
 	exec_vmwrite32(field, value32);
 	pr_dbg("VMX_HOST_IA32_SYSENTER_CS: 0x%x ",

--- a/hypervisor/include/arch/x86/gdt.h
+++ b/hypervisor/include/arch/x86/gdt.h
@@ -76,7 +76,7 @@
 #include <types.h>
 #include <cpu.h>
 
-#define TSS_AVAIL  (9)
+#define TSS_AVAIL  (9U)
 
 /*
  * Definition of an 8 byte code segment descriptor.


### PR DESCRIPTION
There are potential value outside range of underlying type
in some assignment expressions. This violates Rule 10.3 or
Rule 10.4 of MISRA C:2012.
BTW, all operations shall be conducted in exactly the same
arithmetic (underlying) type, otherwise, there is a
value outside range violation.

Update related assignment expressions.

V1-->V2:
	* Fix potential overflow in "pit_calibrate_tsc";
	* Move PTDEV_INVALID_PIN definition before
	  get_entry_info since this MACRO is only used by
	  debug function.

Signed-off-by: Xiangyang Wu <xiangyang.wu@linux.intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>