### PR TITLE
security: Enable '-fpie -pie' options

### DIFF
--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -14,6 +14,8 @@ CFLAGS	+= -m64 -D_GNU_SOURCE
 ifeq ($(RELEASE),0)
 CFLAGS	+= -DDEBUG_ACRN_CRASHLOG
 endif
+CFLAGS += -fpie
+LDFLAGS += -pie
 INCLUDE := -I $(BASEDIR)/common/include
 export INCLUDE
 export BUILDDIR
@@ -43,6 +45,7 @@ ifeq ($(strip $(LIB_EXIST)),ltelemetry)
         EXTRA_LIBS += -ltelemetry
 endif
 export CFLAGS
+export LDFLAGS
 export EXTRA_LIBS
 
 .PHONY:all

--- a/tools/acrn-crashlog/usercrash/Makefile
+++ b/tools/acrn-crashlog/usercrash/Makefile
@@ -15,7 +15,7 @@ LIBS = -levent -lpthread $(EXTRA_LIBS)
 usercrash_s: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/server.o \
 	$(BUILDDIR)/common/obj/log_sys.o
-	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS)
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS) $(LDFLAGS)
 
 usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/usercrash/obj/client.o \
@@ -24,7 +24,7 @@ usercrash_c: $(BUILDDIR)/usercrash/obj/protocol.o \
 	$(BUILDDIR)/common/obj/cmdutils.o \
 	$(BUILDDIR)/common/obj/fsutils.o \
 	$(BUILDDIR)/common/obj/strutils.o
-	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS)
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS) $(LDFLAGS)
 
 debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 	$(BUILDDIR)/usercrash/obj/crash_dump.o \
@@ -32,7 +32,7 @@ debugger: $(BUILDDIR)/usercrash/obj/debugger.o \
 	$(BUILDDIR)/common/obj/cmdutils.o \
 	$(BUILDDIR)/common/obj/fsutils.o \
 	$(BUILDDIR)/common/obj/strutils.o
-	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS)
+	$(CC) -g $(CFLAGS) $(INCLUDE) $^ -o $(BUILDDIR)/usercrash/bin/$@ $(LIBS) $(LDFLAGS)
 
 $(BUILDDIR)/usercrash/obj/%.o:%.c
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -1,8 +1,10 @@
 
 OUT_DIR ?= .
+CFLAGS += -fpie
+LDFLAGS += -pie
 
 all:
-	$(CC) -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread
+	$(CC) -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread $(CFLAGS) $(LDFLAGS)
 	cp acrnlog.service $(OUT_DIR)/acrnlog.service
 
 clean:

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -1,8 +1,10 @@
 
 OUT_DIR ?= .
+CFLAGS += -fpie
+LDFLAGS += -pie
 
 all:
-	$(CC) -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread -lrt
+	$(CC) -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread -lrt $(CFLAGS) $(LDFLAGS)
 
 clean:
 	rm -f $(OUT_DIR)/acrntrace


### PR DESCRIPTION
To be sure acrn debug tools are position independent
and executable.

Tracked-On: #1122
Signed-off-by: wenshelx <wenshengx.wang@intel.com>
Acked-by: CHEN Gang <gang.c.chen@intel.com>
Acked-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>