### PR TITLE
hv: drop the macro arguments acting as formal parameter names

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -633,19 +633,19 @@ static void vie_update_rflags(struct vcpu *vcpu, uint64_t rflags2, uint64_t psl)
 /*
  * Return the status flags that would result from doing (x - y).
  */
-#define build_getcc(name, type, x, y)	\
-static uint64_t name(type x, type y)	\
-{					\
-	uint64_t rflags;		\
-					\
+#define build_getcc(name, type)					\
+static uint64_t name(type x, type y)				\
+{								\
+	uint64_t rflags;					\
+								\
 	__asm __volatile("sub %2,%1; pushfq; popq %0" :		\
 			"=r" (rflags), "+r" (x) : "m" (y));	\
 	return rflags;						\
 }
-build_getcc(getcc8, uint8_t, x, y)
-build_getcc(getcc16, uint16_t, x, y)
-build_getcc(getcc32, uint32_t, x, y)
-build_getcc(getcc64, uint64_t, x, y)
+build_getcc(getcc8, uint8_t)
+build_getcc(getcc16, uint16_t)
+build_getcc(getcc32, uint32_t)
+build_getcc(getcc64, uint64_t)
 
 /**
  * @pre opsize = 1, 2, 4 or 8

--- a/hypervisor/include/lib/atomic.h
+++ b/hypervisor/include/lib/atomic.h
@@ -31,7 +31,7 @@
 #define ATOMIC_H
 #include <cpu.h>
 
-#define build_atomic_load(name, size, type, ptr)	\
+#define build_atomic_load(name, size, type)		\
 static inline type name(const volatile type *ptr)	\
 {							\
 	type ret;					\
@@ -41,10 +41,10 @@ static inline type name(const volatile type *ptr)	\
 			: "cc", "memory");		\
 	return ret;					\
 }
-build_atomic_load(atomic_load32, "l", uint32_t, p)
-build_atomic_load(atomic_load64, "q", uint64_t, p)
+build_atomic_load(atomic_load32, "l", uint32_t)
+build_atomic_load(atomic_load64, "q", uint64_t)
 
-#define build_atomic_store(name, size, type, ptr, v)	\
+#define build_atomic_store(name, size, type)		\
 static inline void name(volatile type *ptr, type v)	\
 {							\
 	asm volatile("mov" size " %1,%0"		\
@@ -52,30 +52,30 @@ static inline void name(volatile type *ptr, type v)	\
 			: "r" (v)			\
 			: "cc", "memory");		\
 }
-build_atomic_store(atomic_store16, "w", uint16_t, p, v)
-build_atomic_store(atomic_store32, "l", uint32_t, p, v)
-build_atomic_store(atomic_store64, "q", uint64_t, p, v)
+build_atomic_store(atomic_store16, "w", uint16_t)
+build_atomic_store(atomic_store32, "l", uint32_t)
+build_atomic_store(atomic_store64, "q", uint64_t)
 
-#define build_atomic_inc(name, size, type, ptr)		\
+#define build_atomic_inc(name, size, type)		\
 static inline void name(type *ptr)			\
 {							\
 	asm volatile(BUS_LOCK "inc" size " %0"		\
 			: "=m" (*ptr)			\
 			:  "m" (*ptr));			\
 }
-build_atomic_inc(atomic_inc32, "l", uint32_t, p)
-build_atomic_inc(atomic_inc64, "q", uint64_t, p)
+build_atomic_inc(atomic_inc32, "l", uint32_t)
+build_atomic_inc(atomic_inc64, "q", uint64_t)
 
-#define build_atomic_dec(name, size, type, ptr)		\
+#define build_atomic_dec(name, size, type)		\
 static inline void name(type *ptr)			\
 {							\
 	asm volatile(BUS_LOCK "dec" size " %0"		\
 			: "=m" (*ptr)			\
 			:  "m" (*ptr));			\
 }
-build_atomic_dec(atomic_dec16, "w", uint16_t, p)
-build_atomic_dec(atomic_dec32, "l", uint32_t, p)
-build_atomic_dec(atomic_dec64, "q", uint64_t, p)
+build_atomic_dec(atomic_dec16, "w", uint16_t)
+build_atomic_dec(atomic_dec32, "l", uint32_t)
+build_atomic_dec(atomic_dec64, "q", uint64_t)
 
 /**
  *  #define atomic_set32(P, V)		(*(unsigned int *)(P) |= (V))
@@ -112,9 +112,9 @@ static inline void atomic_clear32(uint32_t *p, uint32_t v)
  *  #define atomic_set64(P, V)		(*(uint64_t *)(P) |= (V))
  *
  *  Parameters:
- *  uint32_t*   p       A pointer to memory area that stores source
+ *  uint64_t*   p       A pointer to memory area that stores source
  *                      value and setting result;
- *  uint32_t    v       The value needs to be set.
+ *  uint64_t    v       The value needs to be set.
  */
 static inline void atomic_set64(uint64_t *p, uint64_t v)
 {
@@ -128,9 +128,9 @@ static inline void atomic_set64(uint64_t *p, uint64_t v)
  *  #define atomic_clear64(P, V)	(*(uint64_t *)(P) &= ~(V))
  *
  *  Parameters:
- *  uint32_t*   p       A pointer to memory area that stores source
+ *  uint64_t*   p       A pointer to memory area that stores source
  *                      value and clearing result;
- *  uint32_t    v       The value needs to be cleared.
+ *  uint64_t    v       The value needs to be cleared.
  */
 static inline void atomic_clear64(uint64_t *p, uint64_t v)
 {
@@ -140,7 +140,7 @@ static inline void atomic_clear64(uint64_t *p, uint64_t v)
 			:  "cc", "memory");
 }
 
-#define build_atomic_swap(name, size, type, ptr, v)	\
+#define build_atomic_swap(name, size, type)		\
 static inline type name(type *ptr, type v)		\
 {							\
 	asm volatile(BUS_LOCK "xchg" size " %1,%0"	\
@@ -149,8 +149,8 @@ static inline type name(type *ptr, type v)		\
 			:  "cc", "memory");		\
 	return v;					\
 }
-build_atomic_swap(atomic_swap32, "l", uint32_t, p, v)
-build_atomic_swap(atomic_swap64, "q", uint64_t, p, v)
+build_atomic_swap(atomic_swap32, "l", uint32_t)
+build_atomic_swap(atomic_swap64, "q", uint64_t)
 
  /*
  * #define atomic_readandclear32(P) \
@@ -170,9 +170,8 @@ static inline uint64_t atomic_readandclear64(uint64_t *p)
 	return atomic_swap64(p, 0UL);
 }
 
-#define build_atomic_cmpxchg(name, size, type, ptr, old, new)	\
-static inline type name(volatile type *ptr,			\
-			type old, type new)			\
+#define build_atomic_cmpxchg(name, size, type)			\
+static inline type name(volatile type *ptr, type old, type new)	\
 {								\
 	type ret;						\
 	asm volatile(BUS_LOCK "cmpxchg" size " %2,%1"		\
@@ -181,10 +180,10 @@ static inline type name(volatile type *ptr,			\
 			: "memory");				\
 	return ret;						\
 }
-build_atomic_cmpxchg(atomic_cmpxchg32, "l", uint32_t, p, old, new)
-build_atomic_cmpxchg(atomic_cmpxchg64, "q", uint64_t, p, old, new)
+build_atomic_cmpxchg(atomic_cmpxchg32, "l", uint32_t)
+build_atomic_cmpxchg(atomic_cmpxchg64, "q", uint64_t)
 
-#define build_atomic_xadd(name, size, type, ptr, v)		\
+#define build_atomic_xadd(name, size, type)			\
 static inline type name(type *ptr, type v)			\
 {								\
 	asm volatile(BUS_LOCK "xadd" size " %0,%1"		\
@@ -193,9 +192,9 @@ static inline type name(type *ptr, type v)			\
 			: "cc", "memory");			\
 	return v;						\
  }
-build_atomic_xadd(atomic_xadd16, "w", uint16_t, p, v)
-build_atomic_xadd(atomic_xadd32, "l", int32_t, p, v)
-build_atomic_xadd(atomic_xadd64, "q", int64_t, p, v)
+build_atomic_xadd(atomic_xadd16, "w", uint16_t)
+build_atomic_xadd(atomic_xadd32, "l", int32_t)
+build_atomic_xadd(atomic_xadd64, "q", int64_t)
 
 static inline int32_t atomic_add_return(int32_t *p, int32_t v)
 {

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -190,40 +190,40 @@ static inline uint16_t clz64(uint64_t value)
  * Note:Input parameter nr shall be less than 64. 
  * If nr>=64, it will be truncated.
  */
-#define build_bitmap_set(name, op_len, op_type, lock, nr, addr)	\
+#define build_bitmap_set(name, op_len, op_type, lock)			\
 static inline void name(uint16_t nr_arg, volatile op_type *addr)	\
-{								\
-	uint16_t nr;					\
-	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);	        \
-	asm volatile(lock "or" op_len " %1,%0"			\
-			:  "+m" (*addr)				\
-			:  "r" ((op_type)(1UL<<nr))		\
-			:  "cc", "memory");			\
+{									\
+	uint16_t nr;							\
+	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
+	asm volatile(lock "or" op_len " %1,%0"				\
+			:  "+m" (*addr)					\
+			:  "r" ((op_type)(1UL<<nr))			\
+			:  "cc", "memory");				\
 }
-build_bitmap_set(bitmap_set_nolock, "q", uint64_t, "", nr, addr)
-build_bitmap_set(bitmap_set_lock, "q", uint64_t, BUS_LOCK, nr, addr)
-build_bitmap_set(bitmap32_set_nolock, "l", uint32_t, "", nr, addr)
-build_bitmap_set(bitmap32_set_lock, "l", uint32_t, BUS_LOCK, nr, addr)
+build_bitmap_set(bitmap_set_nolock, "q", uint64_t, "")
+build_bitmap_set(bitmap_set_lock, "q", uint64_t, BUS_LOCK)
+build_bitmap_set(bitmap32_set_nolock, "l", uint32_t, "")
+build_bitmap_set(bitmap32_set_lock, "l", uint32_t, BUS_LOCK)
 
 /*
  * (*addr) &= ~(1UL<<nr);
  * Note:Input parameter nr shall be less than 64. 
  * If nr>=64, it will be truncated.
  */
-#define build_bitmap_clear(name, op_len, op_type, lock, nr, addr)	\
-static inline void name(uint16_t nr_arg, volatile op_type *addr)        \
+#define build_bitmap_clear(name, op_len, op_type, lock)			\
+static inline void name(uint16_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;					        \
+	uint16_t nr;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "and" op_len " %1,%0"				\
 			:  "+m" (*addr)					\
 			:  "r" ((op_type)(~(1UL<<(nr))))		\
 			:  "cc", "memory");				\
 }
