### PR TITLE
hv:fixed several return value violations

### DIFF
--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -210,10 +210,10 @@ void  destroy_secure_world(struct vm *vm, bool need_clr_mem)
 static void save_world_ctx(struct vcpu *vcpu, struct ext_context *ext_ctx)
 {
 	/* cache on-demand run_context for efer/rflags/rsp/rip */
-	vcpu_get_efer(vcpu);
-	vcpu_get_rflags(vcpu);
-	vcpu_get_rsp(vcpu);
-	vcpu_get_rip(vcpu);
+	(void)vcpu_get_efer(vcpu);
+	(void)vcpu_get_rflags(vcpu);
+	(void)vcpu_get_rsp(vcpu);
+	(void)vcpu_get_rip(vcpu);
 
 	/* VMCS GUEST field */
 	ext_ctx->vmx_cr0 = exec_vmread(VMX_GUEST_CR0);
@@ -426,7 +426,7 @@ bool initialize_trusty(struct vcpu *vcpu, uint64_t param)
 	struct vm *vm = vcpu->vm;
 	struct trusty_boot_param boot_param;
 
-	memset(&boot_param, 0U, sizeof(boot_param));
+	(void)memset(&boot_param, 0U, sizeof(boot_param));
 	if (copy_from_gpa(vcpu->vm, &boot_param, param, sizeof(boot_param))) {
 		pr_err("%s: Unable to copy trusty_boot_param\n", __func__);
 		return false;
@@ -497,7 +497,7 @@ void trusty_set_dseed(void *dseed, uint8_t dseed_num)
 
 void save_sworld_context(struct vcpu *vcpu)
 {
-	memcpy_s(&vcpu->vm->sworld_snapshot,
+	(void)memcpy_s(&vcpu->vm->sworld_snapshot,
 			sizeof(struct cpu_context),
 			&vcpu->arch_vcpu.contexts[SECURE_WORLD],
 			sizeof(struct cpu_context));
@@ -513,7 +513,7 @@ void restore_sworld_context(struct vcpu *vcpu)
 		sworld_ctl->sworld_memory.length,
 		TRUSTY_EPT_REBASE_GPA);
 
-	memcpy_s(&vcpu->arch_vcpu.contexts[SECURE_WORLD],
+	(void)memcpy_s(&vcpu->arch_vcpu.contexts[SECURE_WORLD],
 			sizeof(struct cpu_context),
 			&vcpu->vm->sworld_snapshot,
 			sizeof(struct cpu_context));

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -219,7 +219,7 @@ uint64_t prepare_trampoline(void)
 	pr_dbg("trampoline code: %llx size %x", dest_pa, size);
 
 	/* Copy segment for AP initialization code below 1MB */
-	memcpy_s(HPA2HVA(dest_pa), (size_t)size, &_ld_trampoline_load,
+	(void)memcpy_s(HPA2HVA(dest_pa), (size_t)size, &_ld_trampoline_load,
 			(size_t)size);
 	update_trampoline_code_refs(dest_pa);
 	trampoline_start16_paddr = dest_pa;

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -177,7 +177,7 @@ static void *parse_image_boot_params(struct vm *vm, char *cmdline)
 	 */
 	arg_end = strchr(arg, ' ');
 	len = arg_end ? (uint32_t)(arg_end - arg) : strnlen_s(arg, MEM_2K);
-	memset(arg, ' ', len);
+	(void)memset(arg, ' ', len);
 
 	return (void *)boot_params;
 
@@ -297,7 +297,7 @@ int init_vm_boot_info(struct vm *vm)
 		 * kernel cmdline
 		 */
 		if (boot_params_addr != NULL) {
-			memset(buf, 0U, sizeof(buf));
+			(void)memset(buf, 0U, sizeof(buf));
 			snprintf(buf, MAX_BOOT_PARAMS_LEN, "%s0x%X ",
 				boot_params_arg,
 				HVA2GPA(vm, (uint64_t)boot_params_addr));

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -32,7 +32,7 @@ char console_getc(void)
 	return uart16550_getc();
 }
 
-static int console_timer_callback(__unused void *data)
+static void console_timer_callback(__unused void *data)
 {
 	struct vuart *vu;
 
@@ -46,7 +46,6 @@ static int console_timer_callback(__unused void *data)
 	} else {
 		shell_kick();
 	}
-	return 0;
 }
 
 void console_setup_timer(void)

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -813,18 +813,19 @@ static int shell_show_vioapic_info(int argc, char **argv)
 
 static int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 {
+	int err = 0;
 	char *temp_str = alloc_pages(2U);
 
 	if (temp_str == NULL) {
 		return -ENOMEM;
 	}
 
-	get_ioapic_info(temp_str, 2 * CPU_PAGE_SIZE);
+	err = get_ioapic_info(temp_str, 2 * CPU_PAGE_SIZE);
 	shell_puts(temp_str);
 
 	free(temp_str);
 
-	return 0;
+	return err;
 }
 
 static int shell_show_vmexit_profile(__unused int argc, __unused char **argv)

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -7,7 +7,7 @@
 #ifndef TIMER_H
 #define TIMER_H
 
-typedef int (*timer_handle_t)(void *data);
+typedef void (*timer_handle_t)(void *data);
 
 enum tick_mode {
 	TICK_MODE_ONESHOT = 0,


### PR DESCRIPTION
-- change two timer callbacks to void type
-- ignore the return value for add_timer
-- add (void) before several functions(memset/memcpy/
   vcpu_get_xxx)

v1-->v2:
   ignore the return value for add_timer
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>