### PR TITLE
HV:MM:gpa2hpa related error checking fix

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -336,9 +336,10 @@ static inline uint32_t local_copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
 	void *g_ptr;
 
 	hpa = local_gpa2hpa(vm, gpa, &pg_size);
-	if (pg_size == 0U) {
-		pr_err("GPA2HPA not found");
-		return 0;
+	if (hpa == INVALID_HPA) {
+		pr_err("%s,vm[%hu] gpa 0x%llx,GPA is unmapping",
+			__func__, vm->vm_id, gpa);
+		return 0U;
 	}
 
 	if (fix_pg_size != 0U) {

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -292,7 +292,8 @@ bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg)
 		curr_hpa = gpa2hpa(vm, gpa);
 		gpa += PAGE_SIZE_4K;
 		next_hpa = gpa2hpa(vm, gpa);
-		if (next_hpa != (curr_hpa + PAGE_SIZE_4K)) {
+		if ((curr_hpa == INVALID_HPA) || (next_hpa == INVALID_HPA)
+			|| (next_hpa != (curr_hpa + PAGE_SIZE_4K))) {
 			return false;
 		}
 		size -= PAGE_SIZE_4K;

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -417,14 +417,13 @@ void mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
 	}
 }
 
+/**
+ * @pre (pml4_page != NULL) && (pg_size != NULL)
+ */
 uint64_t *lookup_address(uint64_t *pml4_page,
 		uint64_t addr, uint64_t *pg_size, enum _page_table_type ptt)
 {
 	uint64_t *pml4e, *pdpte, *pde, *pte;
-
-	if ((pml4_page == NULL) || (pg_size == NULL)) {
-		return NULL;
-	}
 
 	pml4e = pml4e_offset(pml4_page, addr);
 	if (pgentry_present(ptt, *pml4e) == 0UL) {

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -63,6 +63,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	uint64_t nworld_pml4e;
 	uint64_t sworld_pml4e;
 	uint64_t gpa;
+	/* Check the HPA of parameter gpa_orig when invoking check_continuos_hpa */
 	uint64_t hpa = gpa2hpa(vm, gpa_orig);
 	uint64_t table_present = EPT_RWX;
 	uint64_t pdpte, *dest_pdpte_p, *src_pdpte_p;
@@ -76,7 +77,10 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 		return;
 	}
 
-	/* Check the physical address should be continuous */
+	/**
+	 * Check the HPA of parameter gpa_orig should exist
+	 * Check the physical address should be continuous
+	 */
 	if (!check_continuous_hpa(vm, gpa_orig, size))	{
 		ASSERT(false, "The physical addr is not continuous for Trusty");
 		return;

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -90,6 +90,9 @@ void flush_vpid_single(uint16_t vpid);
 void flush_vpid_global(void);
 void invept(struct vcpu *vcpu);
 bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg);
+/**
+ *@pre (pml4_page != NULL) && (pg_size != NULL)
+ */
 uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, enum _page_table_type ptt);
 
@@ -125,15 +128,32 @@ static inline void clflush(volatile void *p)
 	asm volatile ("clflush (%0)" :: "r"(p));
 }
 
+/**
+ * Invalid HPA is defined for error checking,
+ * according to SDM vol.3A 4.1.4, the maximum
+ * host physical address width is 52
+ */
+#define INVALID_HPA	(0x1UL << 52U)
 /* External Interfaces */
 void destroy_ept(struct vm *vm);
+/**
+ * @return INVALID_HPA - the HPA of parameter gpa is unmapping
+ * @return hpa - the HPA of parameter gpa is hpa
+ */
 uint64_t gpa2hpa(struct vm *vm, uint64_t gpa);
+/**
+ * @return INVALID_HPA - the HPA of parameter gpa is unmapping
+ * @return hpa - the HPA of parameter gpa is hpa
+ */
 uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size);
 uint64_t hpa2gpa(struct vm *vm, uint64_t hpa);
 void ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
 		uint64_t gpa, uint64_t size, uint64_t prot_orig);
 void ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size, uint64_t prot_set, uint64_t prot_clr);
+/**
+ * @pre [gpa,gpa+size) has been mapped into host physical memory region
+ */
 void ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size);
 void free_ept_mem(uint64_t *pml4_page);


### PR DESCRIPTION
In the current hypervisor design, when HPA is not
found for the specified gpa by calling gpa2hpa or
local_gpa2hpa, 0 will be returned as a error code,
but 0 may be a valid HPA for vm0; error checking
is missed when invoking gpa2hpa or local_gpa2hpa;
when invoking lookup_address, the caller guarantees
that parameter pointer pml4_page and pointer pg_size
is not NULL.

If local_gpa2hpa/gpa2hpa returns a invalid HPA,
it means that this function fails to find the
HPA of the specified gpa of vm. If local_gpa2hpa/gpa2hpa
return value is a valid HPA, it means that this
function have found the HPA of the specified gpa of vm.

Each valid vm's EPTP is initialized during vm creating,
vm's EPTP is valid until this vm is destroyed. So the caller
can guarantee parameter pointer pml4_page is not NULL.
The caller uses a temporary variable to store page size.
So the caller can guarantee parameter pointer pg_size
is not NULL.

In this patch, define a invalid HPA for gpa2hpa and
local_gpa2hpa;add some error checking when invoking
local_gpa2hpa/gpa2hpa;add precondition for lookup_address
function and remove redundant error checking.

V1-->V2:
	Define INVALID_HPA as a invalid HPA for gpa2hpa
	and local_gpa2hpa;
	Updated related error checking when invoking
	gpa2hpa or local_gpa2hpa;
V2-->V3:
	Add some debug information if specified gpa2hpa
	mapping doesn't exit and ept_mr_del is called;
	Update INVALID_HPA definition easier to be reviewed.
V3-->V4:
	Add vm->id and gpa into pr_error;
	Add precondition to ept_mr_del to cover [gpa,gpa+size)
	unmapping case.

Tracked-On:#1258

Signed-off-by: Xiangyang Wu <xiangyang.wu@linux.intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>