### PR TITLE
hv: Adding a wrapper on top of prepare_vm0

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -563,7 +563,7 @@ static void bsp_boot_post(void)
 
 	exec_vmxon_instr(BOOT_CPU_ID);
 
-	prepare_vm0();
+	prepare_vm(BOOT_CPU_ID);
 
 	default_idle();
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -437,6 +437,18 @@ int prepare_vm0(void)
 	return err;
 }
 
+int prepare_vm(uint16_t pcpu_id)
+{
+	int err = 0;
+
+	/* prepare vm0 if pcpu_id is BOOT_CPU_ID */
+	if (pcpu_id == BOOT_CPU_ID) {
+		err  = prepare_vm0();
+	}
+
+	return err;
+}
+
 #ifdef CONFIG_VM0_DESC
 static inline bool vcpu_in_vm_desc(struct vcpu *vcpu,
 		struct vm_description *vm_desc)

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -181,7 +181,7 @@ void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec);
 int start_vm(struct vm *vm);
 int reset_vm(struct vm *vm);
 int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm);
-int prepare_vm0(void);
+int prepare_vm(uint16_t pcpu_id);
 #ifdef CONFIG_VM0_DESC
 void vm_fixup(struct vm *vm);
 #endif


### PR DESCRIPTION
Added prepare_vm function as a wrapper function on top of prepare_vm0.
This makes adding support for partition mode ACRN to boot multiple
VMs from HV cleaner.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>