### PR TITLE
hv: ioapic: convert some MACROs to inline functions

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -324,7 +324,7 @@ static void remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin)
 	if (is_entry_active(entry)) {
 		phys_irq = entry->allocated_pirq;
 		/* disable interrupt */
-		GSI_MASK_IRQ(phys_irq);
+		gsi_mask_irq(phys_irq);
 
 		ptdev_deactivate_entry(entry);
 		dev_dbg(ACRN_DBG_IRQ,
@@ -472,7 +472,7 @@ void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 
 	dev_dbg(ACRN_DBG_PTIRQ, "dev-assign: irq=0x%x acked vr: 0x%x",
 			phys_irq, irq_to_vector(phys_irq));
-	GSI_UNMASK_IRQ(phys_irq);
+	gsi_unmask_irq(phys_irq);
 }
 
 /* Main entry for PCI device assignment with MSI and MSI-X
@@ -548,7 +548,7 @@ static void activate_physical_ioapic(struct vm *vm,
 	bool is_lvl_trigger = false;
 
 	/* disable interrupt */
-	GSI_MASK_IRQ(phys_irq);
+	gsi_mask_irq(phys_irq);
 
 	/* build physical IOAPIC RTE */
 	rte = ptdev_build_physical_rte(vm, entry);
@@ -565,7 +565,7 @@ static void activate_physical_ioapic(struct vm *vm,
 	ioapic_set_rte(phys_irq, rte);
 
 	if (intr_mask == IOAPIC_RTE_INTMCLR) {
-		GSI_UNMASK_IRQ(phys_irq);
+		gsi_unmask_irq(phys_irq);
 	}
 }
 

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -286,7 +286,7 @@ uint32_t pin_to_irq(uint8_t pin)
 	return IRQ_INVALID;
 }
 
-void
+static void
 irq_gsi_mask_unmask(uint32_t irq, bool mask)
 {
 	void *addr;
@@ -309,6 +309,16 @@ irq_gsi_mask_unmask(uint32_t irq, bool mask)
 	ioapic_set_rte_entry(addr, pin, rte);
 	dev_dbg(ACRN_DBG_PTIRQ, "update: irq:%d pin:%hhu rte:%lx",
 		irq, pin, rte.full);
+}
+
+void gsi_mask_irq(uint32_t irq)
+{
+	irq_gsi_mask_unmask(irq, true);
+}
+
+void gsi_unmask_irq(uint32_t irq)
+{
+	irq_gsi_mask_unmask(irq, false);
 }
 
 static uint8_t

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -302,7 +302,7 @@ static inline void handle_irq(struct irq_desc *desc)
 	irq_action_t action = desc->action;
 
 	if (irq_need_mask(desc))  {
-		GSI_MASK_IRQ(desc->irq);
+		gsi_mask_irq(desc->irq);
 	}
 
 	/* Send EOI to LAPIC/IOAPIC IRR */
@@ -313,7 +313,7 @@ static inline void handle_irq(struct irq_desc *desc)
 	}
 
 	if (irq_need_unmask(desc)) {
-		GSI_UNMASK_IRQ(desc->irq);
+		gsi_unmask_irq(desc->irq);
 	}
 }
 

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -16,20 +16,19 @@
 #define NR_LEGACY_PIN		NR_LEGACY_IRQ
 #define NR_MAX_GSI		(CONFIG_NR_IOAPICS * IOAPIC_MAX_LINES)
 
-#define GSI_MASK_IRQ(irq) irq_gsi_mask_unmask((irq), true)
-#define GSI_UNMASK_IRQ(irq) irq_gsi_mask_unmask((irq), false)
-
 void setup_ioapic_irqs(void);
 
 bool irq_is_gsi(uint32_t irq);
 uint8_t irq_to_pin(uint32_t irq);
 uint32_t pin_to_irq(uint8_t pin);
-void irq_gsi_mask_unmask(uint32_t irq, bool mask);
 void ioapic_set_rte(uint32_t irq, union ioapic_rte rte);
 void ioapic_get_rte(uint32_t irq, union ioapic_rte *rte);
 
 void suspend_ioapic(void);
 void resume_ioapic(void);
+
+void gsi_mask_irq(uint32_t irq);
+void gsi_unmask_irq(uint32_t irq);
 
 extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
 


### PR DESCRIPTION
Convert GSI_MASK_IRQ and GSI_UNMASK_IRQ to inline functions.

v1 -> v2:
After changing GSI_MASK_IRQ and GSI_UNMASK_IRQ from MACROs to functions,
'gsi_(mask|unmask)_irq' are the exposed APIs and 'irq_gsi_mask_unmask'
becomes internal.
In order to reflect this change,
- change 'irq_gsi_mask_unmask' as internal function in ioapic.c
- declare 'gsi_(mask|unmask)_irq' in ioapic.h
- define 'gsi_(mask|unmask)_irq' in ioapic.c

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>