### PR TITLE
HV: improve pass-thru device interrupt process

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -185,6 +185,9 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 	list_add(&vm->list, &vm_list);
 	spinlock_release(&vm_list_lock);
 
+	INIT_LIST_HEAD(&vm->softirq_dev_entry_list);
+	spinlock_init(&vm->softirq_dev_lock);
+
 	/* Set up IO bit-mask such that VM exit occurs on
 	 * selected IO ranges
 	 */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -167,6 +167,9 @@ struct vm {
 	struct vpci vpci;
 	uint8_t vrtc_offset;
 #endif
+
+	spinlock_t softirq_dev_lock;
+	struct list_head softirq_dev_entry_list;
 };
 
 #ifdef CONFIG_PARTITION_MODE

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -66,11 +66,11 @@ struct ptdev_remapping_info {
 extern struct list_head ptdev_list;
 extern spinlock_t ptdev_lock;
 
-void ptdev_softirq(__unused uint16_t cpu_id);
+void ptdev_softirq(uint16_t pcpu_id);
 void ptdev_init(void);
 void ptdev_release_all_entries(struct vm *vm);
 
-struct ptdev_remapping_info *ptdev_dequeue_softirq(void);
+struct ptdev_remapping_info *ptdev_dequeue_softirq(struct vm *vm);
 struct ptdev_remapping_info *alloc_entry(struct vm *vm,
 		uint32_t intr_type);
 void release_entry(struct ptdev_remapping_info *entry);


### PR DESCRIPTION
this patch is used to avoid pass-thru devices interrupt 
interferences between different VMs.

for each pass-thru device and its entry owned by one VM, 
so change the pass-thru device's softirq lock & entry list 
into per VM, so one VM's PT device interrupt process will 
not interfere with other VMs; especially in case one UOS
"interrupt storm" happens, it will have little effect on SOS.

Tracked-On: #866
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>