### PR TITLE
HV: update opcode when decode_two_byte_opcode()

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1743,6 +1743,7 @@ static int decode_two_byte_opcode(struct instr_emul_vie *vie)
 		return -1;
 	}
 
+	vie->opcode = x;
 	vie->op = two_byte_opcodes[x];
 
 	if (vie->op.op_type == VIE_OP_TYPE_NONE) {


### PR DESCRIPTION
The vie->opcode should be updated when decode_two_byte_opcode(),
otherwise for two bytes opcode emulate(movzx/movsx) will fail.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>