### PR TITLE
hv: long and long long is same for printf within x86_64

### DIFF
--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -38,8 +38,8 @@
 /** The original value was a (unsigned) short. */
 #define PRINT_FLAG_SHORT		0x00000080U
 
-/** The original value was a (unsigned) long. */
-#define PRINT_FLAG_LONG			0x00000100U
+/** The original value was a (unsigned) long. 64bit on ACRN also */
+#define PRINT_FLAG_LONG			0x00000200U
 
 /** The original value was a (unsigned) long long. */
 #define PRINT_FLAG_LONG_LONG		0x00000200U


### PR DESCRIPTION
In ACRN hypervisor, u/int64_t is defined as unsigned/ long.
It's nature to use %l to print it. But current printf use
%l to print int and only use %ll for long.

This patch fix it by treat long and long long same for printf.

Tracked-On: #1230
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>