### PR TITLE
3nd vcpu state refine push

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -269,6 +269,8 @@ add_cpu(struct vmctx *ctx, int guest_ncpus)
 		mt_vmm_info[i].mt_vcpu = i;
 	}
 
+	vm_set_vcpu_regs(ctx, &ctx->bsp_regs);
+
 	error = pthread_create(&mt_vmm_info[0].mt_thr, NULL,
 	    start_thread, &mt_vmm_info[0]);
 

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -576,10 +576,13 @@ vm_system_reset(struct vmctx *ctx)
 	}
 
 	vm_reset_vdevs(ctx);
-
-	acrn_sw_load(ctx);
 	vm_reset(ctx);
 	vm_set_suspend_mode(VM_SUSPEND_NONE);
+
+	/* set the BSP init state */
+	acrn_sw_load(ctx);
+	vm_set_vcpu_regs(ctx, &ctx->bsp_regs);
+	vm_run(ctx);
 }
 
 static void
@@ -616,6 +619,10 @@ vm_suspend_resume(struct vmctx *ctx)
 	pm_backto_wakeup(ctx);
 	vm_reset_watchdog(ctx);
 	vm_reset(ctx);
+
+	/* set the BSP init state */
+	vm_set_vcpu_regs(ctx, &ctx->bsp_regs);
+	vm_run(ctx);
 }
 
 static void

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -613,6 +613,12 @@ vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id)
 }
 
 int
