### PR TITLE
dm: fix possible buffer overflow in 'acrn_load_elf()'

### DIFF
--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -194,7 +194,7 @@ acrn_load_elf(struct vmctx *ctx, char *elf_file_name, unsigned long *entry,
 	 * info prepared.
 	 */
 	ptr32 = (unsigned int *) elf_buf;
-	for (i = 0; i < ELF_BUF_LEN/4; i++) {
+	for (i = 0; i <= ((ELF_BUF_LEN/4) - 3); i++) {
 		if (ptr32[i] == MULTIBOOT_HEAD_MAGIC) {
 			int j = 0;
 			unsigned int sum = 0;


### PR DESCRIPTION
  Will attempt to access element 2048..2049 of
  array "ptr32" if below conditions are both true:
  1) ptr32[i] == MULTIBOOT_HEAD_MAGIC
  2) (i == (ELF_BUF_LEN/4) - 1)

Tracked-On: #1252
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Fengwei Yin <fengwei.yin@intel.com>