### PR TITLE
DM: wrap ASSERT/DEASSERT IRQ line with Set/Clear IRQ line

### DIFF
--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -93,7 +93,7 @@ sci_assert(struct vmctx *ctx)
 {
 	if (sci_active)
 		return;
-	vm_isa_assert_irq(ctx, SCI_INT, SCI_INT);
+	vm_set_gsi_irq(ctx, SCI_INT, GSI_SET_HIGH);
 	sci_active = 1;
 }
 
@@ -102,7 +102,7 @@ sci_deassert(struct vmctx *ctx)
 {
 	if (!sci_active)
 		return;
-	vm_isa_deassert_irq(ctx, SCI_INT, SCI_INT);
+	vm_set_gsi_irq(ctx, SCI_INT, GSI_SET_LOW);
 	sci_active = 0;
 }
 

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -429,58 +429,15 @@ vm_lapic_msi(struct vmctx *ctx, uint64_t addr, uint64_t msg)
 }
 
 int
-vm_ioapic_assert_irq(struct vmctx *ctx, int irq)
+vm_set_gsi_irq(struct vmctx *ctx, int gsi, uint32_t operation)
 {
-	struct acrn_irqline ioapic_irq;
+	struct acrn_irqline_ops op;
+	uint64_t *req =  (uint64_t *)&op;
 
-	bzero(&ioapic_irq, sizeof(ioapic_irq));
-	ioapic_irq.intr_type = ACRN_INTR_TYPE_IOAPIC;
-	ioapic_irq.ioapic_irq = irq;
+	op.op = operation;
+	op.nr_gsi = (uint32_t)gsi;
 
-	return ioctl(ctx->fd, IC_ASSERT_IRQLINE, &ioapic_irq);
-}
-
-int
-vm_ioapic_deassert_irq(struct vmctx *ctx, int irq)
-{
-	struct acrn_irqline ioapic_irq;
-
-	bzero(&ioapic_irq, sizeof(ioapic_irq));
-	ioapic_irq.intr_type = ACRN_INTR_TYPE_IOAPIC;
-	ioapic_irq.ioapic_irq = irq;
-
-	return ioctl(ctx->fd, IC_DEASSERT_IRQLINE, &ioapic_irq);
-}
-
-static int
-vm_isa_irq(struct vmctx *ctx, int irq, int ioapic_irq, unsigned long call_id)
-{
-	struct acrn_irqline isa_irq;
-
-	bzero(&isa_irq, sizeof(isa_irq));
-	isa_irq.intr_type = ACRN_INTR_TYPE_ISA;
-	isa_irq.pic_irq = irq;
-	isa_irq.ioapic_irq = ioapic_irq;
-
-	return ioctl(ctx->fd, call_id, &isa_irq);
-}
-
-int
-vm_isa_assert_irq(struct vmctx *ctx, int atpic_irq, int ioapic_irq)
-{
-	return vm_isa_irq(ctx, atpic_irq, ioapic_irq, IC_ASSERT_IRQLINE);
-}
-
-int
-vm_isa_deassert_irq(struct vmctx *ctx, int atpic_irq, int ioapic_irq)
-{
-	return vm_isa_irq(ctx, atpic_irq, ioapic_irq, IC_DEASSERT_IRQLINE);
-}
-
-int
-vm_isa_pulse_irq(struct vmctx *ctx, int atpic_irq, int ioapic_irq)
-{
-	return vm_isa_irq(ctx, atpic_irq, ioapic_irq, IC_PULSE_IRQLINE);
+	return ioctl(ctx->fd, IC_SET_IRQLINE, *req);
 }
 
 int

--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -105,9 +105,9 @@ lpc_uart_intr_assert(void *arg)
 	assert(lpc_uart->irq >= 0);
 
 	if (lpc_bridge)
-		vm_isa_pulse_irq(lpc_bridge->vmctx,
+		vm_set_gsi_irq(lpc_bridge->vmctx,
 				 lpc_uart->irq,
-				 lpc_uart->irq);
+				 GSI_RAISING_PULSE);
 }
 
 static void

--- a/devicemodel/hw/platform/atkbdc.c
+++ b/devicemodel/hw/platform/atkbdc.c
@@ -49,7 +49,7 @@ atkbdc_assert_kbd_intr(struct atkbdc_base *base)
 {
 	if ((base->ram[0] & KBD_ENABLE_KBD_INT) != 0) {
 		base->kbd.irq_active = true;
-		vm_isa_pulse_irq(base->ctx, base->kbd.irq, base->kbd.irq);
+		vm_set_gsi_irq(base->ctx, base->kbd.irq, GSI_RAISING_PULSE);
 	}
 }
 
@@ -58,7 +58,7 @@ atkbdc_assert_aux_intr(struct atkbdc_base *base)
 {
 	if ((base->ram[0] & KBD_ENABLE_AUX_INT) != 0) {
 		base->aux.irq_active = true;
-		vm_isa_pulse_irq(base->ctx, base->aux.irq, base->aux.irq);
+		vm_set_gsi_irq(base->ctx, base->aux.irq, GSI_RAISING_PULSE);
 	}
 }
 

--- a/devicemodel/hw/platform/pit.c
+++ b/devicemodel/hw/platform/pit.c
@@ -245,7 +245,7 @@ vpit_timer_handler(union sigval s)
 	c = &vpit->channel[arg->channel_num];
 
 	/* generate a rising edge on OUT */
