### PR TITLE
HV: debug: Check if vUART is configured in partition mode

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -726,8 +726,9 @@ static int shell_to_sos_console(__unused int argc, __unused char **argv)
 
 	struct vm *vm;
 	struct acrn_vuart *vu;
-
 #ifdef CONFIG_PARTITION_MODE
+	struct vm_description *vm_desc;
+
 	if (argc == 2U) {
 		guest_no = atoi(argv[1]);
 	}
@@ -739,6 +740,16 @@ static int shell_to_sos_console(__unused int argc, __unused char **argv)
 	if (vm == NULL) {
 		return -EINVAL;
 	}
+
+#ifdef CONFIG_PARTITION_MODE
+	vm_desc = vm->vm_desc;
+	if (vm_desc != NULL && vm_desc->vm_vuart == false) {
+		snprintf(temp_str, TEMP_STR_SIZE, "No vUART configured for vm%d\n", guest_no);
+		shell_puts(temp_str);
+		return 0;
+	}
+#endif
+
 	vu = vm_vuart(vm);
 	/* UART is now owned by the SOS.
 	 * Indicate by toggling the flag.


### PR DESCRIPTION
If vUART is not configured in partition mode and we try to connect vm's console
through sos_console vmid, it will trigger crash of HV.

This patch check whether vUART is configured. If no, just print out "No vUART
configured for xxx" and return.

Tracked-On: #1160
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>