### PR TITLE
tools: acrn-manager: init vmmngr_head with LIST_HEAD_INITIALIZER

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -47,7 +47,7 @@ static int check_dir(const char *path)
 
 /* List head of all vm */
 static pthread_mutex_t vmmngr_mutex = PTHREAD_MUTEX_INITIALIZER;
-struct vmmngr_list_struct vmmngr_head;
+struct vmmngr_list_struct vmmngr_head = LIST_HEAD_INITIALIZER(vmmngr_head);
 static unsigned long update_count = 0;
 
 struct vmmngr_struct *vmmngr_find(const char *name)

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -47,7 +47,7 @@ static int check_dir(const char *path)
 
 /* List head of all vm */
 static pthread_mutex_t vmmngr_mutex = PTHREAD_MUTEX_INITIALIZER;
-struct vmmngr_list_struct vmmngr_head = LIST_HEAD_INITIALIZER(vmmngr_head);
+struct vmmngr_list_struct vmmngr_head = { NULL };
 static unsigned long update_count = 0;
 
 struct vmmngr_struct *vmmngr_find(const char *name)


### PR DESCRIPTION
To fix the issue that vmmngr_head may be used uninitialized.

Tracked-On: #1157
Signed-off-by: Yan, Like <like.yan@intel.com>