-	vm_isa_pulse_irq(vpit->vm, PIT_ATPIC_IRQ, PIT_IOAPIC_IRQ);
+	vm_set_gsi_irq(vpit->vm, PIT_IOAPIC_IRQ, GSI_RAISING_PULSE);
 
 	/* CR -> CE if necessary */
 	pit_load_ce(c);

--- a/devicemodel/hw/platform/rtc.c
+++ b/devicemodel/hw/platform/rtc.c
@@ -717,13 +717,10 @@ vrtc_set_reg_c(struct vrtc *vrtc, uint8_t newval)
 	}
 
 	if (!oldirqf && newirqf) {
-
-		vm_isa_assert_irq(vrtc->vm, RTC_IRQ, RTC_IRQ);
-		/*vm_ioapic_assert_irq(vrtc->vm, RTC_IRQ);*/
+		vm_set_gsi_irq(vrtc->vm, RTC_IRQ, GSI_SET_HIGH);
 		RTC_DEBUG("RTC irq %d asserted\n", RTC_IRQ);
 	} else if (oldirqf && !newirqf) {
-		vm_isa_deassert_irq(vrtc->vm, RTC_IRQ, RTC_IRQ);
-		/*vm_ioapic_deassert_irq(vrtc->vm, RTC_IRQ);*/
+		vm_set_gsi_irq(vrtc->vm, RTC_IRQ, GSI_SET_LOW);
 		RTC_DEBUG("RTC irq %d deasserted\n", RTC_IRQ);
 	}
 }

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -350,39 +350,22 @@ struct acrn_set_ioreq_buffer {
 	uint64_t req_buf;
 } __aligned(8);
 
-/** Interrupt type for acrn_irqline: inject interrupt to IOAPIC */
-#define	ACRN_INTR_TYPE_ISA	0U
-
-/** Interrupt type for acrn_irqline: inject interrupt to both PIC and IOAPIC */
-#define	ACRN_INTR_TYPE_IOAPIC	1U
+/** Operation types for setting IRQ line */
+#define GSI_SET_HIGH		0U
+#define GSI_SET_LOW		1U
+#define GSI_RAISING_PULSE	2U
+#define GSI_FALLING_PULSE	3U
 
 /**
- * @brief Info to assert/deassert/pulse a virtual IRQ line for a VM
+ * @brief Info to Set/Clear/Pulse a virtual IRQ line for a VM
  *
- * the parameter for HC_ASSERT_IRQLINE/HC_DEASSERT_IRQLINE/HC_PULSE_IRQLINE
- * hypercall
+ * the parameter for HC_SET_IRQLINE hypercall
  */
-struct acrn_irqline {
-	/** interrupt type which could be IOAPIC or ISA */
-	uint32_t intr_type;
-
-	/** reserved for alignment padding */
-	uint32_t reserved;
-
-	/** pic IRQ for ISA type */
-	uint32_t pic_irq;
-
-	/** Reserved */
-	uint32_t reserved0;
-
-	/** ioapic IRQ for IOAPIC & ISA TYPE,
-	 *  if ~0U then this IRQ will not be injected
-	 */
-	uint32_t ioapic_irq;
-
-	/** Reserved */
-	uint32_t reserved1;
+struct acrn_irqline_ops {
+	uint32_t nr_gsi;
+	uint32_t op;
 } __aligned(8);
+
 
 /**
  * @brief Info to inject a MSI interrupt to VM

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -77,11 +77,9 @@
 
 /* IRQ and Interrupts */
 #define IC_ID_IRQ_BASE                 0x20UL
-#define IC_ASSERT_IRQLINE              _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x00)
-#define IC_DEASSERT_IRQLINE            _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x01)
-#define IC_PULSE_IRQLINE               _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x02)
 #define IC_INJECT_MSI                  _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x03)
 #define IC_VM_INTR_MONITOR             _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x04)
+#define IC_SET_IRQLINE                 _IC_ID(IC_ID, IC_ID_IRQ_BASE + 0x05)
 
 /* DM ioreq management */
 #define IC_ID_IOREQ_BASE                0x30UL

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -130,11 +130,7 @@ int	vm_run(struct vmctx *ctx);
 int	vm_suspend(struct vmctx *ctx, enum vm_suspend_how how);
 int	vm_apicid2vcpu(struct vmctx *ctx, int apicid);
 int	vm_lapic_msi(struct vmctx *ctx, uint64_t addr, uint64_t msg);
-int	vm_ioapic_assert_irq(struct vmctx *ctx, int irq);
-int	vm_ioapic_deassert_irq(struct vmctx *ctx, int irq);
-int	vm_isa_assert_irq(struct vmctx *ctx, int atpic_irq, int ioapic_irq);
-int	vm_isa_deassert_irq(struct vmctx *ctx, int atpic_irq, int ioapic_irq);
-int	vm_isa_pulse_irq(struct vmctx *ctx, int atpic_irq, int ioapic_irq);
+int	vm_set_gsi_irq(struct vmctx *ctx, int gsi, uint32_t operation);
 int	vm_assign_ptdev(struct vmctx *ctx, int bus, int slot, int func);
 int	vm_unassign_ptdev(struct vmctx *ctx, int bus, int slot, int func);
 int	vm_map_ptdev_mmio(struct vmctx *ctx, int bus, int slot, int func,


### PR DESCRIPTION
 - remove ASSERT & DEASSET IRQ line IOCTLs
 - remove PULSE IRQ line IOCTLs, use set/clear
   IRQ line instead.
 - Use IC_SET_IRQLINE to set or clear IRQ line

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>