### PR TITLE
Documentation: add instruction to use a specific version of Clear

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -62,6 +62,12 @@ complete this setup.
 
       # swupd autoupdate --disable
 
+   .. note::
+      The Clear Linux installer will automatically check for updates and install the
+      latest version available on your system. If you wish to use a specific version
+      (such as 25130), you can achieve that after the installation has completed using
+      ``swupd verify --fix --picky -m 25130``
+
 #. If you have an older version of Clear Linux already installed
    on your hardware, use this command to upgrade Clear Linux
    to version 25130 (or newer):


### PR DESCRIPTION
Add a note (and instruction) on how to use a specific version of
Clear Linux on a system. Picking up the image of a specific release
is not sufficient as Clear Linux always grabs the very latest image
when installing.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>