### PR TITLE
DM USB: xHCI: fix a potential issue of crash

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -593,7 +593,7 @@ pci_xhci_native_usb_dev_disconn_cb(void *hci_data, void *dev_data)
 		if (xdev->slots[slot] == edev)
 			break;
 
-	assert(slot < USB_NATIVE_NUM_BUS);
+	assert(slot < XHCI_MAX_SLOTS);
 
 	status = VPORT_STATE(xdev->port_map_tbl[di.bus][di.port]);
 	assert(status == VPORT_EMULATED || status == VPORT_CONNECTED);


### PR DESCRIPTION
This patch is used to fix a potential issue resulted from typo.

Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>