### PR TITLE
Add string api, replace banned functions for virtio-blk

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -56,6 +56,9 @@ LIBS += -luuid
 LIBS += -lusb-1.0
 LIBS += -lacrn-mngr
 
+# lib
+SRCS += lib/dm_string.c
+
 # hw
 SRCS += hw/block_if.c
 SRCS += hw/usb_core.c

--- a/devicemodel/include/dm_string.h
+++ b/devicemodel/include/dm_string.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef _DM_STRING_H_
+#define _DM_STRING_H_
+
+/**
+ * @brief Convert string to a long integer.
+ *
+ * @param s Pointer to original string.
+ * @param end Pointer to end string.
+ * @param base Base: 8, 10, 16...
+ * @param val Long integer convert from string.
+ *
+ * @return -1 error.
+ * @return 0  no error.
+ */
+
+int dm_strtol(char *s, char **end, unsigned int base, long *val);
+
+/**
+ * @brief Convert string to an integer.
+ *
+ * @param s Pointer to original string.
+ * @param end Pointer to end string.
+ * @param base Base: 8, 10, 16...
+ * @param val Integer convert from string.
+ *
+ * @return -1 error.
+ * @return 0  no error.
+ */
+
+int dm_strtoi(char *s, char **end, unsigned int base, int *val);
+
+/**
+ * @brief Convert string to an unsigned long integer.
+ *
+ * @param s Pointer to original string.
+ * @param end Pointer to end string.
+ * @param base Base: 8, 10, 16...
+ * @param val Unsigned long integer convert from string.
+ *
+ * @return -1 error.
+ * @return 0  no error.
+ */
+
+int dm_strtoul(char *s, char **end, unsigned int base, unsigned long *val);
+
+/**
+ * @brief Convert string to an unsigned integer.
+ *
+ * @param s Pointer to original string.
+ * @param end Pointer to end string after strtol.
+ * @param base Base: 8, 10, 16...
+ * @param val Unsigned integer convert from string.
+ *
+ * @return -1 error.
+ * @return 0  no error.
+ */
+
+int dm_strtoui(char *s, char **end, unsigned int base, unsigned int *val);
+
+#endif

--- a/devicemodel/lib/dm_string.c
+++ b/devicemodel/lib/dm_string.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "dm_string.h"
+
+int
+dm_strtol(char *s, char **end, unsigned int base, long *val)
+{
+	if (!s)
+		goto err;
+
+	*val = strtol(s, end, base);
+	if (*end == s) {
+		printf("ERROR! nothing covert for: %s!\n", s);
+		goto err;
+	}
+	return 0;
+
+err:
+	return -1;
+}
+
+int
+dm_strtoi(char *s, char **end, unsigned int base, int *val)
+{
+	long l_val;
+	int ret;
+
+	l_val = 0;
+	ret = dm_strtol(s, end, base, &l_val);
+	*val = (int)l_val;
+	return ret;
+}
+
+int
+dm_strtoul(char *s, char **end, unsigned int base, unsigned long *val)
+{
+	if (!s)
+		goto err;
+
+	*val = strtoul(s, end, base);
+	if (*end == s) {
+		printf("ERROR! nothing covert for: %s!\n", s);
+		goto err;
+	}
+	return 0;
+
+err:
+	return -1;
+}
+
+int
+dm_strtoui(char *s, char **end, unsigned int base, unsigned int *val)
+{
+	unsigned long l_val;
+	int ret;
+
+	l_val = 0;
+	ret = dm_strtoul(s, end, base, &l_val);
+	*val = (unsigned int)l_val;
+	return ret;
+}


### PR DESCRIPTION
1.  As function sscanf is banned, to get value from parameter buffer,strto*
    is recommended. To reduce the inspection code when using strto*, it's
    better to use a string convert API.
2.  replace banned functions for virtio-blk.