### PR TITLE
hv: remove unused MACROs

### DIFF
--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -6,12 +6,6 @@
 
 #include <hypervisor.h>
 
-/* Rate range 1 to 1000 or 1uSec to 1mSec */
-#define APIC_TIMER_MAX      0xffffffffU
-#define HYPE_PERIOD_MAX     1000
-#define APIC_DIVIDE_BY_ONE  0x0b
-#define PIT_TARGET          0x3FFFU
-
 /* xAPIC/x2APIC Interrupt Command Register (ICR) structure */
 union apic_icr {
 	uint64_t value;

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -7,7 +7,6 @@
 #include <hypervisor.h>
 
 #define EXCEPTION_ERROR_CODE_VALID  8U
-#define INTERRPUT_QUEUE_BUFF_SIZE   255
 
 #define ACRN_DBG_INTR	6U
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -22,7 +22,6 @@
  */
 #define IOMMU_INIT_BUS_LIMIT        (0xfU)
 
-#define PAGE_MASK                   (0xFFFUL)
 #define LEVEL_WIDTH 9U
 
 #define ROOT_ENTRY_LOWER_PRESENT_POS        (0U)
@@ -79,8 +78,6 @@ dmar_set_bitslice(uint64_t var, uint64_t mask,
 #define DMAR_MSI_REDIRECTION_SHIFT       (3)
 #define DMAR_MSI_REDIRECTION_CPU         (0 << DMAR_MSI_REDIRECTION_SHIFT)
 #define DMAR_MSI_REDIRECTION_LOWPRI      (1 << DMAR_MSI_REDIRECTION_SHIFT)
-
-#define DMAR_OP_TIMEOUT CYCLES_PER_MS
 
 enum dmar_cirg_type {
 	DMAR_CIRG_RESERVED = 0,

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -10,9 +10,6 @@
 #include <spinlock.h>
 
 #define SHELL_CMD_MAX_LEN		100U
-#define SHELL_NAME_MAX_LEN		50
-#define SHELL_PARA_MAX_LEN		64
-#define SHELL_HELP_MAX_LEN		256
 #define SHELL_STRING_MAX_LEN		(CPU_PAGE_SIZE << 2)
 
 /* Shell Command Function */

--- a/hypervisor/include/arch/x86/gdt.h
+++ b/hypervisor/include/arch/x86/gdt.h
@@ -66,11 +66,6 @@
 	(HOST_GDT_RING0_CPU_TSS_SEL +					\
 		(HOST_GDT_RING0_TSS_SELECTORS * X64_TSS_DESC_SIZE))
 
-/* Defined position of Interrupt Stack Tables */
-#define MACHINE_CHECK_IST   (0x1)
-#define DOUBLE_FAULT_IST    (0x2)
-#define STACK_FAULT_IST     (0x3)
-
 #ifndef ASSEMBLER
 
 #include <types.h>

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -9,9 +9,6 @@
 
 #define	ACRN_VCPU_MMIO_COMPLETE		(0U)
 
-/* Size of various elements within the VCPU structure */
-#define REG_SIZE                            8
-
 /* Number of GPRs saved / restored for guest in VCPU structure */
 #define NUM_GPRS                            16U
 #define GUEST_STATE_AREA_SIZE               512

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -18,7 +18,6 @@ enum vm_privilege_level {
 	VM_PRIVILEGE_LEVEL_LOW
 };
 
-#define	MAX_VM_NAME_LEN		16
 #define INVALID_VM_ID 0xffffU
 
 struct vm_hw_info {

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -7,8 +7,6 @@
 #ifndef INTR_LAPIC_H
 #define INTR_LAPIC_H
 
-#define DEBUG_LAPIC 0
-
 /* intr_lapic_icr_delivery_mode */
 #define INTR_LAPIC_ICR_FIXED    0x0U
 #define INTR_LAPIC_ICR_LP          0x1U

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -14,7 +14,6 @@
 
 /* Trusty EPT rebase gpa: 511G */
 #define TRUSTY_EPT_REBASE_GPA (511UL * 1024UL * 1024UL * 1024UL)
-#define TRUSTY_MEMORY_SIZE        0x01000000
 
 #define NON_TRUSTY_PDPT_ENTRIES         511U
 

--- a/hypervisor/include/common/softirq.h
+++ b/hypervisor/include/common/softirq.h
@@ -10,7 +10,6 @@
 #define SOFTIRQ_TIMER		0U
 #define SOFTIRQ_PTDEV		1U
 #define NR_SOFTIRQS		2U
-#define SOFTIRQ_MASK		((1UL << NR_SOFTIRQS) - 1UL)
 
 typedef void (*softirq_handler)(uint16_t cpu_id);
 

--- a/hypervisor/include/lib/types.h
+++ b/hypervisor/include/lib/types.h
@@ -7,10 +7,6 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-/* Defines for TRUE / FALSE conditions */
-#define		HV_FALSE		0
-#define		HV_TRUE			1
-
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #define __aligned(x)		__attribute__((aligned(x)))
 #define __packed	__attribute__((packed))

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -79,7 +79,6 @@
 #define HC_ID_PM_BASE               0x80UL
 #define HC_PM_GET_CPU_STATE         BASE_HC_ID(HC_ID, HC_ID_PM_BASE + 0x00UL)
 
-#define ACRN_DOM0_VMID (0UL)
 #define ACRN_INVALID_VMID (0xffffU)
 #define ACRN_INVALID_HPA (~0UL)
 


### PR DESCRIPTION
MISRA-C states that redundant macros reduce the maintainability of code.

In some cases, we would like to keep the current unused macros for code
completeness, such as cpu registers. These macros might be used later.

This patch removes some unused macros that is not critical for code
completeness.

v1 -> v2:
 * Keep TRUSTY_VERSION in trusty.c.
   Yadong will cook another patch which will utilize TRUSTY_VERSION.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>