### PR TITLE
Provide virtual S3 support by Trusty.

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -107,9 +107,8 @@ void destroy_ept(struct vm *vm)
 	 *  - trusty is enabled. But not initialized yet.
 	 *    Check vm->arch_vm.sworld_eptp.
 	 */
-	if (vm->sworld_control.sworld_enabled &&
-			(vm->arch_vm.sworld_eptp != NULL)) {
-		free_ept_mem(vm->arch_vm.sworld_eptp);
+	if (vm->sworld_control.flag.active) {
+		free_ept_mem(HPA2HVA(vm->arch_vm.sworld_eptp));
 		vm->arch_vm.sworld_eptp = NULL;
 	}
 }

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -793,7 +793,7 @@ uint64_t create_guest_initial_paging(struct vm *vm)
 	 * FIXME: this is a tempory solution for trusty enabling,
 	 * the final solution is that vSBL will setup guest page tables
 	 */
-	if (vm->sworld_control.sworld_enabled && !is_vm0(vm)) {
+	if (vm->sworld_control.flag.supported && !is_vm0(vm)) {
 		/* clear page entry for trusty */
 		(void)memset(pml4_addr + 6U * PAGE_SIZE_4K, 0U, PAGE_SIZE_4K);
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -156,8 +156,8 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 #endif
 	} else {
 		/* populate UOS vm fields according to vm_desc */
-		vm->sworld_control.sworld_enabled =
-			vm_desc->sworld_enabled;
+		vm->sworld_control.flag.supported =
+			vm_desc->sworld_supported;
 		(void)memcpy_s(&vm->GUID[0], sizeof(vm->GUID),
 					&vm_desc->GUID[0],
 					sizeof(vm_desc->GUID));
@@ -266,7 +266,7 @@ int shutdown_vm(struct vm *vm)
 	vioapic_cleanup(vm->arch_vm.virt_ioapic);
 
 	/* Destroy secure world */
-	if (vm->sworld_control.sworld_enabled) {
+	if (vm->sworld_control.flag.active) {
 		destroy_secure_world(vm);
 	}
 	/* Free EPT allocated resources assigned to VM */

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -29,7 +29,8 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 	}
 
 	if (!is_vm0(vm) && hypcall_id != HC_WORLD_SWITCH &&
-		hypcall_id != HC_INITIALIZE_TRUSTY) {
+		hypcall_id != HC_INITIALIZE_TRUSTY &&
+		hypcall_id != HC_SAVE_RESTORE_SWORLD_CTX) {
 		pr_err("hypercall %d is only allowed from VM0!\n", hypcall_id);
 		goto out;
 	}
@@ -168,6 +169,10 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 
 	case HC_PM_GET_CPU_STATE:
 		ret = hcall_get_cpu_pm_state(vm, param1, param2);
+		break;
+
+	case HC_SAVE_RESTORE_SWORLD_CTX:
+		ret = hcall_save_restore_sworld_ctx(vcpu);
 		break;
 
 	default:

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -175,8 +175,7 @@ void invept(struct vcpu *vcpu)
 		desc.eptp = HVA2HPA(vcpu->vm->arch_vm.nworld_eptp) |
 				(3UL << 3U) | 6UL;
 		local_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
-		if (vcpu->vm->sworld_control.sworld_enabled &&
-			vcpu->vm->arch_vm.sworld_eptp != NULL) {
+		if (vcpu->vm->sworld_control.flag.active) {
 			desc.eptp = HVA2HPA(vcpu->vm->arch_vm.sworld_eptp)
 				| (3UL << 3U) | 6UL;
 			local_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -92,9 +92,9 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 		return;
 	}
 
-	if (!vm->sworld_control.sworld_enabled
+	if (!vm->sworld_control.flag.supported
 			|| vm->arch_vm.sworld_eptp != NULL) {
-		pr_err("Sworld is not enabled or Sworld eptp is not NULL");
+		pr_err("Sworld is not supported or Sworld eptp is not NULL");
 		return;
 	}
 
@@ -164,8 +164,9 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 			gpa, size);
 
 	/* Backup secure world info, will be used when
-	 * destroy secure world */
-	vm->sworld_control.sworld_memory.base_gpa = gpa;
+	 * destroy secure world and suspend UOS */
+	vm->sworld_control.sworld_memory.base_gpa_in_sos = gpa;
+	vm->sworld_control.sworld_memory.base_gpa_in_uos = gpa_orig;
 	vm->sworld_control.sworld_memory.base_hpa = hpa;
 	vm->sworld_control.sworld_memory.length = size;
 
@@ -194,7 +195,7 @@ void  destroy_secure_world(struct vm *vm)
 	map_params.pml4_inverted = vm0->arch_vm.m2p;
 
 	map_mem(&map_params, (void *)vm->sworld_control.sworld_memory.base_hpa,
-			(void *)vm->sworld_control.sworld_memory.base_gpa,
+		(void *)vm->sworld_control.sworld_memory.base_gpa_in_sos,
 			vm->sworld_control.sworld_memory.length,
 			(IA32E_EPT_R_BIT |
 			 IA32E_EPT_W_BIT |

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -494,6 +494,30 @@ void trusty_set_dseed(void *dseed, uint8_t dseed_num)
 			dseed, sizeof(struct seed_info) * dseed_num);
 }
 
+void save_sworld_context(struct vcpu *vcpu)
+{
+	memcpy_s(&vcpu->vm->sworld_snapshot,
+			sizeof(struct cpu_context),
+			&vcpu->arch_vcpu.contexts[SECURE_WORLD],
+			sizeof(struct cpu_context));
+}
+
+void restore_sworld_context(struct vcpu *vcpu)
+{
+	struct secure_world_control *sworld_ctl =
+		&vcpu->vm->sworld_control;
+
+	create_secure_world_ept(vcpu->vm,
+		sworld_ctl->sworld_memory.base_gpa_in_uos,
+		sworld_ctl->sworld_memory.length,
+		TRUSTY_EPT_REBASE_GPA);
+
+	memcpy_s(&vcpu->arch_vcpu.contexts[SECURE_WORLD],
+			sizeof(struct cpu_context),
+			&vcpu->vm->sworld_snapshot,
+			sizeof(struct cpu_context));
+}
+
 /**
  * @}
  */ // End of trusty_apis

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -7,6 +7,8 @@
 #include <hypervisor.h>
 #include <hkdf.h>
 
+#define ACRN_DBG_TRUSTY 6U
+
 #define TRUSTY_VERSION   1U
 #define TRUSTY_VERSION_2 2U
 
@@ -430,7 +432,7 @@ bool initialize_trusty(struct vcpu *vcpu, uint64_t param)
 	}
 
 	if (boot_param.version > TRUSTY_VERSION_2) {
-		pr_err("%s: Version(%u) not supported!\n",
+		dev_dbg(ACRN_DBG_TRUSTY, "%s: Version(%u) not supported!\n",
 				__func__, boot_param.version);
 		return false;
 	}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -171,7 +171,7 @@ int32_t hcall_create_vm(struct vm *vm, uint64_t param)
 	}
 
 	(void)memset(&vm_desc, 0U, sizeof(vm_desc));
-	vm_desc.sworld_enabled =
+	vm_desc.sworld_supported =
 		((cv.vm_flag & (SECURE_WORLD_ENABLED)) != 0U);
 	(void)memcpy_s(&vm_desc.GUID[0], 16U, &cv.GUID[0], 16U);
 	ret = create_vm(&vm_desc, &target_vm);

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -7,6 +7,8 @@
 #include <hypervisor.h>
 #include <hypercall.h>
 
+#define ACRN_DBG_TRUSTY_HYCALL 6U
+
 /* this hcall is only come from trusty enabled vcpu itself, and cannot be
  * called from other vcpus
  */
@@ -15,18 +17,21 @@ int32_t hcall_world_switch(struct vcpu *vcpu)
 	int32_t next_world_id = !(vcpu->arch_vcpu.cur_context);
 
 	if (next_world_id >= NR_WORLD) {
-		pr_err("%s world_id %d exceed max number of Worlds\n",
+		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
+			"%s world_id %d exceed max number of Worlds\n",
 			__func__, next_world_id);
 		return -EINVAL;
 	}
 
 	if (!vcpu->vm->sworld_control.flag.supported) {
-		pr_err("Secure World is not supported!\n");
+		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
+			"Secure World is not supported!\n");
 		return -EPERM;
 	}
 
 	if (!vcpu->vm->sworld_control.flag.active) {
-		pr_err("Trusty is not initialized!\n");
+		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
+			"Trusty is not initialized!\n");
 		return -EPERM;
 	}
 
