### PR TITLE
hv: enable MSI remapping and fix 2 known bugs

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -176,15 +176,19 @@ endif
 
 C_SRCS += dm/vpic.c
 C_SRCS += dm/vioapic.c
-ifeq ($(CONFIG_PARTITION_MODE),y)
-C_SRCS += $(wildcard partition/*.c)
 C_SRCS += dm/hw/pci.c
 C_SRCS += dm/vpci/core.c
 C_SRCS += dm/vpci/vpci.c
+ifeq ($(CONFIG_PARTITION_MODE),y)
+C_SRCS += $(wildcard partition/*.c)
 C_SRCS += dm/vpci/partition_mode.c
 C_SRCS += dm/vpci/hostbridge.c
 C_SRCS += dm/vpci/pci_pt.c
 C_SRCS += dm/vrtc.c
+else
+C_SRCS += dm/vpci/sharing_mode.c
+C_SRCS += dm/vpci/msi.c
+C_SRCS += dm/vpci/msix.c
 endif
 
 C_SRCS += bsp/$(CONFIG_PLATFORM)/$(CONFIG_PLATFORM).c

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -151,8 +151,9 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 		vuart_init(vm);
 	}
 	vrtc_init(vm);
-	vpci_init(vm);
 #endif
+
+	vpci_init(vm);
 
 	/* vpic wire_mode default is INTR */
 	vm->wire_mode = VPIC_WIRE_INTR;
@@ -230,10 +231,7 @@ int shutdown_vm(struct vm *vm)
 	free_vm_id(vm);
 #endif
 
-
-#ifdef CONFIG_PARTITION_MODE
 	vpci_cleanup(vm);
-#endif
 
 	/* Return status to caller */
 	return status;

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -119,10 +119,12 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_write_protect_page(vm, (uint16_t)param1, param2);
 		break;
 
-
+	/*
+	 * Don't do MSI remapping and make the pmsi_data equal to vmsi_data
+	 * This is a temporary solution before this hypercall is removed from SOS
+	 */
 	case HC_VM_PCI_MSIX_REMAP:
-		/* param1: vmid */
-		ret = hcall_remap_pci_msix(vm, (uint16_t)param1, param2);
+		ret = 0;
 		break;
 
 	case HC_VM_GPA2HPA:

--- a/hypervisor/dm/hw/pci.c
+++ b/hypervisor/dm/hw/pci.c
@@ -170,11 +170,6 @@ void pci_scan_bus(pci_enumeration_cb cb_func, void *cb_data)
 						bus_to_scan[secondary_bus] = BUS_SCAN_PENDING;
 					}
 				}
-
-				/* skip if it doesn't have multiple functions */
-				if ((hdr_type & PCIM_MFDEV) == 0U) {
-					break;
-				}
 			}
 		}
 	}

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -55,7 +55,7 @@ static int vmsix_remap_entry(struct pci_vdev *vdev, uint32_t index, bool enable)
 	info.vmsi_addr = vdev->msix.tables[index].addr;
 	info.vmsi_data = (enable) ? vdev->msix.tables[index].data : 0U;
 
-	ret = ptdev_msix_remap(vdev->vpci->vm, vdev->vbdf.value, index, &info);
+	ret = ptdev_msix_remap(vdev->vpci->vm, vdev->vbdf.value, (uint16_t)index, &info);
 	if (ret != 0) {
 		return ret;
 	}
