### PR TITLE
2nd vcpu stat init refine

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -252,6 +252,17 @@ void reset_vcpu_regs(struct vcpu *vcpu)
 	set_vcpu_regs(vcpu, &realmode_init_regs);
 }
 
+void set_ap_entry(struct vcpu *vcpu, uint64_t entry)
+{
+	struct ext_context *ectx;
+
+	ectx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx);
+	ectx->cs.selector = (uint16_t)((entry >> 4UL) & 0xFFFFU);
+	ectx->cs.base = ectx->cs.selector << 4UL;
+
+	vcpu_set_rip(vcpu, 0UL);
+}
+
 /***********************************************************************
  *
  *  @pre vm != NULL && rtn_vcpu_handle != NULL

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -207,6 +207,18 @@ void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs)
 	ectx->ldtr.selector = vcpu_regs->ldt_sel;
 	ectx->tr.selector = vcpu_regs->tr_sel;
 
+	/* NOTE:
+	 * This is to set the ldtr and tr to default value.
+	 * If the set_vcpu_regs is used not only for vcpu state
+	 * initialization, this part of code needs be revised.
+	 */
+	ectx->ldtr.base = 0UL;
+	ectx->tr.base = 0UL;
+	ectx->ldtr.limit = 0xFFFFU;
+	ectx->tr.limit = 0xFFFFU;
+	ectx->ldtr.attr = LDTR_AR;
+	ectx->tr.attr = TR_AR;
+
 	memcpy_s(&(ctx->guest_cpu_regs), sizeof(struct acrn_gp_regs),
 			&(vcpu_regs->gprs), sizeof(struct acrn_gp_regs));
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -263,6 +263,51 @@ void set_ap_entry(struct vcpu *vcpu, uint64_t entry)
 	vcpu_set_rip(vcpu, 0UL);
 }
 
+
+/* NOTE: set_bsp_real_mode_entry & set_bsp_protect_mode_regs is only temporary
+ * function called by UOS. Once we make UOS to use hypercall to set BSP entry,
+ * we will remove these two functions.
+ */
+
+/*
+ * @pre reset_vcpu_regs is called in advance
+ */
+void set_bsp_real_mode_entry(struct vcpu *vcpu)
+{
+	struct ext_context *ectx;
+
+	ectx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx);
+
+	ectx->cs.selector = REAL_MODE_BSP_INIT_CODE_SEL;
+	ectx->cs.base = 0x3ff0000UL;
+	vcpu_set_rip(vcpu, 0xFFF0UL);
+}
+
+static struct acrn_vcpu_regs protect_mode_init_regs = {
+	.cs_ar = PROTECTED_MODE_CODE_SEG_AR,
+	.cs_sel = 0x10U,
+	.ss_sel = 0x18U,
+	.ds_sel = 0x18U,
+	.es_sel = 0x18U,
+	.cr0 = CR0_ET | CR0_NE | CR0_PE,
+	.cr3 = 0UL,
+	.cr4 = 0UL,
+};
+
+void set_bsp_protect_mode_regs(struct vcpu *vcpu)
+{
+	/* if vcpu is in protect mode, we need to set registers
+	 * according to protect_init_regs first.
+	 */
+	uint32_t limit;
+	protect_mode_init_regs.gdt.base = create_guest_init_gdt(vcpu->vm,
+			&limit);
+	protect_mode_init_regs.gdt.limit = (uint16_t) (limit & 0xFFFFU);
+	set_vcpu_regs(vcpu, &protect_mode_init_regs);
+
+	vcpu_set_rip(vcpu, (uint64_t)vcpu->entry_addr);
+}
+
 /***********************************************************************
  *
  *  @pre vm != NULL && rtn_vcpu_handle != NULL
@@ -593,8 +638,7 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 			vcpu->arch_vcpu.cpu_mode = CPU_MODE_PROTECTED;
 #else
 		if (is_vm0(vcpu->vm)) {
-			struct acrn_vcpu_regs *vm0_init_ctx =
-				(struct acrn_vcpu_regs *)(&vm0_boot_context);
+			struct acrn_vcpu_regs *vm0_init_ctx = &vm0_boot_context;
 			/* VM0 bsp start mode is decided by the boot context
 			 * setup by bootloader / bios */
 			if ((vm0_init_ctx->ia32_efer & MSR_IA32_EFER_LMA_BIT) &&

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1207,11 +1207,11 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
 				continue;
 			}
 
-			target_vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
-			target_vcpu->arch_vcpu.sipi_vector = vec;
 			pr_err("Start Secondary VCPU%hu for VM[%d]...",
 					target_vcpu->vcpu_id,
 					target_vcpu->vm->vm_id);
+			target_vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
+			set_ap_entry(target_vcpu, vec << 12U);
 			schedule_vcpu(target_vcpu);
 		} else if (mode == APIC_DELMODE_SMI) {
 			pr_info("vlapic: SMI IPI do not support\n");

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -314,11 +314,11 @@ int reset_vm(struct vm *vm)
 
 	foreach_vcpu(i, vm, vcpu) {
 		reset_vcpu(vcpu);
+
+		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 		if (is_vcpu_bsp(vcpu)) {
 			vm_sw_loader(vm, vcpu);
 		}
-
-		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 	}
 
 	vioapic_reset(vm_ioapic(vm));

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -384,10 +384,14 @@ void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec)
 	vm->state = VM_STARTED;
 
 	reset_vcpu(bsp);
