### PR TITLE
hv: treewide: fix 'Function prototype/defn param type mismatch'

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -78,13 +78,14 @@ static inline void vlapic_dump_isr(struct acrn_vlapic *vlapic, char *msg)
 static void *apicv_apic_access_addr;
 
 static int
-apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
+apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector,
+			__unused bool level);
 
 static int
 apicv_pending_intr(struct acrn_vlapic *vlapic, __unused uint32_t *vecptr);
 
 static void
-apicv_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
+apicv_set_tmr(__unused struct acrn_vlapic *vlapic, uint32_t vector, bool level);
 
 static void
 apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
@@ -2132,7 +2133,8 @@ void vlapic_free(struct vcpu *vcpu)
  * APIC-v functions
  * **/
 static int
-apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, __unused bool level)
+apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector,
+			__unused bool level)
 {
 	struct vlapic_pir_desc *pir_desc;
 	uint64_t mask;

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -179,10 +179,8 @@ void free_irq_vector(uint32_t irq)
  *
  * return value: valid irq (>=0) on success, otherwise errno (< 0).
  */
-int32_t request_irq(uint32_t req_irq,
-		    irq_action_t action_fn,
-		    void *priv_data,
-		    uint32_t flags)
+int32_t request_irq(uint32_t req_irq, irq_action_t action_fn, void *priv_data,
+			uint32_t flags)
 {
 	struct irq_desc *desc;
 	uint32_t irq, vector;

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -14,11 +14,12 @@ void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
 		struct ptdev_msi_info *info);
 int ptdev_intx_pin_remap(struct vm *vm, struct ptdev_intx_info *info);
-int ptdev_add_intx_remapping(struct vm *vm, uint16_t virt_bdf,
-	uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin, bool pic_pin);
+int ptdev_add_intx_remapping(struct vm *vm, __unused uint16_t virt_bdf,
+	__unused uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin,
+	bool pic_pin);
 void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin);
-int ptdev_add_msix_remapping(struct vm *vm, __unused uint16_t virt_bdf,
-	__unused uint16_t phys_bdf, uint32_t vector_count);
+int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
+	uint16_t phys_bdf, uint32_t vector_count);
 void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 		uint32_t vector_count);
 

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -61,10 +61,10 @@ bool is_vlapic_msr(uint32_t msr);
 int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
 int vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t wval);
 
-int vlapic_read_mmio_reg(struct vcpu *vcpu, uint64_t gpa,
-		uint64_t *rval, uint8_t size);
+int vlapic_read_mmio_reg(struct vcpu *vcpu, uint64_t gpa, uint64_t *rval,
+			__unused uint8_t size);
 int vlapic_write_mmio_reg(struct vcpu *vcpu, uint64_t gpa,
-		uint64_t wval, uint8_t size);
+			uint64_t wval, uint8_t size);
 
 /*
  * Signals to the LAPIC that an interrupt at 'vector' needs to be generated

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -37,10 +37,8 @@ struct irq_desc {
 	spinlock_t lock;
 };
 
-int32_t request_irq(uint32_t irq,
-		    irq_action_t action_fn,
-		    void *priv_data,
-		    uint32_t flags);
+int32_t request_irq(uint32_t req_irq, irq_action_t action_fn, void *priv_data,
+			uint32_t flags);
 
 void free_irq(uint32_t irq);
 

--- a/hypervisor/include/lib/crypto/hkdf.h
+++ b/hypervisor/include/lib/crypto/hkdf.h
@@ -38,7 +38,7 @@
  */
 int hkdf_sha256(uint8_t *out_key, size_t out_len,
 		const uint8_t *secret, size_t secret_len,
-		const uint8_t *salt, size_t salt_len,
-		const uint8_t *info, size_t info_len);
+		__unused const uint8_t *salt, __unused size_t salt_len,
+		__unused const uint8_t *info, __unused size_t info_len);
 
 #endif  /* HKDF_H */


### PR DESCRIPTION
Fix the parameter type mismatch between API declaration and definition.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>