### PR TITLE
hv:fix return value violations for vpic/vioapic

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -896,7 +896,8 @@ int ptdev_add_intx_remapping(struct vm *vm,
 {
 	struct ptdev_remapping_info *entry;
 
-	if (vm == NULL) {
+	if (vm == NULL || (!pic_pin && virt_pin >= vioapic_pincount(vm))
+			|| (pic_pin && virt_pin >= vpic_pincount())) {
 		pr_err("ptdev_add_intx_remapping fails!\n");
 		return -EINVAL;
 	}

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -41,9 +41,9 @@ struct vioapic *vioapic_init(struct vm *vm);
 void	vioapic_cleanup(struct vioapic *vioapic);
 void	vioapic_reset(struct vioapic *vioapic);
 
-int	vioapic_assert_irq(struct vm *vm, uint32_t irq);
-int	vioapic_deassert_irq(struct vm *vm, uint32_t irq);
-int	vioapic_pulse_irq(struct vm *vm, uint32_t irq);
+void	vioapic_assert_irq(struct vm *vm, uint32_t irq);
+void	vioapic_deassert_irq(struct vm *vm, uint32_t irq);
+void	vioapic_pulse_irq(struct vm *vm, uint32_t irq);
 void	vioapic_update_tmr(struct vcpu *vcpu);
 
 void	vioapic_mmio_write(struct vm *vm, uint64_t gpa, uint32_t wval);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -93,17 +93,15 @@ enum vpic_trigger {
 void *vpic_init(struct vm *vm);
 void vpic_cleanup(struct vm *vm);
 
-int vpic_assert_irq(struct vm *vm, uint32_t irq);
-int vpic_deassert_irq(struct vm *vm, uint32_t irq);
-int vpic_pulse_irq(struct vm *vm, uint32_t irq);
+void vpic_assert_irq(struct vm *vm, uint32_t irq);
+void vpic_deassert_irq(struct vm *vm, uint32_t irq);
+void vpic_pulse_irq(struct vm *vm, uint32_t irq);
 
 void vpic_pending_intr(struct vm *vm, uint32_t *vecptr);
 void vpic_intr_accepted(struct vm *vm, uint32_t vector);
-int vpic_set_irq_trigger(struct vm *vm, uint32_t irq,
-	enum vpic_trigger trigger);
-int vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
+void vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
 	enum vpic_trigger *trigger);
-
+uint32_t vpic_pincount(void);
 bool vpic_is_pin_mask(struct acrn_vpic *vpic, uint8_t virt_pin_arg);
 
 #endif	/* _VPIC_H_ */


### PR DESCRIPTION
-- Change these APIs to void type, add pre-conditions,
   and move parameter-check to upper-layer functions.
   handle_vpic_irqline
   vpic_set_irqstate
   vpic_assert_irq
   vpic_deassert_irq
   vpic_pulse_irq
   vpic_get_irq_trigger
   handle_vioapic_irqline
   vioapic_assert_irq
   vioapic_deassert_irq
   vioapic_pulse_irq
-- Remove dead code
   vpic_set_irq_trigger

v1-->v2:
   add cleanup vpic
   change some APIs to void type, add pre-conditions,
   and move the parameter-check to upper-layer functions.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>