### PR TITLE
HV: add pcpu id check before send IPI

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -104,8 +104,9 @@ void vcpu_make_request(struct vcpu *vcpu, uint16_t eventid)
 	 *  scheduling, we need change here to determine it target vcpu is
 	 *  VMX non-root or root mode
 	 */
-	if ((int)get_cpu_id() != vcpu->pcpu_id)
+	if (get_cpu_id() != vcpu->pcpu_id) {
 		send_single_ipi(vcpu->pcpu_id, VECTOR_NOTIFY_VCPU);
+	}
 }
 
 static int vcpu_do_pending_event(struct vcpu *vcpu)

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -157,7 +157,7 @@ int vmexit_handler(struct vcpu *vcpu)
 	uint16_t basic_exit_reason;
 	int ret;
 
-	if ((int)get_cpu_id() != vcpu->pcpu_id) {
+	if (get_cpu_id() != vcpu->pcpu_id) {
 		pr_fatal("vcpu is not running on its pcpu!");
 		return -EINVAL;
 	}

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -101,7 +101,9 @@ void make_reschedule_request(struct vcpu *vcpu)
 	struct sched_context *ctx = &per_cpu(sched_ctx, vcpu->pcpu_id);
 
 	bitmap_set_lock(NEED_RESCHEDULE, &ctx->flags);
-	send_single_ipi(vcpu->pcpu_id, VECTOR_NOTIFY_VCPU);
+	if (get_cpu_id() != vcpu->pcpu_id) {
+		send_single_ipi(vcpu->pcpu_id, VECTOR_NOTIFY_VCPU);
+	}
 }
 
 int need_reschedule(uint16_t pcpu_id)
@@ -153,7 +155,9 @@ void make_pcpu_offline(uint16_t pcpu_id)
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 
 	bitmap_set_lock(NEED_OFFLINE, &ctx->flags);
-	send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
+	if (get_cpu_id() != pcpu_id) {
+		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
+	}
 }
 
 int need_offline(uint16_t pcpu_id)


### PR DESCRIPTION
to avoid send IPI to self, also improve the related code:
1. get_cpu_id is uint16_t now
2. MISRA-C requirement. like add {}

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>