### PR TITLE
IOC mediator: add new signal for VBUS control

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -533,6 +533,7 @@ static struct cbc_signal cbc_rx_signal_table[] = {
 	{(uint16_t)CBC_SIG_ID_HTUST,	32,	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_HVSST,	32,	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_HRAST,	32,	CBC_ACTIVE},
+	{(uint16_t)CBC_SIG_ID_USBVBUS,  1,      CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_VICL,	8,	CBC_ACTIVE},
 };
 
@@ -572,6 +573,7 @@ static struct wlist_signal wlist_rx_signal_table[] = {
 	{(uint16_t)CBC_SIG_ID_HTUST,	DEFAULT_WLIST_NODE},
 	{(uint16_t)CBC_SIG_ID_HVSST,	DEFAULT_WLIST_NODE},
 	{(uint16_t)CBC_SIG_ID_HRAST,	DEFAULT_WLIST_NODE},
+	{(uint16_t)CBC_SIG_ID_USBVBUS,  DEFAULT_WLIST_NODE},
 };
 
 static struct wlist_signal wlist_tx_signal_table[] = {

--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -252,6 +252,7 @@ enum cbc_rx_signal_id {
 	CBC_SIG_ID_HTUST	= 20025,	/* HvacTemperatureUnitsSetting */
 	CBC_SIG_ID_HVSST	= 20026,	/* HvacVentilationSeatSetting */
 	CBC_SIG_ID_HRAST	= 20027,	/* HvacRecirculationAutomaticSetting */
+	CBC_SIG_ID_USBVBUS	= 20028,	/* SupportUsbOtgVbusControl */
 	CBC_SIG_ID_VICL		= 651,		/* VideoInCtrl */
 };
 


### PR DESCRIPTION
Support VBUS control for USB OTG.

Tracked-On: #1159
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>