### PR TITLE
dm: inline functions defined in header must be static

### DIFF
--- a/devicemodel/include/rpmb_sim.h
+++ b/devicemodel/include/rpmb_sim.h
@@ -28,7 +28,7 @@
 #ifndef __RPMB_SIM_H__
 #define __RPMB_SIM_H__
 
-inline uint32_t swap32(uint32_t val)
+static inline uint32_t swap32(uint32_t val)
 {
 	return ((val & (uint32_t)0x000000ffUL) << 24)
 		| ((val & (uint32_t)0x0000ff00UL) <<  8)
@@ -36,7 +36,7 @@ inline uint32_t swap32(uint32_t val)
 		| ((val & (uint32_t)0xff000000UL) >> 24);
 }
 
-inline uint16_t swap16(uint16_t val)
+static inline uint16_t swap16(uint16_t val)
 {
 	return ((val & (uint16_t)0x00ffU) << 8)
 		| ((val & (uint16_t)0xff00U) >> 8);

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -227,8 +227,8 @@ enum USB_ERRCODE {
 #define USB_NATIVE_NUM_BUS 4
 
 extern int usb_log_level;
-inline int usb_get_log_level(void)		{ return usb_log_level; }
-inline void usb_set_log_level(int level)	{ usb_log_level = level; }
+static inline int usb_get_log_level(void)		{ return usb_log_level; }
+static inline void usb_set_log_level(int level)	{ usb_log_level = level; }
 void usb_parse_log_level(char level);
 struct usb_devemu *usb_emu_finddev(char *name);
 int usb_native_is_bus_existed(uint8_t bus_num);


### PR DESCRIPTION
An inline function defined in headers must be static
otherwise compilation may fail, depending on gcc optimization level,
particularly if dropping -O2 from the Makefile dm doesn't
compile reporting unresolved symbols.

Tracked-On: #1406
Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>