### PR TITLE
Add the emulation of Cpuid 0x16 for guest to obtain cpu hz by calling cpuid

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -243,6 +243,11 @@ static int hardware_detect_support(void)
 		return -ENODEV;
 	}
 
+	if (boot_cpu_data.cpuid_level < 0x15U) {
+		pr_fatal("%s, required CPU feature not supported\n", __func__);
+		return -ENODEV;
+	}
+
 	ret = check_vmx_mmu_cap();
 	if (ret != 0) {
 		return ret;


### PR DESCRIPTION
This is the patch set that adds the emulation of cupid 0x16 so that the guest can obtain the cpu hz by calling cupid.
At the same time HV also obtains the cpu hz by using cupid 0x16 if zero tsc is returned by cupid 0x15.