### PR TITLE
DM USB: xHCI: Fix a potential NULL pointer issue.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -4001,12 +4001,12 @@ pci_xhci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	 * ended by EXCAP_GROUP_END at last item.
 	 */
 	excap = xdev->excap_ptr;
-	xdev->excapoff = excap->start;
-
 	if (!excap) {
-		UPRINTF(LWRN, "Failed to set xHCI extended capability\r\n");
-		return -1;
+		error = -1;
+		goto done;
 	}
+
+	xdev->excapoff = excap->start;
 
 	do {
 		xdev->regsend = excap->end;


### PR DESCRIPTION
After excap pointer is assigned, it should be checked whether it's
possible to get assignment for NULL pointer or not. This patch
fixes this issue.

Signed-off-by: Liang Yang <liang3.yang@intel.com>
Reviewed-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liu Shuo <shuo.a.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>