### PR TITLE
dm: pass vrpmb key via cmos interface

### DIFF
--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -112,6 +112,8 @@ static int vsbl_size;
 
 static int boot_blk_bdf;
 
+extern int init_cmos_vrpmb(struct vmctx *ctx);
+
 #define	LOW_8BIT(x)	((x) & 0xFF)
 void
 vsbl_set_bdf(int bnum, int snum, int fnum)
@@ -250,6 +252,7 @@ acrn_sw_load_vsbl(struct vmctx *ctx)
 	uint64_t *cfg_offset =
 		(uint64_t *)(ctx->baseaddr + GUEST_CFG_OFFSET);
 
+	init_cmos_vrpmb(ctx);
 	*cfg_offset = ctx->lowmem;
 
 	vsbl_para = (struct vsbl_para *)

--- a/devicemodel/hw/platform/cmos_io.c
+++ b/devicemodel/hw/platform/cmos_io.c
@@ -21,20 +21,26 @@
  * writing.
  *************************************************************************/
 
-/* cmos io device is used for android device reboot to bootloader or
- * recovery or normal boot usage
+/* cmos io device
+ * - nvram 0x10 ~ 0x1F is used for android device reboot to bootloader or
+ *   recovery or normal boot usage
+ * - vrpmb 0x20 ~ 0x9F is used to store vrpmb for guest, read to clear
  */
 
 #include <stdio.h>
 #include <assert.h>
+#include <stdbool.h>
 
 #include "inout.h"
+#include "vmmapi.h"
+#include "vrpmb.h"
 
 #define CMOS_ADDR		0x74
 #define CMOS_DATA		0x75
-#define CMOS_BUF_SIZE		256
 
 #define CMOS_NAME		"cmos_io"
+#define CMOS_VRPMB_START	0x20
+#define CMOS_VRPMB_END		0x9F
 
 /* #define CMOS_DEBUG */
 #ifdef CMOS_DEBUG
@@ -44,11 +50,6 @@ do { fprintf(dbg_file, format, args); fflush(dbg_file); } while (0)
 #else
 #define DPRINTF(format, arg...)
 #endif
-
-/* cmos buffer used to store write/read contents,
- * and it should not be cleared when reboot
- */
-static uint8_t cmos_buffer[CMOS_BUF_SIZE];
 
 static int
 cmos_io_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
@@ -88,10 +89,15 @@ cmos_io_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 			return -1;
 		}
 
-		if (in)
-			*eax = cmos_buffer[buf_offset];
+		if (in) {
+			*eax = ctx->cmos_buffer[buf_offset];
+			/* read to clear for Key range */
+			if ((buf_offset >= CMOS_VRPMB_START) ||
+			    (buf_offset <= CMOS_VRPMB_END))
+				ctx->cmos_buffer[buf_offset] = 0;
+		}
 		else
-			cmos_buffer[buf_offset] = (uint8_t)*eax;
+			ctx->cmos_buffer[buf_offset] = (uint8_t)*eax;
 
 		next_ops = 0;
 	}
@@ -101,3 +107,15 @@ cmos_io_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 
 INOUT_PORT(cmos_io, CMOS_ADDR, IOPORT_F_INOUT, cmos_io_handler);
 INOUT_PORT(cmos_io, CMOS_DATA, IOPORT_F_INOUT, cmos_io_handler);
+
+int init_cmos_vrpmb(struct vmctx *ctx)
+{
+	uint8_t *vrpmb_buffer = &ctx->cmos_buffer[CMOS_VRPMB_START];
+
+	/* get vrpmb key, and store it to cmos buffer */
+	if (!get_vrpmb_key(vrpmb_buffer, RPMB_KEY_LEN)) {
+		printf("SW_LOAD: failed to get vrpmb key\n");
+		return -1;
+	}
+	return 0;
+}

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -45,6 +45,8 @@
 #define ALIGN_UP(x, align)	(((x) + ((align)-1)) & ~((align)-1))
 #define ALIGN_DOWN(x, align)	((x) & ~((align)-1))
 
+#define CMOS_BUF_SIZE		256
+
 struct vmctx {
 	int     fd;
 	int     vmid;
@@ -61,6 +63,10 @@ struct vmctx {
 	void *atkbdc_base;
 	void *vrtc;
 	void *ioc_dev;
+	/* cmos buffer used to store write/read contents,
+	 * and it should not be cleared when reboot
+	 */
+	uint8_t cmos_buffer[CMOS_BUF_SIZE];
 };
 
 /*


### PR DESCRIPTION
CMOS offset from 0x20 to 0x9F is used to store rpmb key information.
vsbl loader will init vrpmb key in CMOS when boot/reboot.
vsbl loader will not init vrpmb key during S3 resume.
vsbl will read vrpmb key via CMOS interface.
After reading, the key value is cleared in CMOS. So the key can only be
read once until next boot.

Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>