### PR TITLE
hv: vioapic: fix 'No definition in system for prototyped procedure'

### DIFF
--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -46,9 +46,6 @@ void	vioapic_deassert_irq(struct vm *vm, uint32_t irq);
 void	vioapic_pulse_irq(struct vm *vm, uint32_t irq);
 void	vioapic_update_tmr(struct vcpu *vcpu);
 
-void	vioapic_mmio_write(struct vm *vm, uint64_t gpa, uint32_t wval);
-void	vioapic_mmio_read(struct vm *vm, uint64_t gpa, uint32_t *rval);
-
 uint32_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
 void	vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte);


### PR DESCRIPTION
Remove two APIs without definition

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>