### PR TITLE
hv: Enable the compiler warning as error for HV

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -42,7 +42,7 @@ CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -nostdinc -nostdlib -fno-common
 CFLAGS += -O2 -D_FORTIFY_SOURCE=2
-CFLAGS += -Wformat -Wformat-security
+CFLAGS += -Wformat -Wformat-security -Werror
 ifeq (y, $(CONFIG_RELOC))
 CFLAGS += -fpie
 else

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -167,7 +167,7 @@ static int local_gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_inf
 	/* if smap is enabled and supervisor-mode access */
 	if (pw_info->is_smap_on && !pw_info->is_user_mode_access &&
 			is_user_mode_addr) {
-		bool rflags_ac = ((vcpu_get_rflags(vcpu) & RFLAGS_AC) == 1UL);
+		bool rflags_ac = ((vcpu_get_rflags(vcpu) & RFLAGS_AC) != 0UL);
 
 		/* read from user mode address, eflags.ac = 0 */
 		if (!pw_info->is_write_access && !rflags_ac) {

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -66,7 +66,7 @@ void *get_rsdp_from_uefi(void)
 	if (!efi_initialized)
 		efi_init();
 
-	return hpa2hva(efi_ctx->rsdp);
+	return hpa2hva((uint64_t)efi_ctx->rsdp);
 }
 
 void *get_ap_trampoline_buf(void)

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -143,7 +143,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 
 	/* Check if flags specify to output to memory */
 	if (do_mem_log) {
-		int i, msg_len;
+		unsigned int i, msg_len;
 		struct shared_buf *sbuf = (struct shared_buf *)
 					per_cpu(sbuf, pcpu_id)[ACRN_HVLOG];
 		struct shared_buf *early_sbuf = per_cpu(earlylog_sbuf, pcpu_id);
@@ -162,7 +162,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 		if (sbuf != NULL) {
 			msg_len = strnlen_s(buffer, LOG_MESSAGE_MAX_SIZE);
 
-			for (i = 0; i < (((msg_len - 1) / LOG_ENTRY_SIZE) + 1);
+			for (i = 0U; i < (((msg_len - 1U) / LOG_ENTRY_SIZE) + 1U);
 					i++) {
 				(void)sbuf_put(sbuf, (uint8_t *)buffer +
 							(i * LOG_ENTRY_SIZE));
@@ -213,7 +213,8 @@ void print_logmsg_buffer(uint16_t pcpu_id)
 			return;
 		}
 
-		idx = (read_cnt < LOG_ENTRY_SIZE) ? read_cnt : LOG_ENTRY_SIZE;
+		idx = ((uint32_t)read_cnt < LOG_ENTRY_SIZE) ?
+				(uint32_t)read_cnt : LOG_ENTRY_SIZE;
 		buffer[idx] = '\0';
 
 		spinlock_irqsave_obtain(&(logmsg.lock), &rflags);


### PR DESCRIPTION
Fix the compiler warning and turn on the flag to make
compiler warning as compiler error.

Tracked-On: #1343
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>