### PR TITLE
fix bug: multi-warm reboot UOS can cuase SOS/HV hung 

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -121,6 +121,10 @@ static void *intr_storm_monitor_thread(void *arg)
 			if (hdr->buffer[i] != intr_cnt_buf[i])
 				continue;
 
+			/* avoid delta overflow */
+			if (hdr->buffer[i + 1] < intr_cnt_buf[i + 1])
+				continue;
+
 			delta = hdr->buffer[i + 1] - intr_cnt_buf[i + 1];
 			if (delta > INTR_STORM_THRESHOLD) {
 #ifdef INTR_MONITOR_DBG

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -65,6 +65,7 @@ ptdev_dequeue_softirq(struct vm *vm)
 		} else {
 			/* add it into timer list; dequeue next one */
 			(void)add_timer(&entry->intr_delay_timer);
+			entry = NULL;
 		}
 	}
 
@@ -187,6 +188,7 @@ ptdev_deactivate_entry(struct ptdev_remapping_info *entry)
 	/* remove from softirq list if added */
 	spinlock_irqsave_obtain(&entry->vm->softirq_dev_lock, &rflags);
 	list_del_init(&entry->softirq_node);
+	del_timer(&entry->intr_delay_timer);
 	spinlock_irqrestore_release(&entry->vm->softirq_dev_lock, rflags);
 }
 


### PR DESCRIPTION
It need correct two points:
1. DM can trigger a "fake" interrupt storm during warm reboot; compare the two unsigned 
number before minus to avoid overflow.
2. Correct HV interrupt delay timer handling; detailed in patch. 