### PR TITLE
frame pointer: force enable fno-omit-frame-pointer

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -19,7 +19,7 @@ HV_OBJDIR ?= $(CURDIR)/build
 HV_FILE := acrn
 
 # initialize the flags we used
-CFLAGS :=
+CFLAGS := -fno-omit-frame-pointer
 ASFLAGS :=
 LDFLAGS :=
 ARCH_CFLAGS :=


### PR DESCRIPTION
No matter the optimization level, keep frame pointer for backtrace

Signed-off-by: Liu Changcheng <changcheng.liu@aliyun.com>