### PR TITLE
Tools: minor fix incorrect initialization for local variable in fsuti…

### DIFF
--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -1213,7 +1213,7 @@ fail:
 
 int read_file(const char *path, unsigned long *size, void **data)
 {
-	char tmp[1024] = "\0";
+	char tmp[1024];
 	int len = 0;
 	int fd = 0;
 	int memsize = 1; /* for '\0' */


### PR DESCRIPTION
…ls.c

 - initializationf for string array 'tmp' is confusing @read_file()

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Gang Chen <gang.c.chen@intel.com>