### PR TITLE
dm: rpmb: DM customized changes for RPMB mux kernel module

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_rpmb.c
+++ b/devicemodel/hw/pci/virtio/virtio_rpmb.c
@@ -297,7 +297,7 @@ rpmb_read_block(__u8 mode, __u8 *key, __u16 addr, void *buf, __u32 count)
 	}
 
 	rc = rpmb_check_response("read blocks", RPMB_RESP_DATA_READ,
-							frame_out, count, key, NULL, &addr);
+							frame_out, count, NULL, NULL, &addr);
 
 	if (rc)
 		return rc;

--- a/devicemodel/include/rpmb.h
+++ b/devicemodel/include/rpmb.h
@@ -37,7 +37,7 @@
 #define RPMB_SIM_MODE       1
 #define RPMB_BLOCK_SIZE     256
 #define RPMB_FRAME_SIZE     512
-#define RPMB_PHY_PATH_NAME  "/dev/rpmb0"
+#define RPMB_PHY_PATH_NAME  "/dev/rpmbmux"
 #define RPMB_SIM_PATH_NAME  "/data/rpmbfile"
 #define SEQ_CMD_MAX         3	/*support up to 3 cmds*/
 


### PR DESCRIPTION
As RPMB mux kernel module is going to be created,
there are two corresponding changes required for DM:
1. The name has been changed to /dev/rpmbmux.
2. DM does NOT check MAC of RPMB result returned by kernel
   module because DM doesn't own the real key.

Tracked-On: #1508
Signed-off-by: Huang, Yang <yang.huang@intel.com>
Acked-by: Zhu Bing <bing.zhu@intel.com>