### PR TITLE
HV: refine 'struct lapic_regs' definition.

### DIFF
--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -241,66 +241,68 @@ void init_lapic(uint16_t pcpu_id)
 
 void save_lapic(struct lapic_regs *regs)
 {
-	regs->id = read_lapic_reg32(LAPIC_ID_REGISTER);
-	regs->tpr = read_lapic_reg32(LAPIC_TASK_PRIORITY_REGISTER);
-	regs->apr = read_lapic_reg32(LAPIC_ARBITRATION_PRIORITY_REGISTER);
-	regs->ppr = read_lapic_reg32(LAPIC_PROCESSOR_PRIORITY_REGISTER);
-	regs->ldr = read_lapic_reg32(LAPIC_LOGICAL_DESTINATION_REGISTER);
-	regs->dfr = read_lapic_reg32(LAPIC_DESTINATION_FORMAT_REGISTER);
-	regs->tmr[0].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_0);
-	regs->tmr[1].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_1);
-	regs->tmr[2].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_2);
-	regs->tmr[3].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_3);
-	regs->tmr[4].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_4);
-	regs->tmr[5].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_5);
-	regs->tmr[6].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_6);
-	regs->tmr[7].val = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_7);
-	regs->svr = read_lapic_reg32(LAPIC_SPURIOUS_VECTOR_REGISTER);
-	regs->lvt[APIC_LVT_TIMER].val =
+	regs->id.v = read_lapic_reg32(LAPIC_ID_REGISTER);
+	regs->tpr.v = read_lapic_reg32(LAPIC_TASK_PRIORITY_REGISTER);
+	regs->apr.v = read_lapic_reg32(LAPIC_ARBITRATION_PRIORITY_REGISTER);
+	regs->ppr.v = read_lapic_reg32(LAPIC_PROCESSOR_PRIORITY_REGISTER);
+	regs->ldr.v = read_lapic_reg32(LAPIC_LOGICAL_DESTINATION_REGISTER);
+	regs->dfr.v = read_lapic_reg32(LAPIC_DESTINATION_FORMAT_REGISTER);
+	regs->tmr[0].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_0);
+	regs->tmr[1].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_1);
+	regs->tmr[2].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_2);
+	regs->tmr[3].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_3);
+	regs->tmr[4].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_4);
+	regs->tmr[5].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_5);
+	regs->tmr[6].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_6);
+	regs->tmr[7].v = read_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_7);
+	regs->svr.v = read_lapic_reg32(LAPIC_SPURIOUS_VECTOR_REGISTER);
+	regs->lvt[APIC_LVT_TIMER].v =
 		read_lapic_reg32(LAPIC_LVT_TIMER_REGISTER);
-	regs->lvt[APIC_LVT_LINT0].val =
+	regs->lvt[APIC_LVT_LINT0].v =
 		read_lapic_reg32(LAPIC_LVT_LINT0_REGISTER);
-	regs->lvt[APIC_LVT_LINT1].val =
+	regs->lvt[APIC_LVT_LINT1].v =
 		read_lapic_reg32(LAPIC_LVT_LINT1_REGISTER);
-	regs->lvt[APIC_LVT_ERROR].val =
+	regs->lvt[APIC_LVT_ERROR].v =
 		read_lapic_reg32(LAPIC_LVT_ERROR_REGISTER);
-	regs->icr_timer = read_lapic_reg32(LAPIC_INITIAL_COUNT_REGISTER);
-	regs->ccr_timer = read_lapic_reg32(LAPIC_CURRENT_COUNT_REGISTER);
-	regs->dcr_timer = read_lapic_reg32(LAPIC_DIVIDE_CONFIGURATION_REGISTER);
+	regs->icr_timer.v = read_lapic_reg32(LAPIC_INITIAL_COUNT_REGISTER);
+	regs->ccr_timer.v = read_lapic_reg32(LAPIC_CURRENT_COUNT_REGISTER);
+	regs->dcr_timer.v =
+		read_lapic_reg32(LAPIC_DIVIDE_CONFIGURATION_REGISTER);
 }
 
 static void restore_lapic(struct lapic_regs *regs)
 {
-	write_lapic_reg32(LAPIC_ID_REGISTER, regs->id);
-	write_lapic_reg32(LAPIC_TASK_PRIORITY_REGISTER, regs->tpr);
-	write_lapic_reg32(LAPIC_LOGICAL_DESTINATION_REGISTER, regs->ldr );
-	write_lapic_reg32(LAPIC_DESTINATION_FORMAT_REGISTER, regs->dfr );
-	write_lapic_reg32(LAPIC_SPURIOUS_VECTOR_REGISTER, regs->svr );
+	write_lapic_reg32(LAPIC_ID_REGISTER, regs->id.v);
+	write_lapic_reg32(LAPIC_TASK_PRIORITY_REGISTER, regs->tpr.v);
+	write_lapic_reg32(LAPIC_LOGICAL_DESTINATION_REGISTER, regs->ldr.v);
+	write_lapic_reg32(LAPIC_DESTINATION_FORMAT_REGISTER, regs->dfr.v);
+	write_lapic_reg32(LAPIC_SPURIOUS_VECTOR_REGISTER, regs->svr.v);
 	write_lapic_reg32(LAPIC_LVT_TIMER_REGISTER,
-			regs->lvt[APIC_LVT_TIMER].val);
+			regs->lvt[APIC_LVT_TIMER].v);
 
 	write_lapic_reg32(LAPIC_LVT_LINT0_REGISTER,
-			regs->lvt[APIC_LVT_LINT0].val);
+			regs->lvt[APIC_LVT_LINT0].v);
 	write_lapic_reg32(LAPIC_LVT_LINT1_REGISTER,
-			regs->lvt[APIC_LVT_LINT1].val);
+			regs->lvt[APIC_LVT_LINT1].v);
 
 	write_lapic_reg32(LAPIC_LVT_ERROR_REGISTER,
-			regs->lvt[APIC_LVT_ERROR].val);
-	write_lapic_reg32(LAPIC_INITIAL_COUNT_REGISTER, regs->icr_timer);
-	write_lapic_reg32(LAPIC_DIVIDE_CONFIGURATION_REGISTER, regs->dcr_timer);
+			regs->lvt[APIC_LVT_ERROR].v);
+	write_lapic_reg32(LAPIC_INITIAL_COUNT_REGISTER, regs->icr_timer.v);
+	write_lapic_reg32(LAPIC_DIVIDE_CONFIGURATION_REGISTER,
+			regs->dcr_timer.v);
 
 
-	write_lapic_reg32(LAPIC_ARBITRATION_PRIORITY_REGISTER, regs->apr);
-	write_lapic_reg32(LAPIC_PROCESSOR_PRIORITY_REGISTER, regs->ppr);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_0, regs->tmr[0].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_1, regs->tmr[1].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_2, regs->tmr[2].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_3, regs->tmr[3].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_4, regs->tmr[4].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_5, regs->tmr[5].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_6, regs->tmr[6].val);
-	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_7, regs->tmr[7].val);
-	write_lapic_reg32(LAPIC_CURRENT_COUNT_REGISTER, regs->ccr_timer);
+	write_lapic_reg32(LAPIC_ARBITRATION_PRIORITY_REGISTER, regs->apr.v);
+	write_lapic_reg32(LAPIC_PROCESSOR_PRIORITY_REGISTER, regs->ppr.v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_0, regs->tmr[0].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_1, regs->tmr[1].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_2, regs->tmr[2].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_3, regs->tmr[3].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_4, regs->tmr[4].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_5, regs->tmr[5].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_6, regs->tmr[6].v);
+	write_lapic_reg32(LAPIC_TRIGGER_MODE_REGISTER_7, regs->tmr[7].v);
+	write_lapic_reg32(LAPIC_CURRENT_COUNT_REGISTER, regs->ccr_timer.v);
 }
 
 void suspend_lapic(void)

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -118,55 +118,38 @@
 /******************************************************************************
  * LOCAL APIC structure
  */
