### PR TITLE
hv: vtd: add config for bus limitation when init

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -147,3 +147,8 @@ config MTRR_ENABLED
 config RELOC
 	bool "Enable relocation"
 	default y
+
+config IOMMU_INIT_BUS_LIMIT
+	hex "bus limitation when iommu init"
+	default 0xf if PLATFORM_SBL
+	default 0xff if PLATFORM_UEFI

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -17,11 +17,6 @@
 #define ACRN_DBG_IOMMU 6U
 #endif
 
-/* set an appropriate bus limitation when iommu init,
- * to reduce memory & time cost
- */
-#define IOMMU_INIT_BUS_LIMIT        (0xfU)
-
 #define LEVEL_WIDTH 9U
 
 #define ROOT_ENTRY_LOWER_PRESENT_POS        (0U)
@@ -1300,7 +1295,7 @@ void init_iommu_vm0_domain(struct vm *vm0)
 
 	vm0_domain = (struct iommu_domain *) vm0->iommu;
 
-	for (bus = 0U; bus <= IOMMU_INIT_BUS_LIMIT; bus++) {
+	for (bus = 0U; bus <= CONFIG_IOMMU_INIT_BUS_LIMIT; bus++) {
 		for (devfun = 0U; devfun <= 255U; devfun++) {
 			add_iommu_device(vm0_domain, 0U,
 				(uint8_t)bus, (uint8_t)devfun);


### PR DESCRIPTION
Currently, hypervisor doesn't have the information of pci devices
on the platform when init. In order to reduce boot time and memory
usage, hypervisor set a bus limitation for pci devices when init vtd.
However, maximum bus number varies on different platforms.
This patch add a config for the bus limitation.
Set 0xF as the default value for the maximum bus number on sbl platform.
Set 0xFF as the default value for the maximum bus number on uefi platfrom.

Tracked-On: #1339
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>