### PR TITLE
HV:fixed "Pointer param should be declared pointer to const"

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -17,7 +17,7 @@
  */
 static inline struct ptdev_remapping_info *
 ptdev_lookup_entry_by_sid(uint32_t intr_type,
-		union source_id *sid, struct vm *vm)
+		union source_id *sid,const struct vm *vm)
 {
 	struct ptdev_remapping_info *entry;
 	struct list_head *pos;
@@ -43,7 +43,7 @@ is_entry_active(struct ptdev_remapping_info *entry)
 	return atomic_load32(&entry->active) == ACTIVE_FLAG;
 }
 
-static bool ptdev_hv_owned_intx(struct vm *vm, union source_id *virt_sid)
+static bool ptdev_hv_owned_intx(const struct vm *vm, union source_id *virt_sid)
 {
 	/* vm0 pin 4 (uart) is owned by hypervisor under debug version */
 	if (is_vm0(vm) && (virt_sid->intx_id.pin == 4U)) {
@@ -230,7 +230,7 @@ add_msix_remapping(struct vm *vm, uint16_t virt_bdf, uint16_t phys_bdf,
 
 /* deactive & remove mapping entry of vbdf:entry_nr for vm */
 static void
-remove_msix_remapping(struct vm *vm, uint16_t virt_bdf, uint32_t entry_nr)
+remove_msix_remapping(const struct vm *vm, uint16_t virt_bdf, uint32_t entry_nr)
 {
 	struct ptdev_remapping_info *entry;
 	DEFINE_MSI_SID(virt_sid, virt_bdf, entry_nr);
@@ -324,7 +324,7 @@ add_intx_remapping(struct vm *vm, uint8_t virt_pin,
 }
 
 /* deactive & remove mapping entry of vpin for vm */
-static void remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin)
+static void remove_intx_remapping(const struct vm *vm, uint8_t virt_pin, bool pic_pin)
 {
 	uint32_t phys_irq;
 	struct ptdev_remapping_info *entry;
@@ -732,7 +732,7 @@ int ptdev_add_intx_remapping(struct vm *vm, uint8_t virt_pin, uint8_t phys_pin,
 /*
  * @pre vm != NULL
  */
-void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin)
+void ptdev_remove_intx_remapping(const struct vm *vm, uint8_t virt_pin, bool pic_pin)
 {
 	remove_intx_remapping(vm, virt_pin, pic_pin);
 }
@@ -761,7 +761,7 @@ int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 /*
  * @pre vm != NULL
  */
-void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
+void ptdev_remove_msix_remapping(const struct vm *vm, uint16_t virt_bdf,
 		uint32_t vector_count)
 {
 	uint32_t i;

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -6,9 +6,9 @@
 
 #include <hypervisor.h>
 
-int validate_pstate(struct vm *vm, uint64_t perf_ctl)
+int validate_pstate(const struct vm *vm, uint64_t perf_ctl)
 {
-	struct cpu_px_data *px_data;
+	const struct cpu_px_data *px_data;
 	int i, px_cnt;
 
 	if (is_vm0(vm)) {

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -140,11 +140,11 @@ static uint16_t vm_apicid2vcpu_id(struct vm *vm, uint8_t lapicid)
 }
 
 static uint64_t
-vm_active_cpus(struct vm *vm)
+vm_active_cpus(const struct vm *vm)
 {
 	uint64_t dmask = 0UL;
 	uint16_t i;
-	struct vcpu *vcpu;
+	const struct vcpu *vcpu;
 
 	foreach_vcpu(i, vm, vcpu) {
 		bitmap_set_lock(vcpu->vcpu_id, &dmask);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -30,7 +30,7 @@ static inline uint16_t alloc_vm_id(void)
 	return INVALID_VM_ID;
 }
 
-static inline void free_vm_id(struct vm *vm)
+static inline void free_vm_id(const struct vm *vm)
 {
 	bitmap_clear_lock(vm->vm_id, &vmid_bitmap);
 }

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -72,7 +72,7 @@ int32_t hcall_get_api_version(struct vm *vm, uint64_t param)
  *@pre Pointer vm shall point to VM0
  */
 static int32_t
-handle_virt_irqline(struct vm *vm, uint16_t target_vmid,
+handle_virt_irqline(const struct vm *vm, uint16_t target_vmid,
 		struct acrn_irqline *param, uint32_t operation)
 {
 	int32_t ret = 0;
@@ -333,7 +333,7 @@ int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_irqline(struct vm *vm, uint16_t vmid,
+int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
 				struct acrn_irqline_ops *ops)
 {
 	struct vm *target_vm = get_vm_from_vmid(vmid);
@@ -1073,7 +1073,7 @@ int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_callback_vector(struct vm *vm, uint64_t param)
+int32_t hcall_set_callback_vector(const struct vm *vm, uint64_t param)
 {
 	if (!is_vm0(vm)) {
 		pr_err("%s: Targeting to service vm", __func__);

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -119,7 +119,7 @@ release_entry(struct ptdev_remapping_info *entry)
 
 /* require ptdev_lock protect */
 static void
-release_all_entries(struct vm *vm)
+release_all_entries(const struct vm *vm)
 {
 	struct ptdev_remapping_info *entry;
 	struct list_head *pos, *tmp;
@@ -202,7 +202,7 @@ void ptdev_init(void)
 	register_softirq(SOFTIRQ_PTDEV, ptdev_softirq);
 }
 
-void ptdev_release_all_entries(struct vm *vm)
+void ptdev_release_all_entries(const struct vm *vm)
 {
 	/* VM already down */
 	spinlock_obtain(&ptdev_lock);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -523,7 +523,7 @@ vioapic_cleanup(struct acrn_vioapic *vioapic)
 }
 
 uint32_t
-vioapic_pincount(struct vm *vm)
+vioapic_pincount(const struct vm *vm)
 {
 	if (is_vm0(vm)) {
 		return REDIR_ENTRIES_HW;

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -17,10 +17,10 @@ int ptdev_intx_pin_remap(struct vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
 int ptdev_add_intx_remapping(struct vm *vm, uint8_t virt_pin, uint8_t phys_pin,
 		bool pic_pin);
-void ptdev_remove_intx_remapping(struct vm *vm, uint8_t virt_pin, bool pic_pin);
+void ptdev_remove_intx_remapping(const struct vm *vm, uint8_t virt_pin, bool pic_pin);
 int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, uint32_t vector_count);
-void ptdev_remove_msix_remapping(struct vm *vm, uint16_t virt_bdf,
+void ptdev_remove_msix_remapping(const struct vm *vm, uint16_t virt_bdf,
 		uint32_t vector_count);
 
 #endif /* ASSIGN_H */

--- a/hypervisor/include/arch/x86/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/guest/guest_pm.h
@@ -9,7 +9,7 @@
 
 void vm_setup_cpu_state(struct vm *vm);
 int vm_load_pm_s_state(struct vm *vm);
-int validate_pstate(struct vm *vm, uint64_t perf_ctl);
+int validate_pstate(const struct vm *vm, uint64_t perf_ctl);
 void register_pm1ab_handler(struct vm *vm);
 
 #endif /* PM_H */

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -57,7 +57,7 @@ void	vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
 void	vioapic_set_irq_nolock(struct vm *vm, uint32_t irq, uint32_t operation);
 void	vioapic_update_tmr(struct vcpu *vcpu);
 
-uint32_t	vioapic_pincount(struct vm *vm);
+uint32_t	vioapic_pincount(const struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
 void	vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte);
 int	vioapic_mmio_access_handler(struct vcpu *vcpu,

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -194,7 +194,7 @@ struct vm_description {
 #endif
 };
 
-static inline bool is_vm0(struct vm *vm)
+static inline bool is_vm0(const struct vm *vm)
 {
 	return (vm->vm_id) == 0U;
 }

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -215,7 +215,7 @@ int32_t hcall_pulse_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_irqline(struct vm *vm, uint16_t vmid,
+int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
 				struct acrn_irqline_ops *ops);
 /**
  * @brief inject MSI interrupt
@@ -501,7 +501,7 @@ int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_callback_vector(struct vm *vm, uint64_t param);
+int32_t hcall_set_callback_vector(const struct vm *vm, uint64_t param);
 
 /**
  * @}

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -72,7 +72,7 @@ extern spinlock_t ptdev_lock;
 
 void ptdev_softirq(uint16_t pcpu_id);
 void ptdev_init(void);
-void ptdev_release_all_entries(struct vm *vm);
+void ptdev_release_all_entries(const struct vm *vm);
 
 struct ptdev_remapping_info *ptdev_dequeue_softirq(struct vm *vm);
 struct ptdev_remapping_info *alloc_entry(struct vm *vm,


### PR DESCRIPTION
Pointer param should be declared pointer to const if
the parameter is keeped read-only.
This patch changes pointer param whose name is vm.

Tracked-On:#861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>