### PR TITLE
fix several corner cases for USB emulation

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1942,7 +1942,8 @@ pci_xhci_cmd_reset_ep(struct pci_xhci_vdev *xdev,
 	assert(dev_ctx != NULL);
 	ep_ctx = &dev_ctx->ctx_ep[epid];
 
-	if ((ep_ctx->dwEpCtx0 & 0x7) != XHCI_ST_EPCTX_HALTED) {
+	if (type == XHCI_TRB_TYPE_RESET_EP &&
+			(ep_ctx->dwEpCtx0 & 0x7) != XHCI_ST_EPCTX_HALTED) {
 		cmderr = XHCI_TRB_ERROR_CONTEXT_STATE;
 		goto done;
 	}


### PR DESCRIPTION
This patch series does two things
1. Change Enable Slot and Address Device emulation logic according xHCI spec.
2. Fix a corner case under Flat Mode Hub implementation.

Tracked-On: #1365 #1366 
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>