### PR TITLE
hv:No need to create inverted page tables for trusty memory

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -279,7 +279,8 @@ int ept_mr_add(const struct vm *vm, uint64_t *pml4_page,
 	}
 
 	ret = mmu_add(pml4_page, hpa, gpa, size, prot, PTT_EPT);
-	if (ret == 0) {
+	/* No need to create inverted page tables for trusty memory */
+	if (ret == 0 && ((void *)pml4_page == vm->arch_vm.nworld_eptp)) {
 		ret = mmu_add((uint64_t *)vm->arch_vm.m2p,
 			gpa, hpa, size, prot, PTT_EPT);
 	}

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -127,7 +127,6 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	}
 
 	/* Map [gpa_rebased, gpa_rebased + size) to secure ept mapping
-	 * TODO: not create inverted page tables for trusty memory
 	 */
 	ept_mr_add(vm, (uint64_t *)vm->arch_vm.sworld_eptp,
 			hpa, gpa_rebased, size, EPT_RWX | EPT_WB);


### PR DESCRIPTION
There is no requirement to  hpa2gpa for trusty memory,
now we use the same inverted eptp for normal world and secure world,
that is it can get some trusty memory information by the inverted
page tables in normal world,then this patch removed the inverted
page tables for trusty memory.

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>