### PR TITLE
Mmu: cleanup mmu.h

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -227,6 +227,11 @@ static int hardware_detect_support(void)
 		return -ENODEV;
 	}
 
+	if (!cpu_has_cap(X86_FEATURE_PAGE1GB)) {
+		pr_fatal("%s, not support 1GB page\n", __func__);
+		return -ENODEV;
+	}
+
 	if (!cpu_has_cap(X86_FEATURE_VMX)) {
 		pr_fatal("%s, vmx not supported\n", __func__);
 		return -ENODEV;

--- a/hypervisor/arch/x86/cpu_primary.S
+++ b/hypervisor/arch/x86/cpu_primary.S
@@ -225,14 +225,14 @@ cpu_primary32_gdt_ptr:
     .align  0x1000
     .global cpu_boot32_page_tables_start
 cpu_boot32_page_tables_start:
-    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    /* 0x3 = (PAGE_PRESENT | PAGE_RW) */
     .quad   cpu_primary32_pdpt_addr + 0x3
     /*0x1000 = CPU_PAGE_SIZE*/
     .align  0x1000
 cpu_primary32_pdpt_addr:
     address = 0
     .rept   4
-    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    /* 0x3 = (PAGE_PRESENT | PAGE_RW) */
     .quad   cpu_primary32_pdt_addr + address + 0x3
     /*0x1000 = CPU_PAGE_SIZE*/
     address = address + 0x1000
@@ -242,7 +242,7 @@ cpu_primary32_pdpt_addr:
 cpu_primary32_pdt_addr:
     address = 0
     .rept  2048
-    /* 0x83 = (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    /* 0x83 = (PAGE_PSE | PAGE_PRESENT | PAGE_RW) */
     .quad  address + 0x83
     address = address + 0x200000
     .endr

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -27,7 +27,7 @@ static uint64_t find_next_table(uint32_t table_offset, const void *table_base)
 	}
 
 	/* Set table present bits to any of the read/write/execute bits */
