### PR TITLE
Memory range disable push

### DIFF
--- a/devicemodel/core/inout.c
+++ b/devicemodel/core/inout.c
@@ -26,6 +26,7 @@
  * $FreeBSD$
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -44,6 +45,7 @@ static struct {
 	int		flags;
 	inout_func_t	handler;
 	void		*arg;
+	bool		enabled;
 } inout_handlers[MAX_IOPORTS];
 
 static int
@@ -113,6 +115,11 @@ emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *pio_request)
 		if (!(flags & IOPORT_F_OUT))
 			return -1;
 	}
+
+	if (inout_handlers[port].enabled == false) {
+		return -1;
+	}
+
 	retval = handler(ctx, *pvcpu, in, port, bytes,
 		(uint32_t *)&(pio_request->value), arg);
 	return retval;
@@ -142,6 +149,42 @@ init_inout(void)
 }
 
 int
+disable_inout(struct inout_port *iop)
+{
+	int i;
+
+	if (!VERIFY_IOPORT(iop->port, iop->size)) {
+		printf("invalid input: port:0x%x, size:%d",
+				iop->port, iop->size);
+		return -1;
+	}
+
+	for (i = iop->port; i < iop->port + iop->size; i++) {
+		inout_handlers[i].enabled = false;
+	}
+
+	return 0;
+}
+
+int
+enable_inout(struct inout_port *iop)
+{
+	int i;
+
+	if (!VERIFY_IOPORT(iop->port, iop->size)) {
+		printf("invalid input: port:0x%x, size:%d",
+				iop->port, iop->size);
+		return -1;
+	}
+
+	for (i = iop->port; i < iop->port + iop->size; i++) {
+		inout_handlers[i].enabled = true;
+	}
+
+	return 0;
+}
+
+int
 register_inout(struct inout_port *iop)
 {
 	int i;
@@ -168,6 +211,7 @@ register_inout(struct inout_port *iop)
 		inout_handlers[i].flags = iop->flags;
 		inout_handlers[i].handler = iop->handler;
 		inout_handlers[i].arg = iop->arg;
+		inout_handlers[i].enabled = true;
 	}
 
 	return 0;

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -493,11 +493,7 @@ modify_bar_registration(struct pci_vdev *dev, int idx, int registration)
 		error = EINVAL;
 		break;
 	}
-
-	/* FIXME: workaround for unregister_mem for fastboot. */
-	if (error != 0) {
-		printf("modify_bar_registration failed with %d", error);
-	}
+	assert(error == 0);
 }
 
 static void

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -508,6 +508,66 @@ register_bar(struct pci_vdev *dev, int idx)
 	modify_bar_registration(dev, idx, 1);
 }
 
+static void
+enable_bar(struct pci_vdev *dev, int idx)
+{
+	int error = 0;
+	struct inout_port iop;
+	struct mem_range mr;
+
+	switch (dev->bar[idx].type) {
+	case PCIBAR_IO:
+		bzero(&iop, sizeof(struct inout_port));
+		iop.name = dev->name;
+		iop.port = dev->bar[idx].addr;
+		iop.size = dev->bar[idx].size;
+		error = enable_inout(&iop);
+		break;
+	case PCIBAR_MEM32:
+	case PCIBAR_MEM64:
+		bzero(&mr, sizeof(struct mem_range));
+		mr.name = dev->name;
+		mr.base = dev->bar[idx].addr;
+		mr.size = dev->bar[idx].size;
+		error = enable_mem(&mr);
+		break;
+	default:
+		error = EINVAL;
+		break;
+	}
+	assert(error == 0);
+}
+
+static void
+disable_bar(struct pci_vdev *dev, int idx)
+{
+	int error = 0;
+	struct inout_port iop;
+	struct mem_range mr;
+
+	switch (dev->bar[idx].type) {
+	case PCIBAR_IO:
+		bzero(&iop, sizeof(struct inout_port));
+		iop.name = dev->name;
+		iop.port = dev->bar[idx].addr;
+		iop.size = dev->bar[idx].size;
+		error = disable_inout(&iop);
+		break;
+	case PCIBAR_MEM32:
+	case PCIBAR_MEM64:
+		bzero(&mr, sizeof(struct mem_range));
+		mr.name = dev->name;
+		mr.base = dev->bar[idx].addr;
+		mr.size = dev->bar[idx].size;
+		error = disable_mem(&mr);
+		break;
+	default:
+		error = EINVAL;
+		break;
+	}
+	assert(error == 0);
+}
+
 /* Are we decoding i/o port accesses for the emulated pci device? */
 static int
 porten(struct pci_vdev *dev)
@@ -1875,9 +1935,9 @@ pci_emul_cmdsts_write(struct pci_vdev *dev, int coff, uint32_t new, int bytes)
 		/* I/O address space decoding changed? */
 			if (changed & PCIM_CMD_PORTEN) {
 				if (porten(dev))
-					register_bar(dev, i);
+					enable_bar(dev, i);
 				else
-					unregister_bar(dev, i);
+					disable_bar(dev, i);
 			}
 			break;
 		case PCIBAR_MEM32:
@@ -1885,9 +1945,9 @@ pci_emul_cmdsts_write(struct pci_vdev *dev, int coff, uint32_t new, int bytes)
 		/* MMIO address space decoding changed? */
 			if (changed & PCIM_CMD_MEMEN) {
 				if (memen(dev))
-					register_bar(dev, i);
+					enable_bar(dev, i);
 				else
-					unregister_bar(dev, i);
+					disable_bar(dev, i);
 				}
 			break;
 		default:

--- a/devicemodel/include/inout.h
+++ b/devicemodel/include/inout.h
@@ -74,6 +74,8 @@ void	init_inout(void);
 int	emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *req);
 int	register_inout(struct inout_port *iop);
 int	unregister_inout(struct inout_port *iop);
+int	enable_inout(struct inout_port *iop);
+int	disable_inout(struct inout_port *iop);
 int	init_bvmcons(void);
 void	deinit_bvmcons(void);
 void	enable_bvmcons(void);

--- a/devicemodel/include/mem.h
+++ b/devicemodel/include/mem.h
@@ -42,6 +42,7 @@ struct mem_range {
 	long		arg2;
 	uint64_t	base;
 	uint64_t	size;
+	bool		enabled;
 };
 #define	MEM_F_READ		0x1
 #define	MEM_F_WRITE		0x2
@@ -54,5 +55,7 @@ int	register_mem(struct mem_range *memp);
 int	register_mem_fallback(struct mem_range *memp);
 int	unregister_mem(struct mem_range *memp);
 int	unregister_mem_fallback(struct mem_range *memp);
+int	disable_mem(struct mem_range *memp);
+int	enable_mem(struct mem_range *memp);
 
 #endif	/* _MEM_H_ */


### PR DESCRIPTION
This patchset revert the old temporary workaround and add fixing for the issue of
memory range disable/enable for PCI.

Tracked-On: #1277