### PR TITLE
hv: code clean up regarding to % and / operations

### DIFF
--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -17,7 +17,7 @@ static inline struct vcpuid_entry *find_vcpuid_entry(const struct vcpu *vcpu,
 	uint32_t leaf = leaf_arg;
 
 	nr = vm->vcpuid_entry_nr;
-	half = nr / 2U;
+	half = nr >> 1U;
 	if (vm->vcpuid_entries[half].leaf < leaf) {
 		i = half;
 	}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -180,7 +180,7 @@ vlapic_build_id(struct acrn_vlapic *vlapic)
 		vlapic_id = (uint8_t)vcpu->vcpu_id;
 	}
 
-	lapic_regs_id = vlapic_id << APIC_ID_SHIFT;
+	lapic_regs_id = (uint32_t)vlapic_id << APIC_ID_SHIFT;
 
 	dev_dbg(ACRN_DBG_LAPIC, "vlapic APIC PAGE ID : 0x%08x", lapic_regs_id);
 
@@ -487,12 +487,13 @@ vlapic_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 			(vlapic, vector, level);
 	}
 
-	idx = vector / 32U;
-	mask = 1U << (vector % 32U);
+	idx = vector >> 5U;
+	mask = 1U << (vector & 0x1fU);
 
 	irrptr = &lapic->irr[0];
 	/* If the interrupt is set, don't try to do it again */
