### PR TITLE
doc: filter error exit status incorrect

### DIFF
--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -38,6 +38,7 @@ if [ -s "${LOG_FILE}" ]; then
 	   echo
 	   cat doc.warnings
 	   echo
+	   exit 1
    else
 	   echo -e "${green}No new errors/warnings."
 	   $TPUT sgr0


### PR DESCRIPTION
When the doc log is scanned for potential "new" errors, if any are found
it wasn't returning a non-zero error code.

Tracked-on: #1514

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>