### PR TITLE
dm: virtio: use strnlen instead of strlen

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -40,6 +40,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <termios.h>
+#include <limits.h>
 
 #include "dm.h"
 #include "pci_core.h"
@@ -326,7 +327,7 @@ virtio_console_announce_port(struct virtio_console_port *port)
 
 	event.event = VIRTIO_CONSOLE_PORT_NAME;
 	virtio_console_control_send(port->console, &event, port->name,
-	    strlen(port->name));
+	    strnlen(port->name, NAME_MAX));
 }
 
 static void

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -470,7 +470,8 @@ virtio_input_get_config(struct virtio_input *vi, uint8_t select,
 			cfg->u.string);
 		if (rc >= 0) {
 			cfg->select = VIRTIO_INPUT_CFG_ID_NAME;
-			cfg->size = strlen(cfg->u.string);
+			cfg->size = strnlen(cfg->u.string,
+				sizeof(cfg->u.string));
 			found = true;
 		}
 		break;


### PR DESCRIPTION
Use strnlen instead of strlen to avoid potential security issue.

Tracked-On: #1364
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>