### PR TITLE
hv: fix 'No brackets to then/else'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -172,8 +172,9 @@ static void get_cpu_capabilities(void)
 #ifndef CONFIG_RETPOLINE
 	if (cpu_has_cap(X86_FEATURE_IBRS_IBPB)) {
 		ibrs_type = IBRS_RAW;
-		if (cpu_has_cap(X86_FEATURE_STIBP))
+		if (cpu_has_cap(X86_FEATURE_STIBP)) {
 			ibrs_type = IBRS_OPT;
+		}
 	}
 #endif
 }
@@ -789,14 +790,16 @@ static void ept_cap_detect(void)
 	msr_val = msr_val >> 32U;
 
 	/* Check if secondary processor based VM control is available. */
-	if ((msr_val & VMX_PROCBASED_CTLS_SECONDARY) == 0UL)
+	if ((msr_val & VMX_PROCBASED_CTLS_SECONDARY) == 0UL) {
 		return;
+	}
 
 	/* Read secondary processor based VM control. */
 	msr_val = msr_read(MSR_IA32_VMX_PROCBASED_CTLS2);
 
-	if (is_ctrl_setting_allowed(msr_val, VMX_PROCBASED_CTLS2_EPT))
+	if (is_ctrl_setting_allowed(msr_val, VMX_PROCBASED_CTLS2_EPT)) {
 		cpu_caps.ept_features = 1U;
+	}
 }
 
 static void apicv_cap_detect(void)

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -55,10 +55,12 @@ void free_ept_mem(uint64_t *pml4_page)
 
 void destroy_ept(struct vm *vm)
 {
-	if (vm->arch_vm.nworld_eptp != NULL)
+	if (vm->arch_vm.nworld_eptp != NULL) {
 		free_ept_mem((uint64_t *)vm->arch_vm.nworld_eptp);
-	if (vm->arch_vm.m2p != NULL)
+	}
+	if (vm->arch_vm.m2p != NULL) {
 		free_ept_mem((uint64_t *)vm->arch_vm.m2p);
+	}
 }
 /* using return value INVALID_HPA as error code */
 uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -2213,8 +2213,9 @@ static int instr_check_gva(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
 		/* RIP relative addressing starts from the
 		 * following instruction
 		 */
-		if (vie->base_register == CPU_REG_RIP)
+		if (vie->base_register == CPU_REG_RIP) {
 			base += vie->num_processed;
+		}
 
 	}
 
@@ -2332,8 +2333,9 @@ int decode_instruction(struct vcpu *vcpu)
 	 */
 	if ((emul_ctxt->vie.op.op_flags & VIE_OP_F_CHECK_GVA_DI) != 0U) {
 		retval = instr_check_di(vcpu, emul_ctxt);
-		if (retval < 0)
+		if (retval < 0) {
 			return retval;
+		}
 	} else {
 		instr_check_gva(vcpu, emul_ctxt, cpu_mode);
 	}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1982,9 +1982,10 @@ int vlapic_create(struct vcpu *vcpu)
 		uint64_t *pml4_page =
 			(uint64_t *)vcpu->vm->arch_vm.nworld_eptp;
 		/* only need unmap it from SOS as UOS never mapped it */
