### PR TITLE
IOC Mediator: Revise banned functions

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -270,6 +270,7 @@ static struct cbc_signal cbc_tx_signal_table[] = {
 	{(uint16_t)CBC_SIG_ID_SWSCB,	3,	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_SWPLB,	3,	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_SWPCB,	3,	CBC_ACTIVE},
+	{(uint16_t)CBC_SIG_ID_SWPSB,    3, 	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_SWHB,	3,	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_SWEB,	3,	CBC_ACTIVE},
 	{(uint16_t)CBC_SIG_ID_SWECB,	3,	CBC_ACTIVE},


### PR DESCRIPTION
Revise strtok and snprintf functions

v2: adjust the patch sequence.

Tracked-On: #1401 

Yuan Liu (2):
  IOC Mediator: Add return value check for snprintf
  IOC Mediator: Replace strtok with strsep

 devicemodel/hw/platform/ioc.c | 64 +++++++++++++++++++++++++++++--------------
 1 file changed, 44 insertions(+), 20 deletions(-)