### PR TITLE
DM USB: xHCI: fix a crash issue when usb device is disconnected

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -704,7 +704,9 @@ pci_xhci_native_usb_dev_disconn_cb(void *hci_data, void *dev_data)
 		if (xdev->slots[slot] == edev)
 			break;
 
-	assert(status == VPORT_EMULATED || status == VPORT_CONNECTED);
+	assert(VPORT_STATE(status) == VPORT_EMULATED ||
+			VPORT_STATE(status) == VPORT_CONNECTED);
+
 	xdev->port_map_tbl[di.bus][di.port] = VPORT_NUM_STATE(VPORT_ASSIGNED,
 			0);
 


### PR DESCRIPTION
This is an issue result from incomplete process logic of commit:
"ba68bd4 DM USB: xHCI: fix enumeration error after rebooting".
This patch is used to fix it.

Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>
Tracked-On: #1425