### PR TITLE
HV: Enclose debug specific code with #ifdef HV_DEBUG

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -155,9 +155,11 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_reset_ptdev_intr_info(vm, (uint16_t)param1, param2);
 		break;
 
+#ifdef HV_DEBUG
 	case HC_SETUP_SBUF:
 		ret = hcall_setup_sbuf(vm, param1);
 		break;
+#endif
 
 	case HC_WORLD_SWITCH:
 		ret = hcall_world_switch(vcpu);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -788,6 +788,7 @@ hcall_reset_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
 	return ret;
 }
 
+#ifdef HV_DEBUG
 int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
 {
 	struct sbuf_setup_param ssp;
@@ -808,6 +809,12 @@ int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
 
 	return sbuf_share_setup(ssp.pcpu_id, ssp.sbuf_id, hva);
 }
+#else
+int32_t hcall_setup_sbuf(__unused struct vm *vm, __unused uint64_t param)
+{
+	return -ENODEV;
+}
+#endif
 
 int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param)
 {

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -19,10 +19,12 @@
 #include "arch/x86/guest/instr_emul.h"
 
 struct per_cpu_region {
+#ifdef HV_DEBUG
 	uint64_t *sbuf[ACRN_SBUF_ID_MAX];
-	uint64_t irq_count[NR_IRQS];
 	uint64_t vmexit_cnt[64];
 	uint64_t vmexit_time[64];
+#endif
+	uint64_t irq_count[NR_IRQS];
 	uint64_t softirq_pending;
 	uint64_t spurious;
 	uint64_t vmxon_region_pa;


### PR DESCRIPTION
Thare some debug specific code which don't run on release version, such as vmexit_time,
vmexit_cnt, sbuf related codes, etc...

This patch enclose these codes with #ifdef HV_DEBUG.

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>