-	table_present = (IA32E_EPT_R_BIT | IA32E_EPT_W_BIT | IA32E_EPT_X_BIT);
+	table_present = EPT_RWX;
 
 	/* Determine if a valid entry exists */
 	if ((table_entry & table_present) == 0UL) {
@@ -274,8 +274,8 @@ int ept_mr_add(const struct vm *vm, uint64_t *pml4_page,
 	 * to force snooping of PCIe devices if the page
 	 * is cachable
 	 */
-	if ((prot & IA32E_EPT_MT_MASK) != IA32E_EPT_UNCACHED) {
-		prot |= IA32E_EPT_SNOOP_CTRL;
+	if ((prot & EPT_MT_MASK) != EPT_UNCACHED) {
+		prot |= EPT_SNOOP_CTRL;
 	}
 
 	ret = mmu_add(pml4_page, hpa, gpa, size, prot, PTT_EPT);

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -126,12 +126,12 @@ static int local_gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_inf
 		}
 
 		/* check if the entry present */
-		if ((entry & MMU_32BIT_PDE_P) == 0U) {
+		if ((entry & PAGE_PRESENT) == 0U) {
 			ret = -EFAULT;
 			goto out;
 		}
 		/* check for R/W */
-		if (pw_info->is_write_access && ((entry & MMU_32BIT_PDE_RW) == 0U)) {
+		if (pw_info->is_write_access && ((entry & PAGE_RW) == 0U)) {
 			/* Case1: Supermode and wp is 1
 			 * Case2: Usermode */
 			if (pw_info->is_user_mode || pw_info->wp) {
@@ -141,16 +141,16 @@ static int local_gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_inf
 		/* check for nx, since for 32-bit paing, the XD bit is
 		 * reserved(0), use the same logic as PAE/4-level paging */
 		if (pw_info->is_inst_fetch && pw_info->nxe &&
-		    ((entry & MMU_MEM_ATTR_BIT_EXECUTE_DISABLE) != 0U)) {
+		    ((entry & PAGE_NX) != 0U)) {
 			fault = 1;
 		}
 
 		/* check for U/S */
-		if (((entry & MMU_32BIT_PDE_US) == 0U) && pw_info->is_user_mode) {
+		if (((entry & PAGE_USER) == 0U) && pw_info->is_user_mode) {
 			fault = 1;
 		}
 
-		if (pw_info->pse && ((i > 0U) && ((entry & MMU_32BIT_PDE_PS) != 0U))) {
+		if (pw_info->pse && ((i > 0U) && ((entry & PAGE_PSE) != 0U))) {
 			break;
 		}
 		addr = entry;
@@ -189,7 +189,7 @@ static int local_gva2gpa_pae(struct vcpu *vcpu, struct page_walk_info *pw_info,
 	index = (gva >> 30) & 0x3UL;
 	entry = base[index];
 
-	if ((entry & MMU_32BIT_PDE_P) == 0U) {
+	if ((entry & PAGE_PRESENT) == 0U) {
 		ret = -EFAULT;
 		goto out;
 	}

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -244,7 +244,7 @@ void init_paging(void)
 	/* Map all memory regions to UC attribute */
 	mmu_add((uint64_t *)mmu_pml4_addr, e820_mem.mem_bottom,
 		e820_mem.mem_bottom, e820_mem.mem_top - e820_mem.mem_bottom,
-		attr_uc, PTT_HOST);
+		attr_uc, PTT_PRIMARY);
 
 	/* Modify WB attribute for E820_TYPE_RAM */
 	for (i = 0U; i < e820_entries; i++) {
@@ -253,7 +253,7 @@ void init_paging(void)
 			mmu_modify_or_del((uint64_t *)mmu_pml4_addr,
 					entry->baseaddr, entry->length,
 					PAGE_CACHE_WB, PAGE_CACHE_MASK,
-					PTT_HOST, MR_MODIFY);
+					PTT_PRIMARY, MR_MODIFY);
 		}
 	}
 
@@ -263,7 +263,7 @@ void init_paging(void)
 	hv_hpa = get_hv_image_base();
 	mmu_modify_or_del((uint64_t *)mmu_pml4_addr, hv_hpa, CONFIG_RAM_SIZE,
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER,
-			PTT_HOST, MR_MODIFY);
+			PTT_PRIMARY, MR_MODIFY);
 
 	/* Enable paging */
 	enable_paging(HVA2HPA(mmu_pml4_addr));

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -131,6 +131,11 @@ int check_vmx_mmu_cap(void)
 		return -ENODEV;
 	}
 
+	if (!cpu_has_vmx_ept_cap(VMX_EPT_1GB_PAGE)) {
+		pr_fatal("%s, ept not support 1GB large page\n", __func__);
+		return -ENODEV;
+	}
+
 	return 0;
 }
 
@@ -185,18 +190,6 @@ void invept(struct vcpu *vcpu)
 	} else {
 		/* Neither type of INVEPT is supported. Skip. */
 	}
-}
-
-bool check_mmu_1gb_support(enum _page_table_type page_table_type)
-{
-	bool status = false;
-
-	if (page_table_type == PTT_EPT) {
-		status = cpu_has_vmx_ept_cap(VMX_EPT_1GB_PAGE);
-	} else {
-		status = cpu_has_cap(X86_FEATURE_PAGE1GB);
-	}
-	return status;
 }
 
 uint64_t get_paging_pml4(void)

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -129,24 +129,24 @@ static uint32_t update_ept(struct vm *vm, uint64_t start,
 
 	switch ((uint64_t)type) {
 	case MTRR_MEM_TYPE_WC:
-		attr = IA32E_EPT_WC;
+		attr = EPT_WC;
 		break;
 	case MTRR_MEM_TYPE_WT:
-		attr = IA32E_EPT_WT;
+		attr = EPT_WT;
 		break;
 	case MTRR_MEM_TYPE_WP:
-		attr = IA32E_EPT_WP;
+		attr = EPT_WP;
 		break;
 	case MTRR_MEM_TYPE_WB:
-		attr = IA32E_EPT_WB;
+		attr = EPT_WB;
 		break;
 	case MTRR_MEM_TYPE_UC:
 	default:
-		attr = IA32E_EPT_UNCACHED;
+		attr = EPT_UNCACHED;
 	}
 
 	ept_mr_modify(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
-			start, size, attr, IA32E_EPT_MT_MASK);
+			start, size, attr, EPT_MT_MASK);
 	return attr;
 }
 

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -48,7 +48,7 @@ static int split_large_page(uint64_t *pte,
 		paddr += paddrinc;
 	}
 
-	ref_prot = (ptt == PTT_HOST) ? PAGE_TABLE : EPT_RWX;
+	ref_prot = (ptt == PTT_PRIMARY) ? PAGE_TABLE : EPT_RWX;
 	set_pgentry(pte, HVA2HPA((void *)pbase) | ref_prot);
 
 	/* TODO: flush the TLB */
@@ -80,7 +80,7 @@ static inline int construct_pgentry(enum _page_table_type ptt, uint64_t *pde)
 		return -ENOMEM;
 	}
 