-build_bitmap_clear(bitmap_clear_nolock, "q", uint64_t, "", nr, addr)
-build_bitmap_clear(bitmap_clear_lock, "q", uint64_t, BUS_LOCK, nr, addr)
-build_bitmap_clear(bitmap32_clear_nolock, "l", uint32_t, "", nr, addr)
-build_bitmap_clear(bitmap32_clear_lock, "l", uint32_t, BUS_LOCK, nr, addr)
+build_bitmap_clear(bitmap_clear_nolock, "q", uint64_t, "")
+build_bitmap_clear(bitmap_clear_lock, "q", uint64_t, BUS_LOCK)
+build_bitmap_clear(bitmap32_clear_nolock, "l", uint32_t, "")
+build_bitmap_clear(bitmap32_clear_lock, "l", uint32_t, BUS_LOCK)
 
 /*
  * return !!((*addr) & (1UL<<nr));
@@ -261,22 +261,22 @@ static inline bool bitmap32_test(uint16_t nr_arg, volatile uint32_t *addr)
  * Note:Input parameter nr shall be less than 64. If nr>=64, it
  * will be truncated.
  */
-#define build_bitmap_testandset(name, op_len, op_type, lock, nr, addr)	\
-static inline bool name(uint16_t nr_arg, volatile op_type *addr)        \
+#define build_bitmap_testandset(name, op_len, op_type, lock)		\
+static inline bool name(uint16_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;						\
+	uint16_t nr;							\
 	int32_t ret=0;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "bts" op_len " %2,%1\n\tsbbl %0,%0"		\
 			: "=r" (ret), "=m" (*addr)			\
 			: "r" ((op_type)nr)				\
 			: "cc", "memory");				\
