### PR TITLE
 Adding VPCI (PCI passthru) support for partition mode

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -95,7 +95,9 @@ INCLUDE_PATH += include/arch/x86
 INCLUDE_PATH += include/arch/x86/guest
 INCLUDE_PATH += include/debug
 INCLUDE_PATH += include/public
-INCLUDE_PATH += include/common
+ifeq ($(CONFIG_PARTITION_MODE),y)
+INCLUDE_PATH += include/dm/vpci
+endif
 INCLUDE_PATH += bsp/include
 INCLUDE_PATH += bsp/$(CONFIG_PLATFORM)/include/bsp
 INCLUDE_PATH += boot/include
@@ -169,6 +171,11 @@ C_SRCS += common/ptdev.c
 
 ifdef STACK_PROTECTOR
 C_SRCS += common/stack_protector.c
+endif
+
+ifeq ($(CONFIG_PARTITION_MODE),y)
+C_SRCS += $(wildcard dm/vpci/*.c)
+C_SRCS += $(wildcard partition/*.c)
 endif
 
 C_SRCS += bsp/$(CONFIG_PLATFORM)/vm_description.c

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -186,6 +186,10 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 	}
 	vm->vpic = vpic_init(vm);
 
+#ifdef CONFIG_PARTITION_MODE
+	vpci_init(vm);
+#endif
+
 	/* vpic wire_mode default is INTR */
 	vm->wire_mode = VPIC_WIRE_INTR;
 
@@ -289,6 +293,10 @@ int shutdown_vm(struct vm *vm)
 	if (vm->vpic != NULL) {
 		vpic_cleanup(vm);
 	}
+
+#ifdef CONFIG_PARTITION_MODE
+	vpci_cleanup(vm);
+#endif
 
 	free(vm->hw.vcpu_array);
 

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -1,0 +1,129 @@
+/*-
+* Copyright (c) 2011 NetApp, Inc.
+* Copyright (c) 2018 Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* $FreeBSD$
+*/
+
+
+/*_
+* Emulate a PCI Host bridge:
+* Intel Corporation Celeron N3350/Pentium N4200/Atom E3900
+* Series Host Bridge (rev 0b)
+*/
+
+#include <hypervisor.h>
+#include <hv_lib.h>
+#include <acrn_common.h>
+#include <hv_arch.h>
+#include <hv_debug.h>
+#include "pci_priv.h"
+
+static int vdev_hostbridge_init(struct pci_vdev *vdev)
+{
+	/* PCI config space */
+	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, 0x8086U);
+	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, 0x5af0U);
+
+	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, 0xbU);
+
+	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, PCIM_HDRTYPE_NORMAL
+		| PCIM_MFDEV);
+	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, PCIC_BRIDGE);
+	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, PCIS_BRIDGE_HOST);
+
+	pci_vdev_write_cfg_u8(vdev, 0x34U, 0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0x3cU, 0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0x48U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x4aU, 0xd1U);
+	pci_vdev_write_cfg_u8(vdev, 0x4bU, 0xfeU);
+	pci_vdev_write_cfg_u8(vdev, 0x50U, 0xc1U);
+	pci_vdev_write_cfg_u8(vdev, 0x51U, 0x2U);
+	pci_vdev_write_cfg_u8(vdev, 0x54U, 0x33U);
+	pci_vdev_write_cfg_u8(vdev, 0x58U, 0x7U);
+	pci_vdev_write_cfg_u8(vdev, 0x5aU, 0xf0U);
+	pci_vdev_write_cfg_u8(vdev, 0x5bU, 0x7fU);
+	pci_vdev_write_cfg_u8(vdev, 0x60U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x63U, 0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0xabU, 0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xacU, 0x2U);
+	pci_vdev_write_cfg_u8(vdev, 0xb0U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xb3U, 0x7cU);
+	pci_vdev_write_cfg_u8(vdev, 0xb4U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xb6U, 0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xb7U, 0x7bU);
+	pci_vdev_write_cfg_u8(vdev, 0xb8U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xbbU, 0x7bU);
+	pci_vdev_write_cfg_u8(vdev, 0xbcU, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xbfU, 0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xe0U, 0x9U);
+	pci_vdev_write_cfg_u8(vdev, 0xe2U, 0xcU);
+	pci_vdev_write_cfg_u8(vdev, 0xe3U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xf5U, 0xfU);
+	pci_vdev_write_cfg_u8(vdev, 0xf6U, 0x1cU);
+	pci_vdev_write_cfg_u8(vdev, 0xf7U, 0x1U);
+
+	return 0;
+}
+
+static int vdev_hostbridge_deinit(__unused struct pci_vdev *vdev)
+{
+	return 0;
+}
+
+static int vdev_hostbridge_cfgread(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t *val)
+{
+	/* Assumption: access needed to be aligned on 1/2/4 bytes */
+	if ((offset & (bytes - 1)) != 0U) {
+		*val = 0xffffffffU;
+		return -EINVAL;
+	}
+
+	*val = pci_vdev_read_cfg(vdev, offset, bytes);
+
+	return 0;
+}
+
+static int vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t val)
+{
+	/* Assumption: access needed to be aligned on 1/2/4 bytes */
+	if ((offset & (bytes - 1)) != 0U) {
+		return -EINVAL;
+	}
+
+	pci_vdev_write_cfg(vdev, offset, bytes, val);
+
+	return 0;
+}
+
+struct pci_vdev_ops pci_ops_vdev_hostbridge = {
+	.init = vdev_hostbridge_init,
+	.deinit = vdev_hostbridge_deinit,
+	.cfgwrite = vdev_hostbridge_cfgwrite,
+	.cfgread = vdev_hostbridge_cfgread,
+};
+

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -1,0 +1,81 @@
+/*-
+* Copyright (c) 2011 NetApp, Inc.
+* Copyright (c) 2018 Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* $FreeBSD$
+*/
+
+#ifndef PCI_PRIV_H_
+#define PCI_PRIV_H_
+
+#include <hv_debug.h>
+#include "vpci.h"
+
+#define PCIM_BAR_MEM_BASE   0xfffffff0U
+#define PCI_BAR_BASE(val)   ((val) & PCIM_BAR_MEM_BASE)
+#define PCI_BAR(base, type) ((base) | (type))
+
+#define PCI_BUS(bdf)   (((bdf) >> 8) & 0xFFU)
+#define PCI_SLOT(bdf)  (((bdf) >> 3) & 0x1FU)
+#define PCI_FUNC(bdf)  ((bdf) & 0x07U)
+
+#define LOBYTE(w)   ((uint8_t)((w) & 0xffU))
+
+#define PCI_BUSMAX    0xffU
+#define PCI_SLOTMAX   0x1fU
+#define PCI_FUNCMAX   0x7U
+
+#define MAXBUSES   (PCI_BUSMAX + 1U)
+#define MAXSLOTS   (PCI_SLOTMAX + 1U)
+#define MAXFUNCS   (PCI_FUNCMAX + 1U)
+
+#define PCIR_VENDOR      0x00U
+#define PCIR_DEVICE      0x02U
+#define PCIR_COMMAND     0x04U
+#define PCIM_CMD_MEMEN   0x0002U
+#define PCIR_REVID       0x08U
+#define PCIR_SUBCLASS    0x0aU
+#define PCIR_CLASS       0x0bU
+#define PCIR_HDRTYPE     0x0eU
+#define PCIM_HDRTYPE_NORMAL   0x00U
+#define PCIM_MFDEV            0x80U
+
+#define PCIR_BARS     0x10U
+#define PCIR_BAR(x)   (PCIR_BARS + ((x) * 4U))
+
+#define PCIM_BAR_MEM_SPACE   0U
+
+#define PCIC_BRIDGE       0x06U
+#define PCIS_BRIDGE_HOST  0x00U
+
+#define PCI_CONFIG_ADDR   0xcf8U
+#define PCI_CONFIG_DATA   0xcfcU
+
+#define PCI_CFG_ENABLE    0x80000000U
+
+void pci_vdev_cfg_handler(struct vpci *vpci, uint32_t in, uint16_t vbdf,
+	uint32_t offset, uint32_t bytes, uint32_t *val);
+
+#endif /* PCI_PRIV_H_ */

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -78,4 +78,76 @@
 void pci_vdev_cfg_handler(struct vpci *vpci, uint32_t in, uint16_t vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 
+static inline uint8_t
+pci_vdev_read_cfg_u8(struct pci_vdev *vdev, uint32_t offset)
+{
+	return (*(uint8_t *)(&vdev->cfgdata[0] + offset));
+}
+
+static inline uint16_t pci_vdev_read_cfg_u16(struct pci_vdev *vdev,
+	uint32_t offset)
+{
+	return (*(uint16_t *)(&vdev->cfgdata[0] + offset));
+}
+
+static inline uint32_t pci_vdev_read_cfg_u32(struct pci_vdev *vdev,
+	uint32_t offset)
+{
+	return (*(uint32_t *)(&vdev->cfgdata[0] + offset));
+}
+
+static inline void
+pci_vdev_write_cfg_u8(struct pci_vdev *vdev, uint32_t offset, uint8_t val)
+{
+	*(uint8_t *)(vdev->cfgdata + offset) = val;
+}
+
+static inline void
+pci_vdev_write_cfg_u16(struct pci_vdev *vdev, uint32_t offset, uint16_t val)
+{
+	*(uint16_t *)(vdev->cfgdata + offset) = val;
+}
+
+static inline void
+pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset, uint32_t val)
+{
+	*(uint32_t *)(vdev->cfgdata + offset) = val;
+}
+
+static inline uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev,
+	uint32_t offset, uint32_t bytes)
+{
+	uint32_t val;
+
+	switch (bytes) {
+	case 1U:
+		val = pci_vdev_read_cfg_u8(vdev, offset);
+		break;
+	case 2U:
+		val = pci_vdev_read_cfg_u16(vdev, offset);
+		break;
+	default:
+		val = pci_vdev_read_cfg_u32(vdev, offset);
+		break;
+	}
+
+	return val;
+}
+
+static inline void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t val)
+{
+	switch (bytes) {
+	case 1U:
+		pci_vdev_write_cfg_u8(vdev, offset, val);
+		break;
+	case 2U:
+		pci_vdev_write_cfg_u16(vdev, offset, val);
+		break;
+	default:
+		pci_vdev_write_cfg_u32(vdev, offset, val);
+		break;
+	}
+}
+
 #endif /* PCI_PRIV_H_ */

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -1,0 +1,292 @@
+/*-
+* Copyright (c) 2011 NetApp, Inc.
+* Copyright (c) 2018 Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* $FreeBSD$
+*/
+
+/* Passthrough PCI device related operations */
+
+#include <hypervisor.h>
+#include <hv_lib.h>
+#include <acrn_common.h>
+#include <hv_arch.h>
+#include <hv_debug.h>
+#include "pci_priv.h"
+
+
+static spinlock_t pci_device_lock = { .head = 0, .tail = 0 };
+
+
+static uint32_t pci_pdev_calc_address(uint16_t bdf, uint32_t offset)
+{
+	uint32_t addr = bdf;
+
+	addr <<= 8;
+	addr |= (offset | PCI_CFG_ENABLE);
+
+	return addr;
+}
+
+static uint32_t pci_pdev_read_cfg(struct pci_pdev *pdev,
+	uint32_t offset, uint32_t bytes)
+{
+	uint32_t addr;
+	uint32_t val;
+
+	spinlock_obtain(&pci_device_lock);
+
+	addr = pci_pdev_calc_address(pdev->bdf, offset);
+
+	/* Write address to ADDRESS register */
+	pio_write(addr, PCI_CONFIG_ADDR, 4);
+
+	/* Read result from DATA register */
+	switch (bytes) {
+	case 1U:
+		val = pio_read8(PCI_CONFIG_DATA + (offset & 3U));
+		break;
+	case 2U:
+		val = pio_read16(PCI_CONFIG_DATA + (offset & 2U));
+		break;
+	default:
+		val = pio_read32(PCI_CONFIG_DATA);
+		break;
+	}
+	spinlock_release(&pci_device_lock);
+
+	return val;
+}
+
+static void pci_pdev_write_cfg(struct pci_pdev *pdev, uint32_t offset,
+	uint32_t bytes, uint32_t val)
+{
+	uint32_t addr;
+
+	spinlock_obtain(&pci_device_lock);
+
+	addr = pci_pdev_calc_address(pdev->bdf, offset);
+
+	/* Write address to ADDRESS register */
+	pio_write(addr, PCI_CONFIG_ADDR, 4);
+
+	/* Write value to DATA register */
+	switch (bytes) {
+	case 1U:
+		pio_write8(val, PCI_CONFIG_DATA + (offset & 3U));
+		break;
+	case 2U:
+		pio_write16(val, PCI_CONFIG_DATA + (offset & 2U));
+		break;
+	default:
+		pio_write32(val, PCI_CONFIG_DATA);
+		break;
+	}
+	spinlock_release(&pci_device_lock);
+}
+
+static int vdev_pt_init_validate(struct pci_vdev *vdev)
+{
+	uint32_t idx;
+
+	for (idx = 0; idx < (uint32_t)PCI_BAR_COUNT; idx++) {
+		if (vdev->bar[idx].type != PCIM_BAR_MEM_32) {
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static void vdev_pt_init_bar_registers(struct pci_vdev *vdev)
+{
+	uint32_t idx;
+
+	for (idx = 0; idx < (uint32_t)PCI_BAR_COUNT; idx++) {
+		/* Initialize the BAR register in config space */
+		pci_vdev_write_cfg_u32(vdev, PCIR_BAR(idx),
+			PCI_BAR(vdev->bar[idx].base, vdev->bar[idx].type));
+	}
+}
+
+static int vdev_pt_init(struct pci_vdev *vdev)
+{
+	int ret;
+	struct vm *vm = vdev->vpci->vm;
+
+	ret = vdev_pt_init_validate(vdev);
+	if (ret != 0) {
+		pr_err("virtual bar can only be of type PCIM_BAR_MEM_32!");
+		return ret;
+	}
+
+	/* Create an iommu domain for target VM if not created */
+	if (vm->iommu == NULL) {
+		if (vm->arch_vm.nworld_eptp == 0UL) {
+			vm->arch_vm.nworld_eptp = alloc_paging_struct();
+		}
+		vm->iommu = create_iommu_domain(vm->vm_id,
+			HVA2HPA(vm->arch_vm.nworld_eptp), 48U);
+	}
+
+	ret = assign_iommu_device(vm->iommu,
+		PCI_BUS(vdev->pdev.bdf), LOBYTE(vdev->pdev.bdf));
+
+	vdev_pt_init_bar_registers(vdev);
+
+	return ret;
+}
+
+static int vdev_pt_deinit(struct pci_vdev *vdev)
+{
+	int ret;
+	struct vm *vm = vdev->vpci->vm;
+
+	ret = unassign_iommu_device(vm->iommu, PCI_BUS(vdev->pdev.bdf),
+		LOBYTE(vdev->pdev.bdf));
+
+	return ret;
+}
+
+static int bar_access(uint32_t coff)
+{
+	if ((coff >= PCIR_BAR(0U)) && (coff < PCIR_BAR(PCI_BAR_COUNT))) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+static int vdev_pt_cfgread(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t *val)
+{
+	/* Assumption: access needed to be aligned on 1/2/4 bytes */
+	if ((offset & (bytes - 1)) != 0U) {
+		*val = 0xffffffffU;
+		return -EINVAL;
+	}
+
+	/* PCI BARs is emulated */
+	if (bar_access(offset)) {
+		*val = pci_vdev_read_cfg(vdev, offset, bytes);
+	} else {
+		*val = pci_pdev_read_cfg(&vdev->pdev, offset, bytes);
+	}
+
+	return 0;
+}
+
+static int vdev_pt_remap_bar(struct pci_vdev *vdev, uint32_t idx,
+	uint32_t new_base)
+{
+	int error = 0;
+	struct vm *vm = vdev->vpci->vm;
+
+	if (vdev->bar[idx].base != 0) {
+		error = ept_mr_del(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
+			vdev->bar[idx].base,
+			vdev->bar[idx].size);
+		if (error) {
+			return error;
+		}
+	}
+
+	if (new_base != 0U) {
+		/* Map the physical BAR in the guest MMIO space */
+		error = ept_mr_add(vm,
+			vdev->pdev.bar[idx].base, /* HPA */
+			new_base, /*GPA*/
+			vdev->bar[idx].size,
+			EPT_WR | EPT_RD | EPT_UNCACHED);
+		if (error) {
+			return error;
+		}
+	}
+	return error;
+}
+
+static uint32_t memen(struct pci_vdev *vdev)
+{
+	return pci_pdev_read_cfg(&vdev->pdev, PCIR_COMMAND, 2)
+		& PCIM_CMD_MEMEN;
+}
+
+static void vdev_pt_cfgwrite_bar(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t new_bar_uos)
+{
+	uint32_t idx;
+	uint32_t new_bar, mask;
+	bool bar_update_normal = 1;
+	bool do_map;
+	int error;
+
+	idx = (offset - PCIR_BAR(0U)) / 4U;
+	mask = ~(vdev->bar[idx].size - 1U);
+	bar_update_normal = (new_bar_uos != (uint32_t)~0U);
+	new_bar = new_bar_uos & mask;
+	new_bar |= PCIM_BAR_MEM_SPACE | PCIM_BAR_MEM_32;
+
+	if (PCI_BAR_BASE(new_bar) == vdev->bar[idx].base) {
+		return;
+	}
+
+	do_map = (memen(vdev)) && bar_update_normal;
+	if (do_map) {
+		error = vdev_pt_remap_bar(vdev, idx, PCI_BAR_BASE(new_bar));
+		if (error) {
+			pr_err("vdev_pt_remap_bar failed: %d", idx);
+		}
+	}
+
+	pci_vdev_write_cfg_u32(vdev, offset, new_bar);
+	vdev->bar[idx].base = PCI_BAR_BASE(new_bar);
+}
+
+static int vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
+	uint32_t bytes, uint32_t val)
+{
+	/* Assumption: access needed to be aligned on 1/2/4 bytes */
+	if ((offset & (bytes - 1)) != 0U) {
+		return -EINVAL;
+	}
+
+	/* PCI BARs are emulated */
+	if (bar_access(offset)) {
+		vdev_pt_cfgwrite_bar(vdev, offset, bytes, val);
+	} else {
+		/* Write directly to physical device's config space */
+		pci_pdev_write_cfg(&vdev->pdev, offset, bytes, val);
+	}
+
+	return 0;
+}
+
+struct pci_vdev_ops pci_ops_vdev_pt = {
+	.init = vdev_pt_init,
+	.deinit = vdev_pt_deinit,
+	.cfgwrite = vdev_pt_cfgwrite,
+	.cfgread = vdev_pt_cfgread,
+};
+

--- a/hypervisor/dm/vpci/pci_vdev.c
+++ b/hypervisor/dm/vpci/pci_vdev.c
@@ -1,0 +1,85 @@
+/*-
+* Copyright (c) 2011 NetApp, Inc.
+* Copyright (c) 2018 Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* $FreeBSD$
+*/
+
+/* Virtual PCI device related operations (read/write, etc) */
+
+#include <hypervisor.h>
+#include <hv_lib.h>
+#include <acrn_common.h>
+#include <hv_arch.h>
+#include <hv_debug.h>
+#include <acrn_hv_defs.h>
+#include "pci_priv.h"
+
+
+static struct pci_vdev *pci_vdev_find(struct vpci *vpci, uint16_t vbdf)
+{
+	struct vpci_vdev_array *vdev_array;
+	struct pci_vdev *vdev;
+	int i;
+
+	vdev_array = vpci->vm->vm_desc->vpci_vdev_array;
+	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
+		vdev = &vdev_array->vpci_vdev_list[i];
+		if (vdev->vbdf == vbdf) {
+			return vdev;
+		}
+	}
+
+	return NULL;
+}
+
+/* PCI cfg vm-exit handler */
+void pci_vdev_cfg_handler(struct vpci *vpci, uint32_t in, uint16_t vbdf,
+	uint32_t offset, uint32_t bytes, uint32_t *val)
+{
+	struct pci_vdev *vdev;
+	int ret;
+
+	vdev = pci_vdev_find(vpci, vbdf);
+	if (vdev == NULL) {
+		return;
+	}
+
+	ret = -EINVAL;
+	if (in) {
+		if ((vdev->ops != NULL) && (vdev->ops->cfgread != NULL)) {
+			ret = vdev->ops->cfgread(vdev, offset, bytes, val);
+		}
+	} else {
+		if ((vdev->ops != NULL) && (vdev->ops->cfgwrite != NULL)) {
+			ret = vdev->ops->cfgwrite(vdev, offset, bytes, *val);
+		}
+	}
+
+	if (ret) {
+		pr_dbg("pci_vdev_cfg_handler failed, ret=%d", ret);
+	}
+}
+

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -167,9 +167,3 @@ void vpci_cleanup(struct vm *vm)
 		}
 	}
 }
