### PR TITLE
hv: clean up spinlock wrappers

### DIFF
--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -29,9 +29,6 @@
 
 #include <hypervisor.h>
 
-/* TODO: add spinlock_locked support? */
-/*#define VPIC_LOCKED(vpic)	spinlock_locked(&((vpic)->lock))*/
-
 #define ACRN_DBG_PIC	6U
 
 enum irqstate {


### PR DESCRIPTION
- remove the following unnecessary spinlock wrappers
  #define IOMMU_LOCK(u) spinlock_obtain(&((u)->lock))
  #define IOMMU_UNLOCK(u) spinlock_release(&((u)->lock))
- remove the unnecessary comments in vpic.c

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>