### PR TITLE
HV: pirq: renamed irq APIs

### DIFF
--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -29,7 +29,7 @@ static int request_notification_irq(irq_action_t func, void *data,
 	}
 
 	/* all cpu register the same notification vector */
-	retval = pri_register_handler(NOTIFY_IRQ, func, data, name);
+	retval = request_irq(NOTIFY_IRQ, func, data, name);
 	if (retval < 0) {
 		pr_err("Failed to add notify isr");
 		return -ENODEV;
@@ -64,7 +64,7 @@ void setup_notification(void)
 static void cleanup_notification(void)
 {
 	if (notification_irq != IRQ_INVALID) {
-		unregister_handler_common(notification_irq);
+		free_irq(notification_irq);
 	}
 	notification_irq = IRQ_INVALID;
 }

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -20,7 +20,6 @@ static int kick_notification(__unused uint32_t irq, __unused void *data)
 static int request_notification_irq(irq_action_t func, void *data,
 				const char *name)
 {
-	uint32_t irq = IRQ_INVALID; /* system allocate */
 	int32_t retval;
 
 	if (notification_irq != IRQ_INVALID) {
@@ -30,7 +29,7 @@ static int request_notification_irq(irq_action_t func, void *data,
 	}
 
 	/* all cpu register the same notification vector */
-	retval = pri_register_handler(irq, VECTOR_NOTIFY_VCPU, func, data, name);
+	retval = pri_register_handler(NOTIFY_IRQ, func, data, name);
 	if (retval < 0) {
 		pr_err("Failed to add notify isr");
 		return -ENODEV;

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -8,7 +8,6 @@
 #include <softirq.h>
 
 #define MAX_TIMER_ACTIONS	32U
-#define TIMER_IRQ		(NR_IRQS - 1U)
 #define CAL_MS			10U
 #define MIN_TIMER_PERIOD_US	500U
 
@@ -112,8 +111,7 @@ static int request_timer_irq(irq_action_t func, const char *name)
 {
 	int32_t retval;
 
-	retval = pri_register_handler(TIMER_IRQ, VECTOR_TIMER,
-				      func, NULL, name);
+	retval = pri_register_handler(TIMER_IRQ, func, NULL, name);
 	if (retval >= 0) {
 		update_irq_handler(TIMER_IRQ, quick_handler_nolock);
 	} else {

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -111,7 +111,7 @@ static int request_timer_irq(irq_action_t func, const char *name)
 {
 	int32_t retval;
 
-	retval = pri_register_handler(TIMER_IRQ, func, NULL, name);
+	retval = request_irq(TIMER_IRQ, func, NULL, name);
 	if (retval >= 0) {
 		update_irq_handler(TIMER_IRQ, quick_handler_nolock);
 	} else {
@@ -208,7 +208,7 @@ void timer_cleanup(void)
 	uint16_t pcpu_id = get_cpu_id();
 
 	if (pcpu_id == BOOT_CPU_ID) {
-		unregister_handler_common(TIMER_IRQ);
+		free_irq(TIMER_IRQ);
 	}
 }
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -826,10 +826,10 @@ static int dmar_setup_interrupt(struct dmar_drhd_rt *dmar_uint)
 		return 0;
 	}
 
-	retval = normal_register_handler(IRQ_INVALID,
-					dmar_fault_handler,
-					dmar_uint,
-					"dmar_fault_event");
+	retval = request_irq(IRQ_INVALID,
+			     dmar_fault_handler,
+			     dmar_uint,
+			     "dmar_fault_event");
 
 	if (retval < 0 ) {
 		pr_err("%s: fail to setup interrupt", __func__);

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -134,7 +134,7 @@ ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq)
 	int32_t retval;
 
 	/* register and allocate host vector/irq */
-	retval = normal_register_handler(phys_irq, ptdev_interrupt_handler,
+	retval = request_irq(phys_irq, ptdev_interrupt_handler,
 				         (void *)entry, "dev assign");
 
 	ASSERT(retval >= 0, "dev register failed");
@@ -150,7 +150,7 @@ ptdev_deactivate_entry(struct ptdev_remapping_info *entry)
 
 	atomic_clear32(&entry->active, ACTIVE_FLAG);
 
-	unregister_handler_common(entry->allocated_pirq);
+	free_irq(entry->allocated_pirq);
 	entry->allocated_pirq = IRQ_INVALID;
 
 	/* remove from softirq list if added */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -27,6 +27,9 @@
 #define NR_IRQS		(256U + 16U)
 #define IRQ_INVALID		0xffffffffU
 
+#define TIMER_IRQ		(NR_IRQS - 1U)
+#define NOTIFY_IRQ		(NR_IRQS - 2U)
+
 #define DEFAULT_DEST_MODE	IOAPIC_RTE_DESTLOG
 #define DEFAULT_DELIVERY_MODE	IOAPIC_RTE_DELLOPRI
 #define ALL_CPUS_MASK		((1U << phys_cpu_num) - 1U)

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -28,7 +28,6 @@ struct irq_request_info {
 	/* vector set to 0xE0 ~ 0xFF for pri_register_handler
 	 * and set to VECTOR_INVALID for normal_register_handler
 	 */
-	uint32_t vector;
 	irq_action_t func;
 	void *priv_data;
 	char *name;
@@ -60,7 +59,6 @@ void irq_desc_try_free_vector(uint32_t irq);
 uint32_t irq_to_vector(uint32_t irq);
 
 int32_t pri_register_handler(uint32_t irq,
-		uint32_t vector,
 		irq_action_t func,
 		void *priv_data,
 		const char *name);

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -23,15 +23,7 @@ enum irq_desc_state {
 	IRQ_DESC_IN_PROCESS,
 };
 
-typedef int (*irq_action_t)(uint32_t irq, void *dev_data);
-struct irq_request_info {
-	/* vector set to 0xE0 ~ 0xFF for pri_register_handler
-	 * and set to VECTOR_INVALID for normal_register_handler
-	 */
-	irq_action_t func;
-	void *priv_data;
-	char *name;
-};
+typedef int (*irq_action_t)(uint32_t irq, void *priv_data);
 
 /* any field change in below required irq_lock protection with irqsave */
 struct irq_desc {
@@ -58,17 +50,12 @@ void irq_desc_try_free_vector(uint32_t irq);
 
 uint32_t irq_to_vector(uint32_t irq);
 
-int32_t pri_register_handler(uint32_t irq,
-		irq_action_t func,
-		void *priv_data,
-		const char *name);
+int32_t request_irq(uint32_t irq,
+		    irq_action_t action_fn,
+		    void *priv_data,
+		    const char *name);
 
-int32_t normal_register_handler(uint32_t irq,
-		irq_action_t func,
-		void *priv_data,
-		const char *name);
-
-void unregister_handler_common(uint32_t irq);
+void free_irq(uint32_t irq);
 
 typedef int (*irq_handler_t)(struct irq_desc *desc, void *handler_data);
 void update_irq_handler(uint32_t irq, irq_handler_t func);


### PR DESCRIPTION
Two commits included:
hv: pirq: add static irq:vector mappings
 - to remove "vector" in irq API for special irq with vector determined statically;

hv: pirq: rename common irq APIs
 - renamed the APIs to request_irq()/free_irq()
