### PR TITLE
Add support for profiling [sep/socwatch tools]

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -218,7 +218,7 @@ endif
 C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(C_SRCS))
 ifneq ($(CONFIG_RELEASE),y)
 C_OBJS += $(patsubst %.c,$(HV_OBJDIR)/%.o,$(D_SRCS))
-CFLAGS += -DHV_DEBUG
+CFLAGS += -DHV_DEBUG -DPROFILING_ON
 endif
 S_OBJS := $(patsubst %.S,$(HV_OBJDIR)/%.o,$(S_SRCS))
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -485,6 +485,7 @@ static void bsp_boot_post(void)
 	init_iommu();
 
 	timer_init();
+	profiling_setup();
 	setup_notification();
 	setup_posted_intr_notification();
 	ptdev_init();
@@ -564,7 +565,7 @@ static void cpu_secondary_post(void)
 	interrupt_init(get_cpu_id());
 
 	timer_init();
-
+	profiling_setup();
 	/* Wait for boot processor to signal all secondary cores to continue */
 	wait_sync_change(&pcpu_sync, 0UL);
 

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -173,6 +173,10 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 	case HC_SETUP_HV_NPK_LOG:
 		ret = hcall_setup_hv_npk_log(vm, param1);
 		break;
+
+	case HC_PROFILING_OPS:
+		ret = hcall_profiling_ops(vm, param1, param2);
+		break;
 #endif
 
 	case HC_WORLD_SWITCH:

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -26,6 +26,7 @@ static struct static_mapping_table irq_static_mappings[NR_STATIC_MAPPINGS] = {
 	{TIMER_IRQ, VECTOR_TIMER},
 	{NOTIFY_IRQ, VECTOR_NOTIFY_VCPU},
 	{POSTED_INTR_NOTIFY_IRQ, VECTOR_POSTED_INTR},
+	{PMI_IRQ, VECTOR_PMI},
 };
 
 /*
@@ -96,7 +97,7 @@ uint32_t alloc_irq_vector(uint32_t irq)
 	}
 
 	desc = &irq_desc_array[irq];
-	
+
 	if (desc->vector != VECTOR_INVALID) {
 		if (vector_to_irq[desc->vector] == irq) {
 			/* statically binded */
@@ -121,7 +122,7 @@ uint32_t alloc_irq_vector(uint32_t irq)
 			}
 		}
 		vr = (vr > VECTOR_DYNAMIC_END) ? VECTOR_INVALID : vr;
-		
+
 		spinlock_irqrestore_release(&irq_alloc_spinlock, rflags);
 	}
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -12,7 +12,7 @@ static spinlock_t irq_alloc_spinlock = { .head = 0U, .tail = 0U, };
 
 #define IRQ_ALLOC_BITMAP_SIZE	INT_DIV_ROUNDUP(NR_IRQS, 64U)
 static uint64_t irq_alloc_bitmap[IRQ_ALLOC_BITMAP_SIZE];
-static struct irq_desc irq_desc_array[NR_IRQS];
+struct irq_desc irq_desc_array[NR_IRQS];
 static uint32_t vector_to_irq[NR_MAX_VECTOR + 1];
 
 spurious_handler_t spurious_handler;
@@ -350,7 +350,12 @@ void dispatch_interrupt(const struct intr_excp_ctx *ctx)
 		/* mask irq if possible */
 		goto ERR;
 	}
-
+#ifdef PROFILING_ON
+	/* Saves ctx info into irq_desc */
+	desc->ctx_rip = ctx->rip;
+	desc->ctx_rflags = ctx->rflags;
+	desc->ctx_cs = ctx->cs;
+#endif
 	handle_irq(desc);
 	return;
 ERR:

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -372,6 +372,9 @@ int external_interrupt_vmexit_handler(struct vcpu *vcpu)
 	}
 
 	ctx.vector = intr_info & 0xFFU;
+	ctx.rip    = vcpu_get_rip(vcpu);
+	ctx.rflags = vcpu_get_rflags(vcpu);
+	ctx.cs     = exec_vmread32(VMX_GUEST_CS_SEL);
 
 #ifdef CONFIG_PARTITION_MODE
 	partition_mode_dispatch_interrupt(&ctx);

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -70,6 +70,8 @@ void vcpu_thread(struct vcpu *vcpu)
 #endif
 		TRACE_2L(TRACE_VM_ENTER, 0UL, 0UL);
 
