### PR TITLE
tools: acrnd: Refine log msg to avoid confusing.

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -281,14 +281,13 @@ static int send_msg(const char *vmname, struct mngr_msg *req,
 
 	fd = mngr_open_un(vmname, MNGR_CLIENT);
 	if (fd < 0) {
-		printf("%s: Unable to open %s. line %d\n", __FUNCTION__,
-		       vmname, __LINE__);
+		printf("Unable to open vm %s socket. It may have been shutdown\n", vmname);
 		return -1;
 	}
 
 	ret = mngr_send_msg(fd, req, ack, 1);
 	if (ret < 0) {
-		printf("%s: Unable to send msg\n", __FUNCTION__);
+		printf("Unable to send msg to vm %s socket. It may have been shutdown\n", vmname);
 		mngr_close(fd);
 		return ret;
 	}

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -423,11 +423,17 @@ static int wait_for_stop(unsigned int timeout)
 
 	/* list and update the vm status */
 	do {
-		if (check_vms_status(VM_CREATED) == 0)
-			return SHUTDOWN;
+		printf("Waiting %lu seconds for all vms enter S3/S5 state\n", t);
 
-		if (check_vms_status(VM_PAUSED) == 0)
+		if (check_vms_status(VM_CREATED) == 0) {
+			printf("All vms have entered S5 state successfully\n");
+			return SHUTDOWN;
+		}
+
+		if (check_vms_status(VM_PAUSED) == 0) {
+			printf("All vms have entered S3 state successfully\n");
 			return SUSPEND;
+		}
 
 		sleep(1);
 	}
@@ -446,7 +452,7 @@ static void* notify_stop_state(void *arg)
 
 	rc = wait_for_stop(acrnd_stop_timeout);
 	if (rc < 0) {
-		fprintf(stderr, "cannot get VMs stop state\n");
+		fprintf(stderr, "Timeout(%u sec) to wait all vms enter S3/S5\n", acrnd_stop_timeout);
 		req.msgid = SUSPEND;
 		req.data.err = -1;
 	} else {


### PR DESCRIPTION
When guest enter S5, its monitor socket will be closed. If we try to use it to
query the vm state, an error msg will be print out. Acctually, we should not take
it as an error.

So, this patch refine the log msg to show more details when guest trying to enter
S3/S5.

Tracked-On: #1506
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>