### PR TITLE
remove Device Manager memory allocation mechanism

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -339,6 +339,16 @@ Set up Reference UOS
       :align: center
       :name: gsg-successful-boot
 
+Device Manager memory allocation mechanism
+==========================================
+
+The ACRN Device Manager (DM) virtual memory allocation uses the HugeTLB mechanism.
+(You can read more about `HugeTLB in the linux kernel <https://linuxgazette.net/155/krishnakumar.html>`_
+for more information about how this mechanism works.)
+For hugeTLB to work with 1GB huge page reservation in runtime, it is possible fail sometime.  
+to guarantee 1G huge page reservation you'll need to set SOS command line to reserve manually
+For a (large) 1GB huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
+(for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in ``acrn.conf`` (for EFI)
 
 Build ACRN from Source
 **********************

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -340,30 +340,6 @@ Set up Reference UOS
       :name: gsg-successful-boot
 
 
-Device Manager memory allocation mechanism
-==========================================
-
-The ACRN Device Manager (DM) virtual memory allocation uses the HugeTLB mechanism.
-(You can read more about `HugeTLB in the linux kernel <https://linuxgazette.net/155/krishnakumar.html>`_
-for more information about how this mechanism works.)
-
-For hugeTLB to work, you'll need to reserve huge pages:
-
-  - For a (large) 1GB huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
-    (for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in
-    ``acrn.conf`` (for EFI)
-
-  - For a (smaller) 2MB huge page reservation, after the SOS starts up, run the
-    command::
-
-       echo reserved_pg_num > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
-
-  .. note::
-     You can use 2M reserving method to do reservation for 1G page size, but it
-     may fail.  For an EFI platform, you may skip 1G page reservation
-     by using a 2M page, but make sure your huge page reservation size is
-     large enough for your usage.
-
 Build ACRN from Source
 **********************
 

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -345,8 +345,9 @@ Device Manager memory allocation mechanism
 The ACRN Device Manager (DM) virtual memory allocation uses the HugeTLB mechanism.
 (You can read more about `HugeTLB in the linux kernel <https://linuxgazette.net/155/krishnakumar.html>`_
 for more information about how this mechanism works.)
-For hugeTLB to work with 1GB huge page reservation in runtime, it is possible fail sometime.  
-to guarantee 1G huge page reservation you'll need to set SOS command line to reserve manually
+For hugeTLB to work with 1GB huge page reservation in runtime, it is possible fail sometime. 
+This will make DM fall back to use 2M huge pages. If you want to guarantee 1G huge page reservation
+you'll need to set SOS command line to reserve manually
 For a (large) 1GB huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
 (for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in ``acrn.conf`` (for EFI)
 

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -345,11 +345,13 @@ Device Manager memory allocation mechanism
 The ACRN Device Manager (DM) virtual memory allocation uses the HugeTLB mechanism.
 (You can read more about `HugeTLB in the linux kernel <https://linuxgazette.net/155/krishnakumar.html>`_
 for more information about how this mechanism works.)
-For hugeTLB to work with 1GB huge page reservation in runtime, it is possible fail sometime. 
-This will make DM fall back to use 2M huge pages. If you want to guarantee 1G huge page reservation
-you'll need to set SOS command line to reserve manually
-For a (large) 1GB huge page reservation, add ``hugepagesz=1G hugepages=reserved_pg_num``
-(for example, ``hugepagesz=1G hugepages=4``) to the SOS cmdline in ``acrn.conf`` (for EFI)
+For hugeTLB to work with a 1GB huge page reservation at runtime, 
+set an SOS command line parameter to reserve this space.  Add 
+``hugepagesz=1G hugepages=<reserved_pg_num>``
+(for example, ``hugepagesz=1G hugepages=4``) to the SOS
+cmdline in ``acrn.conf`` (for EFI).  Without this reservation, the
+DM may fall back to use 2M huge pages.
+
 
 Build ACRN from Source
 **********************


### PR DESCRIPTION
removing Device Manager memory allocation mechanism section from getting started guide because no need to set it manually any more.
and remove it to avoid people confuse to use latest release.

Signed-off-by: ailun258 <ailin.yang@intel.com>