### PR TITLE
hv: Device MSIs in partition mode ACRN

### DIFF
--- a/hypervisor/arch/x86/guest/mptable.c
+++ b/hypervisor/arch/x86/guest/mptable.c
@@ -170,7 +170,7 @@ struct mptable_info mptable_vm1 = {
 				},
 				{
 					.type = MPCT_ENTRY_PROCESSOR,
-					.apic_id = 1U,
+					.apic_id = 4U,
 					.apic_version = LAPIC_VERSION,
 					.cpu_flags = PROCENTRY_FLAG_EN,
 					.cpu_signature = MPEP_SIG,
@@ -232,7 +232,7 @@ struct mptable_info mptable_vm2 = {
 			.proc_entry_array = {
 				{
 					.type = MPCT_ENTRY_PROCESSOR,
-					.apic_id = 0U,
+					.apic_id = 6U,
 					.apic_version = LAPIC_VERSION,
 					.cpu_flags = PROCENTRY_FLAG_EN | PROCENTRY_FLAG_BP,
 					.cpu_signature = MPEP_SIG,
@@ -240,7 +240,7 @@ struct mptable_info mptable_vm2 = {
 				},
 				{
 					.type = MPCT_ENTRY_PROCESSOR,
-					.apic_id = 1U,
+					.apic_id = 2U,
 					.apic_version = LAPIC_VERSION,
 					.cpu_flags = PROCENTRY_FLAG_EN,
 					.cpu_signature = MPEP_SIG,

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -170,12 +170,21 @@ vlapic_build_id(struct acrn_vlapic *vlapic)
 	uint8_t vlapic_id;
 	uint32_t lapic_regs_id;
 
+#ifdef CONFIG_PARTITION_MODE
+	/*
+	 * Partition mode UOS is forced to use physical mode in xAPIC
+	 * Hence ACRN needs to maintain physical APIC ids for partition
+	 * mode.
+	 */
+	vlapic_id = per_cpu(lapic_id, vcpu->pcpu_id);
+#else
 	if (is_vm0(vcpu->vm)) {
 		/* Get APIC ID sequence format from cpu_storage */
 		vlapic_id = per_cpu(lapic_id, vcpu->vcpu_id);
 	} else {
 		vlapic_id = (uint8_t)vcpu->vcpu_id;
 	}
+#endif
 
 	lapic_regs_id = (uint32_t)vlapic_id << APIC_ID_SHIFT;
 

--- a/hypervisor/partition/vm_description.c
+++ b/hypervisor/partition/vm_description.c
@@ -137,7 +137,7 @@ const struct vm_description_array vm_desc_partition = {
 				.vm_vuart = true,
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
-						consoleblank=0 tsc=reliable",
+						consoleblank=0 tsc=reliable xapic_phys",
 				.vpci_vdev_array = &vpci_vdev_array1,
 				.mptable = &mptable_vm1,
 			},
@@ -152,7 +152,7 @@ const struct vm_description_array vm_desc_partition = {
 				.vm_vuart = true,
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
-						consoleblank=0 tsc=reliable",
+						consoleblank=0 tsc=reliable xapic_phys",
 				.vpci_vdev_array = &vpci_vdev_array2,
 				.mptable = &mptable_vm2,
 			},


### PR DESCRIPTION
VMs in partition mode uses a kernel patch to switch to physical mode xAPIC.
The kernel patch together with this patch makes sure device MSIs use
physical mode as DM and physical APIC IDs in Destination field. bootargs in
partition/vm_description.c uses a new parameter xapic_phys for the kernel patch
to take effect.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>