### PR TITLE
doc: update doc version menu for v0.2 release

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -188,6 +188,7 @@ else:
 html_context = {
    'current_version': current_version,
    'versions': ( ("latest", "/latest/"),
+                 ("0.2", "/0.2/"),
                  ("0.1", "/0.1/"),
                )
     }

--- a/doc/release_notes_0.2.rst
+++ b/doc/release_notes_0.2.rst
@@ -27,7 +27,7 @@ use Git clone and checkout commands:
 
 The project's online technical documentation is also tagged to correspond
 with a specific release: generated v0.2 documents can be found at
-https://projectacrn.github.io/v0.2/.  Documentation for the latest
+https://projectacrn.github.io/0.2/.  Documentation for the latest
 (master) branch is found at https://projectacrn.github.io/latest/.
 
 


### PR DESCRIPTION
Update conf.py selector list to include version 0.2 documentation (and
fix an URL typo in the release notes).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>