### PR TITLE
hv:Simplify for-loop when walk through the vcpu

### DIFF
--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -38,11 +38,11 @@ uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 	uint64_t dmask = 0UL;
 	struct vcpu *vcpu;
 
-	for (vcpu_id = ffs64(vdmask); vcpu_id != INVALID_BIT_INDEX;
-		vcpu_id = ffs64(vdmask)) {
-		bitmap_clear_lock(vcpu_id, &vdmask);
-		vcpu = vcpu_from_vid(vm, vcpu_id);
-		bitmap_set_lock(vcpu->pcpu_id, &dmask);
+	for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
+		if (vdmask & (1U << vcpu_id)) {
+			vcpu = vcpu_from_vid(vm, vcpu_id);
+			bitmap_set_lock(vcpu->pcpu_id, &dmask);
+		}
 	}
 
 	return dmask;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -319,12 +319,12 @@ int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param)
 		return -1;
 	}
 
-	vcpu = vcpu_from_vid(target_vm, vcpu_regs.vcpu_id);
-	if (vcpu == NULL) {
+	if (vcpu_regs.vcpu_id >= CONFIG_MAX_VCPUS_PER_VM) {
 		pr_err("%s: invalid vcpu_id for set_vcpu_regs\n", __func__);
 		return -1;
 	}
 
+	vcpu = vcpu_from_vid(target_vm, vcpu_regs.vcpu_id);
 	set_vcpu_regs(vcpu, &(vcpu_regs.vcpu_regs));
 
 	return 0;
@@ -437,13 +437,13 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 	dev_dbg(ACRN_DBG_HYCALL, "[%d] NOTIFY_FINISH for vcpu %d",
 			vmid, vcpu_id);
 
-	vcpu = vcpu_from_vid(target_vm, vcpu_id);
-	if (vcpu == NULL) {
+	if (vcpu_id >= CONFIG_MAX_VCPUS_PER_VM) {
 		pr_err("%s, failed to get VCPU %d context from VM %d\n",
 			__func__, vcpu_id, target_vm->vm_id);
 		return -EINVAL;
 	}
 
+	vcpu = vcpu_from_vid(target_vm, vcpu_id);
 	emulate_io_post(vcpu);
 
 	return 0;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -651,13 +651,13 @@ static int shell_vcpu_dumpreg(int argc, char **argv)
 		goto out;
 	}
 
-	vcpu = vcpu_from_vid(vm, vcpu_id);
-	if (vcpu == NULL) {
+	if (vcpu_id >= CONFIG_MAX_VCPUS_PER_VM) {
 		shell_puts("No vcpu found in the input <vm_id, vcpu_id>\r\n");
 		status = -EINVAL;
 		goto out;
 	}
 
+	vcpu = vcpu_from_vid(vm, vcpu_id);
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
 	dump.str_max = CPU_PAGE_SIZE;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -199,6 +199,9 @@ static inline bool is_vm0(struct vm *vm)
 	return (vm->vm_id) == 0U;
 }
 
+/*
+ * @pre vcpu_id < CONFIG_MAX_VCPUS_PER_VM
+ */
 static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 {
 	uint16_t i;
@@ -206,11 +209,10 @@ static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (vcpu->vcpu_id == vcpu_id) {
-			return vcpu;
+			break;
 		}
 	}
-
-	return NULL;
+	return vcpu;
 }
 
 static inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)


### PR DESCRIPTION
-- Not return NULL for vcpu_from_vid
  We have replaced dynamic memory with static memory for vcpu,
  then if vcpu_id is valid, this API should not return NULL.
-- Simplify the for-loop when walk through the vcpu

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Reviewed-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>