### PR TITLE
hv: Add vuart flag to VM descriptions in partition mode

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -197,6 +197,11 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 	vm->vpic = vpic_init(vm);
 
 #ifdef CONFIG_PARTITION_MODE
+	/* Create virtual uart */
+	if (vm_desc->vm_vuart) {
+		vm->vuart = vuart_init(vm);
+	}
+
 	vpci_init(vm);
 #endif
 

--- a/hypervisor/bsp/sbl/vm_description.c
+++ b/hypervisor/bsp/sbl/vm_description.c
@@ -66,6 +66,7 @@ const struct vm_description_array vm_desc_mrb = {
 				.vm_id = 1U,
 				.start_hpa = 0x100000000UL,
 				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
+				.vm_vuart = true,
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable"
@@ -78,6 +79,7 @@ const struct vm_description_array vm_desc_mrb = {
 				.vm_id = 2U,
 				.start_hpa = 0x180000000UL,
 				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
+				.vm_vuart = true,
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable"

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -190,6 +190,7 @@ struct vm_description {
 	struct mptable_info	*mptable;
 	uint64_t		start_hpa;
 	uint64_t		mem_size; /* UOS memory size in hex */
+	bool			vm_vuart;
 	const char		*bootargs;
 	struct vpci_vdev_array  *vpci_vdev_array;
 #endif


### PR DESCRIPTION
ACRN in partition mode emulates UART for the VMs directly launced
from HV. This patch adds an option to enable/disable vUART for a
VM.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>