### PR TITLE
hv:irq: correct the size of irq_alloc_bitmap

### DIFF
--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -10,7 +10,7 @@
 static spinlock_t exception_spinlock = { .head = 0U, .tail = 0U, };
 static spinlock_t irq_alloc_spinlock = { .head = 0U, .tail = 0U, };
 
-#define IRQ_ALLOC_BITMAP_SIZE	INT_DIV_ROUNDUP(NR_IRQS, sizeof(uint64_t))
+#define IRQ_ALLOC_BITMAP_SIZE	INT_DIV_ROUNDUP(NR_IRQS, 64U)
 static uint64_t irq_alloc_bitmap[IRQ_ALLOC_BITMAP_SIZE];
 static struct irq_desc irq_desc_array[NR_IRQS];
 static uint32_t vector_to_irq[NR_MAX_VECTOR + 1];


### PR DESCRIPTION
This commit corrected the size of irq_alloc_bitmap[].

Signed-off-by: Yan, Like <like.yan@intel.com>