### PR TITLE
hv: fix NULL pointer dereference in "hcall_set_vm_memory_regions()"

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -533,6 +533,10 @@ int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param)
 	}
 
 	target_vm = get_vm_from_vmid(set_regions.vmid);
+	if (target_vm == NULL) {
+		return -EINVAL;
+	}
+
 	if (is_vm0(target_vm)) {
 		pr_err("%s: Targeting to service vm", __func__);
 		return -EFAULT;


### PR DESCRIPTION
'target_vm' returned from 'get_vm_from_vmid()' maybe NULL,
 passing to 'is_vm0()' without check.

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>