### PR TITLE
HV: Fix boot failure of partition mode

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -482,6 +482,8 @@ static void bsp_boot_post(void)
 	/* Initialize interrupts */
 	interrupt_init(BOOT_CPU_ID);
 
+	init_iommu();
+
 	timer_init();
 	setup_notification();
 	setup_posted_intr_notification();
@@ -494,8 +496,6 @@ static void bsp_boot_post(void)
 	start_cpus();
 
 	ASSERT(get_cpu_id() == BOOT_CPU_ID, "");
-
-	init_iommu();
 
 	console_setup_timer();
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1286,6 +1286,8 @@ void init_iommu(void)
 	register_hrhd_units();
 
 	enable_iommu();
+
+	cache_flush_invalidate_all();
 }
 
 void init_iommu_vm0_domain(struct vm *vm0)


### PR DESCRIPTION
When drdh_info_array[0].ignore = false with partition mode enabled,the following
assert error will be triggered when trying to boot vm:

Assertion failed in file arch/x86/vtd.c: fatal error

The root cause is that root_table_addr reading from CPU3(vm2's bsp) is NULL.

This patch move the init_iommu which initialize root_table_addr before starting
secondary cores and flush the cache at the end if the function to avoid getting
NULL pointer from secondary cores.
Tracked-On: #1160
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Reviewed-by: Binin Wu <binbin.wu@intel.com>