### PR TITLE
fix "use of single line comments(s) //"

### DIFF
--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -498,4 +498,5 @@ void restore_sworld_context(struct vcpu *vcpu)
 
 /**
  * @}
- */ // End of trusty_apis
+ */
+/* End of trusty_apis */

--- a/hypervisor/bsp/uefi/efi/multiboot.h
+++ b/hypervisor/bsp/uefi/efi/multiboot.h
@@ -42,8 +42,6 @@
 struct multiboot_info;
 extern struct multiboot_info mbi;
 
-// ========================================================================
-
 /*
  * Multiboot header structure.
  */
@@ -79,7 +77,6 @@ struct multiboot_header {
  */
 extern struct multiboot_header *Multiboot_Header;
 
-// ========================================================================
 /*
  * Multiboot information structure.
  */
@@ -178,7 +175,5 @@ struct multiboot_module {
 };
 
 #endif /* !defined(_LOCORE) */
-
-// ========================================================================
 
 #endif /* _MULTIBOOT_H */

--- a/hypervisor/bsp/uefi/efi/pe.c
+++ b/hypervisor/bsp/uefi/efi/pe.c
@@ -43,7 +43,7 @@
 #include <efilib.h>
 #include "stdlib.h"
 
-#define	DOS_FILE_MAGIC_NUMBER	0x5A4D  //"MZ"
+#define	DOS_FILE_MAGIC_NUMBER	0x5A4D  /* "MZ" */
 struct DosFileHeader {
 	uint16_t  mMagic;
         uint16_t  LastSize;
@@ -68,7 +68,7 @@ struct DosFileHeader {
 
 #define IMAGE_FILE_MACHINE_I386	0x14c
 #define IMAGE_FILE_MACHINE_AMD64    0x8664
-#define PE_FILE_MAGIC_NUMBER	0x00004550 	//"PE\0\0" 
+#define PE_FILE_MAGIC_NUMBER	0x00004550 	/* "PE\0\0" */
 struct PeHeader {
 	uint32_t mMagic; 
 	uint16_t mMachine;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -49,7 +49,7 @@ struct per_cpu_region {
 	char logbuf[LOG_MESSAGE_MAX_SIZE];
 	uint32_t lapic_id;
 	struct smp_call_info_data smp_call_info;
-} __aligned(CPU_PAGE_SIZE); //per_cpu_region size aligned with CPU_PAGE_SIZE
+} __aligned(CPU_PAGE_SIZE); /* per_cpu_region size aligned with CPU_PAGE_SIZE */
 
 extern struct per_cpu_region *per_cpu_data_base_ptr;
 extern uint16_t phys_cpu_num;

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -486,7 +486,8 @@ int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu);
 
 /**
  * @}
- */ // End of trusty_hypercall
+ */
+/* End of trusty_hypercall */
 
 /**
  * @brief set upcall notifier vector
@@ -505,6 +506,7 @@ int32_t hcall_set_callback_vector(struct vm *vm, uint64_t param);
 
 /**
  * @}
- */ // End of acrn_hypercall
+ */
+/* End of acrn_hypercall */
 
 #endif /* HYPERCALL_H*/


### PR DESCRIPTION
Replace "//" with '/*','*/' couples.

Tracked-on:#861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>