### PR TITLE
USB: Enable multiple hubs support (Flat Mode)

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2053,7 +2053,8 @@ pci_xhci_cmd_reset_ep(struct pci_xhci_vdev *xdev,
 
 	epid = XHCI_TRB_3_EP_GET(trb->dwTrb3);
 
-	UPRINTF(LDBG, "reset ep %u: slot %u\r\n", epid, slot);
+	UPRINTF(LDBG, "reset ep %u: slot %u cmd_type: %02X\r\n", epid, slot,
+			XHCI_TRB_3_TYPE_GET(trb->dwTrb3));
 
 	cmderr = XHCI_TRB_ERROR_SUCCESS;
 
@@ -2082,6 +2083,12 @@ pci_xhci_cmd_reset_ep(struct pci_xhci_vdev *xdev,
 		cmderr = XHCI_TRB_ERROR_CONTEXT_STATE;
 		goto done;
 	}
+
+	/* FIXME: Currently nothing to do when Stop Endpoint Command is
+	 * received. Will refine it strictly according to xHCI spec.
+	 */
+	if (type == XHCI_TRB_TYPE_STOP_EP)
+		goto done;
 
 	devep = &dev->eps[epid];
 	if (devep->ep_xfer != NULL)

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -548,6 +548,9 @@ pci_xhci_get_native_port_index_by_path(struct pci_xhci_vdev *xdev,
 	for (i = 0; i < XHCI_MAX_VIRT_PORTS; i++) {
 		p = &xdev->native_ports[i].info.path;
 
+		if (p->bus != path->bus)
+			continue;
+
 		if (p->depth != path->depth)
 			continue;
 

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -244,22 +244,6 @@ usb_dev_comp_req(struct libusb_transfer *libusb_xfer)
 		}
 	}
 
-	/* in case the xfer is reset by the USB_DATA_XFER_RESET */
-	if (xfer->reset == 1) {
-		UPRINTF(LDBG, "ep%d reset detected\r\n", xfer->epid);
-		xfer->reset = 0;
-		/* ONLY interrupt transfer needs this.
-		 * The transfer here is an old one before endpoint reset, so it
-		 * should be discarded. But for bulk transfer, the transfer here
-		 * is a new one after reset, so it should be kept.
-		 */
-		if (usb_dev_get_ep_type(req->udev, xfer->pid & 1,
-					xfer->epid / 2) == USB_ENDPOINT_INT) {
-			UPRINTF(LDBG, "goto reset out\r\n");
-			goto reset_out;
-		}
-	}
-
 	/* handle the blocks belong to this request */
 	buf_idx = 0;
 	idx = req->blk_start;
@@ -323,7 +307,6 @@ out:
 	if (do_intr && g_ctx.intr_cb)
 		g_ctx.intr_cb(xfer->dev, NULL);
 
-reset_out:
 	/* unlock and release memory */
 	USB_DATA_XFER_UNLOCK(xfer);
 	libusb_free_transfer(libusb_xfer);

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -243,3 +243,24 @@ void usb_parse_log_level(char level)
 		usb_set_log_level(LFTL);
 	}
 }
+
+char *
+usb_dev_path(struct usb_devpath *path)
+{
+	static char output[sizeof("01.02.03.04.05.06.07")+1];
+	int i, r, n;
+
+	if (!path)
+		return NULL;
+
+	r = n = sizeof(output);
+	r -= snprintf(output, n, "%d", path->path[0]);
+
+	for (i = 1; i < path->depth; i++) {
+		r -= snprintf(output + n - r, r, ".%d", path->path[i]);
+		if (r < 0)
+			return NULL;
+	}
+
+	return output;
+}

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -84,6 +84,14 @@ enum usb_xfer_blk_stat {
 	USB_XFER_BLK_HANDLED
 };
 
+enum usb_native_devtype {
+	USB_TYPE_ROOTHUB,
+	USB_TYPE_EXTHUB,
+	USB_TYPE_ROOTHUB_SUBDEV,
+	USB_TYPE_EXTHUB_SUBDEV,
+	USB_TYPE_NONE
+};
+
 #define USB_MAX_TIERS 7
 
 struct usb_hci;
