### PR TITLE
Documentation: correct URL pointing at sample 'acrn.conf' file

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -201,7 +201,7 @@ partition. Follow these steps:
 
    A starter acrn.conf configuration file is included in the Clear Linux release and is
    also available in the acrn-hypervisor/hypervisor GitHub repo as `acrn.conf
-   <https://github.com/projectacrn/acrn-hypervisor/hypervisor/tree/master/bsp/uefi/clearlinux/acrn.conf>`__
+   <https://github.com/projectacrn/acrn-hypervisor/blob/master/hypervisor/bsp/uefi/clearlinux/acrn.conf>`__
    as shown here:
 
    .. literalinclude:: ../../hypervisor/bsp/uefi/clearlinux/acrn.conf


### PR DESCRIPTION
Update the Getting Started Guide to correct the URL pointing at
the sample 'acrn.conf' file that is in the source code tree.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>