### PR TITLE
hypercall: no need check HV memory overlap for MR_DEL

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -430,21 +430,23 @@ static int32_t local_set_vm_memory_region(struct vm *vm,
 		return -EINVAL;
 	}
 
-	hpa = gpa2hpa(vm, region->vm0_gpa);
-	dev_dbg(ACRN_DBG_HYCALL, "[vm%d] gpa=0x%x hpa=0x%x size=0x%x",
-		target_vm->vm_id, region->gpa, hpa, region->size);
-
-	base_paddr = get_hv_image_base();
-	if (((hpa <= base_paddr) &&
-		((hpa + region->size) > base_paddr)) ||
-		((hpa >= base_paddr) &&
-		(hpa < (base_paddr + CONFIG_RAM_SIZE)))) {
-		pr_err("%s: overlap the HV memory region.", __func__);
-		return -EFAULT;
-	}
+	dev_dbg(ACRN_DBG_HYCALL,
+		"[vm%d] type=%d gpa=0x%x vm0_gpa=0x%x size=0x%x",
+		target_vm->vm_id, region->type, region->gpa,
+		region->vm0_gpa, region->size);
 
 	pml4_page = (uint64_t *)target_vm->arch_vm.nworld_eptp;
 	if (region->type != MR_DEL) {
+		hpa = gpa2hpa(vm, region->vm0_gpa);
+		base_paddr = get_hv_image_base();
+		if (((hpa <= base_paddr) &&
+				((hpa + region->size) > base_paddr)) ||
+				((hpa >= base_paddr) &&
+				 (hpa < (base_paddr + CONFIG_RAM_SIZE)))) {
+			pr_err("%s: overlap the HV memory region.", __func__);
+			return -EFAULT;
+		}
+
 		prot = 0UL;
 		/* access right */
 		if ((region->prot & MEM_ACCESS_READ) != 0U) {


### PR DESCRIPTION
in local_set_vm_memory_region, hpa is not used for MR_DEL, and it does
not need check HV memory overlap for a MR_DEL operation.

this is a bug exposed by remapping SOS first page, as the remap page whose
gpa = 0 actually fall into HV memory area; while during MR_DEL, the input
param vm0_gpa is set to 0 by default.

Tracked-On: #1124
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>