### PR TITLE
HV: change wake vector to accommodate abl 1820HF1release

### DIFF
--- a/hypervisor/bsp/sbl/platform_acpi_info.c
+++ b/hypervisor/bsp/sbl/platform_acpi_info.c
@@ -52,8 +52,8 @@ const struct acpi_info host_acpi_info = {
 		.wake_vector_32 = (uint32_t *)0x7A86BBDCUL,
 		.wake_vector_64 = (uint64_t *)0x7A86BBE8UL
 #else
-		.wake_vector_32 = (uint32_t *)0x7AEDCEFCUL,
-		.wake_vector_64 = (uint64_t *)0x7AEDCF08UL
+		.wake_vector_32 = (uint32_t *)0x7AFDCEFCUL,
+		.wake_vector_64 = (uint64_t *)0x7AFDCF08UL
 #endif
 	}
 };


### PR DESCRIPTION
MRB bootloader is switched to ABL ver 1820HF1_release, so change platform
acpi info accordingly to support system S3.

Tracked-On: #1196

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>