### PR TITLE
hv: Fixing build issue with PARTITION_MODE

### DIFF
--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -444,7 +444,7 @@ void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx)
 	 * HV services are handled by HV using dispatch_interrupt.
 	 */
 	vcpu = per_cpu(vcpu, get_cpu_id());
-	if (vr < VECTOR_FOR_PRI_START) {
+	if (vr < VECTOR_FIXED_START) {
 		send_lapic_eoi();
 		vlapic_intr_edge(vcpu, vr);
 	} else {


### PR DESCRIPTION
Modified the vector MACRO that is failing build with PARTITION_MODE selected

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>