### PR TITLE
hv: treewide: fix 'Potential side effect problem in expression'

### DIFF
--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -14,11 +14,13 @@ static int charout(int cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
 	int *nchars = (int *)hnd;
 	/* working pointer */
 	const char *p = s;
+	int len;
 
 	/* copy mode ? */
 	if (cmd == PRINT_CMD_COPY) {
 		if (sz > 0U) { /* copy 'sz' characters */
-			s += console_write(s, sz);
+			len = console_write(s, sz);
+			s += len;
 		}
 
 		*nchars += (s - p);

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -152,7 +152,10 @@ static inline uint8_t mmio_read8(void *addr)
  */
 static inline void set32(void *addr, uint32_t mask, uint32_t value)
 {
-	mmio_write32((mmio_read32(addr) & ~mask) | value, addr);
+	uint32_t temp_val;
+
+	temp_val = mmio_read32(addr);
+	mmio_write32((temp_val & ~mask) | value, addr);
 }
 
 /** Reads a 16 Bit memory mapped IO register, mask it and write it back into
@@ -164,7 +167,10 @@ static inline void set32(void *addr, uint32_t mask, uint32_t value)
  */
 static inline void set16(void *addr, uint16_t mask, uint16_t value)
 {
-	mmio_write16((mmio_read16(addr) & ~mask) | value, addr);
+	uint16_t temp_val;
+
+	temp_val = mmio_read16(addr);
+	mmio_write16((temp_val & ~mask) | value, addr);
 }
 
 /** Reads a 8 Bit memory mapped IO register, mask it and write it back into
@@ -176,7 +182,10 @@ static inline void set16(void *addr, uint16_t mask, uint16_t value)
  */
 static inline void set8(void *addr, uint8_t mask, uint8_t value)
 {
-	mmio_write8((mmio_read8(addr) & ~mask) | value, addr);
+	uint8_t temp_val;
+
+	temp_val = mmio_read8(addr);
+	mmio_write8((temp_val & ~mask) | value, addr);
 }
 
 #endif /* _IO_H defined */


### PR DESCRIPTION
MISRA-C requirement:
The value of an expression shall be the same under any order of
evaluation.
The order in which side effects take place is unspecified and may lead
to unexpected results.

This patch add a temporary variable for temporary storage to avoid the
side effects of evaluation order.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>