### PR TITLE
samples: remove extra option for dm

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -287,7 +287,6 @@ else
 fi
 
  acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
-   -l com1,stdio \
    -s 9,virtio-net,$tap \
    -s 3,virtio-blk$boot_dev_flag,/data/$5/$5.img \
    -s 7,passthru,0/15/0 \


### PR DESCRIPTION
remove extra "-l com1,stdio" option for dm

Tracked-On: #1123
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>