-	if (bitmap32_test_and_set_lock((uint16_t)(vector % 32U), &irrptr[idx].val)) {
+	if (bitmap32_test_and_set_lock((uint16_t)(vector & 0x1fU),
+							&irrptr[idx].val)) {
 		return 0;
 	}
 
@@ -784,8 +785,9 @@ vlapic_update_ppr(struct acrn_vlapic *vlapic)
 		i = 1U;
 		isrptr = &vlapic->apic_page->isr[0];
 		for (vector = 0U; vector < 256U; vector++) {
-			idx = vector / 32U;
-			if ((isrptr[idx].val & (1U << (vector % 32U))) != 0U) {
+			idx = vector >> 5U;
+			if ((isrptr[idx].val & (1U << (vector & 0x1fU)))
+									!= 0U) {
 				isrvec = (uint32_t)vlapic->isrvec_stk[i];
 				if ((i > vlapic->isrvec_stk_top) ||
 					((i < ISRVEC_STK_SIZE) &&
@@ -1258,14 +1260,14 @@ vlapic_intr_accepted(struct acrn_vlapic *vlapic, uint32_t vector)
 	 * clear the ready bit for vector being accepted in irr
 	 * and set the vector as in service in isr.
 	 */
-	idx = vector / 32U;
+	idx = vector >> 5U;
 
 	irrptr = &lapic->irr[0];
-	atomic_clear32(&irrptr[idx].val, 1U << (vector % 32U));
+	atomic_clear32(&irrptr[idx].val, 1U << (vector & 0x1fU));
 	vlapic_dump_irr(vlapic, "vlapic_intr_accepted");
 
 	isrptr = &lapic->isr[0];
-	isrptr[idx].val |= 1U << (vector % 32U);
+	isrptr[idx].val |= 1U << (vector & 0x1fU);
 	vlapic_dump_isr(vlapic, "vlapic_intr_accepted");
 
 	/*
@@ -1731,8 +1733,8 @@ vlapic_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 
 	lapic = vlapic->apic_page;
 	tmrptr = &lapic->tmr[0];
-	idx = vector / 32U;
-	mask = 1U << (vector % 32U);
+	idx = vector >> 5U;
+	mask = 1U << (vector & 0x1fU);
 	if (level) {
 		tmrptr[idx].val |= mask;
 	} else {
@@ -2143,8 +2145,8 @@ apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector,
 
 	pir_desc = vlapic->pir_desc;
 
-	idx = vector / 64U;
-	mask = 1UL << (vector % 64U);
+	idx = vector >> 6U;
+	mask = 1UL << (vector & 0x3fU);
 
 	atomic_set64(&pir_desc->pir[idx], mask);
 	notify = (atomic_cmpxchg64(&pir_desc->pending, 0UL, 1UL) == 0UL) ? 1 : 0;
@@ -2192,7 +2194,7 @@ apicv_set_tmr(__unused struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 	uint64_t mask, val;
 	uint32_t field;
 
-	mask = 1UL << (vector % 64U);
+	mask = 1UL << (vector & 0x3fU);
 	field = VMX_EOI_EXIT(vector);
 
 	val = exec_vmread64(field);
@@ -2386,8 +2388,8 @@ int veoi_vmexit_handler(struct vcpu *vcpu)
 	vector = (uint32_t)(vcpu->arch_vcpu.exit_qualification & 0xFFUL);
 
 	tmrptr = &lapic->tmr[0];
-	idx = vector / 32U;
-	mask = 1U << (vector % 32U);
+	idx = vector >> 5U;
+	mask = 1U << (vector & 0x1fU);
 
 	if ((tmrptr[idx].val & mask) != 0U) {
 		/* hook to vIOAPIC */

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -44,11 +44,11 @@ static void enable_msr_interception(uint8_t *bitmap, uint32_t msr_arg)
 	}
 
 	msr &= 0x1FFFU;
-	value = read_map[(msr>>3U)];
-	value |= 1U<<(msr%8U);
+	value = read_map[(msr >> 3U)];
+	value |= 1U << (msr & 0x7U);
 	/* right now we trap for both r/w */
-	read_map[(msr>>3U)] = value;
-	write_map[(msr>>3U)] = value;
+	read_map[(msr >> 3U)] = value;
+	write_map[(msr >> 3U)] = value;
 }
 
 void init_msr_emulation(struct vcpu *vcpu)

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -109,7 +109,7 @@ static void dump_guest_stack(struct vcpu *vcpu)
 	printf("\r\nGuest Stack:\r\n");
 	printf("Dump stack for vcpu %hu, from gva 0x%016llx\r\n",
 			vcpu->vcpu_id, vcpu_get_gpreg(vcpu, CPU_REG_RSP));
-	for (i = 0U; i < (DUMP_STACK_SIZE/32U); i++) {
+	for (i = 0U; i < (DUMP_STACK_SIZE >> 5U); i++) {
 		printf("guest_rsp(0x%llx):  0x%016llx  0x%016llx  "
 				"0x%016llx  0x%016llx\r\n",
 				(vcpu_get_gpreg(vcpu, CPU_REG_RSP)+(i*32)),
@@ -181,10 +181,11 @@ static void show_host_call_trace(uint64_t rsp, uint64_t rbp_arg, uint16_t pcpu_i
 	uint64_t *sp = (uint64_t *)rsp;
 
 	printf("\r\nHost Stack: CPU_ID = %hu\r\n", pcpu_id);
-	for (i = 0U; i < (DUMP_STACK_SIZE/32U); i++) {
+	for (i = 0U; i < (DUMP_STACK_SIZE >> 5U); i++) {
 		printf("addr(0x%llx)	0x%016llx  0x%016llx  0x%016llx  "
-			  "0x%016llx\r\n", (rsp+(i*32U)), sp[i*4U], sp[(i*4U)+1U],
-			  sp[(i*4U)+2U], sp[(i*4U)+3U]);
+			"0x%016llx\r\n", (rsp + (i * 32U)), sp[i * 4U],
+			sp[(i * 4U) + 1U], sp[(i * 4U) + 2U],
+			sp[(i * 4U) + 3U]);
 	}
 	printf("\r\n");
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -14,7 +14,7 @@
 /* Input Line Other - Switch to the "other" input line (there are only two
  * input lines total).
  */
-#define SHELL_INPUT_LINE_OTHER(v)	(((v) + 1U) % 2U)
+#define SHELL_INPUT_LINE_OTHER(v)	(((v) + 1U) & 0x1U)
 
 static int shell_cmd_help(__unused int argc, __unused char **argv);
 static int shell_list_vm(__unused int argc, __unused char **argv);
@@ -331,7 +331,7 @@ static int shell_process_cmd(char *p_input_line)
 	int status = -EINVAL;
 	struct shell_cmd *p_cmd;
 	char cmd_argv_str[SHELL_CMD_MAX_LEN + 1U];
-	int cmd_argv_mem[sizeof(char *) * ((SHELL_CMD_MAX_LEN + 1U) / 2U)];
+	int cmd_argv_mem[sizeof(char *) * ((SHELL_CMD_MAX_LEN + 1U) >> 1U)];
 	int cmd_argc;
 	char **cmd_argv;
 
@@ -696,7 +696,7 @@ static int shell_dumpmem(int argc, char **argv)
 	shell_puts(temp_str);
 
 	ptr = (uint64_t *)addr;
-	for (i = 0U; i < (length/32U); i++) {
+	for (i = 0U; i < (length >> 5U); i++) {
 		snprintf(temp_str, MAX_STR_SIZE,
 			"=  0x%016llx  0x%016llx  0x%016llx  0x%016llx\r\n",
 			*(ptr + (i*4)), *(ptr + ((i*4)+1)),
@@ -704,7 +704,7 @@ static int shell_dumpmem(int argc, char **argv)
 		shell_puts(temp_str);
 	}
 
-	if ((length % 32U) != 0) {
+	if ((length & 0x1fU) != 0) {
 		snprintf(temp_str, MAX_STR_SIZE,
 			"=  0x%016llx  0x%016llx  0x%016llx 0x%016llx\r\n",
 			*(ptr + (i*4)), *(ptr + ((i*4)+1)),

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -384,7 +384,7 @@ void *vuart_init(struct vm *vm)
 	ASSERT(vu != NULL, "");
 
 	/* Set baud rate*/
-	divisor = UART_CLOCK_RATE / BAUD_9600 / 16U;
+	divisor = (UART_CLOCK_RATE / BAUD_9600) >> 4U;
 	vu->dll = (uint8_t)divisor;
 	vu->dlh = (uint8_t)(divisor >> 8U);
 

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -259,9 +259,9 @@ vioapic_indirect_read(struct vioapic *vioapic, uint32_t addr)
 	if ((regnum >= IOAPIC_REDTBL) &&
 	    (regnum < (IOAPIC_REDTBL + (pincount * 2U)))) {
 		uint32_t addr_offset = regnum - IOAPIC_REDTBL;
-		uint32_t rte_offset = addr_offset / 2U;
+		uint32_t rte_offset = addr_offset >> 1U;
 		pin = rte_offset;
-		if ((addr_offset % 2U) != 0U) {
+		if ((addr_offset & 0x1U) != 0U) {
 			return vioapic->rtbl[pin].u.hi_32;
 		} else {
 			return vioapic->rtbl[pin].u.lo_32;

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -242,7 +242,7 @@ static void vdev_pt_cfgwrite_bar(struct pci_vdev *vdev, uint32_t offset,
 	bool do_map;
 	int error;
 
-	idx = (offset - PCIR_BAR(0U)) / 4U;
+	idx = (offset - PCIR_BAR(0U)) >> 2U;
 	mask = ~(vdev->bar[idx].size - 1U);
 	bar_update_normal = (new_bar_uos != (uint32_t)~0U);
 	new_bar = new_bar_uos & mask;

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -58,7 +58,7 @@
 #define	VMX_EOI_EXIT2_HIGH			0x00002021U
 #define	VMX_EOI_EXIT3_FULL			0x00002022U
 #define	VMX_EOI_EXIT3_HIGH			0x00002023U
-#define	VMX_EOI_EXIT(vector)	(VMX_EOI_EXIT0_FULL + (((vector) / 64U) * 2U))
+#define	VMX_EOI_EXIT(vector)	(VMX_EOI_EXIT0_FULL + (((vector) >> 6U) * 2U))
 #define VMX_XSS_EXITING_BITMAP_FULL		0x0000202CU
 #define VMX_XSS_EXITING_BITMAP_HIGH		0x0000202DU
 /* 64-bit read-only data fields */

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -403,10 +403,10 @@ void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg)
 
 		asm volatile ("cld; rep; movsq"
 				: "=&c"(ecx), "=&D"(dest8), "=&S"(src8)
-				: "0" (slen / 8), "1" (dest8), "2" (src8)
+				: "0" (slen >> 3), "1" (dest8), "2" (src8)
 				: "memory");
 
-		slen = slen % 8U;
+		slen = slen & 0x7U;
 	}
 
 	/* tail bytes */


### PR DESCRIPTION
- Clean up some code regarding to % and / operations since bit
  operations are faster.
        x % 64U ---> x & 0x3fU
        x % 32U ---> x & 0x1fU
        x % 16U ---> x & 0xfU
        x % 8U  ---> x & 0x7U
        x % 4U  ---> x & 0x3U
        x % 2U  ---> x & 0x1U

        x / 64U ---> x >> 6U
        x / 32U ---> x >> 5U
        x / 16U ---> x >> 4U
        x / 8U  ---> x >> 3U
        x / 4U  ---> x >> 2U
        x / 2U  ---> x >> 1U
- Minor changes regarding to coding styles

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>