### PR TITLE
Irqv5

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -827,7 +827,7 @@ static int dmar_setup_interrupt(struct dmar_drhd_rt *dmar_uint)
 
 	dmar_uint->dmar_irq_node = normal_register_handler(IRQ_INVALID,
 					dmar_fault_handler,
-					dmar_uint, true,
+					dmar_uint,
 					"dmar_fault_event");
 
 	if (dmar_uint->dmar_irq_node == NULL) {

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -135,7 +135,7 @@ ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq)
 
 	/* register and allocate host vector/irq */
 	node = normal_register_handler(phys_irq, ptdev_interrupt_handler,
-		(void *)entry, true, "dev assign");
+		(void *)entry, "dev assign");
 
 	ASSERT(node != NULL, "dev register failed");
 	entry->node = node;

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -23,14 +23,14 @@ enum irq_desc_state {
 	IRQ_DESC_IN_PROCESS,
 };
 
-typedef int (*dev_handler_t)(int irq, void *dev_data);
+typedef int (*irq_action_t)(uint32_t irq, void *dev_data);
 struct irq_request_info {
 	/* vector set to 0xE0 ~ 0xFF for pri_register_handler
 	 * and set to VECTOR_INVALID for normal_register_handler
 	 */
 	uint32_t vector;
-	dev_handler_t func;
-	void *dev_data;
+	irq_action_t func;
+	void *priv_data;
 	char *name;
 };
 
@@ -40,20 +40,16 @@ struct irq_desc {
 	enum irq_state used;	/* this irq have assigned to device */
 	enum irq_desc_state state; /* irq_desc status */
 	uint32_t vector;	/* assigned vector */
-	void *handler_data;	/* irq_handler private data */
+
 	int (*irq_handler)(struct irq_desc *irq_desc, void *handler_data);
-	struct dev_handler_node *action;
+				/* callback for irq flow handling */
+	irq_action_t action;	/* callback registered from component */
+	void *priv_data;	/* irq_action private data */
+	char name[32];		/* name of component */
+
 	spinlock_t irq_lock;
 	uint64_t *irq_cnt; /* this irq cnt happened on CPUs */
 	uint64_t irq_lost_cnt;
-};
-
-struct dev_handler_node {
-	char name[32];
-	void *dev_data;
-	dev_handler_t dev_handler;
-	struct dev_handler_node *next;
-	struct irq_desc *desc;
 };
 
 uint32_t irq_mark_used(uint32_t irq);
@@ -62,24 +58,20 @@ uint32_t irq_desc_alloc_vector(uint32_t irq);
 void irq_desc_try_free_vector(uint32_t irq);
 
 uint32_t irq_to_vector(uint32_t irq);
-uint32_t dev_to_irq(struct dev_handler_node *node);
-uint32_t dev_to_vector(struct dev_handler_node *node);
 
-struct dev_handler_node*
-pri_register_handler(uint32_t irq,
+int32_t pri_register_handler(uint32_t irq,
 		uint32_t vector,
-		dev_handler_t func,
-		void *dev_data,
+		irq_action_t func,
+		void *priv_data,
 		const char *name);
 
-struct dev_handler_node*
-normal_register_handler(uint32_t irq,
-		dev_handler_t func,
-		void *dev_data,
+int32_t normal_register_handler(uint32_t irq,
+		irq_action_t func,
+		void *priv_data,
 		const char *name);
-void unregister_handler_common(struct dev_handler_node *node);
+
+void unregister_handler_common(uint32_t irq);
 
 typedef int (*irq_handler_t)(struct irq_desc *desc, void *handler_data);
 void update_irq_handler(uint32_t irq, irq_handler_t func);
-
 #endif /* COMMON_IRQ_H */

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -15,8 +15,7 @@ enum irq_mode {
 
 enum irq_state {
 	IRQ_NOT_ASSIGNED = 0,
-	IRQ_ASSIGNED_SHARED,
-	IRQ_ASSIGNED_NOSHARE,
+	IRQ_ASSIGNED,
 };
 
 enum irq_desc_state {
@@ -32,7 +31,6 @@ struct irq_request_info {
 	uint32_t vector;
 	dev_handler_t func;
 	void *dev_data;
-	bool share;
 	char *name;
 };
 
@@ -44,7 +42,7 @@ struct irq_desc {
 	uint32_t vector;	/* assigned vector */
 	void *handler_data;	/* irq_handler private data */
 	int (*irq_handler)(struct irq_desc *irq_desc, void *handler_data);
-	struct dev_handler_node *dev_list;
+	struct dev_handler_node *action;
 	spinlock_t irq_lock;
 	uint64_t *irq_cnt; /* this irq cnt happened on CPUs */
 	uint64_t irq_lost_cnt;
@@ -78,7 +76,6 @@ struct dev_handler_node*
 normal_register_handler(uint32_t irq,
 		dev_handler_t func,
 		void *dev_data,
-		bool share,
 		const char *name);
 void unregister_handler_common(struct dev_handler_node *node);
 

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -51,7 +51,7 @@ struct ptdev_remapping_info {
 	uint16_t phys_bdf;	/* PCI bus:slot.func*/
 	uint32_t active;	/* 1=active, 0=inactive and to free*/
 	enum ptdev_intr_type type;
-	struct dev_handler_node *node;
+	uint32_t allocated_pirq;
 	struct list_head softirq_node;
 	struct list_head entry_node;
 


### PR DESCRIPTION
This two commits remove the irq sharing support,  main changes including:
 - removed the dev_list field in irq_desc, and clean up codes for the list operation; 
 - replace IRQ_ASSIGNED_SHARED and IRQ_ASSIGNED_NOSHARE with IRQ_ASSIGNED;
 - remove "shared" argument in irq APIs;
 - remove dev_handler_node struct and change the return type of pri_/normal_register_handler() from dev_handler_node* to int32_t, which is irq num (>= 0) on success, and errno (> 0) on failure;
 - changes unregister_irq_handler() to take argument unint32_t instead of dev_handler_node*;

In addition,  irq request flow for pt devices is revised, in order to remove dependency on irq sharing:  register irq on adding remapping entery and unregister irq on removal an entry, and do not register/unregister at remapping an entry.