@@ -222,7 +222,7 @@ static void vmsix_table_rw(struct pci_vdev *vdev, struct mmio_request *mmio, uin
 		if ((pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U) & PCIM_MSIXCTRL_MSIX_ENABLE)
 			== PCIM_MSIXCTRL_MSIX_ENABLE) {
 
-			if ((((entry->vector_control ^ vector_control) & PCIM_MSIX_VCTRL_MASK) != 0U) || message_changed)  {
+			if ((((entry->vector_control ^ vector_control) & PCIM_MSIX_VCTRL_MASK) != 0U) || message_changed) {
 				unmasked = ((entry->vector_control & PCIM_MSIX_VCTRL_MASK) == 0U);
 				(void)vmsix_remap_one_entry(vdev, index, unmasked);
 			}
@@ -271,7 +271,7 @@ static void decode_msix_table_bar(struct pci_vdev *vdev)
 	}
 
 	/* Get the base address */
-	base = (uint64_t)(bar_lo & PCIM_BAR_MEM_BASE);
+	base = (uint64_t)bar_lo & PCIM_BAR_MEM_BASE;
 	if ((bar_lo & PCIM_BAR_MEM_TYPE) == PCIM_BAR_MEM_64) {
 		bar_hi = pci_pdev_read_cfg(pbdf, pci_bar_offset(bir + 1U), 4U);
 		base |= ((uint64_t)bar_hi << 32U);

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -48,6 +48,7 @@ static int vmsix_remap_entry(struct pci_vdev *vdev, uint32_t index, bool enable)
 {
 	struct msix_table_entry *pentry;
 	struct ptdev_msi_info info;
+	uint32_t *ptr32;
 	uint64_t hva;
 	int ret;
 
@@ -63,7 +64,15 @@ static int vmsix_remap_entry(struct pci_vdev *vdev, uint32_t index, bool enable)
 	/* Write the table entry to the physical structure */
 	hva = vdev->msix.mmio_hva + vdev->msix.table_offset;
 	pentry = (struct msix_table_entry *)hva + index;
-	pentry->addr = info.pmsi_addr;
+
+	/*
+	 * PCI 3.0 Spec allows writing to Message Address and Message Upper Address
+	 * fields with a single QWORD write, but some hardware can accept 32 bits
+	 * write only
+	 */
+	ptr32 = (uint32_t *)&pentry->addr;
+	ptr32[0] = (uint32_t)info.pmsi_addr;
+	ptr32[1] = (info.pmsi_addr >> 32U);
 	pentry->data = info.pmsi_data;
 	pentry->vector_control = vdev->msix.tables[index].vector_control;
 

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -37,40 +37,34 @@ static inline bool in_range(uint32_t value, uint32_t lower, uint32_t len)
 	return ((value >= lower) && (value < (lower + len)));
 }
 
-static inline uint8_t
-pci_vdev_read_cfg_u8(struct pci_vdev *vdev, uint32_t offset)
+static inline uint8_t pci_vdev_read_cfg_u8(struct pci_vdev *vdev, uint32_t offset)
 {
-	return (*(uint8_t *)(&vdev->cfgdata[0] + offset));
+	return vdev->cfgdata.data_8[offset];
 }
 
-static inline uint16_t pci_vdev_read_cfg_u16(struct pci_vdev *vdev,
-	uint32_t offset)
+static inline uint16_t pci_vdev_read_cfg_u16(struct pci_vdev *vdev, uint32_t offset)
 {
-	return (*(uint16_t *)(&vdev->cfgdata[0] + offset));
+	return vdev->cfgdata.data_16[offset >> 1U];
 }
 
-static inline uint32_t pci_vdev_read_cfg_u32(struct pci_vdev *vdev,
-	uint32_t offset)
+static inline uint32_t pci_vdev_read_cfg_u32(struct pci_vdev *vdev, uint32_t offset)
 {
-	return (*(uint32_t *)(&vdev->cfgdata[0] + offset));
+	return vdev->cfgdata.data_32[offset >> 2U];
 }
 
-static inline void
-pci_vdev_write_cfg_u8(struct pci_vdev *vdev, uint32_t offset, uint8_t val)
+static inline void pci_vdev_write_cfg_u8(struct pci_vdev *vdev, uint32_t offset, uint8_t val)
 {
-	*(uint8_t *)(vdev->cfgdata + offset) = val;
+	vdev->cfgdata.data_8[offset] = val;
 }
 
-static inline void
-pci_vdev_write_cfg_u16(struct pci_vdev *vdev, uint32_t offset, uint16_t val)
+static inline void pci_vdev_write_cfg_u16(struct pci_vdev *vdev, uint32_t offset, uint16_t val)
 {
-	*(uint16_t *)(vdev->cfgdata + offset) = val;
+	vdev->cfgdata.data_16[offset >> 1U] = val;
 }
 
-static inline void
-pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset, uint32_t val)
+static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset, uint32_t val)
 {
-	*(uint32_t *)(vdev->cfgdata + offset) = val;
+	vdev->cfgdata.data_32[offset >> 2U] = val;
 }
 
 extern struct vpci_ops partition_mode_vpci_ops;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -7,10 +7,10 @@
 #ifndef VM_H_
 #define VM_H_
 #include <bsp_extern.h>
