### PR TITLE
hv: vuart: fix the data type violations

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -37,6 +37,7 @@ include scripts/kconfig/kconfig.mk
 CFLAGS += -Wall -W
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -fshort-wchar -ffreestanding
+CFLAGS += -fsigned-char
 CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -nostdinc -nostdlib -fno-common

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -32,10 +32,10 @@
 
 struct fifo {
 	char *buf;
-	int rindex;	/* index to read from */
-	int windex;	/* index to write to */
-	int num;	/* number of characters in the fifo */
-	int size;	/* size of the fifo */
+	uint32_t rindex;	/* index to read from */
+	uint32_t windex;	/* index to write to */
+	uint32_t num;		/* number of characters in the fifo */
+	uint32_t size;		/* size of the fifo */
 };
 
 struct vuart {
@@ -52,7 +52,7 @@ struct vuart {
 
 	struct fifo rxfifo;
 	struct fifo txfifo;
-	int base;
+	uint16_t base;
 
 	bool thre_int_pending;	/* THRE interrupt pending */
 	bool active;

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -366,7 +366,7 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg)
 		ASSERT(false);
 	}
 
-	/*same memory block, no need to copy*/
+	/* same memory block, no need to copy */
 	if (d == s) {
 		return d;
 	}
@@ -374,28 +374,30 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg)
 	dest8 = (uint8_t *)d;
 	src8 = (uint8_t *)s;
 
-        /*small data block*/
-        if (slen < 8U) {
-                while (slen != 0U) {
-                        *dest8 = *src8;
-                        dest8++;
-                        src8++;
-                        slen--;
-                }
+	/* small data block */
+	if (slen < 8U) {
+		while (slen != 0U) {
+			*dest8 = *src8;
+			dest8++;
+			src8++;
+			slen--;
+		}
 
 		return d;
 	}
 
-        /*make sure 8bytes-aligned for at least one addr.*/
-        if ((!MEM_ALIGNED_CHECK(src8, 8)) && (!MEM_ALIGNED_CHECK(dest8, 8))) {
-                for (; (slen != 0U) && ((((uint64_t)src8) & 7UL) != 0UL); slen--) {
-                        *dest8 = *src8;
-                        dest8++;
-                        src8++;
-                }
-        }
+	/* make sure 8bytes-aligned for at least one addr. */
+	if ((!MEM_ALIGNED_CHECK(src8, 8UL)) &&
+			(!MEM_ALIGNED_CHECK(dest8, 8UL))) {
+		for (; (slen != 0U) && ((((uint64_t)src8) & 7UL) != 0UL);
+				slen--) {
+			*dest8 = *src8;
+			dest8++;
+			src8++;
+		}
+	}
 
-	/*copy main data blocks, with rep prefix*/
+	/* copy main data blocks, with rep prefix */
 	if (slen > 8U) {
 		uint32_t ecx;
 
@@ -407,13 +409,13 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg)
 		slen = slen % 8U;
 	}
 
-        /*tail bytes*/
-        while (slen != 0U) {
-                *dest8 = *src8;
-                dest8++;
-                src8++;
-                slen--;
-        }
+	/* tail bytes */
+	while (slen != 0U) {
+		*dest8 = *src8;
+		dest8++;
+		src8++;
+		slen--;
+	}
 
 	return d;
 }
@@ -430,14 +432,14 @@ void *memset(void *base, uint8_t v, size_t n)
 		return NULL;
 	}
 
-        /*do the few bytes to get uint64_t alignment*/
-        count = n;
-        for (; (count != 0U) && (((uint64_t)dest_p & 7UL) != 0UL); count--) {
-                *dest_p = v;
-                dest_p++;
-        }
+	/* do the few bytes to get uint64_t alignment */
+	count = n;
+	for (; (count != 0U) && (((uint64_t)dest_p & 7UL) != 0UL); count--) {
+		*dest_p = v;
+		dest_p++;
+	}
 
-	/*64-bit mode*/
+	/* 64-bit mode */
 	n_q = count >> 3U;
 	asm volatile("cld ; rep ; stosq ; movl %3,%%ecx ; rep ; stosb"
 				: "+c"(n_q), "+D"(dest_p)


### PR DESCRIPTION
- Fix the data type violations based on MISRA-C requirements
- Add '-fsigned-char' in Makefile to let the compiler treats 'char' be
   signed, like 'signed char'.
  Otherwise, the static checker treats 'char', 'signed char' and 'unsigned
   char' as three different types.
- Fix some minor coding style issues, such as TAB issues, line over 80
   characters issues and comments style

v1 -> v2:
 * fix the violation regarding to 'fifo_getchar'

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>