-	bsp->entry_addr = (void *)(uint64_t)wakeup_vec;
-	bsp->arch_vcpu.cpu_mode = CPU_MODE_REAL;
-	init_vmcs(bsp);
 
+	/* When SOS resume from S3, it will return to real mode
+	 * with entry set to wakeup_vec.
+	 */
+	bsp->arch_vcpu.cpu_mode = CPU_MODE_REAL;
+	set_ap_entry(bsp, wakeup_vec);
+
+	init_vmcs(bsp);
 	schedule_vcpu(bsp);
 }
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -673,8 +673,7 @@ static void init_guest_state(struct vcpu *vcpu)
 {
 	struct cpu_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
-	struct acrn_vcpu_regs* init_ctx =
-		(struct acrn_vcpu_regs*)(&vm0_boot_context);
+	struct acrn_vcpu_regs* init_ctx = &vm0_boot_context;
 	enum vm_cpu_mode vcpu_mode = get_vcpu_mode(vcpu);
 
 	vcpu_set_rflags(vcpu, 0x2UL); /* Bit 1 is a active high reserved bit */

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -39,8 +39,7 @@ void efi_spurious_handler(int vector)
 int uefi_sw_loader(struct vm *vm, struct vcpu *vcpu)
 {
 	int ret = 0;
-	struct acrn_vcpu_regs *vcpu_regs =
-		(struct acrn_vcpu_regs *)&vm0_boot_context;
+	struct acrn_vcpu_regs *vcpu_regs = &vm0_boot_context;
 
 	ASSERT(vm != NULL, "Incorrect argument");
 

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -138,6 +138,8 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 	}
 #endif
 
+	set_vcpu_regs(vcpu, (struct acrn_vcpu_regs *)&vm0_boot_context);
+
 	/* calculate the kernel entry point */
 	zeropage = (struct zero_page *)sw_kernel->kernel_src_addr;
 	kernel_entry_offset = (uint32_t)(zeropage->hdr.setup_sects + 1U) * 512U;
@@ -151,9 +153,10 @@ int general_sw_loader(struct vm *vm, struct vcpu *vcpu)
 			+ kernel_entry_offset);
 	if (is_vcpu_bsp(vcpu)) {
 		/* Set VCPU entry point to kernel entry */
-		vcpu->entry_addr = sw_kernel->kernel_entry_addr;
+		vcpu_set_rip(vcpu, (uint64_t)sw_kernel->kernel_entry_addr);
 		pr_info("%s, VM %hu VCPU %hu Entry: 0x%016llx ",
-			__func__, vm->vm_id, vcpu->vcpu_id, vcpu->entry_addr);
+			__func__, vm->vm_id, vcpu->vcpu_id,
+			sw_kernel->kernel_entry_addr);
 	}
 
 	/* Calculate the host-physical address where the guest will be loaded */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -163,7 +163,7 @@ int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 
 uint64_t create_guest_init_gdt(struct vm *vm, uint32_t *limit);
-extern uint8_t vm0_boot_context;
+extern struct acrn_vcpu_regs vm0_boot_context;
 
 #endif	/* !ASSEMBLER */
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -288,6 +288,8 @@ void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
 void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 void reset_vcpu_regs(struct vcpu *vcpu);
 void set_ap_entry(struct vcpu *vcpu, uint64_t entry);
+void set_bsp_real_mode_entry(struct vcpu *vcpu);
+void set_bsp_protect_mode_regs(struct vcpu *vcpu);
 
 static inline bool is_long_mode(struct vcpu *vcpu)
 {

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -194,7 +194,6 @@ struct vcpu_arch {
 	/* Information related to secondary / AP VCPU start-up */
 	enum vm_cpu_mode cpu_mode;
 	uint8_t nr_sipi;
-	uint32_t sipi_vector;
 
 	/* interrupt injection information */
 	uint64_t pending_req;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -286,6 +286,7 @@ void vcpu_set_cr4(struct vcpu *vcpu, uint64_t val);
 uint64_t vcpu_get_pat_ext(struct vcpu *vcpu);
 void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
 void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
+void reset_vcpu_regs(struct vcpu *vcpu);
 
 static inline bool is_long_mode(struct vcpu *vcpu)
 {

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -287,6 +287,7 @@ uint64_t vcpu_get_pat_ext(struct vcpu *vcpu);
 void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
 void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 void reset_vcpu_regs(struct vcpu *vcpu);
+void set_ap_entry(struct vcpu *vcpu, uint64_t entry);
 
 static inline bool is_long_mode(struct vcpu *vcpu)
 {


### PR DESCRIPTION
This patchset is 2nd cycle refine to vcpu state initialization. It mainly focus
on the SOS BSP and all AP state initialization.

Tracked-On: #1231
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>