### PR TITLE
dm mevent fixes and enhancements 

### DIFF
--- a/devicemodel/core/mevent.c
+++ b/devicemodel/core/mevent.c
@@ -122,8 +122,14 @@ mevent_kq_filter(struct mevent *mevp)
 	if (mevp->me_type == EVF_READ)
 		retval = EPOLLIN;
 
+	if (mevp->me_type == EVF_READ_ET)
+		retval = EPOLLIN | EPOLLET;
+
 	if (mevp->me_type == EVF_WRITE)
 		retval = EPOLLOUT;
+
+	if (mevp->me_type == EVF_WRITE_ET)
+		retval = EPOLLOUT | EPOLLET;
 
 	return retval;
 }
@@ -142,8 +148,11 @@ mevent_destroy(void)
 		ee.data.ptr = mevp;
 		epoll_ctl(epoll_fd, EPOLL_CTL_DEL, mevp->me_fd, &ee);
 
-		if ((mevp->me_type == EVF_READ || mevp->me_type == EVF_WRITE) &&
-		    mevp->me_fd != STDIN_FILENO)
+		if ((mevp->me_type == EVF_READ ||
+		     mevp->me_type == EVF_READ_ET ||
+		     mevp->me_type == EVF_WRITE ||
+		     mevp->me_type == EVF_WRITE_ET) &&
+		     mevp->me_fd != STDIN_FILENO)
 			close(mevp->me_fd);
 
 		free(mevp);

--- a/devicemodel/include/mevent.h
+++ b/devicemodel/include/mevent.h
@@ -36,7 +36,6 @@ enum ev_type {
 	EVF_SIGNAL		/* Not supported yet */
 };
 
-char *vmname;
 struct mevent;
 
 struct mevent *mevent_add(int fd, enum ev_type type,

--- a/devicemodel/include/mevent.h
+++ b/devicemodel/include/mevent.h
@@ -32,6 +32,8 @@
 enum ev_type {
 	EVF_READ,
 	EVF_WRITE,
+	EVF_READ_ET,
+	EVF_WRITE_ET,
 	EVF_TIMER,		/* Not supported yet */
 	EVF_SIGNAL		/* Not supported yet */
 };


### PR DESCRIPTION
dm: mevent: remove useless vmname global variable - trivial fix
dm: mevent: implement enable/disable functions - implement required API.
Added edge triggered read and write events.
For mei mediator we need to detect changes in
sysfs files, it's not possible to do it via
level based triggers as the files are always
readable.

Tracked-On: #1417
Change-Id: Ib360ad31f30afa576b2b7b833f9bb139c269a030
Signed-off-by: Aviad Nissel <aviad.nissel@intel.com>
Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>