### PR TITLE
Vbs k s3 support

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_audio.c
+++ b/devicemodel/hw/pci/virtio/virtio_audio.c
@@ -195,7 +195,7 @@ virtio_audio_reset(void *base)
 		DPRINTF(("virtio_audio: VBS-K reset requested!\n"));
 		virtio_audio_kernel_stop(virt_audio);
 		virtio_audio_kernel_reset(virt_audio);
-		virt_audio->vbs_k.kstatus = VIRTIO_DEV_INITIAL;
+		virt_audio->vbs_k.kstatus = VIRTIO_DEV_INIT_SUCCESS;
 	}
 }
 

--- a/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
+++ b/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
@@ -186,7 +186,7 @@ virtio_hyper_dmabuf_reset(void *base)
 	if (kstatus == VIRTIO_DEV_STARTED) {
 		virtio_hyper_dmabuf_k_stop();
 		virtio_hyper_dmabuf_k_reset();
-		kstatus = VIRTIO_DEV_INITIAL;
+		kstatus = VIRTIO_DEV_INIT_SUCCESS;
 	}
 }
 

--- a/devicemodel/hw/pci/virtio/virtio_kernel.c
+++ b/devicemodel/hw/pci/virtio/virtio_kernel.c
@@ -38,7 +38,7 @@ vbs_kernel_init(int fd)
 int
 vbs_kernel_reset(int fd)
 {
-	return VIRTIO_SUCCESS;
+	return ioctl(fd, VBS_K_RESET_DEV, NULL);
 }
 
 /*

--- a/devicemodel/hw/pci/virtio/virtio_rnd.c
+++ b/devicemodel/hw/pci/virtio/virtio_rnd.c
@@ -293,7 +293,7 @@ virtio_rnd_reset(void *base)
 		DPRINTF(("virtio_rnd: VBS-K reset requested!\n"));
 		virtio_rnd_kernel_stop(rnd);
 		virtio_rnd_kernel_reset(rnd);
-		rnd->vbs_k.status = VIRTIO_DEV_INITIAL;
+		rnd->vbs_k.status = VIRTIO_DEV_INIT_SUCCESS;
 	}
 }
 

--- a/devicemodel/include/vbs_common_if.h
+++ b/devicemodel/include/vbs_common_if.h
@@ -43,5 +43,6 @@ struct vbs_dev_info {
 
 #define VBS_K_SET_DEV _IOW(VBS_K_IOCTL, 0x00, struct vbs_dev_info)
 #define VBS_K_SET_VQ _IOW(VBS_K_IOCTL, 0x01, struct vbs_vqs_info)
+#define VBS_K_RESET_DEV _IO(VBS_K_IOCTL, 0x02)
 
 #endif /* _VBS_COMMON_IF_H_ */


### PR DESCRIPTION
A new ioctl is introduced in VBS-K to issue reset command to kernel
VBS-K driver. This is used to support VBS-K S3. When FE enters S3
reset command is sent to device model. Backend driver in device model
should use this ioctl to inform the VBS-K drvier in kernel.

Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Reviewed-by: Shuo Liu <shuo.a.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>
