### PR TITLE
Fixed Acrnd crash caused by fd leaking

### DIFF
--- a/tools/acrn-manager/acrn_mngr.c
+++ b/tools/acrn-manager/acrn_mngr.c
@@ -484,7 +484,6 @@ static int connect_to_server(const char *name)
 	if ((ret >= 0) && (ret < strlen(s_name)))
 		printf("WARN: %s is truncated\n", s_name);
 
-	closedir(dir);
 	ret =
 	    connect(mfd->fd, (struct sockaddr *)&mfd->addr, sizeof(mfd->addr));
 	if (ret < 0) {
@@ -499,6 +498,7 @@ static int connect_to_server(const char *name)
 		goto alloc_val;
 	}
 
+	closedir(dir);
 	return ret;
 
  alloc_val:
@@ -507,6 +507,7 @@ static int connect_to_server(const char *name)
  sock_err:
 	free(mfd);
  alloc_mfd:
+	closedir(dir);
 	return ret;
 }
 

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -150,6 +150,7 @@ static void _scan_alive_vm(void)
 		vm->update = update_count;
 	}
 
+	closedir(dir);
 }
 
 static void _scan_added_vm(void)
@@ -218,6 +219,8 @@ static void _scan_added_vm(void)
 		vm->state = VM_CREATED;
 		vm->update = update_count;
 	}
+
+	closedir(dir);
 }
 
 static void _remove_dead_vm(void)


### PR DESCRIPTION
Fixed Acrnd crash caused by fd leaking and removed an unnecessary pre-assumption that fd num less than 1024.
Tracked-On: #1477
Signed-off-by: Tao, Yuhong <yuhong.tao@intel.com>
Signed-off-by: Yan, Like <like.yan@intel.com>