### PR TITLE
Add the support of switch the upcall vector from 0xF7 to 0xF3

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -50,6 +50,11 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_get_api_version(vm, param1);
 		break;
 
+	case HC_SET_CALLBACK_VECTOR:
+		ret = hcall_set_callback_vector(vm, param1);
+
+		break;
+
 	case HC_CREATE_VM:
 		ret = hcall_create_vm(vm, param1);
 		break;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1039,3 +1039,23 @@ int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param)
 
 	return 0;
 }
+
+/**
+ *@pre Pointer vm shall point to VM0
+ */
+int32_t hcall_set_callback_vector(struct vm *vm, uint64_t param)
+{
+	if (!is_vm0(vm)) {
+		pr_err("%s: Targeting to service vm", __func__);
+		return -EPERM;
+	}
+
+	if ((param > NR_MAX_VECTOR) || (param < VECTOR_DYNAMIC_START)) {
+		pr_err("%s: Invalid passed vector\n");
+		return -EINVAL;
+	}
+
+	acrn_vhm_vector = param;
+
+	return 0;
+}

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -7,6 +7,8 @@
 
 #define ACRN_DBG_IOREQUEST	6U
 
+uint32_t acrn_vhm_vector = VECTOR_VIRT_IRQ_VHM;
+
 static void fire_vhm_interrupt(void)
 {
 	/*
@@ -22,7 +24,7 @@ static void fire_vhm_interrupt(void)
 	vcpu = vcpu_from_vid(vm0, 0U);
 	ASSERT(vcpu != NULL, "vcpu_from_vid failed");
 
-	vlapic_intr_edge(vcpu, VECTOR_VIRT_IRQ_VHM);
+	vlapic_intr_edge(vcpu, acrn_vhm_vector);
 }
 
 static void acrn_print_request(uint16_t vcpu_id, struct vhm_request *req)

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -21,6 +21,7 @@
 #define VECTOR_NOTIFY_VCPU	0xF0U
 #define VECTOR_VIRT_IRQ_VHM	0xF7U
 #define VECTOR_SPURIOUS		0xFFU
+#define VECTOR_HYPERVISOR_CALLBACK_VHM	0xF3U
 
 /* the maximum number of msi entry is 2048 according to PCI
  * local bus specification

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -121,4 +121,6 @@ void cancel_event_injection(struct vcpu *vcpu);
 void get_cpu_interrupt_info(char *str_arg, int str_max);
 #endif /* HV_DEBUG */
 
+extern uint32_t acrn_vhm_vector;
+
 #endif /* ARCH_IRQ_H */

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -456,6 +456,21 @@ int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu);
  */ // End of trusty_hypercall
 
 /**
+ * @brief set upcall notifier vector
+ *
+ * This is the API that helps to switch the notifer vecotr. If this API is
+ * not called, the hypervisor will use the default notifier vector(0xF7)
+ * to notify the SOS kernel.
+ *
+ * @param vm Pointer to VM data structure
+ * @param the expected notifier vector from guest
+ *
+ * @pre Pointer vm shall point to VM0
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_set_callback_vector(struct vm *vm, uint64_t param);
+
+/**
  * @}
  */ // End of acrn_hypercall
 

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -27,6 +27,7 @@
 #define HC_ID_GEN_BASE               0x0UL
 #define HC_GET_API_VERSION          BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x00UL)
 #define HC_SOS_OFFLINE_CPU          BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x01UL)
+#define HC_SET_CALLBACK_VECTOR      BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x02UL)
 
 /* VM management */
 #define HC_ID_VM_BASE               0x10UL


### PR DESCRIPTION
This is the patch set that tries to switch the up-notify vector from PLATFORM_IPI to HYPERVISOR_CALLBACK_VECTOR. (0xF7 is changed to 0xF3).

Currently the acrn-hypervisor is using the PLATFORM_IPI vector to notify the sos_kernel. 
And then sos_kernel will handle the notification from acrn hypervisor in PLATFORM_IPI ISR. 
But as the PLATFORM_IPI ISR can be registered by the other modules, it will have the conflict when trying to register   acrn intr ISR. So the HYPERVISOR_CALLBACK_VECTOR will be used instead.
    
 In order to switch the notification vector from PLATFORM_IPI to HYPERVISOR_CALLBACK_VECTOR, one Hypercall API is added so that sos can configure  the up-notifier interrrupt vector. This is also used to allow the sos_kernel to configure the expected upcall vector based on the allocation policy in sos kernel.
