### PR TITLE
hv: fix MISRA-C issues related to space or newline

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -255,7 +255,7 @@ int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa,
 	if (pm == PAGING_MODE_4_LEVEL) {
 		pw_info.width = 9U;
 		ret = local_gva2gpa_common(vcpu, &pw_info, gva, gpa, err_code);
-	} else if(pm == PAGING_MODE_3_LEVEL) {
+	} else if (pm == PAGING_MODE_3_LEVEL) {
 		pw_info.width = 9U;
 		ret = local_gva2gpa_pae(vcpu, &pw_info, gva, gpa, err_code);
 	} else if (pm == PAGING_MODE_2_LEVEL) {

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -327,7 +327,7 @@ static uint8_t dmar_uint_get_msagw(struct dmar_drhd_rt *dmar_uint)
 	uint8_t i;
 	uint8_t sgaw = iommu_cap_sagaw(dmar_uint->cap);
 
-	for (i = 5U; i > 0U;) {
+	for (i = 5U; i > 0U; ) {
 		i--;
 		if (((1U << i) & sgaw) != 0U) {
 			break;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -536,13 +536,17 @@ static int shell_list_vm(__unused int argc, __unused char **argv)
 		vm = list_entry(pos, struct vm, list);
 		switch (vm->state) {
 		case VM_CREATED:
-			(void)strcpy_s(state, 32, "Created"); break;
+			(void)strcpy_s(state, 32, "Created");
+			break;
 		case VM_STARTED:
-			(void)strcpy_s(state, 32, "Started"); break;
+			(void)strcpy_s(state, 32, "Started");
+			break;
 		case VM_PAUSED:
-			(void)strcpy_s(state, 32, "Paused"); break;
+			(void)strcpy_s(state, 32, "Paused");
+			break;
 		default:
-			(void)strcpy_s(state, 32, "Unknown"); break;
+			(void)strcpy_s(state, 32, "Unknown");
+			break;
 		}
 		/* Create output string consisting of VM name and VM id
 		 */
@@ -577,13 +581,17 @@ static int shell_list_vcpu(__unused int argc, __unused char **argv)
 		foreach_vcpu(i, vm, vcpu) {
 			switch (vcpu->state) {
 			case VCPU_INIT:
-				(void)strcpy_s(state, 32, "Init"); break;
+				(void)strcpy_s(state, 32, "Init");
+				break;
 			case VCPU_PAUSED:
-				(void)strcpy_s(state, 32, "Paused"); break;
+				(void)strcpy_s(state, 32, "Paused");
+				break;
 			case VCPU_RUNNING:
-				(void)strcpy_s(state, 32, "Running"); break;
+				(void)strcpy_s(state, 32, "Running");
+				break;
 			case VCPU_ZOMBIE:
-				(void)strcpy_s(state, 32, "Zombie"); break;
+				(void)strcpy_s(state, 32, "Zombie");
+				break;
 			default:
 				(void)strcpy_s(state, 32, "Unknown");
 			}


### PR DESCRIPTION
This patch fixes the following issues:
- No newline after semi colon.
- No space after semi colon in for expression.
- No space between if, while, for and expresn.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>