### PR TITLE
dm: passthru: enable NHLT table for audio passthru

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -72,11 +72,14 @@
 
 #define	PCI_BDF_GPU		0x00000010	/* 00:02.0 */
 
-/* Some audio driver get topology data from ACPI NHLT table, thus need copy host
- * NHLT to guest. Default audio driver doesn't require this, so make it off by
- * default to avoid unexpected failure.
+/* Some audio drivers get topology data from ACPI NHLT table.
+ * For such drivers, we need to copy the host NHLT table to make it
+ * available to the Guest OS. Most audio drivers don't need this by
+ * default, when that's the case setting this macro to 0 will avoid
+ * unexpected failures.
+ * The cAVS audio needs this however, so we enable this feature.
  */
-#define AUDIO_NHLT_HACK 0
+#define AUDIO_NHLT_HACK 1
 
 static int iofd = -1;
 static int memfd = -1;

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -80,7 +80,7 @@
 #define	MCFG_OFFSET		0x380
 #define FACS_OFFSET		0x3C0
 #define NHLT_OFFSET		0x400
-#define DSDT_OFFSET		0xC00
+#define DSDT_OFFSET		0xE00
 
 #define	ASL_TEMPLATE	"dm.XXXXXXX"
 #define ASL_SUFFIX	".aml"
@@ -166,6 +166,10 @@ basl_fwrite_rsdt(FILE *fp, struct vmctx *ctx)
 	    basl_acpi_base + HPET_OFFSET);
 	EFPRINTF(fp, "[0004]\t\tACPI Table Address 3 : %08X\n",
 	    basl_acpi_base + MCFG_OFFSET);
+
+	if (acpi_table_is_valid(NHLT_ENTRY_NO))
+		EFPRINTF(fp, "[0004]\t\tACPI Table Address 4 : %08X\n",
+		    basl_acpi_base + NHLT_OFFSET);
 
 	EFFLUSH(fp);
 
@@ -615,7 +619,7 @@ basl_fwrite_nhlt(FILE *fp, struct vmctx *ctx)
 	EFPRINTF(fp, "[0001]\t\tChecksum : 00\n");
 	EFPRINTF(fp, "[0006]\t\tOem ID : \"INTEL \"\n");
 	EFPRINTF(fp, "[0008]\t\tOem Table ID : \"NHLT-GPA\"\n");
-	EFPRINTF(fp, "[0004]\t\tOem Revision : 00000008\n");
+	EFPRINTF(fp, "[0004]\t\tOem Revision : 00000003\n");
 
 	/* iasl will fill in the compiler ID/revision fields */
 	EFPRINTF(fp, "[0004]\t\tAsl Compiler ID : \"xxxx\"\n");


### PR DESCRIPTION
CAVS audio driver depends on the NHLT table to get topology info.
Enable NHLT table in DM for audio passthrough.
Also increase the size reserved for NHLT in ACPI table from 2048B to 2560B.

Tracked-On: #1284
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>