### PR TITLE
HV: Add const qualifiers where required

### DIFF
--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -89,7 +89,7 @@ static const struct cpu_state_table {
 	}
 };
 
-static int get_state_tbl_idx(char *cpuname)
+static int get_state_tbl_idx(const char *cpuname)
 {
 	int i;
 	int count = ARRAY_SIZE(cpu_state_tbl);

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -8,7 +8,7 @@
 
 extern bool x2apic_enabled;
 
-static inline struct vcpuid_entry *find_vcpuid_entry(struct vcpu *vcpu,
+static inline struct vcpuid_entry *find_vcpuid_entry(const struct vcpu *vcpu,
 					uint32_t leaf_arg, uint32_t subleaf)
 {
 	uint32_t i = 0U, nr, half;
@@ -66,7 +66,7 @@ static inline struct vcpuid_entry *find_vcpuid_entry(struct vcpu *vcpu,
 }
 
 static inline int set_vcpuid_entry(struct vm *vm,
-				struct vcpuid_entry *entry)
+				const struct vcpuid_entry *entry)
 {
 	struct vcpuid_entry *tmp;
 	size_t entry_size = sizeof(struct vcpuid_entry);
@@ -293,7 +293,7 @@ int set_vcpuid_entries(struct vm *vm)
 	return 0;
 }
 
-void guest_cpuid(struct vcpu *vcpu,
+void guest_cpuid(const struct vcpu *vcpu,
 		uint32_t *eax, uint32_t *ebx,
 		uint32_t *ecx, uint32_t *edx)
 {

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -10,7 +10,7 @@
 
 #define ACRN_DBG_EPT	6U
 
-static uint64_t find_next_table(uint32_t table_offset, void *table_base)
+static uint64_t find_next_table(uint32_t table_offset, const void *table_base)
 {
 	uint64_t table_entry;
 	uint64_t table_present;
@@ -100,7 +100,7 @@ void destroy_ept(struct vm *vm)
 		free_ept_mem(vm->arch_vm.m2p);
 }
 
-uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
+uint64_t local_gpa2hpa(const struct vm *vm, uint64_t gpa, uint32_t *size)
 {
 	uint64_t hpa = 0UL;
 	uint64_t *pgentry, pg_size = 0UL;
@@ -124,12 +124,12 @@ uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
 }
 
 /* using return value 0 as failure, make sure guest will not use hpa 0 */
-uint64_t gpa2hpa(struct vm *vm, uint64_t gpa)
+uint64_t gpa2hpa(const struct vm *vm, uint64_t gpa)
 {
 	return local_gpa2hpa(vm, gpa, NULL);
 }
 
-uint64_t hpa2gpa(struct vm *vm, uint64_t hpa)
+uint64_t hpa2gpa(const struct vm *vm, uint64_t hpa)
 {
 	uint64_t *pgentry, pg_size = 0UL;
 
@@ -251,7 +251,7 @@ int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu)
 	return status;
 }
 
-int ept_mr_add(struct vm *vm, uint64_t hpa_arg,
+int ept_mr_add(const struct vm *vm, uint64_t hpa_arg,
 	uint64_t gpa_arg, uint64_t size, uint32_t prot_arg)
 {
 	struct mem_map_params map_params;
@@ -290,7 +290,7 @@ int ept_mr_add(struct vm *vm, uint64_t hpa_arg,
 	return 0;
 }
 
-int ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
+int ept_mr_modify(const struct vm *vm, uint64_t *pml4_page,
 		uint64_t gpa, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr)
 {
@@ -308,7 +308,7 @@ int ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
 	return ret;
 }
 
-int ept_mr_del(struct vm *vm, uint64_t *pml4_page,
+int ept_mr_del(const struct vm *vm, uint64_t *pml4_page,
 		uint64_t gpa, uint64_t size)
 {
 	struct vcpu *vcpu;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -46,7 +46,7 @@ uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 	return dmask;
 }
 
-bool vm_lapic_disabled(struct vm *vm)
+bool vm_lapic_disabled(const struct vm *vm)
 {
 	uint16_t i;
 	struct vcpu *vcpu;
@@ -276,7 +276,7 @@ int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa,
 	return ret;
 }
 
-static inline uint32_t local_copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
+static inline uint32_t local_copy_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa,
 	uint32_t size, uint32_t fix_pg_size, bool cp_from_vm)
 {
 	uint64_t hpa;
@@ -308,7 +308,7 @@ static inline uint32_t local_copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
 	return len;
 }
 
-static inline int copy_gpa(struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
+static inline int copy_gpa(const struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
 	uint32_t size_arg, bool cp_from_vm)
 {
 	void *h_ptr = h_ptr_arg;
@@ -385,12 +385,12 @@ static inline int copy_gva(struct vcpu *vcpu, void *h_ptr_arg, uint64_t gva_arg,
  * - some other gpa from hypercall parameters, VHM should make sure it's
  *   continuous
  */
-int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
+int copy_from_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 {
 	return copy_gpa(vm, h_ptr, gpa, size, 1);
 }
 
-int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
+int copy_to_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 {
 	return copy_gpa(vm, h_ptr, gpa, size, 0);
 }

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -132,7 +132,7 @@ static inline void cpuid_subleaf(uint32_t leaf, uint32_t subleaf,
 }
 
 int set_vcpuid_entries(struct vm *vm);
-void guest_cpuid(struct vcpu *vcpu,
+void guest_cpuid(const struct vcpu *vcpu,
 			uint32_t *eax, uint32_t *ebx,
 			uint32_t *ecx, uint32_t *edx);
 

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -93,7 +93,7 @@ enum vm_paging_mode {
 /*
  * VM related APIs
  */
-bool vm_lapic_disabled(struct vm *vm);
+bool vm_lapic_disabled(const struct vm *vm);
 uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
 
 int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
@@ -133,8 +133,8 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu);
 typedef int (*vm_sw_loader_t)(struct vm *vm, struct vcpu *vcpu);
 extern vm_sw_loader_t vm_sw_loader;
 
-int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
-int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+int copy_from_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+int copy_to_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
 int copy_from_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -81,7 +81,7 @@ static inline uint32_t pio_read(uint16_t addr, size_t sz)
  *  @param value The 32 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write32(uint32_t value, void *addr)
+static inline void mmio_write32(uint32_t value, const void *addr)
 {
 	volatile uint32_t *addr32 = (volatile uint32_t *)addr;
 	*addr32 = value;
@@ -92,7 +92,7 @@ static inline void mmio_write32(uint32_t value, void *addr)
  *  @param value The 16 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write16(uint16_t value, void *addr)
+static inline void mmio_write16(uint16_t value, const void *addr)
 {
 	volatile uint16_t *addr16 = (volatile uint16_t *)addr;
 	*addr16 = value;
@@ -103,7 +103,7 @@ static inline void mmio_write16(uint16_t value, void *addr)
  *  @param value The 8 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write8(uint8_t value, void *addr)
+static inline void mmio_write8(uint8_t value, const void *addr)
 {
 	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
 	*addr8 = value;
@@ -115,7 +115,7 @@ static inline void mmio_write8(uint8_t value, void *addr)
  *
  *  @return The 32 bit value read from the given address.
  */
-static inline uint32_t mmio_read32(void *addr)
+static inline uint32_t mmio_read32(const void *addr)
 {
 	return *((volatile uint32_t *)addr);
 }
@@ -126,7 +126,7 @@ static inline uint32_t mmio_read32(void *addr)
  *
  *  @return The 16 bit value read from the given address.
  */
-static inline uint16_t mmio_read16(void *addr)
+static inline uint16_t mmio_read16(const void *addr)
 {
 	return *((volatile uint16_t *)addr);
 }
@@ -137,7 +137,7 @@ static inline uint16_t mmio_read16(void *addr)
  *
  *  @return The 8 bit  value read from the given address.
  */
-static inline uint8_t mmio_read8(void *addr)
+static inline uint8_t mmio_read8(const void *addr)
 {
 	return *((volatile uint8_t *)addr);
 }
@@ -150,7 +150,7 @@ static inline uint8_t mmio_read8(void *addr)
  * @param mask    The mask to apply to the value read.
  * @param value   The 32 bit value to write.
  */
-static inline void set32(void *addr, uint32_t mask, uint32_t value)
+static inline void set32(const void *addr, uint32_t mask, uint32_t value)
 {
 	uint32_t temp_val;
 
@@ -165,7 +165,7 @@ static inline void set32(void *addr, uint32_t mask, uint32_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 16 bit value to write.
  */
-static inline void set16(void *addr, uint16_t mask, uint16_t value)
+static inline void set16(const void *addr, uint16_t mask, uint16_t value)
 {
 	uint16_t temp_val;
 
@@ -180,7 +180,7 @@ static inline void set16(void *addr, uint16_t mask, uint16_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 8 bit value to write.
  */
-static inline void set8(void *addr, uint8_t mask, uint8_t value)
+static inline void set8(const void *addr, uint8_t mask, uint8_t value)
 {
 	uint8_t temp_val;
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -259,27 +259,27 @@ enum _page_table_present {
 #define PAGE_SIZE_1G	MEM_1G
 
 /* Inline functions for reading/writing memory */
-static inline uint8_t mem_read8(void *addr)
+static inline uint8_t mem_read8(const void *addr)
 {
 	return *(volatile uint8_t *)(addr);
 }
 
-static inline uint16_t mem_read16(void *addr)
+static inline uint16_t mem_read16(const void *addr)
 {
 	return *(volatile uint16_t *)(addr);
 }
 
-static inline uint32_t mem_read32(void *addr)
+static inline uint32_t mem_read32(const void *addr)
 {
 	return *(volatile uint32_t *)(addr);
 }
 
-static inline uint64_t mem_read64(void *addr)
+static inline uint64_t mem_read64(const void *addr)
 {
 	return *(volatile uint64_t *)(addr);
 }
 
-static inline void mem_write8(void *addr, uint8_t data)
+static inline void mem_write8(const void *addr, uint8_t data)
 {
 	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
 	*addr8 = data;
@@ -378,15 +378,15 @@ static inline void clflush(volatile void *p)
 /* External Interfaces */
 uint64_t create_guest_initial_paging(struct vm *vm);
 void    destroy_ept(struct vm *vm);
-uint64_t  gpa2hpa(struct vm *vm, uint64_t gpa);
-uint64_t  local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size);
-uint64_t  hpa2gpa(struct vm *vm, uint64_t hpa);
-int ept_mr_add(struct vm *vm, uint64_t hpa_arg,
+uint64_t  gpa2hpa(const struct vm *vm, uint64_t gpa);
+uint64_t  local_gpa2hpa(const struct vm *vm, uint64_t gpa, uint32_t *size);
+uint64_t  hpa2gpa(const struct vm *vm, uint64_t hpa);
+int ept_mr_add(const struct vm *vm, uint64_t hpa_arg,
 	uint64_t gpa_arg, uint64_t size, uint32_t prot_arg);
-int ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
+int ept_mr_modify(const struct vm *vm, uint64_t *pml4_page,
 	uint64_t gpa, uint64_t size,
 	uint64_t prot_set, uint64_t prot_clr);
-int ept_mr_del(struct vm *vm, uint64_t *pml4_page,
+int ept_mr_del(const struct vm *vm, uint64_t *pml4_page,
 	uint64_t gpa, uint64_t size);
 void free_ept_mem(void *pml4_addr);
 int     ept_violation_vmexit_handler(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -53,17 +53,17 @@ static inline uint64_t *pml4e_offset(uint64_t *pml4_page, uint64_t addr)
 	return pml4_page + pml4e_index(addr);
 }
 
-static inline uint64_t *pdpte_offset(uint64_t *pml4e, uint64_t addr)
+static inline uint64_t *pdpte_offset(const uint64_t *pml4e, uint64_t addr)
 {
 	return pml4e_page_vaddr(*pml4e) + pdpte_index(addr);
 }
 
-static inline uint64_t *pde_offset(uint64_t *pdpte, uint64_t addr)
+static inline uint64_t *pde_offset(const uint64_t *pdpte, uint64_t addr)
 {
 	return pdpte_page_vaddr(*pdpte) + pde_index(addr);
 }
 
-static inline uint64_t *pte_offset(uint64_t *pde, uint64_t addr)
+static inline uint64_t *pte_offset(const uint64_t *pde, uint64_t addr)
 {
 	return pde_page_vaddr(*pde) + pte_index(addr);
 }
@@ -71,7 +71,7 @@ static inline uint64_t *pte_offset(uint64_t *pde, uint64_t addr)
 /*
  * pgentry may means pml4e/pdpte/pde/pte
  */
-static inline uint64_t get_pgentry(uint64_t *pte)
+static inline uint64_t get_pgentry(const uint64_t *pte)
 {
 	return *pte;
 }

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -449,7 +449,7 @@ int vmx_wrmsr_pat(struct vcpu *vcpu, uint64_t value);
 int vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0);
 int vmx_write_cr4(struct vcpu *vcpu, uint64_t cr4);
 
-static inline enum vm_cpu_mode get_vcpu_mode(struct vcpu *vcpu)
+static inline enum vm_cpu_mode get_vcpu_mode(const struct vcpu *vcpu)
 {
 	return vcpu->arch_vcpu.cpu_mode;
 }


### PR DESCRIPTION
V1:
In order to better comply with MISRA C,
add const qualifiers whereever required.
In the patch, these are being added to pointers
which are normally used in "get" functions.

V2: Corrected the issues in the patch
pointed by Junjie in his review comments.
Moved the const qualifiers to the correct
places. Removed some changes which are not
needed.

V3: Updated patch comment.
This modifies a subset of all the functions
which might need constant qualifiers
for the their parameters.
This is not and exhaustive patch. This only
targets obvious places where we can use
the const qualifier. More changes will be
submitted in future patches, if required.

Signed-off-by: Arindam Roy <arindam.roy@intel.com>