-	return (ret != 0);			        		\
+	return (ret != 0);						\
 }
-build_bitmap_testandset(bitmap_test_and_set_nolock, "q", uint64_t, "", nr, addr)
-build_bitmap_testandset(bitmap_test_and_set_lock, "q", uint64_t, BUS_LOCK, nr, addr)
-build_bitmap_testandset(bitmap32_test_and_set_nolock, "l", uint32_t, "", nr, addr)
-build_bitmap_testandset(bitmap32_test_and_set_lock, "l", uint32_t, BUS_LOCK, nr, addr)
+build_bitmap_testandset(bitmap_test_and_set_nolock, "q", uint64_t, "")
+build_bitmap_testandset(bitmap_test_and_set_lock, "q", uint64_t, BUS_LOCK)
+build_bitmap_testandset(bitmap32_test_and_set_nolock, "l", uint32_t, "")
+build_bitmap_testandset(bitmap32_test_and_set_lock, "l", uint32_t, BUS_LOCK)
 
 /*
  * bool ret = (*addr) & (1UL<<nr);
@@ -285,24 +285,21 @@ build_bitmap_testandset(bitmap32_test_and_set_lock, "l", uint32_t, BUS_LOCK, nr,
  * Note:Input parameter nr shall be less than 64. If nr>=64,
  * it will be truncated.
  */
