### PR TITLE
Documentation: typo in Ubuntu tutorial and additional note

### DIFF
--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -268,7 +268,7 @@ For the User OS, we are using the same `Clear Linux`_ release version as the Ser
 
   .. code-block:: none
 
-     sudo apt-get instal iasl
+     sudo apt-get install iasl
      sudo cp /usr/bin/iasl /usr/sbin/iasl
 
 * Adjust ``launch_uos.sh``
@@ -329,7 +329,11 @@ script example shows how to set this up (verified in Ubuntu 14.04 and 16.04 as t
   
     brctl addif acrn-br0 acrn_tap0
     ip link set dev acrn_tap0 up
- 
+
+.. note::
+   The SOS network interface is called ``enp3s0`` in the script above. You will need
+   to adjust the script if your system uses a different name (e.g. ``eno1``).
+
 Enabling USB keyboard and mouse
 *******************************
 


### PR DESCRIPTION
Fix one typo (in a command) in the tutorial entitled "Using
Ubuntu as the Service OS".

Add a note explaining that a script may have to be adjusted
based on the HW set-up (network interface name).

Tracked-On: #1502

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>