### PR TITLE
Virtio mei reset Tracked-On: #1632

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -962,6 +962,9 @@ vmei_host_client_native_connect(struct vmei_host_client *hclient)
 	struct vmei_me_client *mclient;
 	struct mei_connect_client_data_vtag connection_data;
 
+	if (!vmei)
+		return MEI_HBM_REJECTED;
+
 	mclient = hclient->mclient;
 
 	/* open mei node */
@@ -1636,6 +1639,9 @@ vmei_host_client_native_read(struct vmei_host_client *hclient)
 {
 	struct virtio_mei *vmei = vmei_host_client_to_vmei(hclient);
 	ssize_t len;
+
+	if (!vmei)
+		return -1;
 
 	if (hclient->client_fd < 0) {
 		HCL_WARN(hclient, "RX: invalid client fd\n");

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -1257,6 +1257,8 @@ vmei_hbm_handler(struct virtio_mei *vmei, const void *data)
 		memset(&disconnect_res, 0, sizeof(disconnect_res));
 		disconnect_res.hbm_cmd.cmd = MEI_HBM_CLIENT_DISCONNECT;
 		disconnect_res.hbm_cmd.is_response = 1;
+		disconnect_res.me_addr = disconnect_req->me_addr;
+		disconnect_res.host_addr = disconnect_req->host_addr;
 		disconnect_res.status = status;
 		vmei_hbm_response(vmei, &disconnect_res,
 				  sizeof(disconnect_res));


### PR DESCRIPTION
The FW reset is currently detected from two points upon
    a read failure from native read and from the reset
    handler.
    The fix removes the detection from the mevent rx callback,
    leaving a single detection point.
    To prevent reset hiccup, hw_ready is not set if a full rescan is
    performed, it will be set only when virtio FW will request the FW reset.

Tracked-On: #1570
Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>