-
-void pci_vdev_cfg_handler(struct vpci *vpci, uint32_t in, uint16_t vbdf,
-	uint32_t offset, uint32_t bytes, uint32_t *val)
-{
-	/* vm-exit handler */
-}

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -1,0 +1,175 @@
+/*-
+* Copyright (c) 2011 NetApp, Inc.
+* Copyright (c) 2018 Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* $FreeBSD$
+*/
+
+#include <hypervisor.h>
+#include <hv_lib.h>
+#include <acrn_common.h>
+#include <hv_arch.h>
+#include <hv_debug.h>
+#include "pci_priv.h"
+
+
+static bool is_cfg_addr(uint16_t addr)
+{
+	return (addr >= PCI_CONFIG_ADDR) && (addr < (PCI_CONFIG_ADDR + 4));
+}
+
+static bool is_cfg_data(uint16_t addr)
+{
+	return (addr >= PCI_CONFIG_DATA) && (addr < (PCI_CONFIG_DATA + 4));
+}
+
+static void pci_cfg_clear_cache(struct pci_addr_info *pi)
+{
+	pi->cached_bdf = 0xffffU;
+	pi->cached_reg = 0U;
+	pi->cached_enable = 0U;
+}
+
+static uint32_t pci_cfg_io_read(__unused struct vm_io_handler *hdlr,
+	struct vm *vm, uint16_t addr, size_t bytes)
+{
+	uint32_t val = 0xffffffffU;
+	struct vpci *vpci = &vm->vpci;
+	struct pci_addr_info *pi = &vpci->addr_info;
+
+	if (is_cfg_addr(addr)) {
+		/* TODO: handling the non 4 bytes access */
+		if (bytes == 4U) {
+			val = (PCI_BUS(pi->cached_bdf) << 16)
+				| (PCI_SLOT(pi->cached_bdf) << 11)
+				| (PCI_FUNC(pi->cached_bdf) << 8)
+				| pi->cached_reg;
+
+			if (pi->cached_enable) {
+				val |= PCI_CFG_ENABLE;
+			}
+		}
+	} else if (is_cfg_data(addr)) {
+		if (pi->cached_enable) {
+			uint16_t offset = addr - 0xcfc;
+
+			pci_vdev_cfg_handler(&vm->vpci, 1U, pi->cached_bdf,
+				pi->cached_reg + offset, bytes, &val);
+
+			pci_cfg_clear_cache(pi);
+		}
+	}  else {
+		val = 0xffffffffU;
+	}
+
+	return val;
+}
+
+static void pci_cfg_io_write(__unused struct vm_io_handler *hdlr,
+	struct vm *vm, uint16_t addr, size_t bytes, uint32_t val)
+{
+	struct vpci *vpci = &vm->vpci;
+	struct pci_addr_info *pi = &vpci->addr_info;
+
+	if (is_cfg_addr(addr)) {
+		/* TODO: handling the non 4 bytes access */
+		if (bytes == 4U) {
+			pi->cached_bdf = PCI_BDF(
+				((val >> 16) & PCI_BUSMAX),
+				((val >> 11) & PCI_SLOTMAX),
+				((val >> 8) & PCI_FUNCMAX));
+
+			pi->cached_reg = val & PCI_REGMAX;
+			pi->cached_enable =
+			(val & PCI_CFG_ENABLE) == PCI_CFG_ENABLE;
+		}
+	} else if (is_cfg_data(addr)) {
+		if (pi->cached_enable) {
+			uint16_t offset = addr - 0xcfc;
+
+			pci_vdev_cfg_handler(&vm->vpci, 0U, pi->cached_bdf,
+				pi->cached_reg + offset, bytes, &val);
+
+			pci_cfg_clear_cache(pi);
+		}
+	} else {
+		pr_err("Not PCI cfg data/addr port access!");
+	}
+
+}
+
+void vpci_init(struct vm *vm)
+{
+	struct vpci *vpci = &vm->vpci;
+	struct vpci_vdev_array *vdev_array;
+	struct pci_vdev *vdev;
+	int i;
+	int ret;
+	struct vm_io_range pci_cfg_range = {.flags = IO_ATTR_RW,
+		.base = PCI_CONFIG_ADDR, .len = 8U};
+
+	vpci->vm = vm;
+	vdev_array = vm->vm_desc->vpci_vdev_array;
+
+	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
+		vdev = &vdev_array->vpci_vdev_list[i];
+		vdev->vpci = vpci;
+		if ((vdev->ops != NULL) && (vdev->ops->init != NULL)) {
+			ret = vdev->ops->init(vdev);
+			if (ret) {
+				pr_err("vdev->ops->init failed!");
+			}
+		}
+	}
+
+	register_io_emulation_handler(vm, &pci_cfg_range,
+		&pci_cfg_io_read, &pci_cfg_io_write);
+}
+
+void vpci_cleanup(struct vm *vm)
+{
+	struct vpci_vdev_array *vdev_array;
+	struct pci_vdev *vdev;
+	int i;
+	int ret;
+
+	vdev_array = vm->vm_desc->vpci_vdev_array;
+
+	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
+		vdev = &vdev_array->vpci_vdev_list[i];
+		if ((vdev->ops != NULL) && (vdev->ops->deinit != NULL)) {
+			ret = vdev->ops->deinit(vdev);
+			if (ret) {
+				pr_err("vdev->ops->deinit failed!");
+			}
+		}
+	}
+}
+
+void pci_vdev_cfg_handler(struct vpci *vpci, uint32_t in, uint16_t vbdf,
+	uint32_t offset, uint32_t bytes, uint32_t *val)
+{
+	/* vm-exit handler */
+}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -10,6 +10,7 @@
 
 #ifdef CONFIG_PARTITION_MODE
 #include <mptable.h>
