### PR TITLE
hv: Support HV console for multiple VMs - ACRN partition mode

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -723,6 +723,13 @@ static int shell_to_sos_console(__unused int argc, __unused char **argv)
 	struct vm *vm;
 	struct vuart *vuart;
 
+#ifdef CONFIG_PARTITION_MODE
+	if (argc == 2U) {
+		guest_no = atoi(argv[1]);
+	}
+
+	vuart_vmid = guest_no;
+#endif
 	/* Get the virtual device node */
 	vm = get_vm_from_vmid(guest_no);
 	if (vm == NULL) {

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -43,6 +43,10 @@
 
 #define vm_vuart(vm)		(vm->vuart)
 
+#ifdef CONFIG_PARTITION_MODE
+int8_t vuart_vmid = - 1;
+#endif
+
 static void fifo_reset(struct fifo *fifo)
 {
 	fifo->rindex = 0;
@@ -348,7 +352,17 @@ void vuart_console_rx_chars(struct vuart *vu)
 
 struct vuart *vuart_console_active(void)
 {
+#ifdef CONFIG_PARTITION_MODE
+	struct vm *vm;
+
+	if (vuart_vmid == -1) {
+		return NULL;
+	}
+
+	vm = get_vm_from_vmid(vuart_vmid);
+#else
 	struct vm *vm = get_vm_from_vmid(0U);
+#endif
 
 	if ((vm != NULL) && (vm->vuart != NULL)) {
 		struct vuart *vu = vm->vuart;

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -59,7 +59,9 @@ struct vuart {
 	struct vm *vm;
 	spinlock_t lock;	/* protects all softc elements */
 };
-
+#ifdef CONFIG_PARTITION_MODE
+extern int8_t vuart_vmid;
+#endif
 #ifdef HV_DEBUG
 void *vuart_init(struct vm *vm);
 struct vuart *vuart_console_active(void);


### PR DESCRIPTION
ACRN in partition mode provides vUART for all VMs. This patch adds
support to add console redirection for multiple VMs.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>