+vm_set_vcpu_regs(struct vmctx *ctx, struct acrn_set_vcpu_regs *vcpu_regs)
+{
+	return ioctl(ctx->fd, IC_SET_VCPU_REGS, vcpu_regs);
+}
+
+int
 vm_get_device_fd(struct vmctx *ctx)
 {
 	return ctx->fd;

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -269,6 +269,77 @@ struct acrn_create_vcpu {
 	uint16_t pcpu_id;
 } __aligned(8);
 
+struct acrn_gp_regs {
+	uint64_t rax;
+	uint64_t rcx;
+	uint64_t rdx;
+	uint64_t rbx;
+	uint64_t rsp;
+	uint64_t rbp;
+	uint64_t rsi;
+	uint64_t rdi;
+	uint64_t r8;
+	uint64_t r9;
+	uint64_t r10;
+	uint64_t r11;
+	uint64_t r12;
+	uint64_t r13;
+	uint64_t r14;
+	uint64_t r15;
+};
+
+struct acrn_descriptor_ptr {
+	uint16_t limit;
+	uint64_t base;
+	uint16_t reserved[3];
+} __attribute__((packed));
+
+struct acrn_vcpu_regs {
+	struct acrn_gp_regs gprs;
+	struct acrn_descriptor_ptr gdt;
+	struct acrn_descriptor_ptr idt;
+
+	uint64_t        rip;
+	uint64_t        cs_base;
+	uint64_t        cr0;
+	uint64_t        cr4;
+	uint64_t        cr3;
+	uint64_t        ia32_efer;
+	uint64_t        rflags;
+	uint64_t        reserved_64[4];
+
+	uint32_t        cs_ar;
+	uint32_t        reserved_32[4];
+
+	/* don't change the order of following sel */
+	uint16_t        cs_sel;
+	uint16_t        ss_sel;
+	uint16_t        ds_sel;
+	uint16_t        es_sel;
+	uint16_t        fs_sel;
+	uint16_t        gs_sel;
+	uint16_t        ldt_sel;
+	uint16_t        tr_sel;
+
+	uint16_t        reserved_16[4];
+};
+
+/**
+ * @brief Info to set vcpu state
+ *
+ * the pamameter for HC_SET_VCPU_STATE
+ */
+struct acrn_set_vcpu_regs {
+	/** the virtual CPU ID for the VCPU to set state */
+	uint16_t vcpu_id;
+
+	/** reserved space to make cpu_state aligned to 8 bytes */
+	uint16_t reserved0[3];
+
+	/** the structure to hold vcpu state */
+	struct acrn_vcpu_regs vcpu_regs;
+} __attribute__((aligned(8)));
+
 /**
  * @brief Info to set ioreq buffer for a created VM
  *

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -73,6 +73,7 @@
 #define IC_PAUSE_VM                    _IC_ID(IC_ID, IC_ID_VM_BASE + 0x03)
 #define IC_CREATE_VCPU                 _IC_ID(IC_ID, IC_ID_VM_BASE + 0x04)
 #define IC_RESET_VM                    _IC_ID(IC_ID, IC_ID_VM_BASE + 0x05)
+#define IC_SET_VCPU_REGS               _IC_ID(IC_ID, IC_ID_VM_BASE + 0x06)
 
 /* IRQ and Interrupts */
 #define IC_ID_IRQ_BASE                 0x20UL

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -64,6 +64,9 @@ struct vmctx {
 	void *vrtc;
 	void *vpit;
 	void *ioc_dev;
+
+	/* BSP state. guest loader needs to fill it */
+	struct acrn_set_vcpu_regs bsp_regs;
 };
 
 /*
@@ -148,6 +151,7 @@ int	vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
 
 int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
+int	vm_set_vcpu_regs(struct vmctx *ctx, struct acrn_set_vcpu_regs *cpu_regs);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
 int	vm_intr_monitor(struct vmctx *ctx, void *intr_buf);

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -714,36 +714,3 @@ uint64_t e820_alloc_low_memory(uint32_t size_arg)
 	pr_fatal("Can't allocate memory under 1M from E820\n");
 	return ACRN_INVALID_HPA;
 }
-
-/*******************************************************************
- *         GUEST initial GDT table
- *
- * If guest starts with protected mode, HV needs to prepare Guest GDT.
- ******************************************************************/
-
-#define GUEST_INIT_GDT_SKIP_SIZE	0x8000UL
-#define GUEST_INIT_GDT_START	(trampoline_start16_paddr +	\
-					GUEST_INIT_GDT_SKIP_SIZE)
-
-/* The GDT defined below compatible with linux kernel */
-#define GUEST_INIT_GDT_DESC_0	(0x0)
-#define GUEST_INIT_GDT_DESC_1	(0x0)
-#define GUEST_INIT_GDT_DESC_2	(0x00CF9B000000FFFFUL) /* Linear Code */
-#define GUEST_INIT_GDT_DESC_3	(0x00CF93000000FFFFUL) /* Linear Data */
-
-static const uint64_t guest_init_gdt[] = {
-	GUEST_INIT_GDT_DESC_0,
-	GUEST_INIT_GDT_DESC_1,
-	GUEST_INIT_GDT_DESC_2,
-	GUEST_INIT_GDT_DESC_3,
-};
-
-uint64_t create_guest_init_gdt(struct vm *vm, uint32_t *limit)
-{
-	void *gtd_addr = gpa2hva(vm, GUEST_INIT_GDT_START);
-
-	*limit = sizeof(guest_init_gdt) - 1U;
-	(void)memcpy_s(gtd_addr, 64U, guest_init_gdt, sizeof(guest_init_gdt));
-
-	return GUEST_INIT_GDT_START;
-};

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -293,51 +293,6 @@ void set_ap_entry(struct vcpu *vcpu, uint64_t entry)
 	vcpu_set_rip(vcpu, 0UL);
 }
 
-
-/* NOTE: set_bsp_real_mode_entry & set_bsp_protect_mode_regs is only temporary
- * function called by UOS. Once we make UOS to use hypercall to set BSP entry,
- * we will remove these two functions.
- */
-
-/*
- * @pre reset_vcpu_regs is called in advance
- */
-void set_bsp_real_mode_entry(struct vcpu *vcpu)
-{
-	struct ext_context *ectx;
-
-	ectx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx);
-
-	ectx->cs.selector = REAL_MODE_BSP_INIT_CODE_SEL;
-	ectx->cs.base = 0x3ff0000UL;
-	vcpu_set_rip(vcpu, 0xFFF0UL);
-}
-
-static struct acrn_vcpu_regs protect_mode_init_regs = {
-	.cs_ar = PROTECTED_MODE_CODE_SEG_AR,
-	.cs_sel = 0x10U,
-	.ss_sel = 0x18U,
-	.ds_sel = 0x18U,
-	.es_sel = 0x18U,
-	.cr0 = CR0_ET | CR0_NE | CR0_PE,
-	.cr3 = 0UL,
-	.cr4 = 0UL,
-};
-
-void set_bsp_protect_mode_regs(struct vcpu *vcpu)
-{
-	/* if vcpu is in protect mode, we need to set registers
-	 * according to protect_init_regs first.
-	 */
-	uint32_t limit;
-	protect_mode_init_regs.gdt.base = create_guest_init_gdt(vcpu->vm,
-			&limit);
-	protect_mode_init_regs.gdt.limit = (uint16_t) (limit & 0xFFFFU);
-	set_vcpu_regs(vcpu, &protect_mode_init_regs);
-
-	vcpu_set_rip(vcpu, (uint64_t)vcpu->entry_addr);
-}
-
 /***********************************************************************
  *
  *  @pre vm != NULL && rtn_vcpu_handle != NULL

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -661,6 +661,7 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 			} else {
 				return -EINVAL;
 			}
+			vm_sw_loader(vm);
 		} else {
 #ifdef CONFIG_EFI_STUB
 			/* currently non-vm0 will boot kernel directly */
