### PR TITLE
[REVERTME] dm: script: disable xHCI runtime PM to WA USB role switch …

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -226,6 +226,9 @@ else
   npk_virt=""
 fi
 
+# WA for USB role switch hang issue, disable runtime PM of xHCI device
+echo on > /sys/devices/pci0000:00/0000:00:15.0/power/control
+
 boot_ipu_option=""
 if [ $ipu_passthrough == 1 ];then
     # for ipu passthrough - ipu device 0:3.0


### PR DESCRIPTION
…hang issue

When do USB role switch between host and device mode, we hit hang issue.
It might be caused by accessing suspended xHCI during that. This issue
need to be root caused later in xHCI driver.

This is a workaround solution, which will be reverted when got a fix.

Tracked-On: #1516
Signed-off-by: Shuo Liu <shuo.a.liu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>