### PR TITLE
script: re-enable PVMMIO ppgtt update optimization for GVT-g

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -276,10 +276,6 @@ else
 fi
 kernel_cmdline="$kernel_cmdline_generic"
 
-if [ "$kernel_version" = "4.19" ]; then
-  kernel_cmdline="$kernel_cmdline_generic"" i915.enable_pvmmio=0x27"
-fi
-
 : '
 select right virtual slots for acrn_dm:
 1. some passthru device need virtual slot same as physical, like audio 0:e.0 at


### PR DESCRIPTION
This reverts partial of commit: 9bf5aafe "script: workarounds for UOS of
4.19-rc kernel", since our fixing patch for the PVMMIO ppgtt update bug
is ready.
For the remaining audio pass-through workaround, we still need to keep
it until it's fixed.

Tracked-On: #1413
Signed-off-by: Min He <min.he@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>