### PR TITLE
doc: fix typo in network virt hld

### DIFF
--- a/doc/developer-guides/network-virt-hld.rst
+++ b/doc/developer-guides/network-virt-hld.rst
@@ -136,7 +136,7 @@ ACRN UOS TX FLOW
 ================
 
 The following shows the ACRN UOS network TX flow, using TCP as an
-example, showing the flow through each layer:.
+example, showing the flow through each layer:
 
 UOS TCP Layer
 -------------


### PR DESCRIPTION
punctuation fix

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>