### PR TITLE
DM: check more in guest service & launch script

### DIFF
--- a/devicemodel/samples/apl-mrb/acrn_guest.service
+++ b/devicemodel/samples/apl-mrb/acrn_guest.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=Start ACRN UOS
-After=systemd-networkd.service
+After=acrnprobe.service
+After=weston.service
+After=systemd-resolved.service
 
 ConditionPathExists=/sys/kernel/gvt
+ConditionPathExists=/dev/acrn_vhm 
 
 [Service]
 Type=simple

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -330,6 +330,11 @@ do
 	esac
 done
 
+if [ ! -b "/dev/mmcblk1p3" ]; then
+  echo "no /dev/mmcblk1p3 data partition, exit"
+  exit
+fi
+
 mkdir -p /data
 mount /dev/mmcblk1p3 /data
 


### PR DESCRIPTION
some exceptions can happen if westnon or network name service
not started before launch uos guest, like gvt and network exceptions,
which can cause SOS reboot. so add the dependency.

add data partiton check in launch script, for it can be called in every
clearlinux platform.

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>