### PR TITLE
 interrupt storm detect(get data) & act as policy(delay intr) 

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -651,3 +651,9 @@ vm_get_cpu_state(struct vmctx *ctx, void *state_buf)
 {
 	return ioctl(ctx->fd, IC_PM_GET_CPU_STATE, state_buf);
 }
+
+int
+vm_intr_monitor(struct vmctx *ctx, void *intr_buf)
+{
+	return ioctl(ctx->fd, IC_VM_INTR_MONITOR, intr_buf);
+}

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -456,6 +456,26 @@ enum pm_cmd_type {
 };
 
 /**
+ * @brief Info to get a VM interrupt count data
+ *
+ * the parameter for HC_VM_INTR_MONITOR hypercall
+ */
+#define MAX_PTDEV_NUM 24
+struct acrn_intr_monitor {
+	/** sub command for intr monitor */
+	uint32_t cmd;
+	/** the count of this buffer to save */
+	uint32_t buf_cnt;
+
+	/** the buffer which save each interrupt count */
+	uint64_t buffer[MAX_PTDEV_NUM * 2];
+} __aligned(8);
+
+/** cmd for intr monitor **/
+#define INTR_CMD_GET_DATA 0
+#define INTR_CMD_DELAY_INT 1
+
+/**
  * @}
  */
 #endif /* _ACRN_COMMON_H_ */

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -80,6 +80,7 @@
 #define IC_DEASSERT_IRQLINE            _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x01)
 #define IC_PULSE_IRQLINE               _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x02)
 #define IC_INJECT_MSI                  _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x03)
+#define IC_VM_INTR_MONITOR             _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x04)
 
 /* DM ioreq management */
 #define IC_ID_IOREQ_BASE                0x30UL

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -152,6 +152,7 @@ int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
 int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
+int	vm_intr_monitor(struct vmctx *ctx, void *intr_buf);
 void	vm_stop_watchdog(struct vmctx *ctx);
 void	vm_reset_watchdog(struct vmctx *ctx);
 #endif	/* _VMMAPI_H_ */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -187,6 +187,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 
 	INIT_LIST_HEAD(&vm->softirq_dev_entry_list);
 	spinlock_init(&vm->softirq_dev_lock);
+	vm->intr_inject_delay_delta = 0UL;
 
 	/* Set up IO bit-mask such that VM exit occurs on
 	 * selected IO ranges

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -181,6 +181,10 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_save_restore_sworld_ctx(vcpu);
 		break;
 
+	case HC_VM_INTR_MONITOR:
+		ret = hcall_vm_intr_monitor(vm, (uint16_t)param1, param2);
+		break;
+
 	default:
 		pr_err("op %d: Invalid hypercall\n", hypcall_id);
 		ret = -EPERM;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -173,6 +173,7 @@ struct vm {
 
 	spinlock_t softirq_dev_lock;
 	struct list_head softirq_dev_entry_list;
+	uint64_t intr_inject_delay_delta; /* delay of intr injection */
 } __aligned(CPU_PAGE_SIZE);
 
 #ifdef CONFIG_PARTITION_MODE

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -48,6 +48,11 @@ static inline void initialize_timer(struct hv_timer *timer,
 	}
 }
 
+static inline bool timer_expired(const struct hv_timer *timer)
+{
+	return ((timer->fire_tsc == 0UL) || (rdtsc() >= timer->fire_tsc));
+}
+
 /*
  * Don't call add_timer/del_timer in the timer callback function.
  */

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -388,6 +388,19 @@ int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param);
 int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param);
 
 /**
+ * @brief Get VCPU a VM's interrupt count data.
+ *
+ * @param vm pointer to VM data structure
+ * @param vmid id of the VM
+ * @param param guest physical address. This gpa points to data structure of
+ *              acrn_intr_monitor
+ *
+ * @pre Pointer vm shall point to VM0
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param);
+
+/**
  * @defgroup trusty_hypercall Trusty Hypercalls
  *
  * This is a special group that includes all hypercalls

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -61,6 +61,9 @@ struct ptdev_remapping_info {
 	struct list_head softirq_node;
 	struct list_head entry_node;
 	struct ptdev_msi_info msi;
+
+	uint64_t intr_count;
+	struct hv_timer intr_delay_timer; /* used for delay intr injection */
 };
 
 extern struct list_head ptdev_list;
@@ -82,5 +85,8 @@ void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
 #ifdef HV_DEBUG
 void get_ptdev_info(char *str_arg, int str_max);
 #endif /* HV_DEBUG */
+
+uint32_t get_vm_ptdev_intr_data(const struct vm *target_vm, uint64_t *buffer,
+	uint32_t buffer_cnt);
 
 #endif /* PTDEV_H */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -454,6 +454,26 @@ enum pm_cmd_type {
 };
 
 /**
+ * @brief Info to get a VM interrupt count data
+ *
+ * the parameter for HC_VM_INTR_MONITOR hypercall
+ */
+#define MAX_PTDEV_NUM 24
+struct acrn_intr_monitor {
+	/** sub command for intr monitor */
+	uint32_t cmd;
+	/** the count of this buffer to save */
+	uint32_t buf_cnt;
+
+	/** the buffer which save each interrupt count */
+	uint64_t buffer[MAX_PTDEV_NUM * 2];
+} __aligned(8);
+
+/** cmd for intr monitor **/
+#define INTR_CMD_GET_DATA 0U
+#define INTR_CMD_DELAY_INT 1U
+
+/**
  * @}
  */
 #endif /* ACRN_COMMON_H */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -43,6 +43,7 @@
 #define HC_DEASSERT_IRQLINE         BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x01UL)
 #define HC_PULSE_IRQLINE            BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x02UL)
 #define HC_INJECT_MSI               BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x03UL)
+#define HC_VM_INTR_MONITOR          BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x04UL)
 
 /* DM ioreq management */
 #define HC_ID_IOREQ_BASE            0x30UL


### PR DESCRIPTION
This serial of patches are used to enhance the feature of "interrupt storm mitigation"; when interrupt storm happens on one UOS, SOS can delay the interrupt injection of UOS pass-through devices.


Tracked-On: #866
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>