### PR TITLE
doc: fix spaces in release notes

### DIFF
--- a/doc/release_notes_0.2.rst
+++ b/doc/release_notes_0.2.rst
@@ -19,10 +19,10 @@ Version 0.2 new features
 
 VT-x, VT-d
 ================
-Based on Intel VT-x virtualization technology, ACRN emulates a virtual 
-CPU with core partition and simple schedule. VT-d provides hardware 
-support for isolating and restricting device accesses to the owner of 
-the partition managing the device.It allows assigning I/O devices to a VM, 
+Based on Intel VT-x virtualization technology, ACRN emulates a virtual
+CPU with core partition and simple schedule. VT-d provides hardware
+support for isolating and restricting device accesses to the owner of
+the partition managing the device. It allows assigning I/O devices to a VM,
 and extending the protection and isolation properties of VMs for I/O operations.
 
 PIC/IOAPIC/MSI/MSI-X/PCI/LAPIC
@@ -31,22 +31,22 @@ ACRN hypervisor supports virtualized APIC-V/EPT/IOAPIC/LAPIC functionality.
 
 Ethernet
 ================
-ACRN hypervisor supports virtualized Ethernet functionality. Ethernet Mediator is 
-executed in the Service OS and provides packet forwarding between the physical 
-networking devices (Ethernet, Wi-Fi, etc.) and virtual devices in the Guest 
-VMs(also called "User OS"). Virtual Ethernet device could be shared by Linux, 
-Android, and Service OS guests for regular (i.e. non-AVB) traffic. All hypervisor 
+ACRN hypervisor supports virtualized Ethernet functionality. Ethernet Mediator is
+executed in the Service OS and provides packet forwarding between the physical
+networking devices (Ethernet, Wi-Fi, etc.) and virtual devices in the Guest
+VMs(also called "User OS"). Virtual Ethernet device could be shared by Linux,
+Android, and Service OS guests for regular (i.e. non-AVB) traffic. All hypervisor
 para-virtualized I/O is implemented using the VirtIO specification Ethernet pass-through.
 
 Storage (eMMC)
 ================
-ACRN hypervisor supports virtualized non-volatile R/W storage for the Service 
-OS and Guest OS instances, supporting VM private storage and/or storage shared 
+ACRN hypervisor supports virtualized non-volatile R/W storage for the Service
+OS and Guest OS instances, supporting VM private storage and/or storage shared
 between Guest OS instances.
 
 USB (xDCI)
 ================
-ACRN hypervisor supports virtualized assignment of all USB xHCI and/or xDCI 
+ACRN hypervisor supports virtualized assignment of all USB xHCI and/or xDCI
 controllers to a Guest OS from the platform.
 
 USB Mediator (xHCI and DRD)
@@ -55,19 +55,19 @@ ACRN hypervisor supports a virtualized USB Mediator.
 
 CSME
 ================
-ACRN hypervisor supports a CSME to a single Linux, Android, or RTOS guest or 
+ACRN hypervisor supports a CSME to a single Linux, Android, or RTOS guest or
 the Service OS even when in a virtualized environment.
 
 WiFi
 ================
-ACRN hypervisor supports the passthrough assignment of the WiFi subsystem to the IVI, 
-enables control of the WiFi as an in-vehicle hotspot for 3rd party devices, 
-provides 3rd party device applications access to the vehicle, 
+ACRN hypervisor supports the passthrough assignment of the WiFi subsystem to the IVI,
+enables control of the WiFi as an in-vehicle hotspot for 3rd party devices,
+provides 3rd party device applications access to the vehicle,
 and provides access of 3rd party devices to the TCU provided connectivity.
 
 IPU (MIPI-CS2, HDMI-in)
 ========================
-ACRN hypervisor supports passthrough IPU assignment to Service OS or 
+ACRN hypervisor supports passthrough IPU assignment to Service OS or
 guest OS, without sharing.
 
 Bluetooth
@@ -85,11 +85,11 @@ i915 SOS scheduler.
 
 GPU – display surface sharing via Hyper DMA
 ============================================
-Surface sharing is one typical automotive use case which requires 
-that the SOS accesses an individual surface or a set of surfaces 
-from the UOS without having to access the entire frame buffer of 
-the UOS. Hyper DMA Buffer sharing extends the Linux DMA buffer 
-sharing mechanism where one driver is able to share its pages 
+Surface sharing is one typical automotive use case which requires
+that the SOS accesses an individual surface or a set of surfaces
+from the UOS without having to access the entire frame buffer of
+the UOS. Hyper DMA Buffer sharing extends the Linux DMA buffer
+sharing mechanism where one driver is able to share its pages
 with another driver within one domain.
 
 S3


### PR DESCRIPTION
Removed white space at the end of the line, and fixed a sentence that
did not have a space after the period.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>