### PR TITLE
HV: remove 'spinlock_rfags' declaration

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -93,17 +93,16 @@ static inline uint32_t
 ioapic_read_reg32(const void *ioapic_base, const uint32_t offset)
 {
 	uint32_t v;
+	uint64_t rflags;
 
-	spinlock_rflags;
-
-	spinlock_irqsave_obtain(&ioapic_lock);
+	spinlock_irqsave_obtain(&ioapic_lock, &rflags);
 
 	/* Write IOREGSEL */
 	mmio_write32(offset, (void *)ioapic_base + IOAPIC_REGSEL);
 	/* Read  IOWIN */
 	v = mmio_read32((void *)ioapic_base + IOAPIC_WINDOW);
 
-	spinlock_irqrestore_release(&ioapic_lock);
+	spinlock_irqrestore_release(&ioapic_lock, rflags);
 	return v;
 }
 
@@ -111,16 +110,16 @@ static inline void
 ioapic_write_reg32(const void *ioapic_base,
 		const uint32_t offset, const uint32_t value)
 {
-	spinlock_rflags;
+	uint64_t rflags;
 
-	spinlock_irqsave_obtain(&ioapic_lock);
+	spinlock_irqsave_obtain(&ioapic_lock, &rflags);
 
 	/* Write IOREGSEL */
 	mmio_write32(offset, (void *)ioapic_base + IOAPIC_REGSEL);
 	/* Write IOWIN */
 	mmio_write32(value, (void *)ioapic_base + IOAPIC_WINDOW);
 
-	spinlock_irqrestore_release(&ioapic_lock);
+	spinlock_irqrestore_release(&ioapic_lock, rflags);
 }
 
 static inline uint64_t

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -421,13 +421,6 @@ void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 	*timestamp_ptr = ((uint64_t)tsh << 32) | tsl;         \
 }
 
-/* Define variable(s) required to save / restore architecture interrupt state.
- * These variable(s) are used in conjunction with the ESAL_AR_INT_ALL_DISABLE()
- * and ESAL_AR_INT_ALL_RESTORE() macros to hold any data that must be preserved
- * in order to allow these macros to function correctly.
- */
-#define         CPU_INT_CONTROL_VARS                uint64_t    cpu_int_value
-
 /* Macro to save rflags register */
 #define CPU_RFLAGS_SAVE(rflags_ptr)                     \
 {                                                       \
@@ -453,9 +446,9 @@ void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
  *        defined below and CPU_INT_CONTROL_VARS defined above.
  */
 
-#define CPU_INT_ALL_DISABLE()                       \
+#define CPU_INT_ALL_DISABLE(p_rflags)               \
 {                                                   \
-	CPU_RFLAGS_SAVE(&cpu_int_value);            \
+	CPU_RFLAGS_SAVE(p_rflags);	             \
 	CPU_IRQ_DISABLE();                          \
 }
 
@@ -466,9 +459,9 @@ void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
  * NOTE:  This macro is used in conjunction with CPU_INT_ALL_DISABLE
  *        and CPU_INT_CONTROL_VARS defined above.
  */
-#define CPU_INT_ALL_RESTORE()                       \
+#define CPU_INT_ALL_RESTORE(rflags)                 \
 {                                                   \
-	CPU_RFLAGS_RESTORE(cpu_int_value);          \
+	CPU_RFLAGS_RESTORE(rflags);                 \
 }
 
 /*

--- a/hypervisor/include/lib/spinlock.h
+++ b/hypervisor/include/lib/spinlock.h
@@ -63,18 +63,15 @@ static inline void spinlock_release(spinlock_t *lock)
 
 #endif	/* ASSEMBLER */
 
-#define spinlock_rflags unsigned long cpu_int_value
-
-#define spinlock_irqsave_obtain(l)			\
+#define spinlock_irqsave_obtain(lock, p_rflags)		\
 	do {						\
-		CPU_INT_ALL_DISABLE();			\
-		spinlock_obtain(l);			\
+		CPU_INT_ALL_DISABLE(p_rflags);		\
+		spinlock_obtain(lock);			\
 	} while (0)
 
-#define spinlock_irqrestore_release(l)			\
+#define spinlock_irqrestore_release(lock, rflags)	\
 	do {						\
-		spinlock_release(l);			\
-		CPU_INT_ALL_RESTORE();			\
+		spinlock_release(lock);			\
+		CPU_INT_ALL_RESTORE(rflags);		\
 	} while (0)
-
 #endif /* SPINLOCK_H */


### PR DESCRIPTION
 - remove the global declaration of 'cpu_int_value'

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>