+#include <vpci.h>
 #endif
 enum vm_privilege_level {
 	VM_PRIVILEGE_LEVEL_HIGH = 0,
@@ -164,8 +165,16 @@ struct vm {
 	struct vcpuid_entry vcpuid_entries[MAX_VM_VCPUID_ENTRIES];
 #ifdef CONFIG_PARTITION_MODE
 	struct vm_description	*vm_desc;
+	struct vpci vpci;
 #endif
 };
+
+#ifdef CONFIG_PARTITION_MODE
+struct vpci_vdev_array {
+	int num_pci_vdev;
+	struct pci_vdev vpci_vdev_list[];
+};
+#endif
 
 struct vm_description {
 	/* The physical CPU IDs associated with this VM - The first CPU listed
@@ -180,6 +189,7 @@ struct vm_description {
 	uint8_t			vm_id;
 	struct mptable_info	*mptable;
 	const char		*bootargs;
+	struct vpci_vdev_array  *vpci_vdev_array;
 #endif
 };
 
@@ -193,6 +203,10 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm);
 int prepare_vm(uint16_t pcpu_id);
 #ifdef CONFIG_VM0_DESC
 void vm_fixup(struct vm *vm);
+#endif
+
+#ifdef CONFIG_PARTITION_MODE
+const struct vm_description_array *get_vm_desc_base(void);
 #endif
 
 struct vm *get_vm_from_vmid(uint16_t vm_id);

--- a/hypervisor/include/dm/vpci/vpci.h
+++ b/hypervisor/include/dm/vpci/vpci.h
@@ -92,4 +92,7 @@ struct vpci {
 	struct pci_addr_info addr_info;
 };
 
+void vpci_init(struct vm *vm);
+void vpci_cleanup(struct vm *vm);
+
 #endif /* VPCI_H_ */

--- a/hypervisor/include/dm/vpci/vpci.h
+++ b/hypervisor/include/dm/vpci/vpci.h
@@ -92,6 +92,7 @@ struct vpci {
 	struct pci_addr_info addr_info;
 };
 
+extern struct pci_vdev_ops pci_ops_vdev_hostbridge;
 extern struct pci_vdev_ops pci_ops_vdev_pt;
 
 void vpci_init(struct vm *vm);

--- a/hypervisor/include/dm/vpci/vpci.h
+++ b/hypervisor/include/dm/vpci/vpci.h
@@ -1,0 +1,95 @@
+/*-
+* Copyright (c) 2011 NetApp, Inc.
+* Copyright (c) 2018 Intel Corporation
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+* $FreeBSD$
+*/
+
+#ifndef VPCI_H_
+#define VPCI_H_
+
+#define PCI_BAR_COUNT    0x6U
+#define PCI_REGMAX       0xFFU
+#define PCIM_BAR_MEM_32  0U
+#define PCIM_BAR_MEM_64  4U
+
+#define PCI_BDF(b, d, f)   (((b & 0xFFU) << 8) \
+	| ((d & 0x1FU) << 3) | ((f & 0x7U)))
+
+#define ALIGN_UP(x, y)   (((x)+((y)-1))&(~((y)-1U)))
+#define ALIGN_UP_4K(x)   ALIGN_UP(x, 4096)
+
+struct pci_vdev;
+struct pci_vdev_ops {
+	int (*init)(struct pci_vdev *vdev);
+
+	int (*deinit)(struct pci_vdev *vdev);
+
+	int (*cfgwrite)(struct pci_vdev *vdev, uint32_t offset,
+		uint32_t bytes, uint32_t val);
+
+	int (*cfgread)(struct pci_vdev *vdev, uint32_t offset,
+		uint32_t bytes, uint32_t *val);
+};
+
+struct pcibar {
+	uint64_t base;
+	uint64_t size;
+	uint8_t  type;
+};
+
+struct pci_pdev {
+	/* The bar info of the physical PCI device. */
+	struct pcibar bar[PCI_BAR_COUNT];
+
+	/* The bus/device/function triple of the physical PCI device. */
+	uint16_t bdf;
+};
+
+struct pci_vdev {
+	struct pci_vdev_ops *ops;
+	struct vpci *vpci;
+	/* The bus/device/function triple of the virtual PCI device. */
+	uint16_t vbdf;
+
+	struct pci_pdev pdev;
+
+	uint8_t cfgdata[PCI_REGMAX + 1U];
+
+	/* The bar info of the virtual PCI device. */
+	struct pcibar bar[PCI_BAR_COUNT];
+};
+
+struct pci_addr_info {
+	uint16_t cached_bdf;
+	uint32_t cached_reg, cached_enable;
+};
+
+struct vpci {
+	struct vm *vm;
+	struct pci_addr_info addr_info;
+};
+
+#endif /* VPCI_H_ */

--- a/hypervisor/include/dm/vpci/vpci.h
+++ b/hypervisor/include/dm/vpci/vpci.h
@@ -92,6 +92,8 @@ struct vpci {
 	struct pci_addr_info addr_info;
 };
 
+extern struct pci_vdev_ops pci_ops_vdev_pt;
+
 void vpci_init(struct vm *vm);
 void vpci_cleanup(struct vm *vm);
 

--- a/hypervisor/partition/vm_description.c
+++ b/hypervisor/partition/vm_description.c
@@ -12,7 +12,7 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf = PCI_BDF(0x00U, 0x00U, 0x00U),
-	  .ops = NULL,
+	  .ops = &pci_ops_vdev_hostbridge,
 	  .bar = {}, /* don't care for hostbridge */
 	  .pdev = {} /* don't care for hostbridge */
 	 },
