### PR TITLE
hv: mmu: make page table operation no fault

### DIFF
--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -160,16 +160,12 @@ void  destroy_secure_world(struct vm *vm, bool need_clr_mem)
 	}
 
 	/* restore memory to SOS ept mapping */
-	if (ept_mr_add(vm0, vm0->arch_vm.nworld_eptp,
-			hpa, gpa_sos, size, EPT_RWX | EPT_WB) != 0) {
-		pr_warn("Restore trusty mem to SOS failed");
-	}
+	ept_mr_add(vm0, vm0->arch_vm.nworld_eptp,
+			hpa, gpa_sos, size, EPT_RWX | EPT_WB);
 
 	/* Restore memory to guest normal world */
-	if (ept_mr_add(vm, vm->arch_vm.nworld_eptp,
-			hpa, gpa_uos, size, EPT_RWX | EPT_WB) != 0)	{
-		pr_warn("Restore trusty mem to nworld failed");
-	}
+	ept_mr_add(vm, vm->arch_vm.nworld_eptp,
+			hpa, gpa_uos, size, EPT_RWX | EPT_WB);
 
 	/* Free trusty ept page-structures */
 	pdpt_addr =

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -470,13 +470,14 @@ static int32_t local_set_vm_memory_region(struct vm *vm,
 			prot |= EPT_UNCACHED;
 		}
 		/* create gpa to hpa EPT mapping */
-		return ept_mr_add(target_vm, pml4_page, hpa,
+		ept_mr_add(target_vm, pml4_page, hpa,
 				region->gpa, region->size, prot);
 	} else {
-		return ept_mr_del(target_vm, pml4_page,
+		ept_mr_del(target_vm, pml4_page,
 				region->gpa, region->size);
 	}
 
+	return 0;
 }
 
 /**
@@ -571,8 +572,10 @@ static int32_t write_protect_page(struct vm *vm, struct wp_data *wp)
 	prot_set = (wp->set != 0U) ? 0UL : EPT_WR;
 	prot_clr = (wp->set != 0U) ? EPT_WR : 0UL;
 
-	return ept_mr_modify(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
+	ept_mr_modify(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
 		wp->gpa, CPU_PAGE_SIZE, prot_set, prot_clr);
+
+	return 0;
 }
 
 /**

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -77,10 +77,10 @@ void free_paging_struct(void *ptr);
 void enable_paging(uint64_t pml4_base_addr);
 void enable_smep(void);
 void init_paging(void);
-int mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
+void mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
 		uint64_t vaddr_base, uint64_t size,
 		uint64_t prot, enum _page_table_type ptt);
-int mmu_modify_or_del(uint64_t *pml4_page,
+void mmu_modify_or_del(uint64_t *pml4_page,
 		uint64_t vaddr_base, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr,
 		enum _page_table_type ptt, uint32_t type);
@@ -130,11 +130,11 @@ void destroy_ept(struct vm *vm);
 uint64_t gpa2hpa(struct vm *vm, uint64_t gpa);
 uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size);
 uint64_t hpa2gpa(struct vm *vm, uint64_t hpa);
-int ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
+void ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
 		uint64_t gpa, uint64_t size, uint64_t prot_orig);
-int ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
+void ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size, uint64_t prot_set, uint64_t prot_clr);
-int ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
+void ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size);
 void free_ept_mem(uint64_t *pml4_page);
 int ept_violation_vmexit_handler(struct vcpu *vcpu);


### PR DESCRIPTION
Page table operation would not fault except:
1. the hypervisor it out of memory to allcate a page for page table operation
2. there is a bug with page table operation in hypervisor or devicemodle
While we assue that these would not happened in our platform when release, so
there is no need to check whether there is a fault with page table operation. However,
for debug version, we would panic the hypervisor if we can't meet the conditions really.

Tracked-On: #1124
Signed-off-by: Li, Fei1 <fei1.li@intel.com>