### PR TITLE
hv: timer: add debug information for add_timer

### DIFF
--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -80,6 +80,8 @@ int add_timer(struct hv_timer *timer)
 		return -EINVAL;
 	}
 
+	ASSERT(list_empty(&timer->node), "add timer again!\n");
+
 	/* limit minimal periodic timer cycle period */
 	if (timer->mode == TICK_MODE_PERIODIC) {
 		timer->period_in_cycle = max(timer->period_in_cycle,


### PR DESCRIPTION
If a timer added more than once, assert the debug information.

Tracked-On: #1546
Signed-off-by: Li, Fei1 <fei1.li@intel.com>