### PR TITLE
Documentation: add note and instructions for Ubuntu 16.04

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -447,6 +447,19 @@ each with their own way to install development tools:
      $ sudo pip3 install kconfiglib
 
   .. note::
+     You need to use ``gcc`` version 7.3.* or higher else you will run into issue
+     `#1396 <https://github.com/projectacrn/acrn-hypervisor/issues/1396>`_. Follow
+     these instructions to install the ``gcc-7`` package on Ubuntu 16.04:
+
+     .. code-block:: none
+
+        $ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        $ sudo apt update
+        $ sudo apt install g++-7 -y
+        $ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
+                             --slave /usr/bin/g++ g++ /usr/bin/g++-7
+
+  .. note::
      Ubuntu 14.04 requires ``libsystemd-journal-dev`` instead of ``libsystemd-dev``
      as indicated above.
 


### PR DESCRIPTION
There is a compilation error when using the stock gcc compiler
from Ubuntu 16.04. This adds a note to our Getting Started
Guide to indicate what the error is and how to work around it.

Tracked-On: #1482

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>