### PR TITLE
dm: virtio: use the correct register size

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -569,14 +569,8 @@ static struct config_reg modern_config_regs[] = {
 	{ VIRTIO_COMMON_GF,		4, 0, "GF" },
 	{ VIRTIO_COMMON_MSIX,		2, 0, "MSIX" },
 	{ VIRTIO_COMMON_NUMQ,		2, 1, "NUMQ" },
-
-	/*
-	 * TODO: change size to 1 for the below 2 registers when
-	 * HV can report corret size
-	 */
-	{ VIRTIO_COMMON_STATUS,		4, 0, "STATUS" },
-	{ VIRTIO_COMMON_CFGGENERATION,	4, 1, "CFGGENERATION" },
-
+	{ VIRTIO_COMMON_STATUS,		1, 0, "STATUS" },
+	{ VIRTIO_COMMON_CFGGENERATION,	1, 1, "CFGGENERATION" },
 	{ VIRTIO_COMMON_Q_SELECT,	2, 0, "Q_SELECT" },
 	{ VIRTIO_COMMON_Q_SIZE,		2, 0, "Q_SIZE" },
 	{ VIRTIO_COMMON_Q_MSIX,		2, 0, "Q_MSIX" },


### PR DESCRIPTION
movb is used for registers STATUS and CFGGENERATION whose size is 1
byte. Previously hv cannot report the correct MMIO trap size for
movb and virtio hard coded their size to 4 as a workaround. hv fixed
movb instruction emulation and MMIO size can be reported correctly.
This patch removes those workaround.

commit 9df8790ffc50 ("hv: Fix two minor issues in instruction emulation code")

Tracked-On: #1449
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>