### PR TITLE
Enable support for USB hub and 'cold plug' mode

### DIFF
--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -855,6 +855,65 @@ out:
 	return xfer->status;
 }
 
+int
+usb_dev_is_hub(void *pdata)
+{
+	struct libusb_device *ldev;
+	struct libusb_device_descriptor desc;
+	int rc;
+
+	assert(pdata);
+
+	ldev = pdata;
+	rc = libusb_get_device_descriptor(ldev, &desc);
+
+	if (rc)
+		return USB_TYPE_INVALID;
+
+	if (desc.bDeviceClass == LIBUSB_CLASS_HUB)
+		return USB_HUB;
+	else
+		return USB_DEV;
+
+}
+
+enum usb_native_dev_type
+usb_get_parent_dev_type(void *pdata, uint16_t *bus, uint16_t *port)
+{
+	struct libusb_device *ldev;
+	struct libusb_device *libdev;
+	struct libusb_device_descriptor desc;
+	int rc;
+
+	assert(pdata);
+	assert(bus);
+	assert(port);
+
+	ldev = pdata;
+	libdev = libusb_get_parent(ldev);
+
+	if (libdev == NULL) {
+		UPRINTF(LWRN, "libusb_get_parent return NULL\r\n");
+		return USB_TYPE_INVALID;
+	}
+
+	*bus = libusb_get_bus_number(libdev);
+	*port = libusb_get_port_number(libdev);
+
+	rc = libusb_get_device_descriptor(libdev, &desc);
+	if (rc) {
+		UPRINTF(LWRN, "libusb_get_device_descriptor error %d\r\n", rc);
+		return USB_TYPE_INVALID;
+	}
+
+	if (*port == 0)
+		return ROOT_HUB;
+	if (desc.bDeviceClass == LIBUSB_CLASS_HUB)
+		return USB_HUB;
+
+	return USB_TYPE_INVALID;
+}
+
 void *
 usb_dev_init(void *pdata, char *opt)
 {
@@ -1039,6 +1098,9 @@ usb_dev_native_sys_disconn_cb(struct libusb_context *ctx, struct libusb_device
 		*ldev, libusb_hotplug_event event, void *pdata)
 {
 	uint8_t port;
+	uint16_t pport;
+	uint16_t pbus;
+	int rc;
 
 	UPRINTF(LDBG, "disconnect event\r\n");
 
@@ -1048,6 +1110,13 @@ usb_dev_native_sys_disconn_cb(struct libusb_context *ctx, struct libusb_device
 	}
 
 	port = libusb_get_port_number(ldev);
+	rc = usb_get_parent_dev_type(ldev, &pbus, &pport);
+	if (rc == USB_TYPE_INVALID) {
+		UPRINTF(LWRN, "usb_get_parent_dev_type return %d\r\n", rc);
+		return 0;
+	} else if (rc == USB_HUB)
+		port += PORT_HUB_BASE;
+
 	if (g_ctx.disconn_cb)
 		g_ctx.disconn_cb(g_ctx.hci_data, &port);
 

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -20,6 +20,9 @@
 #define USB_EP_NR(d) (USB_EP_ADDR(d) & 0xF)
 #define USB_EP_ERR_TYPE 0xFF
 
+/* hub port start address */
+#define PORT_HUB_BASE	0x0A
+
 enum {
 	USB_INFO_VERSION,
 	USB_INFO_SPEED,
@@ -27,6 +30,15 @@ enum {
 	USB_INFO_PORT,
 	USB_INFO_VID,
 	USB_INFO_PID
+};
+
+enum usb_native_dev_type {
+	ROOT_HUB,
+	USB_HUB,
+	USB_DEV,
+	USB_VALID_SUB_DEV,
+	USB_INVALID_SUB_DEV,
+	USB_TYPE_INVALID
 };
 
 struct usb_dev_ep {
@@ -119,4 +131,7 @@ int usb_dev_info(void *pdata, int type, void *value, int size);
 int usb_dev_request(void *pdata, struct usb_data_xfer *xfer);
 int usb_dev_reset(void *pdata);
 int usb_dev_data(void *pdata, struct usb_data_xfer *xfer, int dir, int epctx);
+enum usb_native_dev_type usb_get_parent_dev_type(void *pdata, uint16_t *bus,
+		uint16_t *port);
+int usb_dev_is_hub(void *pdata);
 #endif

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -42,10 +42,6 @@ fi
 
 #for VT-d device setting
 modprobe pci_stub
-echo "8086 5aa8" > /sys/bus/pci/drivers/pci-stub/new_id
-echo "0000:00:15.0" > /sys/bus/pci/devices/0000:00:15.0/driver/unbind
-echo "0000:00:15.0" > /sys/bus/pci/drivers/pci-stub/bind
-
 echo "8086 5aaa" > /sys/bus/pci/drivers/pci-stub/new_id
 echo "0000:00:15.1" > /sys/bus/pci/devices/0000:00:15.1/driver/unbind
 echo "0000:00:15.1" > /sys/bus/pci/drivers/pci-stub/bind
@@ -119,7 +115,7 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   -s 8,wdt-i6300esb \
   -s 3,virtio-blk$boot_dev_flag,/data/$5/$5.img \
   -s 4,virtio-net,$tap $boot_image_option \
-  -s 7,passthru,0/15/0 \
+  -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
   -s 9,passthru,0/15/1 \
   -s 15,passthru,0/f/0 \
   -s 27,passthru,0/1b/0 \
@@ -178,10 +174,6 @@ fi
 
 #for VT-d device setting
 modprobe pci_stub
-echo "8086 5aa8" > /sys/bus/pci/drivers/pci-stub/new_id
-echo "0000:00:15.0" > /sys/bus/pci/devices/0000:00:15.0/driver/unbind
-echo "0000:00:15.0" > /sys/bus/pci/drivers/pci-stub/bind
-
 echo "8086 5aaa" > /sys/bus/pci/drivers/pci-stub/new_id
 echo "0000:00:15.1" > /sys/bus/pci/devices/0000:00:15.1/driver/unbind
 echo "0000:00:15.1" > /sys/bus/pci/drivers/pci-stub/bind
@@ -297,7 +289,7 @@ fi
  acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio $npk_virt\
    -s 9,virtio-net,$tap \
    -s 3,virtio-blk$boot_dev_flag,/data/$5/$5.img \
-   -s 7,passthru,0/15/0 \
+   -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
    -s 8,passthru,0/15/1 \
    -s 13,virtio-rpmb \
    -s 10,virtio-hyper_dmabuf \


### PR DESCRIPTION
This patch series is used to support 'flat mode' hub emulation and 'cold
plug' feature.

1. Flat mode hub emulation means DM only emulates USB devices under hub,
   the Guest OS cannot see emulated hub. In the perspective of Guest OS,
   all the emulated devices are under root hub.

2. Cold plug mode refers to USB devices are plugged in before Guest OS
   is booted. In this case, the libusb will not report 'connect' event
   to DM, and hence the Guest OS will have no opportunity to do enumeration
   for those devices. The second patch is used to fix this issue.