### PR TITLE
hv: treewide: fix 'Shifting value too far'

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -169,19 +169,21 @@ static inline uint32_t
 vlapic_build_id(struct acrn_vlapic *vlapic)
 {
 	struct vcpu *vcpu = vlapic->vcpu;
-	uint16_t id;
+	uint8_t vlapic_id;
+	uint32_t lapic_regs_id;
 
 	if (is_vm0(vcpu->vm)) {
 		/* Get APIC ID sequence format from cpu_storage */
-		id = per_cpu(lapic_id, vcpu->vcpu_id);
+		vlapic_id = per_cpu(lapic_id, vcpu->vcpu_id);
 	} else {
-		id = vcpu->vcpu_id;
+		vlapic_id = (uint8_t)vcpu->vcpu_id;
 	}
 
-	dev_dbg(ACRN_DBG_LAPIC, "vlapic APIC PAGE ID : 0x%08x",
-		(id << APIC_ID_SHIFT));
+	lapic_regs_id = vlapic_id << APIC_ID_SHIFT;
 
-	return (id << APIC_ID_SHIFT);
+	dev_dbg(ACRN_DBG_LAPIC, "vlapic APIC PAGE ID : 0x%08x", lapic_regs_id);
+
+	return lapic_regs_id;
 }
 
 static void

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -209,6 +209,9 @@ void early_init_lapic(void)
 	}
 }
 
+/**
+ * @pre pcpu_id < 8U
+ */
 void init_lapic(uint16_t pcpu_id)
 {
 	/* Set the Logical Destination Register */


### PR DESCRIPTION
MISRA-C requires that shift operation cannot exceed the word length.

What this patch does:
- Add the pre condition for 'init_lapic' regarding to 'pcpu_id'
  Currently, max 8 physical cpus are supported.
  Re-design will be required if we would like to support more physical
   cpus.
  So, add the pre condition here to avoid the unintentional shift
   operation mistakes.

- Replace the id type with uint8_t in 'vlapic_build_id'
  - For VM0, it uses 'lapic_id' as its id, which is uint8_t.
  - For non VM0, it uses 'vcpu_id' as its id, which is uint16_t.
    Cast this id to uint8_t to make sure there is no loss of data after
     left shifting 24U.

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>