### PR TITLE
hv:treewide:fix multiple MISRAC violations

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -639,15 +639,15 @@ build_getcc(getcc64, uint64_t, x, y)
 static uint64_t getcc(uint8_t opsize, uint64_t x, uint64_t y)
 {
 	switch (opsize) {
-		case 1:
-			return getcc8((uint8_t) x, (uint8_t) y);
-		case 2:
-			return getcc16((uint16_t) x, (uint16_t) y);
-		case 4:
-			return getcc32((uint32_t) x, (uint32_t) y);
-		default:	/* opsize == 8 */
-			return getcc64(x, y);
-		}
+	case 1U:
+		return getcc8((uint8_t) x, (uint8_t) y);
+	case 2U:
+		return getcc16((uint16_t) x, (uint16_t) y);
+	case 4U:
+		return getcc32((uint32_t) x, (uint32_t) y);
+	default:	/* opsize == 8 */
+		return getcc64(x, y);
+	}
 }
 
 static int emulate_mov(struct vcpu *vcpu, struct instr_emul_vie *vie)
@@ -740,7 +740,7 @@ static int emulate_mov(struct vcpu *vcpu, struct instr_emul_vie *vie)
 		 * REX + C6/0	mov r/m8, imm8
 		 */
 		size = 1U;	/* override for byte operation */
-		error = mmio_write(vcpu, vie->immediate);
+		error = mmio_write(vcpu, (uint64_t)vie->immediate);
 		break;
 	case 0xC7U:
 		/*

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -265,7 +265,7 @@ void *alloc_paging_struct(void)
 	ptr = alloc_page();
 
 	ASSERT(ptr != NULL, "page alloc failed!");
-	(void)memset(ptr, 0, CPU_PAGE_SIZE);
+	(void)memset(ptr, 0U, CPU_PAGE_SIZE);
 
 	return ptr;
 }
@@ -273,7 +273,7 @@ void *alloc_paging_struct(void)
 void free_paging_struct(void *ptr)
 {
 	if (ptr != NULL) {
-		(void)memset(ptr, 0, CPU_PAGE_SIZE);
+		(void)memset(ptr, 0U, CPU_PAGE_SIZE);
 		free(ptr);
 	}
 }

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -261,7 +261,7 @@ static uint64_t pit_calibrate_tsc(uint32_t cal_ms_arg)
  */
 static uint64_t native_calibrate_tsc(void)
 {
-	uint64_t tsc_hz = 0;
+	uint64_t tsc_hz = 0UL;
 
 	if (boot_cpu_data.cpuid_level >= 0x15U) {
 		uint32_t eax_denominator, ebx_numerator, ecx_hz, reserved;
@@ -275,7 +275,7 @@ static uint64_t native_calibrate_tsc(void)
 		}
 	}
 
-	if ((tsc_hz == 0) && (boot_cpu_data.cpuid_level >= 0x16U)) {
+	if ((tsc_hz == 0UL) && (boot_cpu_data.cpuid_level >= 0x16U)) {
 		uint32_t eax_base_mhz, ebx_max_mhz, ecx_bus_mhz, edx;
 		cpuid(0x16U, &eax_base_mhz, &ebx_max_mhz, &ecx_bus_mhz, &edx);
 		tsc_hz = (uint64_t) eax_base_mhz * 1000000U;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -65,7 +65,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	uint64_t gpa = 0UL;
 	uint64_t hpa = gpa2hpa(vm, gpa_orig);
 	uint64_t table_present = EPT_RWX;
-	uint64_t pdpte = 0, *dest_pdpte_p = NULL, *src_pdpte_p = NULL;
+	uint64_t pdpte = 0UL, *dest_pdpte_p = NULL, *src_pdpte_p = NULL;
 	void *sub_table_addr = NULL, *pml4_base = NULL;
 	struct vm *vm0 = get_vm_from_vmid(0U);
 	uint16_t i;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -681,14 +681,14 @@ static void init_guest_state(struct vcpu *vcpu)
 
 	if (vcpu_mode == CPU_MODE_REAL) {
 		init_guest_context_real(vcpu);
-		init_guest_vmx(vcpu, CR0_ET | CR0_NE, 0, 0);
+		init_guest_vmx(vcpu, CR0_ET | CR0_NE, 0UL, 0UL);
 	} else if (is_vm0(vcpu->vm) && is_vcpu_bsp(vcpu)) {
 		init_guest_context_vm0_bsp(vcpu);
 		init_guest_vmx(vcpu, init_ctx->cr0, init_ctx->cr3,
 			       init_ctx->cr4 & ~CR4_VMXE);
 	} else {
 		init_guest_context_protect(vcpu);
-		init_guest_vmx(vcpu, CR0_ET | CR0_NE | CR0_PE, 0, 0);
+		init_guest_vmx(vcpu, CR0_ET | CR0_NE | CR0_PE, 0UL, 0UL);
 	}
 }
 
@@ -984,7 +984,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 		exec_vmwrite64(VMX_EOI_EXIT2_FULL, 0UL);
 		exec_vmwrite64(VMX_EOI_EXIT3_FULL, 0UL);
 
-		exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0);
+		exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0U);
 	}
 
 	/* Load EPTP execution control

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -36,8 +36,8 @@
 #define ACPI_SIG_MADT             "APIC" /* Multiple APIC Description Table */
 #define ACPI_SIG_DMAR             "DMAR"
 #define RSDP_CHECKSUM_LENGTH       20
