### PR TITLE
checkpatch: fix the line limit back to 120

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,4 +1,4 @@
 --ignore BRACES
 --ignore GLOBAL_INITIALISERS
 --ignore INITIALISED_STATIC
---max-line-length=20
+--max-line-length=120


### PR DESCRIPTION
The checkpatch configuration set by commit 7b06be9 ("HV: checkpatch: add
configurations to customize checkpatch.pl") is unintendedly set to 20 (instead
of 120). This patch fix the setting to the expected value.

Tracked-On: #1557
Signed-off-by: Junjie Mao <junjie.mao@intel.com>