### PR TITLE
Revert "DM: Disable plane_restriction on 4.19 kernel"

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -399,18 +399,12 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
         fi
 done
 
-gvt_args=0x070F00
-# this is the temporal solution before plane_restriction is ready on 4.19
-if [ "$kernel_version" = "4.19" ]; then
-gvt_args=0
-fi
-
 case $launch_type in
 	1) echo "Launch clearlinux UOS"
-		launch_clearlinux 1 3 "64 448 8" $gvt_args clearlinux "LaaG" $debug
+		launch_clearlinux 1 3 "64 448 8" 0x070F00 clearlinux "LaaG" $debug
 		;;
 	2) echo "Launch android UOS"
-		launch_android 1 3 "64 448 8" $gvt_args android "AaaG" $debug
+		launch_android 1 3 "64 448 8" 0x070F00 android "AaaG" $debug
 		;;
 	3) echo "Launch clearlinux UOS + android UOS"
 		launch_android 1 2 "64 448 4" 0x00000C android "AaaG" $debug &

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-kernel_version=$(uname -r | awk -F. '{ printf("%d.%d", $1,$2) }')
-
 function launch_clear()
 {
 vm_name=vm$1
@@ -43,10 +41,4 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
         fi
 done
 
-gvt_args=0x070F00
-# this is the temporal solution before plane_restriction is ready on 4.19
-if [ "$kernel_version" = "4.19" ]; then
-gvt_args=0
-fi
-
-launch_clear 1 1 "64 448 8" $gvt_args clear
+launch_clear 1 1 "64 448 8" 0x070F00 clear


### PR DESCRIPTION
This reverts commit 072e77e746f39e3f9cfc50de19d9d77572f3a30c so that
plane_restriction can be enabled.

Tracked-on: https://github.com/projectacrn/acrn-hypervisor/issues/1373
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: He, Min <min.he@intel.com>