### PR TITLE
hv: Remove const qualifier for struct vm

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -61,7 +61,7 @@ void destroy_ept(struct vm *vm)
 		free_ept_mem((uint64_t *)vm->arch_vm.m2p);
 }
 
-uint64_t local_gpa2hpa(const struct vm *vm, uint64_t gpa, uint32_t *size)
+uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
 {
 	uint64_t hpa = 0UL;
 	uint64_t *pgentry, pg_size = 0UL;
@@ -92,12 +92,12 @@ uint64_t local_gpa2hpa(const struct vm *vm, uint64_t gpa, uint32_t *size)
 }
 
 /* using return value 0 as failure, make sure guest will not use hpa 0 */
-uint64_t gpa2hpa(const struct vm *vm, uint64_t gpa)
+uint64_t gpa2hpa(struct vm *vm, uint64_t gpa)
 {
 	return local_gpa2hpa(vm, gpa, NULL);
 }
 
-uint64_t hpa2gpa(const struct vm *vm, uint64_t hpa)
+uint64_t hpa2gpa(struct vm *vm, uint64_t hpa)
 {
 	uint64_t *pgentry, pg_size = 0UL;
 
@@ -219,7 +219,7 @@ int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu)
 	return status;
 }
 
-int ept_mr_add(const struct vm *vm, uint64_t *pml4_page,
+int ept_mr_add(struct vm *vm, uint64_t *pml4_page,
 	uint64_t hpa, uint64_t gpa, uint64_t size, uint64_t prot_orig)
 {
 	uint16_t i;
@@ -253,7 +253,7 @@ int ept_mr_add(const struct vm *vm, uint64_t *pml4_page,
 	return ret;
 }
 
-int ept_mr_modify(const struct vm *vm, uint64_t *pml4_page,
+int ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
 		uint64_t gpa, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr)
 {
@@ -271,7 +271,7 @@ int ept_mr_modify(const struct vm *vm, uint64_t *pml4_page,
 	return ret;
 }
 
-int ept_mr_del(const struct vm *vm, uint64_t *pml4_page,
+int ept_mr_del(struct vm *vm, uint64_t *pml4_page,
 		uint64_t gpa, uint64_t size)
 {
 	struct vcpu *vcpu;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -328,7 +328,7 @@ int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa,
 	return ret;
 }
 
-static inline uint32_t local_copy_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa,
+static inline uint32_t local_copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
 	uint32_t size, uint32_t fix_pg_size, bool cp_from_vm)
 {
 	uint64_t hpa;
@@ -360,7 +360,7 @@ static inline uint32_t local_copy_gpa(const struct vm *vm, void *h_ptr, uint64_t
 	return len;
 }
 
-static inline int copy_gpa(const struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
+static inline int copy_gpa(struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
 	uint32_t size_arg, bool cp_from_vm)
 {
 	void *h_ptr = h_ptr_arg;
@@ -433,7 +433,7 @@ static inline int copy_gva(struct vcpu *vcpu, void *h_ptr_arg, uint64_t gva_arg,
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_from_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
+int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 {
 	return copy_gpa(vm, h_ptr, gpa, size, 1);
 }
@@ -444,7 +444,7 @@ int copy_from_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_to_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
+int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 {
 	return copy_gpa(vm, h_ptr, gpa, size, 0);
 }

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -149,7 +149,7 @@ extern vm_sw_loader_t vm_sw_loader;
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_from_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
 /* @pre Caller(Guest) should make sure gpa is continuous.
  * - gpa from hypercall input which from kernel stack is gpa continuous, not
  *   support kernel stack from vmap
@@ -157,7 +157,7 @@ int copy_from_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_to_gpa(const struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
 int copy_from_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -215,7 +215,7 @@ static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 	return NULL;
 }
 
-static inline struct vcpu *vcpu_from_pid(const struct vm *vm, uint16_t pcpu_id)
+static inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
 {
 	uint16_t i;
 	struct vcpu *vcpu;

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -127,14 +127,14 @@ static inline void clflush(volatile void *p)
 
 /* External Interfaces */
 void destroy_ept(struct vm *vm);
-uint64_t gpa2hpa(const struct vm *vm, uint64_t gpa);
-uint64_t local_gpa2hpa(const struct vm *vm, uint64_t gpa, uint32_t *size);
-uint64_t hpa2gpa(const struct vm *vm, uint64_t hpa);
-int ept_mr_add(const struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
+uint64_t gpa2hpa(struct vm *vm, uint64_t gpa);
+uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size);
+uint64_t hpa2gpa(struct vm *vm, uint64_t hpa);
+int ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
 		uint64_t gpa, uint64_t size, uint64_t prot_orig);
-int ept_mr_modify(const struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
+int ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size, uint64_t prot_set, uint64_t prot_clr);
-int ept_mr_del(const struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
+int ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size);
 void free_ept_mem(uint64_t *pml4_page);
 int ept_violation_vmexit_handler(struct vcpu *vcpu);

--- a/hypervisor/include/hypervisor.h
+++ b/hypervisor/include/hypervisor.h
@@ -38,12 +38,12 @@
 
 #ifndef ASSEMBLER
 /* gpa --> hpa -->hva */
-static inline void *gpa2hva(const struct vm *vm, uint64_t x)
+static inline void *gpa2hva(struct vm *vm, uint64_t x)
 {
 	return hpa2hva(gpa2hpa(vm, x));
 }
 
-static inline uint64_t hva2gpa(const struct vm *vm, void *x)
+static inline uint64_t hva2gpa(struct vm *vm, void *x)
 {
 	return hpa2gpa(vm, hva2hpa(x));
 }


### PR DESCRIPTION
This patch is ready for next one,we will switch from
pointer to embedded structures such as structure vcpu,
some const qualifiers can be improper and raise compilation errors,
this patch remove const qualifier for struct vm.

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>