### PR TITLE
tools:acrn-crashlog: Change the algorithm of generating event key

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/history.c
+++ b/tools/acrn-crashlog/acrnprobe/history.c
@@ -192,7 +192,8 @@ void hist_raise_uptime(char *lastuptime)
 		if (hours / uptime_hours >= loop_uptime_event) {
 			loop_uptime_event = (hours / uptime_hours) + 1;
 
-			key = generate_event_id(uptime->name, "");
+			key = generate_event_id((const char *)uptime->name,
+						NULL, KEY_SHORT);
 			if (key == NULL) {
 				LOGE("generate event id failed, error (%s)\n",
 				     strerror(errno));
@@ -210,7 +211,7 @@ void hist_raise_infoerror(char *type)
 {
 	char *key;
 
-	key = generate_event_id("ERROR", type);
+	key = generate_event_id("ERROR", (const char *)type, KEY_SHORT);
 	if (key == NULL) {
 		LOGE("generate event id failed, error (%s)\n",
 		     strerror(errno));

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -11,6 +11,7 @@
 #include <openssl/sha.h>
 #include <ext2fs/ext2fs.h>
 #include "event_queue.h"
+#include "probeutils.h"
 
 #define CONTENT_MAX 10
 #define EXPRESSION_MAX 5
@@ -38,7 +39,7 @@ struct vm_t {
 	ext2_filsys datafs;
 	unsigned long history_size[SENDER_MAX];
 	char *history_data;
-	char last_synced_line_key[SENDER_MAX][SHA_DIGEST_LENGTH + 1];
+	char last_synced_line_key[SENDER_MAX][SHORT_KEY_LENGTH + 1];
 };
 
 struct log_t {

--- a/tools/acrn-crashlog/acrnprobe/include/probeutils.h
+++ b/tools/acrn-crashlog/acrnprobe/include/probeutils.h
@@ -24,6 +24,8 @@
 
 #define UPTIME_SIZE 24
 #define LONG_TIME_SIZE 32
+#define SHORT_KEY_LENGTH 20
+#define LONG_KEY_LENGTH 32
 
 enum e_dir_mode {
 	MODE_CRASH = 0,
@@ -31,11 +33,16 @@ enum e_dir_mode {
 	MODE_VMEVENT,
 };
 
+enum key_type {
+	KEY_SHORT = 0,
+	KEY_LONG,
+};
+
 int get_uptime_string(char newuptime[24], int *hours);
 int get_current_time_long(char buf[32]);
 unsigned long long get_uptime(void);
-char *generate_event_id(char *seed1, char *seed2);
-char *generate_eventid256(char *seed);
+char *generate_event_id(const char *seed1, const char *seed2,
+				enum key_type type);
 void generate_crashfile(char *dir, char *event, char *hashkey,
 			char *type, char *data0,
 			char *data1, char *data2);

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -357,7 +357,7 @@ static void telemd_send_crash(struct event_t *e)
 		return;
 	}
 
-	eventid = generate_eventid256(class);
+	eventid = generate_event_id((const char *)class, NULL, KEY_LONG);
 	if (eventid == NULL) {
 		LOGE("generate eventid failed, error (%s)\n", strerror(errno));
 		goto free_class;
@@ -436,7 +436,7 @@ static void telemd_send_info(struct event_t *e)
 		return;
 	}
 
-	eventid = generate_eventid256(class);
+	eventid = generate_event_id((const char *)class, NULL, KEY_LONG);
 	if (eventid == NULL) {
 		LOGE("generate eventid failed, error (%s)\n", strerror(errno));
 		goto free_class;
@@ -608,7 +608,7 @@ static int telemd_new_vmevent(const char *line_to_sync,
 		goto free_vmlogpath;
 	}
 
-	eventid = generate_eventid256(class);
+	eventid = generate_event_id((const char *)class, NULL, KEY_LONG);
 	if (eventid == NULL) {
 		LOGE("generate eventid failed, error (%s)\n", strerror(errno));
 		ret = VMEVT_DEFER;
@@ -739,7 +739,7 @@ static void crashlog_send_crash(struct event_t *e)
 
 	/* change the class for other senders */
 	e->private = (void *)crash;
-	key = generate_event_id("CRASH", crash->name);
+	key = generate_event_id("CRASH", (const char *)crash->name, KEY_SHORT);
 	if (key == NULL) {
 		LOGE("generate event id failed, error (%s)\n",
 		     strerror(errno));
@@ -818,7 +818,8 @@ static void crashlog_send_info(struct event_t *e)
 	int id;
 	struct info_t *info = (struct info_t *)e->private;
 	struct log_t *log;
-	char *key = generate_event_id("INFO", info->name);
+	char *key = generate_event_id("INFO", (const char *)info->name,
+				      KEY_SHORT);
 
 	if (key == NULL) {
 		LOGE("generate event id failed, error (%s)\n",
@@ -862,7 +863,7 @@ static void crashlog_send_reboot(void)
 		return;
 
 	if (swupdated(crashlog)) {
-		key = generate_event_id("INFO", "SWUPDATE");
+		key = generate_event_id("INFO", "SWUPDATE", KEY_SHORT);
 		if (key == NULL) {
 			LOGE("generate event id failed, error (%s)\n",
 			     strerror(errno));
@@ -874,7 +875,7 @@ static void crashlog_send_reboot(void)
 	}
 
 	read_startupreason(reason, sizeof(reason));
-	key = generate_event_id("REBOOT", reason);
+	key = generate_event_id("REBOOT", (const char *)reason, KEY_SHORT);
 	if (key == NULL) {
 		LOGE("generate event id failed, error (%s)\n",
 		     strerror(errno));
@@ -931,7 +932,7 @@ static int crashlog_new_vmevent(const char *line_to_sync,
 		return ret;
 	}
 
-	key = generate_event_id("SOS", vmkey);
+	key = generate_event_id("SOS", (const char *)vmkey, KEY_SHORT);
 	if (key == NULL) {
 		LOGE("generate event id failed, error (%s)\n",
 		     strerror(errno));


### PR DESCRIPTION
Acrnprobe is using SHA to generate ids for events. These ids are only used
to index events, not for cryptographic purpose.

This patch unify the generating algorithm of short and long ids to
SHA256.

Tracked-On: #1024
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Acked-by: Chen Gang <gang.c.chen@intel.com>