### PR TITLE
hv: include: fix 'Unused procedure parameter'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -450,8 +450,7 @@ static void bsp_boot_post(void)
 	calibrate_tsc();
 
 	/* Enable logging */
-	init_logmsg(CONFIG_LOG_BUF_SIZE,
-		       CONFIG_LOG_DESTINATION);
+	init_logmsg(CONFIG_LOG_DESTINATION);
 
 	pr_acrnlog("HV version %s-%s-%s %s (daily tag:%s) build by %s, start time %lluus",
 			HV_FULL_VERSION,

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -257,8 +257,7 @@ hv_emulate_mmio(struct vcpu *vcpu, struct io_request *io_req)
 			return -EIO;
 		} else {
 			/* Handle this MMIO operation */
-			status = mmio_handler->read_write(vcpu, io_req,
-					mmio_handler->handler_private_data);
+			status = mmio_handler->read_write(vcpu, io_req);
 			break;
 		}
 	}

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -69,7 +69,7 @@ static void do_copy_earlylog(struct shared_buf *dst_sbuf,
 	}
 }
 
-void init_logmsg(__unused uint32_t mem_size, uint32_t flags)
+void init_logmsg(uint32_t flags)
 {
 	uint16_t pcpu_id;
 

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -529,8 +529,7 @@ vioapic_pincount(struct vm *vm)
 	}
 }
 
-int vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req,
-		__unused void *handler_private_data)
+int vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req)
 {
 	struct vm *vm = vcpu->vm;
 	struct acrn_vioapic *vioapic;

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -61,7 +61,7 @@ uint32_t	vioapic_pincount(struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
 void	vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu,
-	struct io_request *io_req, __unused void *handler_private_data);
+	struct io_request *io_req);
 
 #ifdef HV_DEBUG
 void get_vioapic_info(char *str_arg, int str_max, uint16_t vmid);

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -94,8 +94,8 @@ struct vm_io_handler {
 
 /* Typedef for MMIO handler and range check routine */
 struct mmio_request;
-typedef int (*hv_mem_io_handler_t)(struct vcpu *vcpu, struct io_request *io_req,
-					void *handler_private_data);
+typedef int (*hv_mem_io_handler_t)(struct vcpu *vcpu,
+					struct io_request *io_req);
 
 /* Structure for MMIO handler node */
 struct mem_io_node {

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -31,7 +31,7 @@
 extern uint32_t console_loglevel;
 extern uint32_t mem_loglevel;
 extern uint32_t npk_loglevel;
-void init_logmsg(__unused uint32_t mem_size, uint32_t flags);
+void init_logmsg(uint32_t flags);
 void print_logmsg_buffer(uint16_t pcpu_id);
 void do_logmsg(uint32_t severity, const char *fmt, ...);
 
@@ -70,8 +70,7 @@ int vprintf(const char *fmt, va_list args);
 
 #else /* HV_DEBUG */
 
-static inline void init_logmsg(__unused uint32_t mem_size,
-			__unused uint32_t flags)
+static inline void init_logmsg(__unused uint32_t flags)
 {
 }
 

--- a/hypervisor/include/debug/trace.h
+++ b/hypervisor/include/debug/trace.h
@@ -76,7 +76,7 @@ struct trace_entry {
 } __attribute__((aligned(8)));
 
 static inline bool
-trace_check(uint16_t cpu_id, __unused uint32_t evid)
+trace_check(uint16_t cpu_id)
 {
 	if (per_cpu(sbuf, cpu_id)[ACRN_TRACE] == NULL) {
 		return false;
@@ -105,7 +105,7 @@ TRACE_2L(uint32_t evid, uint64_t e, uint64_t f)
 	struct trace_entry entry;
 	uint16_t cpu_id = get_cpu_id();
 
-	if (!trace_check(cpu_id, evid)) {
+	if (!trace_check(cpu_id)) {
 		return;
 	}
 
@@ -121,7 +121,7 @@ TRACE_4I(uint32_t evid, uint32_t a, uint32_t b, uint32_t c,
 	struct trace_entry entry;
 	uint16_t cpu_id = get_cpu_id();
 
-	if (!trace_check(cpu_id, evid)) {
+	if (!trace_check(cpu_id)) {
 		return;
 	}
 
@@ -139,7 +139,7 @@ TRACE_6C(uint32_t evid, uint8_t a1, uint8_t a2, uint8_t a3,
 	struct trace_entry entry;
 	uint16_t cpu_id = get_cpu_id();
 
-	if (!trace_check(cpu_id, evid)) {
+	if (!trace_check(cpu_id)) {
 		return;
 	}
 
@@ -163,7 +163,7 @@ TRACE_16STR(uint32_t evid, const char name[])
 	uint16_t cpu_id = get_cpu_id();
 	size_t len, i;
 
-	if (!trace_check(cpu_id, evid)) {
+	if (!trace_check(cpu_id)) {
 		return;
 	}
 


### PR DESCRIPTION
MISRA-C requires that there should be no unused parameters in
functions.

This patch removes the unused parameters that is not being used
unconditionally.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>