### PR TITLE
hv: Build mptable for OS in partition mode

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -421,6 +421,8 @@ int prepare_vm(uint16_t pcpu_id)
 		ret = create_vm(vm_desc, &vm);
 		ASSERT(ret == 0, "VM creation failed!");
 
+		mptable_build(vm);
+
 		prepare_vcpu(vm, vm_desc->vm_pcpu_ids[0]);
 
 		/* Prepare the AP for vm */


### PR DESCRIPTION
This patch is an extension to the commit 6643adff8bfa05139992dfa1af7d129f8782b2e9.
It uses the mptable API to build mptable for each VM booted by ACRN in partition mode.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>