### PR TITLE
DM: correct the predefine DM option string.

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -756,7 +756,7 @@ static struct option long_options[] = {
 	{0,			0,			0,  0  },
 };
 
-static char optstr[] = "abehuwxACHIPSWYvk:r:B:p:g:c:s:m:l:U:G:i:";
+static char optstr[] = "abhuwxACSWYvE:k:r:B:p:g:c:s:m:l:U:G:i:";
 
 int
 dm_run(int argc, char *argv[])


### PR DESCRIPTION
That string was changed by accident and introduced the removed
items.

Tracked-On: #1465
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>