### PR TITLE
Partition boot fix

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -598,14 +598,6 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 		return ret;
 	}
 
-	if (!vm_sw_loader) {
-		vm_sw_loader = general_sw_loader;
-	}
-
-	if (is_vm0(vm)) {
-		vm_sw_loader(vm);
-	}
-
 	/* init_vmcs is delayed to vcpu vmcs launch first time */
 	/* initialize the vcpu tsc aux */
 	vcpu->msr_tsc_aux_guest = vcpu->vcpu_id;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -272,7 +272,7 @@ int reset_vm(struct vm *vm)
 	}
 
 	if (is_vm0(vm)) {
-		vm_sw_loader(vm);
+		(void )vm_sw_loader(vm);
 	}
 
 	vioapic_reset(vm_ioapic(vm));
@@ -372,6 +372,12 @@ int prepare_vm(uint16_t pcpu_id)
 		for (i = 1U; i < vm_desc->vm_hw_num_cores; i++)
 			prepare_vcpu(vm, vm_desc->vm_pcpu_ids[i]);
 
+		if (!vm_sw_loader) {
+			vm_sw_loader = general_sw_loader;
+		}
+
+		(void )vm_sw_loader(vm);
+
 		/* start vm BSP automatically */
 		start_vm(vm);
 
@@ -405,6 +411,14 @@ int prepare_vm0(void)
 		if (err != 0) {
 			return err;
 		}
+	}
+
+	if (!vm_sw_loader) {
+		vm_sw_loader = general_sw_loader;
+	}
+
+	if (is_vm0(vm)) {
+		(void )vm_sw_loader(vm);
 	}
 
 	/* start vm0 BSP automatically */


### PR DESCRIPTION
After the vm loader reshuffle, the partition mode booting was broken because we only do guest sw loading for VM0. For partition mode, we need to do it for all VMs.

Tracked-On: #1565
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