@@ -58,7 +58,7 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf = PCI_BDF(0x00U, 0x00U, 0x00U),
-	  .ops = NULL,
+	  .ops = &pci_ops_vdev_hostbridge,
 	  .bar = {}, /* don't care for hostbridge */
 	  .pdev = {} /* don't care for hostbridge */
 	 },

--- a/hypervisor/partition/vm_description.c
+++ b/hypervisor/partition/vm_description.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+
+static struct vpci_vdev_array vpci_vdev_array1 = {
+	.num_pci_vdev = 2,
+
+	.vpci_vdev_list = {
+	 {/*vdev 0: hostbridge */
+	  .vbdf = PCI_BDF(0x00U, 0x00U, 0x00U),
+	  .ops = NULL,
+	  .bar = {}, /* don't care for hostbridge */
+	  .pdev = {} /* don't care for hostbridge */
+	 },
+
+	 {/*vdev 1*/
+	  .vbdf = PCI_BDF(0x00U, 0x01U, 0x00U),
+	  .ops = NULL,
+	  .bar = {
+		[0] = {
+		.base = 0UL,
+		.size = ALIGN_UP_4K(0x100UL),
+		.type = PCIM_BAR_MEM_32
+		},
+		[5] = {
+		.base = 0UL,
+		.size = ALIGN_UP_4K(0x2000UL),
+		.type = PCIM_BAR_MEM_32
+		},
+	  },
+	 .pdev = {
+		.bdf = PCI_BDF(0x00U, 0x01U, 0x00U),
+		.bar = {
+			[0] = {
+			.base = 0xa9000000UL,
+			.size = 0x100UL,
+			.type = PCIM_BAR_MEM_32
+			},
+			[5] = {
+			.base = 0x1a0000000UL,
+			.size = 0x2000UL,
+			.type = PCIM_BAR_MEM_64
+			},
+			}
+		}
+	 },
+	}
+};
+
+
+static struct vpci_vdev_array vpci_vdev_array2 = {
+	.num_pci_vdev = 2,
+
+	.vpci_vdev_list = {
+	 {/*vdev 0: hostbridge*/
+	  .vbdf = PCI_BDF(0x00U, 0x00U, 0x00U),
+	  .ops = NULL,
+	  .bar = {}, /* don't care for hostbridge */
+	  .pdev = {} /* don't care for hostbridge */
+	 },
+
+	 {/*vdev 1*/
+	  .vbdf = PCI_BDF(0x00U, 0x01U, 0x00U),
+	  .ops = NULL,
+	  .bar = {
+		[0] = {
+		.base = 0UL,
+		.size = ALIGN_UP_4K(0x100UL),
+		.type = PCIM_BAR_MEM_32
+		},
+		[5] = {
+		.base = 0UL,
+		.size = ALIGN_UP_4K(0x2000UL),
+		.type = PCIM_BAR_MEM_32
+		},
+	 },
+	 .pdev = {
+		.bdf = PCI_BDF(0x00U, 0x02U, 0x00U),
+		.bar = {
+			[0] = {
+			.base = 0xa8000000UL,
+			.size = 0x100UL,
+			.type = PCIM_BAR_MEM_32
+			},
+			[5] = {
+			.base = 0x1b0000000UL,
+			.size = 0x2000UL,
+			.type = PCIM_BAR_MEM_64
+			},
+			}
+		}
+	 },
+	}
+};
+
+/*******************************/
+/* User Defined VM definitions */
+/*******************************/
+const struct vm_description_array vm_desc_partition = {
+	/* Number of user virtual machines */
+	.num_vm_desc = 2,
+
+	.vm_desc_array = {
+		{
+			/* vm1 */
+			.vm_hw_num_cores = 2,
+			.vpci_vdev_array = &vpci_vdev_array1,
+		},
+
+		{
+			/* vm2 */
+			.vm_hw_num_cores = 2,
+			.vpci_vdev_array = &vpci_vdev_array2,
+		},
+	}
+};
+
+const struct vm_description_array *get_vm_desc_base(void)
+{
+	return &vm_desc_partition;
+}
+

