### PR TITLE
HV: add ACPI fixup feature

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -116,6 +116,10 @@ config RAM_SIZE
 	hex "Size of the RAM region assigned to the hypervisor"
 	default 0x02000000
 
+config CONSTANT_ACPI
+	bool "The platform ACPI info is constant"
+	default n
+
 config DMAR_PARSE_ENABLED
 	bool
 	default n if PLATFORM_SBL

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -364,4 +364,19 @@ static void *get_facs_table(void)
 	return facs_addr;
 }
 
+/* put all ACPI fix up code here */
+void acpi_fixup(void)
+{
+	uint8_t *facs_addr;
+
+	facs_addr = get_facs_table();
+
+	if (facs_addr != NULL) {
+		host_acpi_info.pm_s_state.wake_vector_32 =
+			(uint32_t *)(facs_addr + OFFSET_WAKE_VECTOR_32);
+		host_acpi_info.pm_s_state.wake_vector_64 =
+			(uint64_t *)(facs_addr + OFFSET_WAKE_VECTOR_64);
+	}
+}
+
 #endif

--- a/hypervisor/bsp/include/bsp_extern.h
+++ b/hypervisor/bsp/include/bsp_extern.h
@@ -31,7 +31,7 @@ struct acpi_info {
 /* EXTERNAL VARIABLES             */
 /**********************************/
 extern struct vm_description vm0_desc;
-extern const struct acpi_info host_acpi_info;
+extern struct acpi_info host_acpi_info;
 
 /* BSP Interfaces */
 void init_bsp(void);

--- a/hypervisor/bsp/include/bsp_extern.h
+++ b/hypervisor/bsp/include/bsp_extern.h
@@ -36,4 +36,8 @@ extern struct acpi_info host_acpi_info;
 /* BSP Interfaces */
 void init_bsp(void);
 
+#ifndef CONFIG_CONSTANT_ACPI
+void acpi_fixup(void);
+#endif
+
 #endif /* BSP_EXTERN_H */

--- a/hypervisor/bsp/sbl/platform_acpi_info.c
+++ b/hypervisor/bsp/sbl/platform_acpi_info.c
@@ -6,7 +6,7 @@
 
 #include <hypervisor.h>
 
-const struct acpi_info host_acpi_info = {
+struct acpi_info host_acpi_info = {
 	.x86_family = 6U,
 	.x86_model = 0x5CU,			/* ApolloLake */
 	.pm_s_state = {

--- a/hypervisor/bsp/sbl/sbl.c
+++ b/hypervisor/bsp/sbl/sbl.c
@@ -62,4 +62,7 @@ struct dmar_info *get_dmar_info(void)
 
 void    init_bsp(void)
 {
+#ifndef CONFIG_CONSTANT_ACPI
+	acpi_fixup();
+#endif
 }

--- a/hypervisor/bsp/uefi/platform_acpi_info.c
+++ b/hypervisor/bsp/uefi/platform_acpi_info.c
@@ -10,17 +10,49 @@
 
 #include <hypervisor.h>
 
-const struct acpi_info host_acpi_info = {
-	0,				/* x86 family */
-	0,				/* x86 model */
-	{
-		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1a EVT */
-		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1b EVT */
-		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1a CNT */
-		{SPACE_SYSTEM_IO, 0, 0, 0, 0},	/* PM1b CNT */
-		{0,	0,	0},		/* _S3 Package */
-		{0,	0,	0},		/* _S5 Package */
-		(uint32_t *)0,			/* Wake Vector 32 */
-		(uint64_t *)0			/* Wake Vector 64 */
+struct acpi_info host_acpi_info = {
+	.x86_family = 0U,
+	.x86_model = 0U,
+	.pm_s_state = {
+		.pm1a_evt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0U,
+			.bit_offset = 0U,
+			.access_size = 0U,
+			.address = 0UL
+		},
+		.pm1b_evt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0U,
+			.bit_offset = 0U,
+			.access_size = 0U,
+			.address = 0UL
+		},
+		.pm1a_cnt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0U,
+			.bit_offset = 0U,
+			.access_size = 0U,
+			.address = 0UL
+		},
+		.pm1b_cnt = {
+			.space_id = SPACE_SYSTEM_IO,
+			.bit_width = 0U,
+			.bit_offset = 0U,
+			.access_size = 0U,
+			.address = 0UL
+		},
+		.s3_pkg = {
+			.val_pm1a = 0U,
+			.val_pm1b = 0U,
+			.reserved = 0U
+		},
+		.s5_pkg = {
+			.val_pm1a = 0U,
+			.val_pm1b = 0U,
+			.reserved = 0U
+		},
+		.wake_vector_32 = (uint32_t *)0UL,
+		.wake_vector_64 = (uint64_t *)0UL
 	}
 };

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -115,6 +115,9 @@ static void efi_init(void)
 
 void init_bsp(void)
 {
+#ifndef CONFIG_CONSTANT_ACPI
+	acpi_fixup();
+#endif
 	parse_hv_cmdline();
 
 #ifdef CONFIG_EFI_STUB


### PR DESCRIPTION
The platform ACPI table might be changed before production, this brings
issue to us as current host_acpi_info data is hard-coded.

The patch set enable the feature that could parse the needed ACPI data
after boot and then override the host_acpi_info structure for system
usage.

change log:
	v2 -> v1:
		1) remove MACRO of CONST;
		2) move parser code into acpi.c;

	v3 -> v2:
		1) remove memcpy to simplify parser logic;
		2) remove strcmp to simplify signature verification;
		3) move acpi_fix() caller to init_bsp();