### PR TITLE
doc: code-block text not readable

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -19,7 +19,7 @@
 .highlight-console .highlight {
    background-color: black;
 }
-.highlight-console .highlight .go, .highlight-console .highlight .gp {
+.highlight-console .highlight pre, .highlight-console .highlight .go, .highlight-console .highlight .gp {
    color: white;
 }
 .highlight-console .highlight .hll {


### PR DESCRIPTION
The .. code-block:: console directive (used for white text on a black
background) didn't handle some CSS cases properly resulting in
unreadable grey text on a black background.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>