### PR TITLE
Documentation: tweak 'partition mode' tutorial

### DIFF
--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -187,9 +187,8 @@ Enabling partition mode
   .. code-block:: console
      :emphasize-lines: 2
 
-      ACRN Partition Mode with Zephyr
-     *ACRN Partition Mode
-      ADG Partition Mode
+     *Ubuntu
+      ACRN Partition Mode
       Advanced options for Ubuntu
       System setup
       Restore Ubuntu 16.04 to factory state


### PR DESCRIPTION
Tweak the 'Using partition mode on UP2' tutorial by removing
a couple of Grub menu entries that are not present by default
(nor introduced as part of the tutorial).

Also make it more obvious that there is still a default entry
called 'Ubuntu' which is the one by default.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>