### PR TITLE
hv: Fix the warning for ACRN release build

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -291,8 +291,6 @@ static void init_percpu_data_area(void)
 {
 	uint16_t i;
 	uint16_t pcpu_num = 0U;
-	uint16_t bsp_cpu_id;
-	uint8_t bsp_lapic_id = 0U;
 	uint8_t lapic_id_array[MAX_PCPU_NUM];
 
 	/* Save all lapic_id detected via parse_mdt in lapic_id_array */
@@ -308,10 +306,8 @@ static void init_percpu_data_area(void)
 		per_cpu(lapic_id, i) = lapic_id_array[i];
 	}
 
-	bsp_lapic_id = get_cur_lapic_id();
-
-	bsp_cpu_id = get_cpu_id_from_lapic_id(bsp_lapic_id);
-	ASSERT(bsp_cpu_id != INVALID_CPU_ID, "fail to get phy cpu id");
+	ASSERT(get_cpu_id_from_lapic_id(get_cur_lapic_id()) != INVALID_CPU_ID,
+		"fail to get phy cpu id");
 }
 
 static void cpu_set_current_state(uint16_t pcpu_id, enum cpu_state state)

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -19,7 +19,9 @@ static void run_vcpu_pre_work(struct vcpu *vcpu)
 
 void vcpu_thread(struct vcpu *vcpu)
 {
+#ifdef HV_DEBUG
 	uint64_t vmexit_begin = 0UL, vmexit_end = 0UL;
+#endif
 	uint32_t basic_exit_reason = 0U;
 	uint64_t tsc_aux_hyp_cpu = (uint64_t) vcpu->pcpu_id;
 	int32_t ret = 0;


### PR DESCRIPTION
Now, the warning is promoted to error. The warning break ACRN
release build.

Tracked-On: #1343
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>