@@ -40,17 +45,20 @@ int32_t hcall_world_switch(struct vcpu *vcpu)
 int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param)
 {
 	if (!vcpu->vm->sworld_control.flag.supported) {
-		pr_err("Secure World is not supported!\n");
+		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
+			"Secure World is not supported!\n");
 		return -EPERM;
 	}
 
 	if (vcpu->vm->sworld_control.flag.active) {
-		pr_err("Trusty already initialized!\n");
+		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
+			"Trusty already initialized!\n");
 		return -EPERM;
 	}
 
 	if (vcpu->arch_vcpu.cur_context != NORMAL_WORLD) {
-		pr_err("%s, must initialize Trusty from Normal World!\n",
+		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
+			"%s, must initialize Trusty from Normal World!\n",
 			__func__);
 		return -EPERM;
 	}

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -20,13 +20,13 @@ int32_t hcall_world_switch(struct vcpu *vcpu)
 		return -EINVAL;
 	}
 
-	if (!vcpu->vm->sworld_control.sworld_enabled) {
-		pr_err("%s, Secure World is not enabled!\n", __func__);
+	if (!vcpu->vm->sworld_control.flag.supported) {
+		pr_err("Secure World is not supported!\n");
 		return -EPERM;
 	}
 
-	if (vcpu->vm->arch_vm.sworld_eptp == NULL) {
-		pr_err("%s, Trusty is not initialized!\n", __func__);
+	if (!vcpu->vm->sworld_control.flag.active) {
+		pr_err("Trusty is not initialized!\n");
 		return -EPERM;
 	}
 
@@ -39,13 +39,13 @@ int32_t hcall_world_switch(struct vcpu *vcpu)
  */
 int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param)
 {
-	if (!vcpu->vm->sworld_control.sworld_enabled) {
-		pr_err("%s, Secure World is not enabled!\n", __func__);
+	if (!vcpu->vm->sworld_control.flag.supported) {
+		pr_err("Secure World is not supported!\n");
 		return -EPERM;
 	}
 
-	if (vcpu->vm->arch_vm.sworld_eptp != NULL) {
-		pr_err("%s, Trusty already initialized!\n", __func__);
+	if (vcpu->vm->sworld_control.flag.active) {
+		pr_err("Trusty already initialized!\n");
 		return -EPERM;
 	}
 
@@ -58,6 +58,8 @@ int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param)
 	if (!initialize_trusty(vcpu, param)) {
 		return -ENODEV;
 	}
+
+	vcpu->vm->sworld_control.flag.active = 1UL;
 
 	return 0;
 }

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -153,6 +153,13 @@ struct vm {
 	unsigned char GUID[16];
 	struct secure_world_control sworld_control;
 
+	/* Secure World's snapshot
+	 * Currently, Secure World is only running on vcpu[0],
+	 * so the snapshot only stores the vcpu0's run_context
+	 * of secure world.
+	 */
+	struct cpu_context sworld_snapshot;
+
 	uint32_t vcpuid_entry_nr, vcpuid_level, vcpuid_xlevel;
 	struct vcpuid_entry vcpuid_entries[MAX_VM_VCPUID_ENTRIES];
 #ifdef CONFIG_PARTITION_MODE

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -167,8 +167,8 @@ struct vm_description {
 	uint16_t               *vm_pcpu_ids;
 	unsigned char          GUID[16]; /* GUID of the vm will be created */
 	uint16_t               vm_hw_num_cores;   /* Number of virtual cores */
-	/* Whether secure world is enabled for current VM. */
-	bool                   sworld_enabled;
+	/* Whether secure world is supported for current VM. */
+	bool                   sworld_supported;
 #ifdef CONFIG_PARTITION_MODE
 	struct mptable_info	*mptable;
 #endif

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -104,11 +104,13 @@ struct secure_world_memory {
 struct secure_world_control {
 	/* Flag indicates Secure World's state */
 	struct {
-		/* secure world supporting: 0(unsupported), 1(supported) */
+		/* sworld supporting: 0(unsupported), 1(supported) */
 		uint64_t supported :  1;
-		/* secure world running status: 0(inactive), 1(active) */
+		/* sworld running status: 0(inactive), 1(active) */
 		uint64_t active    :  1;
-		uint64_t reserved  : 62;
+		/* sworld context saving status: 0(unsaved), 1(saved) */
+		uint64_t ctx_saved :  1;
+		uint64_t reserved  : 61;
 	} flag;
 	/* Secure world memory structure */
 	struct secure_world_memory sworld_memory;
@@ -126,7 +128,8 @@ struct trusty_startup_param {
 void switch_world(struct vcpu *vcpu, int next_world);
 bool initialize_trusty(struct vcpu *vcpu, uint64_t param);
 void destroy_secure_world(struct vm *vm);
-
+void save_sworld_context(struct vcpu *vcpu);
+void restore_sworld_context(struct vcpu *vcpu);
 void trusty_set_dseed(void *dseed, uint8_t dseed_num);
 
 #endif /* TRUSTY_H_ */

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -92,7 +92,9 @@ struct trusty_key_info {
 
 struct secure_world_memory {
 	/* The secure world base address of GPA in SOS */
-	uint64_t base_gpa;
+	uint64_t base_gpa_in_sos;
+	/* The original secure world base address allocated by bootloader */
+	uint64_t base_gpa_in_uos;
 	/* The secure world base address of HPA */
 	uint64_t base_hpa;
 	/* Secure world runtime memory size */
@@ -100,8 +102,14 @@ struct secure_world_memory {
 };
 
 struct secure_world_control {
-	/* Whether secure world is enabled for current VM */
-	bool sworld_enabled;
+	/* Flag indicates Secure World's state */
+	struct {
+		/* secure world supporting: 0(unsupported), 1(supported) */
+		uint64_t supported :  1;
+		/* secure world running status: 0(inactive), 1(active) */
+		uint64_t active    :  1;
+		uint64_t reserved  : 62;
+	} flag;
 	/* Secure world memory structure */
 	struct secure_world_memory sworld_memory;
 };

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -398,6 +398,15 @@ int32_t hcall_world_switch(struct vcpu *vcpu);
 int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param);
 
 /**
+ * @brief Save/Restore Context of Secure World.
+ *
+ * @param vcpu Pointer to VCPU data structure
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu);
+
+/**
  * @}
  */ // End of trusty_hypercall
 

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -75,6 +75,7 @@
 #define HC_ID_TRUSTY_BASE           0x70UL
 #define HC_INITIALIZE_TRUSTY        BASE_HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x00UL)
 #define HC_WORLD_SWITCH             BASE_HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x01UL)
+#define HC_SAVE_RESTORE_SWORLD_CTX  BASE_HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x02UL)
 
 /* Power management */
 #define HC_ID_PM_BASE               0x80UL

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -75,7 +75,6 @@
 #define HC_ID_TRUSTY_BASE           0x70UL
 #define HC_INITIALIZE_TRUSTY        BASE_HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x00UL)
 #define HC_WORLD_SWITCH             BASE_HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x01UL)
-#define HC_GET_SEC_INFO             BASE_HC_ID(HC_ID, HC_ID_TRUSTY_BASE + 0x02UL)
 
 /* Power management */
 #define HC_ID_PM_BASE               0x80UL


### PR DESCRIPTION
This patch series provide virtual S3 support by Trusty.

Main parts of this patch:
1. secure_world_control structure refine
   Previous definition of secure_world_control is not very accurate, break
   sworld_enable into 2 bit flags: supported and active. Check active bit
   instead of sworld_eptp. Record base_gpa_in_sos and base_gpa_in_uos since
   they will be used in virtual S3/warm reset path. This assumes the trusty's
   memory address is contiguous in both SOS and physical side.
2. Remove unused hypercall id: HC_GET_SEC_INFO
3. Log printing cleanup
4. New hypercall: HC_SAVE_RESTORE_SWORLD_CTX
   In UOS S3 suspend path: trusty kernel driver will call this hypercall
   to require Hypervisor save context of secure world.
   In UOS S3 resume path: virtual firmware will call this hypercall to
   require Hypervisor restore context of secure world.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>