### PR TITLE
hv: mmu: remove dynamic memory allocation in memory management

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -121,6 +121,7 @@ C_SRCS += arch/x86/cpu.c
 C_SRCS += arch/x86/cpuid.c
 C_SRCS += arch/x86/mmu.c
 C_SRCS += arch/x86/pagetable.c
+C_SRCS += arch/x86/page.c
 C_SRCS += arch/x86/notify.c
 C_SRCS += arch/x86/vtd.c
 C_SRCS += arch/x86/gdt.c

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -222,7 +222,7 @@ config HV_RAM_START
 
 config HV_RAM_SIZE
 	hex "Size of the RAM region used by the hypervisor"
-	default 0x04000000
+	default 0x06000000
 	help
 	  A 64-bit integer indicating the size of RAM used by the hypervisor.
 	  It is ensured at link time that the footprint of the hypervisor

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -164,10 +164,6 @@ config MALLOC_ALIGN
 	range 8 32
 	default 16
 
-config NUM_ALLOC_PAGES
-	hex "Capacity in pages of the heap for page_alloc()"
-	default 0x1000
-
 config HEAP_SIZE
 	hex "Capacity of the heap for malloc()"
 	default 0x100000
@@ -222,7 +218,7 @@ config HV_RAM_START
 
 config HV_RAM_SIZE
 	hex "Size of the RAM region used by the hypervisor"
-	default 0x06000000
+	default 0x04800000
 	help
 	  A 64-bit integer indicating the size of RAM used by the hypervisor.
 	  It is ensured at link time that the footprint of the hypervisor

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -235,6 +235,21 @@ config PLATFORM_RAM_SIZE
 	  A 64-bit integer indicating the size of the physical platform RAM
 	  (not included the MMIO).
 
+config SOS_RAM_SIZE
+	hex "Size of the vm0 RAM"
+	default 0x200000000 if SHARING_MODE
+	default 0x000000000 if PARTITION_MODE
+	help
+	  A 64-bit integer indicating the size of the vm0 RAM (not included the MMIO).
+
+ config UOS_RAM_SIZE
+	hex "Size of the UOS RAM"
+	default 0x100000000 if SHARING_MODE
+	default 0x100000000 if PARTITION_MODE
+	help
+	  A 64-bit integer indicating the size of the user OS RAM (not included the MMIO).
+	  Now we assume each UOS uses same amount of RAM size.
+
 config CONSTANT_ACPI
 	bool "The platform ACPI info is constant"
 	default n

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -208,25 +208,32 @@ config LOW_RAM_SIZE
 	  A 32-bit integer indicating the size of RAM region below address
 	  0x10000, starting from address 0x0.
 
-config RAM_START
-	hex "Address of the RAM region assigned to the hypervisor"
+config HV_RAM_START
+	hex "Start physical address of the RAM region used by the hypervisor"
 	default 0x6e000000 if PLATFORM_SBL
 	default 0x00100000 if PLATFORM_UEFI
 	help
-	  A 64-bit integer indicating the base address to where the hypervisor
+	  A 64-bit integer indicating the base physical address to where the hypervisor
 	  should be loaded to. If RELOC is disabled the bootloader is required
 	  to load the hypervisor to this specific address. Otherwise the
 	  hypervisor will not boot. With RELOC enabled the hypervisor is capable
 	  of relocating its symbols to where it is placed at, and thus the
 	  bootloader may not place the hypervisor at this specific address.
 
-config RAM_SIZE
-	hex "Size of the RAM region assigned to the hypervisor"
-	default 0x02000000
+config HV_RAM_SIZE
+	hex "Size of the RAM region used by the hypervisor"
+	default 0x04000000
 	help
-	  A 64-bit integer indicating the size of RAM assigned to the
-	  hypervisor. It is ensured at link time that the footprint of the
-	  hypervisor does not exceed this size.
+	  A 64-bit integer indicating the size of RAM used by the hypervisor.
+	  It is ensured at link time that the footprint of the hypervisor
+	  does not exceed this size.
+
+config PLATFORM_RAM_SIZE
+	hex "Size of the physical platform RAM"
+	default 0x200000000
+	help
+	  A 64-bit integer indicating the size of the physical platform RAM
+	  (not included the MMIO).
 
 config CONSTANT_ACPI
 	bool "The platform ACPI info is constant"

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -542,7 +542,7 @@ void cpu_secondary_init(void)
 	/* Switch this CPU to use the same page tables set-up by the
 	 * primary/boot CPU
 	 */
-	enable_paging(get_paging_pml4());
+	enable_paging();
 
 	enable_smep();
 

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -619,6 +619,10 @@ int prepare_vm0_memmap_and_e820(struct vm *vm)
 		"vm0: bottom memory - 0x%llx, top memory - 0x%llx\n",
 		e820_mem.mem_bottom, e820_mem.mem_top);
 
