### PR TITLE
3th patch set for vioapic/vlapic/vpic reshuffle

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -495,9 +495,18 @@ INTR_WIN:
 	 * and automatic inject the virtual interrupts in appropriate time.
 	 * And from SDM Vol3 29.2.1, the apicv only trigger evaluation of
 	 * pending virtual interrupts when "interrupt-window exiting" is 0.
+	 *
+	 * External interrupt(from vpic) can't be delivered by "virtual-
+	 * interrupt delivery", it only deliver interrupt from vlapic.
+	 *
+	 * So need to enable "interrupt-window exiting", when there is
+	 * an ExtInt or there is lapic interrupt and virtual interrupt
+	 * deliver is disabled.
 	 */
-	if (is_apicv_intr_delivery_supported() ||
-		!vcpu_pending_request(vcpu)) {
+	if (!bitmap_test(ACRN_REQUEST_EXTINT,
+						pending_req_bits) &&
+		(is_apicv_intr_delivery_supported() ||
+		!vcpu_pending_request(vcpu))) {
 		return ret;
 	}
 

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -503,6 +503,10 @@ INTR_WIN:
 	 * an ExtInt or there is lapic interrupt and virtual interrupt
 	 * deliver is disabled.
 	 */
+	if (arch_vcpu->irq_window_enabled == 1U) {
+		return ret;
+	}
+
 	if (!bitmap_test(ACRN_REQUEST_EXTINT,
 						pending_req_bits) &&
 		(is_apicv_intr_delivery_supported() ||
@@ -510,13 +514,10 @@ INTR_WIN:
 		return ret;
 	}
 
-	/* Enable interrupt window exiting if pending */
-	if (arch_vcpu->irq_window_enabled == 0U) {
-		arch_vcpu->irq_window_enabled = 1U;
-		tmp = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
-		tmp |= VMX_PROCBASED_CTLS_IRQ_WIN;
-		exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, tmp);
-	}
+	tmp = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
+	tmp |= VMX_PROCBASED_CTLS_IRQ_WIN;
+	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, tmp);
+	arch_vcpu->irq_window_enabled = 1U;
 
 	return ret;
 }


### PR DESCRIPTION
The 3th patch set is majorly for "interrupt-window exiting" related reshuffle.

-avoid enable interrupt window if interrupt delivery enabled.
-enable interrupt-window if any vpic pending interrupts.
-refine the irq_window_enabled parameter usage.

Tracked-On: #1187, #1189, #1190
Signed-off-by: Yu Wang <yu1.wang@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>