### PR TITLE
hv: retain rip if the fault is injected to guest

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -261,6 +261,9 @@ static void vcpu_inject_exception(struct vcpu *vcpu, uint32_t vector)
 			(exception_type[vector] << 8U) | (vector & 0xFFU));
 
 	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
+
+	/* retain rip for exception injection */
+	vcpu_retain_rip(vcpu);
 }
 
 static int vcpu_inject_hi_exception(struct vcpu *vcpu)


### PR DESCRIPTION
According to SDM 6.5 exception classification, if the fault
happens, the CPU will return to the faulting instruction. So
we shouldn't change rip to the next instruction if inject fault
to guest.

Tracked-on: #1473
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>