+		profiling_vmenter_handler(vcpu);
+
 		/* Restore guest TSC_AUX */
 		if (vcpu->launched) {
 			cpu_msr_write(MSR_IA32_TSC_AUX,
@@ -109,6 +111,8 @@ void vcpu_thread(struct vcpu *vcpu)
 #endif
 
 		TRACE_2L(TRACE_VM_EXIT, basic_exit_reason, vcpu_get_rip(vcpu));
+
+		profiling_vmexit_handler(vcpu, basic_exit_reason);
 	} while (1);
 }
 

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+#include <schedule.h>
+#include <hypercall.h>
+#include <version.h>
+#include <reloc.h>
+
+#ifdef PROFILING_ON
+/**
+ *@pre Pointer vm shall point to VM0
+ */
+int32_t hcall_profiling_ops(struct vm *vm, uint64_t cmd, uint64_t param)
+{
+	int32_t ret;
+	switch (cmd) {
+	case PROFILING_MSR_OPS:
+		ret = profiling_msr_ops_all_cpus(vm, param);
+		break;
+	case PROFILING_GET_VMINFO:
+		ret = profiling_vm_list_info(vm, param);
+		break;
+	case PROFILING_GET_VERSION:
+		ret = profiling_get_version_info(vm, param);
+		break;
+	case PROFILING_GET_CONTROL_SWITCH:
+		ret = profiling_get_control(vm, param);
+		break;
+	case PROFILING_SET_CONTROL_SWITCH:
+		ret = profiling_set_control(vm, param);
+		break;
+	case PROFILING_CONFIG_PMI:
+		ret = profiling_configure_pmi(vm, param);
+		break;
+	case PROFILING_CONFIG_VMSWITCH:
+		ret = profiling_configure_vmsw(vm, param);
+		break;
+	case PROFILING_GET_PCPUID:
+		ret = profiling_get_pcpu_id(vm, param);
+		break;
+	default:
+		pr_err("%s: invalid profiling command %llu\n", __func__, cmd);
+		ret = -1;
+		break;
+	}
+ 	return ret;
+}
+#endif

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifdef PROFILING_ON
+
+#include <hypervisor.h>
+
+#define ACRN_DBG_PROFILING		5U
+
+#define LVT_PERFCTR_BIT_MASK		0x10000U
+
+static uint32_t profiling_pmi_irq = IRQ_INVALID;
+
+static void profiling_initialize_vmsw(void)
+{
+	/* to be implemented */
+}
+
+/*
+ * Configure the PMU's for sep/socwatch profiling.
+ */
+static void profiling_initialize_pmi(void)
+{
+	/* to be implemented */
+}
+
+/*
+ * Enable all the Performance Monitoring Control registers.
+ */
+static void profiling_enable_pmu(void)
+{
+	/* to be implemented */
+}
+
+/*
+ * Disable all Performance Monitoring Control registers
+ */
+static void profiling_disable_pmu(void)
+{
+	/* to be implemented */
+}
+
+/*
+ * Performs MSR operations - read, write and clear
+ */
+static void profiling_handle_msrops(void)
+{
+	/* to be implemented */
+}
+
+/*
+ * Interrupt handler for performance monitoring interrupts
+ */
+static void profiling_pmi_handler(__unused unsigned int irq, __unused void *data)
+{
+	/* to be implemented */
+}
+
+/*
+ * Performs MSR operations on all the CPU's
+ */
+ int32_t profiling_msr_ops_all_cpus(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented
+	 * call to smp_call_function profiling_ipi_handler
+	 */
+	return 0;
+}
+
+/*
+ * Generate VM info list
+ */
+int32_t profiling_vm_list_info(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented */
+	return 0;
+}
+
+/*
+ * Sep/socwatch profiling version
+ */
+int32_t profiling_get_version_info(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented */
+	return 0;
+}
+
+/*
+ * Gets type of profiling - sep/socwatch
+ */
+int32_t profiling_get_control(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented */
+	return 0;
+}
+
+/*
+ * Update the profiling type based on control switch
+ */
+int32_t profiling_set_control(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented */
+	return 0;
+}
+
+/*
+ * Configure PMI on all cpus
+ */
+int32_t profiling_configure_pmi(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented
+	 * call to smp_call_function profiling_ipi_handler
+	 */
+	return 0;
+}
+
+/*
+ * Configure for VM-switch data on all cpus
+ */
+int32_t profiling_configure_vmsw(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented
+	 * call to smp_call_function profiling_ipi_handler
+	 */
+	return 0;
+}
+
+/*
+ * Get the physical cpu id
+ */
+int32_t profiling_get_pcpu_id(__unused struct vm *vm, __unused uint64_t addr)
+{
+	/* to be implemented */
+	return 0;
+}
+
+/*
+ * IPI interrupt handler function
+ */
+void profiling_ipi_handler(__unused void *data)
+{
+	switch (get_cpu_var(profiling_info.ipi_cmd)) {
+	case IPI_PMU_START:
+		profiling_enable_pmu();
+		break;
+	case IPI_PMU_STOP:
+		profiling_disable_pmu();
+		break;
+	case IPI_MSR_OP:
+		profiling_handle_msrops();
+		break;
+	case IPI_PMU_CONFIG:
+		profiling_initialize_pmi();
+		break;
+	case IPI_VMSW_CONFIG:
+		profiling_initialize_vmsw();
+		break;
+	default:
+		pr_err("%s: unknown IPI command %d on cpu %d",
+		__func__, get_cpu_var(profiling_info.ipi_cmd), get_cpu_id());
+		break;
+	}
+	get_cpu_var(profiling_info.ipi_cmd) = IPI_UNKNOWN;
+}
+
+/*
+ * Save the VCPU info on vmenter
+ */
+void profiling_vmenter_handler(__unused struct vcpu *vcpu)
+{
+	/* to be implemented */
+}
+
+/*
+ * Save the VCPU info on vmexit
+ */
+void profiling_vmexit_handler(__unused struct vcpu *vcpu, __unused uint64_t exit_reason)
+{
+	if (exit_reason == VMX_EXIT_REASON_EXTERNAL_INTERRUPT) {
+		/* to be implemented */
+	} else {
+		/* to be implemented */
+	}
+}
+
+/*
+ * Setup PMI irq vector
+ */
+void profiling_setup(void)
+{
+	uint16_t cpu;
+	int32_t retval;
+	dev_dbg(ACRN_DBG_PROFILING, "%s: entering", __func__);
+	cpu = get_cpu_id();
+	/* support PMI notification, VM0 will register all CPU */
+	if ((cpu == BOOT_CPU_ID) && (profiling_pmi_irq == IRQ_INVALID)) {
+		pr_info("%s: calling request_irq", __func__);
+		retval = request_irq(PMI_IRQ,
+			profiling_pmi_handler, NULL, IRQF_NONE);
+		if (retval < 0) {
+			pr_err("Failed to add PMI isr");
+			return;
+		}
+		profiling_pmi_irq = (uint32_t)retval;
+	}
+
+	msr_write(MSR_IA32_EXT_APIC_LVT_PMI,
+		VECTOR_PMI | LVT_PERFCTR_BIT_MASK);
+
+	dev_dbg(ACRN_DBG_PROFILING, "%s: exiting", __func__);
+}
+
+#endif

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -13,7 +13,8 @@
 #define MAJOR_VERSION			1
 #define MINOR_VERSION			0
 
