### PR TITLE
HV: VMX reshuffle: put EPT check before enabling

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -144,35 +144,6 @@ uint64_t hpa2gpa(struct vm *vm, uint64_t hpa)
 			| (hpa & (pg_size - 1UL)));
 }
 
-bool is_ept_supported(void)
-{
-	bool status;
-	uint64_t tmp64;
-
-	/* Read primary processor based VM control. */
-	tmp64 = msr_read(MSR_IA32_VMX_PROCBASED_CTLS);
-
-	/* Check if secondary processor based VM control is available. */
-	if ((tmp64 & MMU_MEM_ATTR_BIT_EXECUTE_DISABLE) != 0U) {
-		/* Read primary processor based VM control. */
-		tmp64 = msr_read(MSR_IA32_VMX_PROCBASED_CTLS2);
-
-		/* Check if EPT is supported. */
-		if ((tmp64 & (((uint64_t)VMX_PROCBASED_CTLS2_EPT) << 32)) != 0U) {
-			/* EPT is present. */
-			status = true;
-		} else {
-			status = false;
-		}
-
-	} else {
-		/* Secondary processor based VM control is not present */
-		status = false;
-	}
-
-	return status;
-}
-
 int ept_violation_vmexit_handler(struct vcpu *vcpu)
 {
 	int status = -EINVAL, ret;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1054,14 +1054,6 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 		}
 	}
 
-	/* Check for EPT support */
-	if (is_ept_supported()) {
-		pr_dbg("EPT is supported");
-	}
-	else {
-		pr_err("Error: EPT is not supported");
-	}
-
 	/* Load EPTP execution control
 	 * TODO: introduce API to make this data driven based
 	 * on VMX_EPT_VPID_CAP

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -324,6 +324,7 @@ void trampoline_start16(void);
 bool is_vapic_supported(void);
 bool is_vapic_intr_delivery_supported(void);
 bool is_vapic_virt_reg_supported(void);
+bool is_ept_supported(void);
 bool cpu_has_cap(uint32_t bit);
 void load_cpu_state_data(void);
 void bsp_boot_init(void);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -376,7 +376,6 @@ static inline void clflush(volatile void *p)
 }
 
 /* External Interfaces */
-bool is_ept_supported(void);
 uint64_t create_guest_initial_paging(struct vm *vm);
 void    destroy_ept(struct vm *vm);
 uint64_t  gpa2hpa(struct vm *vm, uint64_t gpa);


### PR DESCRIPTION
Current EPT check runs after EPT enabling in init_exec_ctrl. This
patch fixes wrong order.

Signed-off-by: Edwin Zhai <edwin.zhai@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>