### PR TITLE
hv: fix 'Static procedure is not explicitly called in code analysed'

### DIFF
--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -115,19 +115,6 @@ struct e820_entry {
 #define E820_TYPE_ACPI_NVS	4U	/* EFI 10 */
 #define E820_TYPE_UNUSABLE	5U	/* EFI 8 */
 
-/** Calculates the page table address for a given address.
- *
- * @param pd The base address of the page directory.
- * @param vaddr The virtual address to calculate the page table address for.
- *
- * @return A pointer to the page table for the specified virtual address.
- *
- */
-static inline void *mmu_pt_for_pde(uint32_t *pd, uint32_t vaddr)
-{
-	return pd + (((vaddr >> 22U) + 1U) * 1024U);
-}
-
 static inline void cache_flush_invalidate_all(void)
 {
 	asm volatile ("   wbinvd\n" : : : "memory");


### PR DESCRIPTION
MISRA-C states that redundant code reduce the maintainability of code.

In some cases, we would like to keep the current unused static functions
for code completeness, such as checking register info. These functions
might be used later.

This patch removes the unused static function 'mmu_pt_for_pde'.
Looks like it is legacy code and not being used in our project.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>