### PR TITLE
HV: Removed unused parameters and unions from gdt

### DIFF
--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -6,7 +6,7 @@
 
 #include <hypervisor.h>
 
-static void set_tss_desc(union tss_64_descriptor *desc,
+static void set_tss_desc(struct tss_64_descriptor *desc,
 		uint64_t tss, size_t tss_limit, uint32_t type)
 {
 	uint32_t u1, u2, u3;
@@ -18,9 +18,9 @@ static void set_tss_desc(union tss_64_descriptor *desc,
 	u3 = (tss_lo_32 & 0x00FF0000U) >> 16U;
 
 
-	desc->fields.low32.value = u1 | (tss_limit & 0xFFFFU);
-	desc->fields.base_addr_63_32 = tss_hi_32;
-	desc->fields.high32.value = u2 | (type << 8U) | 0x8000U | u3;
+	desc->low32_value = u1 | (tss_limit & 0xFFFFU);
+	desc->base_addr_63_32 = tss_hi_32;
+	desc->high32_value = u2 | (type << 8U) | 0x8000U | u3;
 }
 
 void load_gdtr_and_tr(void)
@@ -32,9 +32,9 @@ void load_gdtr_and_tr(void)
 	/* first entry is not used */
 	gdt->rsvd = 0xAAAAAAAAAAAAAAAAUL;
 	/* ring 0 code sel descriptor */
-	gdt->host_gdt_code_descriptor.value = 0x00Af9b000000ffffUL;
+	gdt->code_segment_descriptor = 0x00Af9b000000ffffUL;
 	/* ring 0 data sel descriptor */
-	gdt->host_gdt_data_descriptor.value = 0x00cf93000000ffffUL;
+	gdt->data_segment_descriptor = 0x00cf93000000ffffUL;
 
 	tss->ist1 = (uint64_t)get_cpu_var(mc_stack) + CONFIG_STACK_SIZE;
 	tss->ist2 = (uint64_t)get_cpu_var(df_stack) + CONFIG_STACK_SIZE;

--- a/hypervisor/include/arch/x86/gdt.h
+++ b/hypervisor/include/arch/x86/gdt.h
@@ -79,146 +79,13 @@
 #define TSS_AVAIL  (9U)
 
 /*
- * Definition of an 8 byte code segment descriptor.
- */
-union code_segment_descriptor {
-	uint64_t value;
-	struct {
-		union {
-			uint32_t value;
-			struct {
-				uint32_t limit_15_0:16;
-				uint32_t base_15_0:16;
-			} bits;
-		} low32;
-		union {
-			uint32_t value;
-			struct {
-				uint32_t base_23_16:8;
-				uint32_t accessed:1;
-				uint32_t readeable:1;
-				uint32_t conforming:1;
-				uint32_t bit11_set:1;
-				uint32_t bit12_set:1;
-				uint32_t dpl:2;
-				uint32_t present:1;
-				uint32_t limit_19_16:4;
-				uint32_t avl:1;
-				uint32_t x64flag:1;
-				uint32_t dflt:1;
-				uint32_t granularity:1;
-				uint32_t base_31_24:8;
-			} bits;
-		} high32;
-	} fields;
-} __aligned(8);
-
-/*
- * Definition of an 8 byte data segment descriptor.
- */
-union data_segment_descriptor {
-	uint64_t value;
-	struct {
-		union {
-			uint32_t value;
-			struct {
-				uint32_t limit_15_0:16;
-				uint32_t base_15_0:16;
-			} bits;
-		} low32;
-		union {
-			uint32_t value;
-			struct {
-				uint32_t base_23_16:8;
-				uint32_t accessed:1;
-				uint32_t writeable:1;
-				uint32_t expansion:1;
-				uint32_t bit11_clr:1;
-				uint32_t bit12_set:1;
-				uint32_t dpl:2;
-				uint32_t present:1;
-				uint32_t limit_19_16:4;
-				uint32_t avl:1;
-				uint32_t rsvd_clr:1;
-				uint32_t big:1;
-				uint32_t granularity:1;
-				uint32_t base_31_24:8;
-			} bits;
-		} high32;
-	} fields;
-} __aligned(8);
-
-/*
- * Definition of an 8 byte system segment descriptor.
- */
-union system_segment_descriptor {
-	uint64_t value;
-	struct {
-		union {
-			uint32_t value;
-			struct {
-				uint32_t limit_15_0:16;
-				uint32_t base_15_0:16;
-			} bits;
-		} low32;
-		union {
-			uint32_t value;
-			struct {
-				uint32_t base_23_16:8;
-				uint32_t type:4;
-				uint32_t bit12_clr:1;
-				uint32_t dpl:2;
-				uint32_t present:1;
-				uint32_t limit_19_16:4;
-				uint32_t rsvd_1:1;
-				uint32_t rsvd_2_clr:1;
-				uint32_t rsvd_3:1;
-				uint32_t granularity:1;
-				uint32_t base_31_24:8;
-			} bits;
-		} high32;
-	} fields;
-} __aligned(8);
-
-/*
  * Definition of 16 byte TSS and LDT selectors.
  */
-union tss_64_descriptor {
-	uint64_t value;
-	struct {
-		union {
-			uint32_t value;
-			struct {
-				uint32_t limit_15_0:16;
-				uint32_t base_15_0:16;
-			} bits;
-		} low32;
-		union {
-			uint32_t value;
-			struct {
-				uint32_t base_23_16:8;
-				uint32_t type:4;
-				uint32_t bit12_clr:1;
-				uint32_t dpl:2;
-				uint32_t present:1;
-				uint32_t limit_19_16:4;
-				uint32_t rsvd_1:1;
-				uint32_t rsvd_2_clr:1;
-				uint32_t rsvd_3:1;
-				uint32_t granularity:1;
-				uint32_t base_31_24:8;
-			} bits;
-		} high32;
+struct tss_64_descriptor {
+		uint32_t low32_value;
+		uint32_t high32_value;
 		uint32_t base_addr_63_32;
-		union {
-			uint32_t value;
-			struct {
-				uint32_t rsvd_7_0:8;
-				uint32_t bits_12_8_clr:4;
-				uint32_t rsvd_31_13:20;
-			} bits;
-		} offset_12;
-	} fields;
+		uint32_t offset_12;
 } __aligned(8);
 
 /*****************************************************************************
@@ -233,9 +100,9 @@ union tss_64_descriptor {
 struct host_gdt {
 	uint64_t rsvd;
 
-	union code_segment_descriptor host_gdt_code_descriptor;
-	union data_segment_descriptor host_gdt_data_descriptor;
-	union tss_64_descriptor host_gdt_tss_descriptors;
+	uint64_t code_segment_descriptor;
+	uint64_t data_segment_descriptor;
+	struct tss_64_descriptor host_gdt_tss_descriptors;
 } __aligned(8);
 
 /*****************************************************************************


### PR DESCRIPTION
In the gdt.h, it defines unions and parameters which is not used
in hypervisor. Removed them to keep the gdt definition simple.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>