### PR TITLE
hv: code clean up regarding to guest_msrs

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -385,7 +385,6 @@ void destroy_vcpu(struct vcpu *vcpu)
 
 	vlapic_free(vcpu);
 	free(vcpu->arch_vcpu.vmcs);
-	free(vcpu->guest_msrs);
 	per_cpu(ever_run_vcpu, vcpu->pcpu_id) = NULL;
 	free_pcpu(vcpu->pcpu_id);
 	free(vcpu);

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -105,14 +105,6 @@ void init_msr_emulation(struct vcpu *vcpu)
 	value64 = HVA2HPA(vcpu->vm->arch_vm.msr_bitmap);
 	exec_vmwrite64(VMX_MSR_BITMAP_FULL, value64);
 	pr_dbg("VMX_MSR_BITMAP: 0x%016llx ", value64);
-
-	if (!vcpu->guest_msrs) {
-		vcpu->guest_msrs =
-			(uint64_t *)calloc(msrs_count, sizeof(uint64_t));
-	}
-
-	ASSERT(vcpu->guest_msrs != NULL, "");
-	(void)memset(vcpu->guest_msrs, 0U, msrs_count * sizeof(uint64_t));
 }
 
 int rdmsr_vmexit_handler(struct vcpu *vcpu)

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -240,7 +240,7 @@ struct vcpu {
 	 * code.
 	 */
 	uint64_t msr_tsc_aux_guest;
-	uint64_t *guest_msrs;
+	uint64_t guest_msrs[IDX_MAX_MSR];
 #ifdef CONFIG_MTRR_ENABLED
 	struct mtrr_state mtrr;
 #endif


### PR DESCRIPTION
Change guest_msrs in vcpu data structure from pointer to array, which
could avoid the dynamic memory allocation.

v1 -> v2:
 * Remove the unnecessary initialization for guest_msrs[] since vcpu is
   allocated by calloc.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>