### PR TITLE
dm: passthru: fix hardcoded nhlt table length

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -69,6 +69,8 @@
  */
 #define AUDIO_NHLT_HACK 1
 
+extern uint64_t audio_nhlt_len;
+
 /* TODO: Add support for IO BAR of PTDev */
 static int iofd = -1;
 
@@ -1555,9 +1557,10 @@ write_dsdt_hdas(struct pci_vdev *dev)
 				" MaxNotFixed, NonCacheable, ReadOnly,");
 	dsdt_line("	    0x0000000000000000, // Granularity");
 	dsdt_line("	    0x00000000000F2800, // Range Minimum");
-	dsdt_line("	    0x00000000000F2FDE, // Range Maximum");
+	dsdt_line("	    0x%08X, 		// Range Maximum",
+				0xF2800 + audio_nhlt_len -1);
 	dsdt_line("	    0x0000000000000000, // Translation Offset");
-	dsdt_line("	    0x00000000000007DF, // Length");
+	dsdt_line("	    0x%08X, 		// Length", audio_nhlt_len);
 	dsdt_line("	    ,, _Y06, AddressRangeACPI, TypeStatic)");
 	dsdt_line("    })");
 	dsdt_line("    Name (_S0W, 0x03)  // _S0W: S0 Device Wake State");

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -86,6 +86,8 @@
 #define ASL_SUFFIX	".aml"
 #define ASL_COMPILER	"/usr/sbin/iasl"
 
+uint64_t audio_nhlt_len = 0;
+
 static int basl_keep_temps;
 static int basl_verbose_iasl;
 static int basl_ncpu;
@@ -595,8 +597,10 @@ basl_fwrite_nhlt(FILE *fp, struct vmctx *ctx)
 		return -1;
 	}
 
+
+	audio_nhlt_len = lseek(fd, 0, SEEK_END);
 	/* check if file size exceeds reserved room */
-	if (lseek(fd, 0, SEEK_END) > DSDT_OFFSET - NHLT_OFFSET) {
+	if (audio_nhlt_len > DSDT_OFFSET - NHLT_OFFSET) {
 		fprintf(stderr, "Host NHLT exceeds reserved room!\n");
 		close(fd);
 		return -1;


### PR DESCRIPTION
NHLT table contains the settings some audio drivers need.
An ACPI method is used to get NHLT table address & length.
In current DM code, the NHLT talbe length in the ACPI method
is hardcoded, which will cause troubles when the length of the
table changed.
This patch replaces the hardcoded NHLT table length according to
the table length read from SOS.

Tracked-On: #1461
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>