### PR TITLE
Fix to kernel hang in smp_call_function

### DIFF
--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -25,7 +25,7 @@ static void kick_notification(__unused uint32_t irq, __unused void *data)
 		if (smp_call->func != NULL) {
 			smp_call->func(smp_call->data);
 		}
-		bitmap_clear_nolock(pcpu_id, &smp_call_mask);
+		bitmap_clear_lock(pcpu_id, &smp_call_mask);
 	}
 }
 


### PR DESCRIPTION
smp_call_function:
 smp_call_mask can be modified by more than one process which can cause kernel hang and timeout

Adding a lock to smp_call_mask to prevent race condition

Tracked-On: #1606
Acked-by:   Xu, Anthony <anthony.xu.intel.com>
Signed-off-by: Manisha Chinthapally <manisha.chinthapally@intel.com>