### PR TITLE
hv: fix potential buffer overflow in vpic_set_pinstate()

### DIFF
--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -405,6 +405,10 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
 	uint8_t old_lvl;
 	bool lvl_trigger;
 
+	if (pin >= NR_VPIC_PINS_TOTAL) {
+		return;
+	}
+
 	i8259 = &vpic->i8259[pin >> 3U];
 	old_lvl = i8259->pin_state[pin & 0x7U];
 	if (level) {


### PR DESCRIPTION
Input 'pin' should be less than 'NR_VPIC_PINS_TOTAL'

Tracked-On: #1479
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>