### PR TITLE
hv: physical irq reshuffle - allocation/free and irq handler

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -334,7 +334,7 @@ ioapic_nr_pins(void *ioapic_base)
 	return nr_pins;
 }
 
-void setup_ioapic_irq(void)
+void setup_ioapic_irqs(void)
 {
 	uint8_t ioapic_id;
 	uint32_t gsi = 0U;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -371,8 +371,8 @@ void setup_ioapic_irq(void)
 			 * for legacy irq, reserved vector and never free
 			 */
 			if (gsi < NR_LEGACY_IRQ) {
-				vr = irq_desc_alloc_vector(gsi);
-				if (vr > NR_MAX_VECTOR) {
+				vr = alloc_irq_vector(gsi);
+				if (vr == VECTOR_INVALID) {
 					pr_err("failed to alloc VR");
 					gsi++;
 					continue;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -361,7 +361,7 @@ void setup_ioapic_irq(void)
 			}
 
 			/* pinned irq before use it */
-			if (irq_mark_used(gsi) >= NR_IRQS) {
+			if (alloc_irq_num(gsi) == IRQ_INVALID) {
 				pr_err("failed to alloc IRQ[%d]", gsi);
 				gsi++;
 				continue;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -219,9 +219,9 @@ static void ioapic_set_routing(uint32_t gsi, uint32_t vr)
 	ioapic_set_rte_entry(addr, gsi_table[gsi].pin, rte);
 
 	if ((rte.full & IOAPIC_RTE_TRGRMOD) != 0UL) {
-		update_irq_handler(gsi, handle_level_interrupt_common);
+		set_irq_trigger_mode(gsi, true);
 	} else {
-		update_irq_handler(gsi, common_handler_edge);
+		set_irq_trigger_mode(gsi, false);
 	}
 
 	dev_dbg(ACRN_DBG_IRQ, "GSI: irq:%d pin:%hhu rte:%lx",

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -55,8 +55,7 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 	wait_sync_change(&smp_call_mask, 0UL);
 }
 
-static int request_notification_irq(irq_action_t func, void *data,
-				const char *name)
+static int request_notification_irq(irq_action_t func, void *data)
 {
 	int32_t retval;
 
@@ -67,7 +66,7 @@ static int request_notification_irq(irq_action_t func, void *data,
 	}
 
 	/* all cpu register the same notification vector */
-	retval = request_irq(NOTIFY_IRQ, func, data, name);
+	retval = request_irq(NOTIFY_IRQ, func, data);
 	if (retval < 0) {
 		pr_err("Failed to add notify isr");
 		return -ENODEV;
@@ -80,17 +79,14 @@ static int request_notification_irq(irq_action_t func, void *data,
 
 void setup_notification(void)
 {
-	uint16_t cpu;
-	char name[32] = {0};
+	uint16_t cpu = get_cpu_id();
 
-	cpu = get_cpu_id();
 	if (cpu > 0U) {
 		return;
 	}
 
 	/* support IPI notification, VM0 will register all CPU */
-	snprintf(name, 32, "NOTIFY_ISR%d", cpu);
-	if (request_notification_irq(kick_notification, NULL, name) < 0) {
+	if (request_notification_irq(kick_notification, NULL) < 0) {
 		pr_err("Failed to setup notification");
 		return;
 	}

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -66,7 +66,7 @@ static int request_notification_irq(irq_action_t func, void *data)
 	}
 
 	/* all cpu register the same notification vector */
-	retval = request_irq(NOTIFY_IRQ, func, data);
+	retval = request_irq(NOTIFY_IRQ, func, data, IRQF_NONE);
 	if (retval < 0) {
 		pr_err("Failed to add notify isr");
 		return -ENODEV;

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -107,11 +107,11 @@ void del_timer(struct hv_timer *timer)
 	}
 }
 
-static int request_timer_irq(irq_action_t func, const char *name)
+static int request_timer_irq(irq_action_t func)
 {
 	int32_t retval;
 
-	retval = request_irq(TIMER_IRQ, func, NULL, name);
+	retval = request_irq(TIMER_IRQ, func, NULL);
 	if (retval >= 0) {
 		update_irq_handler(TIMER_IRQ, quick_handler_nolock);
 	} else {
@@ -185,16 +185,14 @@ static void timer_softirq(uint16_t pcpu_id)
 
 void timer_init(void)
 {
-	char name[32] = {0};
 	uint16_t pcpu_id = get_cpu_id();
 
 	init_percpu_timer(pcpu_id);
 
-	snprintf(name, 32, "timer_tick[%hu]", pcpu_id);
 	if (pcpu_id == BOOT_CPU_ID) {
 		register_softirq(SOFTIRQ_TIMER, timer_softirq);
 
-		if (request_timer_irq((irq_action_t)tsc_deadline_handler, name)
+		if (request_timer_irq((irq_action_t)tsc_deadline_handler)
 				< 0) {
 			pr_err("Timer setup failed");
 			return;

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -828,8 +828,7 @@ static int dmar_setup_interrupt(struct dmar_drhd_rt *dmar_uint)
 
 	retval = request_irq(IRQ_INVALID,
 			     dmar_fault_handler,
-			     dmar_uint,
-			     "dmar_fault_event");
+			     dmar_uint);
 
 	if (retval < 0 ) {
 		pr_err("%s: fail to setup interrupt", __func__);

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -828,7 +828,8 @@ static int dmar_setup_interrupt(struct dmar_drhd_rt *dmar_uint)
 
 	retval = request_irq(IRQ_INVALID,
 			     dmar_fault_handler,
-			     dmar_uint);
+			     dmar_uint,
+			     IRQF_NONE);
 
 	if (retval < 0 ) {
 		pr_err("%s: fail to setup interrupt", __func__);

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -136,7 +136,7 @@ ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq)
 
 	/* register and allocate host vector/irq */
 	retval = request_irq(phys_irq, ptdev_interrupt_handler,
-				         (void *)entry, "dev assign");
+				         (void *)entry);
 
 	ASSERT(retval >= 0, "dev register failed");
 	entry->allocated_pirq = (uint32_t)retval;

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -136,7 +136,7 @@ ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq)
 
 	/* register and allocate host vector/irq */
 	retval = request_irq(phys_irq, ptdev_interrupt_handler,
-				         (void *)entry);
+		             (void *)entry, IRQF_PT);
 
 	ASSERT(retval >= 0, "dev register failed");
 	entry->allocated_pirq = (uint32_t)retval;

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -19,7 +19,7 @@
 #define GSI_MASK_IRQ(irq) irq_gsi_mask_unmask((irq), true)
 #define GSI_UNMASK_IRQ(irq) irq_gsi_mask_unmask((irq), false)
 
-void setup_ioapic_irq(void);
+void setup_ioapic_irqs(void);
 
 bool irq_is_gsi(uint32_t irq);
 uint32_t irq_gsi_num(void);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -74,6 +74,8 @@ void setup_notification(void);
 typedef void (*spurious_handler_t)(uint32_t vector);
 extern spurious_handler_t spurious_handler;
 
+uint32_t alloc_irq_num(uint32_t req_irq);
+
 /*
  * Some MSI message definitions
  */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -75,6 +75,9 @@ typedef void (*spurious_handler_t)(uint32_t vector);
 extern spurious_handler_t spurious_handler;
 
 uint32_t alloc_irq_num(uint32_t req_irq);
+uint32_t alloc_irq_vector(uint32_t irq);
+
+uint32_t irq_to_vector(uint32_t irq);
 
 /*
  * Some MSI message definitions

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -34,11 +34,6 @@ struct irq_desc {
 	spinlock_t lock;
 };
 
-uint32_t irq_desc_alloc_vector(uint32_t irq);
-void irq_desc_try_free_vector(uint32_t irq);
-
-uint32_t irq_to_vector(uint32_t irq);
-
 int32_t request_irq(uint32_t irq,
 		    irq_action_t action_fn,
 		    void *priv_data);

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -13,14 +13,9 @@ enum irq_mode {
 	IRQ_DEASSERT,
 };
 
-enum irq_state {
+enum irq_use_state {
 	IRQ_NOT_ASSIGNED = 0,
 	IRQ_ASSIGNED,
-};
-
-enum irq_desc_state {
-	IRQ_DESC_PENDING,
-	IRQ_DESC_IN_PROCESS,
 };
 
 typedef int (*irq_action_t)(uint32_t irq, void *priv_data);
@@ -28,19 +23,15 @@ typedef int (*irq_action_t)(uint32_t irq, void *priv_data);
 /* any field change in below required irq_lock protection with irqsave */
 struct irq_desc {
 	uint32_t irq;		/* index to irq_desc_base */
-	enum irq_state used;	/* this irq have assigned to device */
-	enum irq_desc_state state; /* irq_desc status */
+	enum irq_use_state used;	/* this irq have assigned to device */
 	uint32_t vector;	/* assigned vector */
 
 	int (*irq_handler)(struct irq_desc *irq_desc, void *handler_data);
 				/* callback for irq flow handling */
 	irq_action_t action;	/* callback registered from component */
 	void *priv_data;	/* irq_action private data */
-	char name[32];		/* name of component */
 
-	spinlock_t irq_lock;
-	uint64_t *irq_cnt; /* this irq cnt happened on CPUs */
-	uint64_t irq_lost_cnt;
+	spinlock_t lock;
 };
 
 uint32_t irq_mark_used(uint32_t irq);
@@ -52,8 +43,7 @@ uint32_t irq_to_vector(uint32_t irq);
 
 int32_t request_irq(uint32_t irq,
 		    irq_action_t action_fn,
-		    void *priv_data,
-		    const char *name);
+		    void *priv_data);
 
 void free_irq(uint32_t irq);
 

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -7,6 +7,10 @@
 #ifndef COMMON_IRQ_H
 #define COMMON_IRQ_H
 
+#define IRQF_NONE	(0U)
+#define IRQF_LEVEL	(1U << 1U)	/* 1: level trigger; 0: edge trigger */
+#define IRQF_PT		(1U << 2U)	/* 1: for passthrough dev */
+
 enum irq_mode {
 	IRQ_PULSE,
 	IRQ_ASSERT,
@@ -26,20 +30,19 @@ struct irq_desc {
 	enum irq_use_state used;	/* this irq have assigned to device */
 	uint32_t vector;	/* assigned vector */
 
-	int (*irq_handler)(struct irq_desc *irq_desc, void *handler_data);
-				/* callback for irq flow handling */
 	irq_action_t action;	/* callback registered from component */
 	void *priv_data;	/* irq_action private data */
+	uint32_t flags;		/* flags for trigger mode/ptdev */
 
 	spinlock_t lock;
 };
 
 int32_t request_irq(uint32_t irq,
 		    irq_action_t action_fn,
-		    void *priv_data);
+		    void *priv_data,
+		    uint32_t flags);
 
 void free_irq(uint32_t irq);
 
-typedef int (*irq_handler_t)(struct irq_desc *desc, void *handler_data);
-void update_irq_handler(uint32_t irq, irq_handler_t func);
+void set_irq_trigger_mode(uint32_t irq, bool is_level_trigger);
 #endif /* COMMON_IRQ_H */

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -34,8 +34,6 @@ struct irq_desc {
 	spinlock_t lock;
 };
 
-uint32_t irq_mark_used(uint32_t irq);
-
 uint32_t irq_desc_alloc_vector(uint32_t irq);
 void irq_desc_try_free_vector(uint32_t irq);
 


### PR DESCRIPTION
This series makes following changes:
- refactored codes for irq request/free code clearer and easy to read;
- merged confusing irq handlers into a single generic one with lock removed;
- clean up irq_desc struct and function orders in irq.c.
