### PR TITLE
hv:Fix unused var value on all paths

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -247,6 +247,9 @@ static void encode_vmcs_seg_desc(enum cpu_reg_name seg,
 		desc->access_field = 0xffffffffU;
 		break;
 	default:
+		desc->base_field = 0U;
+		desc->limit_field = 0U;
+		desc->access_field = 0U;
 		pr_err("%s: invalid seg %d", __func__, seg);
 		break;
 	}
@@ -374,7 +377,7 @@ static void vm_set_register(struct vcpu *vcpu, enum cpu_reg_name reg,
  */
 static void vm_get_seg_desc(enum cpu_reg_name seg, struct seg_desc *desc)
 {
-	struct seg_desc_vmcs tdesc = {0U, 0U, 0U};
+	struct seg_desc_vmcs tdesc;
 
 	/* tdesc->access != 0xffffffffU in this function */
 	encode_vmcs_seg_desc(seg, &tdesc);
@@ -2188,7 +2191,7 @@ static int instr_check_di(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt)
 static int instr_check_gva(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
 		enum vm_cpu_mode cpu_mode)
 {
-	int ret = 0;
+	int ret;
 	uint64_t base, segbase, idx, gva, gpa;
 	uint32_t err_code;
 	enum cpu_reg_name seg;
@@ -2274,7 +2277,7 @@ int decode_instruction(struct vcpu *vcpu)
 {
 	struct instr_emul_ctxt *emul_ctxt;
 	uint32_t csar;
-	int retval = 0;
+	int retval;
 	enum vm_cpu_mode cpu_mode;
 
 	emul_ctxt = &per_cpu(g_inst_ctxt, vcpu->pcpu_id);

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -10,7 +10,7 @@
 uint64_t get_microcode_version(void)
 {
 	uint64_t val;
-	uint32_t eax = 0U, ebx = 0U, ecx = 0U, edx = 0U;
+	uint32_t eax, ebx, ecx, edx;
 
 	msr_write(MSR_IA32_BIOS_SIGN_ID, 0U);
 	cpuid(CPUID_FEATURES, &eax, &ebx, &ecx, &edx);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -280,8 +280,8 @@ void free_paging_struct(void *ptr)
 
 bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg)
 {
-	uint64_t curr_hpa = 0UL;
-	uint64_t next_hpa = 0UL;
+	uint64_t curr_hpa;
+	uint64_t next_hpa;
 	uint64_t gpa = gpa_arg;
 	uint64_t size = size_arg;
 

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -60,13 +60,13 @@ static struct trusty_key_info g_key_info = {
 static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 		uint64_t size, uint64_t gpa_rebased)
 {
-	uint64_t nworld_pml4e = 0UL;
-	uint64_t sworld_pml4e = 0UL;
-	uint64_t gpa = 0UL;
+	uint64_t nworld_pml4e;
+	uint64_t sworld_pml4e;
+	uint64_t gpa;
 	uint64_t hpa = gpa2hpa(vm, gpa_orig);
 	uint64_t table_present = EPT_RWX;
-	uint64_t pdpte = 0UL, *dest_pdpte_p = NULL, *src_pdpte_p = NULL;
-	void *sub_table_addr = NULL, *pml4_base = NULL;
+	uint64_t pdpte, *dest_pdpte_p, *src_pdpte_p;
+	void *sub_table_addr, *pml4_base;
 	struct vm *vm0 = get_vm_from_vmid(0U);
 	uint16_t i;
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -965,7 +965,7 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 	struct dmar_context_entry *context_table;
 	struct dmar_root_entry *root_entry;
 	struct dmar_context_entry *context_entry;
-	uint64_t upper = 0UL;
+	uint64_t upper;
 	uint64_t lower = 0UL;
 
 	if (domain == NULL) {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -179,7 +179,7 @@ handle_virt_irqline(struct vm *vm, uint16_t target_vmid,
  */
 int32_t hcall_create_vm(struct vm *vm, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct vm *target_vm = NULL;
 	struct acrn_create_vm cv;
 	struct vm_description vm_desc;
@@ -215,7 +215,7 @@ int32_t hcall_create_vm(struct vm *vm, uint64_t param)
 
 int32_t hcall_destroy_vm(uint16_t vmid)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
@@ -228,7 +228,7 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 
 int32_t hcall_start_vm(uint16_t vmid)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
@@ -302,7 +302,7 @@ int32_t hcall_reset_vm(uint16_t vmid)
  */
 int32_t hcall_assert_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct acrn_irqline irqline;
 
 	if (copy_from_gpa(vm, &irqline, param, sizeof(irqline)) != 0) {
@@ -319,7 +319,7 @@ int32_t hcall_assert_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
  */
 int32_t hcall_deassert_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct acrn_irqline irqline;
 
 	if (copy_from_gpa(vm, &irqline, param, sizeof(irqline)) != 0) {
@@ -336,7 +336,7 @@ int32_t hcall_deassert_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
  */
 int32_t hcall_pulse_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct acrn_irqline irqline;
 
 	if (copy_from_gpa(vm, &irqline, param, sizeof(irqline)) != 0) {
@@ -353,7 +353,7 @@ int32_t hcall_pulse_irqline(struct vm *vm, uint16_t vmid, uint64_t param)
  */
 int32_t hcall_inject_msi(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct acrn_msi_entry msi;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
@@ -376,8 +376,7 @@ int32_t hcall_inject_msi(struct vm *vm, uint16_t vmid, uint64_t param)
  */
 int32_t hcall_set_ioreq_buffer(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
-	uint64_t hpa = 0UL;
+	uint64_t hpa;
 	struct acrn_set_ioreq_buffer iobuf;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 	union vhm_request_buffer *req_buf;
@@ -411,7 +410,7 @@ int32_t hcall_set_ioreq_buffer(struct vm *vm, uint16_t vmid, uint64_t param)
 		atomic_store32(&req_buf->req_queue[i].processed, REQ_STATE_FREE);
 	}
 
-	return ret;
+	return 0;
 }
 
 int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
@@ -634,7 +633,7 @@ int32_t hcall_write_protect_page(struct vm *vm, uint16_t vmid, uint64_t wp_gpa)
  */
 int32_t hcall_remap_pci_msix(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct acrn_vm_pci_msix_remap remap;
 	struct ptdev_msi_info info;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
@@ -767,7 +766,7 @@ int32_t hcall_deassign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
  */
 int32_t hcall_set_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
 {
-	int32_t ret = 0;
+	int32_t ret;
 	struct hc_ptdev_irq irq;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -450,7 +450,7 @@ void shell_init(void)
 #define MAX_INDENT_LEN	16
 static int shell_cmd_help(__unused int argc, __unused char **argv)
 {
-	int spaces = 0;
+	int spaces;
 	struct shell_cmd *p_cmd = NULL;
 	char space_buf[MAX_INDENT_LEN + 1];
 
@@ -679,7 +679,7 @@ static int shell_dumpmem(int argc, char **argv)
 {
 	uint64_t addr;
 	uint64_t *ptr;
-	uint32_t i, length = 32U;
+	uint32_t i, length;
 	char temp_str[MAX_STR_SIZE];
 
 	/* User input invalidation */

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -657,7 +657,7 @@ int vsnprintf(char *dst_arg, size_t sz_arg, const char *fmt, va_list args)
 {
 	char *dst = dst_arg;
 	uint32_t sz = sz_arg;
-	int res = 0;
+	int res;
 
 	if ((sz == 0U) || (dst == NULL)) {
 		return -1;


### PR DESCRIPTION
MISRAC checks whether a variable is assigned a value not used in
all branches of a program. Var value which is unused on all paths
can be removed with a consequent improvement in the readability
and efficiency of the code. This patch is used to fix these
violations.

Tracked-On: #861
Signed-off-by: Junjun Shan <junjun.shan@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>