### PR TITLE
HV: change wake vector info to accommodate ww32 sbl

### DIFF
--- a/hypervisor/bsp/sbl/platform_acpi_info.c
+++ b/hypervisor/bsp/sbl/platform_acpi_info.c
@@ -48,7 +48,7 @@ const struct acpi_info host_acpi_info = {
 			.val_pm1b = 0U,
 			.reserved = 0U
 		},
-		.wake_vector_32 = (uint32_t *)0x7A86BC9CUL,
-		.wake_vector_64 = (uint64_t *)0x7A86BCA8UL
+		.wake_vector_32 = (uint32_t *)0x7A86BBDCUL,
+		.wake_vector_64 = (uint64_t *)0x7A86BBE8UL
 	}
 };


### PR DESCRIPTION
The wake vector address in SBL ACPI table was changed since ww30,
so change platform acpi info accordingly to support system S3.

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>