### PR TITLE
dm: uart: fix acrn-dm crash issue

### DIFF
--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -188,8 +188,10 @@ rxfifo_reset(struct uart_vdev *uart, int size)
 		 * Enable mevent to trigger when new characters are available
 		 * on the tty fd.
 		 */
-		error = mevent_enable(uart->mev);
-		assert(error == 0);
+		if (isatty(uart->tty.fd)) {
+			error = mevent_enable(uart->mev);
+			assert(error == 0);
+		}
 	}
 }
 
@@ -219,8 +221,10 @@ rxfifo_putchar(struct uart_vdev *uart, uint8_t ch)
 				/*
 				 * Disable mevent callback if the FIFO is full.
 				 */
-				error = mevent_disable(uart->mev);
-				assert(error == 0);
+				if (isatty(uart->tty.fd)) {
+					error = mevent_disable(uart->mev);
+					assert(error == 0);
+				}
 			}
 		}
 		return 0;
@@ -243,7 +247,7 @@ rxfifo_getchar(struct uart_vdev *uart)
 		fifo->rindex = (fifo->rindex + 1) % fifo->size;
 		fifo->num--;
 		if (wasfull) {
-			if (uart->tty.opened) {
+			if (uart->tty.opened && isatty(uart->tty.fd)) {
 				error = mevent_enable(uart->mev);
 				assert(error == 0);
 			}


### PR DESCRIPTION
This patch resolves acrn-dm crash issue when acrnd boots up the acrn-dm.
The rootcause is mevent_enable and mevent_disable have NULL pointer as
its parameter if uart backend is not tty capable, so add check code for
the uart backend before invoking mevent_enable and mevent_disable.

The issue can be reproduced when acrnd boots up the acrn-dm.

Tracked-On: #1466
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Tomas Winkler <tomas.winkler@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>