### PR TITLE
hv: fix 'Switch case not terminated with break'

### DIFF
--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -145,6 +145,7 @@ static uint32_t update_ept(struct vm *vm, uint64_t start,
 	case MTRR_MEM_TYPE_UC:
 	default:
 		attr = EPT_UNCACHED;
+		break;
 	}
 
 	ept_mr_modify(vm, (uint64_t *)vm->arch_vm.nworld_eptp,

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -128,6 +128,10 @@ enum irqstate {
 
 /**
  * @pre irq < vioapic_pincount(vm)
+ * @pre irqstate value shall be one of the folllowing values:
+ *	IRQSTATE_ASSERT
+ *	IRQSTATE_DEASSERT
+ *	IRQSTATE_PULSE
  */
 static void
 vioapic_set_irqstate(struct vm *vm, uint32_t irq, enum irqstate irqstate)
@@ -150,7 +154,11 @@ vioapic_set_irqstate(struct vm *vm, uint32_t irq, enum irqstate irqstate)
 		vioapic_set_pinstate(vioapic, pin, false);
 		break;
 	default:
-		panic("vioapic_set_irqstate: invalid irqstate %d", irqstate);
+		/*
+		 * The function caller could guarantee the pre condition.
+		 * All the possible 'irqstate' has been handled in prior cases.
+		 */
+		break;
 	}
 	spinlock_release(&(vioapic->mtx));
 }

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -453,6 +453,10 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin, bool newstate
 
 /**
  * @pre irq < NR_VPIC_PINS_TOTAL
+ * @pre irqstate value shall be one of the folllowing values:
+ *	IRQSTATE_ASSERT
+ *	IRQSTATE_DEASSERT
+ *	IRQSTATE_PULSE
  */
 static void vpic_set_irqstate(struct vm *vm, uint32_t irq,
 		enum irqstate irqstate)
@@ -486,7 +490,11 @@ static void vpic_set_irqstate(struct vm *vm, uint32_t irq,
 		vpic_set_pinstate(vpic, pin, false);
 		break;
 	default:
-		ASSERT(false, "vpic_set_irqstate: invalid irqstate");
+		/*
+		 * The function caller could guarantee the pre condition.
+		 * All the possible 'irqstate' has been handled in prior cases.
+		 */
+		break;
 	}
 	spinlock_release(&(vpic->lock));
 }


### PR DESCRIPTION
MISRA-C requires that every switch case shall be terminated with break
to avoid the unintentional fall through.

The code will become redundant if we enforce this rule.
So, we will keep the current implementation for the following two cases.
1. The fall through is intentional.
2. The function is returned in the switch case.
    If we decide to eliminate the mutiple returns in one function later,
    this case would be handled properly at that time.

What this patch does:
- add the mssing break for the default case
- add the pre condition for some functions and remove the corresponding
  panic which will never happen since the function caller could guarantee
  the pre condition based on the code implementation

v1 -> v2:
 * remove the redundant cases above default in 'vlapic_get_lvtptr'
 * add the similar pre condition for 'lvt_off_to_idx' as
   'vlapic_get_lvtptr' since all the function callers could guarantee it
 * remove the assertion in 'lvt_off_to_idx' since the pre condition
   could guarantee that the assertion will never happen
 * add the similar pre condition for 'vpic_set_irqstate' as
   'vioapic_set_irqstate' since all the function callers could guarantee it
 * remove the assertion in 'vpic_set_irqstate' since the pre condition
   could guarantee that the assertion will never happen

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>