### PR TITLE
Documentation: add 'make' to GSG and expand PATH for `sphinx-build`

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -416,14 +416,12 @@ each with their own way to install development tools:
      ACRN uses ``menuconfig``, a python3 text-based user interface (TUI) for
      configuring hypervisor options and using python's ``kconfiglib`` library.
 
-* On a Clear Linux development system, install the ``os-clr-on-clr`` bundle to get
-  the necessary tools:
+* On a Clear Linux development system, install the necessary tools:
 
   .. code-block:: none
 
-     $ sudo swupd bundle-add os-clr-on-clr
-     $ sudo swupd bundle-add python3-basic
-     $ sudo pip3 install kconfiglib
+     $ sudo swupd bundle-add os-clr-on-clr os-core-dev python3-basic
+     $ pip3 install --user kconfiglib
 
 * On a Ubuntu/Debian development system:
 

--- a/doc/tutorials/docbuild.rst
+++ b/doc/tutorials/docbuild.rst
@@ -137,6 +137,9 @@ Our documentation processing has been tested to run with:
 
 Depending on your Linux version, install the needed tools:
 
+* For Clear Linux: follow the :ref:`getting-started-apl-nuc` to install
+  all the tools required
+
 * For Ubuntu use:
 
   .. code-block:: bash
@@ -150,13 +153,26 @@ Depending on your Linux version, install the needed tools:
 
      sudo dnf install doxygen python3-pip python3-wheel make graphviz
 
-And for either Linux environment, install the remaining python-based
+And for any of these Linux environments, install the remaining python-based
 tools:
 
 .. code-block:: bash
 
    cd ~/projectacrn/acrn-hypervisor/doc
    pip3 install --user -r scripts/requirements.txt
+
+Add ``$HOME/.local/bin`` to the front of your ``PATH`` so the system will
+find expected versions of python utilities such as ``sphinx-build`` and
+``breathe``:
+
+.. code-block:: bash
+
+   printf "\nexport PATH=\$HOME/.local/bin:\$PATH" >> ~/.bashrc
+
+.. note::
+
+   You will need to open a new terminal for this change to be effective.
+   Adding this to your ``~/.bashrc`` file ensures it is set by default.
 
 And with that you're ready to generate the documentation.
 


### PR DESCRIPTION
Getting Started Guide: add one more bundle to be added on a Clear
Linux development machine to make sure 'make' and other development
packages are available.

ACRN Documentation Generation: expand the 'PATH' variable to include
'~/.local/bin' where 'sphinx-build' is installed.

Tracked-On: #1650

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>