### PR TITLE
hv:clear up the usage of printf data struct

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -798,11 +798,11 @@ static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
 	}
 }
 
-void get_ptdev_info(char *str_arg, int str_max)
+void get_ptdev_info(char *str_arg, size_t str_max)
 {
 	char *str = str_arg;
 	struct ptdev_remapping_info *entry;
-	int len, size = str_max;
+	size_t len, size = str_max;
 	uint32_t irq, vector;
 	char type[16];
 	uint64_t dest;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -543,7 +543,7 @@ void vcpu_dumpreg(void *data)
 	struct vcpu_dump *dump = data;
 	struct vcpu *vcpu = dump->vcpu;
 	char *str = dump->str;
-	int len, size = dump->str_max;
+	size_t len, size = dump->str_max;
 
 	len = snprintf(str, size,
 		"=  VM ID %d ==== CPU ID %hu========================\r\n"

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -446,11 +446,11 @@ static void get_rte_info(union ioapic_rte rte, bool *mask, bool *irr,
 	*dest = (uint32_t)(rte.full >> APIC_ID_SHIFT);
 }
 
-int get_ioapic_info(char *str_arg, int str_max_len)
+int get_ioapic_info(char *str_arg, size_t str_max_len)
 {
 	char *str = str_arg;
 	uint32_t irq;
-	int len, size = str_max_len;
+	size_t len, size = str_max_len;
 
 	len = snprintf(str, size,
 	"\r\nIRQ\tPIN\tRTE.HI32\tRTE.LO32\tVEC\tDST\tDM\tTM\tDELM\tIRR\tMASK");
@@ -481,7 +481,7 @@ int get_ioapic_info(char *str_arg, int str_max_len)
 		size -= len;
 		str += len;
 
-		if (size < 2) {
+		if (size < 2U) {
 			pr_err("\r\nsmall buffer for ioapic dump");
 			return -1;
 		}

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -394,12 +394,12 @@ void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx)
 #endif
 
 #ifdef HV_DEBUG
-void get_cpu_interrupt_info(char *str_arg, int str_max)
+void get_cpu_interrupt_info(char *str_arg, size_t str_max)
 {
 	char *str = str_arg;
 	uint16_t pcpu_id;
 	uint32_t irq, vector;
-	int len, size = str_max;
+	size_t len, size = str_max;
 
 	len = snprintf(str, size, "\r\nIRQ\tVECTOR");
 	size -= len;

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -68,7 +68,7 @@ static void parse_other_modules(struct vm *vm,
 			static int copy_once = 1;
 
 			start = end + 1; /*it is fw name for boot args */
-			snprintf(dyn_bootargs, 100, " %s=0x%x@0x%x ",
+			snprintf(dyn_bootargs, 100U, " %s=0x%x@0x%x ",
 				start, mod_size, mod_addr);
 			dev_dbg(ACRN_DBG_BOOT, "fw-%d: %s", i, dyn_bootargs);
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -113,11 +113,11 @@ void vcpu_thread(struct vcpu *vcpu)
 }
 
 #ifdef HV_DEBUG
-void get_vmexit_profile(char *str_arg, int str_max)
+void get_vmexit_profile(char *str_arg, size_t str_max)
 {
 	char *str = str_arg;
 	uint16_t cpu, i;
-	int len, size = str_max;
+	size_t len, size = str_max;
 
 	len = snprintf(str, size, "\r\nNow(us) = %16lld\r\n",
 			ticks_to_us(rdtsc()));

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -185,7 +185,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 #ifdef CONFIG_CMA
 		/* add "cma=XXXXM@0xXXXXXXXX" to cmdline*/
 		if (is_vm0(vm) && (e820_mem.max_ram_blk_size > 0)) {
-			snprintf(dyn_bootargs, 100, " cma=%dM@0x%llx",
+			snprintf(dyn_bootargs, 100U, " cma=%dM@0x%llx",
 					(e820_mem.max_ram_blk_size >> 20),
 					e820_mem.max_ram_blk_base);
 			(void)strcpy_s((char *)hva
@@ -208,7 +208,7 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 						3;
 #endif
 			if (reserving_1g_pages > 0) {
-				snprintf(dyn_bootargs, 100,
+				snprintf(dyn_bootargs, 100U,
 					" hugepagesz=1G hugepages=%d",
 					reserving_1g_pages);
 				(void)strcpy_s((char *)hva

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -22,7 +22,7 @@ void console_putc(const char *ch)
 }
 
 
-int console_write(const char *s, size_t len)
+size_t console_write(const char *s, size_t len)
 {
 	return  uart16550_puts(s, len);
 }

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -165,11 +165,11 @@ static void uart16550_putc(char c)
 	uart16550_write_reg(uart_base_address, (uint32_t)temp, UART16550_THR);
 }
 
-int uart16550_puts(const char *buf, uint32_t len)
+size_t uart16550_puts(const char *buf, uint32_t len)
 {
 	uint32_t i;
 	if (!uart_enabled) {
-		return (int)len;
+		return len;
 	}
 	spinlock_obtain(&uart_tx_lock);
 	for (i = 0U; i < len; i++) {
@@ -182,7 +182,7 @@ int uart16550_puts(const char *buf, uint32_t len)
 		buf++;
 	}
 	spinlock_release(&uart_tx_lock);
-	return (int)len;
+	return len;
 }
 
 void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr)

--- a/hypervisor/debug/uart16550.h
+++ b/hypervisor/debug/uart16550.h
@@ -108,6 +108,6 @@
 
 void uart16550_init(void);
 char uart16550_getc(void);
-int uart16550_puts(const char *buf, uint32_t len);
+size_t uart16550_puts(const char *buf, uint32_t len);
 
 #endif /* !UART16550_H */

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -554,10 +554,10 @@ void vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte)
 }
 
 #ifdef HV_DEBUG
-void get_vioapic_info(char *str_arg, int str_max, uint16_t vmid)
+void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 {
 	char *str = str_arg;
-	int len, size = str_max;
+	size_t len, size = str_max;
 	union ioapic_rte rte;
 	uint32_t delmode, vector, dest;
 	bool level, phys, remote_irr, mask;

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -62,7 +62,7 @@ int	vioapic_mmio_access_handler(struct vcpu *vcpu,
 	struct io_request *io_req);
 
 #ifdef HV_DEBUG
-void get_vioapic_info(char *str_arg, int str_max, uint16_t vmid);
+void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid);
 #endif /* HV_DEBUG */
 
 #endif

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -33,7 +33,7 @@ void gsi_unmask_irq(uint32_t irq);
 extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
 
 #ifdef HV_DEBUG
-int get_ioapic_info(char *str_arg, int str_max_len);
+int get_ioapic_info(char *str_arg, size_t str_max_len);
 #endif /* HV_DEBUG */
 
 #endif /* IOAPIC_H */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -119,7 +119,7 @@ void interrupt_init(uint16_t pcpu_id);
 void cancel_event_injection(struct vcpu *vcpu);
 
 #ifdef HV_DEBUG
-void get_cpu_interrupt_info(char *str_arg, int str_max);
+void get_cpu_interrupt_info(char *str_arg, size_t str_max);
 #endif /* HV_DEBUG */
 
 extern uint32_t acrn_vhm_vector;

--- a/hypervisor/include/arch/x86/vmexit.h
+++ b/hypervisor/include/arch/x86/vmexit.h
@@ -85,7 +85,7 @@ static inline uint64_t vm_exit_io_instruction_port_number(uint64_t exit_qual)
 }
 
 #ifdef HV_DEBUG
-void get_vmexit_profile(char *str_arg, int str_max);
+void get_vmexit_profile(char *str_arg, size_t str_max);
 #endif /* HV_DEBUG */
 
 #endif /* VMEXIT_H_ */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -83,7 +83,7 @@ void ptdev_activate_entry(
 void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
 
 #ifdef HV_DEBUG
-void get_ptdev_info(char *str_arg, int str_max);
+void get_ptdev_info(char *str_arg, size_t str_max);
 #endif /* HV_DEBUG */
 
 uint32_t get_vm_ptdev_intr_data(const struct vm *target_vm, uint64_t *buffer,

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -28,7 +28,7 @@ void console_init(void);
  *          and no character was written.
  */
 
-int console_write(const char *s, size_t len);
+size_t console_write(const char *s, size_t len);
 
 /** Writes a single character to the console.
  *
@@ -62,13 +62,13 @@ static inline void console_init(void)
 {
 }
 
-static inline int console_write(__unused const char *str,
+static inline size_t console_write(__unused const char *str,
 			__unused size_t len)
 {
 	return 0;
 }
 static inline void console_putc(__unused const char *ch) { }
-static inline int console_getc(void) { return 0; }
+static inline char console_getc(void) { return '\0'; }
 static inline void console_setup_timer(void) {}
 static inline void suspend_console(void) {}
 static inline void resume_console(void) {}

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -653,7 +653,7 @@ size_t snprintf(char *dest, size_t sz, const char *fmt, ...)
 	va_start(args, fmt);
 
 	/* execute the printf() */
-	res = vsnprintf(dest, (size_t)sz, fmt, args);
+	res = vsnprintf(dest, sz, fmt, args);
 
 	/* destroy parameter list */
 	va_end(args);


### PR DESCRIPTION
The printf related functions have been called by other various
functions, e.g. get_ptdev_info(), get_ioapic_info, etc. The patch
is used to clear up the usage.

Tracked-On: #861
Signed-off-by: Junjun Shan <junjun.shan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>