### PR TITLE
hv: fix 'No definition in system for prototyped procedure'

### DIFF
--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -57,7 +57,6 @@ int vlapic_pending_intr(struct acrn_vlapic *vlapic, uint32_t *vecptr);
 void vlapic_intr_accepted(struct acrn_vlapic *vlapic, uint32_t vector);
 
 struct acrn_vlapic *vm_lapic_from_pcpuid(struct vm *vm, uint16_t pcpu_id);
-bool is_vlapic_msr(uint32_t msr);
 int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
 int vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t wval);
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -376,7 +376,6 @@ static inline void clflush(volatile void *p)
 }
 
 /* External Interfaces */
-uint64_t create_guest_initial_paging(struct vm *vm);
 void    destroy_ept(struct vm *vm);
 uint64_t  gpa2hpa(const struct vm *vm, uint64_t gpa);
 uint64_t  local_gpa2hpa(const struct vm *vm, uint64_t gpa, uint32_t *size);

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -40,7 +40,6 @@ int console_write(const char *s, size_t len);
 
 void console_putc(const char *ch);
 char console_getc(void);
-int console_gets(char *buffer, uint32_t length);
 
 void console_setup_timer(void);
 
@@ -70,7 +69,6 @@ static inline int console_write(__unused const char *str,
 }
 static inline void console_putc(__unused const char *ch) { }
 static inline int console_getc(void) { return 0; }
-static inline int console_gets(char *buffer, uint32_t length) { return 0; }
 static inline void console_setup_timer(void) {}
 static inline void suspend_console(void) {}
 static inline void resume_console(void) {}


### PR DESCRIPTION
Remove the functions without definition.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>