### PR TITLE
hv: Fix comments referring to wrong hypervisor name

### DIFF
--- a/doc/developer-guides/primer.rst
+++ b/doc/developer-guides/primer.rst
@@ -486,8 +486,8 @@ assign all devices to VM0 except the UART.
 
 If a PCI device (with MSI/MSI-x) is assigned to Guest, the User OS will
 program the PCI config space and set the guest vector to this device. A
-Hypercall ``CWP_VM_PCI_MSIX_FIXUP`` is provided. Once the guest programs
-the guest vector, the User OS may call this hypercall to notify the ACRN
+Hypercall ``HC_VM_PCI_MSIX_REMAP`` is provided. Once the guest programs
+the guest vector, the Service OS may call this hypercall to notify the ACRN
 hypervisor. The hypervisor allocates a host vector, creates a guest-host
 mapping relation, and replaces the guest vector with a real native
 vector for the device:

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -40,7 +40,7 @@ struct trusty_key_info {
 		0: Dummy (fake secret)
 		1: APL (APL + ABL)
 		2: ICL (ICL + SBL)
-		3: CWP (APL|ICL + SBL + CWP)
+		3: ACRN (APL|ICL + SBL + ACRN)
 		4: Brillo (Android Things)
 	*/
 	uint32_t platform;


### PR DESCRIPTION
Fix comments referring to wrong hypervisor name

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>