### PR TITLE
hv: Partition mode ACRN -kernel load and bootargs load address

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -62,6 +62,9 @@ static void init_vm(struct vm_description *vm_desc,
 #else
 	vm_handle->hw.num_vcpus = vm_desc->vm_hw_num_cores;
 #endif
+#ifdef CONFIG_PARTITION_MODE
+	vm_handle->vm_desc = vm_desc;
+#endif
 }
 
 /* return a pointer to the virtual machine structure associated with
@@ -155,7 +158,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 			goto err;
 		}
 #ifndef CONFIG_EFI_STUB
-		status = init_vm0_boot_info(vm);
+		status = init_vm_boot_info(vm);
 		if (status != 0) {
 			goto err;
 		}
@@ -170,6 +173,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 #ifdef CONFIG_PARTITION_MODE
 		ept_mr_add(vm, vm_desc->start_hpa,
 					0UL, vm_desc->mem_size, EPT_RWX|EPT_WB);
+		init_vm_boot_info(vm);
 #endif
 	}
 

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -186,6 +186,53 @@ fail:
 	return NULL;
 }
 
+#ifdef CONFIG_PARTITION_MODE
+int init_vm_boot_info(struct vm *vm)
+{
+	struct multiboot_module *mods = NULL;
+	struct multiboot_info *mbi = NULL;
+
+	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
+		ASSERT(false, "no multiboot info found");
+		return -EINVAL;
+	}
+
+	mbi = HPA2HVA((uint64_t)boot_regs[1]);
+
+	dev_dbg(ACRN_DBG_BOOT, "Multiboot detected, flag=0x%x", mbi->mi_flags);
+	if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_MODS) == 0U) {
+		ASSERT(false, "no kernel info found");
+		return -EINVAL;
+	}
+
+	dev_dbg(ACRN_DBG_BOOT, "mod counts=%d\n", mbi->mi_mods_count);
+
+	/* mod[0] is for kernel&cmdline, other mod for ramdisk/firmware info*/
+	mods = (struct multiboot_module *)(uint64_t)mbi->mi_mods_addr;
+
+	dev_dbg(ACRN_DBG_BOOT, "mod0 start=0x%x, end=0x%x",
+		mods[0].mm_mod_start, mods[0].mm_mod_end);
+	dev_dbg(ACRN_DBG_BOOT, "cmd addr=0x%x, str=%s", mods[0].mm_string,
+		(char *) (uint64_t)mods[0].mm_string);
+
+	vm->sw.kernel_type = VM_LINUX_GUEST;
+	vm->sw.kernel_info.kernel_src_addr =
+			HPA2HVA((uint64_t)mods[0].mm_mod_start);
+	vm->sw.kernel_info.kernel_size =
+			mods[0].mm_mod_end - mods[0].mm_mod_start;
+
+	vm->sw.kernel_info.kernel_load_addr = (void *)(16 * 1024 * 1024UL);
+
+	vm->sw.linux_info.bootargs_src_addr =
+				vm->vm_desc->bootargs;
+	vm->sw.linux_info.bootargs_size =
+			strnlen_s(vm->vm_desc->bootargs, MEM_2K);
+
+	vm->sw.linux_info.bootargs_load_addr = (void *)(vm->vm_desc->mem_size -  8*1024UL);
+
+	return 0;
+}
+#else
 /**
  * @param[inout] vm pointer to a vm descriptor
  *
@@ -195,7 +242,7 @@ fail:
  * @pre vm != NULL
  * @pre is_vm0(vm) == true
  */
-int init_vm0_boot_info(struct vm *vm)
+int init_vm_boot_info(struct vm *vm)
 {
 	struct multiboot_module *mods = NULL;
 	struct multiboot_info *mbi = NULL;
@@ -290,3 +337,4 @@ int init_vm0_boot_info(struct vm *vm)
 	}
 	return 0;
 }
+#endif

--- a/hypervisor/include/arch/x86/multiboot.h
+++ b/hypervisor/include/arch/x86/multiboot.h
@@ -79,6 +79,5 @@ struct multiboot_module {
 };
 
 int parse_hv_cmdline(void);
-int init_vm0_boot_info(struct vm *vm);
-
+int init_vm_boot_info(struct vm *vm);
 #endif


### PR DESCRIPTION
For Partition mode ACRN, kernel load address and Boot args load address
are hardcoded. Boot args are currently passed from vm description for
each VM. Renamed init_vm0_boot_info to init_vm_boot_info.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>