### PR TITLE
DM: increase UOS memory size for MRB

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -81,7 +81,9 @@ echo "0000:00:1b.0" > /sys/bus/pci/drivers/pci-stub/bind
 
 #for memsize setting
 memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`
-if [ $memsize -gt 4000000 ];then
+if [ $memsize -gt 8000000 ];then
+    mem_size=6G
+elif [ $memsize -gt 4000000 ];then
     mem_size=2048M
 else
     mem_size=1750M
@@ -241,7 +243,9 @@ fi
 
 #for memsize setting
 memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`
-if [ $memsize -gt 4000000 ];then
+if [ $memsize -gt 8000000 ];then
+    mem_size=6G
+elif [ $memsize -gt 4000000 ];then
     mem_size=2048M
 else
     mem_size=1750M


### PR DESCRIPTION
on MRB, if memory >= 8GB, will allocate 6GB to UOS;
for MRB now just runs one UOS with more workload.

Tracked-On: #1369
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>