### PR TITLE
samples: Add tap name as launch function parameter

### DIFF
--- a/devicemodel/samples/apl-mrb/acrn_guest.service
+++ b/devicemodel/samples/apl-mrb/acrn_guest.service
@@ -10,7 +10,7 @@ ConditionPathExists=/dev/acrn_vhm
 [Service]
 Type=simple
 RemainAfterExit=false
-ExecStart=/bin/sh /usr/share/acrn/samples/apl-mrb/launch_uos.sh -V 5
+ExecStart=/bin/sh /usr/share/acrn/samples/apl-mrb/launch_uos.sh -V 6
 
 [Install]
 WantedBy=multi-user.target

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -316,6 +316,13 @@ fi
    -B "$kernel_cmdline" $vm_name
 }
 
+function launch_alios()
+{
+#AliOS is not Android, only has same configuration currently, reuse launch function
+
+launch_android "$@"
+}
+
 function help()
 {
 echo "Use luanch_uos.sh like that ./launch_uos.sh -V <#>"
@@ -324,7 +331,8 @@ echo "-V 1 means just launching 1 clearlinux UOS"
 echo "-V 2 means just launching 1 android UOS"
 echo "-V 3 means launching 1 clearlinux UOS + 1 android UOS"
 echo "-V 4 means launching 2 clearlinux UOSs"
-echo "-V 5 means auto check android/linux UOS; if exist, launch it"
+echo "-V 5 means just launching 1 alios UOS"
+echo "-V 6 means auto check android/linux/alios UOS; if exist, launch it"
 }
 
 launch_type=1
@@ -356,9 +364,11 @@ fi
 mkdir -p /data
 mount /dev/mmcblk1p3 /data
 
-if [ $launch_type == 5 ]; then
+if [ $launch_type == 6 ]; then
 	if [ -f "/data/android/android.img" ]; then
 	  launch_type=2;
+	elif [ -f "/data/alios/alios.img" ]; then
+	  launch_type=5;
 	else
 	  launch_type=1;  
 	fi
@@ -391,6 +401,9 @@ case $launch_type in
 		launch_clearlinux 1 1 "64 448 4" 0x00000C clearlinux "L1aaG" $debug &
 		sleep 5
 		launch_clearlinux 2 1 "64 448 4" 0x070F00 clearlinux_dup "L2aaG" $debug
+		;;
+	5) echo "Launch alios UOS"
+		launch_alios 1 3 "64 448 8" 0x070F00 alios "AliaaG" $debug
 		;;
 esac
 

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -15,7 +15,7 @@ vm_name=vm$1
 vm_name=${vm_name}-${mac:9:8}
 
 # create a unique tap device for each VM
-tap=tap_LaaG
+tap=tap_$6
 tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
   echo "tap device existed, reuse acrn_$tap"
@@ -96,7 +96,7 @@ if [ "$setup_mem" != "" ];then
 fi
 
 boot_dev_flag=",b"
-if [ $6 == 1 ];then
+if [ $7 == 1 ];then
   boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"
 else
   boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
@@ -146,7 +146,7 @@ vm_name=vm$1
 vm_name=${vm_name}-${mac:9:8}
 
 # create a unique tap device for each VM
-tap=tap_AaaG
+tap=tap_$6
 tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
   echo "tap device existed, reuse acrn_$tap"
@@ -265,7 +265,7 @@ kernel_cmdline_generic="maxcpus=$2 nohpet tsc=reliable intel_iommu=off \
    i915.enable_hangcheck=0 use_nuclear_flip=1 i915.enable_guc_submission=0 i915.enable_guc=0"
 
 boot_dev_flag=",b"
-if [ $6 == 1 ];then
+if [ $7 == 1 ];then
   boot_image_option="--vsbl /usr/share/acrn/bios/VSBL_debug.bin"
 else
   boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
@@ -377,20 +377,20 @@ done
 
 case $launch_type in
 	1) echo "Launch clearlinux UOS"
-		launch_clearlinux 1 3 "64 448 8" 0x070F00 clearlinux $debug
+		launch_clearlinux 1 3 "64 448 8" 0x070F00 clearlinux "LaaG" $debug
 		;;
 	2) echo "Launch android UOS"
-		launch_android 1 3 "64 448 8" 0x070F00 android $debug
+		launch_android 1 3 "64 448 8" 0x070F00 android "AaaG" $debug
 		;;
 	3) echo "Launch clearlinux UOS + android UOS"
-		launch_android 1 2 "64 448 4" 0x00000C android $debug &
+		launch_android 1 2 "64 448 4" 0x00000C android "AaaG" $debug &
 		sleep 5
-		launch_clearlinux 2 1 "64 448 4" 0x070F00 clearlinux $debug
+		launch_clearlinux 2 1 "64 448 4" 0x070F00 clearlinux "LaaG" $debug
 		;;
 	4) echo "Launch two clearlinux UOSs"
-		launch_clearlinux 1 1 "64 448 4" 0x00000C clearlinux $debug &
+		launch_clearlinux 1 1 "64 448 4" 0x00000C clearlinux "L1aaG" $debug &
 		sleep 5
-		launch_clearlinux 2 1 "64 448 4" 0x070F00 clearlinux_dup $debug
+		launch_clearlinux 2 1 "64 448 4" 0x070F00 clearlinux_dup "L2aaG" $debug
 		;;
 esac
 


### PR DESCRIPTION
launch two clearlinux will use the same 'LaaG' as tap interface name. Add tap
name as parameter that will meet two UOS using different tap interface.

Tracked-On: projectacrn/acrn-hypervisor#1173
Signed-off-by: Jiangbo Wu <jiangbo.wu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
Signed-off-by: Jiangbo Wu <jiangbo.wu@intel.com>