### PR TITLE
hv: remove deprecated functions declartion

### DIFF
--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -153,55 +153,6 @@ int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param);
 int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param);
 
 /**
- * @brief assert IRQ line
- *
- * Assert a virtual IRQ line for a VM, which could be from ISA or IOAPIC,
- * normally it will active a level IRQ.
- * The function will return -1 if the target VM does not exist.
- *
- * @param vm Pointer to VM data structure
- * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to struct acrn_irqline
- *
- * @pre Pointer vm shall point to VM0
- * @return 0 on success, non-zero on error.
- */
-int32_t hcall_assert_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
-
-/**
- * @brief deassert IRQ line
- *
- * Deassert a virtual IRQ line for a VM, which could be from ISA or IOAPIC,
- * normally it will deactive a level IRQ.
- * The function will return -1 if the target VM does not exist.
- *
- * @param vm Pointer to VM data structure
- * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to struct acrn_irqline
- *
- * @pre @pre Pointer vm shall point to VM0
- * @return 0 on success, non-zero on error.
- */
-int32_t hcall_deassert_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
-
-/**
- * @brief trigger a pulse on IRQ line
- *
- * Trigger a pulse on a virtual IRQ line for a VM, which could be from ISA
- * or IOAPIC, normally it triggers an edge IRQ.
- * The function will return -1 if the target VM does not exist.
- *
- * @param vm Pointer to VM data structure
- * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to struct acrn_irqline
- *
- * @pre Pointer vm shall point to VM0
- * @return 0 on success, non-zero on error.
- */
-int32_t hcall_pulse_irqline(struct vm *vm, uint16_t vmid, uint64_t param);
-
-
-/**
  * @brief set or clear IRQ line
  *
  * Set or clear a virtual IRQ line for a VM, which could be from ISA


### PR DESCRIPTION
Below functions are deprecated, remove them from hypercall.h
hc_assert_irqline()/hc_deassert_irqline()/hc_pulse_irqline()

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>