### PR TITLE
hv: vmx: fix 'Array has no bounds specified'

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -499,7 +499,7 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 #else
 		if (is_vm0(vcpu->vm)) {
 			struct boot_ctx *vm0_init_ctx =
-				(struct boot_ctx *)vm0_boot_context;
+				(struct boot_ctx *)(&vm0_boot_context);
 			/* VM0 bsp start mode is decided by the boot context
 			 * setup by bootloader / bios */
 			if ((vm0_init_ctx->ia32_efer & MSR_IA32_EFER_LMA_BIT) &&

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -609,7 +609,7 @@ static void init_guest_context_vm0_bsp(struct vcpu *vcpu)
 {
 	struct ext_context *ectx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx;
-	struct boot_ctx * init_ctx = (struct boot_ctx *)vm0_boot_context;
+	struct boot_ctx * init_ctx = (struct boot_ctx *)(&vm0_boot_context);
 	uint16_t *sel;
 	struct segment_sel *seg;
 
@@ -709,7 +709,7 @@ static void init_guest_state(struct vcpu *vcpu)
 {
 	struct cpu_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
-	struct boot_ctx * init_ctx = (struct boot_ctx *)vm0_boot_context;
+	struct boot_ctx * init_ctx = (struct boot_ctx *)(&vm0_boot_context);
 	enum vm_cpu_mode vcpu_mode = get_vcpu_mode(vcpu);
 
 	vcpu_set_rflags(vcpu, 0x2UL); /* Bit 1 is a active high reserved bit */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -141,7 +141,7 @@ int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 
 uint64_t create_guest_init_gdt(struct vm *vm, uint32_t *limit);
-extern uint8_t vm0_boot_context[];
+extern uint8_t vm0_boot_context;
 
 #ifdef HV_DEBUG
 void get_req_info(char *str_arg, int str_max);


### PR DESCRIPTION
MISRAC requires that the array size should be declared explicitly.

This patch fixes the issues caused by vm0_boot_context.

Fix pattern is like below:
   extern char start_of_ROM, end_of_ROM, start_of_FLASH;
   memcpy (& start_of_FLASH, & start_of_ROM, & end_of_ROM - &
start_of_ROM);

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>