### PR TITLE
ptdev cleanup

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -426,7 +426,7 @@ void ptdev_softirq(__unused uint16_t cpu_id)
 			dev_dbg(ACRN_DBG_PTIRQ,
 				"dev-assign: irq=0x%x MSI VR: 0x%x-0x%x",
 				entry->allocated_pirq,
-			        msi->virt_vector,
+				msi->vmsi_data & 0xFFU,
 				irq_to_vector(entry->allocated_pirq));
 			dev_dbg(ACRN_DBG_PTIRQ,
 				" vmsi_addr: 0x%x vmsi_data: 0x%x",
@@ -527,15 +527,13 @@ int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
 	/* build physical config MSI, update to info->pmsi_xxx */
 	ptdev_build_physical_msi(vm, info, irq_to_vector(entry->allocated_pirq));
 	entry->msi = *info;
-	entry->msi.virt_vector = info->vmsi_data & 0xFFU;
-	entry->msi.phys_vector = irq_to_vector(entry->allocated_pirq);
 
 	dev_dbg(ACRN_DBG_IRQ,
 		"PCI %x:%x.%x MSI VR[%d] 0x%x->0x%x assigned to vm%d",
 		(virt_bdf >> 8) & 0xFFU, (virt_bdf >> 3) & 0x1FU,
 		(virt_bdf) & 0x7U, entry_nr,
-		entry->msi.virt_vector,
-		entry->msi.phys_vector,
+		info->vmsi_data & 0xFFU,
+		irq_to_vector(entry->allocated_pirq),
 		entry->vm->vm_id);
 END:
 	return 0;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -622,7 +622,7 @@ int32_t hcall_remap_pci_msix(struct vm *vm, uint16_t vmid, uint64_t param)
 	if (!is_vm0(vm)) {
 		ret = -1;
 	} else {
-		info.msix = remap.msix;
+		info.is_msix = remap.msix;
 		info.vmsi_ctl = remap.msi_ctl;
 		info.vmsi_addr = remap.msi_addr;
 		info.vmsi_data = remap.msi_data;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -623,13 +623,12 @@ int32_t hcall_remap_pci_msix(struct vm *vm, uint16_t vmid, uint64_t param)
 		ret = -1;
 	} else {
 		info.msix = remap.msix;
-		info.msix_entry_index = remap.msix_entry_index;
 		info.vmsi_ctl = remap.msi_ctl;
 		info.vmsi_addr = remap.msi_addr;
 		info.vmsi_data = remap.msi_data;
 
 		ret = ptdev_msix_remap(target_vm,
-				remap.virt_bdf, &info);
+			remap.virt_bdf, remap.msix_entry_index, &info);
 		remap.msi_data = info.pmsi_data;
 		remap.msi_addr = info.pmsi_addr;
 

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -14,11 +14,6 @@ static struct list_head softirq_dev_entry_list;
 struct list_head ptdev_list;
 spinlock_t ptdev_lock;
 
-/* invalid_entry for error return */
-struct ptdev_remapping_info invalid_entry = {
-	.type = PTDEV_INTR_INV,
-};
-
 /*
  * entry could both be in ptdev_list and softirq_dev_entry_list.
  * When release entry, we need make sure entry deleted from both
@@ -64,14 +59,14 @@ ptdev_dequeue_softirq(void)
 
 /* require ptdev_lock protect */
 struct ptdev_remapping_info *
-alloc_entry(struct vm *vm, enum ptdev_intr_type type)
+alloc_entry(struct vm *vm, uint32_t intr_type)
 {
 	struct ptdev_remapping_info *entry;
 
 	/* allocate */
 	entry = calloc(1U, sizeof(*entry));
 	ASSERT(entry != NULL, "alloc memory failed");
-	entry->type = type;
+	entry->intr_type = intr_type;
 	entry->vm = vm;
 
 	INIT_LIST_HEAD(&entry->softirq_node);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -397,12 +397,9 @@ vioapic_indirect_write(struct vioapic *vioapic, uint32_t addr, uint32_t data)
 		if (((new.full & IOAPIC_RTE_INTMASK) == 0UL) ||
 				((last.full & IOAPIC_RTE_INTMASK) == 0UL)) {
 			/* VM enable intr */
-			struct ptdev_intx_info intx;
-
 			/* NOTE: only support max 256 pin */
-			intx.virt_pin = (uint8_t)pin;
-			intx.vpin_src = PTDEV_VPIN_IOAPIC;
-			ptdev_intx_pin_remap(vioapic->vm, &intx);
+			ptdev_intx_pin_remap(vioapic->vm,
+					(uint8_t)pin, PTDEV_VPIN_IOAPIC);
 		}
 	}
 }

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -374,7 +374,7 @@ static int vpic_ocw1(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 		 * remap for deactive: when vIOAPIC take it over
 		 */
 		if (((i8259->mask & bit) == 0U) && ((old & bit) != 0U)) {
-			struct ptdev_intx_info intx;
+			uint8_t virt_pin;
 
 			/* master i8259 pin2 connect with slave i8259,
 			 * not device, so not need pt remap
@@ -383,12 +383,10 @@ static int vpic_ocw1(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 				continue;
 			}
 
-			intx.virt_pin = pin;
-			intx.vpin_src = PTDEV_VPIN_PIC;
-			if (!master_pic(vpic, i8259)) {
-				intx.virt_pin += 8U;
-			}
-			ptdev_intx_pin_remap(vpic->vm, &intx);
+			virt_pin = (master_pic(vpic, i8259)) ?
+					pin : (pin + 8U);
+			ptdev_intx_pin_remap(vpic->vm,
+					virt_pin, PTDEV_VPIN_PIC);
 		}
 	}
 

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -13,7 +13,8 @@ void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
 int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
 		struct ptdev_msi_info *info);
-int ptdev_intx_pin_remap(struct vm *vm, struct ptdev_intx_info *info);
+int ptdev_intx_pin_remap(struct vm *vm, uint8_t virt_pin,
+		enum ptdev_vpin_source vpin_src);
 int ptdev_add_intx_remapping(struct vm *vm, __unused uint16_t virt_bdf,
 	__unused uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin,
 	bool pic_pin);

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -12,7 +12,7 @@
 void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
 int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
-		struct ptdev_msi_info *info);
+		uint16_t entry_nr, struct ptdev_msi_info *info);
 int ptdev_intx_pin_remap(struct vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
 int ptdev_add_intx_remapping(struct vm *vm, __unused uint16_t virt_bdf,

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -44,7 +44,6 @@ struct ptdev_msi_info {
 	uint32_t pmsi_addr; /* phys msi_addr */
 	uint32_t pmsi_data; /* phys msi_data */
 	int msix;	/* 0-MSI, 1-MSIX */
-	uint32_t msix_entry_index; /* MSI: 0, MSIX: index of vector table*/
 	uint32_t virt_vector;
 	uint32_t phys_vector;
 };

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -43,9 +43,7 @@ struct ptdev_msi_info {
 	uint16_t vmsi_ctl; /* virt msi_ctl */
 	uint32_t pmsi_addr; /* phys msi_addr */
 	uint32_t pmsi_data; /* phys msi_data */
-	int msix;	/* 0-MSI, 1-MSIX */
-	uint32_t virt_vector;
-	uint32_t phys_vector;
+	int is_msix;	/* 0-MSI, 1-MSIX */
 };
 
 /* entry per each allocated irq/vector


### PR DESCRIPTION
Try to simplify the ptdev logic:
1. simplify the lookup method: use source id to identify the ptdev;
2. only check whether phys_pin is valid in add_intx_remapping
3. remove unnecessary variable from structure ptdev_msi_info