### PR TITLE
HV: handle trusty on vm reset

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -396,6 +396,7 @@ void destroy_vcpu(struct vcpu *vcpu)
  */
 void reset_vcpu(struct vcpu *vcpu)
 {
+	int i;
 	struct acrn_vlapic *vlapic;
 
 	pr_dbg("vcpu%hu reset", vcpu->vcpu_id);
@@ -418,6 +419,12 @@ void reset_vcpu(struct vcpu *vcpu)
 	vcpu->arch_vcpu.irq_window_enabled = 0;
 	vcpu->arch_vcpu.inject_event_pending = false;
 	(void)memset(vcpu->arch_vcpu.vmcs, 0U, CPU_PAGE_SIZE);
+
+	for (i = 0; i < NR_WORLD; i++) {
+		(void)memset(&vcpu->arch_vcpu.contexts[i], 0U,
+			sizeof(struct run_context));
+	}
+	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
 
 	vlapic = vcpu->arch_vcpu.vlapic;
 	vlapic_reset(vlapic);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -366,6 +366,8 @@ int reset_vm(struct vm *vm)
 	}
 
 	vioapic_reset(vm->arch_vm.virt_ioapic);
+	destroy_secure_world(vm, false);
+	vm->sworld_control.flag.active = 0UL;
 
 	start_vm(vm);
 	return 0;


### PR DESCRIPTION
- clear run context when reset vcpu;

- destroy trusty without erase trusty memory when reset vm;

changelog:
	v1 -> v2: fix misra violation on calling memset();

Signed-off-by: Sun Victor <victor.sun@intel.com>
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Chi Mingqiang <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>