### PR TITLE
add pre-assumption for hpa2gpa

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -103,19 +103,12 @@ uint64_t gpa2hpa(struct vm *vm, uint64_t gpa)
 	return local_gpa2hpa(vm, gpa, NULL);
 }
 
-uint64_t hpa2gpa(struct vm *vm, uint64_t hpa)
+/**
+ * @pre: the gpa and hpa are identical mapping in SOS.
+ */
+uint64_t vm0_hpa2gpa(uint64_t hpa)
 {
-	uint64_t *pgentry, pg_size = 0UL;
-
-	pgentry = lookup_address((uint64_t *)vm->arch_vm.m2p,
-			hpa, &pg_size, PTT_EPT);
-	if (pgentry == NULL) {
-		pr_err("VM %d hpa2gpa: failed for hpa 0x%llx",
-				vm->vm_id, hpa);
-		ASSERT(false, "hpa2gpa not found");
-	}
-	return ((*pgentry & (~(pg_size - 1UL)))
-			| (hpa & (pg_size - 1UL)));
+	return hpa;
 }
 
 int ept_violation_vmexit_handler(struct vcpu *vcpu)

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -88,9 +88,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 	vm->hw.gpa_lowtop = 0UL;
 
 	vm->arch_vm.nworld_eptp = alloc_paging_struct();
-	vm->arch_vm.m2p = alloc_paging_struct();
-	if ((vm->arch_vm.nworld_eptp == NULL) ||
-			(vm->arch_vm.m2p == NULL)) {
+	if (vm->arch_vm.nworld_eptp == NULL) {
 		pr_fatal("%s, alloc memory for EPTP failed\n", __func__);
 		status = -ENOMEM;
 		goto err;
@@ -178,10 +176,6 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 err:
 
 	vioapic_cleanup(vm_ioapic(vm));
-
-	if (vm->arch_vm.m2p != NULL) {
-		free(vm->arch_vm.m2p);
-	}
 
 	if (vm->arch_vm.nworld_eptp != NULL) {
 		free(vm->arch_vm.nworld_eptp);

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -131,7 +131,8 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 			hpa, gpa_rebased, size, EPT_RWX | EPT_WB);
 
 	/* Get the gpa address in SOS */
-	gpa = hpa2gpa(vm0, hpa);
+	gpa = vm0_hpa2gpa(hpa);
+
 	/* Unmap trusty memory space from sos ept mapping*/
 	ept_mr_del(vm0, (uint64_t *)vm0->arch_vm.nworld_eptp,
 			gpa, size);

--- a/hypervisor/boot/sbl/sbl_seed_parse.c
+++ b/hypervisor/boot/sbl/sbl_seed_parse.c
@@ -140,7 +140,7 @@ bool sbl_seed_parse(struct vm *vm, char *cmdline, char *out_arg, uint32_t out_le
 	struct image_boot_params *boot_params;
 	uint32_t len;
 
-	if (cmdline == NULL) {
+	if (!is_vm0(vm) || (cmdline == NULL)) {
 		goto fail;
 	}
 
@@ -165,10 +165,8 @@ bool sbl_seed_parse(struct vm *vm, char *cmdline, char *out_arg, uint32_t out_le
 	 * Convert the addresses to SOS GPA since this structure will
 	 * be used in SOS.
 	 */
-	boot_params->p_seed_list =
-			hpa2gpa(vm, boot_params->p_seed_list);
-	boot_params->p_platform_info =
-			hpa2gpa(vm, boot_params->p_platform_info);
+	boot_params->p_seed_list = vm0_hpa2gpa(boot_params->p_seed_list);
+	boot_params->p_platform_info = vm0_hpa2gpa(boot_params->p_platform_info);
 
 	/*
 	 * Replace original arguments with spaces since SOS's GPA is not

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -47,8 +47,9 @@ static uint64_t create_zero_page(struct vm *vm)
 	uint64_t gpa, addr;
 
 	/* Set zeropage in Linux Guest RAM region just past boot args */
-	hva = gpa2hva(vm, (uint64_t)sw_linux->bootargs_load_addr);
-	zeropage = (struct zero_page *)((char *)hva + MEM_4K);
+	gpa = (uint64_t)sw_linux->bootargs_load_addr + MEM_4K;
+	hva = gpa2hva(vm, gpa);
+	zeropage = hva;
 
 	/* clear the zeropage */
 	(void)memset(zeropage, 0U, MEM_2K);
@@ -77,9 +78,6 @@ static uint64_t create_zero_page(struct vm *vm)
 
 	/* Create/add e820 table entries in zeropage */
 	zeropage->e820_nentries = (uint8_t)create_e820_table(zeropage->e820);
-
-	/* Get the host physical address of the zeropage */
-	gpa = hpa2gpa(vm, hva2hpa((void *)zeropage));
 
 	/* Return Physical Base Address of zeropage */
 	return gpa;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -97,7 +97,6 @@ struct vm_arch {
 	 * but Normal World can not access Secure World's memory.
 	 */
 	void *sworld_eptp;
-	void *m2p;		/* machine address to guest physical address */
 	void *tmp_pg_array;	/* Page array for tmp guest paging struct */
 	struct acrn_vioapic vioapic;	/* Virtual IOAPIC base address */
 	struct acrn_vpic vpic;      /* Virtual PIC */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -134,6 +134,7 @@ static inline void clflush(volatile void *p)
  * host physical address width is 52
  */
 #define INVALID_HPA	(0x1UL << 52U)
+#define INVALID_GPA	(0x1UL << 52U)
 /* External Interfaces */
 void destroy_ept(struct vm *vm);
 /**
@@ -146,7 +147,10 @@ uint64_t gpa2hpa(struct vm *vm, uint64_t gpa);
  * @return hpa - the HPA of parameter gpa is hpa
  */
 uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size);
-uint64_t hpa2gpa(struct vm *vm, uint64_t hpa);
+/**
+ * @pre: the gpa and hpa are identical mapping in SOS.
+ */
+uint64_t vm0_hpa2gpa(uint64_t hpa);
 void ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
 		uint64_t gpa, uint64_t size, uint64_t prot_orig);
 void ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,

--- a/hypervisor/include/hypervisor.h
+++ b/hypervisor/include/hypervisor.h
@@ -45,7 +45,7 @@ static inline void *gpa2hva(struct vm *vm, uint64_t x)
 
 static inline uint64_t hva2gpa(struct vm *vm, void *x)
 {
-	return hpa2gpa(vm, hva2hpa(x));
+	return (is_vm0(vm)) ? vm0_hpa2gpa(hva2hpa(x)) : INVALID_GPA;
 }
 
 #endif	/* !ASSEMBLER */


### PR DESCRIPTION
We want to remove the dynamic memory allocation in memory management. So we
must reserve a very big page pool for paging tables. Now we need these paging
tables to transfer gpa to hpa or hpa to gpa. For each direction walking, we need
to reserve about 20 MB for a VM which has 8 GB system memory plus 2 GB pci hole.
While there has very few changes to use hpa2gpa. Now there only has about four place
and only SOS will use it. However, the gpa to hpa is identical mapping in SOS.

The patch wants to add two pre-assumption for hpa2gpa: (a) it only used by SOS; (b) 
the gpa to hpa is identical mapping in SOS.

After this, we could not need to reserve the paging pool which paging tables are used to
walk hpa to gpa.

v1-v2:
add check hpa should not large than physical address length and add error check for hpa2gpa

Tracked-On: #1124