### PR TITLE
hv:Fix Implict conversion:actual to formal param

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -182,58 +182,69 @@ static uint64_t size2mask[9] = {
 
 #define VMX_INVALID_VMCS_FIELD  0xffffffffU
 
-static void encode_vmcs_seg_desc(enum cpu_reg_name seg, struct seg_desc *desc)
+/*
+ * This struct seg_desc_vmcs is defined separately to hold the vmcs field
+ * address of segment selector.
+ */
+struct seg_desc_vmcs {
+	uint32_t	base_field;
+	uint32_t	limit_field;
+	uint32_t	access_field;
+};
+
+static void encode_vmcs_seg_desc(enum cpu_reg_name seg,
+	struct seg_desc_vmcs *desc)
 {
 	switch (seg) {
 	case CPU_REG_ES:
-		desc->base = VMX_GUEST_ES_BASE;
-		desc->limit = VMX_GUEST_ES_LIMIT;
-		desc->access = VMX_GUEST_ES_ATTR;
+		desc->base_field = VMX_GUEST_ES_BASE;
+		desc->limit_field = VMX_GUEST_ES_LIMIT;
+		desc->access_field = VMX_GUEST_ES_ATTR;
 		break;
 	case CPU_REG_CS:
-		desc->base = VMX_GUEST_CS_BASE;
-		desc->limit = VMX_GUEST_CS_LIMIT;
-		desc->access = VMX_GUEST_CS_ATTR;
+		desc->base_field = VMX_GUEST_CS_BASE;
+		desc->limit_field = VMX_GUEST_CS_LIMIT;
+		desc->access_field = VMX_GUEST_CS_ATTR;
 		break;
 	case CPU_REG_SS:
-		desc->base = VMX_GUEST_SS_BASE;
-		desc->limit = VMX_GUEST_SS_LIMIT;
-		desc->access = VMX_GUEST_SS_ATTR;
+		desc->base_field = VMX_GUEST_SS_BASE;
+		desc->limit_field = VMX_GUEST_SS_LIMIT;
+		desc->access_field = VMX_GUEST_SS_ATTR;
 		break;
 	case CPU_REG_DS:
-		desc->base = VMX_GUEST_DS_BASE;
-		desc->limit = VMX_GUEST_DS_LIMIT;
-		desc->access = VMX_GUEST_DS_ATTR;
+		desc->base_field = VMX_GUEST_DS_BASE;
+		desc->limit_field = VMX_GUEST_DS_LIMIT;
+		desc->access_field = VMX_GUEST_DS_ATTR;
 		break;
 	case CPU_REG_FS:
-		desc->base = VMX_GUEST_FS_BASE;
-		desc->limit = VMX_GUEST_FS_LIMIT;
-		desc->access = VMX_GUEST_FS_ATTR;
+		desc->base_field = VMX_GUEST_FS_BASE;
+		desc->limit_field = VMX_GUEST_FS_LIMIT;
+		desc->access_field = VMX_GUEST_FS_ATTR;
 		break;
 	case CPU_REG_GS:
-		desc->base = VMX_GUEST_GS_BASE;
-		desc->limit = VMX_GUEST_GS_LIMIT;
-		desc->access = VMX_GUEST_GS_ATTR;
+		desc->base_field = VMX_GUEST_GS_BASE;
+		desc->limit_field = VMX_GUEST_GS_LIMIT;
+		desc->access_field = VMX_GUEST_GS_ATTR;
 		break;
 	case CPU_REG_TR:
-		desc->base = VMX_GUEST_TR_BASE;
-		desc->limit = VMX_GUEST_TR_LIMIT;
-		desc->access = VMX_GUEST_TR_ATTR;
+		desc->base_field = VMX_GUEST_TR_BASE;
+		desc->limit_field = VMX_GUEST_TR_LIMIT;
+		desc->access_field = VMX_GUEST_TR_ATTR;
 		break;
 	case CPU_REG_LDTR:
-		desc->base = VMX_GUEST_LDTR_BASE;
-		desc->limit = VMX_GUEST_LDTR_LIMIT;
-		desc->access = VMX_GUEST_LDTR_ATTR;
+		desc->base_field = VMX_GUEST_LDTR_BASE;
+		desc->limit_field = VMX_GUEST_LDTR_LIMIT;
+		desc->access_field = VMX_GUEST_LDTR_ATTR;
 		break;
 	case CPU_REG_IDTR:
-		desc->base = VMX_GUEST_IDTR_BASE;
-		desc->limit = VMX_GUEST_IDTR_LIMIT;
-		desc->access = 0xffffffffU;
+		desc->base_field = VMX_GUEST_IDTR_BASE;
+		desc->limit_field = VMX_GUEST_IDTR_LIMIT;
+		desc->access_field = 0xffffffffU;
 		break;
 	case CPU_REG_GDTR:
-		desc->base = VMX_GUEST_GDTR_BASE;
-		desc->limit = VMX_GUEST_GDTR_LIMIT;
-		desc->access = 0xffffffffU;
+		desc->base_field = VMX_GUEST_GDTR_BASE;
+		desc->limit_field = VMX_GUEST_GDTR_LIMIT;
+		desc->access_field = 0xffffffffU;
 		break;
 	default:
 		pr_err("%s: invalid seg %d", __func__, seg);
@@ -363,14 +374,14 @@ static void vm_set_register(struct vcpu *vcpu, enum cpu_reg_name reg,
  */
 static void vm_get_seg_desc(enum cpu_reg_name seg, struct seg_desc *desc)
 {
-	struct seg_desc tdesc = {0UL, 0U, 0U};
+	struct seg_desc_vmcs tdesc = {0U, 0U, 0U};
 
 	/* tdesc->access != 0xffffffffU in this function */
 	encode_vmcs_seg_desc(seg, &tdesc);
 
-	desc->base = exec_vmread(tdesc.base);
-	desc->limit = exec_vmread32(tdesc.limit);
-	desc->access = exec_vmread32(tdesc.access);
+	desc->base = exec_vmread(tdesc.base_field);
+	desc->limit = exec_vmread32(tdesc.limit_field);
+	desc->access = exec_vmread32(tdesc.access_field);
 }
 
 static void get_guest_paging_info(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -154,7 +154,6 @@ struct seg_desc {
 	uint32_t	access;
 };
 
-
 /*
  * Protections are chosen from these bits, or-ed together
  */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -45,7 +45,8 @@ uint32_t alloc_irq_num(uint32_t req_irq)
 	}
 
 	if (irq != IRQ_INVALID) {
-		bitmap_set_nolock(irq & 0x3FU, irq_alloc_bitmap + (irq >> 6U));
+		bitmap_set_nolock((uint16_t)(irq & 0x3FU),
+			      irq_alloc_bitmap + (irq >> 6U));
 	}
 	spinlock_irqrestore_release(&irq_alloc_spinlock, rflags);
 	return irq;
@@ -67,7 +68,7 @@ void free_irq_num(uint32_t irq)
 	if ((irq_is_gsi(irq) == false)
 	    && (desc->vector <= VECTOR_DYNAMIC_END)) {
 		spinlock_irqsave_obtain(&irq_alloc_spinlock, &rflags);
-		bitmap_test_and_clear_nolock(irq & 0x3FU,
+		bitmap_test_and_clear_nolock((uint16_t)(irq & 0x3FU),
 					     irq_alloc_bitmap + (irq >> 6U));
 		spinlock_irqrestore_release(&irq_alloc_spinlock, rflags);
 	}
@@ -333,7 +334,8 @@ void dispatch_interrupt(struct intr_excp_ctx *ctx)
 		goto ERR;
 	}
 
-	if (bitmap_test(irq & 0x3FU, irq_alloc_bitmap + (irq >> 6U)) == 0U) {
+	if (bitmap_test((uint16_t)(irq & 0x3FU),
+		irq_alloc_bitmap + (irq >> 6U)) == 0U) {
 		/* mask irq if possible */
 		goto ERR;
 	}
@@ -403,7 +405,8 @@ void get_cpu_interrupt_info(char *str_arg, int str_max)
 
 	for (irq = 0U; irq < NR_IRQS; irq++) {
 		vector = irq_to_vector(irq);
-		if (bitmap_test(irq & 0x3FU, irq_alloc_bitmap + (irq >> 6U))
+		if (bitmap_test((uint16_t)(irq & 0x3FU),
+			irq_alloc_bitmap + (irq >> 6U))
 			&& (vector != VECTOR_INVALID)) {
 			len = snprintf(str, size, "\r\n%d\t0x%X", irq, vector);
 			size -= len;
@@ -441,7 +444,8 @@ static void init_irq_descs(void)
 
 		irq_desc_array[irq].vector = vr;
 		vector_to_irq[vr] = irq;
-		bitmap_set_nolock(irq & 0x3FU, irq_alloc_bitmap + (irq >> 6U));
+		bitmap_set_nolock((uint16_t)(irq & 0x3FU),
+			      irq_alloc_bitmap + (irq >> 6U));
 	}
 }
 

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -50,7 +50,7 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 		}
 		pcpu_id = ffs64(mask);
 	}
-	send_dest_ipi(smp_call_mask, VECTOR_NOTIFY_VCPU,
+	send_dest_ipi((uint32_t)smp_call_mask, VECTOR_NOTIFY_VCPU,
 				INTR_LAPIC_ICR_LOGICAL);
 	/* wait for current smp call complete */
 	wait_sync_change(&smp_call_mask, 0UL);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -654,9 +654,11 @@ int32_t hcall_remap_pci_msix(struct vm *vm, uint16_t vmid, uint64_t param)
 	info.vmsi_ctl = remap.msi_ctl;
 	info.vmsi_addr = remap.msi_addr;
 	info.vmsi_data = remap.msi_data;
-
-	ret = ptdev_msix_remap(target_vm,
-		remap.virt_bdf, remap.msix_entry_index, &info);
+	if (remap.msix_entry_index >= MAX_MSI_ENTRY) {
+		return -1;
+	}
+	ret = ptdev_msix_remap(target_vm, remap.virt_bdf,
+		    (uint16_t)remap.msix_entry_index, &info);
 	remap.msi_data = info.pmsi_data;
 	remap.msi_addr = info.pmsi_addr;
 

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -84,7 +84,7 @@ void npk_log_write(const char *buf, size_t buf_len)
 	const char *p = buf;
 	int sz;
 	uint32_t ref;
-	size_t len;
+	uint16_t len;
 
 	if (!npk_log_enabled || !channel)
 		return;
@@ -93,7 +93,7 @@ void npk_log_write(const char *buf, size_t buf_len)
 	ref = (atomic_inc_return((int32_t *)&per_cpu(npk_log_ref, cpu_id)) - 1)
 		& HV_NPK_LOG_REF_MASK;
 	channel += (cpu_id << HV_NPK_LOG_REF_SHIFT) + ref;
-	len = min(buf_len, HV_NPK_LOG_MAX);
+	len = (uint16_t)(min(buf_len, HV_NPK_LOG_MAX));
 	mmio_write32(HV_NPK_LOG_HDR, &(channel->DnTS));
 	mmio_write16(len, &(channel->Dn));
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -224,11 +224,11 @@ static void shell_puts(const char *string_ptr)
 				SHELL_STRING_MAX_LEN));
 }
 
-static void shell_handle_special_char(uint8_t ch)
+static void shell_handle_special_char(char ch)
 {
 	switch (ch) {
 	/* Escape character */
-	case 0x1bU:
+	case 0x1b:
 		/* Consume the next 2 characters */
 		(void) shell_getc();
 		(void) shell_getc();

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -150,16 +150,19 @@ char uart16550_getc(void)
 /**
  * @pre uart_enabled == true
  */
-static void uart16550_putc(const char c)
+static void uart16550_putc(char c)
 {
+	uint8_t temp;
 	uint32_t reg;
+
 	/* Ensure there are no further Transmit buffer write requests */
 	do {
 		reg = uart16550_read_reg(uart_base_address, UART16550_LSR);
 	} while ((reg & LSR_THRE) == 0U || (reg & LSR_TEMT) == 0U);
 
+	temp = (uint8_t)c;
 	/* Transmit the character. */
-	uart16550_write_reg(uart_base_address, c, UART16550_THR);
+	uart16550_write_reg(uart_base_address, (uint32_t)temp, UART16550_THR);
 }
 
 int uart16550_puts(const char *buf, uint32_t len)

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -22,6 +22,11 @@
 #define VECTOR_VIRT_IRQ_VHM	0xF7U
 #define VECTOR_SPURIOUS		0xFFU
 
+/* the maximum number of msi entry is 2048 according to PCI
+ * local bus specification
+ */
+#define MAX_MSI_ENTRY 0x800U
+
 #define NR_MAX_VECTOR		0xFFU
 #define VECTOR_INVALID		(NR_MAX_VECTOR + 1U)
 #define NR_IRQS		256U

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -24,7 +24,7 @@
 /* Size of buffer used to store a message being logged,
  * should align to LOG_ENTRY_SIZE.
  */
-#define LOG_MESSAGE_MAX_SIZE	(4 * LOG_ENTRY_SIZE)
+#define LOG_MESSAGE_MAX_SIZE	(4U * LOG_ENTRY_SIZE)
 
 #if defined(HV_DEBUG)
 

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -26,7 +26,7 @@ int strcmp(const char *s1_arg, const char *s2_arg);
 int strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg);
 char *strcpy_s(char *d_arg, size_t dmax, const char *s_arg);
 char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg);
-char *strchr(const char *s_arg, int ch);
+char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
 void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg);

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -156,14 +156,14 @@ int atoi(const char *str)
 	return (int)strtol_deci(str);
 }
 
