### PR TITLE
WAVE-1: 2nd patch set for vioapic/vlapic/vpic reshuffle

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1431,12 +1431,6 @@ vlapic_read(struct acrn_vlapic *vlapic, uint32_t offset_arg,
 	case APIC_OFFSET_TIMER_DCR:
 		*data = lapic->dcr_timer;
 		break;
-	case APIC_OFFSET_SELF_IPI:
-		/*
-		 * XXX generate a GP fault if vlapic is in x2apic mode
-		 */
-		*data = 0UL;
-		break;
 	case APIC_OFFSET_RRR:
 	default:
 		*data = 0UL;
@@ -1525,9 +1519,6 @@ vlapic_write(struct acrn_vlapic *vlapic, uint32_t offset,
 
 	case APIC_OFFSET_ESR:
 		vlapic_esr_write_handler(vlapic);
-		break;
-
-	case APIC_OFFSET_SELF_IPI:
 		break;
 
 	case APIC_OFFSET_VER:

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -425,8 +425,6 @@ static void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic,
 	del_timer(timer);
 
 	if (val != 0UL) {
-		struct vcpu_arch *arch = &vlapic->vcpu->arch_vcpu;
-
 		/* transfer guest tsc to host tsc */
 		val -= exec_vmread64(VMX_TSC_OFFSET_FULL);
 		timer->fire_tsc = val;
@@ -1739,14 +1737,6 @@ vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic)
 {
 	if (vlapic->ops.apicv_batch_set_tmr_fn != NULL) {
 		vlapic->ops.apicv_batch_set_tmr_fn(vlapic);
-	}
-}
-
-static void
-vlapic_apicv_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
-{
-	if (vlapic->ops.apicv_set_tmr_fn != NULL) {
-		vlapic->ops.apicv_set_tmr_fn(vlapic, vector, level);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1194,6 +1194,8 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
 					target_vcpu->vcpu_id,
 					target_vcpu->vm->vm_id);
 			schedule_vcpu(target_vcpu);
+		} else if (mode == APIC_DELMODE_SMI) {
+			pr_info("vmx vapic: SMI IPI do not support\n");
 		} else {
 			pr_err("Unhandled icrlo write with mode %u\n", mode);
 		}

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -80,7 +80,6 @@
 #define APIC_OFFSET_TIMER_ICR	0x380U	/* Timer's Initial Count	*/
 #define APIC_OFFSET_TIMER_CCR	0x390U	/* Timer's Current Count	*/
 #define APIC_OFFSET_TIMER_DCR	0x3E0U	/* Timer's Divide Configuration	*/
-#define APIC_OFFSET_SELF_IPI	0x3F0U	/* Self IPI register */
 
 /*
  * 16 priority levels with at most one vector injected per level.

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -337,22 +337,13 @@ int interrupt_window_vmexit_handler(struct vcpu *vcpu)
 
 	TRACE_2L(TRACE_VMEXIT_INTERRUPT_WINDOW, 0UL, 0UL);
 
-	if (vcpu == NULL)
-		return -1;
-
-	if (vcpu_pending_request(vcpu)) {
-		/* Do nothing
-		 * acrn_handle_pending_request will continue for this vcpu
-		 */
-	} else {
-		/* No interrupts to inject.
-		 * Disable the interrupt window exiting
-		 */
-		vcpu->arch_vcpu.irq_window_enabled = 0U;
-		value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
-		value32 &= ~(VMX_PROCBASED_CTLS_IRQ_WIN);
-		exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
-	}
+	/* Disable interrupt-window exiting first.
+	 * acrn_handle_pending_request will continue handle for this vcpu
+	 */
+	vcpu->arch_vcpu.irq_window_enabled = 0U;
+	value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
+	value32 &= ~(VMX_PROCBASED_CTLS_IRQ_WIN);
+	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
 
 	vcpu_retain_rip(vcpu);
 	return 0;


### PR DESCRIPTION
The 2nd patch set is majorly for vmx vapic reshuffle. The lvt, nmi and split vmx_vapic are still WIP. 

-refine the interrupt-window related code.
-fix several bugs.
-remove x2apic, APIC ID register related code.
-cleanup the APIC-access VM exit handler.
-rename the apicv to vmx_vapic in vlapic.c.
-rename the vapic to vmx_vapic in virq.c.

This the first wave, the second wave need to submit v2 for continue review.

