### PR TITLE
add cpu_do_idle to handle idle

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -748,6 +748,11 @@ void stop_cpus()
 	}
 }
 
+void cpu_do_idle(__unused uint16_t pcpu_id)
+{
+	__asm __volatile("pause" ::: "memory");
+}
+
 void cpu_dead(uint16_t pcpu_id)
 {
 	/* For debug purposes, using a stack variable in the while loop enables

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -172,9 +172,8 @@ void default_idle(void)
 			schedule();
 		} else if (need_offline(pcpu_id) != 0) {
 			cpu_dead(pcpu_id);
-		} else {
-			__asm __volatile("pause" ::: "memory");
-		}
+		} else
+			cpu_do_idle(pcpu_id);
 	}
 }
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -318,6 +318,7 @@ extern struct cpuinfo_x86 boot_cpu_data;
 #define MAX_CX_ENTRY	(MAX_CSTATE - 1U)
 
 /* Function prototypes */
+void cpu_do_idle(__unused uint16_t pcpu_id);
 void cpu_dead(uint16_t pcpu_id);
 void trampoline_start16(void);
 bool is_vapic_supported(void);


### PR DESCRIPTION
add wrap function cpu_do_idle in default_idle to handle arch cpu specific
idle operation.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>