### PR TITLE
dm: fix assertion in pci_irq_reserve

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -499,12 +499,12 @@ vm_reset_vdevs(struct vmctx *ctx)
 	pci_irq_deinit(ctx);
 	ioapic_deinit();
 
+	pci_irq_init(ctx);
 	atkbdc_init(ctx);
 	vrtc_init(ctx);
 	vpit_init(ctx);
 
 	ioapic_init(ctx);
-	pci_irq_init(ctx);
 	init_pci(ctx);
 
 	if (acpi) {


### PR DESCRIPTION
atkbdc_init will call pci_irq_reserve to reserve irq 1 & 12, which need
pci_irq_init be called first.

Tracked-On: #1402
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>