### PR TITLE
hv:Remove deadcode 'vm_lapic_from_pcpuid'

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -112,16 +112,6 @@ vm_lapic_from_vcpu_id(struct vm *vm, uint16_t vcpu_id)
 	return vcpu_vlapic(vcpu);
 }
 
-struct acrn_vlapic *
-vm_lapic_from_pcpuid(struct vm *vm, uint16_t pcpu_id)
-{
-	struct vcpu *vcpu;
-
-	vcpu = vcpu_from_pid(vm, pcpu_id);
-
-	return vcpu_vlapic(vcpu);
-}
-
 static uint16_t vm_apicid2vcpu_id(struct vm *vm, uint8_t lapicid)
 {
 	uint16_t i;

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -125,7 +125,6 @@ void vlapic_intr_accepted(struct acrn_vlapic *vlapic, uint32_t vector);
 void vlapic_post_intr(uint16_t dest_pcpu_id);
 uint64_t apicv_get_pir_desc_paddr(struct vcpu *vcpu);
 
-struct acrn_vlapic *vm_lapic_from_pcpuid(struct vm *vm, uint16_t pcpu_id);
 int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
 int vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t wval);
 


### PR DESCRIPTION
This api is not used, remove it.

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>