### PR TITLE
hv: debug: add the hypervisor NPK log

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -50,7 +50,7 @@ config LOG_BUF_SIZE
 
 config LOG_DESTINATION
 	int "Bitmap of consoles where logs are printed"
-	default 3
+	default 7
 
 config CPU_UP_TIMEOUT
 	int "Timeout in ms when bringing up secondary CPUs"
@@ -97,6 +97,10 @@ config CONSOLE_LOGLEVEL_DEFAULT
 
 config MEM_LOGLEVEL_DEFAULT
 	int "Default loglevel in memory"
+	default 5
+
+config NPK_LOGLEVEL_DEFAULT
+	int "Default loglevel for the hypervisor NPK log"
 	default 5
 
 config LOW_RAM_SIZE

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -159,6 +159,10 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 	case HC_SETUP_SBUF:
 		ret = hcall_setup_sbuf(vm, param1);
 		break;
+
+	case HC_SETUP_HV_NPK_LOG:
+		ret = hcall_setup_hv_npk_log(vm, param1);
+		break;
 #endif
 
 	case HC_WORLD_SWITCH:

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -821,6 +821,34 @@ int32_t hcall_setup_sbuf(__unused struct vm *vm, __unused uint64_t param)
 }
 #endif
 
+#ifdef HV_DEBUG
+int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param)
+{
+	struct hv_npk_log_param npk_param;
+
+	memset((void *)&npk_param, 0, sizeof(npk_param));
+
+	if (copy_from_gpa(vm, &npk_param, param, sizeof(npk_param)) != 0) {
+		pr_err("%s: Unable copy param from vm\n", __func__);
+		return -1;
+	}
+
+	npk_log_setup(&npk_param);
+
+	if (copy_to_gpa(vm, &npk_param, param, sizeof(npk_param)) != 0) {
+		pr_err("%s: Unable copy param to vm\n", __func__);
+		return -1;
+	}
+
+	return 0;
+}
+#else
+int32_t hcall_setup_hv_npk_log(__unused struct vm *vm, __unused uint64_t param)
+{
+	return -ENODEV;
+}
+#endif
+
 int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param)
 {
 	uint16_t target_vm_id;

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -89,14 +89,17 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	uint16_t pcpu_id;
 	bool do_console_log;
 	bool do_mem_log;
+	bool do_npk_log;
 	char *buffer;
 
 	do_console_log = (((logmsg.flags & LOG_FLAG_STDOUT) != 0U) &&
 					(severity <= console_loglevel));
 	do_mem_log = (((logmsg.flags & LOG_FLAG_MEMORY) != 0U) &&
 					(severity <= mem_loglevel));
+	do_npk_log = ((logmsg.flags & LOG_FLAG_NPK) != 0U &&
+					(severity <= npk_loglevel));
 
-	if (!do_console_log && !do_mem_log) {
+	if (!do_console_log && !do_mem_log && !do_npk_log) {
 		return;
 	}
 
@@ -123,6 +126,10 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 		LOG_MESSAGE_MAX_SIZE
 		- strnlen_s(buffer, LOG_MESSAGE_MAX_SIZE), fmt, args);
 	va_end(args);
+
+	/* Check if flags specify to output to NPK */
+	if (do_npk_log)
+		npk_log_write(buffer, strnlen_s(buffer, LOG_MESSAGE_MAX_SIZE));
 
 	/* Check if flags specify to output to stdout */
 	if (do_console_log) {

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018 Intel Corporation.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+
+static int npk_log_enabled, npk_log_setup_ref;
+static uint64_t base;
+
+static inline int npk_write(const char *value, void *addr, size_t sz)
+{
+	int ret = -1;
+
+	if (sz >= 8U) {
+		mmio_write64(*(uint64_t *)value, addr);
+		ret = 8;
+	} else if (sz >= 4U) {
+		mmio_write32(*(uint32_t *)value, addr);
+		ret = 4;
+	} else if (sz >= 2U) {
+		mmio_write16(*(uint16_t *)value, addr);
+		ret = 2;
+	} else if (sz >= 1U) {
+		mmio_write8(*(uint8_t *)value, addr);
+		ret = 1;
+	}
+
+	return ret;
+}
+
+void npk_log_setup(struct hv_npk_log_param *param)
+{
+	int i;
+
+	pr_info("HV_NPK_LOG: cmd %d param 0x%llx\n", param->cmd,
+			param->mmio_addr);
+
+	param->res = HV_NPK_LOG_RES_KO;
+	if (atomic_inc_return(&npk_log_setup_ref) > 1)
+		goto out;
+
+	switch (param->cmd) {
+	case HV_NPK_LOG_CMD_CONF:
+		if (param->mmio_addr || param->loglevel != 0xffffU)
+			param->res = HV_NPK_LOG_RES_OK;
+	case HV_NPK_LOG_CMD_ENABLE:
+		if (param->mmio_addr)
+			base = param->mmio_addr;
+		if (param->loglevel != 0xffffU)
+			npk_loglevel = param->loglevel;
+		if (base && param->cmd == HV_NPK_LOG_CMD_ENABLE) {
+			if (!npk_log_enabled)
+				for (i = 0; i < phys_cpu_num; i++)
+					per_cpu(npk_log_ref, i) = 0;
+			param->res = HV_NPK_LOG_RES_OK;
+			npk_log_enabled = 1;
+		}
+		break;
+	case HV_NPK_LOG_CMD_DISABLE:
+		npk_log_enabled = 0;
+		param->res = HV_NPK_LOG_RES_OK;
+		break;
+	case HV_NPK_LOG_CMD_QUERY:
+		param->res = npk_log_enabled ? HV_NPK_LOG_RES_ENABLED :
+			HV_NPK_LOG_RES_DISABLED;
+		param->loglevel = npk_loglevel;
+		param->mmio_addr = base;
+		break;
+	default:
+		pr_err("HV_NPK_LOG: unknown cmd (%d)\n", param->cmd);
+		break;
+	}
+
+out:
+	pr_info("HV_NPK_LOG: result %d\n", param->res);
+	atomic_dec32((uint32_t *)&npk_log_setup_ref);
+}
+
+void npk_log_write(const char *buf, size_t buf_len)
+{
+	uint32_t cpu_id = get_cpu_id();
+	struct npk_chan *channel = (struct npk_chan *)base;
+	const char *p = buf;
+	int sz;
+	uint32_t ref;
+	size_t len;
+
+	if (!npk_log_enabled || !channel)
+		return;
+
+	/* calculate the channel offset based on cpu_id and npk_log_ref */
+	ref = (atomic_inc_return((int *)&per_cpu(npk_log_ref, cpu_id)) - 1)
+		& HV_NPK_LOG_REF_MASK;
+	channel += (cpu_id << HV_NPK_LOG_REF_SHIFT) + ref;
+	len = min(buf_len, HV_NPK_LOG_MAX);
+	mmio_write32(HV_NPK_LOG_HDR, &(channel->DnTS));
+	mmio_write16(len, &(channel->Dn));
+
+	for (sz = 0; sz >= 0; p += sz)
+		sz = npk_write(p, &(channel->Dn), buf + len - p);
+
+	mmio_write8(0U, &(channel->FLAG));
+
+	atomic_dec32(&per_cpu(npk_log_ref, cpu_id));
+}

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -128,6 +128,7 @@ static struct shell_cmd shell_cmds[] = {
 /* The initial log level*/
 uint32_t console_loglevel = CONFIG_CONSOLE_LOGLEVEL_DEFAULT;
 uint32_t mem_loglevel = CONFIG_MEM_LOGLEVEL_DEFAULT;
+uint32_t npk_loglevel = CONFIG_NPK_LOGLEVEL_DEFAULT;
 
 static struct shell hv_shell;
 static struct shell *p_shell = &hv_shell;
@@ -872,17 +873,21 @@ static int shell_loglevel(int argc, char **argv)
 {
 	char str[MAX_STR_SIZE] = {0};
 
-	if (argc == 1) {
-		snprintf(str, MAX_STR_SIZE,
-			"console_loglevel: %u, mem_loglevel: %u\r\n",
-			console_loglevel, mem_loglevel);
-		shell_puts(str);
-	} else if (argc == 2) {
-		console_loglevel = atoi(argv[1]);
-	} else if (argc == 3) {
-		console_loglevel = atoi(argv[1]);
+	switch (argc) {
+	case 4:
+		npk_loglevel = atoi(argv[3]);
+	case 3:
 		mem_loglevel = atoi(argv[2]);
-	} else {
+	case 2:
+		console_loglevel = atoi(argv[1]);
+		break;
+	case 1:
+		snprintf(str, MAX_STR_SIZE, "console_loglevel: %u, "
+			"mem_loglevel: %u, npk_loglevel: %u\r\n",
+			console_loglevel, mem_loglevel, npk_loglevel);
+		shell_puts(str);
+		break;
+	default:
 		return -EINVAL;
 	}
 

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -90,7 +90,8 @@ struct shell {
 #define SHELL_CMD_LOGDUMP_HELP		"log buffer dump"
 
 #define SHELL_CMD_LOG_LVL		"loglevel"
-#define SHELL_CMD_LOG_LVL_PARAM		"[console_loglevel] [mem_loglevel]"
+#define SHELL_CMD_LOG_LVL_PARAM		"[<console_loglevel> [<mem_loglevel> " \
+					"[npk_loglevel]]]"
 #define SHELL_CMD_LOG_LVL_HELP		"get(para is NULL), or set loglevel [0-6]"
 
 #define SHELL_CMD_CPUID			"cpuid"

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -76,6 +76,17 @@ static inline uint32_t pio_read(uint16_t addr, size_t sz)
 	return pio_read32(addr);
 }
 
+/** Writes a 64 bit value to a memory mapped IO device.
+ *
+ *  @param value The 64 bit value to write.
+ *  @param addr The memory address to write to.
+ */
+static inline void mmio_write64(uint64_t value, const void *addr)
+{
+	volatile uint64_t *addr64 = (volatile uint64_t *)addr;
+	*addr64 = value;
+}
+
 /** Writes a 32 bit value to a memory mapped IO device.
  *
  *  @param value The 32 bit value to write.
@@ -107,6 +118,17 @@ static inline void mmio_write8(uint8_t value, const void *addr)
 {
 	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
 	*addr8 = value;
+}
+
+/** Reads a 64 bit value from a memory mapped IO device.
+ *
+ *  @param addr The memory address to read from.
+ *
+ *  @return The 64 bit value read from the given address.
+ */
+static inline uint64_t mmio_read64(const void *addr)
+{
+	return *((volatile uint64_t *)addr);
 }
 
 /** Reads a 32 bit value from a memory mapped IO device.
@@ -142,6 +164,20 @@ static inline uint8_t mmio_read8(const void *addr)
 	return *((volatile uint8_t *)addr);
 }
 
+/** Reads a 64 Bit memory mapped IO register, mask it and write it back into
+ *  memory mapped IO register.
+ *
+ * @param addr    The address of the memory mapped IO register.
+ * @param mask    The mask to apply to the value read.
+ * @param value   The 64 bit value to write.
+ */
+static inline void set64(const void *addr, uint64_t mask, uint64_t value)
+{
+	uint64_t temp_val;
+
+	temp_val = mmio_read64(addr);
+	mmio_write64((temp_val & ~mask) | value, addr);
+}
 
 /** Reads a 32 Bit memory mapped IO register, mask it and write it back into
  *  memory mapped IO register.

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -23,6 +23,7 @@ struct per_cpu_region {
 	uint64_t *sbuf[ACRN_SBUF_ID_MAX];
 	uint64_t vmexit_cnt[64];
 	uint64_t vmexit_time[64];
+	uint32_t npk_log_ref;
 #endif
 	uint64_t irq_count[NR_IRQS];
 	uint64_t softirq_pending;

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -344,6 +344,17 @@ int32_t hcall_reset_ptdev_intr_info(struct vm *vm, uint16_t vmid,
 int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
 
 /**
+  * @brief Setup the hypervisor NPK log.
+  *
+  * @param vm Pointer to VM data structure
+  * @param param guest physical address. This gpa points to
+  *              struct hv_npk_log_param
+  *
+  * @return 0 on success, non-zero on error.
+  */
+int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param);
+
+/**
  * @brief Get VCPU Power state.
  *
  * @param vm pointer to VM data structure

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -19,6 +19,7 @@
 /* Logging flags */
 #define LOG_FLAG_STDOUT		0x00000001U
 #define LOG_FLAG_MEMORY		0x00000002U
+#define LOG_FLAG_NPK		0x00000004U
 #define LOG_ENTRY_SIZE	80
 /* Size of buffer used to store a message being logged,
  * should align to LOG_ENTRY_SIZE.
@@ -29,6 +30,7 @@
 
 extern uint32_t console_loglevel;
 extern uint32_t mem_loglevel;
+extern uint32_t npk_loglevel;
 void init_logmsg(__unused uint32_t mem_size, uint32_t flags);
 void print_logmsg_buffer(uint16_t pcpu_id);
 void do_logmsg(uint32_t severity, const char *fmt, ...);

--- a/hypervisor/include/debug/npk_log.h
+++ b/hypervisor/include/debug/npk_log.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2018 Intel Corporation.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef NPK_LOG_H
+#define NPK_LOG_H
+
+static inline void npk_log_setup(__unused struct hv_npk_log_param *param)
+{}
+
+#endif /* NPK_LOG_H */

--- a/hypervisor/include/debug/npk_log.h
+++ b/hypervisor/include/debug/npk_log.h
@@ -6,7 +6,51 @@
 #ifndef NPK_LOG_H
 #define NPK_LOG_H
 
+#define HV_NPK_LOG_REF_SHIFT  2U
+#define HV_NPK_LOG_REF_MASK   ((1U << HV_NPK_LOG_REF_SHIFT) - 1U)
+
+#define HV_NPK_LOG_MAX 1024U
+#define HV_NPK_LOG_HDR 0x01000242U
+
+enum {
+	HV_NPK_LOG_CMD_INVALID,
+	HV_NPK_LOG_CMD_CONF,
+	HV_NPK_LOG_CMD_ENABLE,
+	HV_NPK_LOG_CMD_DISABLE,
+	HV_NPK_LOG_CMD_QUERY,
+};
+
+enum {
+	HV_NPK_LOG_RES_INVALID,
+	HV_NPK_LOG_RES_OK,
+	HV_NPK_LOG_RES_KO,
+	HV_NPK_LOG_RES_ENABLED,
+	HV_NPK_LOG_RES_DISABLED,
+};
+
+struct hv_npk_log_param;
+
+struct npk_chan {
+	uint64_t Dn;
+	uint64_t DnM;
+	uint64_t DnTS;
+	uint64_t DnMTS;
+	uint64_t USER;
+	uint64_t USER_TS;
+	uint32_t FLAG;
+	uint32_t FLAG_TS;
+	uint32_t MERR;
+	uint32_t unused;
+} __packed;
+
+#ifdef HV_DEBUG
+void npk_log_setup(struct hv_npk_log_param *param);
+void npk_log_write(const char *buf, size_t len);
+#else
 static inline void npk_log_setup(__unused struct hv_npk_log_param *param)
 {}
+static inline void npk_log_write(__unused const char *buf, __unused size_t len)
+{}
+#endif  /* HV_DEBUG */
 
 #endif /* NPK_LOG_H */

--- a/hypervisor/include/hv_debug.h
+++ b/hypervisor/include/hv_debug.h
@@ -13,5 +13,6 @@
 #include <dump.h>
 #include <trace.h>
 #include <sbuf.h>
+#include <npk_log.h>
 
 #endif /* HV_DEBUG_H */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -67,6 +67,7 @@
 /* DEBUG */
 #define HC_ID_DBG_BASE              0x60UL
 #define HC_SETUP_SBUF               BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x00UL)
+#define HC_SETUP_HV_NPK_LOG         BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x01UL)
 
 /* Trusty */
 #define HC_ID_TRUSTY_BASE           0x70UL
@@ -184,6 +185,28 @@ struct sbuf_setup_param {
 
 	/** sbuf's guest physical address */
 	uint64_t gpa;
+} __aligned(8);
+
+/**
+ * @brief Info to setup the hypervisor NPK log
+ *
+ * the parameter for HC_SETUP_HV_NPK_LOG hypercall
+ */
+struct hv_npk_log_param {
+	/** the setup command for the hypervisor NPK log */
+	uint16_t cmd;
+
+	/** the setup result for the hypervisor NPK log */
+	uint16_t res;
+
+	/** the loglevel for the hypervisor NPK log */
+	uint16_t loglevel;
+
+	/** Reserved */
+	uint16_t reserved;
+
+	/** the MMIO address for the hypervisor NPK log */
+	uint64_t mmio_addr;
 } __aligned(8);
 
 /**


### PR DESCRIPTION
This series of patches implement a log destination for the hypervisor,
npk_log, which is similar to the console_log and the mem_log.
The Intel Trace Hub (aka. North Peak, NPK) is a trace aggregator for
Software, Firmware, and Hardware. The npk_log utilizes the NPK by
writing the hypervisor logs directly to the MMIO address of the
reserved NPK master, so that the hypervisor logs can be consolidated
together with any other logs sent to the NPK from other parts of the
virtualization platform with an unified timestamp.
In order to enable/disable/configure the npk_log from the SOS kernel,
a hypercall HC_SETUP_HV_NPK_LOG (the first patch of the series) and a
kernel driver (covered by another patch series) are also added.