### PR TITLE
DM USB: xHCI: fix process logic of TRB which has zero data length

### DIFF
--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -245,14 +245,18 @@ usb_dev_comp_req(struct libusb_transfer *libusb_xfer)
 	}
 
 	/* handle the blocks belong to this request */
+	i = 0;
 	buf_idx = 0;
 	idx = req->blk_start;
-	for (i = 0; i < req->blk_count; i++) {
+	while (i < req->blk_count) {
 		done = 0;
 		block = &xfer->data[idx % USB_MAX_XFER_BLOCKS];
 
 		/* Link TRB need to be skipped */
 		if (!block->buf || !block->blen) {
+			/* FIXME: should change hard coded USB_MAX_XFER_BLOCKS
+			 * to dynamically mechanism to avoid dead loop.
+			 */
 			idx = (idx + 1) % USB_MAX_XFER_BLOCKS;
 			continue;
 		}
@@ -285,6 +289,7 @@ usb_dev_comp_req(struct libusb_transfer *libusb_xfer)
 				block->blen = 0;
 			}
 		}
+		i++;
 	}
 
 stall_out:


### PR DESCRIPTION
Accoring to xHCI spec, there are some TRBs with zero data length
which used to pass command to xHCI. In the DM, those TRBs should
not be sent to native device through libusb. The logic in the
current implentation fails to process some corner cases, this
patch is used to fix it.

Tracked-On: #1639
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>