### PR TITLE
HV: check secure/normal world for EPTP in gpa2hpa

### DIFF
--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -216,7 +216,7 @@ static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 	return NULL;
 }
 
-static inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
+static inline struct vcpu *vcpu_from_pid(const struct vm *vm, uint16_t pcpu_id)
 {
 	uint16_t i;
 	struct vcpu *vcpu;


### PR DESCRIPTION
for secure and normal world has different EPTP, in secure world,
it could trap to hypervisor and call gpa2hpa function. So it need
check if it is in normal or secure world for EPTP selection.

Detailed explanation from Yadong Qi <yadong.qi@intel.com>:
Currently, trusty OS does not handle interrupt, so when an interrupt
is delivering in trusty, trusty will set it to LAPIC IRR register by
inject self_ipi() and then call world_switch to switch to Android,
So android will receive/handle the interrupt properly.Since the
vLAPIC is enabled in ACRN, so when trusty try to inject self_ipi(),
APIC-ACCESS vmexit will happen. Then ACRN will do instruction
decode/emulation, so the GPA2HPA will fail since page walk is using
nworld_eptp. It is probability an issue.

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>