-
-#ifndef LOCORE
-
-#define PAD3	uint32_t: 32; uint32_t: 32; uint32_t: 32
-#define PAD4	uint32_t: 32; uint32_t: 32; uint32_t: 32; uint32_t: 32
-
 struct lapic_reg {
-	uint32_t val;		PAD3;
+	uint32_t v;
+	uint32_t pad[3];
 };
 
 struct lapic_regs {
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	uint32_t id;		PAD3;
-	uint32_t version;	PAD3;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	uint32_t tpr;		PAD3;
-	uint32_t apr;		PAD3;
-	uint32_t ppr;		PAD3;
-	uint32_t eoi;		PAD3;
-	/* reserved */		PAD4;
-	uint32_t ldr;		PAD3;
-	uint32_t dfr;		PAD3;
-	uint32_t svr;		PAD3;
+	struct lapic_reg	rsv0[2];
+	struct lapic_reg	id;
+	struct lapic_reg	version;
+	struct lapic_reg	rsv1[4];
+	struct lapic_reg	tpr;
+	struct lapic_reg	apr;
+	struct lapic_reg	ppr;
+	struct lapic_reg	eoi;
+	struct lapic_reg	rsv2;
+	struct lapic_reg	ldr;
+	struct lapic_reg	dfr;
+	struct lapic_reg	svr;
 	struct lapic_reg	isr[8];
 	struct lapic_reg	tmr[8];
 	struct lapic_reg	irr[8];
-	uint32_t esr;		PAD3;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	uint32_t lvt_cmci;	PAD3;
-	uint32_t icr_lo;	PAD3;
-	uint32_t icr_hi;	PAD3;
+	struct lapic_reg	esr;
+	struct lapic_reg	rsv3[6];
+	struct lapic_reg	lvt_cmci;
+	struct lapic_reg	icr_lo;
+	struct lapic_reg	icr_hi;
 	struct lapic_reg	lvt[6];
-	uint32_t icr_timer;	PAD3;
-	uint32_t ccr_timer;	PAD3;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	/* reserved */		PAD4;
-	uint32_t dcr_timer;	PAD3;
-	/* reserved */		PAD4;
+	struct lapic_reg	icr_timer;
+	struct lapic_reg	ccr_timer;
+	struct lapic_reg	rsv4[4];
+	struct lapic_reg	dcr_timer;
+	struct lapic_reg	rsv5;
 } __aligned(CPU_PAGE_SIZE);
 
 enum LAPIC_REGISTERS {
@@ -249,8 +232,10 @@ enum LAPIC_REGISTERS {
  */
 
 struct ioapic {
-	uint32_t ioregsel;	PAD3;
-	uint32_t iowin;	PAD3;
+	uint32_t ioregsel;
+	uint32_t rsv0[3];
+	uint32_t iowin;
+	uint32_t rsv1[3];
 };
 
 /* IOAPIC Redirection Table (RTE) Entry structure */
@@ -261,12 +246,6 @@ union ioapic_rte {
 		uint32_t hi_32;
 	} u;
 };
-
-#undef PAD4
-#undef PAD3
-
-#endif  /* !LOCORE */
-
 
 /******************************************************************************
  * various code 'logical' values


### PR DESCRIPTION
 - remove 'PAD3' & 'PAD4'
 - define local APIC registers by 'struct lapic_reg' type.

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>