### PR TITLE
hv: lib: add ffz64_ex

### DIFF
--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -129,6 +129,22 @@ static inline uint16_t ffz64(uint64_t value)
 	return ffs64(~value);
 }
 
+
+/*
+ * find the first zero bit in a uint64_t array.
+ * @pre: the size must be multiple of 64.
+ */
+static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
+{
+	uint64_t idx;
+
+	for (idx = 0; (idx << 6U) < size; idx++) {
+		if (addr[idx] != ~0UL)
+			return (idx << 6U) + ffz64(addr[idx]);
+	}
+
+	return size;
+}
 /**
  * Counts leading zeros.
  *


### PR DESCRIPTION
Add ffz64_ex to find the first zero bit in a uint64_t array.
Note: the API is lockless.

Signed-off-by: Li, Fei1 <fei1.li@intel.com>