### PR TITLE
HV:fix 'missing for discarded return value' violations

### DIFF
--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -71,7 +71,7 @@ void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
 
 	msr_write(MSR_IA32_BIOS_UPDT_TRIG,
 			(uint64_t)ucode_ptr + sizeof(struct ucode_header));
-	get_microcode_version();
+	(void)get_microcode_version();
 
 	free(ucode_ptr);
 }

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -692,14 +692,14 @@ vlapic_mask_lvts(struct acrn_vlapic *vlapic)
 	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_ERROR_LVT);
 }
 
-static int
+static void
 vlapic_fire_lvt(struct acrn_vlapic *vlapic, uint32_t lvt)
 {
 	uint32_t vec, mode;
 	struct vcpu *vcpu = vlapic->vcpu;
 
 	if ((lvt & APIC_LVT_M) != 0U) {
-		return 0;
+		return;
 	}
 
 	vec = lvt & APIC_LVT_VECTOR;
@@ -709,7 +709,7 @@ vlapic_fire_lvt(struct acrn_vlapic *vlapic, uint32_t lvt)
 	case APIC_LVT_DM_FIXED:
 		if (vec < 16U) {
 			vlapic_set_error(vlapic, APIC_ESR_SEND_ILLEGAL_VECTOR);
-			return 0;
+			return;
 		}
 		if (vlapic_set_intr_ready(vlapic, vec, false) != 0) {
 			vcpu_make_request(vcpu, ACRN_REQUEST_EVENT);
@@ -723,9 +723,10 @@ vlapic_fire_lvt(struct acrn_vlapic *vlapic, uint32_t lvt)
 		break;
 	default:
 		/* Other modes ignored */
-		return 0;
+		pr_warn("func:%s other mode is not support\n",__func__);
+		return;
 	}
-	return 1;
+	return;
 }
 
 static void

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -71,7 +71,7 @@ void free_irq_num(uint32_t irq)
 
 	if (irq_is_gsi(irq) == false) {
 		spinlock_irqsave_obtain(&irq_alloc_spinlock, &rflags);
-		bitmap_test_and_clear_nolock((uint16_t)(irq & 0x3FU),
+		(void)bitmap_test_and_clear_nolock((uint16_t)(irq & 0x3FU),
 					     irq_alloc_bitmap + (irq >> 6U));
 		spinlock_irqrestore_release(&irq_alloc_spinlock, rflags);
 	}

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -166,7 +166,7 @@ static void update_ept_mem_type(struct vcpu *vcpu)
 	 * - when def_type.FE is clear, MTRRdefType.type is applied
 	 */
 	if (!is_mtrr_enabled(vcpu) || !is_fixed_range_mtrr_enabled(vcpu)) {
-		update_ept(vcpu->vm, 0U, MAX_FIXED_RANGE_ADDR,
+		(void)update_ept(vcpu->vm, 0U, MAX_FIXED_RANGE_ADDR,
 			get_default_memory_type(vcpu));
 		return;
 	}
@@ -182,14 +182,14 @@ static void update_ept_mem_type(struct vcpu *vcpu)
 			if (type == vcpu->mtrr.fixed_range[i].type[j]) {
 				size += get_subrange_size_of_fixed_mtrr(i);
 			} else {
-				update_ept(vcpu->vm, start, size, type);
+			  (void)update_ept(vcpu->vm, start, size, type);
 				type = vcpu->mtrr.fixed_range[i].type[j];
 				start = get_subrange_start_of_fixed_mtrr(i, j);
 				size = get_subrange_size_of_fixed_mtrr(i);
 			}
 		}
 
-		update_ept(vcpu->vm, start, size, type);
+		(void)update_ept(vcpu->vm, start, size, type);
 	}
 }
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1165,9 +1165,10 @@ int assign_iommu_device(struct iommu_domain *domain, uint8_t bus,
 
 	/* TODO: check if the device assigned */
 
-	remove_iommu_device(vm0_domain, 0U, bus, devfun);
-	add_iommu_device(domain, 0U, bus, devfun);
-	return 0;
+	if (remove_iommu_device(vm0_domain, 0U, bus, devfun) == 1) {
+		return 1;
+	}
+	return add_iommu_device(domain, 0U, bus, devfun);
 }
 
 int unassign_iommu_device(struct iommu_domain *domain, uint8_t bus,
@@ -1179,9 +1180,10 @@ int unassign_iommu_device(struct iommu_domain *domain, uint8_t bus,
 
 	/* TODO: check if the device assigned */
 
-	remove_iommu_device(domain, 0U, bus, devfun);
-	add_iommu_device(vm0_domain, 0U, bus, devfun);
-	return 0;
+	if (remove_iommu_device(domain, 0U, bus, devfun) == 1) {
+		return 1;
+	}
+	return add_iommu_device(vm0_domain, 0U, bus, devfun);
 }
 
 void enable_iommu(void)

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -242,8 +242,7 @@ int32_t hcall_reset_vm(uint16_t vmid)
 		return -1;
 	}
 
-	reset_vm(target_vm);
-	return 0;
+	return reset_vm(target_vm);
 }
 
 /**
@@ -905,7 +904,7 @@ int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param)
 {
 	struct hv_npk_log_param npk_param;
 
-	memset((void *)&npk_param, 0U, sizeof(npk_param));
+	(void)memset((void *)&npk_param, 0U, sizeof(npk_param));
 
 	if (copy_from_gpa(vm, &npk_param, param, sizeof(npk_param)) != 0) {
 		pr_err("%s: Unable copy param from vm\n", __func__);


### PR DESCRIPTION
Return value should be checked,fix it by add
"void" when the function return value is not used.

V1->V2:
    replace printf with pr_warn.
V2->V3:
    change the commit to make read easily.

Tracked-On::#861

Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>