### PR TITLE
Vhost support

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -62,6 +62,7 @@ SRCS += hw/usb_core.c
 SRCS += hw/uart_core.c
 SRCS += hw/pci/virtio/virtio.c
 SRCS += hw/pci/virtio/virtio_kernel.c
+SRCS += hw/pci/virtio/vhost.c
 SRCS += hw/platform/usb_mouse.c
 SRCS += hw/platform/usb_pmapper.c
 SRCS += hw/platform/atkbdc.c

--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -153,12 +153,132 @@ vhost_eventfd_test_and_clear(int fd)
 	return -1;
 }
 
+static void
+vhost_vq_notify(int fd __attribute__((unused)),
+		enum ev_type t __attribute__((unused)),
+		void *arg)
+{
+	struct vhost_vq *vq = arg;
+	struct virtio_vq_info *vqi;
+	struct vhost_dev *vdev;
+
+	vdev = vq->dev;
+	vqi = &vdev->base->queues[vdev->vq_idx + vq->idx];
+	vq_interrupt(vdev->base, vqi);
+}
+
 static int
 vhost_vq_register_eventfd(struct vhost_dev *vdev,
 			  int idx, bool is_register)
 {
-	/* to be implemented */
-	return -1;
+	struct acrn_ioeventfd ioeventfd = {0};
+	struct acrn_irqfd irqfd = {0};
+	struct virtio_base *base;
+	struct vhost_vq *vq;
+	struct virtio_vq_info *vqi;
+	struct pcibar *bar;
+	int rc = -1;
+
+	/* this interface is called only by vhost_vq_start,
+	 * parameters have been checked there
+	 */
+	base = vdev->base;
+	vqi = &vdev->base->queues[vdev->vq_idx + idx];
+	vq = &vdev->vqs[idx];
+
+	if (!is_register) {
+		ioeventfd.flags = ACRN_IOEVENTFD_FLAG_DEASSIGN;
+		irqfd.flags = ACRN_IRQFD_FLAG_DEASSIGN;
+	}
+
+	/* register ioeventfd for kick */
+	if (base->device_caps & ACRN_VIRTIO_F_VERSION_1) {
+		/*
+		 * in the current implementation, if virtio 1.0 with pio
+		 * notity, its bar idx should be set to non-zero
+		 */
+		if (base->modern_pio_bar_idx) {
+			bar = &vdev->base->dev->bar[base->modern_pio_bar_idx];
+			ioeventfd.data = vdev->vq_idx + idx;
+			ioeventfd.addr = bar->addr;
+			ioeventfd.len = 2;
+			ioeventfd.flags |= (ACRN_IOEVENTFD_FLAG_DATAMATCH |
+				ACRN_IOEVENTFD_FLAG_PIO);
+		} else if (base->modern_mmio_bar_idx) {
+			bar = &vdev->base->dev->bar[base->modern_mmio_bar_idx];
+			ioeventfd.data = 0;
+			ioeventfd.addr = bar->addr + VIRTIO_CAP_NOTIFY_OFFSET
+				+ (vdev->vq_idx + idx) *
+				VIRTIO_MODERN_NOTIFY_OFF_MULT;
+			ioeventfd.len = 2;
+			/* no additional flag bit should be set for MMIO */
+		} else {
+			WPRINTF("invalid virtio 1.0 parameters, 0x%lx\n",
+				base->device_caps);
+			return -1;
+		}
+	} else {
+		bar = &vdev->base->dev->bar[base->legacy_pio_bar_idx];
+		ioeventfd.data = vdev->vq_idx + idx;
+		ioeventfd.addr = bar->addr + VIRTIO_CR_QNOTIFY;
+		ioeventfd.len = 2;
+		ioeventfd.flags |= (ACRN_IOEVENTFD_FLAG_DATAMATCH |
+			ACRN_IOEVENTFD_FLAG_PIO);
+	}
+
+	ioeventfd.fd = vq->kick_fd;
+	DPRINTF("[ioeventfd: %d][0x%lx@%d][flags: 0x%x][data: 0x%lx]\n",
+		ioeventfd.fd, ioeventfd.addr, ioeventfd.len,
+		ioeventfd.flags, ioeventfd.data);
+	rc = vm_ioeventfd(vdev->base->dev->vmctx, &ioeventfd);
+	if (rc < 0) {
+		WPRINTF("vm_ioeventfd failed rc = %d, errno = %d\n",
+			rc, errno);
+		return -1;
+	}
+
+	if (pci_msix_enabled(base->dev)) {
+		/* register irqfd for notify */
+		struct msix_table_entry *mte;
+		struct acrn_msi_entry msi;
+
+		mte = &vdev->base->dev->msix.table[vqi->msix_idx];
+		msi.msi_addr = mte->addr;
+		msi.msi_data = mte->msg_data;
+		irqfd.fd = vq->call_fd;
+		/* no additional flag bit should be set */
+		irqfd.msi = msi;
+		DPRINTF("[irqfd: %d][MSIX: %d]\n", irqfd.fd, vqi->msix_idx);
+		rc = vm_irqfd(vdev->base->dev->vmctx, &irqfd);
+	} else {
+		/*
+		 * irqfd only supports MSIx now. For non-MSIx, call_fd is polled
+		 * by dm then inject interrupts to guest
+		 */
+		if (is_register) {
+			vq->mevp = mevent_add(vq->call_fd, EVF_READ,
+				vhost_vq_notify, vq);
+			if (!vq->mevp) {
+				WPRINTF("mevent_add failed\n");
+				rc = -1;
+			}
+		} else if (vq->mevp) {
+			mevent_delete(vq->mevp);
+			vq->mevp = NULL;
+		}
+	}
+
+	if (rc < 0) {
+		WPRINTF("vm_irqfd failed rc = %d, errno = %d\n", rc, errno);
+		/* unregister ioeventfd */
+		if (is_register) {
+			ioeventfd.flags |= ACRN_IOEVENTFD_FLAG_DEASSIGN;
+			vm_ioeventfd(vdev->base->dev->vmctx, &ioeventfd);
+		}
+		return -1;
+	}
+
+	return 0;
 }
 
 static int

