### PR TITLE
hv: treewide: fix 'Empty parameter list to procedure/function'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -667,7 +667,7 @@ static uint16_t get_cpu_id_from_lapic_id(uint8_t lapic_id)
 /*
  * Start all secondary CPUs.
  */
-void start_cpus()
+void start_cpus(void)
 {
 	uint32_t timeout;
 	uint16_t expected_up;
@@ -710,7 +710,7 @@ void start_cpus()
 	}
 }
 
-void stop_cpus()
+void stop_cpus(void)
 {
 	uint16_t pcpu_id, expected_up;
 	uint32_t timeout;

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -328,8 +328,8 @@ bool cpu_has_cap(uint32_t bit);
 void load_cpu_state_data(void);
 void bsp_boot_init(void);
 void cpu_secondary_init(void);
-void start_cpus();
-void stop_cpus();
+void start_cpus(void);
+void stop_cpus(void);
 
 /* Read control register */
 #define CPU_CR_READ(cr, result_ptr)                         \


### PR DESCRIPTION
Use func(void) rather than func() for the function declaration and
definition based on MISRAC requirement.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>