### PR TITLE
dm: vrtc: add memory configuration in RTC CMOS

### DIFF
--- a/devicemodel/include/macros.h
+++ b/devicemodel/include/macros.h
@@ -13,4 +13,8 @@
 #define _CONCAT_(a, b) a ## b
 #define __CONCAT(a, b) _CONCAT_(a, b)
 
+#define	KB		(1024UL)
+#define	MB		(1024 * 1024UL)
+#define	GB		(1024 * 1024 * 1024UL)
+
 #endif

--- a/devicemodel/include/rtc.h
+++ b/devicemodel/include/rtc.h
@@ -33,6 +33,12 @@
 
 #define IO_RTC	0x070	/* RTC */
 
+#define	RTC_LMEM_LSB	0x34
+#define	RTC_LMEM_MSB	0x35
+#define	RTC_HMEM_LSB	0x5b
+#define	RTC_HMEM_SB	0x5c
+#define	RTC_HMEM_MSB	0x5d
+
 struct vrtc;
 struct vmctx;
 

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -30,10 +30,6 @@
 
 #define STR_LEN 1024
 
-#define KB      (1024UL)
-#define MB      (1024 * 1024UL)
-#define GB      (1024 * 1024 * 1024UL)
-
 /* E820 memory types */
 #define E820_TYPE_RAM           1   /* EFI 1, 2, 3, 4, 5, 6, 7 */
 /* EFI 0, 11, 12, 13 (everything not used elsewhere) */


### PR DESCRIPTION
Some firmware (e.g. UEFI) uses RTC CMOS to fetch the system's memory
configuration. Put lowmem / highmem info in the designated area.

This is a port of Bhyve vRTC's user-space logic.

v1 -> v2:
* move KB/MB/GB to macros.h
* move nvram offset definitions to rtc.h

Tracked-On: #1390
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>