### PR TITLE
EFI: Disable RELOC by default temporary

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -146,7 +146,7 @@ config MTRR_ENABLED
 
 config RELOC
 	bool "Enable relocation"
-	default y
+	default n
 
 config IOMMU_INIT_BUS_LIMIT
 	hex "bus limitation when iommu init"


### PR DESCRIPTION
Commit 6085781 replaced __emalloc() with a call to uefi allocate_page()
and allows UEFI FW to allocate memory for hypervisor from high to low
address below 4GB. However, this change triggers an issue (might be
memory corruption), in turn, PXE boot cannot work.

Since root cause the issue might take some time, the PXE boot issue
blocks auto-test, we disable hypervisor relocation by default for the
time being in config option, and users can enable it by themselves. In
the following weeks, if we root cause the issue, we can re-enable
relocation feature.`

Tracked-On: #1371
Signed-off-by: Chaohong guo <chaohong.guo@intel.com>