### PR TITLE
hv: remove deprecated hypercalls

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -83,21 +83,6 @@ int vmcall_vmexit_handler(struct vcpu *vcpu)
 		ret = hcall_set_vcpu_regs(vm, (uint16_t)param1, param2);
 		break;
 
-	case HC_ASSERT_IRQLINE:
-		/* param1: vmid */
-		ret = hcall_assert_irqline(vm, (uint16_t)param1, param2);
-		break;
-
-	case HC_DEASSERT_IRQLINE:
-		/* param1: vmid */
-		ret = hcall_deassert_irqline(vm, (uint16_t)param1, param2);
-		break;
-
-	case HC_PULSE_IRQLINE:
-		/* param1: vmid */
-		ret = hcall_pulse_irqline(vm, (uint16_t)param1, param2);
-		break;
-
 	case HC_SET_IRQLINE:
 		/* param1: vmid */
 		ret = hcall_set_irqline(vm, (uint16_t)param1,

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -336,12 +336,6 @@ struct acrn_set_ioreq_buffer {
 	uint64_t req_buf;
 } __aligned(8);
 
-/** Interrupt type for acrn_irqline: inject interrupt to IOAPIC */
-#define	ACRN_INTR_TYPE_ISA	0U
-
-/** Interrupt type for acrn_irqline: inject interrupt to both PIC and IOAPIC */
-#define	ACRN_INTR_TYPE_IOAPIC	1U
-
 /** Operation types for setting IRQ line */
 #define GSI_SET_HIGH		0U
 #define GSI_SET_LOW		1U
@@ -356,34 +350,6 @@ struct acrn_set_ioreq_buffer {
 struct acrn_irqline_ops {
 	uint32_t nr_gsi;
 	uint32_t op;
-} __aligned(8);
-
-/**
- * @brief Info to assert/deassert/pulse a virtual IRQ line for a VM
- *
- * the parameter for HC_ASSERT_IRQLINE/HC_DEASSERT_IRQLINE/HC_PULSE_IRQLINE
- * hypercall
- */
-struct acrn_irqline {
-	/** interrupt type which could be IOAPIC or ISA */
-	uint32_t intr_type;
-
-	/** reserved for alignment padding */
-	uint32_t reserved;
-
-	/** pic IRQ for ISA type */
-	uint32_t pic_irq;
-
-	/** Reserved */
-	uint32_t reserved0;
-
-	/** ioapic IRQ for IOAPIC & ISA TYPE,
-	 *  if ~0U then this IRQ will not be injected
-	 */
-	uint32_t ioapic_irq;
-
-	/** Reserved */
-	uint32_t reserved1;
 } __aligned(8);
 
 /**

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -41,9 +41,6 @@
 
 /* IRQ and Interrupts */
 #define HC_ID_IRQ_BASE              0x20UL
-#define HC_ASSERT_IRQLINE           BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x00UL)
-#define HC_DEASSERT_IRQLINE         BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x01UL)
-#define HC_PULSE_IRQLINE            BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x02UL)
 #define HC_INJECT_MSI               BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x03UL)
 #define HC_VM_INTR_MONITOR          BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x04UL)
 #define HC_SET_IRQLINE              BASE_HC_ID(HC_ID, HC_ID_IRQ_BASE + 0x05UL)


### PR DESCRIPTION
below hypercalls are wrapped to HC_SET_IRQLINE:
- HC_ASSERT_IRQLINE
- HC_DEASSERT_IRQLINE
- HC_PULSE_IRQLINE

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>