@@ -174,9 +182,11 @@ struct usb_devpath {
 
 struct usb_native_devinfo {
 	int speed;
+	int maxchild;
 	uint16_t bcd;
 	uint16_t pid;
 	uint16_t vid;
+	enum usb_native_devtype type;
 	struct usb_devpath path;
 	void *priv_data;
 };
@@ -247,5 +257,6 @@ struct usb_data_xfer_block *usb_data_xfer_append(struct usb_data_xfer *xfer,
 						 int blen,
 						 void *hci_data,
 						 int ccs);
+int usb_get_hub_port_num(struct usb_devpath *path);
 char *usb_dev_path(struct usb_devpath *path);
 #endif /* _USB_CORE_H_ */

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -84,6 +84,8 @@ enum usb_xfer_blk_stat {
 	USB_XFER_BLK_HANDLED
 };
 
+#define USB_MAX_TIERS 7
+
 struct usb_hci;
 struct usb_device_request;
 struct usb_data_xfer;
@@ -163,13 +165,19 @@ struct usb_data_xfer {
 	pthread_mutex_t mtx;
 };
 
+struct usb_devpath {
+	uint8_t bus;
+	uint8_t depth;
+	uint8_t path[USB_MAX_TIERS];
+};
+#define ROOTHUB_PORT(x) ((x).path[0])
+
 struct usb_native_devinfo {
 	int speed;
-	uint8_t bus;
-	uint8_t port;
 	uint16_t bcd;
 	uint16_t pid;
 	uint16_t vid;
+	struct usb_devpath path;
 	void *priv_data;
 };
 
@@ -239,5 +247,5 @@ struct usb_data_xfer_block *usb_data_xfer_append(struct usb_data_xfer *xfer,
 						 int blen,
 						 void *hci_data,
 						 int ccs);
-
+char *usb_dev_path(struct usb_devpath *path);
 #endif /* _USB_CORE_H_ */

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -168,7 +168,6 @@ struct usb_data_xfer {
 	void    *dev;		/* struct pci_xhci_dev_emu *dev */
 	int     epid;		/* related endpoint id */
 	int     pid;		/* token id */
-	int	reset;		/* detect ep reset */
 	int	status;
 	pthread_mutex_t mtx;
 };
@@ -219,7 +218,6 @@ enum USB_ERRCODE {
 			memset((x)->data, 0, sizeof((x)->data));	\
 			(x)->ndata = 0;					\
 			(x)->head = (x)->tail = 0;			\
-			(x)->reset = 1;					\
 			pthread_mutex_unlock((&(x)->mtx));		\
 		} while (0)
 

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -119,6 +119,4 @@ int usb_dev_info(void *pdata, int type, void *value, int size);
 int usb_dev_request(void *pdata, struct usb_data_xfer *xfer);
 int usb_dev_reset(void *pdata);
 int usb_dev_data(void *pdata, struct usb_data_xfer *xfer, int dir, int epctx);
-enum usb_native_dev_type usb_get_parent_dev_type(void *pdata, uint16_t *bus,
-		uint16_t *port);
 #endif

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -20,9 +20,6 @@
 #define USB_EP_NR(d) (USB_EP_ADDR(d) & 0xF)
 #define USB_EP_ERR_TYPE 0xFF
 
-/* hub port start address */
-#define PORT_HUB_BASE	0x0A
-
 enum {
 	USB_INFO_VERSION,
 	USB_INFO_SPEED,
@@ -30,15 +27,6 @@ enum {
 	USB_INFO_PORT,
 	USB_INFO_VID,
 	USB_INFO_PID
-};
-
-enum usb_native_dev_type {
-	ROOT_HUB,
-	USB_HUB,
-	USB_DEV,
-	USB_VALID_SUB_DEV,
-	USB_INVALID_SUB_DEV,
-	USB_TYPE_INVALID
 };
 
 struct usb_dev_ep {
@@ -133,5 +121,4 @@ int usb_dev_reset(void *pdata);
 int usb_dev_data(void *pdata, struct usb_data_xfer *xfer, int dir, int epctx);
 enum usb_native_dev_type usb_get_parent_dev_type(void *pdata, uint16_t *bus,
 		uint16_t *port);
-int usb_dev_is_hub(void *pdata);
 #endif

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -55,7 +55,7 @@ enum {
 	XHCI_ST_EPCTX_ERROR
 };
 
-#define	XHCI_MAX_DEVICES	MIN(USB_MAX_DEVICES, 128)
+#define	XHCI_MAX_VIRT_PORTS	MIN(USB_MAX_DEVICES, 128)
 #define	XHCI_MAX_ENDPOINTS	32	/* hardcoded - do not change */
 #define	XHCI_MAX_SCRATCHPADS	32
 #define	XHCI_MAX_EVENTS		(16 * 13)


### PR DESCRIPTION
This patch series enable support for multiple hubs and multiple layers
of hubs under Flat Mode, which means the physical hub is not visible to
UOS and all ports of the hub are mapped to the root hub ports of UOS.
Tracked-On: #1434
Signed-off-by: Liang Yang <liang3.yang@intel.com>
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>