### PR TITLE
dm: mei: set addresses in the hbm disconnect reply

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -1257,6 +1257,8 @@ vmei_hbm_handler(struct virtio_mei *vmei, const void *data)
 		memset(&disconnect_res, 0, sizeof(disconnect_res));
 		disconnect_res.hbm_cmd.cmd = MEI_HBM_CLIENT_DISCONNECT;
 		disconnect_res.hbm_cmd.is_response = 1;
+		disconnect_res.me_addr = disconnect_req->me_addr;
+		disconnect_res.host_addr = disconnect_req->host_addr;
 		disconnect_res.status = status;
 		vmei_hbm_response(vmei, &disconnect_res,
 				  sizeof(disconnect_res));


### PR DESCRIPTION
MEI HBM the disconnect replay doesn't have the address set,
breaking the protocol, fix the issue.

Tracked-On: #1570
Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>