-		if (is_vm0(vcpu->vm))
+		if (is_vm0(vcpu->vm)) {
 			ept_mr_del(vcpu->vm, pml4_page,
 				DEFAULT_APIC_BASE, CPU_PAGE_SIZE);
+		}
 
 		ept_mr_add(vcpu->vm, pml4_page,
 			vlapic_apicv_get_apic_access_addr(),

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -308,13 +308,15 @@ int reset_vm(struct vm *vm)
 	int i;
 	struct vcpu *vcpu = NULL;
 
-	if (vm->state != VM_PAUSED)
+	if (vm->state != VM_PAUSED) {
 		return -1;
+	}
 
 	foreach_vcpu(i, vm, vcpu) {
 		reset_vcpu(vcpu);
-		if (is_vcpu_bsp(vcpu))
+		if (is_vcpu_bsp(vcpu)) {
 			vm_sw_loader(vm, vcpu);
+		}
 
 		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 	}

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -134,16 +134,18 @@ static union lapic_base_msr lapic_base_msr;
 
 static inline uint32_t read_lapic_reg32(uint32_t offset)
 {
-	if (offset < 0x20U || offset > 0x3ffU)
+	if ((offset < 0x20U) || (offset > 0x3ffU)) {
 		return 0;
+	}
 
 	return mmio_read32(lapic_info.xapic.vaddr + offset);
 }
 
 void write_lapic_reg32(uint32_t offset, uint32_t value)
 {
-	if (offset < 0x20U || offset > 0x3ffU)
+	if ((offset < 0x20U) || (offset > 0x3ffU)) {
 		return;
+	}
 
 	mmio_write32(value, lapic_info.xapic.vaddr + offset);
 }
@@ -398,10 +400,11 @@ send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 	write_lapic_reg32(LAPIC_INT_COMMAND_REGISTER_0, icr.value_32.lo_32);
 	wait_for_delivery();
 
-	if (boot_cpu_data.family == 6U)
+	if (boot_cpu_data.family == 6U) {
 		udelay(10U); /* 10us is enough for Modern processors */
-	else
+	} else {
 		udelay(200U); /* 200us for old processors */
+	}
 
 	/* Send another start IPI as per the Intel Arch specification */
 	write_lapic_reg32(LAPIC_INT_COMMAND_REGISTER_1, icr.value_32.hi_32);
@@ -449,8 +452,9 @@ int send_shorthand_ipi(uint8_t vector,
 
 	if ((shorthand < INTR_LAPIC_ICR_SELF)
 			|| (shorthand > INTR_LAPIC_ICR_ALL_EX_SELF)
-			|| (delivery_mode > INTR_LAPIC_ICR_NMI))
+			|| (delivery_mode > INTR_LAPIC_ICR_NMI)) {
 		status = -EINVAL;
+	}
 
 	ASSERT(status == 0, "Incorrect arguments");
 

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -95,8 +95,9 @@ void init_mtrr(struct vcpu *vcpu)
 	vcpu->mtrr.def_type.bits.fixed_enable = 1U;
 	vcpu->mtrr.def_type.bits.type = MTRR_MEM_TYPE_UC;
 
-	if (is_vm0(vcpu->vm))
+	if (is_vm0(vcpu->vm)) {
 		cap.value = msr_read(MSR_IA32_MTRR_CAP);
+	}
 
 	for (i = 0U; i < FIXED_RANGE_MTRR_NUM; i++) {
 		if (cap.bits.fix != 0U) {

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -22,8 +22,9 @@ static void kick_notification(__unused uint32_t irq, __unused void *data)
 		struct smp_call_info_data *smp_call =
 			&per_cpu(smp_call_info, pcpu_id);
 
-		if (smp_call->func != NULL)
+		if (smp_call->func != NULL) {
 			smp_call->func(smp_call->data);
+		}
 		bitmap_clear_nolock(pcpu_id, &smp_call_mask);
 	}
 }

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -283,8 +283,10 @@ static void add_pte(uint64_t *pde, uint64_t paddr_start,
 		set_pgentry(pte, paddr | prot);
 		paddr += PTE_SIZE;
 		vaddr += PTE_SIZE;
-		if (vaddr >= vaddr_end)
+
+		if (vaddr >= vaddr_end) {
 			break;	/* done */
+		}
 	}
 }
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -23,20 +23,22 @@ static void acpi_gas_write(struct acpi_generic_address *gas, uint32_t val)
 {
 	uint16_t val16 = (uint16_t)val;
 
-	if (gas->space_id == SPACE_SYSTEM_MEMORY)
+	if (gas->space_id == SPACE_SYSTEM_MEMORY) {
 		mmio_write16(val16, hpa2hva(gas->address));
-	else
+	} else {
 		pio_write16(val16, (uint16_t)gas->address);
+	}
 }
 
 static uint32_t acpi_gas_read(struct acpi_generic_address *gas)
 {
 	uint32_t ret = 0U;
 
-	if (gas->space_id == SPACE_SYSTEM_MEMORY)
+	if (gas->space_id == SPACE_SYSTEM_MEMORY) {
 		ret = mmio_read16(hpa2hva(gas->address));
-	else
+	} else {
 		ret = pio_read16((uint16_t)gas->address);
+	}
 
 	return ret;
 }
