### PR TITLE
hv: fix broken relocation feature

### DIFF
--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -104,7 +104,7 @@ void _relocate(void)
 	 * Need to subtract the relocation delta to get the correct
 	 * absolute addresses
 	 */
-	trampoline_end = (uint64_t)_ld_trampoline_end - delta;
+	trampoline_end = (uint64_t)(&_ld_trampoline_end) - delta;
 	primary_32_start = (uint64_t)(&cpu_primary_start_32) - delta;
 	primary_32_end = (uint64_t)(&cpu_primary_start_64) - delta;
 


### PR DESCRIPTION
commit a71dedecd4dc ("hv: treewide: fix 'Array has no bounds specified")
misses one '&', which breaks the hypervisor relocation feature.

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>