### PR TITLE
hv:Refine destroy_secure_world API

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -45,7 +45,7 @@ static uint64_t find_next_table(uint32_t table_offset, void *table_base)
 /**
  * @pre pml4_addr != NULL
  */
-static void free_ept_mem(void *pml4_addr)
+void free_ept_mem(void *pml4_addr)
 {
 	void *pdpt_addr;
 	void *pde_addr;
@@ -98,18 +98,6 @@ void destroy_ept(struct vm *vm)
 		free_ept_mem(vm->arch_vm.nworld_eptp);
 	if (vm->arch_vm.m2p != NULL)
 		free_ept_mem(vm->arch_vm.m2p);
-
-	/*
-	 * If secure world is initialized, destroy Secure world ept.
-	 * There are two cases secure world is not initialized:
-	 *  - trusty is not enabled. Check sworld_enabled.
-	 *  - trusty is enabled. But not initialized yet.
-	 *    Check vm->arch_vm.sworld_eptp.
-	 */
-	if (vm->sworld_control.flag.active) {
-		free_ept_mem(HPA2HVA(vm->arch_vm.sworld_eptp));
-		vm->arch_vm.sworld_eptp = NULL;
-	}
 }
 
 uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -267,7 +267,7 @@ int shutdown_vm(struct vm *vm)
 
 	/* Destroy secure world */
 	if (vm->sworld_control.flag.active) {
-		destroy_secure_world(vm);
+		destroy_secure_world(vm, true);
 	}
 	/* Free EPT allocated resources assigned to VM */
 	destroy_ept(vm);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -389,7 +389,7 @@ int ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
 	uint64_t prot_set, uint64_t prot_clr);
 int ept_mr_del(struct vm *vm, uint64_t *pml4_page,
 	uint64_t gpa, uint64_t size);
-
+void free_ept_mem(void *pml4_addr);
 int     ept_violation_vmexit_handler(struct vcpu *vcpu);
 int     ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -16,6 +16,8 @@
 #define TRUSTY_EPT_REBASE_GPA (511UL * 1024UL * 1024UL * 1024UL)
 #define TRUSTY_MEMORY_SIZE        0x01000000
 
+#define NON_TRUSTY_PDPT_ENTRIES         511U
+
 /* Structure of seed info */
 struct seed_info {
 	uint8_t cse_svn;
@@ -127,7 +129,7 @@ struct trusty_startup_param {
 
 void switch_world(struct vcpu *vcpu, int next_world);
 bool initialize_trusty(struct vcpu *vcpu, uint64_t param);
-void destroy_secure_world(struct vm *vm);
+void destroy_secure_world(struct vm *vm, bool need_clr_mem);
 void save_sworld_context(struct vcpu *vcpu);
 void restore_sworld_context(struct vcpu *vcpu);
 void trusty_set_dseed(void *dseed, uint8_t dseed_num);


### PR DESCRIPTION
-- add clear trusty memory flag
  In some cases such as UOS power off or UOS full reset,
  need to clear trusty memory,no need to clear memory such as
  UOS S3 or UOS system reset,then add a flag to distinguish it
  when destroy secure world.
-- Restore trusty memory to guest normal world.
-- Moved free trusty EPT inside destroy_secure_world
  In some cases such as UOS S3 or UOS system reset,
  only need to free trusty EPT, this patch move free
  trusty EPT inside destroy_secure_world.
  Because PD/PT are shared in both secure world's EPT
  and normal world's EPT,before freeing trusty EPT,
  it will memset all PDPTEs except trusty memory,
  then call 'free_ept_mem', it can only free trusty EPT,
  and does't affect shared normal world EPT.

v2-->v3:
    -- Used new mmu api ept_mr_add when restore trusty memory
       to SOS and normal world
    -- Dropped this patch "Removed reverted page tables for trusty memory"
       because map_mem will be removed in future
       It will have a patch, need to update this api(ept_mr_add),
       it will not create inverted page tables for trusty memory.

v1-->v2:
   -- free trusty ept
       still use free_ept_mem, not add a new api,but need to
       memset pdptes except trusty memory
   -- Removed reverted page tables for trusty memory.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>