### PR TITLE
hv:fixed MISRA-C return value violations

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -520,7 +520,7 @@ void ptdev_softirq(__unused uint16_t cpu_id)
 			ptdev_intr_handle_irq(vm, entry);
 		} else {
 			/* TODO: msi destmode check required */
-			vlapic_intr_msi(vm,
+			(void)vlapic_intr_msi(vm,
 				        msi->vmsi_addr,
 				        msi->vmsi_data);
 			dev_dbg(ACRN_DBG_PTIRQ,

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -349,18 +349,15 @@ uint8_t get_cur_lapic_id(void)
 	return lapic_id;
 }
 
-int
+/**
+ * @pre cpu_startup_shorthand < INTR_CPU_STARTUP_UNKNOWN
+ */
+void
 send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 	uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address)
 {
 	union apic_icr icr;
 	uint8_t shorthand;
-	int status = 0;
-
-	if (cpu_startup_shorthand >= INTR_CPU_STARTUP_UNKNOWN)
-		status = -EINVAL;
-
-	ASSERT(status == 0, "Incorrect arguments");
 
 	icr.value = 0U;
 	icr.bits.destination_mode = INTR_LAPIC_ICR_PHYSICAL;
@@ -412,8 +409,6 @@ send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 	write_lapic_reg32(LAPIC_INT_COMMAND_REGISTER_1, icr.value_32.hi_32);
 	write_lapic_reg32(LAPIC_INT_COMMAND_REGISTER_0, icr.value_32.lo_32);
 	wait_for_delivery();
-
-	return status;
 }
 
 /* dest_mode must be INTR_LAPIC_ICR_PHYSICAL(0x0U) or

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -298,7 +298,7 @@ void vcpu_inject_nmi(struct vcpu *vcpu)
 /* Inject general protection exception(#GP) to guest */
 void vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code)
 {
-	vcpu_queue_exception(vcpu, IDT_GP, err_code);
+	(void)vcpu_queue_exception(vcpu, IDT_GP, err_code);
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
 }
 
@@ -306,28 +306,28 @@ void vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code)
 void vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code)
 {
 	vcpu_set_cr2(vcpu, addr);
-	vcpu_queue_exception(vcpu, IDT_PF, err_code);
+	(void)vcpu_queue_exception(vcpu, IDT_PF, err_code);
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
 }
 
 /* Inject invalid opcode exception(#UD) to guest */
 void vcpu_inject_ud(struct vcpu *vcpu)
 {
-	vcpu_queue_exception(vcpu, IDT_UD, 0);
+	(void)vcpu_queue_exception(vcpu, IDT_UD, 0);
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
 }
 
 /* Inject alignment check exception(#AC) to guest */
 void vcpu_inject_ac(struct vcpu *vcpu)
 {
-	vcpu_queue_exception(vcpu, IDT_AC, 0);
+	(void)vcpu_queue_exception(vcpu, IDT_AC, 0);
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
 }
 
 /* Inject stack fault exception(#SS) to guest */
 void vcpu_inject_ss(struct vcpu *vcpu)
 {
-	vcpu_queue_exception(vcpu, IDT_SS, 0);
+	(void)vcpu_queue_exception(vcpu, IDT_SS, 0);
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXCP);
 }
 

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -175,7 +175,7 @@ int vmexit_handler(struct vcpu *vcpu)
 		if (type == VMX_INT_TYPE_HW_EXP) {
 			if ((vector_info & VMX_INT_INFO_ERR_CODE_VALID) != 0U)
 				err_code = exec_vmread32(VMX_IDT_VEC_ERROR_CODE);
-			vcpu_queue_exception(vcpu, vector, err_code);
+			(void)vcpu_queue_exception(vcpu, vector, err_code);
 			vcpu->arch_vcpu.idt_vectoring_info = 0U;
 		} else if (type == VMX_INT_TYPE_NMI) {
 			vcpu_make_request(vcpu, ACRN_REQUEST_NMI);

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -42,7 +42,7 @@ static inline void free_earlylog_sbuf(uint16_t pcpu_id)
 	per_cpu(earlylog_sbuf, pcpu_id) = NULL;
 }
 
-static int do_copy_earlylog(struct shared_buf *dst_sbuf,
+static void do_copy_earlylog(struct shared_buf *dst_sbuf,
 			    struct shared_buf *src_sbuf)
 {
 	uint32_t buf_size, valid_size;
@@ -54,7 +54,7 @@ static int do_copy_earlylog(struct shared_buf *dst_sbuf,
 		spinlock_irqsave_obtain(&(logmsg.lock), &rflags);
 		printf("Error to copy early hvlog: size mismatch\n");
 		spinlock_irqrestore_release(&(logmsg.lock), rflags);
-		return -EINVAL;
+		return;
 	}
 
 	cur_tail = src_sbuf->tail;
@@ -67,8 +67,6 @@ static int do_copy_earlylog(struct shared_buf *dst_sbuf,
 		/* there is chance to lose new log from certain pcpu */
 		dst_sbuf->tail = cur_tail;
 	}
-
-	return 0;
 }
 
 void init_logmsg(__unused uint32_t mem_size, uint32_t flags)

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -138,7 +138,7 @@ void early_init_lapic(void);
 void init_lapic(uint16_t pcpu_id);
 void send_lapic_eoi(void);
 uint8_t get_cur_lapic_id(void);
-int send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
+void send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 		uint16_t dest_pcpu_id,
 		uint64_t cpu_startup_start_address);
 /* API to send an IPI to dest guest */


### PR DESCRIPTION
-- change send_start_ipi/do_copy_earlylog to void type
-- drop the return value for vcpu_queue_execption
   when inject GP/PF/UD/AC/SS

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>