@@ -49,8 +51,9 @@ void do_acpi_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 
 	acpi_gas_write(&(sx_data->pm1a_cnt), pm1a_cnt_val);
 
-	if (vm->pm.sx_state_data->pm1b_cnt.address != 0U)
+	if (vm->pm.sx_state_data->pm1b_cnt.address != 0U) {
 		acpi_gas_write(&(sx_data->pm1b_cnt), pm1b_cnt_val);
+	}
 
 	while (1) {
 		/* polling PM1 state register to detect wether
@@ -70,8 +73,9 @@ void do_acpi_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 		 * WAK_STS(bit 15) is set if system will transition to working
 		 * state.
 		 */
-		if ((s1 & (1U << BIT_WAK_STS)) != 0U)
+		if ((s1 & (1U << BIT_WAK_STS)) != 0U) {
 			break;
+		}
 	}
 }
 

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -173,8 +173,9 @@ int vmexit_handler(struct vcpu *vcpu)
 		uint32_t err_code = 0U;
 
 		if (type == VMX_INT_TYPE_HW_EXP) {
-			if ((vector_info & VMX_INT_INFO_ERR_CODE_VALID) != 0U)
+			if ((vector_info & VMX_INT_INFO_ERR_CODE_VALID) != 0U) {
 				err_code = exec_vmread32(VMX_IDT_VEC_ERROR_CODE);
+			}
 			(void)vcpu_queue_exception(vcpu, vector, err_code);
 			vcpu->arch_vcpu.idt_vectoring_info = 0U;
 		} else if (type == VMX_INT_TYPE_NMI) {

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -307,8 +307,9 @@ static void load_pdptrs(struct vcpu *vcpu)
 static bool is_cr0_write_valid(struct vcpu *vcpu, uint64_t cr0)
 {
 	/* Shouldn't set always off bit */
-	if ((cr0 & cr0_always_off_mask) != 0UL)
+	if ((cr0 & cr0_always_off_mask) != 0UL) {
 		return false;
+	}
 
 	/* SDM 25.3 "Changes to instruction behavior in VMX non-root"
 	 *
@@ -318,19 +319,22 @@ static bool is_cr0_write_valid(struct vcpu *vcpu, uint64_t cr0)
 	 * CR0.PE = 0 and CR0.PG = 1 is invalid.
 	 */
 	if (((cr0 & CR0_PG) != 0UL) && !is_pae(vcpu)
-		&& ((vcpu_get_efer(vcpu) & MSR_IA32_EFER_LME_BIT) != 0UL))
+		&& ((vcpu_get_efer(vcpu) & MSR_IA32_EFER_LME_BIT) != 0UL)) {
 		return false;
+	}
 
-	if (((cr0 & CR0_PE) == 0UL) && ((cr0 & CR0_PG) != 0UL))
+	if (((cr0 & CR0_PE) == 0UL) && ((cr0 & CR0_PG) != 0UL)) {
 		return false;
+	}
 
 	/* SDM 6.15 "Exception and Interrupt Refrerence" GP Exception
 	 *
 	 * Loading CR0 regsiter with a set NW flag and a clear CD flag
 	 * is invalid
 	 */
-	if (((cr0 & CR0_CD) == 0UL) && ((cr0 & CR0_NW) != 0UL))
+	if (((cr0 & CR0_CD) == 0UL) && ((cr0 & CR0_NW) != 0UL)) {
 		return false;
+	}
 
 	return true;
 }
