### PR TITLE
hv: fix 'Procedure is not called or referenced in code analysed'

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -46,20 +46,6 @@ uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 	return dmask;
 }
 
-bool vm_lapic_disabled(const struct vm *vm)
-{
-	uint16_t i;
-	struct vcpu *vcpu;
-
-	foreach_vcpu(i, vm, vcpu) {
-		if (vlapic_enabled(vcpu->arch_vcpu.vlapic)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu)
 {
 	enum vm_cpu_mode cpu_mode;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -260,11 +260,6 @@ void ioapic_set_rte(uint32_t irq, union ioapic_rte rte)
 		rte.full);
 }
 
-uint32_t irq_gsi_num(void)
-{
-	return nr_gsi;
-}
-
 bool irq_is_gsi(uint32_t irq)
 {
 	return irq < nr_gsi;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -95,11 +95,6 @@ static inline void local_invept(uint64_t type, struct invept_desc desc)
 	ASSERT(error == 0, "invept error");
 }
 
-static inline void inv_tlb_one_page(void *addr)
-{
-	asm volatile ("invlpg (%0)"  : : "r" (addr) : "memory");
-}
-
 static inline bool cpu_has_vmx_ept_cap(uint32_t bit_mask)
 {
 	return ((vmx_caps.ept & bit_mask) != 0U);

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -305,27 +305,6 @@ static int vpic_icw4(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 	return 0;
 }
 
-bool vpic_is_pin_mask(struct acrn_vpic *vpic, uint8_t virt_pin_arg)
-{
-	struct i8259_reg_state *i8259;
-	uint8_t virt_pin = virt_pin_arg;
-
-	if (virt_pin < 8U) {
-		i8259 = &vpic->i8259[0];
-	} else if (virt_pin < 16U) {
-		i8259 = &vpic->i8259[1];
-		virt_pin -= 8U;
-	} else {
-		return true;
-	}
-
-	if ((i8259->mask & (1U << virt_pin)) != 0U) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
 static int vpic_ocw1(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	uint8_t pin, i, bit;

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -93,7 +93,6 @@ enum vm_paging_mode {
 /*
  * VM related APIs
  */
-bool vm_lapic_disabled(const struct vm *vm);
 uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
 
 int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -130,6 +130,5 @@ void vpic_intr_accepted(struct vm *vm, uint32_t vector);
 void vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
 	enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
-bool vpic_is_pin_mask(struct acrn_vpic *vpic, uint8_t virt_pin_arg);
 
 #endif	/* _VPIC_H_ */

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -22,7 +22,6 @@
 void setup_ioapic_irqs(void);
 
 bool irq_is_gsi(uint32_t irq);
-uint32_t irq_gsi_num(void);
 uint8_t irq_to_pin(uint32_t irq);
 uint32_t pin_to_irq(uint8_t pin);
 void irq_gsi_mask_unmask(uint32_t irq, bool mask);


### PR DESCRIPTION
MISRA-C requires that each function defined and declared shall be called
or referenced in code analyzed.

In some cases, we would like to keep the non-called functions for code
completeness, such as
vcpu_inject_extint/vcpu_inject_nmi/vcpu_inject_gp/vcpu_inject_pf
/vcpu_inject_ud/vcpu_inject_ac/vcpu_inject_ss.

This pacth removes some functions that are independent and are not
called in our code base.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>