-
+#define LBR_NUM_REGISTERS			32U
+#define PERF_OVF_BIT_MASK			0xC0000070000000FULL
 #define LVT_PERFCTR_BIT_UNMASK		0xFFFEFFFFU
 #define LVT_PERFCTR_BIT_MASK		0x10000U
 #define VALID_DEBUGCTL_BIT_MASK		0x1801U
@@ -23,6 +24,8 @@ static uint64_t	socwatch_collection_switch;
 static bool		in_pmu_profiling;
 
 static uint32_t profiling_pmi_irq = IRQ_INVALID;
+
+extern struct irq_desc irq_desc_array[NR_IRQS];
 
 static void profiling_initialize_vmsw(void)
 {
@@ -324,9 +327,151 @@ static void profiling_handle_msrops(void)
 /*
  * Interrupt handler for performance monitoring interrupts
  */
-static void profiling_pmi_handler(__unused unsigned int irq, __unused void *data)
+static void profiling_pmi_handler(unsigned int irq, __unused void *data)
 {
-	/* to be implemented */
+	uint64_t perf_ovf_status;
+	uint32_t lvt_perf_ctr;
+	uint32_t i;
+	uint32_t group_id;
+	struct profiling_msr_op *msrop = NULL;
+	struct pmu_sample *psample = &(get_cpu_var(profiling_info.pmu_sample));
+	struct sep_state *ss = &(get_cpu_var(profiling_info.sep_state));
+
+	if ((ss == NULL) || (psample == NULL)) {
+		dev_dbg(ACRN_ERR_PROFILING, "%s: exiting cpu%d",
+			__func__, get_cpu_id());
+		return;
+	}
+	/* Stop all the counters first */
+	msr_write(MSR_IA32_PERF_GLOBAL_CTRL, 0x0U);
+
+	group_id = ss->current_pmi_group_id;
+	for (i = 0U; i < MAX_MSR_LIST_NUM; i++) {
+		msrop = &(ss->pmi_entry_msr_list[group_id][i]);
+		if (msrop != NULL) {
+			if (msrop->msr_id == (uint32_t)-1) {
+				break;
+			}
+			if (msrop->msr_op_type == (uint8_t)MSR_OP_WRITE) {
+				msr_write(msrop->msr_id, msrop->value);
+			}
+		}
+	}
+
+	ss->total_pmi_count++;
+	perf_ovf_status = msr_read(MSR_IA32_PERF_GLOBAL_STATUS);
+	lvt_perf_ctr = (uint32_t)msr_read(MSR_IA32_EXT_APIC_LVT_PMI);
+
+	if (perf_ovf_status == 0U) {
+		goto reconfig;
+	}
+
+	if ((perf_ovf_status & 0x80000000000000FULL) == 0U) {
+		ss->nofrozen_pmi++;
+	}
+
+	(void)memset(psample, 0U, sizeof(struct pmu_sample));
+
+	/* Attribute PMI to guest context */
+	if ((get_cpu_var(profiling_info.vm_info).vmexit_reason
+			== VMX_EXIT_REASON_EXTERNAL_INTERRUPT) &&
+			((uint64_t)get_cpu_var(profiling_info.vm_info).external_vector
+			== VECTOR_PMI)) {
+		psample->csample.os_id
+		=(uint32_t) get_cpu_var(profiling_info.vm_info).guest_vm_id;
+		(void)memset(psample->csample.task, 0U, 16);
+		psample->csample.cpu_id = get_cpu_id();
+		psample->csample.process_id = 0U;
+		psample->csample.task_id = 0U;
+		psample->csample.overflow_status = perf_ovf_status;
+		psample->csample.rip = get_cpu_var(profiling_info.vm_info).guest_rip;
+		psample->csample.rflags
+			= (uint32_t)get_cpu_var(profiling_info.vm_info).guest_rflags;
+		psample->csample.cs
+			= (uint32_t)get_cpu_var(profiling_info.vm_info).guest_cs;
+		get_cpu_var(profiling_info.vm_info).vmexit_reason = 0U;
+		get_cpu_var(profiling_info.vm_info).external_vector = -1;
+	/* Attribute PMI to hypervisor context */
+	} else {
+		psample->csample.os_id = 0xFFFFFFFFU;
+		(void)memcpy_s(psample->csample.task, 16, "VMM\0", 4);
+		psample->csample.cpu_id = get_cpu_id();
+		psample->csample.process_id = 0U;
+		psample->csample.task_id = 0U;
+		psample->csample.overflow_status = perf_ovf_status;
+		psample->csample.rip = irq_desc_array[irq].ctx_rip;
+		psample->csample.rflags
+			= (uint32_t)irq_desc_array[irq].ctx_rflags;
+		psample->csample.cs = (uint32_t)irq_desc_array[irq].ctx_cs;
+	}
+
+	if ((sep_collection_switch &
+				(1UL << (uint64_t)LBR_PMU_SAMPLING)) > 0UL) {
+		psample->lsample.lbr_tos = msr_read(MSR_CORE_LASTBRANCH_TOS);
+		for (i = 0U; i < LBR_NUM_REGISTERS; i++) {
+			psample->lsample.lbr_from_ip[i]
+				= msr_read(MSR_CORE_LASTBRANCH_0_FROM_IP + i);
+			psample->lsample.lbr_to_ip[i]
+				= msr_read(MSR_CORE_LASTBRANCH_0_TO_IP + i);
+		}
+		/* Generate core pmu sample and lbr data */
+		(void)profiling_generate_data(COLLECT_PROFILE_DATA, LBR_PMU_SAMPLING);
+	} else {
+		/* Generate core pmu sample only */
+		(void)profiling_generate_data(COLLECT_PROFILE_DATA, CORE_PMU_SAMPLING);
+	}
+
+	/* Clear PERF_GLOBAL_OVF_STATUS bits */
+	msr_write(MSR_IA32_PERF_GLOBAL_OVF_CTRL,
+			perf_ovf_status & PERF_OVF_BIT_MASK);
+
+	ss->valid_pmi_count++;
+
+	group_id = ss->current_pmi_group_id;
+	for (i = 0U; i < MAX_MSR_LIST_NUM; i++) {
+		msrop = &(ss->pmi_exit_msr_list[group_id][i]);
+		if (msrop != NULL) {
+			if (msrop->msr_id == (uint32_t)-1) {
+				break;
+			}
+			if (msrop->msr_op_type == (uint8_t)MSR_OP_WRITE) {
+				if (msrop->reg_type != (uint8_t)PMU_MSR_DATA) {
+					if (msrop->msr_id != MSR_IA32_PERF_GLOBAL_CTRL) {
+						msr_write(msrop->msr_id, msrop->value);
+					}
+				}
+				else {
+					if (((perf_ovf_status >> msrop->param) & 0x1U) > 0U) {
+						msr_write(msrop->msr_id, msrop->value);
+					}
+				}
+			}
+		}
+	}
+
+reconfig:
+
+	if (ss->pmu_state == PMU_RUNNING) {
+		/* Unmask the interrupt */
+		lvt_perf_ctr &= LVT_PERFCTR_BIT_UNMASK;
+		msr_write(MSR_IA32_EXT_APIC_LVT_PMI, lvt_perf_ctr);
+		group_id = ss->current_pmi_group_id;
+		for (i = 0U; i < MAX_MSR_LIST_NUM; i++) {
+			msrop = &(ss->pmi_start_msr_list[group_id][i]);
+			if (msrop != NULL) {
+				if (msrop->msr_id == (uint32_t)-1) {
+					break;
+				}
+				if (msrop->msr_op_type == (uint8_t)MSR_OP_WRITE) {
+					msr_write(msrop->msr_id, msrop->value);
+				}
+			}
+		}
+	} else {
+		/* Mask the interrupt */
+		lvt_perf_ctr |= LVT_PERFCTR_BIT_MASK;
+		msr_write(MSR_IA32_EXT_APIC_LVT_PMI, lvt_perf_ctr);
+	}
 }
 
 /*

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -16,7 +16,7 @@ static inline bool sbuf_is_empty(const struct shared_buf *sbuf)
 	return (sbuf->head == sbuf->tail);
 }
 
-static inline uint32_t sbuf_next_ptr(uint32_t pos_arg,
+uint32_t sbuf_next_ptr(uint32_t pos_arg,
 		uint32_t span, uint32_t scope)
 {
 	uint32_t pos = pos_arg;

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -23,6 +23,7 @@
 #define VECTOR_VIRT_IRQ_VHM	0xF7U
 #define VECTOR_SPURIOUS		0xFFU
 #define VECTOR_HYPERVISOR_CALLBACK_VHM	0xF3U
+#define VECTOR_PMI			0xF4U
 
 /* the maximum number of msi entry is 2048 according to PCI
  * local bus specification
@@ -34,10 +35,11 @@
 #define NR_IRQS		256U
 #define IRQ_INVALID		0xffffffffU
 
-#define NR_STATIC_MAPPINGS     (3U)
+#define NR_STATIC_MAPPINGS     (4U)
 #define TIMER_IRQ		(NR_IRQS - 1U)
 #define NOTIFY_IRQ		(NR_IRQS - 2U)
 #define POSTED_INTR_NOTIFY_IRQ	(NR_IRQS - 3U)
+#define PMI_IRQ			(NR_IRQS - 4U)
 
 #define DEFAULT_DEST_MODE	IOAPIC_RTE_DESTLOG
 #define DEFAULT_DELIVERY_MODE	IOAPIC_RTE_DELLOPRI

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -488,6 +488,16 @@
 #define MSR_ATOM_LER_TO_LIP                 0x000001DEU
 /* Last exception record to linear IP */
 
+#ifdef PROFILING_ON
+/* Core (and Goldmont) specific MSRs */
+#define MSR_CORE_LASTBRANCH_TOS				0x000001C9U
+/* Last branch record stack TOS */
+#define MSR_CORE_LASTBRANCH_0_FROM_IP		0x00000680U
+/* Last branch record 0 from IP */
+#define MSR_CORE_LASTBRANCH_0_TO_IP			0x000006C0U
+/* Last branch record 0 to IP */
+#endif
+
 /* LINCROFT specific MSRs */
 #define MSR_LNC_BIOS_CACHE_AS_RAM           0x000002E0U    /* Configure CAR */
 

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -17,6 +17,7 @@
 #include <timer.h>
 #include <logmsg.h>
 #include "arch/x86/guest/instr_emul.h"
+#include <profiling.h>
 
 struct per_cpu_region {
 	/* vmxon_region MUST be 4KB-aligned */
@@ -50,6 +51,9 @@ struct per_cpu_region {
 	uint32_t lapic_id;
 	uint32_t lapic_ldr;
 	struct smp_call_info_data smp_call_info;
+#ifdef PROFILING_ON
+	struct profiling_info_wrapper profiling_info;
+#endif
 } __aligned(CPU_PAGE_SIZE); /* per_cpu_region size aligned with CPU_PAGE_SIZE */
 
 extern struct per_cpu_region *per_cpu_data_base_ptr;

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -46,7 +46,7 @@ int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid);
  * @param param guest physical memory address. The api version returned
  *              will be copied to this gpa
  *
- * @pre Pointer vm shall point to VM0 
+ * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_get_api_version(struct vm *vm, uint64_t param);
@@ -406,6 +406,19 @@ int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
   * @return 0 on success, non-zero on error.
   */
 int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param);
