### PR TITLE
hv: avoid memory leak in trampoline code preparing

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -23,6 +23,7 @@ struct per_cpu_region *per_cpu_data_base_ptr;
 uint16_t phys_cpu_num = 0U;
 static uint64_t pcpu_sync = 0UL;
 static volatile uint16_t up_count = 0U;
+static uint64_t startup_paddr = 0UL;
 
 /* physical cpu active bitmap, support up to 64 cpus */
 uint64_t pcpu_active_bitmap = 0UL;
@@ -491,6 +492,7 @@ static void bsp_boot_post(void)
 	init_scheduler();
 
 	/* Start all secondary cores */
+	startup_paddr = prepare_trampoline();
 	start_cpus();
 
 	ASSERT(get_cpu_id() == BOOT_CPU_ID, "");
@@ -602,12 +604,9 @@ void start_cpus(void)
 {
 	uint32_t timeout;
 	uint16_t expected_up;
-	uint64_t startup_paddr;
 
 	/* secondary cpu start up will wait for pcpu_sync -> 0UL */
 	atomic_store64(&pcpu_sync, 1UL);
-
-	startup_paddr = prepare_trampoline();
 
 	/* Set flag showing number of CPUs expected to be up to all
 	 * cpus


### PR DESCRIPTION
In function start_cpus, we allocated memory under 1M when
preparing AP trampoline code.

With S3 feature enabled, start_cpus is called every time after
ACRN resume from S3 which leaks the allocated memory for AP
trampoline code.

To avoid memory leak, move the AP trampoline preparing function
out of start_cpus to make sure the memory for AP trampoline is
only allocated one time when system boot.

Tracked-On: #1156
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Zide Chen <zide.chen@intel.com>