### PR TITLE
tools: acrn-crashlog: update Makefile flags and fix some compiler warning

### DIFF
--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -5,18 +5,50 @@
 BASEDIR 	:= $(shell pwd)
 OUT_DIR 	?= $(BASEDIR)
 BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
-CC		:= gcc
+CC		?= gcc
 RM		= rm
 RELEASE 	?= 0
 
-CFLAGS	:= -Wall -Wextra -pedantic
-CFLAGS	+= -m64 -D_GNU_SOURCE
 ifeq ($(RELEASE),0)
 CFLAGS	+= -DDEBUG_ACRN_CRASHLOG
 endif
+
+CFLAGS := -g -O0 -std=gnu11
+CFLAGS += -D_GNU_SOURCE
+CFLAGS += -m64
+CFLAGS += -Wall -ffunction-sections
+CFLAGS += -Werror
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 CFLAGS += -fpie
+CFLAGS += -Wall -Wextra -pedantic
+
+CFLAGS += -I$(BASEDIR)/include
+CFLAGS += -I$(BASEDIR)/include/public
+
+GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
+GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
+
+#enable stack overflow check
+STACK_PROTECTOR := 1
+
+ifdef STACK_PROTECTOR
+ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
+CFLAGS += -fstack-protector-strong
+else
+CFLAGS += -fstack-protector
+endif
+endif
+endif
+
+LDFLAGS += -Wl,-z,noexecstack
+LDFLAGS += -Wl,-z,relro,-z,now
 LDFLAGS += -pie
 INCLUDE := -I $(BASEDIR)/common/include
+
 export INCLUDE
 export BUILDDIR
 export CC

--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -8,8 +8,7 @@ LIBS		= -lpthread -lxml2 -lcrypto -lrt -lblkid -lext2fs -lcom_err \
 INCLUDE		+= -I $(CURDIR)/include -I /usr/include/libxml2
 INCLUDE		+= -I $(BUILDDIR)/include/acrnprobe
 CFLAGS 		+= $(INCLUDE)
-CFLAGS 		+= -g -O0 -std=gnu11
-CFLAGS 		+= -ffunction-sections -fdata-sections
+CFLAGS 		+= -fdata-sections
 
 LDFLAGS 	+= $(LIBS) -Wl,--gc-sections
 

--- a/tools/acrn-crashlog/usercrash/crash_dump.c
+++ b/tools/acrn-crashlog/usercrash/crash_dump.c
@@ -31,7 +31,7 @@ static void loginfo(int fd, const char *fmt, ...)
 {
 	char buf[512];
 	va_list ap;
-	size_t len;
+	size_t len, ret;
 
 	va_start(ap, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, ap);
@@ -41,7 +41,10 @@ static void loginfo(int fd, const char *fmt, ...)
 	if (len <= 0)
 		return;
 
-	write(fd, buf, len);
+	ret = write(fd, buf, len);
+	if (ret != len) {
+		LOGE("write in loginfo failed\n");
+	}
 }
 
 static const char *get_signame(int sig)
@@ -113,6 +116,7 @@ static int get_backtrace(int pid, int fd, int sig, const char *comm)
 {
 	char *membkt;
 	char format[FORMAT_LENGTH];
+	size_t len, ret;
 
 	loginfo(fd, "\nBackTrace:\n\n");
 	memset(format, 0, sizeof(format));
@@ -130,8 +134,13 @@ static int get_backtrace(int pid, int fd, int sig, const char *comm)
 		LOGE("get gdb info failed\n");
 		return -1;
 	}
-	write(fd, membkt, strlen(membkt));
+	len = strlen(membkt);
+	ret = write(fd, membkt, len);
 	free(membkt);
+	if (ret != len) {
+		LOGE("write file failed\n");
+		return -1;
+	}
 	return 0;
 
 }
@@ -159,7 +168,11 @@ static int save_proc_info(int pid, int fd, const char *path, const char *name)
 		LOGE("read file failed\n");
 		return -1;
 	}
-	write(fd, data, size);
+	ret = write(fd, data, size);
+	if ((unsigned long)ret != size) {
+		LOGE("write file failed\n");
+		return -1;
+	}
 	free(data);
 	return 0;
 


### PR DESCRIPTION
These two patches are for updating makefile flags and fixing some compiler warning
-----------------------------------------------------------------------------------------
d624220

tools: acrn-crashlog: fix some compiler warnings  …
This patch is to fix some compiler warnings before enabling the flag to make
compiler warning as compiler error.

The warning message is like:
ignoring return value of ‘write’, declared with attribute warn_unused_result.

Tracked-On: #1122
Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: Liu, Xinwu <xinwu.liu@intel.com>

-----------------------------------------------------------------------------------------
8a090ef

tools: acrn-crashlog: update Makefile flags  …
This patch is to sync the compiler options as the Makefile of device model.

Tracked-On: #1122
Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: Liu, Xinwu <xinwu.liu@intel.com>