### PR TITLE
Fix Doxygen comment in hypercall.h header file

### DIFF
--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -463,7 +463,7 @@ int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu);
  * to notify the SOS kernel.
  *
  * @param vm Pointer to VM data structure
- * @param the expected notifier vector from guest
+ * @param param the expected notifier vector from guest
  *
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.


### PR DESCRIPTION
Fix a Doxygen comment in the hypercall.h header file which is
missing the name of the parameter, this is causing warnings when
generating the documentation related to the
hcall_set_callback_vector() hypercall.

Tracked-On: #1335

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>