### PR TITLE
hv: Add EPT mapping for UOS in partitioning mode

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -161,6 +161,10 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 		(void)memcpy_s(&vm->GUID[0], sizeof(vm->GUID),
 					&vm_desc->GUID[0],
 					sizeof(vm_desc->GUID));
+#ifdef CONFIG_PARTITION_MODE
+		ept_mr_add(vm, vm_desc->start_hpa,
+					0UL, vm_desc->mem_size, EPT_RWX|EPT_WB);
+#endif
 	}
 
 	INIT_LIST_HEAD(&vm->list);

--- a/hypervisor/bsp/sbl/vm_description.c
+++ b/hypervisor/bsp/sbl/vm_description.c
@@ -64,6 +64,8 @@ const struct vm_description_array vm_desc_mrb = {
 				.vm_hw_num_cores = VM1_NUM_CPUS,
 				.vm_pcpu_ids = &VM1_CPUS[0],
 				.vm_id = 1U,
+				.start_hpa = 0x100000000UL,
+				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable"
@@ -74,6 +76,8 @@ const struct vm_description_array vm_desc_mrb = {
 				.vm_hw_num_cores = VM2_NUM_CPUS,
 				.vm_pcpu_ids = &VM2_CPUS[0],
 				.vm_id = 2U,
+				.start_hpa = 0x180000000UL,
+				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable"

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -179,6 +179,8 @@ struct vm_description {
 #ifdef CONFIG_PARTITION_MODE
 	uint8_t			vm_id;
 	struct mptable_info	*mptable;
+	uint64_t		start_hpa;
+	uint64_t		mem_size; /* UOS memory size in hex */
 	const char		*bootargs;
 #endif
 };


### PR DESCRIPTION
Adding code to map memory for UOS in partitioning mode ACRN.
HPA starting above 4GB is used for UOS memory. Supports only contiguous memory
from host for UOS. Current implementation supports only 2 GB for UOS memory.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>