@@ -670,7 +671,6 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 #endif
 		}
 #endif //CONFIG_PARTITION_MODE
-		vm_sw_loader(vm, vcpu);
 	} else {
 		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 	}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1210,7 +1210,6 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
 			pr_err("Start Secondary VCPU%hu for VM[%d]...",
 					target_vcpu->vcpu_id,
 					target_vcpu->vm->vm_id);
-			target_vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 			set_ap_entry(target_vcpu, vec << 12U);
 			schedule_vcpu(target_vcpu);
 		} else if (mode == APIC_DELMODE_SMI) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -304,7 +304,6 @@ int reset_vm(struct vm *vm)
 
 	foreach_vcpu(i, vm, vcpu) {
 		reset_vcpu(vcpu);
-		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 	}
 
 	if (is_vm0(vm)) {
@@ -377,7 +376,6 @@ void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec)
 	/* When SOS resume from S3, it will return to real mode
 	 * with entry set to wakeup_vec.
 	 */
-	bsp->arch_vcpu.cpu_mode = CPU_MODE_REAL;
 	set_ap_entry(bsp, wakeup_vec);
 
 	init_vmcs(bsp);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -315,7 +315,6 @@ int reset_vm(struct vm *vm)
 	destroy_secure_world(vm, false);
 	vm->sworld_control.flag.active = 0UL;
 
-	start_vm(vm);
 	return 0;
 }
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -304,11 +304,11 @@ int reset_vm(struct vm *vm)
 
 	foreach_vcpu(i, vm, vcpu) {
 		reset_vcpu(vcpu);
-
 		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
-		if (is_vcpu_bsp(vcpu)) {
-			vm_sw_loader(vm, vcpu);
-		}
+	}
+
+	if (is_vm0(vm)) {
+		vm_sw_loader(vm);
 	}
 
 	vioapic_reset(vm_ioapic(vm));

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -78,6 +78,11 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_create_vcpu(vm, (uint16_t)param1, param2);
 		break;
 
+	case HC_SET_VCPU_REGS:
+		/* param1: vmid */
+		ret = hcall_set_vcpu_regs(vm, (uint16_t)param1, param2);
+		break;
+
 	case HC_ASSERT_IRQLINE:
 		/* param1: vmid */
 		ret = hcall_assert_irqline(vm, (uint16_t)param1, param2);

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -36,17 +36,15 @@ void efi_spurious_handler(int vector)
 	return;
 }
 
