### PR TITLE
hv: treewide: fix 'Empty parameter list to procedure/function'

### DIFF
--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -331,8 +331,8 @@ bool cpu_has_cap(uint32_t bit);
 void load_cpu_state_data(void);
 void bsp_boot_init(void);
 void cpu_secondary_init(void);
-void start_cpus();
-void stop_cpus();
+void start_cpus(void);
+void stop_cpus(void);
 void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 
 /* Read control register */


### PR DESCRIPTION
Use func(void) rather than func() for the function declaration and
definition based on MISRAC requirement.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>