### PR TITLE
dm: uart: add state check of backend tty before uart_closetty

### DIFF
--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -715,6 +715,16 @@ uart_release_backend(struct uart_vdev *uart, const char *opts)
 	if (opts == NULL)
 		return;
 
+	/*
+	 * By current design, for the invalid PTY parameters, the virtual uarts
+	 * are still expose to UOS but all data be dropped by backend service.
+	 * The uart backend is not setup for this case, so don't try to release
+	 * the uart backend in here.
+	 * TODO: need re-visit the whole policy for such scenario in future.
+	 */
+	if (!uart->tty.opened)
+		return;
+
 	uart_closetty(uart);
 	if (strcmp("stdio", opts) == 0) {
 		stdio_in_use = false;


### PR DESCRIPTION
This patch resolves one arcn-dm crash issue when rebooting UOS.

The rootcause is that uart releases unopened backend tty.

One reproduced case is that the board does not support IOC but IOC
feature is enabled in the acrn-dm. After rebooting UOS, crash will
happen.

NOTE: This issue is not related to IOC, it also can be reproduced
with NON-IOC scenario. Just set one invalid PTY to the lpc, then
this issue should be reproduced.
We need re-visit the whole policy for such scenario in future.

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>