### PR TITLE
launch_uos.sh: make sure cpu offline by retry

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -407,6 +407,13 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
         echo cpu$idx online=$online
         if [ "$online" = "1" ]; then
                 echo 0 > $i/online
+		online=`cat $i/online`
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
                 echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
         fi
 done

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -37,6 +37,12 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
         echo cpu$idx online=$online
         if [ "$online" = "1" ]; then
                 echo 0 > $i/online
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
                 echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
         fi
 done


### PR DESCRIPTION
if acrnd or acrn_guest service enabled, launch_uos.sh will be called
early time during system boot up, while a pci driver module may be
insmod and disable cpu hotplug in short time, which could make
cpu offline fail, we need check it to make sure cpu offline real happen
before hypercall to disable vcpu.

Tracked-On: https://github.com/projectacrn/acrn-hypervisor/issues/1584
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
