### PR TITLE
hv: add suffix(U/UL) to come up MISRA-C into include

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -287,8 +287,8 @@ void set_ap_entry(struct vcpu *vcpu, uint64_t entry)
 	struct ext_context *ectx;
 
 	ectx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx);
-	ectx->cs.selector = (uint16_t)((entry >> 4UL) & 0xFFFFU);
-	ectx->cs.base = ectx->cs.selector << 4UL;
+	ectx->cs.selector = (uint16_t)((entry >> 4U) & 0xFFFFU);
+	ectx->cs.base = ectx->cs.selector << 4U;
 
 	vcpu_set_rip(vcpu, 0UL);
 }

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -46,9 +46,9 @@ static inline uint32_t prio(uint32_t x)
 #define VLAPIC_VERSION		(16U)
 
 #define	APICBASE_RESERVED	0x000002ffU
-#define	APICBASE_BSP		0x00000100U
+#define	APICBASE_BSP		0x00000100UL
 #define	APICBASE_X2APIC		0x00000400U
-#define	APICBASE_ENABLED	0x00000800U
+#define	APICBASE_ENABLED	0x00000800UL
 
 #define ACRN_DBG_LAPIC	6U
 
@@ -1714,7 +1714,7 @@ vlapic_enabled(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic = &(vlapic->apic_page);
 
-	if (((vlapic->msr_apicbase & APICBASE_ENABLED) != 0U) &&
+	if (((vlapic->msr_apicbase & APICBASE_ENABLED) != 0UL) &&
 			((lapic->svr.v & APIC_SVR_ENABLE) != 0U)) {
 		return true;
 	} else {

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -182,7 +182,7 @@ union ioapic_rte {
  */
 
 /* default physical locations of LOCAL (CPU) APICs */
-#define DEFAULT_APIC_BASE	0xfee00000U
+#define DEFAULT_APIC_BASE	0xfee00000UL
 
 /* constants relating to APIC ID registers */
 #define APIC_ID_MASK		0xff000000U

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -39,7 +39,7 @@
 #define CPU_H
 
 /* Define page size */
-#define CPU_PAGE_SHIFT          12
+#define CPU_PAGE_SHIFT          12U
 #define CPU_PAGE_SIZE           0x1000U
 #define CPU_PAGE_MASK           0xFFFFFFFFFFFFF000UL
 
@@ -47,7 +47,7 @@
 #define MAX_PCPU_NUM	128U
 
 #define MMU_PTE_PAGE_SHIFT	CPU_PAGE_SHIFT
-#define MMU_PDE_PAGE_SHIFT	21
+#define MMU_PDE_PAGE_SHIFT	21U
 
 /* Define CPU stack alignment */
 #define CPU_STACK_ALIGN         16UL
@@ -269,7 +269,7 @@ extern spinlock_t trampoline_spinlock;
 
 /* CPU states defined */
 enum pcpu_boot_state {
-	PCPU_STATE_RESET = 0,
+	PCPU_STATE_RESET = 0U,
 	PCPU_STATE_INITIALIZING,
 	PCPU_STATE_RUNNING,
 	PCPU_STATE_HALTED,
@@ -517,7 +517,7 @@ write_xcr(int reg, uint64_t val)
 	uint32_t low, high;
 
 	low = (uint32_t)val;
-	high = (uint32_t)(val >> 32);
+	high = (uint32_t)(val >> 32U);
 	asm volatile("xsetbv" : : "c" (reg), "a" (low), "d" (high));
 }
 #else /* ASSEMBLER defined */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -89,17 +89,17 @@ uint32_t irq_to_vector(uint32_t irq);
 /*
  * Some MSI message definitions
  */
-#define	MSI_ADDR_MASK	0xfff00000U
-#define	MSI_ADDR_BASE	0xfee00000U
-#define	MSI_ADDR_RH	0x00000008U	/* Redirection Hint */
-#define	MSI_ADDR_LOG	0x00000004U	/* Destination Mode */
+#define	MSI_ADDR_MASK	0xfff00000UL
+#define	MSI_ADDR_BASE	0xfee00000UL
+#define	MSI_ADDR_RH	0x00000008UL	/* Redirection Hint */
+#define	MSI_ADDR_LOG	0x00000004UL	/* Destination Mode */
 
 /* RFLAGS */
-#define HV_ARCH_VCPU_RFLAGS_IF              (1U<<9)
+#define HV_ARCH_VCPU_RFLAGS_IF              (1UL<<9U)
 
 /* Interruptability State info */
-#define HV_ARCH_VCPU_BLOCKED_BY_MOVSS       (1U<<1)
-#define HV_ARCH_VCPU_BLOCKED_BY_STI         (1U<<0)
+#define HV_ARCH_VCPU_BLOCKED_BY_MOVSS       (1UL<<1U)
+#define HV_ARCH_VCPU_BLOCKED_BY_STI         (1UL<<0U)
 
 void vcpu_inject_extint(struct vcpu *vcpu);
 void vcpu_inject_nmi(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -86,11 +86,11 @@
 #define LAPIC_DIVIDE_CONFIGURATION_REGISTER     0x000003E0U
 
 /* LAPIC CPUID bit and bitmask definitions */
-#define CPUID_OUT_RDX_APIC_PRESENT              ((uint64_t) 1UL <<  9)
-#define CPUID_OUT_RCX_X2APIC_PRESENT            ((uint64_t) 1UL << 21)
+#define CPUID_OUT_RDX_APIC_PRESENT              ((uint64_t) 1UL <<  9U)
+#define CPUID_OUT_RCX_X2APIC_PRESENT            ((uint64_t) 1UL << 21U)
 
 /* LAPIC MSR bit and bitmask definitions */
-#define MSR_01B_XAPIC_GLOBAL_ENABLE             ((uint64_t) 1UL << 11)
+#define MSR_01B_XAPIC_GLOBAL_ENABLE             ((uint64_t) 1UL << 11U)
 
 /* LAPIC register bit and bitmask definitions */
 #define LAPIC_SVR_VECTOR                        0x000000FFU
@@ -100,9 +100,9 @@
 #define LAPIC_DELIVERY_MODE_EXTINT_MASK         0x00000700U
 
 /* LAPIC Timer bit and bitmask definitions */
-#define LAPIC_TMR_ONESHOT                       ((uint32_t) 0x0U << 17)
-#define LAPIC_TMR_PERIODIC                      ((uint32_t) 0x1U << 17)
-#define LAPIC_TMR_TSC_DEADLINE                  ((uint32_t) 0x2U << 17)
+#define LAPIC_TMR_ONESHOT                       ((uint32_t) 0x0U << 17U)
+#define LAPIC_TMR_PERIODIC                      ((uint32_t) 0x1U << 17U)
+#define LAPIC_TMR_TSC_DEADLINE                  ((uint32_t) 0x2U << 17U)
 
 enum intr_cpu_startup_shorthand {
 	INTR_CPU_STARTUP_USE_DEST,

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -498,9 +498,9 @@
 #define MSR_IA32_EFER_NXE_BIT                   (1UL<<11U)
 
 /* FEATURE CONTROL bits */
-#define MSR_IA32_FEATURE_CONTROL_LOCK           (1U<<0)
-#define MSR_IA32_FEATURE_CONTROL_VMX_SMX        (1U<<1)
-#define MSR_IA32_FEATURE_CONTROL_VMX_NO_SMX     (1U<<2)
+#define MSR_IA32_FEATURE_CONTROL_LOCK           (1U<<0U)
+#define MSR_IA32_FEATURE_CONTROL_VMX_SMX        (1U<<1U)
+#define MSR_IA32_FEATURE_CONTROL_VMX_NO_SMX     (1U<<2U)
 
 /* PAT memory type definitions */
 #define PAT_MEM_TYPE_UC                     0x00UL	/* uncached */
@@ -553,8 +553,8 @@ static inline bool pat_mem_type_invalid(uint64_t x)
 #define MTRR_VALID                   0x800U	/* MTRR setting is  valid */
 
 /* SPEC & PRED bit */
-#define SPEC_ENABLE_IBRS		(1U<<0)
-#define SPEC_ENABLE_STIBP		(1U<<1)
-#define PRED_SET_IBPB			(1U<<0)
+#define SPEC_ENABLE_IBRS		(1U<<0U)
+#define SPEC_ENABLE_STIBP		(1U<<1U)
+#define PRED_SET_IBPB			(1U<<0U)
 
 #endif /* MSR_H */

--- a/hypervisor/include/arch/x86/mtrr.h
+++ b/hypervisor/include/arch/x86/mtrr.h
@@ -7,7 +7,7 @@
 #define MTRR_H
 
 #define FIXED_RANGE_MTRR_NUM	11U
-#define MTRR_SUB_RANGE_NUM		8U
+#define MTRR_SUB_RANGE_NUM	8U
 
 union mtrr_cap_reg {
 	uint64_t value;

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -7,9 +7,9 @@
 #ifndef TRUSTY_H_
 #define TRUSTY_H_
 
-#define BOOTLOADER_SEED_MAX_ENTRIES    10U
-#define RPMB_MAX_PARTITION_NUMBER       6
-#define MMC_PROD_NAME_WITH_PSN_LEN      15
+#define BOOTLOADER_SEED_MAX_ENTRIES     10U
+#define RPMB_MAX_PARTITION_NUMBER       6U
+#define MMC_PROD_NAME_WITH_PSN_LEN      15U
 #define BUP_MKHI_BOOTLOADER_SEED_LEN    64U
 
 /* Trusty EPT rebase gpa: 511G */

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -315,13 +315,13 @@ static inline uint8_t dma_ccmd_get_caig_32(uint32_t gaig)
 
 
 /* IOTLB_REG */
-#define DMA_IOTLB_IVT				(((uint64_t)1UL) << 63)
-#define DMA_IOTLB_IVT_32			(((uint32_t)1U) << 31)
-#define DMA_IOTLB_GLOBAL_INVL		(((uint64_t)1UL) << 60)
-#define DMA_IOTLB_DOMAIN_INVL		(((uint64_t)2UL) << 60)
-#define DMA_IOTLB_PAGE_INVL			(((uint64_t)3UL) << 60)
-#define DMA_IOTLB_DR				(((uint64_t)1UL) << 49)
-#define DMA_IOTLB_DW				(((uint64_t)1UL) << 48)
+#define DMA_IOTLB_IVT				(((uint64_t)1UL) << 63U)
+#define DMA_IOTLB_IVT_32			(((uint32_t)1U)  << 31U)
+#define DMA_IOTLB_GLOBAL_INVL			(((uint64_t)1UL) << 60U)
+#define DMA_IOTLB_DOMAIN_INVL			(((uint64_t)2UL) << 60U)
+#define DMA_IOTLB_PAGE_INVL			(((uint64_t)3UL) << 60U)
+#define DMA_IOTLB_DR				(((uint64_t)1UL) << 49U)
+#define DMA_IOTLB_DW				(((uint64_t)1UL) << 48U)
 static inline uint64_t dma_iotlb_did(uint16_t did)
 {
 	return (((uint64_t)(did & 0xffffU)) << 32U);
@@ -338,10 +338,10 @@ static inline uint8_t dma_iotlb_invl_addr_am(uint8_t am)
 	return (am & 0x3fU);
 }
 
-#define DMA_IOTLB_INVL_ADDR_IH_UNMODIFIED	(((uint64_t)1UL) << 6)
+#define DMA_IOTLB_INVL_ADDR_IH_UNMODIFIED	(((uint64_t)1UL) << 6U)
 
 /* FECTL_REG */
-#define DMA_FECTL_IM				(((uint32_t)1U) << 31)
+#define DMA_FECTL_IM				(((uint32_t)1U) << 31U)
 
 /* FSTS_REG */
 static inline bool dma_fsts_pfo(uint32_t pfo)
@@ -441,7 +441,7 @@ static inline uint32_t dma_frcd_up_sid(uint64_t up_sid)
 
 #define DRHD_FLAG_INCLUDE_PCI_ALL_MASK      (1U)
 
-#define DEVFUN(dev, fun)            (((dev & 0x1FU) << 3) | ((fun & 0x7U)))
+#define DEVFUN(dev, fun)            (((dev & 0x1FU) << 3U) | ((fun & 0x7U)))
 
 struct dmar_dev_scope {
 	uint8_t bus;

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -42,12 +42,12 @@
 /* IOAPIC device model info */
 #define VIOAPIC_RTE_NUM	48U  /* vioapic pins */
 
-#if VIOAPIC_RTE_NUM < 24
+#if VIOAPIC_RTE_NUM < 24U
 #error "VIOAPIC_RTE_NUM must be larger than 23"
 #endif
 
 /* Generic VM flags from guest OS */
-#define SECURE_WORLD_ENABLED    (1UL<<0)  /* Whether secure world is enabled */
+#define SECURE_WORLD_ENABLED    (1UL<<0U)  /* Whether secure world is enabled */
 
 /**
  * @brief Hypercall
@@ -524,9 +524,9 @@ struct pm_s_state_data {
 #define PMCMD_STATE_NUM_MASK	0x0000ff00U
 #define PMCMD_TYPE_MASK		0x000000ffU
 
-#define PMCMD_VMID_SHIFT	24
-#define PMCMD_VCPUID_SHIFT	16
-#define PMCMD_STATE_NUM_SHIFT	8
+#define PMCMD_VMID_SHIFT	24U
+#define PMCMD_VCPUID_SHIFT	16U
+#define PMCMD_STATE_NUM_SHIFT	8U
 
 enum pm_cmd_type {
 	PMCMD_GET_PX_CNT,

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -19,7 +19,7 @@
  * Common structures for HV/VHM
  */
 
-#define BASE_HC_ID(x, y) (((x)<<24)|(y))
+#define BASE_HC_ID(x, y) (((x)<<24U)|(y))
 
 #define HC_ID 0x80UL
 


### PR DESCRIPTION
MISRA-C required the suffix(U/UL), such as:
(1) ---> (1U)
(1) ---> (1UL)
(1U << 0) ---> (1U << 0U)
This patch will add the suffix(U/UL) to come up MISRA-C into
hypervisor/include directory.

Tracked-On: #1468
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>