-#define build_bitmap_testandclear(name, op_len, op_type, lock, nr, addr)\
-static inline bool name(uint16_t nr_arg, volatile op_type *addr)        \
+#define build_bitmap_testandclear(name, op_len, op_type, lock)		\
+static inline bool name(uint16_t nr_arg, volatile op_type *addr)	\
 {									\
-	uint16_t nr;						\
+	uint16_t nr;							\
 	int32_t ret=0;							\
 	nr = nr_arg & ((8U * sizeof(op_type)) - 1U);			\
 	asm volatile(lock "btr" op_len " %2,%1\n\tsbbl %0,%0"		\
 			: "=r" (ret), "=m" (*addr)			\
 			: "r" ((op_type)nr)				\
 			: "cc", "memory");				\
-	return (ret != 0);			        		\
+	return (ret != 0);						\
 }
-build_bitmap_testandclear(bitmap_test_and_clear_nolock, "q", uint64_t, "", nr, addr)
-build_bitmap_testandclear(bitmap_test_and_clear_lock, "q",
-				uint64_t, BUS_LOCK, nr, addr)
-build_bitmap_testandclear(bitmap32_test_and_clear_nolock, "l",
-				uint32_t, "", nr, addr)
-build_bitmap_testandclear(bitmap32_test_and_clear_lock, "l",
-				uint32_t, BUS_LOCK, nr, addr)
+build_bitmap_testandclear(bitmap_test_and_clear_nolock, "q", uint64_t, "")
+build_bitmap_testandclear(bitmap_test_and_clear_lock, "q", uint64_t, BUS_LOCK)
+build_bitmap_testandclear(bitmap32_test_and_clear_nolock, "l", uint32_t, "")
+build_bitmap_testandclear(bitmap32_test_and_clear_lock, "l", uint32_t, BUS_LOCK)
 
 #endif /* BITS_H*/


### PR DESCRIPTION
This patch fixes the following issue pointed by Xiangyang and Junjie.
There are some macro arguments acting as formal parameter names.
Drop such arguments since they make no difference to the expanded
implementation and they might confuse some developers.

Here is an example.
'ptr' is dropped in this patch, which is acting as a formal parameter
name and make no difference to the expanded implementation.

-#define build_atomic_load(name, size, type, ptr)       \
+#define build_atomic_load(name, size, type)            \
 static inline type name(const volatile type *ptr)      \
{                                                       \
        type ret;                                       \
        asm volatile("mov" size " %1,%0"                \
                        : "=r" (ret)                    \
                        : "m" (*ptr)                    \
                        : "cc", "memory");              \
        return ret;                                     \
}

Some minor coding style fixes are also included in this patch.
- use TAB for the alignment rather than mixing TAB with space
- fix some typo in the comments

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>