### PR TITLE
hv: fix 'Void procedure used in expression'

### DIFF
--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -438,7 +438,7 @@ void send_single_ipi(uint16_t pcpu_id, uint32_t vector)
 	/* Get the lapic ID of the destination processor. */
 	dest_lapic_id = per_cpu(lapic_id, pcpu_id);
 
-	return send_dest_ipi(dest_lapic_id, vector, INTR_LAPIC_ICR_PHYSICAL);
+	send_dest_ipi(dest_lapic_id, vector, INTR_LAPIC_ICR_PHYSICAL);
 }
 
 int send_shorthand_ipi(uint8_t vector,


### PR DESCRIPTION
MISRA-C states that a void procedure used in expressions is dangerous.

This patch removes the improper 'return' when calling the void procedure
'send_dest_ipi'.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>