### PR TITLE
hv:Clear up printf related definition

### DIFF
--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -6,15 +6,15 @@
 
 #include <hypervisor.h>
 
-static int charout(int cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
+static void charout(size_t cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
 {
 	const char *s = s_arg;
 	uint32_t sz = sz_arg;
 	/* pointer to an integer to store the number of characters */
-	int *nchars = (int *)hnd;
+	size_t *nchars = (size_t *)hnd;
 	/* working pointer */
 	const char *p = s;
-	int len;
+	size_t len;
 
 	/* copy mode ? */
 	if (cmd == PRINT_CMD_COPY) {
@@ -33,17 +33,15 @@ static int charout(int cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
 		}
 	}
 
-	return *nchars;
 }
 
-int vprintf(const char *fmt, va_list args)
+void vprintf(const char *fmt, va_list args)
 {
 	/* struct to store all necessary parameters */
 	struct print_param param;
-	/* the result of this function */
-	int res = 0;
+
 	/* argument fo charout() */
-	int nchars = 0;
+	size_t nchars = 0;
 
 	/* initialize parameters */
 	(void)memset(&param, 0U, sizeof(param));
@@ -51,27 +49,19 @@ int vprintf(const char *fmt, va_list args)
 	param.data = &nchars;
 
 	/* execute the printf() */
-	res = do_print(fmt, &param, args);
-
-	/* done */
-	return res;
+	do_print(fmt, &param, args);
 }
 
-int printf(const char *fmt, ...)
+void printf(const char *fmt, ...)
 {
 	/* variable argument list needed for do_print() */
 	va_list args;
-	/* the result of this function */
-	int res;
 
 	va_start(args, fmt);
 
 	/* execute the printf() */
-	res = vprintf(fmt, args);
+	vprintf(fmt, args);
 
 	/* destroy parameter list */
 	va_end(args);
-
-	/* done */
-	return res;
 }

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -54,7 +54,7 @@ void asm_assert(int32_t line, const char *file, const char *txt);
  *          number if an error occurred.
  */
 
-int printf(const char *fmt, ...);
+void printf(const char *fmt, ...);
 
 /** The well known vprintf() function.
  *
@@ -66,7 +66,7 @@ int printf(const char *fmt, ...);
  *          number if an error occurred.
  */
 
-int vprintf(const char *fmt, va_list args);
+void vprintf(const char *fmt, va_list args);
 
 #else /* HV_DEBUG */
 
@@ -85,14 +85,14 @@ static inline void print_logmsg_buffer(__unused uint16_t pcpu_id)
 
 #define ASSERT(x, ...)	do { } while (0)
 
-static inline int printf(__unused const char *fmt, ...)
+static inline void printf(__unused const char *fmt, ...)
 {
-	return 0;
+
 }
 
-static inline int vprintf(__unused const char *fmt, __unused va_list args)
+static inline void vprintf(__unused const char *fmt, __unused va_list args)
 {
-	return 0;
+
 }
 
 #endif /* HV_DEBUG */

--- a/hypervisor/include/lib/sprintf.h
+++ b/hypervisor/include/lib/sprintf.h
@@ -8,15 +8,15 @@
 #define SPRINTF_H
 
 /* Command for the emit function: copy string to output. */
-#define PRINT_CMD_COPY			0x00000000
+#define PRINT_CMD_COPY			0x00000000U
 
 /* Command for the emit function: fill output with first character. */
-#define PRINT_CMD_FILL			0x00000001
+#define PRINT_CMD_FILL			0x00000001U
 
 /* Structure used to parse parameters and variables to subroutines. */
 struct print_param {
 	/* A pointer to the function that is used to emit characters. */
-	int (*emit)(int, const char *, uint32_t, void *);
+	void (*emit)(size_t, const char *, uint32_t, void *);
 	/* An opaque pointer that is passed as third argument to the emit
 	 * function.
 	 */
@@ -42,7 +42,7 @@ struct print_param {
 	} vars;
 };
 
-int do_print(const char *fmt_arg, struct print_param *param,
+void do_print(const char *fmt_arg, struct print_param *param,
 		__builtin_va_list args);
 
 /**  The well known vsnprintf() function.
@@ -56,7 +56,7 @@ int do_print(const char *fmt_arg, struct print_param *param,
  * @return The number of bytes which would be written, even if the destination
  *         is smaller. On error a negative number is returned.
  */
-int vsnprintf(char *dst_arg, size_t sz_arg, const char *fmt, va_list args);
+size_t vsnprintf(char *dst_arg, size_t sz_arg, const char *fmt, va_list args);
 
 /** The well known snprintf() function.
  *
@@ -72,6 +72,6 @@ int vsnprintf(char *dst_arg, size_t sz_arg, const char *fmt, va_list args);
  *  @bug    sz == 0 doesn't work
  */
 
-int snprintf(char *dest, int sz, const char *fmt, ...);
+size_t snprintf(char *dest, size_t sz, const char *fmt, ...);
 
 #endif /* SPRINTF_H */


### PR DESCRIPTION
In hypervisor, all the parameter and return value printf related are
unsigned int, this patch is used to fix the function definitions.

v1->v2:
  *Modify the return value of various functions, such as printf(),
   vprintf(), charout(), do_printf(), charmem, print_pow2(),
   print_decimal to void due to never used, no necessary to use,
   or has already returned by param.
  *Delete the impossible judgement of param->emit due to the type
   is unsigned.

Tracked-On: #861
Signed-off-by: Junjun Shan <junjun.shan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>