### PR TITLE
hypervisor: Makefile: let OBJS target depend on VERSION file

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -223,8 +223,7 @@ DISTCLEAN_OBJS := $(shell find $(BASEDIR) -name '*.o')
 VERSION := $(HV_OBJDIR)/include/version.h
 
 .PHONY: all
-all: $(VERSION) $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
-	rm -f $(VERSION)
+all: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 
 ifeq ($(CONFIG_PLATFORM), uefi)
 all: efi
@@ -238,7 +237,7 @@ install: efi
 endif
 
 ifeq ($(CONFIG_PLATFORM), sbl)
-install: $(VERSION) $(HV_OBJDIR)/$(HV_FILE).32.out
+install: $(HV_OBJDIR)/$(HV_FILE).32.out
 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).sbl
 endif
 
@@ -297,7 +296,7 @@ $(VERSION):
 -include $(C_OBJS:.o=.d)
 -include $(S_OBJS:.o=.d)
 
-$(HV_OBJDIR)/%.o: %.c $(HV_OBJDIR)/$(HV_CONFIG_H)
+$(HV_OBJDIR)/%.o: %.c $(VERSION) $(HV_OBJDIR)/$(HV_CONFIG_H)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \
 	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@ -MMD -MT $@
 


### PR DESCRIPTION
Let OBJS target depend on VERSION file instead of other targets like
install/all depending on it, since the version.h is being included in
.c files.

This fixes a following compilation issue:
| In file included from include/hv_debug.h:10,
|                  from include/hypervisor.h:37,
|                  from arch/x86/cpu.c:7:
| arch/x86/cpu.c: In function 'bsp_boot_post':
| arch/x86/cpu.c:453:4: error: 'HV_FULL_VERSION' undeclared...

Tracked-On: #1441
Signed-off-by: Ming Liu <liu.ming50@gmail.com>