### PR TITLE
tools: acrnd: Stop all vms when SOS shutdown/reboot

### DIFF
--- a/tools/acrn-manager/acrnd.service
+++ b/tools/acrn-manager/acrnd.service
@@ -8,7 +8,6 @@ ConditionPathExists=/dev/acrn_vhm
 [Service]
 Type=simple
 ExecStart=/usr/bin/acrnd
-ExecStop=/usr/bin/killall -s TERM acrnd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When SOS shutdown/reboot, systemd will send SIGTERM to acrnd. We should catch up
this signal and stop all vms gracefully.

BTW, this path also fix the following error when stop acrnd service by removing
ExecStop config. Systemd will send SIGTERM signal to process by default.

systemd[9378]: acrnd.service: Failed to execute command: No such file or directory
systemd[9378]: acrnd.service: Failed at step EXEC spawning /usr/bin/killall: No such file or directory
-- Subject: Process /usr/bin/killall could not be executed
-- Defined-By: systemd
-- Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
--
-- The process /usr/bin/killall could not be executed and failed.
--
-- The error number returned by this process is 2.

Tracked-On: #1563
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>