### PR TITLE
hv: vuart: fix 'Shifting value too far'

### DIFF
--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -39,16 +39,16 @@ struct fifo {
 };
 
 struct vuart {
-	char data;		/* Data register (R/W) */
-	char ier;		/* Interrupt enable register (R/W) */
-	char lcr;		/* Line control register (R/W) */
-	char mcr;		/* Modem control register (R/W) */
-	char lsr;		/* Line status register (R/W) */
-	char msr;		/* Modem status register (R/W) */
-	char fcr;		/* FIFO control register (W) */
-	char scr;		/* Scratch register (R/W) */
-	char dll;		/* Baudrate divisor latch LSB */
-	char dlh;		/* Baudrate divisor latch MSB */
+	uint8_t data;		/* Data register (R/W) */
+	uint8_t ier;		/* Interrupt enable register (R/W) */
+	uint8_t lcr;		/* Line control register (R/W) */
+	uint8_t mcr;		/* Modem control register (R/W) */
+	uint8_t lsr;		/* Line status register (R/W) */
+	uint8_t msr;		/* Modem status register (R/W) */
+	uint8_t fcr;		/* FIFO control register (W) */
+	uint8_t scr;		/* Scratch register (R/W) */
+	uint8_t dll;		/* Baudrate divisor latch LSB */
+	uint8_t dlh;		/* Baudrate divisor latch MSB */
 
 	struct fifo rxfifo;
 	struct fifo txfifo;


### PR DESCRIPTION
MISRA-C requires that shift operation cannot exceed the word length.

What this patch does:
- Fix the bug in 'vuart_init'
  The register 'dll' and 'dlh' should be uint8_t rather than char.
  'dll' is the lower 8-bit of divisor.
  'dlh' is the higher 8-bit of divisor.
  So, the shift value should be 8U rather than 16U.
- Fix other data type issues regarding to the registers in 'struct
  vuart'
  The registers should be unsigned variables.

v1 -> v2:
 * Use a local variable 'uint8_t value_u8 = (uint8_t)value' to avoid
   mutiple times type conversion
 * Use '(uint8_t)divisor' rather than '(uint8_t)(divisor & 0xFFU)' to
   get the lower 8 bit of 'divisor'
   Direct type conversion is safe and simple per Xiangyang's suggestion.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>