--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/uio.h>
+#include <sys/ioctl.h>
+#include <sys/eventfd.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <linux/vhost.h>
+
+#include "dm.h"
+#include "pci_core.h"
+#include "irq.h"
+#include "vmmapi.h"
+#include "vhost.h"
+
+static int vhost_debug;
+#define LOG_TAG "vhost: "
+#define DPRINTF(fmt, args...) \
+	do { if (vhost_debug) printf(LOG_TAG fmt, ##args); } while (0)
+#define WPRINTF(fmt, args...) printf(LOG_TAG fmt, ##args)
+
+static void
+vhost_kernel_init(struct vhost_dev *vdev, struct virtio_base *base,
+		  int fd, int vq_idx, uint32_t busyloop_timeout)
+{
+	/* to be implemented */
+}
+
+static void
+vhost_kernel_deinit(struct vhost_dev *vdev)
+{
+	/* to be implemented */
+}
+
+static int
+vhost_kernel_set_vring_busyloop_timeout(struct vhost_dev *vdev,
+					struct vhost_vring_state *s)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_kernel_set_features(struct vhost_dev *vdev,
+			  uint64_t features)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_kernel_get_features(struct vhost_dev *vdev,
+			  uint64_t *features)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_kernel_set_owner(struct vhost_dev *vdev)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_kernel_reset_device(struct vhost_dev *vdev)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_kernel_net_set_backend(struct vhost_dev *vdev,
+			     struct vhost_vring_file *file)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_vq_init(struct vhost_dev *vdev, int idx)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_vq_deinit(struct vhost_vq *vq)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_vq_start(struct vhost_dev *vdev, int idx)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_vq_stop(struct vhost_dev *vdev, int idx)
+{
+	/* to be implemented */
+	return -1;
+}
+
+static int
+vhost_set_mem_table(struct vhost_dev *vdev)
+{
+	/* to be implemented */
+	return -1;
+}
+
+int
+vhost_dev_init(struct vhost_dev *vdev,
+	       struct virtio_base *base,
+	       int fd,
+	       int vq_idx,
+	       uint64_t vhost_features,
+	       uint64_t vhost_ext_features,
+	       uint32_t busyloop_timeout)
+{
+	uint64_t features;
+	int i, rc;
+
+	/* sanity check */
+	if (!base || !base->queues || !base->vops) {
+		WPRINTF("virtio_base is not initialized\n");
+		goto fail;
+	}
+
+	if (!vdev->vqs || vdev->nvqs == 0) {
+		WPRINTF("virtqueue is not initialized\n");
+		goto fail;
+	}
+
+	if (vq_idx + vdev->nvqs > base->vops->nvq) {
+		WPRINTF("invalid vq_idx: %d\n", vq_idx);
+		goto fail;
+	}
+
+	vhost_kernel_init(vdev, base, fd, vq_idx, busyloop_timeout);
+
+	rc = vhost_kernel_get_features(vdev, &features);
+	if (rc < 0) {
+		WPRINTF("vhost_get_features failed\n");
+		goto fail;
+	}
+
+	for (i = 0; i < vdev->nvqs; i++) {
+		rc = vhost_vq_init(vdev, i);
+		if (rc < 0)
+			goto fail;
+	}
+
+	/* specific backend features to vhost */
+	vdev->vhost_ext_features = vhost_ext_features & features;
+
+	/* features supported by vhost */
+	vdev->vhost_features = vhost_features & features;
+
+	/*
+	 * If the features bits are not supported by either vhost kernel
+	 * mediator or configuration of device model(specified by
+	 * vhost_features), they should be disabled in device_caps,
+	 * which expose as virtio host_features for virtio FE driver.
+	 */
+	vdev->base->device_caps &= ~(vhost_features ^ features);
+	vdev->started = false;
+
+	return 0;
+
+fail:
+	vhost_dev_deinit(vdev);
+	return -1;
+}
+
+int
+vhost_dev_deinit(struct vhost_dev *vdev)
+{
+	int i;
+
+	if (!vdev->base || !vdev->base->queues || !vdev->base->vops)
+		return -1;
+
+	for (i = 0; i < vdev->nvqs; i++)
+		vhost_vq_deinit(&vdev->vqs[i]);
+
+	vhost_kernel_deinit(vdev);
+
+	return 0;
+}
+
+int
+vhost_dev_start(struct vhost_dev *vdev)
+{
+	struct vhost_vring_state state;
+	uint64_t features;
+	int i, rc;
+
+	if (vdev->started)
+		return 0;
+
+	/* sanity check */
+	if (!vdev->base || !vdev->base->queues || !vdev->base->vops) {
+		WPRINTF("virtio_base is not initialized\n");
+		goto fail;
+	}
+
+	if ((vdev->base->status & VIRTIO_CR_STATUS_DRIVER_OK) == 0) {
+		WPRINTF("status error 0x%x\n", vdev->base->status);
+		goto fail;
+	}
+
+	rc = vhost_kernel_set_owner(vdev);
+	if (rc < 0) {
+		WPRINTF("vhost_set_owner failed\n");
+		goto fail;
+	}
+
+	/* set vhost internal features */
+	features = (vdev->base->negotiated_caps & vdev->vhost_features) |
+		vdev->vhost_ext_features;
+	rc = vhost_kernel_set_features(vdev, features);
+	if (rc < 0) {
+		WPRINTF("set_features failed\n");
+		goto fail;
+	}
+	DPRINTF("set_features: 0x%lx\n", features);
+
+	/* set memory table */
+	rc = vhost_set_mem_table(vdev);
+	if (rc < 0) {
+		WPRINTF("set_mem_table failed\n");
+		goto fail;
+	}
+
+	/* config busyloop timeout */
+	if (vdev->busyloop_timeout) {
+		state.num = vdev->busyloop_timeout;
+		for (i = 0; i < vdev->nvqs; i++) {
+			state.index = i;
+			rc = vhost_kernel_set_vring_busyloop_timeout(vdev,
+				&state);
+			if (rc < 0) {
+				WPRINTF("set_busyloop_timeout failed\n");
+				goto fail;
+			}
+		}
+	}
+
+	/* start vhost virtqueue */
+	for (i = 0; i < vdev->nvqs; i++) {
+		rc = vhost_vq_start(vdev, i);
+		if (rc < 0)
+			goto fail_vq;
+	}
+
+	vdev->started = true;
+	return 0;
+
+fail_vq:
+	while (--i >= 0)
+		vhost_vq_stop(vdev, i);
+fail:
+	return -1;
+}
+
+int
+vhost_dev_stop(struct vhost_dev *vdev)
+{
+	int i, rc = 0;
+
+	for (i = 0; i < vdev->nvqs; i++)
+		vhost_vq_stop(vdev, i);
+
+	/* the following are done by this ioctl:
+	 * 1) resources of the vhost dev are freed
+	 * 2) vhost virtqueues are reset
+	 */
+	rc = vhost_kernel_reset_device(vdev);
+	if (rc < 0) {
+		WPRINTF("vhost_reset_device failed\n");
+		rc = -1;
+	}
+
+	vdev->started = false;
+	return rc;
+}
+
+int
+vhost_net_set_backend(struct vhost_dev *vdev, int backend_fd)
+{
+	struct vhost_vring_file file;
+	int rc, i;
+
+	file.fd = backend_fd;
+	for (i = 0; i < vdev->nvqs; i++) {
+		file.index = i;
+		rc = vhost_kernel_net_set_backend(vdev, &file);
+		if (rc < 0)
+			goto fail;
+	}
+
+	return 0;
+fail:
+	file.fd = -1;
+	while (--i >= 0) {
+		file.index = i;
+		vhost_kernel_net_set_backend(vdev, &file);
+	}
+
+	return -1;
+}

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -64,7 +64,7 @@
 	(VIRTIO_BLK_F_SEG_MAX |						    \
 	VIRTIO_BLK_F_BLK_SIZE |						    \
 	VIRTIO_BLK_F_TOPOLOGY |						    \
-	VIRTIO_RING_F_INDIRECT_DESC)	/* indirect descriptors */
+	ACRN_VIRTIO_RING_F_INDIRECT_DESC)	/* indirect descriptors */
 
 /*
  * Writeback cache bits
@@ -214,7 +214,7 @@ virtio_blk_proc(struct virtio_blk *blk, struct virtio_vq_info *vq)
 	assert(n >= 2 && n <= BLOCKIF_IOV_MAX + 2);
 
 	io = &blk->ios[idx];
-	assert((flags[0] & VRING_DESC_F_WRITE) == 0);
+	assert((flags[0] & ACRN_VRING_DESC_F_WRITE) == 0);
 	assert(iov[0].iov_len == sizeof(struct virtio_blk_hdr));
 	vbh = iov[0].iov_base;
 	memcpy(&io->req.iov, &iov[1], sizeof(struct iovec) * (n - 2));
@@ -222,7 +222,7 @@ virtio_blk_proc(struct virtio_blk *blk, struct virtio_vq_info *vq)
 	io->req.offset = vbh->sector * DEV_BSIZE;
 	io->status = iov[--n].iov_base;
 	assert(iov[n].iov_len == 1);
-	assert(flags[n] & VRING_DESC_F_WRITE);
+	assert(flags[n] & ACRN_VRING_DESC_F_WRITE);
 
 	/*
 	 * XXX
@@ -240,7 +240,7 @@ virtio_blk_proc(struct virtio_blk *blk, struct virtio_vq_info *vq)
 		 * therefore test the inverse of the descriptor bit
 		 * to the op.
 		 */
-		assert(((flags[i] & VRING_DESC_F_WRITE) == 0) == writeop);
+		assert(((flags[i] & ACRN_VRING_DESC_F_WRITE) == 0) == writeop);
 		iolen += iov[i].iov_len;
 	}
 	io->req.resid = iolen;