+#include <vpci.h>
 
 #ifdef CONFIG_PARTITION_MODE
 #include <mptable.h>
-#include <vpci.h>
 #endif
 enum vm_privilege_level {
 	VM_PRIVILEGE_LEVEL_HIGH = 0,
@@ -155,9 +155,9 @@ struct vm {
 
 	uint32_t vcpuid_entry_nr, vcpuid_level, vcpuid_xlevel;
 	struct vcpuid_entry vcpuid_entries[MAX_VM_VCPUID_ENTRIES];
+	struct vpci vpci;
 #ifdef CONFIG_PARTITION_MODE
 	struct vm_description	*vm_desc;
-	struct vpci vpci;
 	uint8_t vrtc_offset;
 #endif
 

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -251,22 +251,6 @@ int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param);
 int32_t hcall_write_protect_page(struct vm *vm, uint16_t vmid, uint64_t wp_gpa);
 
 /**
- * @brief remap PCI MSI interrupt
- *
- * Remap a PCI MSI interrupt from a VM's virtual vector to native vector.
- * The function will return -1 if the target VM does not exist.
- *
- * @param vm Pointer to VM data structure
- * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to
- *              struct acrn_vm_pci_msix_remap
- *
- * @pre Pointer vm shall point to VM0
- * @return 0 on success, non-zero on error.
- */
-int32_t hcall_remap_pci_msix(struct vm *vm, uint16_t vmid, uint64_t param);
-
-/**
  * @brief translate guest physical address to host physical address
  *
  * Translate guest physical address to host physical address for a VM.

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -144,5 +144,7 @@ extern struct pci_vdev_ops pci_ops_vdev_pt;
 
 void vpci_init(struct vm *vm);
 void vpci_cleanup(struct vm *vm);
+void vpci_set_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf);
+void vpci_reset_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 
 #endif /* VPCI_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -84,6 +84,12 @@ struct msix {
 	uint32_t  table_count;
 };
 
+union cfgdata {
+	uint8_t data_8[PCI_REGMAX + 1U];
+	uint16_t data_16[(PCI_REGMAX + 1U) >> 2U];
+	uint32_t data_32[(PCI_REGMAX + 1U) >> 4U];
+};
+
 struct pci_vdev {
 #ifndef CONFIG_PARTITION_MODE
 #define MAX_VPCI_DEV_OPS   4U
@@ -99,7 +105,7 @@ struct pci_vdev {
 
 	struct pci_pdev pdev;
 
-	uint8_t cfgdata[PCI_REGMAX + 1U];
+	union cfgdata cfgdata;
 
 	/* The bar info of the virtual PCI device. */
 	struct pci_bar bar[PCI_BAR_COUNT];

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -77,6 +77,8 @@ struct msix {
 	uint64_t  mmio_gpa;
 	uint64_t  mmio_hva;
 	uint64_t  mmio_size;
+	uint64_t  intercepted_gpa;
+	uint64_t  intercepted_size;
 	uint32_t  capoff;
 	uint32_t  caplen;
 	uint32_t  table_bar;


### PR DESCRIPTION
Fixed 2 known bugs:

1) sizing issue for 64 bits
2) PCI bus scan skips 2 devices on KBL NUC

Enable MSI remapping in SOS;