### PR TITLE
HV: Add hypercall to set/clear IRQ line

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -99,6 +99,12 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_pulse_irqline(vm, (uint16_t)param1, param2);
 		break;
 
+	case HC_SET_IRQLINE:
+		/* param1: vmid */
+		ret = hcall_set_irqline(vm, (uint16_t)param1,
+				(struct acrn_irqline_ops *)&param2);
+		break;
+
 	case HC_INJECT_MSI:
 		/* param1: vmid */
 		ret = hcall_inject_msi(vm, (uint16_t)param1, param2);

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -184,6 +184,23 @@ int32_t hcall_deassert_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
  */
 int32_t hcall_pulse_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
 
+
+/**
+ * @brief set or clear IRQ line
+ *
+ * Set or clear a virtual IRQ line for a VM, which could be from ISA
+ * or IOAPIC, normally it triggers an edge IRQ.
+ * The function will return -1 if the target VM does not exist.
+ *
+ * @param vm Pointer to VM data structure
+ * @param vmid ID of the VM
+ * @irq_req: request command for IRQ set or clear
+ *
+ * @pre Pointer vm shall point to VM0
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_set_irqline(struct vm *vm, uint16_t vmid,
+				struct acrn_irqline_ops *ops);
 /**
  * @brief inject MSI interrupt
  *

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -11,11 +11,6 @@
 #define IRQF_LEVEL	(1U << 1U)	/* 1: level trigger; 0: edge trigger */
 #define IRQF_PT		(1U << 2U)	/* 1: for passthrough dev */
 
-enum irq_mode {
-	IRQ_PULSE,
-	IRQ_ASSERT,
-	IRQ_DEASSERT,
-};
 
 typedef void (*irq_action_t)(uint32_t irq, void *priv_data);
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -264,6 +264,22 @@ struct acrn_set_ioreq_buffer {
 /** Interrupt type for acrn_irqline: inject interrupt to both PIC and IOAPIC */
 #define	ACRN_INTR_TYPE_IOAPIC	1U
 
+/** Operation types for setting IRQ line */
+#define GSI_SET_HIGH		0U
+#define GSI_SET_LOW		1U
+#define GSI_RAISING_PULSE	2U
+#define GSI_FALLING_PULSE	3U
+
+/**
+ * @brief Info to Set/Clear/Pulse a virtual IRQ line for a VM
+ *
+ * the parameter for HC_SET_IRQLINE hypercall
+ */
+struct acrn_irqline_ops {
+	uint32_t nr_gsi;
+	uint32_t op;
+} __aligned(8);
+
 /**
  * @brief Info to assert/deassert/pulse a virtual IRQ line for a VM
  *

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -45,6 +45,7 @@
 #define HC_PULSE_IRQLINE            BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x02UL)
 #define HC_INJECT_MSI               BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x03UL)
 #define HC_VM_INTR_MONITOR          BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x04UL)
+#define HC_SET_IRQLINE              BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x05UL)
 
 /* DM ioreq management */
 #define HC_ID_IOREQ_BASE            0x30UL


### PR DESCRIPTION
    - wraps ASSERT/DEASSERT IRQ line hypercalls.
    - remove 'intr_type' from set/clear IRQ line interface.
    - deprecate "IRQ_ASSERT", "IRQ_DEASSERT" & "IRQ_PULSE".
    - new adding hypercall will support "GSI_SET_HIGH"/
      "GSI_SET_LOW"/ "GSI_RAISING_PULSE"/ "GSI_FALLING_PULSE"
      operations

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>