### PR TITLE
hv:Replace dynamic memory allocation for vuart

### DIFF
--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -253,7 +253,7 @@ static inline struct vcpu *get_primary_vcpu(struct vm *vm)
 static inline struct acrn_vuart*
 vm_vuart(struct vm *vm)
 {
-	return (struct acrn_vuart *)&(vm->vuart);
+	return &(vm->vuart);
 }
 
 static inline struct acrn_vpic *

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -30,6 +30,9 @@
 #ifndef _VUART_H_
 #define	_VUART_H_
 
+#define RX_BUF_SIZE		256U
+#define TX_BUF_SIZE		8192U
+
 struct fifo {
 	char *buf;
 	uint32_t rindex;	/* index to read from */
@@ -53,6 +56,8 @@ struct acrn_vuart {
 	struct fifo rxfifo;
 	struct fifo txfifo;
 	uint16_t base;
+	char vuart_rx_buf[RX_BUF_SIZE];
+	char vuart_tx_buf[TX_BUF_SIZE];
 
 	bool thre_int_pending;	/* THRE interrupt pending */
 	bool active;


### PR DESCRIPTION
Replace dynamic allocation for vuart rx/tx buffer
with static array.

v1-->v2:
   Move vuart rx/tx buffer into acrn_vuart data structure
   Reduce the size of vuart tx buffer from 64K to 8K

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>