+
+/**
+ * @brief Execute profiling operation
+ *
+ * @param vm Pointer to VM data structure
+ * @param cmd profiling command to be executed
+ * @param cmd profiling command to be executed
+ * @param param guest physical address. This gpa points to
+ *             data structure required by each command
+ *
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_profiling_ops(struct vm *vm, uint64_t cmd, uint64_t param);
 
 /**
  * @brief Get VCPU Power state.

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -24,6 +24,11 @@ struct irq_desc {
 	uint32_t flags;		/* flags for trigger mode/ptdev */
 
 	spinlock_t lock;
+#ifdef PROFILING_ON
+	uint64_t ctx_rip;
+	uint64_t ctx_rflags;
+	uint64_t ctx_cs;
+#endif
 };
 
 int32_t request_irq(uint32_t req_irq, irq_action_t action_fn, void *priv_data,

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2018 int32_tel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PROFILING_H
+#define PROFILING_H
+
+#ifdef PROFILING_ON
+
+#include <profiling_internal.h>
+
+void profiling_vmenter_handler(struct vcpu *vcpu);
+void profiling_vmexit_handler(struct vcpu *vcpu, uint64_t exit_reason);
+void profiling_setup(void);
+
+#else
+
+static inline void profiling_vmenter_handler(__unused struct vcpu *vcpu) {}
+static inline void profiling_vmexit_handler(__unused struct vcpu *vcpu,
+	__unused uint64_t exit_reason) {}
+static inline void profiling_setup(void) {}
+
+static inline int32_t hcall_profiling_ops(__unused struct vm *vm,
+	__unused uint64_t cmd, __unused uint64_t param)
+{
+	return -ENODEV;
+}
+
+#endif
+
+#endif /* PROFILING_H */

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -18,6 +18,13 @@
 #define COLLECT_PROFILE_DATA	0
 #define COLLECT_POWER_DATA		1
 
+#define SOCWATCH_MSR_OP			100U
+
+enum MSR_CMD_STATUS {
+	MSR_OP_READY = 0,
+	MSR_OP_REQUESTED,
+	MSR_OP_HANDLED
+};
 enum MSR_CMD_TYPE {
 	MSR_OP_NONE = 0,
 	MSR_OP_READ,
@@ -105,6 +112,13 @@ struct profiling_vm_info_list {
 	struct profiling_vm_info vm_list[MAX_NR_VMS];
 };
 
+struct sw_msr_op_info {
+	uint64_t core_msr[MAX_MSR_LIST_NUM];
+	uint32_t cpu_id;
+	uint32_t valid_entries;
+	uint16_t sample_id;
+};
+
 struct profiling_msr_op {
 	/* value to write or location to write into */
 	uint64_t	value;
@@ -116,6 +130,12 @@ struct profiling_msr_op {
 	uint8_t		reg_type;
 };
 
+struct profiling_msr_ops_list {
+	int32_t		collector_id;
+	uint32_t	num_entries;
+	int32_t		msr_op_state;
+	struct profiling_msr_op entries[MAX_MSR_LIST_NUM];
+};
 struct profiling_pmi_config {
 	uint32_t num_groups;
 	uint32_t trigger_count;
@@ -185,9 +205,11 @@ struct sep_state {
  * Wrapper containing  SEP sampling/profiling related data structures
  */
 struct profiling_info_wrapper {
+	struct profiling_msr_ops_list	*msr_node;
 	struct sep_state		sep_state;
 	ipi_commands			ipi_cmd;
 	socwatch_state			soc_state;
+	struct sw_msr_op_info	sw_msr_op_info;
 } __aligned(8);
 
 int32_t profiling_get_version_info(struct vm *vm, uint64_t addr);

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -217,6 +217,16 @@ struct sep_state {
 	uint64_t saved_debugctl_value;
 } __aligned(8);
 
+struct data_header {
+	int32_t collector_id;
+	uint16_t cpu_id;
+	uint16_t data_type;
+	uint64_t tsc;
+	uint64_t payload_size;
+	uint64_t reserved;
+} __aligned(SEP_BUF_ENTRY_SIZE);
+
+#define DATA_HEADER_SIZE ((uint64_t)sizeof(struct data_header))
 struct core_pmu_sample {
 	/* context where PMI is triggered */
 	uint32_t	os_id;
@@ -238,6 +248,7 @@ struct core_pmu_sample {
 	uint32_t	cs;
 } __aligned(SEP_BUF_ENTRY_SIZE);
 
+#define CORE_PMU_SAMPLE_SIZE ((uint64_t)sizeof(struct core_pmu_sample))
 #define NUM_LBR_ENTRY		32
 
 struct lbr_pmu_sample {
@@ -251,6 +262,7 @@ struct lbr_pmu_sample {
 	uint64_t	lbr_info[NUM_LBR_ENTRY];
 } __aligned(SEP_BUF_ENTRY_SIZE);
 
+#define LBR_PMU_SAMPLE_SIZE ((uint64_t)sizeof(struct lbr_pmu_sample))
 struct pmu_sample {
 	/* core pmu sample */
 	struct core_pmu_sample	csample;
@@ -265,6 +277,7 @@ struct vm_switch_trace {
 	int32_t  os_id;
 }__aligned(SEP_BUF_ENTRY_SIZE);
 
+#define VM_SWITCH_TRACE_SIZE ((uint64_t)sizeof(struct vm_switch_trace))
 /*
  * Wrapper containing  SEP sampling/profiling related data structures
  */

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -18,6 +18,7 @@
 #define COLLECT_PROFILE_DATA	0
 #define COLLECT_POWER_DATA		1
 
+#define SEP_BUF_ENTRY_SIZE 		32U
 #define SOCWATCH_MSR_OP			100U
 
 enum MSR_CMD_STATUS {
@@ -159,6 +160,16 @@ struct vmexit_msr {
 	uint64_t msr_data;
 };
 
+struct guest_vm_info {
+	uint64_t	vmenter_tsc;
+	uint64_t	vmexit_tsc;
+	uint64_t	vmexit_reason;
+	uint64_t	guest_rip;
+	uint64_t	guest_rflags;
+	uint64_t	guest_cs;
+	int32_t		guest_vm_id;
+	int32_t		external_vector;
+};
 struct sep_state {
 	sep_pmu_state pmu_state;
 
@@ -201,13 +212,23 @@ struct sep_state {
 	uint64_t saved_debugctl_value;
 } __aligned(8);
 
+
+struct vm_switch_trace {
+	uint64_t vm_enter_tsc;
+	uint64_t vm_exit_tsc;
+	uint64_t vm_exit_reason;
+	int32_t  os_id;
+}__aligned(SEP_BUF_ENTRY_SIZE);
+
 /*
  * Wrapper containing  SEP sampling/profiling related data structures
  */
 struct profiling_info_wrapper {
 	struct profiling_msr_ops_list	*msr_node;
 	struct sep_state		sep_state;
+	struct guest_vm_info	vm_info;
 	ipi_commands			ipi_cmd;
+	struct vm_switch_trace	vm_switch_trace;
 	socwatch_state			soc_state;
 	struct sw_msr_op_info	sw_msr_op_info;
 } __aligned(8);

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 int32_tel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PROFILING_INTERNAL_H
+#define PROFILING_INTERNAL_H
+
+#ifdef PROFILING_ON
+
+ typedef enum IPI_COMMANDS {
+	IPI_MSR_OP = 0,
+	IPI_PMU_CONFIG,
+	IPI_PMU_START,
+	IPI_PMU_STOP,
+	IPI_VMSW_CONFIG,
+	IPI_UNKNOWN,
+} ipi_commands;
+ /*
+ * Wrapper containing  SEP sampling/profiling related data structures
+ */
+struct profiling_info_wrapper {
+	ipi_commands			ipi_cmd;
+};
+
+int32_t profiling_get_version_info(struct vm *vm, uint64_t addr);
+int32_t profiling_get_pcpu_id(struct vm *vm, uint64_t addr);
+int32_t profiling_msr_ops_all_cpus(struct vm *vm, uint64_t addr);
+int32_t profiling_vm_list_info(struct vm *vm, uint64_t addr);
+int32_t profiling_get_control(struct vm *vm, uint64_t addr);
+int32_t profiling_set_control(struct vm *vm, uint64_t addr);
+int32_t profiling_configure_pmi(struct vm *vm, uint64_t addr);
+int32_t profiling_configure_vmsw(struct vm *vm, uint64_t addr);
+void profiling_ipi_handler(void *data);
+
+#endif
+
+#endif /* PROFILING_INTERNAL_H */

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -9,7 +9,13 @@
 
 #ifdef PROFILING_ON
 
- typedef enum IPI_COMMANDS {
+#define MAX_NR_VCPUS			8
+#define MAX_NR_VMS				6
+
+#define COLLECT_PROFILE_DATA	0
+#define COLLECT_POWER_DATA		1
+
+typedef enum IPI_COMMANDS {
 	IPI_MSR_OP = 0,
 	IPI_PMU_CONFIG,
 	IPI_PMU_START,
@@ -17,7 +23,59 @@
 	IPI_VMSW_CONFIG,
 	IPI_UNKNOWN,
 } ipi_commands;
- /*
+
+typedef enum PROFILING_SEP_FEATURE {
+	CORE_PMU_SAMPLING = 0,
+	CORE_PMU_COUNTING,
+	PEBS_PMU_SAMPLING,
+	LBR_PMU_SAMPLING,
+	UNCORE_PMU_SAMPLING,
+	VM_SWITCH_TRACING,
+	MAX_SEP_FEATURE_ID
+} profiling_sep_feature;
+
+struct profiling_version_info {
+	int32_t major;
+	int32_t minor;
+	int64_t supported_features;
+	int64_t reserved;
+};
+
+struct profiling_pcpuid {
+	uint32_t leaf;
+	uint32_t subleaf;
+	uint32_t eax;
+	uint32_t ebx;
+	uint32_t ecx;
+	uint32_t edx;
+};
+
+struct profiling_control {
+	int32_t		collector_id;
+	int32_t		reserved;
+	uint64_t	switches;
+};
+
+struct profiling_vcpu_pcpu_map {
+	int32_t vcpu_id;
+	int32_t pcpu_id;
+	int32_t apic_id;
+};
+
+struct profiling_vm_info {
+	int32_t		vm_id_num;
+	unsigned char	guid[16];
+	char		vm_name[16];
+	int32_t		num_vcpus;
+	struct profiling_vcpu_pcpu_map	cpu_map[MAX_NR_VCPUS];
+};
+
+struct profiling_vm_info_list {
+	int32_t num_vms;
+	struct profiling_vm_info vm_list[MAX_NR_VMS];
+};
+
+/*
  * Wrapper containing  SEP sampling/profiling related data structures
  */
 struct profiling_info_wrapper {

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -33,6 +33,11 @@ enum MSR_CMD_TYPE {
 	MSR_OP_READ_CLEAR
 };
 
+enum PMU_MSR_TYPE {
+	PMU_MSR_CCCR = 0,
+	PMU_MSR_ESCR,
+	PMU_MSR_DATA
+};
 typedef enum IPI_COMMANDS {
 	IPI_MSR_OP = 0,
 	IPI_PMU_CONFIG,
@@ -212,6 +217,46 @@ struct sep_state {
 	uint64_t saved_debugctl_value;
 } __aligned(8);
 
+struct core_pmu_sample {
+	/* context where PMI is triggered */
+	uint32_t	os_id;
+	/* the task id */
+	uint32_t	task_id;
+	/* instruction pointer */
+	uint64_t	rip;
+	/* the task name */
+	char		task[16];
+	/* physical cpu ID */
+	uint32_t	cpu_id;
+	/* the process id */
+	uint32_t	process_id;
+	/* perf global status msr value (for overflow status) */
+	uint64_t	overflow_status;
+	/* rflags */
+	uint32_t	rflags;
+	/* code segment */
+	uint32_t	cs;
+} __aligned(SEP_BUF_ENTRY_SIZE);
+
+#define NUM_LBR_ENTRY		32
+
+struct lbr_pmu_sample {
+	/* LBR TOS */
+	uint64_t	lbr_tos;
+	/* LBR FROM IP */
+	uint64_t	lbr_from_ip[NUM_LBR_ENTRY];
+	/* LBR TO IP */
+	uint64_t	lbr_to_ip[NUM_LBR_ENTRY];
+	/* LBR info */
+	uint64_t	lbr_info[NUM_LBR_ENTRY];
+} __aligned(SEP_BUF_ENTRY_SIZE);
+
+struct pmu_sample {
+	/* core pmu sample */
+	struct core_pmu_sample	csample;
+	/* lbr pmu sample */
+	struct lbr_pmu_sample	lsample;
+} __aligned(SEP_BUF_ENTRY_SIZE);
 
 struct vm_switch_trace {
 	uint64_t vm_enter_tsc;
@@ -228,6 +273,7 @@ struct profiling_info_wrapper {
 	struct sep_state		sep_state;
 	struct guest_vm_info	vm_info;
 	ipi_commands			ipi_cmd;
+	struct pmu_sample		pmu_sample;
 	struct vm_switch_trace	vm_switch_trace;
 	socwatch_state			soc_state;
 	struct sw_msr_op_info	sw_msr_op_info;

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -39,6 +39,8 @@
 enum {
 	ACRN_TRACE,
 	ACRN_HVLOG,
+	ACRN_SEP,
+	ACRN_SOCWATCH,
 	ACRN_SBUF_ID_MAX,
 };
 
@@ -85,6 +87,7 @@ uint32_t sbuf_get(struct shared_buf *sbuf, uint8_t *data);
  */
 uint32_t sbuf_put(struct shared_buf *sbuf, uint8_t *data);
 int sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva);
+uint32_t sbuf_next_ptr(uint32_t pos, uint32_t span, uint32_t scope);
 
 #else /* HV_DEBUG */
 

--- a/hypervisor/include/hv_debug.h
+++ b/hypervisor/include/hv_debug.h
@@ -13,5 +13,6 @@
 #include <trace.h>
 #include <sbuf.h>
 #include <npk_log.h>
+#include <profiling.h>
 
 #endif /* HV_DEBUG_H */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -72,6 +72,7 @@
 #define HC_ID_DBG_BASE              0x60UL
 #define HC_SETUP_SBUF               BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x00UL)
 #define HC_SETUP_HV_NPK_LOG         BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x01UL)
+#define HC_PROFILING_OPS            BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x02UL)
 
 /* Trusty */
 #define HC_ID_TRUSTY_BASE           0x70UL
@@ -316,5 +317,16 @@ struct trusty_boot_param {
 /**
  * @}
  */
+
+enum profiling_cmd_type {
+	PROFILING_MSR_OPS = 0U,
+	PROFILING_GET_VMINFO,
+	PROFILING_GET_VERSION,
+	PROFILING_GET_CONTROL_SWITCH,
+	PROFILING_SET_CONTROL_SWITCH,
+	PROFILING_CONFIG_PMI,
+	PROFILING_CONFIG_VMSWITCH,
+	PROFILING_GET_PCPUID
+};
 
 #endif /* ACRN_HV_DEFS_H */


### PR DESCRIPTION
Support for the tools[SEP/SOCWATCH] program the performance and power hardware registers to collect the analysis data.

Basic design consists of SEP/SoCWatch driver running inside the SoS sends all information required for configuration to the hypervisor via the hypercalls implemented in this patch set. In turn hypervisor uses the data sent from the driver to program PMU. The patch includes data collection of various counter during an interrupt, buffers the data and periodically sends the data to sampling driver.

Functionality provided by the hypervisor:
    Fetch the VM information
    Transfer PMU/Power programming information to hypervisor
    Profiling collection control - start/stop
    Provide physical cpuid information
    Retrieve buffered PMU samples to SoS
    Fetch VM switch trace information
    Tracked-On: #1409
Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Chinthapally, Manisha <manisha.chinthapally@intel.com>