### PR TITLE
misc: Remove unnecessary ExecStop in systemd services

### DIFF
--- a/misc/cbc_lifecycle/cbc_lifecycle.service
+++ b/misc/cbc_lifecycle/cbc_lifecycle.service
@@ -5,7 +5,6 @@ Description=CBC lifecycle service
 Type=simple
 ExecStart=/usr/bin/cbc_lifecycle
 Restart=no
-ExecStop=/usr/bin/killall -s TERM cbc_lifecycle
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/acrn-crashlog/data/acrnprobe.service
+++ b/tools/acrn-crashlog/data/acrnprobe.service
@@ -9,7 +9,6 @@ After=prepare.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/acrnprobe
-ExecStop=/usr/bin/killall -s TERM acrnprobe
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/acrn-crashlog/data/usercrash.service
+++ b/tools/acrn-crashlog/data/usercrash.service
@@ -7,7 +7,6 @@ Before=acrnprobe.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/usercrash_s
-ExecStop=/usr/bin/killall -s TERM usercrash_s
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/acrn-manager/acrnd.service
+++ b/tools/acrn-manager/acrnd.service
@@ -4,7 +4,6 @@ Description=ACRN manager deamon
 [Service]
 Type=simple
 ExecStart=/usr/bin/acrnd
-ExecStop=/usr/bin/killall -s TERM acrnd
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/acrnlog/acrnlog.service
+++ b/tools/acrnlog/acrnlog.service
@@ -4,7 +4,6 @@ Description=ACRN hypervisor log
 [Service]
 Type=simple
 ExecStart=/usr/bin/acrnlog
-ExecStop=/usr/bin/killall -s TERM acrnlog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
From systemd documentation: https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStop=
> If this option is not specified, the process is terminated by sending the signal specified in KillSignal= when service stop is requested.

https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillSignal=
> Defaults to SIGTERM.

Signed-off-by: Tan Yew Wayne <yew.wayne.tan@intel.com>