### PR TITLE
Makefile: fix cross-compiling issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ TOOLS_OUT := $(ROOT_OUT)/tools
 DOC_OUT := $(ROOT_OUT)/doc
 BUILD_VERSION ?=
 BUILD_TAG ?=
+DESTDIR ?=
+SYSROOTDIR ?=
 export TOOLS_OUT
 
 .PHONY: all hypervisor devicemodel tools doc

--- a/hypervisor/bsp/uefi/efi/Makefile
+++ b/hypervisor/bsp/uefi/efi/Makefile
@@ -53,12 +53,12 @@ endif
 # its tools and libraries in different folders. The next couple of
 # variables will determine and set the right path for both the
 # tools $(GNUEFI_DIR) and libraries $(LIBDIR)
-GNUEFI_DIR := $(shell find /usr/lib* -name elf_$(ARCH)_efi.lds -type f | xargs dirname)
+GNUEFI_DIR := $(shell find $(SYSROOTDIR)/usr/lib* -name elf_$(ARCH)_efi.lds -type f | xargs dirname)
 LIBDIR := $(subst gnuefi,,$(GNUEFI_DIR))
 CRT0 := $(GNUEFI_DIR)/crt0-efi-$(ARCH).o
 LDSCRIPT := $(GNUEFI_DIR)/elf_$(ARCH)_efi.lds
 
-INCDIR := /usr/include
+INCDIR := $(SYSROOTDIR)/usr/include
 
 CFLAGS=-I. -I.. -I../../../include/arch/x86/guest -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \

--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -5,7 +5,7 @@
 BASEDIR 	:= $(shell pwd)
 OUT_DIR 	?= $(BASEDIR)
 BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
-CC		:= gcc
+CC		?= gcc
 RM		= rm
 RELEASE 	?= 0
 
@@ -22,12 +22,12 @@ export BUILDDIR
 export CC
 export RM
 
-PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/lib/pkgconfig
-PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/share/pkgconfig
-PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/local/lib/pkgconfig
-PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/local/share/pkgconfig
-PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/lib32/pkgconfig
-PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):/usr/lib64/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):$(SYSROOTDIR)/usr/lib/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):$(SYSROOTDIR)/usr/share/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):$(SYSROOTDIR)/usr/local/lib/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):$(SYSROOTDIR)/usr/local/share/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):$(SYSROOTDIR)/usr/lib32/pkgconfig
+PKG_CONFIG_PATH := $(PKG_CONFIG_PATH):$(SYSROOTDIR)/usr/lib64/pkgconfig
 
 EXTRA_LIBS = -lsystemd-journal
 PKG_CONFIG := $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH); \

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -5,7 +5,7 @@ VERSION_H	= $(BUILDDIR)/include/acrnprobe/version.h
 
 LIBS		= -lpthread -lxml2 -lcrypto -lrt -lblkid -lext2fs -lcom_err \
 		  $(EXTRA_LIBS)
-INCLUDE		+= -I $(CURDIR)/include -I /usr/include/libxml2
+INCLUDE		+= -I $(CURDIR)/include -I $(SYSROOTDIR)/usr/include/libxml2
 INCLUDE		+= -I $(BUILDDIR)/include/acrnprobe
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -g -O0 -std=gnu11


### PR DESCRIPTION
To be able to support cross compilation, some fixes are needed as
follows:
- Replace all the host paths with a prefix sysroot, it defaults to be
  empty.
- Use weak assignment to compiler variables, like CC, this allows them
  to be overridden by environment variables passed to make.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>