### PR TITLE
dm: workaroud for DM crash when doing fastboot reboot

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -493,7 +493,11 @@ modify_bar_registration(struct pci_vdev *dev, int idx, int registration)
 		error = EINVAL;
 		break;
 	}
-	assert(error == 0);
+
+	/* FIXME: workaround for unregister_mem for fastboot. */
+	if (error != 0) {
+		printf("modify_bar_registration failed with %d", error);
+	}
 }
 
 static void


### PR DESCRIPTION
This is temperory workaround for DM crash when doing fastboot
reboot. In fastboot, it will disable USB host functionality by
disable device respsone to one PCI bar. While DM code just release
the bar in this case. Which break the reboot functionality.

The workaround is to remove the assert to avoid DM abort. This is
safe because reboot will remove all memory range registered.

We will have offiical fixing later.

Tracked-On: #1277
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>