### PR TITLE
vuart: change irq from 4 to 6

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -45,8 +45,8 @@ is_entry_active(struct ptdev_remapping_info *entry)
 
 static bool ptdev_hv_owned_intx(struct vm *vm, union source_id *virt_sid)
 {
-	/* vm0 pin 4 (uart) is owned by hypervisor under debug version */
-	if (is_vm0(vm) && (virt_sid->intx_id.pin == 4U)) {
+	/* vm0 vuart pin is owned by hypervisor under debug version */
+	if (is_vm0(vm) && (virt_sid->intx_id.pin == COM1_IRQ)) {
 		return true;
 	} else {
 		return false;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -33,7 +33,6 @@
 #include "uart16550.h"
 
 #define COM1_BASE		0x3F8U
-#define COM1_IRQ		4U
 
 #ifndef CONFIG_PARTITION_MODE
 static char vuart_rx_buf[RX_BUF_SIZE];

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -69,11 +69,13 @@ struct acrn_vuart {
 extern int8_t vuart_vmid;
 #endif
 #ifdef HV_DEBUG
+#define COM1_IRQ		6U
 void vuart_init(struct vm *vm);
 struct acrn_vuart *vuart_console_active(void);
 void vuart_console_tx_chars(struct acrn_vuart *vu);
 void vuart_console_rx_chars(struct acrn_vuart *vu);
 #else
+#define COM1_IRQ		0xFFU
 static inline void vuart_init(__unused struct vm *vm)
 {
 }


### PR DESCRIPTION
vuart: change irq from 4 to 6

irq 4 is sharing with idma, after change vuart to level trigger, the idma
driver could handle this irq 4 and send out EOI, which cause the irq storm.

move vuart irq to a not used 6.

Tracked-On: https://github.com/projectacrn/acrn-hypervisor/issues/1476
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>

