### PR TITLE
dm: passthru: fix a bug in msix read/write

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -462,7 +462,8 @@ msix_table_read(struct passthru_dev *ptdev, uint64_t offset, int size)
 	int index;
 
 	dev = ptdev->dev;
-	if (offset >= dev->msix.pba_offset &&
+	if (dev->msix.pba_bar == dev->msix.table_bar &&
+	    offset >= dev->msix.pba_offset &&
 	    offset < dev->msix.pba_offset + dev->msix.pba_size) {
 		switch (size) {
 		case 1:
@@ -541,7 +542,8 @@ msix_table_write(struct vmctx *ctx, int vcpu, struct passthru_dev *ptdev,
 	int index;
 
 	dev = ptdev->dev;
-	if (offset >= dev->msix.pba_offset &&
+	if (dev->msix.pba_bar == dev->msix.table_bar &&
+	    offset >= dev->msix.pba_offset &&
 	    offset < dev->msix.pba_offset + dev->msix.pba_size) {
 		switch (size) {
 		case 1:


### PR DESCRIPTION
In current code, when read/write msix table, it first handle the case
the offset is in pba range when msix talbe and pba share the same bar.
But the code didn't add the condition whether pba bar equals msix table
bar. It will cause problems for the passthrugh devices,whose pba and msix
table don't share the same bar.

Tracked-On: #1209
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>