### PR TITLE
HV: remove dead APIC info MACROs in bsp

### DIFF
--- a/hypervisor/bsp/sbl/sbl.c
+++ b/hypervisor/bsp/sbl/sbl.c
@@ -6,19 +6,6 @@
 
 #include <hypervisor.h>
 
-/* IOAPIC id */
-#define SBL_IOAPIC_ID   8U
-/* IOAPIC base address */
-#define SBL_IOAPIC_ADDR 0xfec00000U
-/* IOAPIC range size */
-#define SBL_IOAPIC_SIZE 0x100000U
-/* Local APIC base address */
-#define SBL_LAPIC_ADDR 0xfee00000U
-/* Local APIC range size */
-#define SBL_LAPIC_SIZE 0x100000U
-/* Number of PCI IRQ assignments */
-#define SBL_PCI_IRQ_ASSIGNMENT_NUM 28
-
 #ifndef CONFIG_DMAR_PARSE_ENABLED
 static struct dmar_dev_scope default_drhd_unit_dev_scope0[] = {
 	{ .bus = 0U, .devfun = DEVFUN(0x2U, 0U), },

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -8,19 +8,6 @@
 #include <multiboot.h>
 #include <vm0_boot.h>
 
-/* IOAPIC id */
-#define UEFI_IOAPIC_ID   8
-/* IOAPIC base address */
-#define UEFI_IOAPIC_ADDR 0xfec00000
-/* IOAPIC range size */
-#define UEFI_IOAPIC_SIZE 0x100000
-/* Local APIC base address */
-#define UEFI_LAPIC_ADDR 0xfee00000
-/* Local APIC range size */
-#define UEFI_LAPIC_SIZE 0x100000
-/* Number of PCI IRQ assignments */
-#define UEFI_PCI_IRQ_ASSIGNMENT_NUM 28
-
 #ifdef CONFIG_EFI_STUB
 static void efi_init(void);
 


### PR DESCRIPTION
These MACROs are never used by current code so remove it. The needed APIC
info is defined in other files with other MACROs.

We will unify kinds of APIC info definition in one place soon.

Tracked-On: #1274

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>