### PR TITLE
hv: treewide: fix 'Switch empty default has no comment'

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -525,6 +525,11 @@ static void ptdev_intr_handle_irq(struct vm *vm,
 		break;
 	}
 	default:
+		/*
+		 * In this switch statement, intx->vpin_src shall either be
+		 * PTDEV_VPIN_IOAPIC or PTDEV_VPIN_PIC.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 }
@@ -598,6 +603,12 @@ void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 	case PTDEV_VPIN_PIC:
 		vpic_deassert_irq(vm, virt_pin);
 	default:
+		/*
+		 * In this switch statement,
+		 * entry->ptdev_intr_info.intx.vpin_src shall either be
+		 * PTDEV_VPIN_IOAPIC or PTDEV_VPIN_PIC.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -369,6 +369,12 @@ void guest_cpuid(struct vcpu *vcpu,
 		break;
 
 	default:
+		/*
+		 * In this switch statement, leaf shall either be 0x01U or 0x0bU
+		 * or 0x0dU. All the other cases have been handled properly
+		 * before this switch statement.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 }

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -827,6 +827,12 @@ static int emulate_mov(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		error = mmio_write(vcpu, val);
 		break;
 	default:
+		/*
+		 * For the opcode that is not handled (an invalid opcode), the
+		 * error code is assigned to a default value (-EINVAL).
+		 * Gracefully return this error code if prior case clauses have
+		 * not been met.
+		 */
 		break;
 	}
 
@@ -915,6 +921,12 @@ static int emulate_movx(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		vie_update_register(vcpu, reg, val, size);
 		break;
 	default:
+		/*
+		 * For the opcode that is not handled (an invalid opcode), the
+		 * error code is assigned to a default value (-EINVAL).
+		 * Gracefully return this error code if prior case clauses have
+		 * not been met.
+		 */
 		break;
 	}
 	return error;
@@ -1150,6 +1162,12 @@ static int emulate_test(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		result = val1 & val2;
 		break;
 	default:
+		/*
+		 * For the opcode that is not handled (an invalid opcode), the
+		 * error code is assigned to a default value (-EINVAL).
+		 * Gracefully return this error code if prior case clauses have
+		 * not been met.
+		 */
 		break;
 	}
 
@@ -1232,6 +1250,12 @@ static int emulate_and(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		error = mmio_write(vcpu, result);
 		break;
 	default:
+		/*
+		 * For the opcode that is not handled (an invalid opcode), the
+		 * error code is assigned to a default value (-EINVAL).
+		 * Gracefully return this error code if prior case clauses have
+		 * not been met.
+		 */
 		break;
 	}
 
@@ -1318,6 +1342,12 @@ static int emulate_or(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		error = mmio_write(vcpu, result);
 		break;
 	default:
+		/*
+		 * For the opcode that is not handled (an invalid opcode), the
+		 * error code is assigned to a default value (-EINVAL).
+		 * Gracefully return this error code if prior case clauses have
+		 * not been met.
+		 */
 		break;
 	}
 	if (error == 0) {
@@ -1462,6 +1492,12 @@ static int emulate_sub(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		vie_update_register(vcpu, reg, nval, size);
 		break;
 	default:
+		/*
+		 * For the opcode that is not handled (an invalid opcode), the
+		 * error code is assigned to a default value (-EINVAL).
+		 * Gracefully return this error code if prior case clauses have
+		 * not been met.
+		 */
 		break;
 	}
 

--- a/hypervisor/arch/x86/guest/vioapic.c
+++ b/hypervisor/arch/x86/guest/vioapic.c
@@ -254,6 +254,12 @@ vioapic_indirect_read(struct vioapic *vioapic, uint32_t addr)
 	case IOAPIC_ARB:
 		return vioapic->id;
 	default:
+		/*
+		 * In this switch statement, regnum shall either be IOAPIC_ID or
+		 * IOAPIC_VER or IOAPIC_ARB.
+		 * All the other cases will be handled properly later after this
+		 * switch statement.
+		 */
 		break;
 	}
 
@@ -294,6 +300,12 @@ vioapic_indirect_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 		/* readonly */
 		break;
 	default:
+		/*
+		 * In this switch statement, regnum shall either be IOAPIC_ID or
+		 * IOAPIC_VER or IOAPIC_ARB.
+		 * All the other cases will be handled properly later after this
+		 * switch statement.
+		 */
 		break;
 	}
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -531,6 +531,12 @@ lvt_off_to_idx(uint32_t offset)
 		index = APIC_LVT_ERROR;
 		break;
 	default:
+		/*
+		 * For the offset that is not handled (an invalid offset of
+		 * Local Vector Table), its index is assigned to a default
+		 * value, which indicates an invalid index.
+		 * The index will be checked later to guarantee the validity.
+		 */
 		break;
 	}
 	ASSERT(index <= VLAPIC_MAXLVT_INDEX,
@@ -867,6 +873,11 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t vector)
 			vcpu_inject_nmi(vcpu);
 			break;
 		default:
+			/*
+			 * Only LINT[1:0] pins will be handled here.
+			 * Gracefully return if prior case clauses have not
+			 * been met.
+			 */
 			break;
 		}
 		return 0;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -87,6 +87,11 @@ handle_vpic_irqline(struct vm *vm, uint32_t irq, enum irq_mode mode)
 	case IRQ_PULSE:
 		ret = vpic_pulse_irq(vm, irq);
 	default:
+		/*
+		 * In this switch statement, mode shall either be IRQ_ASSERT or
+		 * IRQ_DEASSERT or IRQ_PULSE.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 
@@ -113,6 +118,11 @@ handle_vioapic_irqline(struct vm *vm, uint32_t irq, enum irq_mode mode)
 		ret = vioapic_pulse_irq(vm, irq);
 		break;
 	default:
+		/*
+		 * In this switch statement, mode shall either be IRQ_ASSERT or
+		 * IRQ_DEASSERT or IRQ_PULSE.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 	return ret;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -194,6 +194,12 @@ static void shell_handle_special_char(uint8_t ch)
 		(void) shell_getc();
 		break;
 	default:
+		/*
+		 * Only the Escape character is treated as special character.
+		 * All the other characters have been handled properly in
+		 * shell_input_line, so they will not be handled in this API.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 }

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -205,6 +205,11 @@ static void vuart_write(__unused struct vm_io_handler *hdlr,
 		vu->scr = value;
 		break;
 	default:
+		/*
+		 * For the offset that is not handled (either a read-only
+		 * register or an invalid register), ignore the write to it.
+		 * Gracefully return if prior case clauses have not been met.
+		 */
 		break;
 	}
 


### PR DESCRIPTION
This patch add some comments after the default and before the break
in the switch statement based on MISRA-C requirement.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>