+	if (e820_mem.mem_top > EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE)) {
+		panic("Please configure VM0_ADDRESS_SPACE correctly!\n");
+	}
+
 	/* create real ept map for all ranges with UC */
 	ept_mr_add(vm, pml4_page,
 			e820_mem.mem_bottom, e820_mem.mem_bottom,

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -268,7 +268,7 @@ void init_paging(void)
 	 * to supervisor-mode for hypervisor owned memroy.
 	 */
 	hv_hpa = get_hv_image_base();
-	mmu_modify_or_del((uint64_t *)mmu_pml4_addr, hv_hpa, CONFIG_RAM_SIZE,
+	mmu_modify_or_del((uint64_t *)mmu_pml4_addr, hv_hpa, CONFIG_HV_RAM_SIZE,
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER,
 			PTT_PRIMARY, MR_MODIFY);
 

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -5,12 +5,9 @@
  */
 #include <hypervisor.h>
 
-#define DEFINE_PGTABLE_PAGE(prefix, lvl, LVL, size)	\
-		static struct page prefix ## lvl ## _pages[LVL ## _PAGE_NUM(size)]
-
-DEFINE_PGTABLE_PAGE(ppt_, pml4, PML4, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
-DEFINE_PGTABLE_PAGE(ppt_, pdpt, PDPT, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
-DEFINE_PGTABLE_PAGE(ppt_, pd, PD, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
+static struct page ppt_pml4_pages[PML4_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)];
+static struct page ppt_pdpt_pages[PDPT_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)];
+static struct page ppt_pd_pages[PD_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)];
 
 /* ppt: pripary page table */
 static union pgtable_pages_info ppt_pages_info = {
@@ -61,10 +58,10 @@ const struct memory_ops ppt_mem_ops = {
 	.get_pd_page = ppt_get_pd_page,
 };
 
-DEFINE_PGTABLE_PAGE(vm0_, pml4, PML4, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
-DEFINE_PGTABLE_PAGE(vm0_, pdpt, PDPT, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
-DEFINE_PGTABLE_PAGE(vm0_, pd, PD, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
-DEFINE_PGTABLE_PAGE(vm0_, pt, PT, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
+static struct page vm0_pml4_pages[PML4_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page vm0_pdpt_pages[PDPT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page vm0_pd_pages[PD_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page vm0_pt_pages[PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
 
 /* uos_nworld_pml4_pages[i] is ...... of UOS i (whose vm_id = i +1) */
 static struct page uos_nworld_pml4_pages[CONFIG_MAX_VM_NUM - 1U][PML4_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -99,25 +99,14 @@ static inline uint64_t ept_pgentry_present(uint64_t pte)
 
 static inline struct page *ept_get_pml4_page(const union pgtable_pages_info *info, __unused uint64_t gpa)
 {
-	struct page *page;
-	if (gpa < TRUSTY_EPT_REBASE_GPA) {
-		page = info->ept.nworld_pml4_base;
-	} else {
-		page = info->ept.sworld_pgtable_base;
-	}
+	struct page *page = info->ept.nworld_pml4_base;
 	(void)memset(page, 0U, PAGE_SIZE);
 	return page;
 }
 
 static inline struct page *ept_get_pdpt_page(const union pgtable_pages_info *info, uint64_t gpa)
 {
-	struct page *page;
-	if (gpa < TRUSTY_EPT_REBASE_GPA) {
-		page = info->ept.nworld_pdpt_base + (gpa >> PML4E_SHIFT);
-	} else {
-		page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
-			((gpa - TRUSTY_EPT_REBASE_GPA) >> PML4E_SHIFT);
-	}
+	struct page *page = info->ept.nworld_pdpt_base + (gpa >> PML4E_SHIFT);
 	(void)memset(page, 0U, PAGE_SIZE);
 	return page;
 }

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -5,11 +5,6 @@
  */
 #include <hypervisor.h>
 
-#define PML4_PAGE_NUM(size)	1UL
-#define PDPT_PAGE_NUM(size)	(((size) + PML4E_SIZE - 1UL) >> PML4E_SHIFT)
-#define PD_PAGE_NUM(size)	(((size) + PDPTE_SIZE - 1UL) >> PDPTE_SHIFT)
-#define PT_PAGE_NUM(size)	(((size) + PDE_SIZE - 1UL) >> PDE_SHIFT)
-
 #define DEFINE_PGTABLE_PAGE(prefix, lvl, LVL, size)	\
 		static struct page prefix ## lvl ## _pages[LVL ## _PAGE_NUM(size)]
 
@@ -66,8 +61,6 @@ const struct memory_ops ppt_mem_ops = {
 	.get_pd_page = ppt_get_pd_page,
 };
 
-/* The size of the guest physical address space, covered by the EPT page table of a VM */
-#define EPT_ADDRESS_SPACE(size)	((size != 0UL) ? (size + PLATFORM_LO_MMIO_SIZE) : 0UL)
 DEFINE_PGTABLE_PAGE(vm0_, pml4, PML4, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
 DEFINE_PGTABLE_PAGE(vm0_, pdpt, PDPT, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
 DEFINE_PGTABLE_PAGE(vm0_, pd, PD, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
@@ -78,13 +71,6 @@ static struct page uos_nworld_pml4_pages[CONFIG_MAX_VM_NUM - 1U][PML4_PAGE_NUM(E
 static struct page uos_nworld_pdpt_pages[CONFIG_MAX_VM_NUM - 1U][PDPT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
 static struct page uos_nworld_pd_pages[CONFIG_MAX_VM_NUM - 1U][PD_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
 static struct page uos_nworld_pt_pages[CONFIG_MAX_VM_NUM - 1U][PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
-
-#define TRUSTY_PML4_PAGE_NUM(size)	(1UL)
-#define TRUSTY_PDPT_PAGE_NUM(size)	(1UL)
-#define TRUSTY_PD_PAGE_NUM(size)	(PD_PAGE_NUM(size))
-#define TRUSTY_PT_PAGE_NUM(size)	(PT_PAGE_NUM(size))
-#define TRUSTY_PGTABLE_PAGE_NUM(size)	\
-(TRUSTY_PML4_PAGE_NUM(size) + TRUSTY_PDPT_PAGE_NUM(size) + TRUSTY_PD_PAGE_NUM(size) + TRUSTY_PT_PAGE_NUM(size))
 
 static struct page uos_sworld_pgtable_pages[CONFIG_MAX_VM_NUM - 1U][TRUSTY_PGTABLE_PAGE_NUM(TRUSTY_RAM_SIZE)];
 

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -65,3 +65,122 @@ const struct memory_ops ppt_mem_ops = {
 	.get_pdpt_page = ppt_get_pdpt_page,
 	.get_pd_page = ppt_get_pd_page,
 };
+
+/* The size of the guest physical address space, covered by the EPT page table of a VM */
+#define EPT_ADDRESS_SPACE(size)	((size != 0UL) ? (size + PLATFORM_LO_MMIO_SIZE) : 0UL)
+DEFINE_PGTABLE_PAGE(vm0_, pml4, PML4, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
+DEFINE_PGTABLE_PAGE(vm0_, pdpt, PDPT, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
+DEFINE_PGTABLE_PAGE(vm0_, pd, PD, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
+DEFINE_PGTABLE_PAGE(vm0_, pt, PT, EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE));
+
+/* uos_nworld_pml4_pages[i] is ...... of UOS i (whose vm_id = i +1) */
+static struct page uos_nworld_pml4_pages[CONFIG_MAX_VM_NUM - 1U][PML4_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
+static struct page uos_nworld_pdpt_pages[CONFIG_MAX_VM_NUM - 1U][PDPT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
+static struct page uos_nworld_pd_pages[CONFIG_MAX_VM_NUM - 1U][PD_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
+static struct page uos_nworld_pt_pages[CONFIG_MAX_VM_NUM - 1U][PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
+
+#define TRUSTY_PML4_PAGE_NUM(size)	(1UL)
+#define TRUSTY_PDPT_PAGE_NUM(size)	(1UL)
+#define TRUSTY_PD_PAGE_NUM(size)	(PD_PAGE_NUM(size))
+#define TRUSTY_PT_PAGE_NUM(size)	(PT_PAGE_NUM(size))
+#define TRUSTY_PGTABLE_PAGE_NUM(size)	\
+(TRUSTY_PML4_PAGE_NUM(size) + TRUSTY_PDPT_PAGE_NUM(size) + TRUSTY_PD_PAGE_NUM(size) + TRUSTY_PT_PAGE_NUM(size))
+
+static struct page uos_sworld_pgtable_pages[CONFIG_MAX_VM_NUM - 1U][TRUSTY_PGTABLE_PAGE_NUM(TRUSTY_RAM_SIZE)];
+
+/* ept: extended page table*/
+static union pgtable_pages_info ept_pages_info[CONFIG_MAX_VM_NUM] = {
+	{
+		.ept = {
+			.top_address_space = EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE),
+			.nworld_pml4_base = vm0_pml4_pages,
+			.nworld_pdpt_base = vm0_pdpt_pages,
+			.nworld_pd_base = vm0_pd_pages,
+			.nworld_pt_base = vm0_pt_pages,
+		},
+	},
+};
+
+static inline uint64_t ept_get_default_access_right(void)
+{
+	return EPT_RWX;
+}
+
+static inline uint64_t ept_pgentry_present(uint64_t pte)
+{
+	return pte & EPT_RWX;
+}
+
+static inline struct page *ept_get_pml4_page(const union pgtable_pages_info *info, __unused uint64_t gpa)
+{
+	struct page *page;
+	if (gpa < TRUSTY_EPT_REBASE_GPA) {
+		page = info->ept.nworld_pml4_base;
+	} else {
+		page = info->ept.sworld_pgtable_base;
+	}
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+static inline struct page *ept_get_pdpt_page(const union pgtable_pages_info *info, uint64_t gpa)
+{
+	struct page *page;
+	if (gpa < TRUSTY_EPT_REBASE_GPA) {
+		page = info->ept.nworld_pdpt_base + (gpa >> PML4E_SHIFT);
+	} else {
+		page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
+			((gpa - TRUSTY_EPT_REBASE_GPA) >> PML4E_SHIFT);
+	}
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+static inline struct page *ept_get_pd_page(const union pgtable_pages_info *info, uint64_t gpa)
+{
+	struct page *page;
+	if (gpa < TRUSTY_EPT_REBASE_GPA) {
+		page = info->ept.nworld_pd_base + (gpa >> PDPTE_SHIFT);
+	} else {
+		page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
+			TRUSTY_PDPT_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) + ((gpa - TRUSTY_EPT_REBASE_GPA) >> PDPTE_SHIFT);
+	}
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+static inline struct page *ept_get_pt_page(const union pgtable_pages_info *info, uint64_t gpa)
+{
+	struct page *page;
+	if (gpa < TRUSTY_EPT_REBASE_GPA) {
+		page = info->ept.nworld_pt_base + (gpa >> PDE_SHIFT);
+	} else {
+		page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
+			TRUSTY_PDPT_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) + TRUSTY_PD_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
+			((gpa - TRUSTY_EPT_REBASE_GPA) >> PDE_SHIFT);
+	}
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+void init_ept_mem_ops(struct vm *vm)
+{
+	uint16_t vm_id = vm->vm_id;
+	if (vm_id != 0U) {
+		ept_pages_info[vm_id].ept.top_address_space = EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE);
+		ept_pages_info[vm_id].ept.nworld_pml4_base = uos_nworld_pml4_pages[vm_id - 1U];
+		ept_pages_info[vm_id].ept.nworld_pdpt_base = uos_nworld_pdpt_pages[vm_id - 1U];
+		ept_pages_info[vm_id].ept.nworld_pd_base = uos_nworld_pd_pages[vm_id - 1U];
+		ept_pages_info[vm_id].ept.nworld_pt_base = uos_nworld_pt_pages[vm_id - 1U];
+		ept_pages_info[vm_id].ept.sworld_pgtable_base = uos_sworld_pgtable_pages[vm_id - 1U];
+	}
+	vm->arch_vm.ept_mem_ops.info = &ept_pages_info[vm_id];
+
+	vm->arch_vm.ept_mem_ops.get_default_access_right = ept_get_default_access_right;
+	vm->arch_vm.ept_mem_ops.pgentry_present = ept_pgentry_present;
+	vm->arch_vm.ept_mem_ops.get_pml4_page = ept_get_pml4_page;
+	vm->arch_vm.ept_mem_ops.get_pdpt_page = ept_get_pdpt_page;
+	vm->arch_vm.ept_mem_ops.get_pd_page = ept_get_pd_page;
+	vm->arch_vm.ept_mem_ops.get_pt_page = ept_get_pt_page;
+
+}

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <hypervisor.h>
+
+#define PML4_PAGE_NUM(size)	1UL
+#define PDPT_PAGE_NUM(size)	(((size) + PML4E_SIZE - 1UL) >> PML4E_SHIFT)
+#define PD_PAGE_NUM(size)	(((size) + PDPTE_SIZE - 1UL) >> PDPTE_SHIFT)
+#define PT_PAGE_NUM(size)	(((size) + PDE_SIZE - 1UL) >> PDE_SHIFT)
+
+#define DEFINE_PGTABLE_PAGE(prefix, lvl, LVL, size)	\
+		static struct page prefix ## lvl ## _pages[LVL ## _PAGE_NUM(size)]
+
+DEFINE_PGTABLE_PAGE(ppt_, pml4, PML4, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
+DEFINE_PGTABLE_PAGE(ppt_, pdpt, PDPT, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
+DEFINE_PGTABLE_PAGE(ppt_, pd, PD, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
+
+/* ppt: pripary page table */
+static union pgtable_pages_info ppt_pages_info = {
+	.ppt = {
+		.pml4_base = ppt_pml4_pages,
+		.pdpt_base = ppt_pdpt_pages,
+		.pd_base = ppt_pd_pages,
+	}
+};
+
+static inline uint64_t ppt_get_default_access_right(void)
+{
+	return (PAGE_PRESENT | PAGE_RW | PAGE_USER);
+}
+
+static inline uint64_t ppt_pgentry_present(uint64_t pte)
+{
+	return pte & PAGE_PRESENT;
+}
+
+static inline struct page *ppt_get_pml4_page(const union pgtable_pages_info *info, __unused uint64_t gpa)
+{
+	struct page *page = info->ppt.pml4_base;
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+static inline struct page *ppt_get_pdpt_page(const union pgtable_pages_info *info, uint64_t gpa)
+{
+	struct page *page = info->ppt.pdpt_base + (gpa >> PML4E_SHIFT);
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+static inline struct page *ppt_get_pd_page(const union pgtable_pages_info *info, uint64_t gpa)
+{
+	struct page *page = info->ppt.pd_base + (gpa >> PDPTE_SHIFT);
+	(void)memset(page, 0U, PAGE_SIZE);
+	return page;
+}
+
+const struct memory_ops ppt_mem_ops = {
+	.info = &ppt_pages_info,
+	.get_default_access_right = ppt_get_default_access_right,
+	.pgentry_present = ppt_pgentry_present,
+	.get_pml4_page = ppt_get_pml4_page,
+	.get_pdpt_page = ppt_get_pdpt_page,
+	.get_pd_page = ppt_get_pd_page,
+};

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -10,11 +10,9 @@
 /*
  * Split a large page table into next level page table.
  */
-static int split_large_page(uint64_t *pte,
-			enum _page_table_level level,
-			enum _page_table_type ptt)
+static void split_large_page(uint64_t *pte, enum _page_table_level level,
+		uint64_t vaddr, const struct memory_ops *mem_ops)
 {
-	int ret = -EINVAL;
 	uint64_t *pbase;
 	uint64_t ref_paddr, paddr, paddrinc;
 	uint64_t i, ref_prot;
@@ -24,23 +22,20 @@ static int split_large_page(uint64_t *pte,
 		ref_paddr = (*pte) & PDPTE_PFN_MASK;
 		paddrinc = PDE_SIZE;
 		ref_prot = (*pte) & ~PDPTE_PFN_MASK;
+		pbase = (uint64_t *)mem_ops->get_pd_page(mem_ops->info, vaddr);
 		break;
 	case IA32E_PD:
 		ref_paddr = (*pte) & PDE_PFN_MASK;
 		paddrinc = PTE_SIZE;
 		ref_prot = (*pte) & ~PDE_PFN_MASK;
 		ref_prot &= ~PAGE_PSE;
+		pbase = (uint64_t *)mem_ops->get_pt_page(mem_ops->info, vaddr);
 		break;
 	default:
-		return ret;
+		panic("invalid paging table level: %d", level);
 	}
 
-	dev_dbg(ACRN_DBG_MMU, "%s, paddr: 0x%llx\n", __func__, ref_paddr);
-
-	pbase = (uint64_t *)alloc_paging_struct();
-	if (pbase == NULL) {
-		return -ENOMEM;
-	}
+	dev_dbg(ACRN_DBG_MMU, "%s, paddr: 0x%llx, pbase: 0x%llx\n", __func__, ref_paddr, pbase);
 
 	paddr = ref_paddr;
 	for (i = 0UL; i < PTRS_PER_PTE; i++) {
@@ -48,12 +43,10 @@ static int split_large_page(uint64_t *pte,
 		paddr += paddrinc;
 	}
 
-	ref_prot = (ptt == PTT_PRIMARY) ? PAGE_TABLE : EPT_RWX;
+	ref_prot = mem_ops->get_default_access_right();
 	set_pgentry(pte, hva2hpa((void *)pbase) | ref_prot);
 
 	/* TODO: flush the TLB */
-
-	return 0;
 }
 
 static inline void local_modify_or_del_pte(uint64_t *pte,
@@ -72,19 +65,11 @@ static inline void local_modify_or_del_pte(uint64_t *pte,
 /*
  * pgentry may means pml4e/pdpte/pde
  */
-static inline int construct_pgentry(enum _page_table_type ptt, uint64_t *pde)
+static inline void construct_pgentry(uint64_t *pde, void *pd_page, uint64_t prot)
 {
-	uint64_t prot;
-	void *pd_page = alloc_paging_struct();
-	if (pd_page == NULL) {
-		return -ENOMEM;
-	}
-
 	sanitize_pte((uint64_t *)pd_page);
 
-	prot = (ptt == PTT_PRIMARY) ? PAGE_TABLE: EPT_RWX;
 	set_pgentry(pde, hva2hpa(pd_page) | prot);
-	return 0;
 }
 
 /*
@@ -94,21 +79,18 @@ static inline int construct_pgentry(enum _page_table_type ptt, uint64_t *pde)
  * type: MR_DEL
  * delete [vaddr_start, vaddr_end) MT PT mapping
  */
-static void modify_or_del_pte(const uint64_t *pde,
-		uint64_t vaddr_start, uint64_t vaddr_end,
-		uint64_t prot_set, uint64_t prot_clr,
-		enum _page_table_type ptt, uint32_t type)
+static void modify_or_del_pte(const uint64_t *pde, uint64_t vaddr_start, uint64_t vaddr_end,
+		uint64_t prot_set, uint64_t prot_clr, const struct memory_ops *mem_ops, uint32_t type)
 {
 	uint64_t *pt_page = pde_page_vaddr(*pde);
 	uint64_t vaddr = vaddr_start;
 	uint64_t index = pte_index(vaddr);
 
-	dev_dbg(ACRN_DBG_MMU, "%s, vaddr: [0x%llx - 0x%llx]\n",
-		__func__, vaddr, vaddr_end);
+	dev_dbg(ACRN_DBG_MMU, "%s, vaddr: [0x%llx - 0x%llx]\n", __func__, vaddr, vaddr_end);
 	for (; index < PTRS_PER_PTE; index++) {
 		uint64_t *pte = pt_page + index;
 
-		if (pgentry_present(ptt, *pte) == 0UL) {
+		if (mem_ops->pgentry_present(*pte) == 0UL) {
 			panic("invalid op, pte not present");
 		}
 
@@ -127,34 +109,26 @@ static void modify_or_del_pte(const uint64_t *pde,
  * type: MR_DEL
  * delete [vaddr_start, vaddr_end) MT PT mapping
  */
-static void modify_or_del_pde(const uint64_t *pdpte,
-		uint64_t vaddr_start, uint64_t vaddr_end,
-		uint64_t prot_set, uint64_t prot_clr,
-		enum _page_table_type ptt, uint32_t type)
+static void modify_or_del_pde(const uint64_t *pdpte, uint64_t vaddr_start, uint64_t vaddr_end,
+		uint64_t prot_set, uint64_t prot_clr, const struct memory_ops *mem_ops, uint32_t type)
 {
 	uint64_t *pd_page = pdpte_page_vaddr(*pdpte);
 	uint64_t vaddr = vaddr_start;
 	uint64_t index = pde_index(vaddr);
 
-	dev_dbg(ACRN_DBG_MMU, "%s, vaddr: [0x%llx - 0x%llx]\n",
-		__func__, vaddr, vaddr_end);
+	dev_dbg(ACRN_DBG_MMU, "%s, vaddr: [0x%llx - 0x%llx]\n", __func__, vaddr, vaddr_end);
 	for (; index < PTRS_PER_PDE; index++) {
 		uint64_t *pde = pd_page + index;
 		uint64_t vaddr_next = (vaddr & PDE_MASK) + PDE_SIZE;
 
-		if (pgentry_present(ptt, *pde) == 0UL) {
+		if (mem_ops->pgentry_present(*pde) == 0UL) {
 			panic("invalid op, pde not present");
 		}
 		if (pde_large(*pde) != 0UL) {
-			if (vaddr_next > vaddr_end ||
-					!mem_aligned_check(vaddr, PDE_SIZE)) {
-				int ret = split_large_page(pde, IA32E_PD, ptt);
-				if (ret != 0) {
-					panic("split large PDE failed");
-				}
+			if (vaddr_next > vaddr_end || !mem_aligned_check(vaddr, PDE_SIZE)) {
+				split_large_page(pde, IA32E_PD, vaddr, mem_ops);
 			} else {
-				local_modify_or_del_pte(pde,
-					prot_set, prot_clr, type);
+				local_modify_or_del_pte(pde, prot_set, prot_clr, type);
 				if (vaddr_next < vaddr_end) {
 					vaddr = vaddr_next;
 					continue;
@@ -162,8 +136,7 @@ static void modify_or_del_pde(const uint64_t *pdpte,
 				break;	/* done */
 			}
 		}
-		modify_or_del_pte(pde, vaddr, vaddr_end,
-				prot_set, prot_clr, ptt, type);
+		modify_or_del_pte(pde, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
 		if (vaddr_next >= vaddr_end) {
 			break;	/* done */
 		}
@@ -178,34 +151,27 @@ static void modify_or_del_pde(const uint64_t *pdpte,
  * type: MR_DEL
  * delete [vaddr_start, vaddr_end) MT PT mapping
  */
-static void modify_or_del_pdpte(const uint64_t *pml4e,
-		uint64_t vaddr_start, uint64_t vaddr_end,
-		uint64_t prot_set, uint64_t prot_clr,
-		enum _page_table_type ptt, uint32_t type)
+static void modify_or_del_pdpte(const uint64_t *pml4e, uint64_t vaddr_start, uint64_t vaddr_end,
+		uint64_t prot_set, uint64_t prot_clr, const struct memory_ops *mem_ops, uint32_t type)
 {
 	uint64_t *pdpt_page = pml4e_page_vaddr(*pml4e);
 	uint64_t vaddr = vaddr_start;
 	uint64_t index = pdpte_index(vaddr);
 
-	dev_dbg(ACRN_DBG_MMU, "%s, vaddr: [0x%llx - 0x%llx]\n",
-		__func__, vaddr, vaddr_end);
+	dev_dbg(ACRN_DBG_MMU, "%s, vaddr: [0x%llx - 0x%llx]\n", __func__, vaddr, vaddr_end);
 	for (; index < PTRS_PER_PDPTE; index++) {
 		uint64_t *pdpte = pdpt_page + index;
 		uint64_t vaddr_next = (vaddr & PDPTE_MASK) + PDPTE_SIZE;
 
-		if (pgentry_present(ptt, *pdpte) == 0UL) {
+		if (mem_ops->pgentry_present(*pdpte) == 0UL) {
 			panic("invalid op, pdpte not present");
 		}
 		if (pdpte_large(*pdpte) != 0UL) {
 			if (vaddr_next > vaddr_end ||
 					!mem_aligned_check(vaddr, PDPTE_SIZE)) {
-				int ret = split_large_page(pdpte, IA32E_PDPT, ptt);
-				if (ret != 0) {
-					panic("split large PDPTE failed");
-				}
+				split_large_page(pdpte, IA32E_PDPT, vaddr, mem_ops);
 			} else {
-				local_modify_or_del_pte(pdpte,
-					prot_set, prot_clr, type);
+				local_modify_or_del_pte(pdpte, prot_set, prot_clr, type);
 				if (vaddr_next < vaddr_end) {
 					vaddr = vaddr_next;
 					continue;
@@ -213,8 +179,7 @@ static void modify_or_del_pdpte(const uint64_t *pml4e,
 				break;	/* done */
 			}
 		}
-		modify_or_del_pde(pdpte, vaddr, vaddr_end,
-				prot_set, prot_clr, ptt, type);
+		modify_or_del_pde(pdpte, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
 		if (vaddr_next >= vaddr_end) {
 			break;	/* done */
 		}
@@ -235,10 +200,8 @@ static void modify_or_del_pdpte(const uint64_t *pml4e,
  * type: MR_DEL
  * delete [vaddr_base, vaddr_base + size ) memory region page table mapping.
  */
-void mmu_modify_or_del(uint64_t *pml4_page,
-		uint64_t vaddr_base, uint64_t size,
-		uint64_t prot_set, uint64_t prot_clr,
-		enum _page_table_type ptt, uint32_t type)
+void mmu_modify_or_del(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
+		uint64_t prot_set, uint64_t prot_clr, const struct memory_ops *mem_ops, uint32_t type)
 {
 	uint64_t vaddr = round_page_up(vaddr_base);
 	uint64_t vaddr_next, vaddr_end;
@@ -251,11 +214,10 @@ void mmu_modify_or_del(uint64_t *pml4_page,
 	while (vaddr < vaddr_end) {
 		vaddr_next = (vaddr & PML4E_MASK) + PML4E_SIZE;
 		pml4e = pml4e_offset(pml4_page, vaddr);
-		if (pgentry_present(ptt, *pml4e) == 0UL) {
+		if (mem_ops->pgentry_present(*pml4e) == 0UL) {
 			panic("invalid op, pml4e not present");
 		}
-		modify_or_del_pdpte(pml4e, vaddr, vaddr_end,
-					prot_set, prot_clr, ptt, type);
+		modify_or_del_pdpte(pml4e, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
 		vaddr = vaddr_next;
 	}
 }
@@ -264,9 +226,8 @@ void mmu_modify_or_del(uint64_t *pml4_page,
  * In PT level,
  * add [vaddr_start, vaddr_end) to [paddr_base, ...) MT PT mapping
  */
-static void add_pte(const uint64_t *pde, uint64_t paddr_start,
-		uint64_t vaddr_start, uint64_t vaddr_end,
-		uint64_t prot, enum _page_table_type ptt)
+static void add_pte(const uint64_t *pde, uint64_t paddr_start, uint64_t vaddr_start, uint64_t vaddr_end,
+		uint64_t prot, const struct memory_ops *mem_ops)
 {
 	uint64_t *pt_page = pde_page_vaddr(*pde);
 	uint64_t vaddr = vaddr_start;
@@ -278,7 +239,7 @@ static void add_pte(const uint64_t *pde, uint64_t paddr_start,
 	for (; index < PTRS_PER_PTE; index++) {
 		uint64_t *pte = pt_page + index;
 
-		if (pgentry_present(ptt, *pte) != 0UL) {
+		if (mem_ops->pgentry_present(*pte) != 0UL) {
 			panic("invalid op, pte present");
 		}
 
@@ -296,9 +257,8 @@ static void add_pte(const uint64_t *pde, uint64_t paddr_start,
  * In PD level,
  * add [vaddr_start, vaddr_end) to [paddr_base, ...) MT PT mapping
  */
-static void add_pde(const uint64_t *pdpte, uint64_t paddr_start,
-		uint64_t vaddr_start, uint64_t vaddr_end,
-		uint64_t prot, enum _page_table_type ptt)
+static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_start, uint64_t vaddr_end,
+		uint64_t prot, const struct memory_ops *mem_ops)
 {
 	uint64_t *pd_page = pdpte_page_vaddr(*pdpte);
 	uint64_t vaddr = vaddr_start;
@@ -311,7 +271,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start,
 		uint64_t *pde = pd_page + index;
 		uint64_t vaddr_next = (vaddr & PDE_MASK) + PDE_SIZE;
 
-		if (pgentry_present(ptt, *pde) == 0UL) {
+		if (mem_ops->pgentry_present(*pde) == 0UL) {
 			if (mem_aligned_check(paddr, PDE_SIZE) &&
 				mem_aligned_check(vaddr, PDE_SIZE) &&
 				(vaddr_next <= vaddr_end)) {
@@ -323,13 +283,11 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start,
 				}
 				break;	/* done */
 			} else {
-				int ret = construct_pgentry(ptt, pde);
-				if (ret != 0) {
-					panic("construct pde page table fail");
-				}
+				void *pt_page = mem_ops->get_pt_page(mem_ops->info, vaddr);
+				construct_pgentry(pde, pt_page, mem_ops->get_default_access_right());
 			}
 		}
-		add_pte(pde, paddr, vaddr, vaddr_end, prot, ptt);
+		add_pte(pde, paddr, vaddr, vaddr_end, prot, mem_ops);
 		if (vaddr_next >= vaddr_end) {
 			break;	/* done */
 		}
@@ -342,22 +300,20 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start,
  * In PDPT level,
  * add [vaddr_start, vaddr_end) to [paddr_base, ...) MT PT mapping
  */
-static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start,
-		uint64_t vaddr_start, uint64_t vaddr_end,
-		uint64_t prot, enum _page_table_type ptt)
+static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vaddr_start, uint64_t vaddr_end,
+		uint64_t prot, const struct memory_ops *mem_ops)
 {
 	uint64_t *pdpt_page = pml4e_page_vaddr(*pml4e);
 	uint64_t vaddr = vaddr_start;
 	uint64_t paddr = paddr_start;
 	uint64_t index = pdpte_index(vaddr);
 
-	dev_dbg(ACRN_DBG_MMU, "%s, paddr: 0x%llx, vaddr: [0x%llx - 0x%llx]\n",
-		__func__, paddr, vaddr, vaddr_end);
+	dev_dbg(ACRN_DBG_MMU, "%s, paddr: 0x%llx, vaddr: [0x%llx - 0x%llx]\n", __func__, paddr, vaddr, vaddr_end);
 	for (; index < PTRS_PER_PDPTE; index++) {
 		uint64_t *pdpte = pdpt_page + index;
 		uint64_t vaddr_next = (vaddr & PDPTE_MASK) + PDPTE_SIZE;
 
-		if (pgentry_present(ptt, *pdpte) == 0UL) {
+		if (mem_ops->pgentry_present(*pdpte) == 0UL) {
 			if (mem_aligned_check(paddr, PDPTE_SIZE) &&
 				mem_aligned_check(vaddr, PDPTE_SIZE) &&
 				(vaddr_next <= vaddr_end)) {
@@ -369,13 +325,11 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start,
 				}
 				break;	/* done */
 			} else {
-				int ret = construct_pgentry(ptt, pdpte);
-				if (ret != 0) {
-					panic("construct pdpte page table fail");
-				}
+				void *pd_page = mem_ops->get_pd_page(mem_ops->info, vaddr);
+				construct_pgentry(pdpte, pd_page, mem_ops->get_default_access_right());
 			}
 		}
-		add_pde(pdpte, paddr, vaddr, vaddr_end, prot, ptt);
+		add_pde(pdpte, paddr, vaddr, vaddr_end, prot, mem_ops);
 		if (vaddr_next >= vaddr_end) {
 			break;	/* done */
 		}
@@ -389,16 +343,14 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start,
  * add [vaddr_base, vaddr_base + size ) memory region page table mapping.
  * @pre: the prot should set before call this function.
  */
-void mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
-		uint64_t vaddr_base, uint64_t size,
-		uint64_t prot, enum _page_table_type ptt)
+void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base, uint64_t size, uint64_t prot,
+		const struct memory_ops *mem_ops)
 {
 	uint64_t vaddr, vaddr_next, vaddr_end;
 	uint64_t paddr;
 	uint64_t *pml4e;
 
-	dev_dbg(ACRN_DBG_MMU, "%s, paddr 0x%llx, vaddr 0x%llx, size 0x%llx\n",
-		__func__, paddr_base, vaddr_base, size);
+	dev_dbg(ACRN_DBG_MMU, "%s, paddr 0x%llx, vaddr 0x%llx, size 0x%llx\n", __func__, paddr_base, vaddr_base, size);
 
 	/* align address to page size*/
 	vaddr = round_page_up(vaddr_base);
@@ -408,13 +360,11 @@ void mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
 	while (vaddr < vaddr_end) {
 		vaddr_next = (vaddr & PML4E_MASK) + PML4E_SIZE;
 		pml4e = pml4e_offset(pml4_page, vaddr);
-		if (pgentry_present(ptt, *pml4e) == 0UL) {
-			int ret = construct_pgentry(ptt, pml4e);
-			if (ret != 0) {
-				panic("construct pml4e page table fail");
-			}
+		if (mem_ops->pgentry_present(*pml4e) == 0UL) {
+			void *pdpt_page = mem_ops->get_pdpt_page(mem_ops->info, vaddr);
+			construct_pgentry(pml4e, pdpt_page, mem_ops->get_default_access_right());
 		}
-		add_pdpte(pml4e, paddr, vaddr, vaddr_end, prot, ptt);
+		add_pdpte(pml4e, paddr, vaddr, vaddr_end, prot, mem_ops);
 
 		paddr += (vaddr_next - vaddr);
 		vaddr = vaddr_next;
@@ -424,18 +374,17 @@ void mmu_add(uint64_t *pml4_page, uint64_t paddr_base,
 /**
  * @pre (pml4_page != NULL) && (pg_size != NULL)
  */
-uint64_t *lookup_address(uint64_t *pml4_page,
-		uint64_t addr, uint64_t *pg_size, enum _page_table_type ptt)
+uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr, uint64_t *pg_size, const struct memory_ops *mem_ops)
 {
 	uint64_t *pml4e, *pdpte, *pde, *pte;
 
 	pml4e = pml4e_offset(pml4_page, addr);
-	if (pgentry_present(ptt, *pml4e) == 0UL) {
+	if (mem_ops->pgentry_present(*pml4e) == 0UL) {
 		return NULL;
 	}
 
 	pdpte = pdpte_offset(pml4e, addr);
-	if (pgentry_present(ptt, *pdpte) == 0UL) {
+	if (mem_ops->pgentry_present(*pdpte) == 0UL) {
 		return NULL;
 	} else if (pdpte_large(*pdpte) != 0UL) {
 		*pg_size = PDPTE_SIZE;
@@ -443,7 +392,7 @@ uint64_t *lookup_address(uint64_t *pml4_page,
 	}
 
 	pde = pde_offset(pdpte, addr);
-	if (pgentry_present(ptt, *pde) == 0UL) {
+	if (mem_ops->pgentry_present(*pde) == 0UL) {
 		return NULL;
 	} else if (pde_large(*pde) != 0UL) {
 		*pg_size = PDE_SIZE;
@@ -451,7 +400,7 @@ uint64_t *lookup_address(uint64_t *pml4_page,
 	}
 
 	pte = pte_offset(pde, addr);
-	if (pgentry_present(ptt, *pte) == 0UL) {
+	if (mem_ops->pgentry_present(*pte) == 0UL) {
 		return NULL;
 	} else {
 		*pg_size = PTE_SIZE;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -97,14 +97,16 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	 * Normal World.PD/PT are shared in both Secure world's EPT
 	 * and Normal World's EPT
 	 */
-	pml4_base = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info, TRUSTY_EPT_REBASE_GPA);
+	pml4_base = vm->arch_vm.ept_mem_ops.info->ept.sworld_pgtable_base;
+	(void)memset(pml4_base, 0U, CPU_PAGE_SIZE);
 	vm->arch_vm.sworld_eptp = pml4_base;
 	sanitize_pte((uint64_t *)vm->arch_vm.sworld_eptp);
 
 	/* The trusty memory is remapped to guest physical address
 	 * of gpa_rebased to gpa_rebased + size
 	 */
-	sub_table_addr = vm->arch_vm.ept_mem_ops.get_pdpt_page(vm->arch_vm.ept_mem_ops.info, TRUSTY_EPT_REBASE_GPA);
+	sub_table_addr = vm->arch_vm.ept_mem_ops.info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA);
+	(void)memset(sub_table_addr, 0U, CPU_PAGE_SIZE);
 	sworld_pml4e = hva2hpa(sub_table_addr) | table_present;
 	set_pgentry((uint64_t *)pml4_base, sworld_pml4e);
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -134,10 +134,10 @@ struct iommu_domain {
 };
 
 struct context_table {
-	struct cpu_page buses[CONFIG_IOMMU_INIT_BUS_LIMIT];
+	struct page buses[CONFIG_IOMMU_INIT_BUS_LIMIT];
 };
 
-static struct cpu_page root_tables[CONFIG_MAX_IOMMU_NUM] __aligned(CPU_PAGE_SIZE);
+static struct page root_tables[CONFIG_MAX_IOMMU_NUM] __aligned(CPU_PAGE_SIZE);
 static struct context_table ctx_tables[CONFIG_MAX_IOMMU_NUM] __aligned(CPU_PAGE_SIZE);
 
 static inline uint8_t*

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -33,7 +33,7 @@ static inline uint64_t elf64_r_type(uint64_t i)
 
 uint64_t trampoline_start16_paddr;
 
-/* get the delta between CONFIG_RAM_START and the actual load address */
+/* get the delta between CONFIG_HV_RAM_START and the actual load address */
 uint64_t get_hv_image_delta(void)
 {
 	uint64_t addr;
@@ -52,7 +52,7 @@ uint64_t get_hv_image_delta(void)
 /* get the actual Hypervisor load address */
 uint64_t get_hv_image_base(void)
 {
-	return (get_hv_image_delta() + CONFIG_RAM_START);
+	return (get_hv_image_delta() + CONFIG_HV_RAM_START);
 }
 
 /*
@@ -63,7 +63,7 @@ uint64_t get_hv_image_base(void)
  * This function is valid if:
  *  - The hpa of HV code is always higher than trampoline code
  *  - The HV code is always relocated to higher address, compared
- *    with CONFIG_RAM_START
+ *    with CONFIG_HV_RAM_START
  */
 static uint64_t trampoline_relo_addr(const void *addr)
 {

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -6,7 +6,7 @@ MEMORY
     lowram  :   ORIGIN = 0, LENGTH = CONFIG_LOW_RAM_SIZE
 
     /* 32 MBytes of RAM for HV */
-    ram     :   ORIGIN = CONFIG_RAM_START, LENGTH = CONFIG_RAM_SIZE
+    ram     :   ORIGIN = CONFIG_HV_RAM_START, LENGTH = CONFIG_HV_RAM_SIZE
 }
 
 SECTIONS

--- a/hypervisor/bsp/uefi/efi/boot.c
+++ b/hypervisor/bsp/uefi/efi/boot.c
@@ -356,7 +356,7 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 	}
 
 	/* without relocateion enabled, hypervisor binary need to reside in
-	 * fixed memory address starting from CONFIG_RAM_START, make a call
+	 * fixed memory address starting from CONFIG_HV_RAM_START, make a call
 	 * to emalloc_fixed_addr for that case. With CONFIG_RELOC enabled,
 	 * hypervisor is able to do relocation, the only requirement is that
 	 * it need to reside in memory below 4GB, call emalloc_reserved_mem()
@@ -365,7 +365,7 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 #ifdef CONFIG_RELOC
 	err = emalloc_reserved_mem(&hv_hpa, HV_RUNTIME_MEM_SIZE, MEM_ADDR_4GB);
 #else
-	err = emalloc_fixed_addr(&hv_hpa, HV_RUNTIME_MEM_SIZE, CONFIG_RAM_START);
+	err = emalloc_fixed_addr(&hv_hpa, HV_RUNTIME_MEM_SIZE, CONFIG_HV_RAM_START);
 #endif
 	if (err != EFI_SUCCESS)
 		goto failed;

--- a/hypervisor/bsp/uefi/efi/boot.h
+++ b/hypervisor/bsp/uefi/efi/boot.h
@@ -78,13 +78,13 @@ typedef void(*hv_func)(int, struct multiboot_info*);
 #define MBOOT_INFO_SIZE (sizeof(struct multiboot_info))
 #define BOOT_CTX_SIZE  (sizeof(struct efi_context))
 #define HV_RUNTIME_MEM_SIZE \
-	(CONFIG_RAM_SIZE + MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE)
+	(CONFIG_HV_RAM_SIZE + MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE)
 #define MBOOT_MMAP_PTR(addr) \
-	((struct multiboot_mmap *)((VOID *)addr + CONFIG_RAM_SIZE))
+	((struct multiboot_mmap *)((VOID *)addr + CONFIG_HV_RAM_SIZE))
 #define MBOOT_INFO_PTR(addr) ((struct multiboot_info *) \
-	((VOID *)addr + CONFIG_RAM_SIZE + MBOOT_MMAP_SIZE))
+	((VOID *)addr + CONFIG_HV_RAM_SIZE + MBOOT_MMAP_SIZE))
 #define BOOT_CTX_PTR(addr) ((struct efi_context *) \
-	((VOID *)addr + CONFIG_RAM_SIZE +  MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE))
+	((VOID *)addr + CONFIG_HV_RAM_SIZE +  MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE))
 
 
 struct efi_info {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -383,7 +383,7 @@ static int32_t local_set_vm_memory_region(struct vm *vm,
 		if (((hpa <= base_paddr) &&
 				((hpa + region->size) > base_paddr)) ||
 				((hpa >= base_paddr) &&
-				 (hpa < (base_paddr + CONFIG_RAM_SIZE)))) {
+				 (hpa < (base_paddr + CONFIG_HV_RAM_SIZE)))) {
 			pr_err("%s: overlap the HV memory region.", __func__);
 			return -EFAULT;
 		}
@@ -515,7 +515,7 @@ static int32_t write_protect_page(struct vm *vm,const struct wp_data *wp)
 	base_paddr = get_hv_image_base();
 	if (((hpa <= base_paddr) && (hpa + CPU_PAGE_SIZE > base_paddr)) ||
 			((hpa >= base_paddr) &&
-			(hpa < base_paddr + CONFIG_RAM_SIZE))) {
+			(hpa < base_paddr + CONFIG_HV_RAM_SIZE))) {
 		pr_err("%s: overlap the HV memory region.", __func__);
 		return -EINVAL;
 	}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -68,7 +68,7 @@ static int vdev_pt_init(struct pci_vdev *vdev)
 	/* Create an iommu domain for target VM if not created */
 	if (vm->iommu == NULL) {
 		if (vm->arch_vm.nworld_eptp == 0UL) {
-			vm->arch_vm.nworld_eptp = alloc_paging_struct();
+			vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info, 0UL);
 			sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp);
 		}
 		vm->iommu = create_iommu_domain(vm->vm_id,

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -8,6 +8,7 @@
 #define VM_H_
 #include <bsp_extern.h>
 #include <vpci.h>
+#include <page.h>
 
 #ifdef CONFIG_PARTITION_MODE
 #include <mptable.h>
@@ -97,6 +98,8 @@ struct vm_arch {
 	 * but Normal World can not access Secure World's memory.
 	 */
 	void *sworld_eptp;
+	struct memory_ops ept_mem_ops;
+
 	void *tmp_pg_array;	/* Page array for tmp guest paging struct */
 	struct acrn_vioapic vioapic;	/* Virtual IOAPIC base address */
 	struct acrn_vpic vpic;      /* Virtual PIC */

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -28,6 +28,7 @@
 #include <vioapic.h>
 #include <vm.h>
 #include <cpuid.h>
+#include <page.h>
 #include <mmu.h>
 #include <pgtable.h>
 #include <irq.h>

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -67,16 +67,9 @@ enum _page_table_level {
 #define PAGE_SIZE_2M	MEM_2M
 #define PAGE_SIZE_1G	MEM_1G
 
-struct cpu_page {
-	uint8_t contents[CPU_PAGE_SIZE];
-};
-
 void sanitize_pte_entry(uint64_t *ptep);
 void sanitize_pte(uint64_t *pt_page);
-uint64_t get_paging_pml4(void);
-void *alloc_paging_struct(void);
-void free_paging_struct(void *ptr);
-void enable_paging(uint64_t pml4_base_addr);
+void enable_paging(void);
 void enable_smep(void);
 void init_paging(void);
 void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base,

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -13,6 +13,21 @@
 /* size of the low MMIO address space: 2GB */
 #define PLATFORM_LO_MMIO_SIZE	0x80000000UL
 
+#define PML4_PAGE_NUM(size)	1UL
+#define PDPT_PAGE_NUM(size)	(((size) + PML4E_SIZE - 1UL) >> PML4E_SHIFT)
+#define PD_PAGE_NUM(size)	(((size) + PDPTE_SIZE - 1UL) >> PDPTE_SHIFT)
+#define PT_PAGE_NUM(size)	(((size) + PDE_SIZE - 1UL) >> PDE_SHIFT)
+
+/* The size of the guest physical address space, covered by the EPT page table of a VM */
+#define EPT_ADDRESS_SPACE(size)	((size != 0UL) ? (size + PLATFORM_LO_MMIO_SIZE) : 0UL)
+
+#define TRUSTY_PML4_PAGE_NUM(size)	(1UL)
+#define TRUSTY_PDPT_PAGE_NUM(size)	(1UL)
+#define TRUSTY_PD_PAGE_NUM(size)	(PD_PAGE_NUM(size))
+#define TRUSTY_PT_PAGE_NUM(size)	(PT_PAGE_NUM(size))
+#define TRUSTY_PGTABLE_PAGE_NUM(size)	\
+(TRUSTY_PML4_PAGE_NUM(size) + TRUSTY_PDPT_PAGE_NUM(size) + TRUSTY_PD_PAGE_NUM(size) + TRUSTY_PT_PAGE_NUM(size))
+
 struct page {
 	uint8_t contents[PAGE_SIZE];
 } __aligned(PAGE_SIZE);

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -25,6 +25,7 @@ union pgtable_pages_info {
 		struct page *pt_base;
 	} ppt;
 	struct {
+		uint64_t top_address_space;
 		struct page *nworld_pml4_base;
 		struct page *nworld_pdpt_base;
 		struct page *nworld_pd_base;
@@ -44,5 +45,6 @@ struct memory_ops {
 };
 
 extern const struct memory_ops ppt_mem_ops;
+void init_ept_mem_ops(struct vm *vm);
 
 #endif /* PAGE_H */

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PAGE_H
+#define PAGE_H
+
+#define PAGE_SHIFT	12U
+#define PAGE_SIZE	(1UL << PAGE_SHIFT)
+
+/* size of the low MMIO address space: 2GB */
+#define PLATFORM_LO_MMIO_SIZE	0x80000000UL
+
+struct page {
+	uint8_t contents[PAGE_SIZE];
+} __aligned(PAGE_SIZE);
+
+union pgtable_pages_info {
+	struct {
+		struct page *pml4_base;
+		struct page *pdpt_base;
+		struct page *pd_base;
+		struct page *pt_base;
+	} ppt;
+	struct {
+		struct page *nworld_pml4_base;
+		struct page *nworld_pdpt_base;
+		struct page *nworld_pd_base;
+		struct page *nworld_pt_base;
+		struct page *sworld_pgtable_base;
+	} ept;
+};
+
+struct memory_ops {
+	union pgtable_pages_info *info;
+	uint64_t (*get_default_access_right)(void);
+	uint64_t (*pgentry_present)(uint64_t pte);
+	struct page *(*get_pml4_page)(const union pgtable_pages_info *info, uint64_t gpa);
+	struct page *(*get_pdpt_page)(const union pgtable_pages_info *info, uint64_t gpa);
+	struct page *(*get_pd_page)(const union pgtable_pages_info *info, uint64_t gpa);
+	struct page *(*get_pt_page)(const union pgtable_pages_info *info, uint64_t gpa);
+};
+
+extern const struct memory_ops ppt_mem_ops;
+
+#endif /* PAGE_H */

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -162,9 +162,4 @@ static inline uint64_t pdpte_large(uint64_t pdpte)
 	return pdpte & PAGE_PSE;
 }
 
-static inline uint64_t pgentry_present(enum _page_table_type ptt, uint64_t pte)
-{
-	return (ptt == PTT_PRIMARY) ? (pte & PAGE_PRESENT) : (pte & EPT_RWX);
-}
-
 #endif /* PGTABLE_H */

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -25,9 +25,6 @@
 #define PAGE_CACHE_UC_MINUS	PAGE_PCD
 #define PAGE_CACHE_UC		(PAGE_PCD | PAGE_PWT)
 
-#define PAGE_TABLE		(PAGE_PRESENT | PAGE_RW | PAGE_USER)
-
-
 #define EPT_RD			(1UL << 0U)
 #define EPT_WR			(1UL << 1U)
 #define EPT_EXE			(1UL << 2U)

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -12,6 +12,8 @@
 #define MMC_PROD_NAME_WITH_PSN_LEN      15U
 #define BUP_MKHI_BOOTLOADER_SEED_LEN    64U
 
+#define TRUSTY_RAM_SIZE	(16UL * 1024UL * 1024UL)	/* 16 MB for now */
+
 /* Trusty EPT rebase gpa: 511G */
 #define TRUSTY_EPT_REBASE_GPA (511UL * 1024UL * 1024UL * 1024UL)
 

--- a/hypervisor/include/lib/mem_mgt.h
+++ b/hypervisor/include/lib/mem_mgt.h
@@ -24,8 +24,6 @@ struct mem_pool {
 /* APIs exposing memory allocation/deallocation abstractions */
 void *malloc(unsigned int num_bytes);
 void *calloc(unsigned int num_elements, unsigned int element_size);
-void *alloc_page(void);
-void *alloc_pages(unsigned int page_num);
 void free(const void *ptr);
 
 #endif /* MEM_MGT_H */


### PR DESCRIPTION
v6:
1. configure all the uos to have the same address space for the moment. Would configure
it according the real use of the UOS later.
2. some fix about the comments.

v5:
refine the implement.

v3-v4:
split this patch into two part: the first part is to add the static allocation API;
the second part is to replace the dynamic memory allocation in memory management with
the static allocation API.
Besides, remove the "node" concept, using vm_id to identify the page array for EPT.
As for HV PRIMARY, it use the fixed page array.

v2-v3:
1. make Kconfig name more clear
2. change related function protetype form (..., paging_table_falg, ...) to (..., paging_table_type, paging_table_node, ...)
paging_table_node here means from which paging_table_array whose node id euqal to paging_table_node to get page.

Remaining:
1. add document to detail how should we configue TOP_ADDRESS_SPACE and RAM_SZIE to reserve big enough page array for memory management
2. if the above step goes wrong, output the necessary message to let the user know what'r wrong.


v1-v2:
1. replace paging table type definition with MACRO, remove enum _page_table_type.
2. refine construct_pgentry to void
3. add MACRO to calculate paging table node
4. some other minor refine related to MISRA C.

Tracked-On: #861 