-int uefi_sw_loader(struct vm *vm, struct vcpu *vcpu)
+int uefi_sw_loader(struct vm *vm)
 {
 	int ret = 0;
+	struct vcpu *vcpu = get_primary_vcpu(vm);
 	struct acrn_vcpu_regs *vcpu_regs = &vm0_boot_context;
 
 	ASSERT(vm != NULL, "Incorrect argument");
 
 	pr_dbg("Loading guest to run-time location");
-
-	if (!is_vm0(vm))
-		return load_guest(vm, vcpu);
 
 	vlapic_restore(vcpu_vlapic(vcpu), &uefi_lapic_regs);
 

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -160,8 +160,6 @@ int copy_from_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
-
-uint64_t create_guest_init_gdt(struct vm *vm, uint32_t *limit);
 extern struct acrn_vcpu_regs vm0_boot_context;
 
 #endif	/* !ASSEMBLER */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -135,10 +135,9 @@ void init_msr_emulation(struct vcpu *vcpu);
 struct run_context;
 int vmx_vmrun(struct run_context *context, int ops, int ibrs);
 
-int load_guest(struct vm *vm, struct vcpu *vcpu);
-int general_sw_loader(struct vm *vm, struct vcpu *vcpu);
+int general_sw_loader(struct vm *vm);
 
-typedef int (*vm_sw_loader_t)(struct vm *vm, struct vcpu *vcpu);
+typedef int (*vm_sw_loader_t)(struct vm *vm);
 extern vm_sw_loader_t vm_sw_loader;
 
 /* @pre Caller(Guest) should make sure gpa is continuous.

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -209,7 +209,6 @@ struct vcpu {
 	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */
 	uint16_t vcpu_id;	/* virtual identifier for VCPU */
 	struct vm *vm;		/* Reference to the VM this VCPU belongs to */
-	void *entry_addr;  /* Entry address for this VCPU when first started */
 
 	/* State of this VCPU before suspend */
 	volatile enum vcpu_state prev_state;
@@ -287,8 +286,6 @@ void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
 void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 void reset_vcpu_regs(struct vcpu *vcpu);
 void set_ap_entry(struct vcpu *vcpu, uint64_t entry);
-void set_bsp_real_mode_entry(struct vcpu *vcpu);
-void set_bsp_protect_mode_regs(struct vcpu *vcpu);
 
 static inline bool is_long_mode(struct vcpu *vcpu)
 {

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -137,6 +137,22 @@ int32_t hcall_pause_vm(uint16_t vmid);
 int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param);
 
 /**
+ * @brief set vcpu regs
+ *
+ * Set the vcpu regs. It will set the vcpu init regs from DM. Now,
+ * it's only applied to BSP. AP always uses fixed init regs.
+ * The function will return -1 if the targat VM or BSP doesn't exist.
+ *
+ * @param vm Pointer to VM data structure
+ * @param vmid ID of the VM
+ * @param param guest physical address. This gpa points to
+ *              struct acrn_vcpu_regs
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param);
+
+/**
  * @brief assert IRQ line
  *
  * Assert a virtual IRQ line for a VM, which could be from ISA or IOAPIC,

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -311,6 +311,22 @@ struct acrn_vcpu_regs {
 };
 
 /**
+ * @brief Info to set vcpu state
+ *
+ * the pamameter for HC_SET_VCPU_STATE
+ */
+struct acrn_set_vcpu_regs {
+	/** the virtual CPU ID for the VCPU to set state */
+	uint16_t vcpu_id;
+
+	/** reserved space to make cpu_state aligned to 8 bytes */
+	uint16_t reserved0[3];
+
+	/** the structure to hold vcpu state */
+	struct acrn_vcpu_regs vcpu_regs;
+} __attribute__((aligned(8)));
+
+/**
  * @brief Info to set ioreq buffer for a created VM
  *
  * the parameter for HC_SET_IOREQ_BUFFER hypercall

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -458,18 +458,6 @@ struct acrn_vm_pci_msix_remap {
 } __aligned(8);
 
 /**
- * @brief The guest config pointer offset.
- *
- * It's designed to support passing DM config data pointer, based on it,
- * hypervisor would parse then pass DM defined configuration to GUEST VCPU
- * when booting guest VM.
- * the address 0xef000 here is designed by DM, as it arranged all memory
- * layout below 1M, DM add this address to E280 reserved range to make sure
- * there is no overlap for the address 0xef000 usage.
- */
-#define GUEST_CFG_OFFSET	0xef000UL
-
-/**
  * @brief Info The power state data of a VCPU.
  *
  */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -37,6 +37,7 @@
 #define HC_PAUSE_VM                 BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x03UL)
 #define HC_CREATE_VCPU              BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x04UL)
 #define HC_RESET_VM                 BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x05UL)
+#define HC_SET_VCPU_REGS            BASE_HC_ID(HC_ID, HC_ID_VM_BASE + 0x06UL)
 
 /* IRQ and Interrupts */
 #define HC_ID_IRQ_BASE              0x20UL


### PR DESCRIPTION
This is third cycle vcpu init state refine patch. After this patchset, we don't need HV help to load UOS software any more.


Tracked-On: #1231
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>