### PR TITLE
tools: acrn-crashlog: update core_pattern content conditionally

### DIFF
--- a/tools/acrn-crashlog/README.rst
+++ b/tools/acrn-crashlog/README.rst
@@ -160,8 +160,8 @@ usercrash
 
 The ``usercrash`` is a tool to get the crash info of the crashing process in
 userspace. It works in Client/Server model. Server is autostarted, and client is
-configured in ``core_pattern``, which will be triggered once crash occurs in
-userspace.
+configured in ``core_pattern`` or ``coredump-wrapper``, which will be
+triggered once crash occurs in userspace.
 For more detail on ``usercrash``, please refer :ref:`usercrash_doc`.
 
 .. _`telemetrics-client`: https://github.com/clearlinux/telemetrics-client

--- a/tools/acrn-crashlog/data/acrnprobe_prepare.sh
+++ b/tools/acrn-crashlog/data/acrnprobe_prepare.sh
@@ -5,7 +5,12 @@
 #
 
 # modify the core_pattern
-echo "|/usr/bin/usercrash_c %p %e %s" > /proc/sys/kernel/core_pattern
+core_pattern_conf="/proc/sys/kernel/core_pattern"
+
+grep -q "coredump-wrapper" $core_pattern_conf
+if [ "$?" -ne "0" ] then
+	echo "|/usr/bin/usercrash_c %p %e %s" > $core_pattern_conf
+fi
 
 default_conf="/usr/share/defaults/telemetrics/telemetrics.conf"
 user_conf="/etc/telemetrics/telemetrics.conf"

--- a/tools/acrn-crashlog/usercrash/README.rst
+++ b/tools/acrn-crashlog/usercrash/README.rst
@@ -54,8 +54,11 @@ Usage
 *****
 
 - The server is launched automatically at boot, and the client is configured in
-  ``core_pattern``. The content of ``core_pattern`` is configured as
-  ``usercrash_c`` while booting up:
+  ``core_pattern`` or ``coredump-wrapper``. In ``prepare.service``, it will
+  check the content of ``/proc/sys/kernel/core_pattern``. If there is
+  ``coredump-wrapper``, which means that ``core_pattern`` has been set in
+  ``systemd``, no need to do it again. Otherwise, the content should be
+  changed by:
 
 .. code-block:: none
 


### PR DESCRIPTION
This patch is to improve the way of updating the core_pattern content
in the shell script, since the previous configuration in core_pattern
will block coredumpctl.
This patch adds an inspection before changing the content of
core_pattern.

Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: xiaojin2 <xiaojing.liu@intel.com>
Reviewed-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>