### PR TITLE
Update Makefile and fix compiler warnings for acrnlog/acrntrace/acrn_manager

### DIFF
--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -1,20 +1,51 @@
+T := $(CURDIR)
+OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
+CC ?= gcc
 
-OUT_DIR ?= .
+CFLAGS := -g -O0 -std=gnu11
+CFLAGS += -D_GNU_SOURCE
+CFLAGS += -DNO_OPENSSL
+CFLAGS += -m64
+CFLAGS += -Wall -ffunction-sections
+CFLAGS += -Werror
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+CFLAGS += -fpie -fpic
+#FIXME: remove me. work-around for system() calls, which will be removed
+CFLAGS += -Wno-format-truncation -Wno-unused-result
 
-CFLAGS := -Wall
 CFLAGS += -I../../devicemodel/include
 CFLAGS += -I../../devicemodel/include/public
 CFLAGS += -I../../hypervisor/include
-CFLAGS += -fpie
+
+GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
+GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
+
+#enable stack overflow check
+STACK_PROTECTOR := 1
+
+ifdef STACK_PROTECTOR
+ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+CFLAGS += -fstack-protector
+endif
+endif
+endif
 
 ifeq ($(RELEASE),0)
 CFLAGS += -g -DMNGR_DEBUG
 endif
 
-LDFLAGS := -L$(OUT_DIR)
-LDFLAGS += -lacrn-mngr
-LDFLAGS +=  -lpthread
+LDFLAGS := -Wl,-z,noexecstack
+LDFLAGS += -Wl,-z,relro,-z,now
 LDFLAGS += -pie
+LDFLAGS += -L$(OUT_DIR)
+LDFLAGS +=  -lpthread
+LDFLAGS += -lacrn-mngr
 
 .PHONY: all
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnctl $(OUT_DIR)/acrnd
@@ -42,11 +73,12 @@ clean:
 	rm -f $(OUT_DIR)/acrnctl
 	rm -f $(OUT_DIR)/acrn_mngr.o
 	rm -f $(OUT_DIR)/libacrn-mngr.a
+	rm -f $(OUT_DIR)/acrnd
 ifneq ($(OUT_DIR),.)
 	rm -f $(OUT_DIR)/acrn_mngr.h
 	rm -f $(OUT_DIR)/acrnd.service
+	rm -rf $(OUT_DIR)
 endif
-	rm -f $(OUT_DIR)/acrnd
 
 .PHONY: install
 install: $(OUT_DIR)/acrnctl $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/libacrn-mngr.a

--- a/tools/acrn-manager/acrn_mngr.c
+++ b/tools/acrn-manager/acrn_mngr.c
@@ -479,8 +479,11 @@ static int connect_to_server(const char *name)
 	}
 
 	mfd->addr.sun_family = AF_UNIX;
-	snprintf(mfd->addr.sun_path, sizeof(mfd->addr.sun_path),
+	ret = snprintf(mfd->addr.sun_path, sizeof(mfd->addr.sun_path),
 		 "/run/acrn/mngr/%s", s_name);
+	if ((ret >= 0) && (ret < strlen(s_name)))
+		printf("WARN: %s is truncated\n", s_name);
+
 	closedir(dir);
 	ret =
 	    connect(mfd->fd, (struct sockaddr *)&mfd->addr, sizeof(mfd->addr));

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -175,7 +175,7 @@ static int load_timer_list(void)
 		}
 
 		memset(arg.name, 0, sizeof(arg.name));
-		strncpy(arg.name, s1, sizeof(s1));
+		strncpy(arg.name, s1, sizeof(arg.name));
 
 		expire = strtoul(s2, NULL, 10);
 		if (expire == 0 || errno == ERANGE) {

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -1,6 +1,37 @@
+T := $(CURDIR)
+OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
+CC ?= gcc
 
-OUT_DIR ?= .
-CFLAGS += -fpie
+CFLAGS := -g -O0 -std=gnu11
+CFLAGS += -D_GNU_SOURCE
+CFLAGS += -DNO_OPENSSL
+CFLAGS += -m64
+CFLAGS += -Wall -ffunction-sections
+CFLAGS += -Werror
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+CFLAGS += -fpie -fpic
+
+GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
+GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
+
+#enable stack overflow check
+STACK_PROTECTOR := 1
+
+ifdef STACK_PROTECTOR
+ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+CFLAGS += -fstack-protector
+endif
+endif
+endif
+
+LDFLAGS := -Wl,-z,noexecstack
+LDFLAGS += -Wl,-z,relro,-z,now
 LDFLAGS += -pie
 
 all:
@@ -11,6 +42,7 @@ clean:
 	rm -f $(OUT_DIR)/acrnlog
 ifneq ($(OUT_DIR),.)
 	rm -f $(OUT_DIR)/acrnlog.service
+	rm -rf $(OUT_DIR)
 endif
 
 install: $(OUT_DIR)/acrnlog

--- a/tools/acrnlog/acrnlog.c
+++ b/tools/acrnlog/acrnlog.c
@@ -67,7 +67,7 @@ static int get_cpu_num(void)
 		return -1;
 	}
 
-	while (pdir = readdir(dir)) {
+	while ((pdir = readdir(dir)) != NULL) {
 		ret = strstr(pdir->d_name, prefix);
 		if (ret)
 			cpu_num++;
@@ -389,7 +389,7 @@ static int mk_dir(const char *path)
 				path, strerror(errno));
 			return -1;
 		}
-		while (pdir = readdir(dir)) {
+		while ((pdir = readdir(dir)) != NULL) {
 			find = strstr(pdir->d_name, prefix);
 			if (!find)
 				continue;
@@ -458,7 +458,7 @@ static pthread_t cur_thread;
 
 int main(int argc, char *argv[])
 {
-	char name[24];
+	char name[32];
 	int i, ret;
 	int num_cur, num_last;
 	struct hvlog_msg *msg;

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -1,6 +1,37 @@
+T := $(CURDIR)
+OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
+CC ?= gcc
 
-OUT_DIR ?= .
-CFLAGS += -fpie
+CFLAGS := -g -O0 -std=gnu11
+CFLAGS += -D_GNU_SOURCE
+CFLAGS += -DNO_OPENSSL
+CFLAGS += -m64
+CFLAGS += -Wall -ffunction-sections
+CFLAGS += -Werror
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+CFLAGS += -fpie -fpic
+
+GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
+GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
+
+#enable stack overflow check
+STACK_PROTECTOR := 1
+
+ifdef STACK_PROTECTOR
+ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+CFLAGS += -fstack-protector
+endif
+endif
+endif
+
+LDFLAGS := -Wl,-z,noexecstack
+LDFLAGS += -Wl,-z,relro,-z,now
 LDFLAGS += -pie
 
 all:
@@ -8,6 +39,9 @@ all:
 
 clean:
 	rm -f $(OUT_DIR)/acrntrace
+ifneq ($(OUT_DIR),.)
+	rm -rf $(OUT_DIR)
+endif
 
 install: $(OUT_DIR)/acrntrace
 	install -d $(DESTDIR)/usr/bin


### PR DESCRIPTION
Update the Makefile to sync the compiler options with devicemode and enable options to harden software.

Tracked-On: #1122
Signed-off-by: Yan, Like <like.yan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>