### PR TITLE
dm: replace banned functions with their safe alternative

### DIFF
--- a/devicemodel/include/dm_string.h
+++ b/devicemodel/include/dm_string.h
@@ -20,7 +20,7 @@
  * @return 0  no error.
  */
 
-int dm_strtol(char *s, char **end, unsigned int base, long *val);
+int dm_strtol(const char *s, char **end, unsigned int base, long *val);
 
 /**
  * @brief Convert string to an integer.
@@ -34,7 +34,7 @@ int dm_strtol(char *s, char **end, unsigned int base, long *val);
  * @return 0  no error.
  */
 
-int dm_strtoi(char *s, char **end, unsigned int base, int *val);
+int dm_strtoi(const char *s, char **end, unsigned int base, int *val);
 
 /**
  * @brief Convert string to an unsigned long integer.
@@ -48,7 +48,7 @@ int dm_strtoi(char *s, char **end, unsigned int base, int *val);
  * @return 0  no error.
  */
 
-int dm_strtoul(char *s, char **end, unsigned int base, unsigned long *val);
+int dm_strtoul(const char *s, char **end, unsigned int base, unsigned long *val);
 
 /**
  * @brief Convert string to an unsigned integer.
@@ -62,6 +62,6 @@ int dm_strtoul(char *s, char **end, unsigned int base, unsigned long *val);
  * @return 0  no error.
  */
 
-int dm_strtoui(char *s, char **end, unsigned int base, unsigned int *val);
+int dm_strtoui(const char *s, char **end, unsigned int base, unsigned int *val);
 
 #endif

--- a/devicemodel/lib/dm_string.c
+++ b/devicemodel/lib/dm_string.c
@@ -11,7 +11,7 @@
 #include "dm_string.h"
 
 int
-dm_strtol(char *s, char **end, unsigned int base, long *val)
+dm_strtol(const char *s, char **end, unsigned int base, long *val)
 {
 	if (!s)
 		goto err;
@@ -28,7 +28,7 @@ err:
 }
 
 int
-dm_strtoi(char *s, char **end, unsigned int base, int *val)
+dm_strtoi(const char *s, char **end, unsigned int base, int *val)
 {
 	long l_val;
 	int ret;
@@ -40,7 +40,7 @@ dm_strtoi(char *s, char **end, unsigned int base, int *val)
 }
 
 int
-dm_strtoul(char *s, char **end, unsigned int base, unsigned long *val)
+dm_strtoul(const char *s, char **end, unsigned int base, unsigned long *val)
 {
 	if (!s)
 		goto err;
@@ -57,7 +57,7 @@ err:
 }
 
 int
-dm_strtoui(char *s, char **end, unsigned int base, unsigned int *val)
+dm_strtoui(const char *s, char **end, unsigned int base, unsigned int *val)
 {
 	unsigned long l_val;
 	int ret;


### PR DESCRIPTION
dm: add const declaration for dm_strto* APIs
dm: virtio-net: replace banned functions

Tracked-on: #1496

Signed-off-by: Jie Deng <jie.deng@intel.com>
Reviewed-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>