### PR TITLE
security: Enable '-fpie, -pie' options

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -18,6 +18,7 @@ CFLAGS += -Wall -ffunction-sections
 CFLAGS += -Werror
 CFLAGS += -O2 -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+CFLAGS += -fpie
 
 CFLAGS += -I$(BASEDIR)/include
 CFLAGS += -I$(BASEDIR)/include/public
@@ -43,6 +44,7 @@ endif
 
 LDFLAGS += -Wl,-z,noexecstack
 LDFLAGS += -Wl,-z,relro,-z,now
+LDFLAGS += -pie
 LDFLAGS += -L$(TOOLS_OUT)
 
 LIBS = -lrt

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -142,4 +142,4 @@ config MTRR_ENABLED
 
 config RELOC
 	bool "Enable relocation"
-	default n
+	default y

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -5,6 +5,7 @@ CFLAGS := -Wall
 CFLAGS += -I../../devicemodel/include
 CFLAGS += -I../../devicemodel/include/public
 CFLAGS += -I../../hypervisor/include
+CFLAGS += -fpie
 
 ifeq ($(RELEASE),0)
 CFLAGS += -g -DMNGR_DEBUG
@@ -13,6 +14,7 @@ endif
 LDFLAGS := -L$(OUT_DIR)
 LDFLAGS += -lacrn-mngr
 LDFLAGS +=  -lpthread
+LDFLAGS += -pie
 
 .PHONY: all
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnctl $(OUT_DIR)/acrnd


### PR DESCRIPTION
To be sure hypervisor and DM are position independent
and executable.

Signed-off-by: wenshelx <wenshengx.wang@intel.com>