### PR TITLE
hv: treewide: fix 'inline function should be declared static'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -67,7 +67,7 @@ static uint64_t start_tsc __attribute__((__section__(".bss_noinit")));
 			 : "r"(rsp), "rm"(SP_BOTTOM_MAGIC), "a"(to));   \
 }
 
-inline bool cpu_has_cap(uint32_t bit)
+bool cpu_has_cap(uint32_t bit)
 {
 	uint32_t feat_idx = bit >> 5U;
 	uint32_t feat_bit = bit & 0x1fU;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -29,55 +29,7 @@ struct page_walk_info {
 	bool nxe;		/* MSR_IA32_EFER_NXE_BIT */
 };
 
-inline bool
-is_vm0(struct vm *vm)
-{
-	return (vm->vm_id) == 0U;
-}
-
-inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
-{
-	uint16_t i;
-	struct vcpu *vcpu;
-
-	foreach_vcpu(i, vm, vcpu) {
-		if (vcpu->vcpu_id == vcpu_id) {
-			return vcpu;
-		}
-	}
-
-	return NULL;
-}
-
-inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
-{
-	uint16_t i;
-	struct vcpu *vcpu;
-
-	foreach_vcpu(i, vm, vcpu) {
-		if (vcpu->pcpu_id == pcpu_id) {
-			return vcpu;
-		}
-	}
-
-	return NULL;
-}
-
-inline struct vcpu *get_primary_vcpu(struct vm *vm)
-{
-	uint16_t i;
-	struct vcpu *vcpu;
-
-	foreach_vcpu(i, vm, vcpu) {
-		if (is_vcpu_bsp(vcpu)) {
-			return vcpu;
-		}
-	}
-
-	return NULL;
-}
-
-inline uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
+uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 {
 	uint16_t vcpu_id;
 	uint64_t dmask = 0UL;
@@ -94,7 +46,7 @@ inline uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 	return dmask;
 }
 
-inline bool vm_lapic_disabled(struct vm *vm)
+bool vm_lapic_disabled(struct vm *vm)
 {
 	uint16_t i;
 	struct vcpu *vcpu;

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -146,7 +146,7 @@ static inline uint32_t read_lapic_reg32(uint32_t offset)
 	return mmio_read32(lapic_info.xapic.vaddr + offset);
 }
 
-inline void write_lapic_reg32(uint32_t offset, uint32_t value)
+void write_lapic_reg32(uint32_t offset, uint32_t value)
 {
 	if (offset < 0x20U || offset > 0x3ffU)
 		return;

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -93,15 +93,10 @@ enum vm_paging_mode {
 /*
  * VM related APIs
  */
-bool is_vm0(struct vm *vm);
 bool vm_lapic_disabled(struct vm *vm);
 uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
 
 int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
-
-struct vcpu *get_primary_vcpu(struct vm *vm);
-struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id);
-struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id);
 
 enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -183,6 +183,53 @@ struct vm_description {
 #endif
 };
 
+static inline bool is_vm0(struct vm *vm)
+{
+	return (vm->vm_id) == 0U;
+}
+
+static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
+{
+	uint16_t i;
+	struct vcpu *vcpu;
+
+	foreach_vcpu(i, vm, vcpu) {
+		if (vcpu->vcpu_id == vcpu_id) {
+			return vcpu;
+		}
+	}
+
+	return NULL;
+}
+
+static inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
+{
+	uint16_t i;
+	struct vcpu *vcpu;
+
+	foreach_vcpu(i, vm, vcpu) {
+		if (vcpu->pcpu_id == pcpu_id) {
+			return vcpu;
+		}
+	}
+
+	return NULL;
+}
+
+static inline struct vcpu *get_primary_vcpu(struct vm *vm)
+{
+	uint16_t i;
+	struct vcpu *vcpu;
+
+	foreach_vcpu(i, vm, vcpu) {
+		if (is_vcpu_bsp(vcpu)) {
+			return vcpu;
+		}
+	}
+
+	return NULL;
+}
+
 int shutdown_vm(struct vm *vm);
 void pause_vm(struct vm *vm);
 void resume_vm(struct vm *vm);

--- a/hypervisor/lib/spinlock.c
+++ b/hypervisor/lib/spinlock.c
@@ -6,10 +6,11 @@
 
 #include <hv_lib.h>
 
-inline void spinlock_init(spinlock_t *lock)
+void spinlock_init(spinlock_t *lock)
 {
 	(void)memset(lock, 0U, sizeof(spinlock_t));
 }
+
 void spinlock_obtain(spinlock_t *lock)
 {
 


### PR DESCRIPTION
MISRAC does not allow the use of an inline function with external
linkage.

What this patch does:
- Add the static keyword for the function that is only used in the
  definition file.
- Remove the inline keyword for the function that is used in multiple
  files.

v1 -> v2:
 * Move some functions to headers as static inline function if it is
    possible

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>