### PR TITLE
hv: fix irq leak for MSI IRQ 

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -701,7 +701,6 @@ void cpu_dead(uint16_t pcpu_id)
 	}
 
 	/* clean up native stuff */
-	timer_cleanup();
 	vmx_off(pcpu_id);
 	cache_flush_invalidate_all();
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -54,20 +54,18 @@ uint32_t alloc_irq_num(uint32_t req_irq)
 }
 
 /*
+ * @pre: irq is not in irq_static_mappings
  * free irq num allocated via alloc_irq_num()
  */
 void free_irq_num(uint32_t irq)
 {
-	struct irq_desc *desc;
 	uint64_t rflags;
 
 	if (irq >= NR_IRQS) {
 		return;
 	}
 
-	desc = &irq_desc_array[irq];
-	if ((irq_is_gsi(irq) == false)
-	    && (desc->vector <= VECTOR_DYNAMIC_END)) {
+	if (irq_is_gsi(irq) == false) {
 		spinlock_irqsave_obtain(&irq_alloc_spinlock, &rflags);
 		bitmap_test_and_clear_nolock((uint16_t)(irq & 0x3FU),
 					     irq_alloc_bitmap + (irq >> 6U));

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -188,15 +188,6 @@ void timer_init(void)
 	init_tsc_deadline_timer();
 }
 
-void timer_cleanup(void)
-{
-	uint16_t pcpu_id = get_cpu_id();
-
-	if (pcpu_id == BOOT_CPU_ID) {
-		free_irq(TIMER_IRQ);
-	}
-}
-
 void check_tsc(void)
 {
 	uint64_t temp64;

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -60,7 +60,6 @@ int add_timer(struct hv_timer *timer);
 void del_timer(struct hv_timer *timer);
 
 void timer_init(void);
-void timer_cleanup(void);
 void check_tsc(void);
 void calibrate_tsc(void);
 


### PR DESCRIPTION
Current free_irq sequence will release vector first, then use the
released vector to free irq number.It will cause irq leak for MSI IRQ.
At present, there is no one to free the irqs which in irq_static_mappings,
So this patch will only make sure free non-gsi irqs.

Tracked-On: #1359
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>