-char *strchr(const char *s_arg, int ch)
+char *strchr(char *s_arg, char ch)
 {
-	const char *s = s_arg;
+	char *s = s_arg;
 	while ((*s != '\0') && (*s != ch)) {
 		++s;
 	}
 
-	return ((*s) != '\0') ? ((char *)s) : NULL;
+	return ((*s) != '\0') ? s : NULL;
 }
 
 /**


### PR DESCRIPTION
MISRAC has requirement about implict conversion: actual to formal
param. This patch is used to fix part of these violations.

1.Add a new structure seg_desc_vmcs to hold the VMCS field address of
segment selector to clean up seg_desc structure.

2.Add the definition of maximum MSI entry and the relevant judgement.

3.The violations in shell.c, logmsg.c will be fixed in other series of
patches with modification of function snprintf(), vsnprintf() and other
related usages.

v1->v2:
  *Move the definition of struct seg_desc_vmcs from instr_emul.h to
   instr_emul.c.
  *Modify the formal parameter type in function definition from uint8_t
   to char instead of using cast.
  *Drop the const declaration for char data in formal parameter.

v2->v3:
  *update the data missing conversion.
  *change type of internal parameter len to avoid casting in npklog.c.
  *change the conversion from signed char to unsigned int in
   uart16550_getc() to solve sign-extension.

Tracked-On: #861
Signed-off-by: Junjun Shan <junjun.shan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>