### PR TITLE
DM: multiboot info address in DM for elf loader is wrong.

### DIFF
--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -294,7 +294,7 @@ acrn_sw_load_elf(struct vmctx *ctx)
 	ctx->bsp_regs.vcpu_regs.gprs.rax = MULTIBOOT_MACHINE_STATE_MAGIC;
 
 	if (multiboot_image == 1) {
-		mi = (struct multiboot_info *)ctx->baseaddr + MULTIBOOT_OFFSET;
+		mi = (struct multiboot_info *)(ctx->baseaddr + MULTIBOOT_OFFSET);
 		memset(mi, 0, sizeof(*mi));
 
 		if (multiboot_flags == (1 << 1)) {


### PR DESCRIPTION
The () was missed during the patch refine. This patch add it.

Tracked-On: #1465
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>