-	prot = (ptt == PTT_HOST) ? PAGE_TABLE: EPT_RWX;
+	prot = (ptt == PTT_PRIMARY) ? PAGE_TABLE: EPT_RWX;
 	set_pgentry(pde, HVA2HPA(pd_page) | prot);
 	return 0;
 }

--- a/hypervisor/arch/x86/trampoline.S
+++ b/hypervisor/arch/x86/trampoline.S
@@ -203,7 +203,7 @@ CPU_Boot_Page_Tables_ptr:
     .align  0x1000
     .global CPU_Boot_Page_Tables_Start
 CPU_Boot_Page_Tables_Start:
-    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    /* 0x3 = (PAGE_PRESENT | PAGE_RW) */
     .quad   trampoline_pdpt_addr + 0x3
     /*0x1000 = CPU_PAGE_SIZE*/
     .align  0x1000
@@ -211,7 +211,7 @@ CPU_Boot_Page_Tables_Start:
 trampoline_pdpt_addr:
     address = 0
     .rept   4
-    /* 0x3 = (IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    /* 0x3 = (PAGE_PRESENT | PAGE_RW) */
     .quad   trampoline_pdt_addr + address + 0x3
     /*0x1000 = CPU_PAGE_SIZE*/
     address = address + 0x1000
@@ -221,7 +221,7 @@ trampoline_pdpt_addr:
 trampoline_pdt_addr:
     address = 0
     .rept  2048
