### PR TITLE
HV: remove IRQSTATE_ASSERT/IRQSTATE_DEASSERT/IRQSTATE_PULSE

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -359,9 +359,11 @@ static void ptdev_intr_handle_irq(struct vm *vm,
 		}
 
 		if (trigger_lvl) {
-			vioapic_assert_irq(vm, virt_sid->intx_id.pin);
+			vioapic_set_irq(vm, virt_sid->intx_id.pin,
+					GSI_SET_HIGH);
 		} else {
-			vioapic_pulse_irq(vm, virt_sid->intx_id.pin);
+			vioapic_set_irq(vm, virt_sid->intx_id.pin,
+					GSI_RAISING_PULSE);
 		}
 
 		dev_dbg(ACRN_DBG_PTIRQ,
@@ -378,9 +380,10 @@ static void ptdev_intr_handle_irq(struct vm *vm,
 		/* VPIN_PIC src means we have vpic enabled */
 		vpic_get_irq_trigger(vm, virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
-			vpic_assert_irq(vm, virt_sid->intx_id.pin);
+			vpic_set_irq(vm, virt_sid->intx_id.pin, GSI_SET_HIGH);
 		} else {
-			vpic_pulse_irq(vm, virt_sid->intx_id.pin);
+			vpic_set_irq(vm, virt_sid->intx_id.pin,
+					GSI_RAISING_PULSE);
 		}
 		break;
 	}
@@ -457,10 +460,10 @@ void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
 	 */
 	switch (vpin_src) {
 	case PTDEV_VPIN_IOAPIC:
-		vioapic_deassert_irq(vm, virt_pin);
+		vioapic_set_irq(vm, virt_pin, GSI_SET_LOW);
 		break;
 	case PTDEV_VPIN_PIC:
-		vpic_deassert_irq(vm, virt_pin);
+		vpic_set_irq(vm, virt_pin, GSI_SET_LOW);
 	default:
 		/*
 		 * In this switch statement, vpin_src shall either be

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -123,13 +123,13 @@ static void vuart_toggle_intr(struct acrn_vuart *vu)
 	intr_reason = vuart_intr_reason(vu);
 
 	if (intr_reason != IIR_NOPEND) {
-		vpic_assert_irq(vu->vm, COM1_IRQ);
+		vpic_set_irq(vu->vm, COM1_IRQ, GSI_SET_HIGH);
 
-		vioapic_assert_irq(vu->vm, COM1_IRQ);
+		vioapic_set_irq(vu->vm, COM1_IRQ, GSI_SET_HIGH);
 
-		vpic_deassert_irq(vu->vm, COM1_IRQ);
+		vpic_set_irq(vu->vm, COM1_IRQ, GSI_SET_LOW);
 
-		vioapic_deassert_irq(vu->vm, COM1_IRQ);
+		vioapic_set_irq(vu->vm, COM1_IRQ, GSI_SET_LOW);
 	}
 }
 

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -52,9 +52,7 @@ void    vioapic_init(struct vm *vm);
 void	vioapic_cleanup(struct acrn_vioapic *vioapic);
 void	vioapic_reset(struct acrn_vioapic *vioapic);
 
-void	vioapic_assert_irq(struct vm *vm, uint32_t irq);
-void	vioapic_deassert_irq(struct vm *vm, uint32_t irq);
-void	vioapic_pulse_irq(struct vm *vm, uint32_t irq);
+void	vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
 void	vioapic_update_tmr(struct vcpu *vcpu);
 
 uint32_t	vioapic_pincount(struct vm *vm);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -121,9 +121,7 @@ struct acrn_vpic {
 
 void vpic_init(struct vm *vm);
 
-void vpic_assert_irq(struct vm *vm, uint32_t irq);
-void vpic_deassert_irq(struct vm *vm, uint32_t irq);
-void vpic_pulse_irq(struct vm *vm, uint32_t irq);
+void vpic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
 
 void vpic_pending_intr(struct vm *vm, uint32_t *vecptr);
 void vpic_intr_accepted(struct vm *vm, uint32_t vector);


### PR DESCRIPTION
   - replace vpic/vioapic_xassert_irq() APIs
      with vpic/vioapic_set_irq()

   - unify the description of IRQ/PIN state in vpic. & vioapic.c

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>