--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -409,7 +409,7 @@ virtio_console_notify_rx(void *vdev, struct virtio_vq_info *vq)
 
 	if (!port->rx_ready) {
 		port->rx_ready = 1;
-		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 	}
 }
 

--- a/devicemodel/hw/pci/virtio/virtio_heci.c
+++ b/devicemodel/hw/pci/virtio/virtio_heci.c
@@ -972,7 +972,7 @@ static void *virtio_heci_tx_thread(void *param)
 	while (vheci->status != VHECI_DEINIT) {
 		/* note - tx mutex is locked here */
 		while (!vq_has_descs(vq)) {
-			vq->used->flags &= ~VRING_USED_F_NO_NOTIFY;
+			vq->used->flags &= ~ACRN_VRING_USED_F_NO_NOTIFY;
 			mb();
 			if (vq_has_descs(vq) &&
 				vheci->status != VHECI_RESET)
@@ -984,7 +984,7 @@ static void *virtio_heci_tx_thread(void *param)
 			if (vheci->status == VHECI_DEINIT)
 				goto out;
 		}
-		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 		pthread_mutex_unlock(&vheci->tx_mutex);
 
 		do {
@@ -1125,7 +1125,7 @@ static void *virtio_heci_rx_thread(void *param)
 	while (vheci->status != VHECI_DEINIT) {
 		/* note - rx mutex is locked here */
 		while (vq_ring_ready(vq)) {
-			vq->used->flags &= ~VRING_USED_F_NO_NOTIFY;
+			vq->used->flags &= ~ACRN_VRING_USED_F_NO_NOTIFY;
 			mb();
 			if (vq_has_descs(vq) &&
 				vheci->rx_need_sched &&
@@ -1138,7 +1138,7 @@ static void *virtio_heci_rx_thread(void *param)
 			if (vheci->status == VHECI_DEINIT)
 				goto out;
 		}
-		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 
 		do {
 			if (virtio_heci_proc_rx(vheci, vq))
@@ -1166,7 +1166,7 @@ virtio_heci_notify_rx(void *heci, struct virtio_vq_info *vq)
 	/* Signal the rx thread for processing */
 	pthread_mutex_lock(&vheci->rx_mutex);
 	DPRINTF(("vheci: RX: New IN buffer available!\n\r"));
-	vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+	vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 	pthread_cond_signal(&vheci->rx_cond);
 	pthread_mutex_unlock(&vheci->rx_mutex);
 }
@@ -1184,7 +1184,7 @@ virtio_heci_notify_tx(void *heci, struct virtio_vq_info *vq)
 	/* Signal the tx thread for processing */
 	pthread_mutex_lock(&vheci->tx_mutex);
 	DPRINTF(("vheci: TX: New OUT buffer available!\n\r"));
-	vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+	vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 	pthread_cond_signal(&vheci->tx_cond);
 	pthread_mutex_unlock(&vheci->tx_mutex);
 }

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -47,7 +47,7 @@ static int virtio_input_debug;
 /*
  * Host capabilities
  */
-#define VIRTIO_INPUT_S_HOSTCAPS		(VIRTIO_F_VERSION_1)
+#define VIRTIO_INPUT_S_HOSTCAPS		(ACRN_VIRTIO_F_VERSION_1)
 
 enum virtio_input_config_select {
 	VIRTIO_INPUT_CFG_UNSET		= 0x00,

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -74,7 +74,7 @@
 
 #define VIRTIO_NET_S_HOSTCAPS      \
 	(VIRTIO_NET_F_MAC | VIRTIO_NET_F_MRG_RXBUF | VIRTIO_NET_F_STATUS | \
-	VIRTIO_F_NOTIFY_ON_EMPTY | VIRTIO_RING_F_INDIRECT_DESC)
+	ACRN_VIRTIO_F_NOTIFY_ON_EMPTY | ACRN_VIRTIO_RING_F_INDIRECT_DESC)
 
 /* is address mcast/bcast? */
 #define ETHER_IS_MULTICAST(addr) (*(addr) & 0x01)
@@ -432,7 +432,7 @@ virtio_net_ping_rxq(void *vdev, struct virtio_vq_info *vq)
 	 */
 	if (net->rx_ready == 0) {
 		net->rx_ready = 1;
-		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 	}
 }
 
@@ -478,7 +478,7 @@ virtio_net_ping_txq(void *vdev, struct virtio_vq_info *vq)
 
 	/* Signal the tx thread for processing */
 	pthread_mutex_lock(&net->tx_mtx);
-	vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+	vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 	if (net->tx_in_progress == 0)
 		pthread_cond_signal(&net->tx_cond);
 	pthread_mutex_unlock(&net->tx_mtx);
@@ -512,7 +512,7 @@ virtio_net_tx_thread(void *param)
 	for (;;) {
 		/* note - tx mutex is locked here */
 		while (net->resetting || !vq_has_descs(vq)) {
-			vq->used->flags &= ~VRING_USED_F_NO_NOTIFY;
+			vq->used->flags &= ~ACRN_VRING_USED_F_NO_NOTIFY;
 			/* memory barrier */
 			mb();
 			if (!net->resetting && vq_has_descs(vq))
@@ -527,7 +527,7 @@ virtio_net_tx_thread(void *param)
 				return NULL;
 			}
 		}
-		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
 		net->tx_in_progress = 1;
 		pthread_mutex_unlock(&net->tx_mtx);
 

--- a/devicemodel/include/vhost.h
+++ b/devicemodel/include/vhost.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef __VHOST_H__
+#define __VHOST_H__
+
+#include "virtio.h"
+#include "mevent.h"
+
+struct vhost_vq {
+	int kick_fd;		/**< fd of kick eventfd */
+	int call_fd;		/**< fd of call eventfd */
+	int idx;		/**< index of this vq in vhost dev */
+	struct mevent *mevp;	/**< mevent for call eventfd */
+	struct vhost_dev *dev;	/**< pointer to vhost_dev */
+};
+
+struct vhost_dev {
+	/**
+	 * backpointer to virtio_base
+	 */
+	struct virtio_base *base;
+
+	/**
+	 * pointer to vhost_vq array
+	 */
+	struct vhost_vq *vqs;
+
+	/**
+	 * number of virtqueues
+	 */
+	int nvqs;
+
+	/**
+	 * vhost chardev fd
+	 */
+	int fd;
+
+	/**
+	 * first vq's index in virtio_vq_info
+	 */
+	int vq_idx;
+
+	/**
+	 * supported virtio defined features
+	 */
+	uint64_t vhost_features;
+
+	/**
+	 * vhost self-defined internal features bits used for
+	 * communicate between vhost user-space and kernel-space modules
+	 */
+	uint64_t vhost_ext_features;
+
+	/**
+	 * vq busyloop timeout in us
+	 */
+	uint32_t busyloop_timeout;
+
+	/**
+	 * whether vhost is started
+	 */
+	bool started;
+};
+
+/**
+ * @brief vhost_dev initialization.
+ *
+ * This interface is called to initialize the vhost_dev. It must be called
+ * before the actual feature negoitiation with the guest OS starts.
+ *
+ * @param vdev Pointer to struct vhost_dev.
+ * @param base Pointer to struct virtio_base.
+ * @param fd fd of the vhost chardev.
+ * @param vq_idx The first virtqueue which would be used by this vhost dev.
+ * @param vhost_features Subset of vhost features which would be enabled.
+ * @param vhost_ext_features Specific vhost internal features to be enabled.
+ * @param busyloop_timeout Busy loop timeout in us.
+ *
+ * @return 0 on success and -1 on failure.
+ */
+int vhost_dev_init(struct vhost_dev *vdev, struct virtio_base *base, int fd,
+		   int vq_idx, uint64_t vhost_features,
+		   uint64_t vhost_ext_features, uint32_t busyloop_timeout);
+
+/**
+ * @brief vhost_dev cleanup.
+ *
+ * This interface is called to cleanup the vhost_dev.
+ *
+ * @param vdev Pointer to struct vhost_dev.
+ *
+ * @return 0 on success and -1 on failure.
+ */
+int vhost_dev_deinit(struct vhost_dev *vdev);
+
+/**
+ * @brief start vhost data plane.
+ *
+ * This interface is called to start the data plane in vhost.
+ *
+ * @param vdev Pointer to struct vhost_dev.
+ *
+ * @return 0 on success and -1 on failure.
+ */
+int vhost_dev_start(struct vhost_dev *vdev);
+
+/**
+ * @brief stop vhost data plane.
+ *
+ * This interface is called to stop the data plane in vhost.
+ *
+ * @param vdev Pointer to struct vhost_dev.
+ *
+ * @return 0 on success and -1 on failure.
+ */
+int vhost_dev_stop(struct vhost_dev *vdev);
+
+/**
+ * @brief set backend fd of vhost net.
+ *
+ * This interface is called to set the backend fd (for example tap fd)
+ * to vhost.
+ *
+ * @param vdev Pointer to struct vhost_dev.
+ * @param backend_fd fd of backend (for example tap fd).
+ *
+ * @return 0 on success and -1 on failure.
+ */
+int vhost_net_set_backend(struct vhost_dev *vdev, int backend_fd);
+
+#endif

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -116,9 +116,9 @@
  * The two event fields, <used_event> and <avail_event>, in the
  * avail and used rings (respectively -- note the reversal!), are
  * always provided, but are used only if the virtual device
- * negotiates the VIRTIO_RING_F_EVENT_IDX feature during feature
+ * negotiates the ACRN_VIRTIO_RING_F_EVENT_IDX feature during feature
  * negotiation.  Similarly, both rings provide a flag --
- * VRING_AVAIL_F_NO_INTERRUPT and VRING_USED_F_NO_NOTIFY -- in
+ * ACRN_VRING_AVAIL_F_NO_INTERRUPT and ACRN_VRING_USED_F_NO_NOTIFY -- in
  * their <flags> field, indicating that the guest does not need an
  * interrupt, or that the hypervisor driver does not need a
  * notify, when descriptors are added to the corresponding ring.
@@ -137,9 +137,9 @@
 
 #define VRING_ALIGN	4096
 
-#define VRING_DESC_F_NEXT	(1 << 0)
-#define VRING_DESC_F_WRITE	(1 << 1)
-#define VRING_DESC_F_INDIRECT	(1 << 2)
+#define ACRN_VRING_DESC_F_NEXT		(1 << 0)
+#define ACRN_VRING_DESC_F_WRITE		(1 << 1)
+#define ACRN_VRING_DESC_F_INDIRECT	(1 << 2)
 
 struct virtio_desc {		/* AKA vring_desc */
 	uint64_t	addr;	/* guest physical address */
@@ -153,17 +153,17 @@ struct virtio_used {		/* AKA vring_used_elem */
 	uint32_t	tlen;	/* length written-to */
 } __attribute__((packed));
 
-#define VRING_AVAIL_F_NO_INTERRUPT	1
+#define ACRN_VRING_AVAIL_F_NO_INTERRUPT	1
 
-struct vring_avail {
+struct virtio_vring_avail {
 	uint16_t	flags;	/* VRING_AVAIL_F_* */
 	uint16_t	idx;	/* counts to 65535, then cycles */
 	uint16_t	ring[];	/* size N, reported in QNUM value */
 /*	uint16_t	used_event;	-- after N ring entries */
 } __attribute__((packed));
 
-#define	VRING_USED_F_NO_NOTIFY		1
-struct vring_used {
+#define	ACRN_VRING_USED_F_NO_NOTIFY	1
+struct virtio_vring_used {
 	uint16_t	flags;	/* VRING_USED_F_* */
 	uint16_t	idx;	/* counts to 65535, then cycles */
 	struct virtio_used ring[];
@@ -310,12 +310,12 @@ struct vring_used {
  * Feature flags.
  * Note: bits 0 through 23 are reserved to each device type.
  */
-#define	VIRTIO_F_NOTIFY_ON_EMPTY	(1 << 24)
-#define	VIRTIO_RING_F_INDIRECT_DESC	(1 << 28)
-#define	VIRTIO_RING_F_EVENT_IDX		(1 << 29)
+#define	ACRN_VIRTIO_F_NOTIFY_ON_EMPTY		(1 << 24)
+#define	ACRN_VIRTIO_RING_F_INDIRECT_DESC	(1 << 28)
+#define	ACRN_VIRTIO_RING_F_EVENT_IDX		(1 << 29)
 
 /* v1.0 compliant. */
-#define VIRTIO_F_VERSION_1		(1UL << 32)
+#define ACRN_VIRTIO_F_VERSION_1		(1UL << 32)
 
 /* From section 2.3, "Virtqueue Configuration", of the virtio specification */
 /**
@@ -327,7 +327,7 @@ struct vring_used {
  * @return size of a certain virtqueue, in bytes.
  */
 static inline size_t
-vring_size(u_int qsz)
+virtio_vring_size(u_int qsz)
 {
 	size_t size;
 
@@ -594,9 +594,9 @@ struct virtio_vq_info {
 
 	volatile struct virtio_desc *desc;
 				/**< descriptor array */
-	volatile struct vring_avail *avail;
+	volatile struct virtio_vring_avail *avail;
 				/**< the "avail" ring */
-	volatile struct vring_used *used;
+	volatile struct virtio_vring_used *used;
 				/**< the "used" ring */
 
 	uint32_t gpa_desc[2];	/**< gpa of descriptors */


### PR DESCRIPTION
This patchset implements the vhost proxy in device model. vhost proxy
acts as a framework in device model. It provides a set of unified
interfaces which can be used by virtio backend drivers in device model
to add their vhost support:
    vhost_dev_init
    vhost_dev_deinit
    vhost_dev_start
    vhost_dev_stop

vhost proxy is implemented based on the virtio framework and vhost char
dev. virtio device related information such as negotiated features and
guest memory map are conveyed to vhost in kernel. virtqueue related
information such as queue size, vring addresses and eventfd pair are
conveyed to vhost kernel as well. They are all done by ioctls of vhost
chardev.

vhost kernel interfaces to vhm thru eventfd. There are 2 eventfds for one
virtqueue, one is for kick and the other is for notify. eventfd used for
kick is associated with a PIO/MMIO region. eventfd used for notify is
associated with a MSIx/INTx. The eventfd pair is registered to VHM thru
VHM char dev.

vhost net is enabled in this patch as well which acts the first vhost
proxy client. It sets up an example about how to use the interfaces
provided by vhost proxy.

This patchset only covers the implementation of vhost proxy. ioeventfd is
implemented in VHM and will be another patchset.
