### PR TITLE
IOC mediator: fix no CBC signals after resuming

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1078,6 +1078,16 @@ process_resume_event(struct ioc_dev *ioc)
 			break;
 		}
 	}
+
+	/*
+	 * The signal channel is inactive after SOS resumed, need to send
+	 * open channel command again to activate the signal channel.
+	 * And it would not impact to UOS itself enter/exit S3.
+	 */
+	if (ioc_ch_xmit(IOC_NATIVE_SIGNAL, cbc_open_channel_command,
+				sizeof(cbc_open_channel_command)) <= 0)
+		DPRINTF("%s", "ioc reopen signal channel failed\r\n");
+
 	return 0;
 }
 


### PR DESCRIPTION
This patch fixes an issue that CBC signal channel
is inactive after SOS resuming, it leads to IOC mediator
cannot transfer any signals between UOS and SOS. So IOC
mediator sends the open channel command to activate CBC
signal channel after resuming.

Tracked-On: #1115
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>