### PR TITLE
tools: acrnd: bugfix: service lack of prerequisition

### DIFF
--- a/tools/acrn-manager/acrnd.service
+++ b/tools/acrn-manager/acrnd.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=ACRN manager deamon
+After=weston.service
+After=systemd-resolved.service
+ConditionPathExists=/sys/kernel/gvt
+ConditionPathExists=/dev/acrn_vhm
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/acrnd
+ExecStop=/usr/bin/killall -s TERM acrnd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As a system service, acrnd will launch UOS, that must be done
after all required services and conditions are ready, such as
acrnprobe, weston, etc.

Tracked-On: #1278 
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>