-    /* 0x83 = (IA32E_PDPTE_PS_BIT | IA32E_COMM_P_BIT | IA32E_COMM_RW_BIT) */
+    /* 0x83 = (PAGE_PSE | PAGE_PRESENT | PAGE_RW) */
     .quad  address + 0x83
     address = address + 0x200000
     .endr

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -181,8 +181,8 @@ void  destroy_secure_world(struct vm *vm, bool need_clr_mem)
 		(void *)pml4e_page_vaddr(*(uint64_t *)vm->arch_vm.sworld_eptp);
 		/* memset PDPTEs except trusty memory */
 		(void)memset(pdpt_addr, 0UL,
-			NON_TRUSTY_PDPT_ENTRIES * IA32E_COMM_ENTRY_SIZE);
-		free_ept_mem(vm->arch_vm.sworld_eptp);
+			NON_TRUSTY_PDPT_ENTRIES * sizeof(uint64_t));
+		free_ept_mem((uint64_t *)vm->arch_vm.sworld_eptp);
 		vm->arch_vm.sworld_eptp = NULL;
 	} else {
 		pr_err("sworld eptp is NULL");

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -119,7 +119,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	for (i = 0U; i < IA32E_NUM_ENTRIES - 1; i++) {
 		pdpte = mem_read64(src_pdpte_p);
 		if ((pdpte & table_present) != 0UL) {
-			pdpte &= ~IA32E_EPT_X_BIT;
+			pdpte &= ~EPT_EXE;
 			mem_write64(dest_pdpte_p, pdpte);
 		}
 		src_pdpte_p++;

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -195,7 +195,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 		 * reserving. Current strategy is "total_mem_size in Giga -
 		 * remained 1G pages" for reserving.
 		 */
-		if (is_vm0(vm) && check_mmu_1gb_support(PTT_HOST)) {
+		if (is_vm0(vm) && check_mmu_1gb_support(PTT_PRIMARY)) {
 			int32_t reserving_1g_pages;
 
 #ifdef CONFIG_REMAIN_1G_PAGES

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -195,7 +195,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 		 * reserving. Current strategy is "total_mem_size in Giga -
 		 * remained 1G pages" for reserving.
 		 */
-		if (is_vm0(vm) && check_mmu_1gb_support(PTT_PRIMARY)) {
+		if (is_vm0(vm)) {
 			int32_t reserving_1g_pages;
 
 #ifdef CONFIG_REMAIN_1G_PAGES

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -40,7 +40,6 @@
 #define CACHE_LINE_SIZE		64U
 
 /* IA32E Paging constants */
-#define IA32E_NUM_ENTRIES	512U
 #define IA32E_REF_MASK		\
 		(boot_cpu_data.physical_address_mask)
 
@@ -65,51 +64,6 @@ enum _page_table_level {
 #define PAGE_SIZE_4K	MEM_4K
 #define PAGE_SIZE_2M	MEM_2M
 #define PAGE_SIZE_1G	MEM_1G
-
-/* Inline functions for reading/writing memory */
-static inline uint8_t mem_read8(const void *addr)
-{
-	return *(volatile uint8_t *)(addr);
-}
-
-static inline uint16_t mem_read16(const void *addr)
-{
-	return *(volatile uint16_t *)(addr);
-}
-
-static inline uint32_t mem_read32(const void *addr)
-{
-	return *(volatile uint32_t *)(addr);
-}
-
-static inline uint64_t mem_read64(const void *addr)
-{
-	return *(volatile uint64_t *)(addr);
-}
-
-static inline void mem_write8(const void *addr, uint8_t data)
-{
-	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
-	*addr8 = data;
-}
-
-static inline void mem_write16(void *addr, uint16_t data)
-{
-	volatile uint16_t *addr16 = (volatile uint16_t *)addr;
-	*addr16 = data;
-}
-
-static inline void mem_write32(void *addr, uint32_t data)
-{
-	volatile uint32_t *addr32 = (volatile uint32_t *)addr;
-	*addr32 = data;
-}
-
-static inline void mem_write64(void *addr, uint64_t data)
-{
-	volatile uint64_t *addr64 = (volatile uint64_t *)addr;
-	*addr64 = data;
-}
 
 uint64_t get_paging_pml4(void);
 void *alloc_paging_struct(void);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -287,7 +287,6 @@ static inline void mem_write64(void *addr, uint64_t data)
 }
 
 uint64_t get_paging_pml4(void);
-bool check_mmu_1gb_support(enum _page_table_type page_table_type);
 void *alloc_paging_struct(void);
 void free_paging_struct(void *ptr);
 void enable_paging(uint64_t pml4_base_addr);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -7,27 +7,6 @@
 #ifndef MMU_H
 #define MMU_H
 
-/* Size of all page-table entries (in bytes) */
-#define     IA32E_COMM_ENTRY_SIZE           8U
-
-/* Definitions exclusive to a Page Directory Pointer Table Entry (PDPTE) */
-#define     IA32E_PDPTE_D_BIT               0x0000000000000040UL
-#define     IA32E_PDPTE_PS_BIT              0x0000000000000080UL
-#define     IA32E_PDPTE_PAT_BIT             0x0000000000001000UL
-#define     IA32E_PDPTE_ADDR_MASK           0x0000FFFFC0000000UL
-
-/* Definitions exclusive to a Page Directory Entry (PDE) 1G or 2M */
-#define     IA32E_PDE_D_BIT                 0x0000000000000040UL
-#define     IA32E_PDE_PS_BIT                0x0000000000000080UL
-#define     IA32E_PDE_PAT_BIT               0x0000000000001000UL
-#define     IA32E_PDE_ADDR_MASK             0x0000FFFFFFE00000UL
-
-/* Definitions exclusive to Page Table Entries (PTE) */
-#define     IA32E_PTE_D_BIT                 0x0000000000000040UL
-#define     IA32E_PTE_PAT_BIT               0x0000000000000080UL
-#define     IA32E_PTE_G_BIT                 0x0000000000000100UL
-#define     IA32E_PTE_ADDR_MASK             0x0000FFFFFFFFF000UL
-
 /** The flag that indicates that the page fault was caused by a non present
  * page.
  */
@@ -211,7 +190,7 @@ int ept_mr_modify(const struct vm *vm, uint64_t *pml4_page,
 	uint64_t prot_set, uint64_t prot_clr);
 int ept_mr_del(const struct vm *vm, uint64_t *pml4_page,
 	uint64_t gpa, uint64_t size);
-void free_ept_mem(void *pml4_addr);
+void free_ept_mem(uint64_t *pml4_page);
 int     ept_violation_vmexit_handler(struct vcpu *vcpu);
 int     ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -10,214 +10,68 @@
 /* Size of all page-table entries (in bytes) */
 #define     IA32E_COMM_ENTRY_SIZE           8U
 
-/* Definitions common for all IA-32e related paging entries */
-#define     IA32E_COMM_P_BIT                0x0000000000000001UL
-#define     IA32E_COMM_RW_BIT               0x0000000000000002UL
-#define     IA32E_COMM_US_BIT               0x0000000000000004UL
-#define     IA32E_COMM_PWT_BIT              0x0000000000000008UL
-#define     IA32E_COMM_PCD_BIT              0x0000000000000010UL
-#define     IA32E_COMM_A_BIT                0x0000000000000020UL
-#define     IA32E_COMM_XD_BIT               0x8000000000000000UL
-
-/* Defines for EPT paging entries */
-#define     IA32E_EPT_R_BIT                 0x0000000000000001UL
-#define     IA32E_EPT_W_BIT                 0x0000000000000002UL
-#define     IA32E_EPT_X_BIT                 0x0000000000000004UL
-#define     IA32E_EPT_UNCACHED              (0UL<<3)
-#define     IA32E_EPT_WC                    (1UL<<3)
-#define     IA32E_EPT_WT                    (4UL<<3)
-#define     IA32E_EPT_WP                    (5UL<<3)
-#define     IA32E_EPT_WB                    (6UL<<3)
-#define     IA32E_EPT_MT_MASK               (7UL<<3)
-#define     IA32E_EPT_PAT_IGNORE            0x0000000000000040UL
-#define     IA32E_EPT_ACCESS_FLAG           0x0000000000000100UL
-#define     IA32E_EPT_DIRTY_FLAG            0x0000000000000200UL
-#define     IA32E_EPT_SNOOP_CTRL            0x0000000000000800UL
-#define     IA32E_EPT_SUPPRESS_VE           0x8000000000000000UL
-
-/* Definitions common or ignored for all IA-32e related paging entries */
-#define     IA32E_COMM_D_BIT                0x0000000000000040UL
-#define     IA32E_COMM_G_BIT                0x0000000000000100UL
-
-/* Definitions exclusive to a Page Map Level 4 Entry (PML4E) */
-#define     IA32E_PML4E_INDEX_MASK_START    39
-#define     IA32E_PML4E_ADDR_MASK           0x0000FF8000000000UL
-
 /* Definitions exclusive to a Page Directory Pointer Table Entry (PDPTE) */
 #define     IA32E_PDPTE_D_BIT               0x0000000000000040UL
 #define     IA32E_PDPTE_PS_BIT              0x0000000000000080UL
 #define     IA32E_PDPTE_PAT_BIT             0x0000000000001000UL
 #define     IA32E_PDPTE_ADDR_MASK           0x0000FFFFC0000000UL
-#define     IA32E_PDPTE_INDEX_MASK_START  \
-		(IA32E_PML4E_INDEX_MASK_START - IA32E_INDEX_MASK_BITS)
 
 /* Definitions exclusive to a Page Directory Entry (PDE) 1G or 2M */
 #define     IA32E_PDE_D_BIT                 0x0000000000000040UL
 #define     IA32E_PDE_PS_BIT                0x0000000000000080UL
 #define     IA32E_PDE_PAT_BIT               0x0000000000001000UL
 #define     IA32E_PDE_ADDR_MASK             0x0000FFFFFFE00000UL
-#define     IA32E_PDE_INDEX_MASK_START    \
-		(IA32E_PDPTE_INDEX_MASK_START - IA32E_INDEX_MASK_BITS)
 
 /* Definitions exclusive to Page Table Entries (PTE) */
 #define     IA32E_PTE_D_BIT                 0x0000000000000040UL
 #define     IA32E_PTE_PAT_BIT               0x0000000000000080UL
 #define     IA32E_PTE_G_BIT                 0x0000000000000100UL
 #define     IA32E_PTE_ADDR_MASK             0x0000FFFFFFFFF000UL
-#define     IA32E_PTE_INDEX_MASK_START    \
-		(IA32E_PDE_INDEX_MASK_START - IA32E_INDEX_MASK_BITS)
 
-/** The 'Present' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_P       0x00000001U
-/** The 'Read/Write' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_RW      0x00000002U
-/** The 'User/Supervisor' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_US      0x00000004U
-/** The 'Page Write Through' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_PWT     0x00000008U
-/** The 'Page Cache Disable' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_PCD     0x00000010U
-/** The 'Accessed' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_A       0x00000020U
-/** The 'Dirty' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_D       0x00000040U
-/** The 'Page Size' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_PS      0x00000080U
-/** The 'Global' bit in a 32 bit paging page directory entry */
-#define MMU_32BIT_PDE_G       0x00000100U
-/** The 'PAT' bit in a page 32 bit paging directory entry */
-#define MMU_32BIT_PDE_PAT     0x00001000U
 /** The flag that indicates that the page fault was caused by a non present
  * page.
  */
-#define PAGE_FAULT_P_FLAG    0x00000001U
+#define PAGE_FAULT_P_FLAG	0x00000001U
 /** The flag that indicates that the page fault was caused by a write access. */
-#define PAGE_FAULT_WR_FLAG   0x00000002U
+#define PAGE_FAULT_WR_FLAG	0x00000002U
 /** The flag that indicates that the page fault was caused in user mode. */
-#define PAGE_FAULT_US_FLAG   0x00000004U
+#define PAGE_FAULT_US_FLAG	0x00000004U
 /** The flag that indicates that the page fault was caused by a reserved bit
  * violation.
  */
-#define PAGE_FAULT_RSVD_FLAG 0x00000008U
+#define PAGE_FAULT_RSVD_FLAG	0x00000008U
 /** The flag that indicates that the page fault was caused by an instruction
  * fetch.
  */
-#define PAGE_FAULT_ID_FLAG   0x00000010U
+#define PAGE_FAULT_ID_FLAG	0x00000010U
 
 /* Defines used for common memory sizes */
-#define             MEM_1K                   1024U
-#define             MEM_2K                  (MEM_1K * 2U)
-#define             MEM_4K                  (MEM_1K * 4U)
-#define             MEM_8K                  (MEM_1K * 8U)
-#define             MEM_16K                 (MEM_1K * 16U)
-#define             MEM_32K                 (MEM_1K * 32U)
-#define             MEM_64K                 (MEM_1K * 64U)
-#define             MEM_128K                (MEM_1K * 128U)
-#define             MEM_256K                (MEM_1K * 256U)
-#define             MEM_512K                (MEM_1K * 512U)
-#define             MEM_1M                  (MEM_1K * 1024U)
-#define             MEM_2M                  (MEM_1M * 2U)
-#define             MEM_4M                  (MEM_1M * 4U)
-#define             MEM_8M                  (MEM_1M * 8U)
-#define             MEM_16M                 (MEM_1M * 16U)
-#define             MEM_32M                 (MEM_1M * 32U)
-#define             MEM_64M                 (MEM_1M * 64U)
-#define             MEM_128M                (MEM_1M * 128U)
-#define             MEM_256M                (MEM_1M * 256U)
-#define             MEM_512M                (MEM_1M * 512U)
-#define             MEM_1G                  (MEM_1M * 1024U)
-#define             MEM_2G                  (MEM_1G * 2U)
-#define             MEM_3G                  (MEM_1G * 3U)
-#define             MEM_4G                  (MEM_1G * 4U)
-#define             MEM_5G                  (MEM_1G * 5U)
-#define             MEM_6G                  (MEM_1G * 6U)
+#define MEM_1K		1024U
+#define MEM_2K		(MEM_1K * 2U)
+#define MEM_4K		(MEM_1K * 4U)
+#define MEM_1M		(MEM_1K * 1024U)
+#define MEM_2M		(MEM_1M * 2U)
+#define MEM_1G		(MEM_1M * 1024U)
 
 #ifndef ASSEMBLER
 
 #include <cpu.h>
 
 /* Define cache line size (in bytes) */
-#define     CACHE_LINE_SIZE                 64U
-
-/* Size of all page structures for IA-32e */
-#define     IA32E_STRUCT_SIZE               MEM_4K
+#define CACHE_LINE_SIZE		64U
 
 /* IA32E Paging constants */
-#define     IA32E_INDEX_MASK_BITS           9
-#define     IA32E_NUM_ENTRIES               512U
-#define     IA32E_INDEX_MASK                (uint64_t)(IA32E_NUM_ENTRIES - 1U)
-#define     IA32E_REF_MASK			\
+#define IA32E_NUM_ENTRIES	512U
+#define IA32E_REF_MASK		\
 		(boot_cpu_data.physical_address_mask)
-#define     IA32E_FIRST_BLOCK_INDEX         1
 
-/* Macro to get PML4 index given an address */
-#define     IA32E_PML4E_INDEX_CALC(address)                 \
-	(uint32_t)((((uint64_t)address >> IA32E_PML4E_INDEX_MASK_START) & \
-		IA32E_INDEX_MASK) * sizeof(uint64_t))
-
-/* Macro to get PDPT index given an address */
-#define     IA32E_PDPTE_INDEX_CALC(address)                 \
-	(uint32_t)((((uint64_t)address >> IA32E_PDPTE_INDEX_MASK_START) & \
-		IA32E_INDEX_MASK) * sizeof(uint64_t))
-
-/* Macro to get PD index given an address */
-#define     IA32E_PDE_INDEX_CALC(address)                   \
-	(uint32_t)((((uint64_t)address >> IA32E_PDE_INDEX_MASK_START) & \
-		IA32E_INDEX_MASK) * sizeof(uint64_t))
-
-/* Macro to get PT index given an address */
-#define     IA32E_PTE_INDEX_CALC(address)                   \
-	(uint32_t)((((uint64_t)address >> IA32E_PTE_INDEX_MASK_START) & \
-		IA32E_INDEX_MASK) * sizeof(uint64_t))
-
-/* Macro to obtain a 2 MB page offset from given linear address */
-#define     IA32E_GET_2MB_PG_OFFSET(address)                \
-		(address & 0x001FFFFF)
-
-/* Macro to obtain a 4KB page offset from given linear address */
-#define     IA32E_GET_4KB_PG_OFFSET(address)                \
-		(address & 0x00000FFF)
-
-/*
- * The following generic attributes MMU_MEM_ATTR_FLAG_xxx may be OR'd with one
- * and only one of the MMU_MEM_ATTR_TYPE_xxx definitions
- */
-
-/* Definitions for memory types related to x64 */
-#define     MMU_MEM_ATTR_BIT_READ_WRITE         IA32E_COMM_RW_BIT
-#define     MMU_MEM_ATTR_BIT_USER_ACCESSIBLE    IA32E_COMM_US_BIT
-#define     MMU_MEM_ATTR_BIT_EXECUTE_DISABLE    IA32E_COMM_XD_BIT
-
-/* Selection of Page Attribute Table (PAT) entries with PAT, PCD and PWT
- * encoding. See also pat.h
- */
-/* Selects PAT0 WB  */
-#define     MMU_MEM_ATTR_TYPE_CACHED_WB       (0x0000000000000000UL)
-/* Selects PAT1 WT  */
-#define     MMU_MEM_ATTR_TYPE_CACHED_WT       (IA32E_COMM_PWT_BIT)
-/* Selects PAT2 UCM */
-#define     MMU_MEM_ATTR_TYPE_UNCACHED_MINUS  (IA32E_COMM_PCD_BIT)
-/* Selects PAT3 UC  */
-#define     MMU_MEM_ATTR_TYPE_UNCACHED        \
-		(IA32E_COMM_PCD_BIT | IA32E_COMM_PWT_BIT)
-/* Selects PAT6 WC  */
-#define     MMU_MEM_ATTR_TYPE_WRITE_COMBINED  \
-		(IA32E_PDPTE_PAT_BIT | IA32E_COMM_PCD_BIT)
-/* Selects PAT7 WP  */
-#define     MMU_MEM_ATTR_TYPE_WRITE_PROTECTED \
-		(IA32E_PDPTE_PAT_BIT | IA32E_COMM_PCD_BIT | IA32E_COMM_PWT_BIT)
-/* memory type bits mask */
-#define     MMU_MEM_ATTR_TYPE_MASK \
-		(IA32E_PDPTE_PAT_BIT | IA32E_COMM_PCD_BIT | IA32E_COMM_PWT_BIT)
-
-#define ROUND_PAGE_UP(addr)  \
+#define ROUND_PAGE_UP(addr)	\
 		((((addr) + (uint64_t)CPU_PAGE_SIZE) - 1UL) & CPU_PAGE_MASK)
 #define ROUND_PAGE_DOWN(addr) ((addr) & CPU_PAGE_MASK)
 
 enum _page_table_type {
-	PTT_PRIMARY = 0,  /* Mapping for hypervisor */
+	PTT_PRIMARY = 0,	/* Mapping for hypervisor */
 	PTT_EPT = 1,
-	PAGETABLE_TYPE_UNKNOWN,
 };
 
 /* Represent the 4 levels of translation tables in IA-32e paging mode */
@@ -226,14 +80,6 @@ enum _page_table_level {
 	IA32E_PDPT = 1,
 	IA32E_PD = 2,
 	IA32E_PT = 3,
-	IA32E_UNKNOWN,
-};
-
-/* Page table entry present */
-enum _page_table_present {
-	PT_NOT_PRESENT = 0,
-	PT_PRESENT = 1,
-	PT_MISCFG_PRESENT = 2,
 };
 
 /* Page size */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -215,7 +215,7 @@
 #define ROUND_PAGE_DOWN(addr) ((addr) & CPU_PAGE_MASK)
 
 enum _page_table_type {
-	PTT_HOST = 0,  /* Mapping for hypervisor */
+	PTT_PRIMARY = 0,  /* Mapping for hypervisor */
 	PTT_EPT = 1,
 	PAGETABLE_TYPE_UNKNOWN,
 };

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -96,7 +96,7 @@ static inline uint64_t pdpte_large(uint64_t pdpte)
 
 static inline uint64_t pgentry_present(enum _page_table_type ptt, uint64_t pte)
 {
-	return (ptt == PTT_HOST) ? (pte & PAGE_PRESENT) : (pte & EPT_RWX);
+	return (ptt == PTT_PRIMARY) ? (pte & PAGE_PRESENT) : (pte & EPT_RWX);
 }
 
 #endif /* PGTABLE_H */

--- a/hypervisor/include/arch/x86/pgtable_types.h
+++ b/hypervisor/include/arch/x86/pgtable_types.h
@@ -38,6 +38,7 @@
 #define EPT_WP			(5UL << EPT_MT_SHIFT)
 #define EPT_WB			(6UL << EPT_MT_SHIFT)
 #define EPT_MT_MASK		(7UL << EPT_MT_SHIFT)
+/* VTD: Second-Level Paging Entries: Snoop Control */
 #define EPT_SNOOP_CTRL		(1UL << 11U)
 #define EPT_VE			(1UL << 63U)
 


### PR DESCRIPTION
Since we reshuffle mmu code, there're many MACRO or structure we don't use 
any more in mmu.h. This serial try to remove them and replace the outdated
with the new one.