--- a/hypervisor/partition/vm_description.c
+++ b/hypervisor/partition/vm_description.c
@@ -19,7 +19,7 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 	 {/*vdev 1*/
 	  .vbdf = PCI_BDF(0x00U, 0x01U, 0x00U),
-	  .ops = NULL,
+	  .ops = &pci_ops_vdev_pt,
 	  .bar = {
 		[0] = {
 		.base = 0UL,
@@ -65,7 +65,7 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 	 {/*vdev 1*/
 	  .vbdf = PCI_BDF(0x00U, 0x01U, 0x00U),
-	  .ops = NULL,
+	  .ops = &pci_ops_vdev_pt,
 	  .bar = {
 		[0] = {
 		.base = 0UL,


### PR DESCRIPTION
From 46436bf4abfa21bce0a4cbbeb79e5ccef1ad2876 Mon Sep 17 00:00:00 2001
From: dongshen <dongsheng.x.zhang@intel.com>
Date: Tue, 7 Aug 2018 19:06:14 -0700
Subject: [PATCH 0/6] V4: Adding VPCI (PCI passthru) support for partition mode

The related files are ported from device model to hypervisor to 
support partition mode.

V4:
 - Renamed members for struct pcibar
 - License header fix
 - Added vpci_vdev_array to struct vm_description
 - Clear address cache info after a full cf8/cfc access
 - Added NULL pointer checking

V3:
 - Defined the static centralized vpci table to reduce code size,
   previously many of the settings are obtained/generated dynamically
 - Do not use ASSERT
 - Assume 64-bit bar size is less than 4G to simply code, and 
   report 64-bit MMIO to UOS as 32-bit bar
 - Patches created in top-down order to aid in code review

V2:
 - Fixed MISRA violations

dongshen (6):
  HV: Defining the per-vm static vpci table for partition hypervisor
  HV: Compiling in VCPI code for partition hypervisor
  HV: Calling into VPCI init/unit functions for partition hypervisor
  HV: Implementing PCI CFG vm-exit handler for partition hypervisor
  HV: Adding passthru vdev device support for partition hypervisor
  HV: Adding hostbridge vdev device support for partition hypervisor

 hypervisor/Makefile                    |   9 +-
 hypervisor/arch/x86/guest/vm.c         |   8 +
 hypervisor/dm/vpci/hostbridge.c        | 129 +++++++++++++++
 hypervisor/dm/vpci/pci_priv.h          | 153 +++++++++++++++++
 hypervisor/dm/vpci/pci_pt.c            | 292 +++++++++++++++++++++++++++++++++
 hypervisor/dm/vpci/pci_vdev.c          |  85 ++++++++++
 hypervisor/dm/vpci/vpci.c              | 169 +++++++++++++++++++
 hypervisor/include/arch/x86/guest/vm.h |  21 +++
 hypervisor/include/dm/vpci/vpci.h      | 101 ++++++++++++
 hypervisor/partition/vm_description.c  | 126 ++++++++++++++
 10 files changed, 1092 insertions(+), 1 deletion(-)
 create mode 100644 hypervisor/dm/vpci/hostbridge.c
 create mode 100644 hypervisor/dm/vpci/pci_priv.h
 create mode 100644 hypervisor/dm/vpci/pci_pt.c
 create mode 100644 hypervisor/dm/vpci/pci_vdev.c
 create mode 100644 hypervisor/dm/vpci/vpci.c
 create mode 100644 hypervisor/include/dm/vpci/vpci.h
 create mode 100644 hypervisor/partition/vm_description.c

-- 
2.7.4
