### PR TITLE
fix "Pointer param should be declared pointer to const."

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -17,7 +17,7 @@
  */
 static inline struct ptdev_remapping_info *
 ptdev_lookup_entry_by_sid(uint32_t intr_type,
-		union source_id *sid,const struct vm *vm)
+		const union source_id *sid,const struct vm *vm)
 {
 	struct ptdev_remapping_info *entry;
 	struct list_head *pos;
@@ -38,12 +38,12 @@ ptdev_lookup_entry_by_sid(uint32_t intr_type,
 }
 
 static inline bool
-is_entry_active(struct ptdev_remapping_info *entry)
+is_entry_active(const struct ptdev_remapping_info *entry)
 {
 	return atomic_load32(&entry->active) == ACTIVE_FLAG;
 }
 
-static bool ptdev_hv_owned_intx(const struct vm *vm, union source_id *virt_sid)
+static bool ptdev_hv_owned_intx(const struct vm *vm, const union source_id *virt_sid)
 {
 	/* vm0 vuart pin is owned by hypervisor under debug version */
 	if (is_vm0(vm) && (virt_sid->intx_id.pin == COM1_IRQ)) {
@@ -360,9 +360,9 @@ END:
 }
 
 static void ptdev_intr_handle_irq(struct vm *vm,
-		struct ptdev_remapping_info *entry)
+		const struct ptdev_remapping_info *entry)
 {
-	union source_id *virt_sid = &entry->virt_sid;
+	const union source_id *virt_sid = &entry->virt_sid;
 	switch (virt_sid->intx_id.src) {
 	case PTDEV_VPIN_IOAPIC:
 	{
@@ -773,7 +773,7 @@ void ptdev_remove_msix_remapping(const struct vm *vm, uint16_t virt_bdf,
 
 #ifdef HV_DEBUG
 #define PTDEV_INVALID_PIN 0xffU
-static void get_entry_info(struct ptdev_remapping_info *entry, char *type,
+static void get_entry_info(const struct ptdev_remapping_info *entry, char *type,
 		uint32_t *irq, uint32_t *vector, uint64_t *dest, bool *lvl_tm,
 		uint8_t *pin, uint8_t *vpin, uint32_t *bdf, uint32_t *vbdf)
 {

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -72,7 +72,7 @@ enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu)
 
 /* TODO: Add code to check for Revserved bits, SMAP and PKE when do translation
  * during page walk */
-static int local_gva2gpa_common(struct vcpu *vcpu, struct page_walk_info *pw_info,
+static int local_gva2gpa_common(struct vcpu *vcpu, const struct page_walk_info *pw_info,
 	uint64_t gva, uint64_t *gpa, uint32_t *err_code)
 {
 	uint32_t i;

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -322,7 +322,7 @@ static uint32_t get_vmcs_field(enum cpu_reg_name ident)
  * @pre ((reg <= CPU_REG_LAST) && (reg >= CPU_REG_FIRST))
  * @pre ((reg != CPU_REG_CR2) && (reg != CPU_REG_IDTR) && (reg != CPU_REG_GDTR))
  */
-static uint64_t vm_get_register(struct vcpu *vcpu, enum cpu_reg_name reg)
+static uint64_t vm_get_register(const struct vcpu *vcpu, enum cpu_reg_name reg)
 {
 	uint64_t reg_val = 0UL;
 	
@@ -492,7 +492,7 @@ static int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 	return 0;
 }
 
-static int mmio_read(struct vcpu *vcpu, uint64_t *rval)
+static int mmio_read(const struct vcpu *vcpu, uint64_t *rval)
 {
 	if (vcpu == NULL) {
 		return -EINVAL;
@@ -538,7 +538,7 @@ static void vie_calc_bytereg(const struct instr_emul_vie *vie,
 	}
 }
 
-static uint8_t vie_read_bytereg(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static uint8_t vie_read_bytereg(const struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int lhbr;
 	uint64_t val;
@@ -883,7 +883,7 @@ static int emulate_movx(struct vcpu *vcpu, const struct instr_emul_vie *vie)
  *
  * It's only used by MOVS/STO
  */
-static void get_gva_si_nocheck(struct vcpu *vcpu, uint8_t addrsize,
+static void get_gva_si_nocheck(const struct vcpu *vcpu, uint8_t addrsize,
 		enum cpu_reg_name seg, uint64_t *gva)
 {
 	uint64_t val;
@@ -2343,7 +2343,7 @@ int decode_instruction(struct vcpu *vcpu)
 	return (int)(emul_ctxt->vie.opsize);
 }
 
-int emulate_instruction(struct vcpu *vcpu)
+int emulate_instruction(const struct vcpu *vcpu)
 {
 	struct instr_emul_ctxt *ctxt = &per_cpu(g_inst_ctxt, vcpu->pcpu_id);
 

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -512,7 +512,7 @@ static int mmio_write(struct vcpu *vcpu, uint64_t wval)
 	return 0;
 }
 
-static void vie_calc_bytereg(struct instr_emul_vie *vie,
+static void vie_calc_bytereg(const struct instr_emul_vie *vie,
 					enum cpu_reg_name *reg, int *lhbr)
 {
 	*lhbr = 0;
@@ -538,7 +538,7 @@ static void vie_calc_bytereg(struct instr_emul_vie *vie,
 	}
 }
 
-static uint8_t vie_read_bytereg(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static uint8_t vie_read_bytereg(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int lhbr;
 	uint64_t val;
@@ -561,7 +561,7 @@ static uint8_t vie_read_bytereg(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return reg_val;
 }
 
-static void vie_write_bytereg(struct vcpu *vcpu, struct instr_emul_vie *vie,
+static void vie_write_bytereg(struct vcpu *vcpu, const struct instr_emul_vie *vie,
 								uint8_t byte)
 {
 	uint64_t origval, val, mask;
@@ -664,7 +664,7 @@ static uint64_t getcc(uint8_t opsize, uint64_t x, uint64_t y)
 	}
 }
 
-static int emulate_mov(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_mov(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -780,7 +780,7 @@ static int emulate_mov(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_movx(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_movx(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -980,7 +980,7 @@ exception_inject:
  * For MOVs instruction, we always check RDI during instruction decoding phase.
  * And access RSI without any check during instruction emulation phase.
  */
-static int emulate_movs(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_movs(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	uint64_t src_gva, gpa, val = 0UL;
 	uint64_t *dst_hva, *src_hva;
@@ -1067,7 +1067,7 @@ done:
 	return error;
 }
 
-static int emulate_stos(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_stos(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error, repeat;
 	uint8_t opsize = vie->opsize;
@@ -1121,7 +1121,7 @@ static int emulate_stos(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return 0;
 }
 
-static int emulate_test(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_test(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1187,7 +1187,7 @@ static int emulate_test(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_and(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_and(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1275,7 +1275,7 @@ static int emulate_and(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_or(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_or(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1366,7 +1366,7 @@ static int emulate_or(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_cmp(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_cmp(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1458,7 +1458,7 @@ static int emulate_cmp(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_sub(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_sub(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1512,7 +1512,7 @@ static int emulate_sub(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_group1(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_group1(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 
@@ -1534,7 +1534,7 @@ static int emulate_group1(struct vcpu *vcpu, struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_bittest(struct vcpu *vcpu, struct instr_emul_vie *vie)
+static int emulate_bittest(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	uint64_t val, rflags, bitmask;
 	int error;
@@ -1664,7 +1664,7 @@ static int vie_init(struct instr_emul_vie *vie, struct vcpu *vcpu)
 	return 0;
 }
 
-static int vie_peek(struct instr_emul_vie *vie, uint8_t *x)
+static int vie_peek(const struct instr_emul_vie *vie, uint8_t *x)
 {
 
 	if (vie->num_processed < vie->num_valid) {

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -193,7 +193,7 @@ struct instr_emul_ctxt {
 	struct vcpu *vcpu;
 };
 
-int emulate_instruction(struct vcpu *vcpu);
+int emulate_instruction(const struct vcpu *vcpu);
 int decode_instruction(struct vcpu *vcpu);
 
 #endif

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -187,7 +187,7 @@ static void pm1ab_io_write(__unused struct vm *vm, uint16_t addr, size_t width,
 }
 
 static void
-register_gas_io_handler(struct vm *vm, struct acpi_generic_address *gas)
+register_gas_io_handler(struct vm *vm, const struct acpi_generic_address *gas)
 {
 	uint8_t io_len[5] = {0, 1, 2, 4, 8};
 	struct vm_io_range gas_io;

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -27,7 +27,7 @@ uint64_t get_microcode_version(void)
  * According to SDM vol 3 Table 9-7. If data_size field of uCode
  * header is zero, the ucode length is 2000
  */
-static inline size_t get_ucode_data_size(struct ucode_header *uhdr)
+static inline size_t get_ucode_data_size(const struct ucode_header *uhdr)
 {
 	return ((uhdr->data_size != 0U) ? uhdr->data_size : 2000U);
 }

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -10,9 +10,9 @@
 
 vm_sw_loader_t vm_sw_loader;
 
-inline uint64_t vcpu_get_gpreg(struct vcpu *vcpu, uint32_t reg)
+inline uint64_t vcpu_get_gpreg(const struct vcpu *vcpu, uint32_t reg)
 {
-	struct run_context *ctx =
+	const struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
 
 	return ctx->guest_cpu_regs.longs[reg];
@@ -146,7 +146,7 @@ inline void vcpu_set_cr4(struct vcpu *vcpu, uint64_t val)
 	vmx_write_cr4(vcpu, val);
 }
 
-inline uint64_t vcpu_get_pat_ext(struct vcpu *vcpu)
+inline uint64_t vcpu_get_pat_ext(const struct vcpu *vcpu)
 {
 	return vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].
 		ext_ctx.ia32_pat;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -88,10 +88,10 @@ static int
 apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector);
 
 static int
-apicv_pending_intr(struct acrn_vlapic *vlapic);
+apicv_pending_intr(const struct acrn_vlapic *vlapic);
 
 static void
-apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
+apicv_batch_set_tmr(const struct acrn_vlapic *vlapic);
 
 /*
  * Post an interrupt to the vcpu running on 'hostcpu'. This will use a
@@ -154,23 +154,23 @@ vm_active_cpus(const struct vm *vm)
 }
 
 uint32_t
-vlapic_get_id(struct acrn_vlapic *vlapic)
+vlapic_get_id(const struct acrn_vlapic *vlapic)
 {
 	uint32_t id = vlapic->apic_page.id.v;
 	return id;
 }
 
 uint8_t
-vlapic_get_apicid(struct acrn_vlapic *vlapic)
+vlapic_get_apicid(const struct acrn_vlapic *vlapic)
 {
 	uint32_t apicid = (vlapic->apic_page.id.v) >> APIC_ID_SHIFT;
 	return (uint8_t)apicid;
 }
 
 static inline uint32_t
-vlapic_build_id(struct acrn_vlapic *vlapic)
+vlapic_build_id(const struct acrn_vlapic *vlapic)
 {
-	struct vcpu *vcpu = vlapic->vcpu;
+	const struct vcpu *vcpu = vlapic->vcpu;
 	uint8_t vlapic_id;
 	uint32_t lapic_regs_id;
 
@@ -236,28 +236,28 @@ vlapic_timer_divisor_shift(uint32_t dcr)
 }
 
 static inline bool
-vlapic_lvtt_oneshot(struct acrn_vlapic *vlapic)
+vlapic_lvtt_oneshot(const struct acrn_vlapic *vlapic)
 {
 	return (((vlapic->apic_page.lvt[APIC_LVT_TIMER].v) & APIC_LVTT_TM)
 				== APIC_LVTT_TM_ONE_SHOT);
 }
 
 static inline bool
-vlapic_lvtt_period(struct acrn_vlapic *vlapic)
+vlapic_lvtt_period(const struct acrn_vlapic *vlapic)
 {
 	return (((vlapic->apic_page.lvt[APIC_LVT_TIMER].v) & APIC_LVTT_TM)
 				==  APIC_LVTT_TM_PERIODIC);
 }
 
 static inline bool
-vlapic_lvtt_tsc_deadline(struct acrn_vlapic *vlapic)
+vlapic_lvtt_tsc_deadline(const struct acrn_vlapic *vlapic)
 {
 	return (((vlapic->apic_page.lvt[APIC_LVT_TIMER].v) & APIC_LVTT_TM)
 				==  APIC_LVTT_TM_TSCDLT);
 }
 
 static inline bool
-vlapic_lvtt_masked(struct acrn_vlapic *vlapic)
+vlapic_lvtt_masked(const struct acrn_vlapic *vlapic)
 {
 	return ((vlapic->apic_page.lvt[APIC_LVT_TIMER].v) & APIC_LVTT_M)
 				!= 0U;
@@ -343,11 +343,11 @@ static void vlapic_update_lvtt(struct acrn_vlapic *vlapic,
 	}
 }
 
-static uint32_t vlapic_get_ccr(struct acrn_vlapic *vlapic)
+static uint32_t vlapic_get_ccr(const struct acrn_vlapic *vlapic)
 {
 	uint64_t now = rdtsc();
 	uint32_t remain_count = 0U;
-	struct vlapic_timer *vtimer;
+	const struct vlapic_timer *vtimer;
 
 	vtimer = &vlapic->vtimer;
 
@@ -400,7 +400,7 @@ static void vlapic_icrtmr_write_handler(struct acrn_vlapic *vlapic)
 	}
 }
 
-static uint64_t vlapic_get_tsc_deadline_msr(struct acrn_vlapic *vlapic)
+static uint64_t vlapic_get_tsc_deadline_msr(const struct acrn_vlapic *vlapic)
 {
 	if (!vlapic_lvtt_tsc_deadline(vlapic)) {
 		return 0;
@@ -621,7 +621,7 @@ vlapic_get_lvtptr(struct acrn_vlapic *vlapic, uint32_t offset)
 }
 
 static inline uint32_t
-vlapic_get_lvt(struct acrn_vlapic *vlapic, uint32_t offset)
+vlapic_get_lvt(const struct acrn_vlapic *vlapic, uint32_t offset)
 {
 	uint32_t idx, val;
 
@@ -762,10 +762,10 @@ vlapic_fire_lvt(struct acrn_vlapic *vlapic, uint32_t lvt)
 }
 
 static void
-dump_isrvec_stk(struct acrn_vlapic *vlapic)
+dump_isrvec_stk(const struct acrn_vlapic *vlapic)
 {
 	uint32_t i;
-	struct lapic_reg *isrptr;
+	const struct lapic_reg *isrptr;
 
 	isrptr = &(vlapic->apic_page.isr[0]);
 	for (i = 0U; i < 8U; i++) {
@@ -1095,9 +1095,9 @@ vlapic_set_tpr(struct acrn_vlapic *vlapic, uint32_t val)
 }
 
 static uint32_t
-vlapic_get_tpr(struct acrn_vlapic *vlapic)
+vlapic_get_tpr(const struct acrn_vlapic *vlapic)
 {
-	struct lapic_regs *lapic = &(vlapic->apic_page);
+	const struct lapic_regs *lapic = &(vlapic->apic_page);
 
 	return lapic->tpr.v;
 }
@@ -1119,7 +1119,7 @@ vlapic_set_cr8(struct acrn_vlapic *vlapic, uint64_t val)
 }
 
 uint64_t
-vlapic_get_cr8(struct acrn_vlapic *vlapic)
+vlapic_get_cr8(const struct acrn_vlapic *vlapic)
 {
 	uint32_t tpr;
 
@@ -1252,11 +1252,11 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
 }
 
 int
-vlapic_pending_intr(struct acrn_vlapic *vlapic, uint32_t *vecptr)
+vlapic_pending_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr)
 {
-	struct lapic_regs *lapic = &(vlapic->apic_page);
+	const struct lapic_regs *lapic = &(vlapic->apic_page);
 	uint32_t i, vector, val, bitpos;
-	struct lapic_reg *irrptr;
+	const struct lapic_reg *irrptr;
 
 	if (is_apicv_intr_delivery_supported()) {
 		return apicv_pending_intr(vlapic);
@@ -1647,7 +1647,7 @@ vlapic_init(struct acrn_vlapic *vlapic)
 	vlapic_reset(vlapic);
 }
 
-void vlapic_restore(struct acrn_vlapic *vlapic, struct lapic_regs *regs)
+void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs)
 {
 	struct lapic_regs *lapic;
 	int i;
@@ -1674,7 +1674,7 @@ void vlapic_restore(struct acrn_vlapic *vlapic, struct lapic_regs *regs)
 }
 
 static uint64_t
-vlapic_get_apicbase(struct acrn_vlapic *vlapic)
+vlapic_get_apicbase(const struct acrn_vlapic *vlapic)
 {
 
 	return vlapic->msr_apicbase;
@@ -1738,9 +1738,9 @@ vlapic_deliver_intr(struct vm *vm, bool level, uint32_t dest, bool phys,
 }
 
 bool
-vlapic_enabled(struct acrn_vlapic *vlapic)
+vlapic_enabled(const struct acrn_vlapic *vlapic)
 {
-	struct lapic_regs *lapic = &(vlapic->apic_page);
+	const struct lapic_regs *lapic = &(vlapic->apic_page);
 
 	if (((vlapic->msr_apicbase & APICBASE_ENABLED) != 0UL) &&
 			((lapic->svr.v & APIC_SVR_ENABLE) != 0U)) {
@@ -2055,10 +2055,10 @@ apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector)
 }
 
 static int
-apicv_pending_intr(struct acrn_vlapic *vlapic)
+apicv_pending_intr(const struct acrn_vlapic *vlapic)
 {
-	struct vlapic_pir_desc *pir_desc;
-	struct lapic_regs *lapic;
+	const struct vlapic_pir_desc *pir_desc;
+	const struct lapic_regs *lapic;
 	uint64_t pending, pirval;
 	uint32_t i, ppr, vpr;
 
@@ -2093,11 +2093,11 @@ apicv_pending_intr(struct acrn_vlapic *vlapic)
 #define	EOI_STEP_LEN	(64U)
 #define	TMR_STEP_LEN	(32U)
 static void
-apicv_batch_set_tmr(struct acrn_vlapic *vlapic)
+apicv_batch_set_tmr(const struct acrn_vlapic *vlapic)
 {
-	struct lapic_regs *lapic = &(vlapic->apic_page);
+	const struct lapic_regs *lapic = &(vlapic->apic_page);
 	uint64_t val;
-	struct lapic_reg *ptr;
+	const struct lapic_reg *ptr;
 	uint32_t s, e;
 
 	ptr = &lapic->tmr[0];

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -22,9 +22,9 @@ static void complete_ioreq(struct vhm_request *vhm_req)
  * request having transferred to the COMPLETE state.
  */
 static void
-emulate_pio_post(struct vcpu *vcpu, struct io_request *io_req)
+emulate_pio_post(struct vcpu *vcpu, const struct io_request *io_req)
 {
-	struct pio_request *pio_req = &io_req->reqs.pio;
+	const struct pio_request *pio_req = &io_req->reqs.pio;
 	uint64_t mask = 0xFFFFFFFFUL >> (32UL - 8UL * pio_req->size);
 
 	if (pio_req->direction == REQUEST_READ) {
@@ -68,9 +68,9 @@ void dm_emulate_pio_post(struct vcpu *vcpu)
  * either a previous call to emulate_io() returning 0 or the corresponding VHM
  * request having transferred to the COMPLETE state.
  */
-void emulate_mmio_post(struct vcpu *vcpu, struct io_request *io_req)
+void emulate_mmio_post(struct vcpu *vcpu, const struct io_request *io_req)
 {
-	struct mmio_request *mmio_req = &io_req->reqs.mmio;
+	const struct mmio_request *mmio_req = &io_req->reqs.mmio;
 
 	if (mmio_req->direction == REQUEST_READ) {
 		/* Emulate instruction and update vcpu register set */
@@ -451,7 +451,7 @@ void setup_io_bitmap(struct vm *vm)
 	}
 }
 
-void register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
+void register_io_emulation_handler(struct vm *vm, const struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr)
 {

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -68,7 +68,7 @@ void dm_emulate_pio_post(struct vcpu *vcpu)
  * either a previous call to emulate_io() returning 0 or the corresponding VHM
  * request having transferred to the COMPLETE state.
  */
-void emulate_mmio_post(struct vcpu *vcpu, const struct io_request *io_req)
+void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req)
 {
 	const struct mmio_request *mmio_req = &io_req->reqs.mmio;
 
@@ -173,7 +173,7 @@ void emulate_io_post(struct vcpu *vcpu)
  * @return -EIO    - The request spans multiple devices and cannot be emulated.
  */
 int32_t
-hv_emulate_pio(struct vcpu *vcpu, struct io_request *io_req)
+hv_emulate_pio(const struct vcpu *vcpu, struct io_request *io_req)
 {
 	int32_t status = -ENODEV;
 	uint16_t port, size;

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -285,14 +285,14 @@ static void handle_spurious_interrupt(uint32_t vector)
 	}
 }
 
-static inline bool irq_need_mask(struct irq_desc *desc)
+static inline bool irq_need_mask(const struct irq_desc *desc)
 {
 	/* level triggered gsi should be masked */
 	return (((desc->flags & IRQF_LEVEL) != 0U)
 		&& irq_is_gsi(desc->irq));
 }
 
-static inline bool irq_need_unmask(struct irq_desc *desc)
+static inline bool irq_need_unmask(const struct irq_desc *desc)
 {
 	/* level triggered gsi for non-ptdev should be unmasked */
 	return (((desc->flags & IRQF_LEVEL) != 0U)
@@ -300,7 +300,7 @@ static inline bool irq_need_unmask(struct irq_desc *desc)
 		&& irq_is_gsi(desc->irq));
 }
 
-static inline void handle_irq(struct irq_desc *desc)
+static inline void handle_irq(const struct irq_desc *desc)
 {
 	irq_action_t action = desc->action;
 
@@ -321,7 +321,7 @@ static inline void handle_irq(struct irq_desc *desc)
 }
 
 /* do_IRQ() */
-void dispatch_interrupt(struct intr_excp_ctx *ctx)
+void dispatch_interrupt(const struct intr_excp_ctx *ctx)
 {
 	uint32_t vr = ctx->vector;
 	uint32_t irq = vector_to_irq[vr];

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -266,7 +266,7 @@ void save_lapic(struct lapic_regs *regs)
 		read_lapic_reg32(LAPIC_DIVIDE_CONFIGURATION_REGISTER);
 }
 
-static void restore_lapic(struct lapic_regs *regs)
+static void restore_lapic(const struct lapic_regs *regs)
 {
 	write_lapic_reg32(LAPIC_ID_REGISTER, regs->id.v);
 	write_lapic_reg32(LAPIC_TASK_PRIORITY_REGISTER, regs->tpr.v);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -167,7 +167,7 @@ void flush_vpid_global(void)
 	local_invvpid(VMX_VPID_TYPE_ALL_CONTEXT, 0U, 0UL);
 }
 
-void invept(struct vcpu *vcpu)
+void invept(const struct vcpu *vcpu)
 {
 	struct invept_desc desc = {0};
 

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -63,18 +63,18 @@ get_subrange_start_of_fixed_mtrr(uint32_t index, uint32_t subrange_id)
 		get_subrange_size_of_fixed_mtrr(index));
 }
 
-static inline bool is_mtrr_enabled(struct vcpu *vcpu)
+static inline bool is_mtrr_enabled(const struct vcpu *vcpu)
 {
 	return (vcpu->mtrr.def_type.bits.enable != 0U);
 }
 
-static inline bool is_fixed_range_mtrr_enabled(struct vcpu *vcpu)
+static inline bool is_fixed_range_mtrr_enabled(const struct vcpu *vcpu)
 {
 	return ((vcpu->mtrr.cap.bits.fix != 0U) &&
 		(vcpu->mtrr.def_type.bits.fixed_enable != 0U));
 }
 
-static inline uint8_t get_default_memory_type(struct vcpu *vcpu)
+static inline uint8_t get_default_memory_type(const struct vcpu *vcpu)
 {
 	return (uint8_t)(vcpu->mtrr.def_type.bits.type);
 }
@@ -154,7 +154,7 @@ static uint32_t update_ept(struct vm *vm, uint64_t start,
 	return attr;
 }
 
-static void update_ept_mem_type(struct vcpu *vcpu)
+static void update_ept_mem_type(const struct vcpu *vcpu)
 {
 	uint8_t type;
 	uint64_t start, size;
@@ -236,9 +236,9 @@ void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value)
 	}
 }
 
-uint64_t mtrr_rdmsr(struct vcpu *vcpu, uint32_t msr)
+uint64_t mtrr_rdmsr(const struct vcpu *vcpu, uint32_t msr)
 {
-	struct mtrr_state *mtrr = &vcpu->mtrr;
+	const struct mtrr_state *mtrr = &vcpu->mtrr;
 	uint64_t ret = 0UL;
 	uint32_t index;
 

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -92,7 +92,7 @@ static inline int construct_pgentry(enum _page_table_type ptt, uint64_t *pde)
  * type: MR_DEL
  * delete [vaddr_start, vaddr_end) MT PT mapping
  */
-static void modify_or_del_pte(uint64_t *pde,
+static void modify_or_del_pte(const uint64_t *pde,
 		uint64_t vaddr_start, uint64_t vaddr_end,
 		uint64_t prot_set, uint64_t prot_clr,
 		enum _page_table_type ptt, uint32_t type)
@@ -125,7 +125,7 @@ static void modify_or_del_pte(uint64_t *pde,
  * type: MR_DEL
  * delete [vaddr_start, vaddr_end) MT PT mapping
  */
-static void modify_or_del_pde(uint64_t *pdpte,
+static void modify_or_del_pde(const uint64_t *pdpte,
 		uint64_t vaddr_start, uint64_t vaddr_end,
 		uint64_t prot_set, uint64_t prot_clr,
 		enum _page_table_type ptt, uint32_t type)
@@ -176,7 +176,7 @@ static void modify_or_del_pde(uint64_t *pdpte,
  * type: MR_DEL
  * delete [vaddr_start, vaddr_end) MT PT mapping
  */
-static void modify_or_del_pdpte(uint64_t *pml4e,
+static void modify_or_del_pdpte(const uint64_t *pml4e,
 		uint64_t vaddr_start, uint64_t vaddr_end,
 		uint64_t prot_set, uint64_t prot_clr,
 		enum _page_table_type ptt, uint32_t type)
@@ -262,7 +262,7 @@ void mmu_modify_or_del(uint64_t *pml4_page,
  * In PT level,
  * add [vaddr_start, vaddr_end) to [paddr_base, ...) MT PT mapping
  */
-static void add_pte(uint64_t *pde, uint64_t paddr_start,
+static void add_pte(const uint64_t *pde, uint64_t paddr_start,
 		uint64_t vaddr_start, uint64_t vaddr_end,
 		uint64_t prot, enum _page_table_type ptt)
 {
@@ -294,7 +294,7 @@ static void add_pte(uint64_t *pde, uint64_t paddr_start,
  * In PD level,
  * add [vaddr_start, vaddr_end) to [paddr_base, ...) MT PT mapping
  */
-static void add_pde(uint64_t *pdpte, uint64_t paddr_start,
+static void add_pde(const uint64_t *pdpte, uint64_t paddr_start,
 		uint64_t vaddr_start, uint64_t vaddr_end,
 		uint64_t prot, enum _page_table_type ptt)
 {
@@ -340,7 +340,7 @@ static void add_pde(uint64_t *pdpte, uint64_t paddr_start,
  * In PDPT level,
  * add [vaddr_start, vaddr_end) to [paddr_base, ...) MT PT mapping
  */
-static void add_pdpte(uint64_t *pml4e, uint64_t paddr_start,
+static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start,
 		uint64_t vaddr_start, uint64_t vaddr_end,
 		uint64_t prot, enum _page_table_type ptt)
 {

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -63,7 +63,7 @@ void restore_msrs(void)
 #endif
 }
 
-static void acpi_gas_write(struct acpi_generic_address *gas, uint32_t val)
+static void acpi_gas_write(const struct acpi_generic_address *gas, uint32_t val)
 {
 	uint16_t val16 = (uint16_t)val;
 
@@ -74,7 +74,7 @@ static void acpi_gas_write(struct acpi_generic_address *gas, uint32_t val)
 	}
 }
 
-static uint32_t acpi_gas_read(struct acpi_generic_address *gas)
+static uint32_t acpi_gas_read(const struct acpi_generic_address *gas)
 {
 	uint32_t ret = 0U;
 

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -13,7 +13,7 @@
 
 uint32_t tsc_khz = 0U;
 
-static void run_timer(struct hv_timer *timer)
+static void run_timer(const struct hv_timer *timer)
 {
 	/* deadline = 0 means stop timer, we should skip */
 	if ((timer->func != NULL) && (timer->fire_tsc != 0UL)) {

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -235,7 +235,7 @@ static void save_world_ctx(struct vcpu *vcpu, struct ext_context *ext_ctx)
 			: : "r" (ext_ctx->fxstore_guest_area) : "memory");
 }
 
-static void load_world_ctx(struct vcpu *vcpu, struct ext_context *ext_ctx)
+static void load_world_ctx(struct vcpu *vcpu, const struct ext_context *ext_ctx)
 {
 	/* mark to update on-demand run_context for efer/rflags/rsp */
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
@@ -282,7 +282,7 @@ static void load_world_ctx(struct vcpu *vcpu, struct ext_context *ext_ctx)
 	asm volatile("fxrstor (%0)" : : "r" (ext_ctx->fxstore_guest_area));
 }
 
-static void copy_smc_param(struct run_context *prev_ctx,
+static void copy_smc_param(const struct run_context *prev_ctx,
 				struct run_context *next_ctx)
 {
 	next_ctx->guest_cpu_regs.regs.rdi = prev_ctx->guest_cpu_regs.regs.rdi;
@@ -455,7 +455,7 @@ bool initialize_trusty(struct vcpu *vcpu, uint64_t param)
 	return false;
 }
 
-void trusty_set_dseed(void *dseed, uint8_t dseed_num)
+void trusty_set_dseed(const void *dseed, uint8_t dseed_num)
 {
 	/* Use fake seed if input param is invalid */
 	if ((dseed == NULL) || (dseed_num == 0U) ||

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -148,7 +148,7 @@ static int vcpu_inject_vlapic_int(struct vcpu *vcpu)
 	return 0;
 }
 
-static int vcpu_do_pending_extint(struct vcpu *vcpu)
+static int vcpu_do_pending_extint(const struct vcpu *vcpu)
 {
 	struct vm *vm;
 	struct vcpu *primary;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -250,7 +250,7 @@ static void init_cr0_cr4_host_mask(void)
 	pr_dbg("CR4 mask value: 0x%016llx", cr4_host_mask);
 }
 
-uint64_t vmx_rdmsr_pat(struct vcpu *vcpu)
+uint64_t vmx_rdmsr_pat(const struct vcpu *vcpu)
 {
 	/*
 	 * note: if context->cr0.CD is set, the actual value in guest's
@@ -288,7 +288,7 @@ int vmx_wrmsr_pat(struct vcpu *vcpu, uint64_t value)
 	return 0;
 }
 
-static void load_pdptrs(struct vcpu *vcpu)
+static void load_pdptrs(const struct vcpu *vcpu)
 {
 	uint64_t guest_cr3 = exec_vmread(VMX_GUEST_CR3);
 	/* TODO: check whether guest cr3 is valid */
@@ -945,7 +945,7 @@ static void init_exec_ctrl(struct vcpu *vcpu)
 	exec_vmwrite(VMX_CR3_TARGET_3, 0UL);
 }
 
-static void init_entry_ctrl(__unused struct vcpu *vcpu)
+static void init_entry_ctrl(__unused const struct vcpu *vcpu)
 {
 	uint32_t value32;
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -170,12 +170,12 @@ static void register_hrhd_units(void)
 	}
 }
 
-static uint32_t iommu_read32(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
+static uint32_t iommu_read32(const struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
 	return mmio_read32(hpa2hva(dmar_uint->drhd->reg_base_addr + offset));
 }
 
-static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
+static uint64_t iommu_read64(const struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 {
 	uint64_t value;
 
@@ -188,13 +188,13 @@ static uint64_t iommu_read64(struct dmar_drhd_rt *dmar_uint, uint32_t offset)
 	return value;
 }
 
-static void iommu_write32(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
+static void iommu_write32(const struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 			  uint32_t value)
 {
 	mmio_write32(value, hpa2hva(dmar_uint->drhd->reg_base_addr + offset));
 }
 
-static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
+static void iommu_write64(const struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 			  uint64_t value)
 {
 	uint32_t temp;
@@ -208,7 +208,7 @@ static void iommu_write64(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 }
 
 static inline void
-dmar_wait_completion(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
+dmar_wait_completion(const struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 	uint32_t mask, bool pre_condition, uint32_t *status)
 {
 	/* variable start isn't used when built as release version */
@@ -239,7 +239,7 @@ dmar_wait_completion(struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 }
 
 /* flush cache when root table, context table updated */
-static void iommu_flush_cache(struct dmar_drhd_rt *dmar_uint,
+static void iommu_flush_cache(const struct dmar_drhd_rt *dmar_uint,
 			      void *p, uint32_t size)
 {
 	uint32_t i;
@@ -335,7 +335,7 @@ static inline uint8_t width_to_agaw(uint32_t width)
 	return width_to_level(width) - 2U;
 }
 
-static uint8_t dmar_uint_get_msagw(struct dmar_drhd_rt *dmar_uint)
+static uint8_t dmar_uint_get_msagw(const struct dmar_drhd_rt *dmar_uint)
 {
 	uint8_t i;
 	uint8_t sgaw = iommu_cap_sagaw(dmar_uint->cap);
@@ -350,7 +350,7 @@ static uint8_t dmar_uint_get_msagw(struct dmar_drhd_rt *dmar_uint)
 }
 
 static bool
-dmar_unit_support_aw(struct dmar_drhd_rt *dmar_uint, uint32_t addr_width)
+dmar_unit_support_aw(const struct dmar_drhd_rt *dmar_uint, uint32_t addr_width)
 {
 	uint8_t aw;
 
@@ -935,7 +935,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 /**
  * @pre domain != NULL
  */
-void destroy_iommu_domain(struct iommu_domain *domain)
+void destroy_iommu_domain(const struct iommu_domain *domain)
 {
 	/* currently only support ept */
 	if (!domain->is_tt_ept) {
@@ -952,7 +952,7 @@ void destroy_iommu_domain(struct iommu_domain *domain)
 	free(domain);
 }
 
-static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
+static int add_iommu_device(const struct iommu_domain *domain, uint16_t segment,
 		uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_uint;
@@ -1100,7 +1100,7 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment,
 }
 
 static int
-remove_iommu_device(struct iommu_domain *domain, uint16_t segment,
+remove_iommu_device(const struct iommu_domain *domain, uint16_t segment,
 		uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_uint;
@@ -1156,7 +1156,7 @@ remove_iommu_device(struct iommu_domain *domain, uint16_t segment,
 	return 0;
 }
 
-int assign_iommu_device(struct iommu_domain *domain, uint8_t bus,
+int assign_iommu_device(const struct iommu_domain *domain, uint8_t bus,
 				uint8_t devfun)
 {
 	if (domain == NULL) {
@@ -1171,7 +1171,7 @@ int assign_iommu_device(struct iommu_domain *domain, uint8_t bus,
 	return add_iommu_device(domain, 0U, bus, devfun);
 }
 
-int unassign_iommu_device(struct iommu_domain *domain, uint8_t bus,
+int unassign_iommu_device(const struct iommu_domain *domain, uint8_t bus,
 				uint8_t devfun)
 {
 	if (domain == NULL) {

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -313,13 +313,13 @@ void *get_dmar_table(void)
 #define OFFSET_WAKE_VECTOR_64	24U
 
 /* get a dword value from given table and its offset */
-static inline uint32_t get_acpi_dt_dword(uint8_t *dt_addr, uint32_t dt_offset)
+static inline uint32_t get_acpi_dt_dword(const uint8_t *dt_addr, uint32_t dt_offset)
 {
 	return *(uint32_t *)(dt_addr + dt_offset);
 }
 
 /* get a qword value from given table and its offset */
-static inline uint64_t get_acpi_dt_qword(uint8_t *dt_addr, uint32_t dt_offset)
+static inline uint64_t get_acpi_dt_qword(const uint8_t *dt_addr, uint32_t dt_offset)
 {
 	return *(uint64_t *)(dt_addr + dt_offset);
 }

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -9,8 +9,8 @@
 extern void relocate(void);
 extern uint64_t get_hv_image_delta(void);
 extern uint64_t get_hv_image_base(void);
-extern uint64_t read_trampoline_sym(void *sym);
-extern void write_trampoline_sym(void *sym, uint64_t val);
+extern uint64_t read_trampoline_sym(const void *sym);
+extern void write_trampoline_sym(const void *sym, uint64_t val);
 extern uint64_t prepare_trampoline(void);
 
 /* external symbols that are helpful for relocation */

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -65,7 +65,7 @@ uint64_t get_hv_image_base(void)
  *  - The HV code is always relocated to higher address, compared
  *    with CONFIG_RAM_START
  */
-static uint64_t trampoline_relo_addr(void *addr)
+static uint64_t trampoline_relo_addr(const void *addr)
 {
 	return (uint64_t)addr - get_hv_image_delta();
 }
@@ -143,7 +143,7 @@ void relocate(void)
 #endif
 }
 
-uint64_t read_trampoline_sym(void *sym)
+uint64_t read_trampoline_sym(const void *sym)
 {
 	uint64_t *hva;
 
@@ -151,7 +151,7 @@ uint64_t read_trampoline_sym(void *sym)
 	return *hva;
 }
 
-void write_trampoline_sym(void *sym, uint64_t val)
+void write_trampoline_sym(const void *sym, uint64_t val)
 {
 	uint64_t *hva;
 

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -73,7 +73,7 @@ static char kernel_cmdline[MEM_2K];
 
 /* now modules support: FIRMWARE & RAMDISK & SeedList */
 static void parse_other_modules(struct vm *vm,
-	struct multiboot_module *mods, uint32_t mods_count)
+	const struct multiboot_module *mods, uint32_t mods_count)
 {
 	uint32_t i;
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -73,7 +73,7 @@ int32_t hcall_get_api_version(struct vm *vm, uint64_t param)
  */
 static int32_t
 handle_virt_irqline(const struct vm *vm, uint16_t target_vmid,
-		struct acrn_irqline *param, uint32_t operation)
+		const struct acrn_irqline *param, uint32_t operation)
 {
 	int32_t ret = 0;
 	uint32_t intr_type;
@@ -334,7 +334,7 @@ int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param)
  *@pre Pointer vm shall point to VM0
  */
 int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
-				struct acrn_irqline_ops *ops)
+				const struct acrn_irqline_ops *ops)
 {
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
@@ -453,7 +453,7 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
  *@pre Pointer vm shall point to VM0
  */
 static int32_t local_set_vm_memory_region(struct vm *vm,
-	struct vm *target_vm, struct vm_memory_region *region)
+	struct vm *target_vm, const struct vm_memory_region *region)
 {
 	uint64_t hpa, base_paddr;
 	uint64_t prot;
@@ -596,7 +596,7 @@ int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-static int32_t write_protect_page(struct vm *vm, struct wp_data *wp)
+static int32_t write_protect_page(struct vm *vm,const struct wp_data *wp)
 {
 	uint64_t hpa, base_paddr;
 	uint64_t prot_set;

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -25,7 +25,7 @@ static void fire_vhm_interrupt(void)
 	vlapic_intr_edge(vcpu, acrn_vhm_vector);
 }
 
-static void acrn_print_request(uint16_t vcpu_id, struct vhm_request *req)
+static void acrn_print_request(uint16_t vcpu_id, const struct vhm_request *req)
 {
 	switch (req->type) {
 	case REQ_MMIO:
@@ -59,7 +59,7 @@ static void acrn_print_request(uint16_t vcpu_id, struct vhm_request *req)
  * @pre vcpu != NULL && io_req != NULL
  */
 int32_t
-acrn_insert_request_wait(struct vcpu *vcpu, struct io_request *io_req)
+acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req)
 {
 	union vhm_request_buffer *req_buf = NULL;
 	struct vhm_request *vhm_req;

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -96,7 +96,7 @@ static struct vcpu *select_next_vcpu(uint16_t pcpu_id)
 	return vcpu;
 }
 
-void make_reschedule_request(struct vcpu *vcpu)
+void make_reschedule_request(const struct vcpu *vcpu)
 {
 	struct sched_context *ctx = &per_cpu(sched_ctx, vcpu->pcpu_id);
 

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -247,7 +247,7 @@ void asm_assert(int32_t line, const char *file, const char *txt)
 	} while (1);
 }
 
-void dump_intr_excp_frame(struct intr_excp_ctx *ctx)
+void dump_intr_excp_frame(const struct intr_excp_ctx *ctx)
 {
 	const char *name = "Not defined";
 

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -43,7 +43,7 @@ static inline void free_earlylog_sbuf(uint16_t pcpu_id)
 }
 
 static void do_copy_earlylog(struct shared_buf *dst_sbuf,
-			    struct shared_buf *src_sbuf)
+			    const struct shared_buf *src_sbuf)
 {
 	uint32_t buf_size, valid_size;
 	uint32_t cur_tail;

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -11,7 +11,7 @@
 
 #include <hypervisor.h>
 
-static inline bool sbuf_is_empty(struct shared_buf *sbuf)
+static inline bool sbuf_is_empty(const struct shared_buf *sbuf)
 {
 	return (sbuf->head == sbuf->tail);
 }

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -329,7 +329,7 @@ static bool shell_input_line(void)
 	return done;
 }
 
-static int shell_process_cmd(char *p_input_line)
+static int shell_process_cmd(const char *p_input_line)
 {
 	int status = -EINVAL;
 	struct shell_cmd *p_cmd;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -80,7 +80,7 @@ static inline char fifo_getchar(struct fifo *fifo)
 	}
 }
 
-static inline uint32_t fifo_numchars(struct fifo *fifo)
+static inline uint32_t fifo_numchars(const struct fifo *fifo)
 {
 	return fifo->num;
 }
@@ -107,7 +107,7 @@ static inline void vuart_fifo_init(struct acrn_vuart *vu)
  *
  * Return an interrupt reason if one is available.
  */
-static uint8_t vuart_intr_reason(struct acrn_vuart *vu)
+static uint8_t vuart_intr_reason(const struct acrn_vuart *vu)
 {
 	if (((vu->lsr & LSR_OE) != 0U) && ((vu->ier & IER_ELSI) != 0U)) {
 		return IIR_RLS;
@@ -125,7 +125,7 @@ static uint8_t vuart_intr_reason(struct acrn_vuart *vu)
  * Toggle the COM port's intr pin depending on whether or not we have an
  * interrupt condition to report to the processor.
  */
-static void vuart_toggle_intr(struct acrn_vuart *vu)
+static void vuart_toggle_intr(const struct acrn_vuart *vu)
 {
 	uint8_t intr_reason;
 	union ioapic_rte rte;

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -208,7 +208,7 @@ vioapic_update_tmr(struct vcpu *vcpu)
 }
 
 static uint32_t
-vioapic_indirect_read(struct acrn_vioapic *vioapic, uint32_t addr)
+vioapic_indirect_read(const struct acrn_vioapic *vioapic, uint32_t addr)
 {
 	uint32_t regnum;
 	uint32_t pin, pincount = vioapic_pincount(vioapic->vm);
@@ -248,7 +248,7 @@ vioapic_indirect_read(struct acrn_vioapic *vioapic, uint32_t addr)
 	return 0;
 }
 
-static inline bool vioapic_need_intr(struct acrn_vioapic *vioapic, uint16_t pin)
+static inline bool vioapic_need_intr(const struct acrn_vioapic *vioapic, uint16_t pin)
 {
 	uint32_t lvl;
 	union ioapic_rte rte;
@@ -515,7 +515,7 @@ vioapic_init(struct vm *vm)
 }
 
 void
-vioapic_cleanup(struct acrn_vioapic *vioapic)
+vioapic_cleanup(const struct acrn_vioapic *vioapic)
 {
 	unregister_mmio_emulation_handler(vioapic->vm,
 		(uint64_t)VIOAPIC_BASE,

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -37,7 +37,7 @@
 
 static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin, uint8_t level);
 
-static inline bool master_pic(struct acrn_vpic *vpic, struct i8259_reg_state *i8259)
+static inline bool master_pic(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259)
 {
 
 	if (i8259 == &vpic->i8259[0]) {
@@ -47,7 +47,7 @@ static inline bool master_pic(struct acrn_vpic *vpic, struct i8259_reg_state *i8
 	}
 }
 
-static inline uint8_t vpic_get_highest_isrpin(struct i8259_reg_state *i8259)
+static inline uint8_t vpic_get_highest_isrpin(const struct i8259_reg_state *i8259)
 {
 	uint8_t bit, pin, i;
 
@@ -74,7 +74,7 @@ static inline uint8_t vpic_get_highest_isrpin(struct i8259_reg_state *i8259)
 	return VPIC_INVALID_PIN;
 }
 
-static inline uint8_t vpic_get_highest_irrpin(struct i8259_reg_state *i8259)
+static inline uint8_t vpic_get_highest_irrpin(const struct i8259_reg_state *i8259)
 {
 	uint8_t serviced, bit, pin, tmp;
 
@@ -207,7 +207,7 @@ static void vpic_notify_intr(struct acrn_vpic *vpic)
 	}
 }
 
-static int vpic_icw1(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int vpic_icw1(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: i8259 icw1 0x%x\n",
 		vpic->vm, val);
@@ -237,7 +237,7 @@ static int vpic_icw1(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 	return 0;
 }
 
-static int vpic_icw2(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int vpic_icw2(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: i8259 icw2 0x%x\n",
 		vpic->vm, val);
@@ -249,7 +249,7 @@ static int vpic_icw2(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 	return 0;
 }
 
-static int vpic_icw3(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int vpic_icw3(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: i8259 icw3 0x%x\n",
 		vpic->vm, val);
@@ -259,7 +259,7 @@ static int vpic_icw3(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 	return 0;
 }
 
-static int vpic_icw4(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int vpic_icw4(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: i8259 icw4 0x%x\n",
 		vpic->vm, val);
@@ -290,7 +290,7 @@ static int vpic_icw4(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint
 	return 0;
 }
 
-static int vpic_ocw1(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int vpic_ocw1(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	uint8_t pin, i, bit;
 	uint8_t old = i8259->mask;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -248,7 +248,7 @@ struct vcpu_dump {
 	int str_max;
 };
 
-static inline bool is_vcpu_bsp(struct vcpu *vcpu)
+static inline bool is_vcpu_bsp(const struct vcpu *vcpu)
 {
 	return (vcpu->vcpu_id == BOOT_CPU_ID);
 }
@@ -266,7 +266,7 @@ vcpu_vlapic(struct vcpu *vcpu)
 }
 
 /* External Interfaces */
-uint64_t vcpu_get_gpreg(struct vcpu *vcpu, uint32_t reg);
+uint64_t vcpu_get_gpreg(const struct vcpu *vcpu, uint32_t reg);
 void vcpu_set_gpreg(struct vcpu *vcpu, uint32_t reg, uint64_t val);
 uint64_t vcpu_get_rip(struct vcpu *vcpu);
 void vcpu_set_rip(struct vcpu *vcpu, uint64_t val);
@@ -282,7 +282,7 @@ uint64_t vcpu_get_cr2(struct vcpu *vcpu);
 void vcpu_set_cr2(struct vcpu *vcpu, uint64_t val);
 uint64_t vcpu_get_cr4(struct vcpu *vcpu);
 void vcpu_set_cr4(struct vcpu *vcpu, uint64_t val);
-uint64_t vcpu_get_pat_ext(struct vcpu *vcpu);
+uint64_t vcpu_get_pat_ext(const struct vcpu *vcpu);
 void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
 void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 void reset_vcpu_regs(struct vcpu *vcpu);

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -50,7 +50,7 @@ struct acrn_vioapic {
 };
 
 void    vioapic_init(struct vm *vm);
-void	vioapic_cleanup(struct acrn_vioapic *vioapic);
+void	vioapic_cleanup(const struct acrn_vioapic *vioapic);
 void	vioapic_reset(struct acrn_vioapic *vioapic);
 
 void	vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -101,7 +101,7 @@ struct acrn_vlapic {
 
 /* APIC write handlers */
 void vlapic_set_cr8(struct acrn_vlapic *vlapic, uint64_t val);
-uint64_t vlapic_get_cr8(struct acrn_vlapic *vlapic);
+uint64_t vlapic_get_cr8(const struct acrn_vlapic *vlapic);
 
 /*
  * Returns 0 if there is no eligible vector that can be delivered to the
@@ -113,7 +113,7 @@ uint64_t vlapic_get_cr8(struct acrn_vlapic *vlapic);
  * Note that the vector does not automatically transition to the ISR as a
  * result of calling this function.
  */
-int vlapic_pending_intr(struct acrn_vlapic *vlapic, uint32_t *vecptr);
+int vlapic_pending_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
 
 /*
  * Transition 'vector' from IRR to ISR. This function is called with the
@@ -172,8 +172,8 @@ void vlapic_set_tmr_one_vec(struct acrn_vlapic *vlapic, uint32_t delmode,
 		uint32_t vector, bool level);
 
 void vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
-uint32_t vlapic_get_id(struct acrn_vlapic *vlapic);
-uint8_t vlapic_get_apicid(struct acrn_vlapic *vlapic);
+uint32_t vlapic_get_id(const struct acrn_vlapic *vlapic);
+uint8_t vlapic_get_apicid(const struct acrn_vlapic *vlapic);
 int vlapic_create(struct vcpu *vcpu);
 /*
  *  @pre vcpu != NULL
@@ -181,8 +181,8 @@ int vlapic_create(struct vcpu *vcpu);
 void vlapic_free(struct vcpu *vcpu);
 void vlapic_init(struct acrn_vlapic *vlapic);
 void vlapic_reset(struct acrn_vlapic *vlapic);
-void vlapic_restore(struct acrn_vlapic *vlapic, struct lapic_regs *regs);
-bool vlapic_enabled(struct acrn_vlapic *vlapic);
+void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs);
+bool vlapic_enabled(const struct acrn_vlapic *vlapic);
 uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);
 void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -121,7 +121,7 @@ int register_mmio_emulation_handler(struct vm *vm,
 	uint64_t end, void *handler_private_data);
 void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
         uint64_t end);
-void emulate_mmio_post(struct vcpu *vcpu, const struct io_request *io_req);
+void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req);
 void dm_emulate_mmio_post(struct vcpu *vcpu);
 
 int32_t emulate_io(struct vcpu *vcpu, struct io_request *io_req);

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -112,7 +112,7 @@ void   setup_io_bitmap(struct vm *vm);
 void   free_io_emulation_resource(struct vm *vm);
 void   allow_guest_pio_access(struct vm *vm, uint16_t port_address,
 		uint32_t nbytes);
-void   register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
+void   register_io_emulation_handler(struct vm *vm, const struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr);
 
@@ -121,7 +121,7 @@ int register_mmio_emulation_handler(struct vm *vm,
 	uint64_t end, void *handler_private_data);
 void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
         uint64_t end);
-void emulate_mmio_post(struct vcpu *vcpu, struct io_request *io_req);
+void emulate_mmio_post(struct vcpu *vcpu, const struct io_request *io_req);
 void dm_emulate_mmio_post(struct vcpu *vcpu);
 
 int32_t emulate_io(struct vcpu *vcpu, struct io_request *io_req);
@@ -129,6 +129,6 @@ void emulate_io_post(struct vcpu *vcpu);
 /*
  * @pre vcpu != NULL && io_req != NULL
  */
-int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct io_request *io_req);
+int32_t acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req);
 
 #endif /* IOREQ_H */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -73,7 +73,7 @@ int quick_handler_nolock(struct irq_desc *desc, __unused void *handler_data);
 void init_default_irqs(uint16_t cpu_id);
 
 void dispatch_exception(struct intr_excp_ctx *ctx);
-void dispatch_interrupt(struct intr_excp_ctx *ctx);
+void dispatch_interrupt(const struct intr_excp_ctx *ctx);
 #ifdef CONFIG_PARTITION_MODE
 void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx);
 #endif

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -88,7 +88,7 @@ int check_vmx_mmu_cap(void);
 uint16_t allocate_vpid(void);
 void flush_vpid_single(uint16_t vpid);
 void flush_vpid_global(void);
-void invept(struct vcpu *vcpu);
+void invept(const struct vcpu *vcpu);
 bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg);
 /**
  *@pre (pml4_page != NULL) && (pg_size != NULL)

--- a/hypervisor/include/arch/x86/mtrr.h
+++ b/hypervisor/include/arch/x86/mtrr.h
@@ -45,7 +45,7 @@ struct mtrr_state {
 };
 
 void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value);
-uint64_t mtrr_rdmsr(struct vcpu *vcpu, uint32_t msr);
+uint64_t mtrr_rdmsr(const struct vcpu *vcpu, uint32_t msr);
 void init_mtrr(struct vcpu *vcpu);
 
 #endif /* MTRR_H */

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -131,6 +131,6 @@ bool initialize_trusty(struct vcpu *vcpu, uint64_t param);
 void destroy_secure_world(struct vm *vm, bool need_clr_mem);
 void save_sworld_context(struct vcpu *vcpu);
 void restore_sworld_context(struct vcpu *vcpu);
-void trusty_set_dseed(void *dseed, uint8_t dseed_num);
+void trusty_set_dseed(const void *dseed, uint8_t dseed_num);
 
 #endif /* TRUSTY_H_ */

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -458,7 +458,7 @@ void vmx_off(uint16_t pcpu_id);
 void exec_vmclear(void *addr);
 void exec_vmptrld(void *addr);
 
-uint64_t vmx_rdmsr_pat(struct vcpu *vcpu);
+uint64_t vmx_rdmsr_pat(const struct vcpu *vcpu);
 int vmx_wrmsr_pat(struct vcpu *vcpu, uint64_t value);
 
 void vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0);

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -468,11 +468,11 @@ extern struct dmar_info *get_dmar_info(void);
 struct iommu_domain;
 
 /* Assign a device specified by bus & devfun to a iommu domain */
-int assign_iommu_device(struct iommu_domain *domain,
+int assign_iommu_device(const struct iommu_domain *domain,
 	uint8_t bus, uint8_t devfun);
 
 /* Unassign a device specified by bus & devfun to a iommu domain */
-int unassign_iommu_device(struct iommu_domain *domain,
+int unassign_iommu_device(const struct iommu_domain *domain,
 	uint8_t bus, uint8_t devfun);
 
 /* Create a iommu domain for a VM specified by vm_id */
@@ -480,7 +480,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id,
 	uint64_t translation_table, uint32_t addr_width);
 
 /* Destroy the iommu domain */
-void destroy_iommu_domain(struct iommu_domain *domain);
+void destroy_iommu_domain(const struct iommu_domain *domain);
 
 /* Enable translation of iommu*/
 void enable_iommu(void);

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -216,7 +216,7 @@ int32_t hcall_pulse_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
-				struct acrn_irqline_ops *ops);
+				const struct acrn_irqline_ops *ops);
 /**
  * @brief inject MSI interrupt
  *

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -31,7 +31,7 @@ void remove_vcpu_from_runqueue(struct vcpu *vcpu);
 
 void default_idle(void);
 
-void make_reschedule_request(struct vcpu *vcpu);
+void make_reschedule_request(const struct vcpu *vcpu);
 int need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
 int need_offline(uint16_t pcpu_id);

--- a/hypervisor/include/debug/dump.h
+++ b/hypervisor/include/debug/dump.h
@@ -13,11 +13,11 @@ struct intr_excp_ctx;
 #define CALL_TRACE_HIERARCHY_MAX    20U
 #define DUMP_STACK_SIZE 0x200U
 
-void dump_intr_excp_frame(struct intr_excp_ctx *ctx);
+void dump_intr_excp_frame(const struct intr_excp_ctx *ctx);
 void dump_exception(struct intr_excp_ctx *ctx, uint16_t pcpu_id);
 
 #else
-static inline void dump_intr_excp_frame(__unused struct intr_excp_ctx *ctx)
+static inline void dump_intr_excp_frame(__unused const struct intr_excp_ctx *ctx)
 {
 }
 

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -231,26 +231,26 @@ build_bitmap_clear(bitmap32_clear_lock, "l", uint32_t, BUS_LOCK)
  * Note:Input parameter nr shall be less than 64. If nr>=64, it will
  * be truncated.
  */
-static inline bool bitmap_test(uint16_t nr_arg, volatile uint64_t *addr)
+static inline bool bitmap_test(uint16_t nr_arg, const volatile uint64_t *addr)
 {
 	uint16_t nr;
 	int32_t ret=0;
 	nr = nr_arg & 0x3fU;
 	asm volatile("btq %q2,%1\n\tsbbl %0, %0"
-			: "=r" (ret), "=m" (*addr)
-			: "r" ((uint64_t)nr)
+			: "=r" (ret)
+			: "m" (*addr), "r" ((uint64_t)nr)
 			: "cc", "memory");
 	return (ret != 0);
 }
 
-static inline bool bitmap32_test(uint16_t nr_arg, volatile uint32_t *addr)
+static inline bool bitmap32_test(uint16_t nr_arg, const volatile uint32_t *addr)
 {
 	uint16_t nr;
 	int32_t ret=0;
 	nr = nr_arg & 0x1fU;
 	asm volatile("btl %2,%1\n\tsbbl %0, %0"
-			: "=r" (ret), "=m" (*addr)
-			: "r" ((uint32_t)nr)
+			: "=r" (ret)
+			: "m" (*addr), "r" ((uint32_t)nr)
 			: "cc", "memory");
 	return (ret != 0);
 }

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -62,7 +62,7 @@ static inline void list_del_node(struct list_head *prev, struct list_head *next)
 	prev->next = next;
 }
 
-static inline void list_del(struct list_head *entry)
+static inline void list_del(const struct list_head *entry)
 {
 	list_del_node(entry->prev, entry->next);
 }
@@ -73,12 +73,12 @@ static inline void list_del_init(struct list_head *entry)
 	INIT_LIST_HEAD(entry);
 }
 
-static inline _Bool list_empty(struct list_head *head)
+static inline _Bool list_empty(const struct list_head *head)
 {
 	return head->next == head;
 }
 
-static inline void list_splice_node(struct list_head *list,
+static inline void list_splice_node(const struct list_head *list,
 				 struct list_head *head)
 {
 	struct list_head *first = list->next;
@@ -92,7 +92,7 @@ static inline void list_splice_node(struct list_head *list,
 	at->prev = last;
 }
 
-static inline void list_splice(struct list_head *list, struct list_head *head)
+static inline void list_splice(const struct list_head *list, struct list_head *head)
 {
 	if (!list_empty(list)) {
 		list_splice_node(list, head);

--- a/hypervisor/include/lib/mem_mgt.h
+++ b/hypervisor/include/lib/mem_mgt.h
@@ -26,6 +26,6 @@ void *malloc(unsigned int num_bytes);
 void *calloc(unsigned int num_elements, unsigned int element_size);
 void *alloc_page(void);
 void *alloc_pages(unsigned int page_num);
-void free(void *ptr);
+void free(const void *ptr);
 
 #endif /* MEM_MGT_H */

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -187,7 +187,7 @@ static void *allocate_mem(struct mem_pool *pool, unsigned int num_bytes)
 	return (void *)NULL;
 }
 
-static void deallocate_mem(struct mem_pool *pool, void *ptr)
+static void deallocate_mem(struct mem_pool *pool, const void *ptr)
 {
 	uint32_t *bitmask, *contiguity_bitmask;
 	uint32_t bmp_idx, bit_idx, buff_idx;
@@ -297,7 +297,7 @@ void *calloc(unsigned int num_elements, unsigned int element_size)
 	return memory;
 }
 
-void free(void *ptr)
+void free(const void *ptr)
 {
 	/* Check if ptr belongs to 16-Bytes aligned Memory Pool */
 	if ((Memory_Pool.start_addr < ptr) &&

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -382,7 +382,7 @@ static void print_decimal(struct print_param *param, int64_t value)
 
 }
 
-static void print_string(struct print_param *param, const char *s)
+static void print_string(const struct print_param *param, const char *s)
 {
 	/* the length of the string (-1) if unknown */
 	uint32_t len;


### PR DESCRIPTION
Violations reports "function's parameter can be read-only",fix it.
Acked-by: Anthony Xu <anthony.xu@intel.com>

Huihuang Shi (3):
  HV:add const to bitmap_test parameter addr
  HV:fix "Pointer param should be declared pointer to const"
  HV:vcpu fix "Pointer param should be declared pointer to const"
Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>