### PR TITLE
hv: treewide: fix 'No default case in switch statement'

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1893,6 +1893,19 @@ static int decode_sib(struct instr_emul_vie *vie)
 	case VIE_MOD_INDIRECT_DISP32:
 		vie->disp_bytes = 4U;
 		break;
+	default:
+		/*
+		 * All possible values of 'vie->mod':
+		 * 1. VIE_MOD_DIRECT
+		 *    has been handled at the start of this function
+		 * 2. VIE_MOD_INDIRECT_DISP8
+		 *    has been handled in prior case clauses
+		 * 3. VIE_MOD_INDIRECT_DISP32
+		 *    has been handled in prior case clauses
+		 * 4. VIE_MOD_INDIRECT
+		 *    will be handled later after this switch statement
+		 */
+		break;
 	}
 
 	if (vie->mod == VIE_MOD_INDIRECT &&

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1127,6 +1127,12 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
 		dmask = vm_active_cpus(vlapic->vm);
 		bitmap_clear_lock(vlapic->vcpu->vcpu_id, &dmask);
 		break;
+	default:
+		/*
+		 * All possible values of 'shorthand' has been handled in prior
+		 * case clauses.
+		 */
+		break;
 	}
 
 	while ((vcpu_id = ffs64(dmask)) != INVALID_BIT_INDEX) {

--- a/hypervisor/arch/x86/guest/vpic.c
+++ b/hypervisor/arch/x86/guest/vpic.c
@@ -579,6 +579,18 @@ int vpic_set_irq_trigger(struct vm *vm, uint32_t irq, enum vpic_trigger trigger)
 		case 8U:
 		case 13U:
 			return -EINVAL;
+		default:
+			/*
+			 * The IRQs handled earlier are the ones that could only
+			 * support edge trigger, while the input parameter
+			 * 'trigger' is set as LEVEL_TRIGGER. So, an error code
+			 * (-EINVAL) shall be returned due to the invalid
+			 * operation.
+			 *
+			 * All the other IRQs will be handled properly after
+			 * this switch statement.
+			 */
+			break;
 		}
 	}
 


### PR DESCRIPTION
MISRAC requires that a switch statement shall contain a default clause.

This patch add the default clause and some comments for the ones
violated the rule.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>