### PR TITLE
samples: let nuc uos only start with 1 cpu

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -41,4 +41,4 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
         fi
 done
 
-launch_clear 1 3 "64 448 8" 0x070F00 clear
+launch_clear 1 1 "64 448 8" 0x070F00 clear


### PR DESCRIPTION
there are only 2 CPUs on UP2 platform, so we can only start 1 cpu for
uos on UP2 platform.

as this is only an example script, user can modify the uos start CPU
number according his requirement.

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>