### PR TITLE
doc: fix Makefile to address multiple publishers

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -69,6 +69,7 @@ clean:
 
 publish:
 	mkdir -p $(PUBLISHDIR)
+	cd $(PUBLISHDIR)/..; git pull origin master
 	rm -fr $(PUBLISHDIR)/*
 	cp -r $(BUILDDIR)/html/* $(PUBLISHDIR)
 	cp scripts/publish-README.md $(PUBLISHDIR)/../README.md


### PR DESCRIPTION
Need to make sure the local projectacrn.github.io is in sync with the
master before starting up the publishing process.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>