### PR TITLE
doc: allow overriding displayed doc version

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,9 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
+RELEASE = ""
+if "RELEASE" in os.environ:
+   RELEASE = os.environ["RELEASE"]
 
 # -- General configuration ------------------------------------------------
 
@@ -177,6 +180,8 @@ else:
 
 if tags.has('release'):
    current_version = version
+   if RELEASE:
+      version = current_version = RELEASE
 else:
    version = current_version = "latest"
 


### PR DESCRIPTION
In special cases, we'd like to freeze doc versions based on a tag (e.g.,
tags/acrn-2018w34.4-140000p) and have that version show up on the
generated docs.  (Normally the version shown is from the
hypervisor/VERSION file.)

With this patch, if DOC_TAG=release then it uses a RELEASE=name
environment variable (e.g., from the make command line) to override the
displayed version:

    make DOC_TAG=release RELEASE=acrn-2018w34.4-140000p html
    make DOC_TAG=release RELEASE=acrn-2018w34.4-140000p publish

Assuming you've checked out the tagged branch (both for acrn-hypervisor
and acrn-kernel), these make commands will generate and publish docs to
https://projectacrn.github.io/acrn-2018w34.4-14000p

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>