### PR TITLE
tools: acrn-crashlog: remove unsafe apis in usercrash

### DIFF
--- a/tools/acrn-crashlog/usercrash/client.c
+++ b/tools/acrn-crashlog/usercrash/client.c
@@ -85,7 +85,8 @@ static int usercrashd_connect(int pid, int *usercrashd_socket,
 		LOGE("crash process name is NULL\n");
 		return -1;
 	}
-	sockfd = socket_local_client(SOCKET_NAME, SOCK_SEQPACKET);
+	sockfd = socket_local_client(SOCKET_NAME, strlen(SOCKET_NAME),
+			SOCK_SEQPACKET);
 	if (sockfd == -1) {
 		LOGE("failed to connect to usercrashd, error (%s)\n",
 			strerror(errno));
@@ -212,8 +213,8 @@ int main(int argc, char *argv[])
 
 	if (argc == 4) {
 		/* it's from coredump */
-		pid = atoi(argv[1]);
-		sig = atoi(argv[3]);
+		pid = (int)strtol(argv[1], NULL, 10);
+		sig = (int)strtol(argv[3], NULL, 10);
 		ret = usercrashd_connect(pid, &sock, &out_fd, argv[2]);
 		if (ret) {
 			LOGE("usercrashd_connect failed, error (%s)\n",

--- a/tools/acrn-crashlog/usercrash/debugger.c
+++ b/tools/acrn-crashlog/usercrash/debugger.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 
 	if (argc == 2) {
 		/* it's from shell cmd */
-		pid = atoi(argv[1]);
+		pid = (int)strtol(argv[1], NULL, 10);
 		crash_dump(pid, 0, STDOUT_FILENO);
 	} else {
 		print_usage();

--- a/tools/acrn-crashlog/usercrash/include/protocol.h
+++ b/tools/acrn-crashlog/usercrash/include/protocol.h
@@ -14,10 +14,11 @@
 #include <sys/cdefs.h>
 
 #define RESERVED_SOCKET_PREFIX "/tmp/"
+#define SOCKET_PATH_MAX 128
 
-int linux_get_control_socket(const char *name);
+int create_socket_server(const char *name, int type);
 
-int socket_local_client(const char *name, int type);
+int socket_local_client(const char *name, const size_t len, int type);
 ssize_t send_fd(int sockfd, const void *data, size_t len, int fd);
 ssize_t recv_fd(int sockfd, void *data, size_t len, int *out_fd);
 


### PR DESCRIPTION
Since strlen/vsnprintf/ato* api are not safe, so use strnlen instead of
strlen, use vasprintf instead of vsnprintf and use strtol instead of
atoi.

Tracked-On: #1254
Signed-off-by: xiaojin2 <xiaojing.liu@intel.com>
Reviewed-by: Huang Yonghua <yonghua.huang@intel.com>
Reviewed-by: Liu, Xinwu <xinwu.liu@intel.com>
Acked-by: Chen Gang <gang.c.chen@intel.com>