### PR TITLE
hv: arch: fix 'Unused procedure parameter'

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -678,9 +678,8 @@ END:
  * - currently, one phys_pin can only be held by one pin source (vPIC or
  *   vIOAPIC)
  */
-int ptdev_add_intx_remapping(struct vm *vm,
-			__unused uint16_t virt_bdf, __unused uint16_t phys_bdf,
-			uint8_t virt_pin, uint8_t phys_pin, bool pic_pin)
+int ptdev_add_intx_remapping(struct vm *vm, uint8_t virt_pin, uint8_t phys_pin,
+				bool pic_pin)
 {
 	struct ptdev_remapping_info *entry;
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -688,7 +688,7 @@ void stop_cpus(void)
 	}
 }
 
-void cpu_do_idle(__unused uint16_t pcpu_id)
+void cpu_do_idle(void)
 {
 	__asm __volatile("pause" ::: "memory");
 }

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -86,8 +86,7 @@ static inline int set_vcpuid_entry(struct vm *vm,
 /**
  * initialization of virtual CPUID leaf
  */
-static void init_vcpuid_entry(__unused struct vm *vm,
-			uint32_t leaf, uint32_t subleaf,
+static void init_vcpuid_entry(uint32_t leaf, uint32_t subleaf,
 			uint32_t flags, struct vcpuid_entry *entry)
 {
 	entry->leaf = leaf;
@@ -180,7 +179,7 @@ int set_vcpuid_entries(struct vm *vm)
 	uint32_t limit;
 	uint32_t i, j;
 
-	init_vcpuid_entry(vm, 0U, 0U, 0U, &entry);
+	init_vcpuid_entry(0U, 0U, 0U, &entry);
 	if (boot_cpu_data.cpuid_level < 0x16U) {
 		/* The cpuid with zero leaf returns the max level.
 		 * Emulate that the 0x16U is supported */
@@ -204,8 +203,7 @@ int set_vcpuid_entries(struct vm *vm)
 		{
 			uint32_t times;
 
-			init_vcpuid_entry(vm, i, 0U,
-				CPUID_CHECK_SUBLEAF, &entry);
+			init_vcpuid_entry(i, 0U, CPUID_CHECK_SUBLEAF, &entry);
 			result = set_vcpuid_entry(vm, &entry);
 			if (result != 0) {
 				return result;
@@ -213,8 +211,8 @@ int set_vcpuid_entries(struct vm *vm)
 
 			times = entry.eax & 0xffUL;
 			for (j = 1U; j < times; j++) {
-				init_vcpuid_entry(vm, i, j,
-					CPUID_CHECK_SUBLEAF, &entry);
+				init_vcpuid_entry(i, j, CPUID_CHECK_SUBLEAF,
+						&entry);
 				result = set_vcpuid_entry(vm, &entry);
 				if (result != 0) {
 					return result;
@@ -230,8 +228,8 @@ int set_vcpuid_entries(struct vm *vm)
 					break;
 				}
 
-				init_vcpuid_entry(vm, i, j,
-					CPUID_CHECK_SUBLEAF, &entry);
+				init_vcpuid_entry(i, j, CPUID_CHECK_SUBLEAF,
+						&entry);
 				if ((i == 0x04U) && (entry.eax == 0U)) {
 					break;
 				}
@@ -257,7 +255,7 @@ int set_vcpuid_entries(struct vm *vm)
 		case 0x14U:
 			break;
 		default:
-			init_vcpuid_entry(vm, i, 0U, 0U, &entry);
+			init_vcpuid_entry(i, 0U, 0U, &entry);
 			result = set_vcpuid_entry(vm, &entry);
 			if (result != 0) {
 				return result;
@@ -266,19 +264,19 @@ int set_vcpuid_entries(struct vm *vm)
 		}
 	}
 
-	init_vcpuid_entry(vm, 0x40000000U, 0U, 0U, &entry);
+	init_vcpuid_entry(0x40000000U, 0U, 0U, &entry);
 	result = set_vcpuid_entry(vm, &entry);
 	if (result != 0) {
 		return result;
 	}
 
-	init_vcpuid_entry(vm, 0x40000010U, 0U, 0U, &entry);
+	init_vcpuid_entry(0x40000010U, 0U, 0U, &entry);
 	result = set_vcpuid_entry(vm, &entry);
 	if (result != 0) {
 		return result;
 	}
 
-	init_vcpuid_entry(vm, 0x80000000U, 0U, 0U, &entry);
+	init_vcpuid_entry(0x80000000U, 0U, 0U, &entry);
 	result = set_vcpuid_entry(vm, &entry);
 	if (result != 0) {
 		return result;
@@ -287,7 +285,7 @@ int set_vcpuid_entries(struct vm *vm)
 	limit = entry.eax;
 	vm->vcpuid_xlevel = limit;
 	for (i = 0x80000001U; i <= limit; i++) {
-		init_vcpuid_entry(vm, i, 0U, 0U, &entry);
+		init_vcpuid_entry(i, 0U, 0U, &entry);
 		result = set_vcpuid_entry(vm, &entry);
 		if (result != 0) {
 			return result;

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -134,8 +134,8 @@ static inline uint8_t get_slp_typx(uint32_t pm1_cnt)
 	return (uint8_t)((pm1_cnt & 0x1fffU) >> BIT_SLP_TYPx);
 }
 
-static uint32_t pm1ab_io_read(__unused struct vm_io_handler *hdlr,
-		__unused struct vm *vm, uint16_t addr, size_t width)
+static uint32_t pm1ab_io_read(__unused struct vm *vm, uint16_t addr,
+			size_t width)
 {
 	uint32_t val = pio_read(addr, width);
 
@@ -150,9 +150,8 @@ static uint32_t pm1ab_io_read(__unused struct vm_io_handler *hdlr,
 	return val;
 }
 
-static void pm1ab_io_write(__unused struct vm_io_handler *hdlr,
-		__unused struct vm *vm, uint16_t addr, size_t width,
-		uint32_t v)
+static void pm1ab_io_write(__unused struct vm *vm, uint16_t addr, size_t width,
+			uint32_t v)
 {
 	static uint32_t pm1a_cnt_ready = 0U;
 

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -200,14 +200,14 @@ hv_emulate_pio(struct vcpu *vcpu, struct io_request *io_req)
 			break;
 		} else {
 			if (pio_req->direction == REQUEST_WRITE) {
-				handler->desc.io_write(handler, vm, port, size,
-					pio_req->value & mask);
+				handler->desc.io_write(vm, port, size,
+							pio_req->value & mask);
 
 				pr_dbg("IO write on port %04x, data %08x", port,
 					pio_req->value & mask);
 			} else {
-				pio_req->value = handler->desc.io_read(handler,
-						vm, port, size);
+				pio_req->value = handler->desc.io_read(vm, port,
+									size);
 
 				pr_dbg("IO read on port %04x, data %08x",
 					port, pio_req->value);

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -203,7 +203,7 @@ void exec_vmwrite16(uint32_t field, uint16_t value)
 	exec_vmwrite64(field, (uint64_t)value);
 }
 
-static void init_cr0_cr4_host_mask(__unused struct vcpu *vcpu)
+static void init_cr0_cr4_host_mask(void)
 {
 	static bool inited = false;
 	uint64_t fixed0, fixed1;
@@ -692,7 +692,7 @@ static void init_guest_state(struct vcpu *vcpu)
 	}
 }
 
-static void init_host_state(__unused struct vcpu *vcpu)
+static void init_host_state(void)
 {
 	uint16_t value16;
 	uint64_t value64;
@@ -968,7 +968,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	pr_dbg("VMX_PROC_VM_EXEC_CONTROLS2: 0x%x ", value32);
 
 	/*APIC-v, config APIC-access address*/
-	value64 = vlapic_apicv_get_apic_access_addr(vcpu->vm);
+	value64 = vlapic_apicv_get_apic_access_addr();
 	exec_vmwrite64(VMX_APIC_ACCESS_ADDR_FULL, value64);
 
 	/*APIC-v, config APIC virtualized page address*/
@@ -1043,7 +1043,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	/* Natural-width */
 	pr_dbg("Natural-width*********");
 
-	init_cr0_cr4_host_mask(vcpu);
+	init_cr0_cr4_host_mask();
 
 	/* The CR3 target registers work in concert with VMX_CR3_TARGET_COUNT
 	 * field. Using these registers guest CR3 access can be managed. i.e.,
@@ -1097,7 +1097,7 @@ static void init_entry_ctrl(__unused struct vcpu *vcpu)
 	exec_vmwrite32(VMX_ENTRY_INSTR_LENGTH, 0U);
 }
 
-static void init_exit_ctrl(__unused struct vcpu *vcpu)
+static void init_exit_ctrl(void)
 {
 	uint32_t value32;
 
@@ -1156,10 +1156,10 @@ void init_vmcs(struct vcpu *vcpu)
 	exec_vmptrld((void *)&vmcs_pa);
 
 	/* Initialize the Virtual Machine Control Structure (VMCS) */
-	init_host_state(vcpu);
+	init_host_state();
 	/* init exec_ctrl needs to run before init_guest_state */
 	init_exec_ctrl(vcpu);
 	init_guest_state(vcpu);
 	init_entry_ctrl(vcpu);
-	init_exit_ctrl(vcpu);
+	init_exit_ctrl();
 }

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -783,10 +783,8 @@ int32_t hcall_set_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
 	}
 
 	if (irq.type == IRQ_INTX) {
-		ret = ptdev_add_intx_remapping(target_vm,
-				irq.virt_bdf, irq.phys_bdf,
-				irq.is.intx.virt_pin, irq.is.intx.phys_pin,
-				irq.is.intx.pic_pin);
+		ret = ptdev_add_intx_remapping(target_vm, irq.is.intx.virt_pin,
+				irq.is.intx.phys_pin, irq.is.intx.pic_pin);
 	} else if ((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) {
 		ret = ptdev_add_msix_remapping(target_vm,
 				irq.virt_bdf, irq.phys_bdf,

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -178,7 +178,7 @@ void default_idle(void)
 			cpu_dead(pcpu_id);
 		} else {
 			CPU_IRQ_ENABLE();
-			cpu_do_idle(pcpu_id);
+			cpu_do_idle();
 			CPU_IRQ_DISABLE();
 		}
 	}

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -133,8 +133,8 @@ static void vuart_toggle_intr(struct acrn_vuart *vu)
 	}
 }
 
-static void vuart_write(__unused struct vm_io_handler *hdlr, struct vm *vm,
-		uint16_t offset_arg, __unused size_t width, uint32_t value)
+static void vuart_write(struct vm *vm, uint16_t offset_arg,
+			__unused size_t width, uint32_t value)
 {
 	uint16_t offset = offset_arg;
 	struct acrn_vuart *vu = vm_vuart(vm);
@@ -219,8 +219,8 @@ done:
 	vuart_unlock(vu);
 }
 
-static uint32_t vuart_read(__unused struct vm_io_handler *hdlr, struct vm *vm,
-		uint16_t offset_arg, __unused size_t width)
+static uint32_t vuart_read(struct vm *vm, uint16_t offset_arg,
+			__unused size_t width)
 {
 	uint16_t offset = offset_arg;
 	uint8_t iir, reg, intr_reason;

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -52,8 +52,7 @@ static void pci_cfg_clear_cache(struct pci_addr_info *pi)
 	pi->cached_enable = 0U;
 }
 
-static uint32_t pci_cfg_io_read(__unused struct vm_io_handler *hdlr,
-	struct vm *vm, uint16_t addr, size_t bytes)
+static uint32_t pci_cfg_io_read(struct vm *vm, uint16_t addr, size_t bytes)
 {
 	uint32_t val = 0xFFFFFFFFU;
 	struct vpci *vpci = &vm->vpci;
@@ -85,8 +84,8 @@ static uint32_t pci_cfg_io_read(__unused struct vm_io_handler *hdlr,
 	return val;
 }
 
-static void pci_cfg_io_write(__unused struct vm_io_handler *hdlr,
-	struct vm *vm, uint16_t addr, size_t bytes, uint32_t val)
+static void pci_cfg_io_write(struct vm *vm, uint16_t addr, size_t bytes,
+			uint32_t val)
 {
 	struct vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -724,8 +724,7 @@ static int vpic_master_handler(struct vm *vm, bool in, uint16_t port,
 	return vpic_write(vpic, i8259, port, eax);
 }
 
-static uint32_t vpic_master_io_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t addr, size_t width)
+static uint32_t vpic_master_io_read(struct vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0U;
 
@@ -736,8 +735,8 @@ static uint32_t vpic_master_io_read(__unused struct vm_io_handler *hdlr,
 	return val;
 }
 
-static void vpic_master_io_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t addr, size_t width, uint32_t v)
+static void vpic_master_io_write(struct vm *vm, uint16_t addr, size_t width,
+				uint32_t v)
 {
 	uint32_t val = v;
 
@@ -767,8 +766,7 @@ static int vpic_slave_handler(struct vm *vm, bool in, uint16_t port,
 	return vpic_write(vpic, i8259, port, eax);
 }
 
-static uint32_t vpic_slave_io_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t addr, size_t width)
+static uint32_t vpic_slave_io_read(struct vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0U;
 
@@ -779,8 +777,8 @@ static uint32_t vpic_slave_io_read(__unused struct vm_io_handler *hdlr,
 	return val;
 }
 
-static void vpic_slave_io_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t addr, size_t width, uint32_t v)
+static void vpic_slave_io_write(struct vm *vm, uint16_t addr, size_t width,
+				uint32_t v)
 {
 	uint32_t val = v;
 
@@ -834,8 +832,7 @@ static int vpic_elc_handler(struct vm *vm, bool in, uint16_t port, size_t bytes,
 	return 0;
 }
 
-static uint32_t vpic_elc_io_read(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t addr, size_t width)
+static uint32_t vpic_elc_io_read(struct vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0U;
 
@@ -845,8 +842,8 @@ static uint32_t vpic_elc_io_read(__unused struct vm_io_handler *hdlr,
 	return val;
 }
 
-static void vpic_elc_io_write(__unused struct vm_io_handler *hdlr,
-		struct vm *vm, uint16_t addr, size_t width, uint32_t v)
+static void vpic_elc_io_write(struct vm *vm, uint16_t addr, size_t width,
+				uint32_t v)
 {
 	uint32_t val = v;
 

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -46,8 +46,7 @@ static uint8_t cmos_get_reg_val(uint8_t addr)
 	return reg;
 }
 
-static uint32_t vrtc_read(__unused struct vm_io_handler *hdlr, struct vm *vm,
-	uint16_t addr, __unused size_t width)
+static uint32_t vrtc_read(struct vm *vm, uint16_t addr, __unused size_t width)
 {
 	uint8_t reg;
 	uint8_t offset;
@@ -62,8 +61,8 @@ static uint32_t vrtc_read(__unused struct vm_io_handler *hdlr, struct vm *vm,
 	return reg;
 }
 
-static void vrtc_write(__unused struct vm_io_handler *hdlr, struct vm *vm, uint16_t addr,
-	size_t width, uint32_t value)
+static void vrtc_write(struct vm *vm, uint16_t addr, size_t width,
+			uint32_t value)
 {
 
 	if (width != 1U)

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -15,9 +15,8 @@ int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
 		uint16_t entry_nr, struct ptdev_msi_info *info);
 int ptdev_intx_pin_remap(struct vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
-int ptdev_add_intx_remapping(struct vm *vm, __unused uint16_t virt_bdf,
-	__unused uint16_t phys_bdf, uint8_t virt_pin, uint8_t phys_pin,
-	bool pic_pin);
+int ptdev_add_intx_remapping(struct vm *vm, uint8_t virt_pin, uint8_t phys_pin,
+		bool pic_pin);
 void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin);
 int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, uint32_t vector_count);

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -314,7 +314,7 @@ extern struct cpuinfo_x86 boot_cpu_data;
 #define MAX_CX_ENTRY	(MAX_CSTATE - 1U)
 
 /* Function prototypes */
-void cpu_do_idle(__unused uint16_t pcpu_id);
+void cpu_do_idle(void);
 void cpu_dead(uint16_t pcpu_id);
 void trampoline_start16(void);
 bool is_apicv_intr_delivery_supported(void);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -178,7 +178,7 @@ void vlapic_init(struct acrn_vlapic *vlapic);
 void vlapic_reset(struct acrn_vlapic *vlapic);
 void vlapic_restore(struct acrn_vlapic *vlapic, struct lapic_regs *regs);
 bool vlapic_enabled(struct acrn_vlapic *vlapic);
-uint64_t vlapic_apicv_get_apic_access_addr(__unused struct vm *vm);
+uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);
 void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);
 int apic_access_vmexit_handler(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -35,12 +35,10 @@ struct vm;
 struct vcpu;
 
 typedef
-uint32_t (*io_read_fn_t)(struct vm_io_handler *handler, struct vm *vm,
-				uint16_t port, size_t size);
+uint32_t (*io_read_fn_t)(struct vm *vm, uint16_t port, size_t size);
 
 typedef
-void (*io_write_fn_t)(struct vm_io_handler *handler, struct vm *vm,
-				uint16_t port, size_t size, uint32_t val);
+void (*io_write_fn_t)(struct vm *vm, uint16_t port, size_t size, uint32_t val);
 
 /* Describes a single IO handler description entry. */
 struct vm_io_handler_desc {


### PR DESCRIPTION
MISRA-C requires that there should be no unused parameters in
functions.

In some cases, we will keep the unused parameters.
vmexit handler is one example. It is used as function pointer.
Some of the vmexit handlers use the input parameter 'vcpu', some of
them don't. We still need to keep the unused parameters 'vcpu' for
those handlers don't use 'vcpu'.

This patch removes the unused parameters that is not being used
unconditionally.

v1 -> v2:
 * remove the non-implemented API 'vlapic_id_write_handler'

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>