### PR TITLE
hv: sw_loader for VMs in ACRN partition mode

### DIFF
--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -128,10 +128,13 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 
 	pr_dbg("Loading guest to run-time location");
 
+/* ACRN in partiton mode boots all VMs without devicemodel */
+#ifndef CONFIG_PARTITION_MODE
 	/* FIXME: set config according to predefined offset */
 	if (!is_vm0(vm)) {
 		return load_guest(vm, vcpu);
 	}
+#endif
 
 	/* calculate the kernel entry point */
 	zeropage = (struct zero_page *)sw_kernel->kernel_src_addr;


### PR DESCRIPTION
ACRN in partition mode needs to boot VMs from HV. This patch make ACRN
treat all VMs in the same way (as vm0)  w.r.t. setting up the guest memory
for kernel, bootargs and zeropage

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>