### PR TITLE
hv: replace 'return' with 'panic' in bsp_boot_post

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -461,8 +461,7 @@ static void bsp_boot_post(void)
 	pr_dbg("Core %hu is up", BOOT_CPU_ID);
 
 	if (hardware_detect_support() != 0) {
-		pr_fatal("hardware not support!\n");
-		return;
+		panic("hardware not support!");
 	}
 
 	/* Warn for security feature not ready */


### PR DESCRIPTION
If hardware_detect_support() failed,as it return to
bsp_boot_init with a different stack and thus returning
from bsp_boot_init becomes an undefined behavior.

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>