### PR TITLE
tools: acrn-crashlog: check the pointer after getting sender

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -463,7 +463,7 @@ free_class:
 
 static void telemd_send_uptime(void)
 {
-	struct sender_t *telemd;
+	struct sender_t *telemd = get_sender_by_name("telemd");
 	struct uptime_t *uptime;
 	char *class;
 	char boot_time[UPTIME_SIZE];
@@ -472,12 +472,14 @@ static void telemd_send_uptime(void)
 	static int uptime_hours;
 	static int loop_uptime_event = 1;
 
+	if (!telemd)
+		return;
+
 	ret = get_uptime_string(boot_time, &hours);
 	if (ret < 0) {
 		LOGE("cannot get uptime - %s\n", strerror(-ret));
 		return;
 	}
-	telemd = get_sender_by_name("telemd");
 	uptime = telemd->uptime;
 	uptime_hours = atoi(uptime->eventhours);
 	if (hours / uptime_hours >= loop_uptime_event) {
@@ -505,12 +507,14 @@ static void telemd_send_uptime(void)
 
 static void telemd_send_reboot(void)
 {
-	struct sender_t *telemd;
+	struct sender_t *telemd = get_sender_by_name("telemd");
 	char *class;
 	char reason[REBOOT_REASON_SIZE];
 	int ret;
 
-	telemd = get_sender_by_name("telemd");
+	if (!telemd)
+		return;
+
 	if (swupdated(telemd)) {
 		char *content;
 


### PR DESCRIPTION
get_sender_from_name would return NULL if the name of sender is not
configured in acrnprobe.xml.
This patch check the return value of it.

Tracked-On: #1024
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Huang Yonghua <yonghua.huang@intel.com>
Acked-by: Chen Gang <gang.c.chen@intel.com>