### PR TITLE
fix spec_ctrl msr save/restore

### DIFF
--- a/hypervisor/arch/x86/vmx_asm.S
+++ b/hypervisor/arch/x86/vmx_asm.S
@@ -59,8 +59,8 @@ vmx_vmrun:
 
     /* 0x00000048 = MSR_IA32_SPEC_CTRL */
     movl        $0x00000048,%ecx
-    /*0xa0=168U=CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL*/
-    mov         0xa0(%rdi),%rax
+    /*0xa8=168U=CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL*/
+    mov         0xa8(%rdi),%rax
     movl        $0,%edx
     wrmsr
 
@@ -231,8 +231,8 @@ vm_eval_error:
      */
     movl        $0x00000048,%ecx
     rdmsr
-    /*168U=0xa0=CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL*/
-    mov         %rax,0xa0(%rsi)
+    /*168U=0xa8=CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL*/
+    mov         %rax,0xa8(%rsi)
     /* 0x1 = SPEC_ENABLE_IBRS */
     movl        $0x1,%eax
     movl        $0,%edx
@@ -255,8 +255,8 @@ ibrs_opt:
      */
     movl        $0x00000048,%ecx
     rdmsr
-    /*168U=0xa0=CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL*/
-    mov         %rax,0xa0(%rsi)
+    /*168U=0xa8=CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL*/
+    mov         %rax,0xa8(%rsi)
     /* 0x2 = SPEC_ENABLE_STIBP */
     movl        $0x2,%eax
     movl        $0,%edx


### PR DESCRIPTION
the CPU_CONTEXT_OFFSET_IA32_SPEC_CTRL is 168U which should be 0xa8
instead of 0xa0

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>