### PR TITLE
doc: move docs to match HLD 0.7 org

### DIFF
--- a/doc/developer-guides/hld/hld-emulated-devices.rst
+++ b/doc/developer-guides/hld/hld-emulated-devices.rst
@@ -1,0 +1,11 @@
+.. _hld-emulated-devices:
+
+Emulated devices high-level design
+##################################
+
+.. toctree::
+   :maxdepth: 1
+
+   GVT-g GPU Virtualization <hld-APL_GVT-g>
+   UART virtualization <uart-virt-hld>
+   Watchdoc virtualization <watchdog-hld>

--- a/doc/developer-guides/hld/hld-hypervisor.rst
+++ b/doc/developer-guides/hld/hld-hypervisor.rst
@@ -10,5 +10,5 @@ Hypervisor high-level design
    hv-startup
    hv-cpu-virt
    Memory management <memmgt-hld>
-
+   I/O Emulation <hld-io-emulation>
    Interrupt management <interrupt-hld>

--- a/doc/developer-guides/hld/hld-io-emulation.rst
+++ b/doc/developer-guides/hld/hld-io-emulation.rst
@@ -362,10 +362,3 @@ The following APIs are provided for I/O emulation at runtime:
    int32_t pio_instr_vmexit_handler(struct vcpu *vcpu)
 
 .. note:: change these to reference API material from ioreq.h
-
-.. toctree::
-   :maxdepth: 1
-
-   GVT-g GPU Virtualization <hld-APL_GVT-g>
-   UART virtualization <uart-virt-hld>
-   Watchdoc virtualization <watchdog-hld>

--- a/doc/developer-guides/hld/index.rst
+++ b/doc/developer-guides/hld/index.rst
@@ -19,7 +19,7 @@ system.
    Overview <hld-overview>
    Hypervisor <hld-hypervisor>
    Device Model <hld-devicemodel>
-   I/O Emulation <hld-io-emulation>
+   Emulated Devices <hld-emulated-devices>
    Virtio Devices <hld-virtio-devices>
    VM Management <hld-vm-management>
    Power Management <hld-power-management>


### PR DESCRIPTION
I/O emulation section was in a different place than in the HLD 0.7 doc

Tracked-on: #1592
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>