### PR TITLE
hv: Build fix for Partition mode

### DIFF
--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -111,7 +111,6 @@ static void io_instr_dest_handler(struct io_request *io_req)
 	if (pio_req->direction == REQUEST_READ) {
 		pio_req->value = 0xFFFFFFFFU;
 	}
-	io_req->processed = REQ_STATE_COMPLETE;
 }
 #endif
 


### PR DESCRIPTION
struct io_request gets rid of "processed" element. Modified io exit handler
for partition mode to accomodate the change.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>