### PR TITLE
tools: acrn-crashlog: exclude crashlog tool for release version

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -2,7 +2,11 @@ T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 
 .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
+ifeq ($(RELEASE),0)
 all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
+else
+all: acrnlog acrn-manager acrntrace acrnbridge
+endif
 
 acrn-crashlog:
 	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
@@ -28,7 +32,11 @@ clean:
 	rm -rf $(OUT_DIR)
 
 .PHONY: install
+ifeq ($(RELEASE),0)
 install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
+else
+install: acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
+endif
 
 acrn-crashlog-install:
 	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) install


### PR DESCRIPTION
This patch is to exclude crashlog tool for release version.

Tracked-On: #1024
Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>