### PR TITLE
tools: acrnalyze: Make the result easier to read

### DIFF
--- a/tools/acrntrace/scripts/irq_analyze.py
+++ b/tools/acrntrace/scripts/irq_analyze.py
@@ -80,12 +80,12 @@ def generate_report(ofile, freq):
 
             rt_sec = float(rt_cycle) / (float(freq) * 1000 * 1000)
 
-            print ("\nVector \t\tCount \tNR_Exit/Sec")
+            print ("%-8s\t%-8s\t%-8s" % ("Vector", "Count", "NR_Exit/Sec"))
             f_csv.writerow(['Vector', 'NR_Exit', 'NR_Exit/Sec'])
             for e in IRQ_EXITS.keys():
                 pct = float(IRQ_EXITS[e]) / rt_sec
-                print ("0x%08x \t %d \t%.2f" % (e, IRQ_EXITS[e], pct))
-                f_csv.writerow([e, IRQ_EXITS[e], '%.2f' % pct])
+                print ("0x%08x\t%-8d\t%-8.2f" % (e, IRQ_EXITS[e], pct))
+                f_csv.writerow(['0x%08x' % e, IRQ_EXITS[e], '%.2f' % pct])
 
     except IOError as err:
         print ("Output File Error: " + str(err))

--- a/tools/acrntrace/scripts/vmexit_analyze.py
+++ b/tools/acrntrace/scripts/vmexit_analyze.py
@@ -171,7 +171,8 @@ def generate_report(ofile, freq):
                             '%.3f' % (rt_sec),
                             '%d' % (freq)])
 
-            print ("Event \tNR_Exit \tNR_Exit/Sec \tTime Consumed \tTime Percentage")
+            print ("%-28s\t%-12s\t%-12s\t%-24s\t%-16s" % ("Event", "NR_Exit",
+                   "NR_Exit/Sec", "Time Consumed(cycles)", "Time percentage"))
             f_csv.writerow(['Exit_Reason',
                             'NR_Exit',
                             'NR_Exit/Sec',
@@ -182,7 +183,7 @@ def generate_report(ofile, freq):
                 ev_freq = float(NR_EXITS[event]) / rt_sec
                 pct = float(TIME_IN_EXIT[event]) * 100 / float(rt_cycle)
 
-                print ("%s \t%d \t%.2f \t%d \t%2.2f" %
+                print ("%-28s\t%-12d\t%-12.2f\t%-24d\t%-16.2f" %
                        (event, NR_EXITS[event], ev_freq, TIME_IN_EXIT[event], pct))
                 row = [event, NR_EXITS[event], '%.2f' % ev_freq, TIME_IN_EXIT[event],
                        '%2.2f' % (pct)]
@@ -190,8 +191,8 @@ def generate_report(ofile, freq):
 
             ev_freq = float(TOTAL_NR_EXITS) / rt_sec
             pct = float(total_exit_time) * 100 / float(rt_cycle)
-            print("Total \t%d \t%.2f \t%d \t%2.2f"
-                  % (TOTAL_NR_EXITS, ev_freq, total_exit_time, pct))
+            print("%-28s\t%-12d\t%-12.2f\t%-24d\t%-16.2f"
+                  % ("Total", TOTAL_NR_EXITS, ev_freq, total_exit_time, pct))
             row = ["Total", TOTAL_NR_EXITS, '%.2f' % ev_freq, total_exit_time,
                    '%2.2f' % (pct)]
             f_csv.writerow(row)


### PR DESCRIPTION
Originally, we don't format the output of analyser well. It is hard to read the
result.

This patch make every entry of the result align with the corresponding title to
make it easier for users to read.

Without patch:
Event                    NR_Exit         NR_Exit/Sec     Time Consumed(cycles)       Time Percentage
VMEXIT_INTERRUPT_WINDOW         78090   130.15  40      0.01
VMEXIT_CR_ACCESS        0       0.00    0       0.00
VMEXIT_APICV_ACCESS     0       0.00    0       0.00
VMEXIT_EXCEPTION_OR_NMI         0       0.00    0       0.00
VMEXIT_RDTSC    0       0.00    0       0.00

...

Vector          Count   NR_Exit/Sec
0x000000f0       82337  137.23
0x000000ef       247713         412.85

With patch:
Event                           NR_Exit         NR_Exit/Sec     Time Consumed(cycles)           Time percentage
VMEXIT_APICV_WRITE              13352           22.25           14331304                        0.00
VMEXIT_WRMSR                    309085          515.14          241166212                       0.02
VMEXIT_INTERRUPT_WINDOW         78090           130.15          76841734                        0.01

...

Vector          Count           NR_Exit/Sec
0x000000f0      82337           137.23
0x000000ef      247713          412.85

Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>