### PR TITLE
dm: cmos: move cmos storage out of vmctx

### DIFF
--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -63,10 +63,6 @@ struct vmctx {
 	void *atkbdc_base;
 	void *vrtc;
 	void *ioc_dev;
-	/* cmos buffer used to store write/read contents,
-	 * and it should not be cleared when reboot
-	 */
-	uint8_t cmos_buffer[CMOS_BUF_SIZE];
 };
 
 /*


### PR DESCRIPTION
The whole vmctx will be cleared during cold reset.
cmos data should not be cleared during cold reset.
Move cmos data out of vmctx.

Tracked-On: #1118
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>