### PR TITLE
dm: fix use of uninitialized variable in monitor.c

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -228,6 +228,7 @@ int set_wakeup_timer(time_t t)
 	strncpy(req.data.rtc_timer.vmname, vmname,
 			sizeof(req.data.rtc_timer.vmname));
 
+	memset(&ack, 0, sizeof(struct mngr_msg));
 	ret = mngr_send_msg(acrnd_fd, &req, &ack, 2);
 	mngr_close(acrnd_fd);
 	if (ret != sizeof(ack)) {


### PR DESCRIPTION
@set_wakeup_timer(), "ack" is not initialized before
passing it to "mngr_send_msg() as input.

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>