### PR TITLE
hv: treewide: fix 'Variable should be declared static'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -14,15 +14,15 @@ spinlock_t trampoline_spinlock = {
 	.tail = 0U
 };
 
-spinlock_t up_count_spinlock = {
+static spinlock_t up_count_spinlock = {
 	.head = 0U,
 	.tail = 0U
 };
 
 struct per_cpu_region *per_cpu_data_base_ptr;
 uint16_t phys_cpu_num = 0U;
-uint64_t pcpu_sync = 0UL;
-volatile uint16_t up_count = 0U;
+static uint64_t pcpu_sync = 0UL;
+static volatile uint16_t up_count = 0U;
 
 /* physical cpu active bitmap, support up to 64 cpus */
 uint64_t pcpu_active_bitmap = 0UL;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -24,7 +24,7 @@ static union ioapic_rte saved_rte[CONFIG_NR_IOAPICS][IOAPIC_MAX_PIN];
  * the irq to ioapic pin mapping should extract from ACPI MADT table
  * hardcoded here
  */
-uint8_t legacy_irq_to_pin[NR_LEGACY_IRQ] = {
+static uint8_t legacy_irq_to_pin[NR_LEGACY_IRQ] = {
 	2U, /* IRQ0*/
 	1U, /* IRQ1*/
 	0U, /* IRQ2 connected to Pin0 (ExtInt source of PIC) if existing */
@@ -43,7 +43,7 @@ uint8_t legacy_irq_to_pin[NR_LEGACY_IRQ] = {
 	15U, /* IRQ15*/
 };
 
-uint64_t legacy_irq_trigger_mode[NR_LEGACY_IRQ] = {
+static uint64_t legacy_irq_trigger_mode[NR_LEGACY_IRQ] = {
 	IOAPIC_RTE_TRGREDG, /* IRQ0*/
 	IOAPIC_RTE_TRGREDG, /* IRQ1*/
 	IOAPIC_RTE_TRGREDG, /* IRQ2*/

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -9,7 +9,7 @@
 #include <ptdev.h>
 
 /* SOFTIRQ_PTDEV list for all CPUs */
-struct list_head softirq_dev_entry_list;
+static struct list_head softirq_dev_entry_list;
 /* passthrough device link */
 struct list_head ptdev_list;
 spinlock_t ptdev_lock;
@@ -26,7 +26,7 @@ struct ptdev_remapping_info invalid_entry = {
  *   ptdev_lock
  *     softirq_dev_lock
  */
-spinlock_t softirq_dev_lock;
+static spinlock_t softirq_dev_lock;
 
 static void ptdev_enqueue_softirq(struct ptdev_remapping_info *entry)
 {

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -45,7 +45,7 @@ static const char *const excp_names[32] = {
 };
 
 /* Global variable for save registers on exception */
-struct intr_excp_ctx *crash_ctx;
+static struct intr_excp_ctx *crash_ctx;
 
 static void dump_guest_reg(struct vcpu *vcpu)
 {

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -32,7 +32,6 @@ void ioapic_get_rte(uint32_t irq, union ioapic_rte *rte);
 void suspend_ioapic(void);
 void resume_ioapic(void);
 
-extern uint8_t legacy_irq_to_pin[NR_LEGACY_IRQ];
 extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
 
 #ifdef HV_DEBUG

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -61,11 +61,9 @@ struct ptdev_remapping_info {
 	} ptdev_intr_info;
 };
 
-extern struct list_head softirq_dev_entry_list;
 extern struct list_head ptdev_list;
 extern spinlock_t ptdev_lock;
 extern struct ptdev_remapping_info invalid_entry;
-extern spinlock_t softirq_dev_lock;
 
 void ptdev_softirq(__unused uint16_t cpu_id);
 void ptdev_init(void);

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -20,7 +20,7 @@ Malloc_Heap[CONFIG_HEAP_SIZE] __aligned(CONFIG_MALLOC_ALIGN);
 static uint32_t Malloc_Heap_Bitmap[MALLOC_HEAP_BITMAP_SIZE];
 static uint32_t Malloc_Heap_Contiguity_Bitmap[MALLOC_HEAP_BITMAP_SIZE];
 
-struct mem_pool Memory_Pool = {
+static struct mem_pool Memory_Pool = {
 	.start_addr = Malloc_Heap,
 	.spinlock = {.head = 0U, .tail = 0U},
 	.size = CONFIG_HEAP_SIZE,
@@ -44,7 +44,7 @@ Paging_Heap[CONFIG_NUM_ALLOC_PAGES][CPU_PAGE_SIZE] __aligned(CPU_PAGE_SIZE);
 static uint32_t Paging_Heap_Bitmap[PAGING_HEAP_BITMAP_SIZE];
 static uint32_t Paging_Heap_Contiguity_Bitmap[MALLOC_HEAP_BITMAP_SIZE];
 
-struct mem_pool Paging_Memory_Pool = {
+static struct mem_pool Paging_Memory_Pool = {
 	.start_addr = Paging_Heap,
 	.spinlock = {.head = 0U, .tail = 0U},
 	.size = CONFIG_NUM_ALLOC_PAGES * CPU_PAGE_SIZE,


### PR DESCRIPTION
Declare a variable with the static qualifier if it is of file scope and
not used in another file.

v1 -> v2:
 * remove the unnecessary change to the following variables, which is
    due to the report issue

   struct multiboot_info *mbi = (struct multiboot_info *)
                        (HPA2HVA((uint64_t)boot_regs[1]));
   struct multiboot_mmap *mmap =
                                (struct multiboot_mmap *)
                                HPA2HVA((uint64_t)mbi->mi_mmap_addr);

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>