### PR TITLE
hv: Fix identifier reuse

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -311,12 +311,12 @@ static void init_percpu_data_area(void)
 		"fail to get phy cpu id");
 }
 
-static void cpu_set_current_state(uint16_t pcpu_id, enum cpu_state state)
+static void cpu_set_current_state(uint16_t pcpu_id, enum pcpu_boot_state state)
 {
 	spinlock_obtain(&up_count_spinlock);
 
 	/* Check if state is initializing */
-	if (state == CPU_STATE_INITIALIZING) {
+	if (state == PCPU_STATE_INITIALIZING) {
 		/* Increment CPU up count */
 		up_count++;
 
@@ -325,12 +325,12 @@ static void cpu_set_current_state(uint16_t pcpu_id, enum cpu_state state)
 	}
 
 	/* If cpu is dead, decrement CPU up count */
-	if (state == CPU_STATE_DEAD) {
+	if (state == PCPU_STATE_DEAD) {
 		up_count--;
 	}
 
 	/* Set state for the specified CPU */
-	per_cpu(cpu_state, pcpu_id) = state;
+	per_cpu(boot_state, pcpu_id) = state;
 
 	spinlock_release(&up_count_spinlock);
 }
@@ -429,7 +429,7 @@ static void bsp_boot_post(void)
 	cpu_xsave_init();
 
 	/* Set state for this CPU to initializing */
-	cpu_set_current_state(BOOT_CPU_ID, CPU_STATE_INITIALIZING);
+	cpu_set_current_state(BOOT_CPU_ID, PCPU_STATE_INITIALIZING);
 
 	/* Perform any necessary BSP initialization */
 	init_bsp();
@@ -527,7 +527,7 @@ void cpu_secondary_init(void)
 	 * and Set state for this CPU to initializing
 	 */
 	cpu_set_current_state(get_cpu_id_from_lapic_id(get_cur_lapic_id()),
-			      CPU_STATE_INITIALIZING);
+			      PCPU_STATE_INITIALIZING);
 
 	bitmap_set_nolock(get_cpu_id(), &pcpu_active_bitmap);
 
@@ -706,7 +706,7 @@ void cpu_dead(uint16_t pcpu_id)
 	cache_flush_invalidate_all();
 
 	/* Set state to show CPU is dead */
-	cpu_set_current_state(pcpu_id, CPU_STATE_DEAD);
+	cpu_set_current_state(pcpu_id, PCPU_STATE_DEAD);
 
 	/* Halt the CPU */
 	do {

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -204,7 +204,7 @@ static struct shell_cmd *shell_find_cmd(const char *cmd_str)
 	struct shell_cmd *p_cmd = NULL;
 
 	for (i = 0U; i < p_shell->cmd_count; i++) {
-		p_cmd = &p_shell->shell_cmd[i];
+		p_cmd = &p_shell->cmds[i];
 		if (strcmp(p_cmd->str, cmd_str) == 0) {
 			return p_cmd;
 		}
@@ -438,7 +438,7 @@ void shell_kick(void)
 
 void shell_init(void)
 {
-	p_shell->shell_cmd = shell_cmds;
+	p_shell->cmds = shell_cmds;
 	p_shell->cmd_count = ARRAY_SIZE(shell_cmds);
 
 	/* Zero fill the input buffer */
@@ -470,7 +470,7 @@ static int shell_cmd_help(__unused int argc, __unused char **argv)
 		uint32_t j;
 
 		for (j = 0U; j < p_shell->cmd_count; j++) {
-			p_cmd = &p_shell->shell_cmd[j];
+			p_cmd = &p_shell->cmds[j];
 
 			/* Check if we've filled the screen with info */
 			/* i + 1 used to avoid 0%SHELL_ROWS=0 */

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -29,7 +29,7 @@ struct shell {
 	char input_line[2][SHELL_CMD_MAX_LEN + 1U];	/* current & last */
 	uint32_t input_line_len;	/* Length of current input line */
 	uint32_t input_line_active;	/* Active input line index */
-	struct shell_cmd *shell_cmd;	/* cmds supported */
+	struct shell_cmd *cmds;	/* cmds supported */
 	uint32_t cmd_count;		/* Count of cmds supported */
 };
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -268,12 +268,12 @@ extern spinlock_t trampoline_spinlock;
 #define BROADCAST_CPU_ID 0xfffeU
 
 /* CPU states defined */
-enum cpu_state {
-	CPU_STATE_RESET = 0,
-	CPU_STATE_INITIALIZING,
-	CPU_STATE_RUNNING,
-	CPU_STATE_HALTED,
-	CPU_STATE_DEAD,
+enum pcpu_boot_state {
+	PCPU_STATE_RESET = 0,
+	PCPU_STATE_INITIALIZING,
+	PCPU_STATE_RUNNING,
+	PCPU_STATE_HALTED,
+	PCPU_STATE_DEAD,
 };
 
 struct cpu_state_info {

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -41,7 +41,7 @@ struct per_cpu_region {
 	struct instr_emul_ctxt g_inst_ctxt;
 	struct host_gdt gdt;
 	struct tss_64 tss;
-	enum cpu_state cpu_state;
+	enum pcpu_boot_state boot_state;
 	uint8_t mc_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t df_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t sf_stack[CONFIG_STACK_SIZE] __aligned(16);


### PR DESCRIPTION
Now we have name reuse definitions in hypervisor as following:
"enum cpu_state cpu_state" in per_cpu.h,
"struct shell_cmd *shell_cmd" in shell_priv.h.
MISRAC requires that tag names shall not be reused anywhere
with in a program.So these definitions violate MISRAC rules
"identifier resue".This patch is used to fix it.

1. modify the definitions to "enum pcpu_boot_state boot_state"
and "struct shell_cmd *cmds".
2. modifty the relevant usage.

v1->v2
    update commit message to be more explicit.

v2->v3
    update the enum definition.

Tracked-On: #861
Signed-off-by: Junjun Shan <junjun.shan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>