@@ -450,16 +454,19 @@ void vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0)
 static bool is_cr4_write_valid(struct vcpu *vcpu, uint64_t cr4)
 {
 	/* Check if guest try to set fixed to 0 bits or reserved bits */
-	if ((cr4 & cr4_always_off_mask) != 0U)
+	if ((cr4 & cr4_always_off_mask) != 0U) {
 		return false;
+	}
 
 	/* Do NOT support nested guest */
-	if ((cr4 & CR4_VMXE) != 0UL)
+	if ((cr4 & CR4_VMXE) != 0UL) {
 		return false;
+	}
 
 	/* Do NOT support PCID in guest */
-	if ((cr4 & CR4_PCIDE) != 0UL)
+	if ((cr4 & CR4_PCIDE) != 0UL) {
 		return false;
+	}
 
 	if (is_long_mode(vcpu)) {
 		if ((cr4 & CR4_PAE) == 0UL) {

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -229,8 +229,9 @@ dmar_wait_completion(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 		 */
 		condition = (temp_condition == pre_condition) ? true : false;
 
-		if (condition)
+		if (condition) {
 			break;
+		}
 		ASSERT(((rdtsc() - start) < CYCLES_PER_MS),
 			"DMAR OP Timeout!");
 		asm volatile ("pause" ::: "memory");

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -82,8 +82,9 @@ void relocate(void)
 
 	/* get the delta that needs to be patched */
 	delta = get_hv_image_delta();
-	if (delta == 0U)
+	if (delta == 0U) {
 		return;
+	}
 
 	/* Look for the descriptoin of relocation sections */
 	for (dyn = (struct Elf64_Dyn *)_DYNAMIC; dyn->d_tag != DT_NULL; dyn++) {
@@ -101,8 +102,9 @@ void relocate(void)
 	}
 
 	/* Sanity check */
-	if ((start == NULL) || (size == 0U))
+	if ((start == NULL) || (size == 0U)) {
 		return;
+	}
 
 	/*
 	 * Need to subtract the relocation delta to get the correct

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -38,8 +38,9 @@ int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid)
 	foreach_vcpu(i, vm, vcpu) {
 		if (vlapic_get_apicid(vcpu_vlapic(vcpu)) == lapicid) {
 			/* should not offline BSP */
-			if (vcpu->vcpu_id == BOOT_CPU_ID)
+			if (vcpu->vcpu_id == BOOT_CPU_ID) {
 				return -1;
+			}
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
 			reset_vcpu(vcpu);
 			destroy_vcpu(vcpu);
@@ -237,8 +238,9 @@ int32_t hcall_reset_vm(uint16_t vmid)
 {
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
-	if ((target_vm == NULL) || is_vm0(target_vm))
+	if ((target_vm == NULL) || is_vm0(target_vm)) {
 		return -1;
+	}
 
 	reset_vm(target_vm);
 	return 0;

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -127,8 +127,9 @@ release_all_entries(struct vm *vm)
 	list_for_each_safe(pos, tmp, &ptdev_list) {
 		entry = list_entry(pos, struct ptdev_remapping_info,
 				entry_node);
-		if (entry->vm == vm)
+		if (entry->vm == vm) {
 			release_entry(entry);
+		}
 	}
 }
 
@@ -191,8 +192,9 @@ ptdev_deactivate_entry(struct ptdev_remapping_info *entry)
 
 void ptdev_init(void)
 {
-	if (get_cpu_id() > 0)
+	if (get_cpu_id() != BOOT_CPU_ID) {
 		return;
+	}
 
 	INIT_LIST_HEAD(&ptdev_list);
 	spinlock_init(&ptdev_lock);

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -39,8 +39,9 @@ void do_softirq(void)
 
 	while (true) {
 		nr = ffs64(*softirq_pending_bitmap);
-		if (nr >= NR_SOFTIRQS)
+		if (nr >= NR_SOFTIRQS) {
 			break;
+		}
 
 		bitmap_clear_lock(nr, softirq_pending_bitmap);
 		(*softirq_handlers[nr])(cpu_id);

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -128,8 +128,9 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	va_end(args);
 
 	/* Check if flags specify to output to NPK */
-	if (do_npk_log)
+	if (do_npk_log) {
 		npk_log_write(buffer, strnlen_s(buffer, LOG_MESSAGE_MAX_SIZE));
+	}
 
 	/* Check if flags specify to output to stdout */
 	if (do_console_log) {

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -38,23 +38,28 @@ void npk_log_setup(struct hv_npk_log_param *param)
 			param->mmio_addr);
 
 	param->res = HV_NPK_LOG_RES_KO;
-	if (atomic_inc_return(&npk_log_setup_ref) > 1)
+	if (atomic_inc_return(&npk_log_setup_ref) > 1) {
 		goto out;
+	}
 
 	switch (param->cmd) {
 	case HV_NPK_LOG_CMD_CONF:
-		if ((param->mmio_addr != 0UL) || (param->loglevel != 0xffffU))
+		if ((param->mmio_addr != 0UL) || (param->loglevel != 0xffffU)) {
 			param->res = HV_NPK_LOG_RES_OK;
+		}
 		/* falls through */
 	case HV_NPK_LOG_CMD_ENABLE:
-		if (param->mmio_addr != 0UL)
+		if (param->mmio_addr != 0UL) {
 			base = param->mmio_addr;
-		if (param->loglevel != 0xffffU)
+		}
+		if (param->loglevel != 0xffffU) {
 			npk_loglevel = param->loglevel;
+		}
 		if ((base != 0UL) && (param->cmd == HV_NPK_LOG_CMD_ENABLE)) {
-			if (!npk_log_enabled)
+			if (!npk_log_enabled) {
 				for (i = 0; i < phys_cpu_num; i++)
 					per_cpu(npk_log_ref, i) = 0;
+			}
 			param->res = HV_NPK_LOG_RES_OK;
 			npk_log_enabled = 1;
 		}
@@ -88,8 +93,9 @@ void npk_log_write(const char *buf, size_t buf_len)
 	uint32_t ref;
 	uint16_t len;
 
-	if (!npk_log_enabled || (channel == NULL))
+	if (!npk_log_enabled || (channel == NULL)) {
 		return;
+	}
 
 	/* calculate the channel offset based on cpu_id and npk_log_ref */
 	ref = (atomic_inc_return((int32_t *)&per_cpu(npk_log_ref, cpu_id)) - 1)

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -661,9 +661,9 @@ static int shell_vcpu_dumpreg(int argc, char **argv)
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
 	dump.str_max = CPU_PAGE_SIZE;
-	if (vcpu->pcpu_id == get_cpu_id())
+	if (vcpu->pcpu_id == get_cpu_id()) {
 		vcpu_dumpreg(&dump);
-	else {
+	} else {
 		bitmap_set_nolock(vcpu->pcpu_id, &mask);
 		smp_call_function(mask, vcpu_dumpreg, &dump);
 	}

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -538,12 +538,11 @@ int vioapic_mmio_access_handler(struct vcpu *vcpu, struct io_request *io_req)
 		if (mmio->direction == REQUEST_READ) {
 			vioapic_mmio_rw(vioapic, gpa, &data, true);
 			mmio->value = (uint64_t)data;
-
 		} else if (mmio->direction == REQUEST_WRITE) {
 			vioapic_mmio_rw(vioapic, gpa, &data, false);
-
-		} else
+		} else {
 			ret = -EINVAL;
+		}
 	} else {
 		pr_err("All RW to IOAPIC must be 32-bits in size");
 		ret = -EINVAL;

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -139,8 +139,9 @@ static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
 	uint64_t idx;
 
 	for (idx = 0UL; (idx << 6U) < size; idx++) {
-		if (addr[idx] != ~0UL)
+		if (addr[idx] != ~0UL) {
 			return (idx << 6U) + ffz64(addr[idx]);
+		}
 	}
 
 	return size;


### PR DESCRIPTION
- add missing brackets for 'if/else' statements based on MISRA-C
  requirements

v1 -> v2:
 * add brackets for each conditions in 'if' statements to improve
   the readability
 * modify 'ptdev_init' to make the logic clearer

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>