### PR TITLE
hv: Leave interrupts disabled during vmexit - ACRN partition mode

### DIFF
--- a/hypervisor/arch/x86/idt.S
+++ b/hypervisor/arch/x86/idt.S
@@ -389,11 +389,7 @@ external_interrupt_save_frame:
     /* Put current stack pointer into 1st param register (rdi) */
     movq    %rsp, %rdi
 
-#ifdef CONFIG_PARTITION_MODE
-    call   partition_mode_dispatch_interrupt
-#else
     call   dispatch_interrupt
-#endif
 
     /*
      * We disable softirq path from interrupt IRET, since right now all IRQ

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -369,17 +369,25 @@ void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 			"a" (msrl), "d" (msrh));            \
 }
 
+#ifdef CONFIG_PARTITION_MODE
+#define CPU_IRQ_DISABLE()
+#else
 /* Disables interrupts on the current CPU */
 #define CPU_IRQ_DISABLE()                                   \
 {                                                           \
 	asm volatile ("cli\n" : : : "cc");                  \
 }
+#endif
 
+#ifdef CONFIG_PARTITION_MODE
+#define CPU_IRQ_ENABLE()
+#else
 /* Enables interrupts on the current CPU */
 #define CPU_IRQ_ENABLE()                                    \
 {                                                           \
 	asm volatile ("sti\n" : : : "cc");                  \
 }
+#endif
 
 /* This macro writes the stack pointer. */
 #define CPU_SP_WRITE(stack_ptr)                             \


### PR DESCRIPTION
Since vmexit handling in ACRN partition mode is not complex (since no SOS and
all devices passthru), interrupts can stay disabled in root mode during
vmexit handling.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>