-#define ACPI_NAME_SIZE             4
-#define ACPI_MADT_TYPE_LOCAL_APIC  0
+#define ACPI_NAME_SIZE             4U
+#define ACPI_MADT_TYPE_LOCAL_APIC  0U
 #define ACPI_MADT_ENABLED          1U
 #define ACPI_OEM_TABLE_ID_SIZE     8
 
@@ -113,7 +113,7 @@ biosacpi_search_rsdp(char *base, int length)
 
 		/* compare signature, validate checksum */
 		if (strncmp(rsdp->signature, ACPI_SIG_RSDP,
-				strnlen_s(ACPI_SIG_RSDP, 8)) == 0) {
+				strnlen_s(ACPI_SIG_RSDP, 8U)) == 0) {
 			cp = (uint8_t *)rsdp;
 			sum = 0U;
 			for (idx = 0; idx < RSDP_CHECKSUM_LENGTH; idx++) {
@@ -179,12 +179,12 @@ static void *get_acpi_tbl(const char *sig)
 	struct acpi_table_rsdp *rsdp;
 	struct acpi_table_rsdt *rsdt;
 	struct acpi_table_xsdt *xsdt;
-	uint64_t addr = 0;
-	int i, count;
+	uint64_t addr = 0UL;
+	uint32_t i, count;
 
 	rsdp = (struct acpi_table_rsdp *)global_rsdp;
 
-	if ((rsdp->revision >= 2) && (rsdp->xsdt_physical_address != 0U)) {
+	if ((rsdp->revision >= 2U) && (rsdp->xsdt_physical_address != 0UL)) {
 		/*
 		 * AcpiOsGetRootPointer only verifies the checksum for
 		 * the version 1.0 portion of the RSDP.  Version 2.0 has
@@ -196,7 +196,7 @@ static void *get_acpi_tbl(const char *sig)
 				sizeof(struct acpi_table_header)) /
 		    sizeof(uint64_t);
 
-		for (i = 0; i < count; i++) {
+		for (i = 0U; i < count; i++) {
 			if (probe_table(xsdt->table_offset_entry[i], sig) != 0) {
 				addr = xsdt->table_offset_entry[i];
 				break;
@@ -210,7 +210,7 @@ static void *get_acpi_tbl(const char *sig)
 				sizeof(struct acpi_table_header)) /
 			sizeof(uint32_t);
 
-		for (i = 0; i < count; i++) {
+		for (i = 0U; i < count; i++) {
 			if (probe_table(rsdt->table_offset_entry[i], sig) != 0) {
 				addr = rsdt->table_offset_entry[i];
 				break;
@@ -223,7 +223,7 @@ static void *get_acpi_tbl(const char *sig)
 
 static uint16_t local_parse_madt(void *madt, uint8_t lapic_id_array[MAX_PCPU_NUM])
 {
-	uint16_t pcpu_id = 0;
+	uint16_t pcpu_id = 0U;
 	struct acpi_madt_local_apic *processor;
 	struct acpi_table_madt *madt_ptr;
 	void *first;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -826,7 +826,7 @@ int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param)
 {
 	struct hv_npk_log_param npk_param;
 
-	memset((void *)&npk_param, 0, sizeof(npk_param));
+	memset((void *)&npk_param, 0U, sizeof(npk_param));
 
 	if (copy_from_gpa(vm, &npk_param, param, sizeof(npk_param)) != 0) {
 		pr_err("%s: Unable copy param from vm\n", __func__);

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -96,7 +96,7 @@ int load_guest(struct vm *vm, struct vcpu *vcpu)
 	lowmem_gpa_top = *(uint64_t *)hva;
 
 	/* hardcode vcpu entry addr(kernel entry) & rsi (zeropage)*/
-	for (i = 0; i < NUM_GPRS; i++) {
+	for (i = 0U; i < NUM_GPRS; i++) {
 		vcpu_set_gpreg(vcpu, i, 0UL);
 	}
 
@@ -170,7 +170,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 		/* Documentation states: ebx=0, edi=0, ebp=0, esi=ptr to
 		 * zeropage
 		 */
-		for (i = 0; i < NUM_GPRS; i++) {
+		for (i = 0U; i < NUM_GPRS; i++) {
 			vcpu_set_gpreg(vcpu, i, 0UL);
 		}
 

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -98,7 +98,7 @@ static void dump_guest_stack(struct vcpu *vcpu)
 {
 	uint32_t i;
 	uint64_t tmp[DUMP_STACK_SIZE], fault_addr;
-	uint32_t err_code = 0;
+	uint32_t err_code = 0U;
 
 	if (copy_from_gva(vcpu, tmp, vcpu_get_gpreg(vcpu, CPU_REG_RSP),
 		DUMP_STACK_SIZE, &err_code, &fault_addr) < 0) {
@@ -112,7 +112,7 @@ static void dump_guest_stack(struct vcpu *vcpu)
 	for (i = 0U; i < (DUMP_STACK_SIZE >> 5U); i++) {
 		printf("guest_rsp(0x%llx):  0x%016llx  0x%016llx  "
 				"0x%016llx  0x%016llx\r\n",
-				(vcpu_get_gpreg(vcpu, CPU_REG_RSP)+(i*32)),
+				(vcpu_get_gpreg(vcpu, CPU_REG_RSP)+(i*32U)),
 				tmp[i*4], tmp[(i*4)+1],
 				tmp[(i*4)+2], tmp[(i*4)+3]);
 	}
@@ -142,7 +142,7 @@ static void show_guest_call_trace(struct vcpu *vcpu)
 	 *  try to print out call trace,here can not check if the rbp is valid
 	 *  if the address is invalid, it will cause hv page fault
 	 *  then halt system */
-	while ((count < CALL_TRACE_HIERARCHY_MAX) && (bp != 0)) {
+	while ((count < CALL_TRACE_HIERARCHY_MAX) && (bp != 0UL)) {
 		uint64_t parent_bp = 0UL, fault_addr;
 
 		err_code = 0U;
@@ -215,7 +215,7 @@ static void show_host_call_trace(uint64_t rsp, uint64_t rbp_arg, uint16_t pcpu_i
 		&& (cb_hierarchy < CALL_TRACE_HIERARCHY_MAX)) {
 		printf("----> 0x%016llx\r\n",
 				*(uint64_t *)(rbp + sizeof(uint64_t)));
-		if (*(uint64_t *)(rbp + (2*sizeof(uint64_t)))
+		if (*(uint64_t *)(rbp + (2U*sizeof(uint64_t)))
 				== SP_BOTTOM_MAGIC) {
 			break;
 		}

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -71,7 +71,7 @@ static void do_copy_earlylog(struct shared_buf *dst_sbuf,
 
 void init_logmsg(__unused uint32_t mem_size, uint32_t flags)
 {
-	int16_t pcpu_id;
+	uint16_t pcpu_id;
 
 	logmsg.flags = flags;
 	logmsg.seq = 0;
@@ -201,7 +201,7 @@ void print_logmsg_buffer(uint16_t pcpu_id)
 
 	do {
 		uint32_t idx;
-		(void)memset(buffer, 0U, LOG_ENTRY_SIZE + 1);
+		(void)memset(buffer, 0U, LOG_ENTRY_SIZE + 1U);
 
 		if (*sbuf == NULL) {
 			return;

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -83,10 +83,10 @@ struct vm_lu_mem_map {
 
 /* Use # of paging level to identify paging mode */
 enum vm_paging_mode {
-	PAGING_MODE_0_LEVEL = 0,	/* Flat */
-	PAGING_MODE_2_LEVEL = 2,	/* 32bit paging, 2-level */
-	PAGING_MODE_3_LEVEL = 3,	/* PAE paging, 3-level */
-	PAGING_MODE_4_LEVEL = 4,	/* 64bit paging, 4-level */
+	PAGING_MODE_0_LEVEL = 0U,	/* Flat */
+	PAGING_MODE_2_LEVEL = 2U,	/* 32bit paging, 2-level */
+	PAGING_MODE_3_LEVEL = 3U,	/* PAE paging, 3-level */
+	PAGING_MODE_4_LEVEL = 4U,	/* 64bit paging, 4-level */
 	PAGING_MODE_NUM,
 };
 

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -20,7 +20,7 @@
 #define LOG_FLAG_STDOUT		0x00000001U
 #define LOG_FLAG_MEMORY		0x00000002U
 #define LOG_FLAG_NPK		0x00000004U
-#define LOG_ENTRY_SIZE	80
+#define LOG_ENTRY_SIZE	80U
 /* Size of buffer used to store a message being logged,
  * should align to LOG_ENTRY_SIZE.
  */

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -13,12 +13,12 @@
 #define SHARED_BUFFER_H
 
 #define SBUF_MAGIC	0x5aa57aa71aa13aa3UL
-#define SBUF_MAX_SIZE	(1 << 22)
-#define SBUF_HEAD_SIZE	64
+#define SBUF_MAX_SIZE	(1UL << 22U)
+#define SBUF_HEAD_SIZE	64U
 
 /* sbuf flags */
-#define OVERRUN_CNT_EN	(1 << 0) /* whether overrun counting is enabled */
-#define OVERWRITE_EN	(1 << 1) /* whether overwrite is enabled */
+#define OVERRUN_CNT_EN	(1U << 0U) /* whether overrun counting is enabled */
+#define OVERWRITE_EN	(1U << 1U) /* whether overwrite is enabled */
 
 /**
  * (sbuf) head + buf (store (ele_num - 1) elements at most)

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -138,7 +138,7 @@ static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
 {
 	uint64_t idx;
 
-	for (idx = 0; (idx << 6U) < size; idx++) {
+	for (idx = 0UL; (idx << 6U) < size; idx++) {
 		if (addr[idx] != ~0UL)
 			return (idx << 6U) + ffz64(addr[idx]);
 	}

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -26,10 +26,10 @@
  */
 #define VHM_REQUEST_MAX 16U
 
-#define REQ_STATE_FREE          3
-#define REQ_STATE_PENDING	0
-#define REQ_STATE_COMPLETE	1
-#define REQ_STATE_PROCESSING	2
+#define REQ_STATE_FREE          3U
+#define REQ_STATE_PENDING	0U
+#define REQ_STATE_COMPLETE	1U
+#define REQ_STATE_PROCESSING	2U
 
 #define REQ_PORTIO	0U
 #define REQ_MMIO	1U


### PR DESCRIPTION
MISRAC has requirements about literal value requires a U suffix and
signed/unsigned conversion with cast. This patch is used to solve
these violations.

v1->v2
 *Drop the cast of sz from uint32_t to int32_t, the signed/unsigned
  violation of nchars will be solved by other patch together with
  printf/sprintf/console/vuart/uart code.

 *Delete the unnecessary L suffix of shifting operand.

Tracked-On: #861 
Signed-off-by: Junjun Shan <junjun.shan@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>