### PR TITLE
Complement struct/API doc for HLD

### DIFF
--- a/doc/acrn.doxyfile
+++ b/doc/acrn.doxyfile
@@ -802,6 +802,7 @@ INPUT                  =  custom-doxygen/mainpage.md \
                           ../hypervisor/include/arch/x86/guest/vlapic.h \
                           ../hypervisor/include/arch/x86/guest/vioapic.h \
                           ../hypervisor/include/arch/x86/guest/vpic.h \
+                          ../hypervisor/include/arch/x86/ioreq.h \
                           ../hypervisor/include/common/hypercall.h \
                           ../hypervisor/include/public/acrn_common.h \
                           ../hypervisor/include/public/acrn_hv_defs.h \

--- a/doc/developer-guides/hld/hv-io-emulation.rst
+++ b/doc/developer-guides/hld/hv-io-emulation.rst
@@ -299,66 +299,54 @@ Initialization and Deinitialization
 
 The following structure represents a port I/O handler:
 
-.. note:: add reference to vm_io_handler_desc definition in ioreq.h
+.. doxygenstruct:: vm_io_handler_desc
+   :project: Project ACRN
 
 The following structure represents a MMIO handler.
 
-.. note:: add reference to mem_io_node definition in ioreq.h
-
+.. doxygenstruct:: mem_io_node
+   :project: Project ACRN
 
 The following APIs are provided to initialize, deinitialize or configure
 I/O bitmaps and register or unregister I/O handlers:
 
-.. code-block:: c
+.. doxygenfunction:: setup_io_bitmap
+   :project: Project ACRN
 
-   /* Initialize the I/O bitmap for vm. */
-   void setup_io_bitmap(struct vm *vm)
+.. doxygenfunction:: allow_guest_pio_access
+   :project: Project ACRN
 
-   /* Allow a VM to access a port I/O range.
-    * This API enables direct access from the given vm to the port I/O space
-    * starting from address_arg to address_arg + nbytes - 1.
-    */
-   void allow_guest_io_access(struct vm *vm, uint32_t address_arg, uint32_t nbytes)
+.. doxygenfunction:: free_io_emulation_resource
+   :project: Project ACRN
 
-   /* Free I/O bitmaps and port I/O handlers of vm. */
-   void free_io_emulation_resource(struct vm *vm)
+.. doxygenfunction:: register_io_emulation_handler
+   :project: Project ACRN
 
-   /* Register a port I/O handler. */
-   void register_io_emulation_handler(struct vm *vm, struct vm_io_range *range,
-                                      io_read_fn_t io_read_fn_ptr, io_write_fn_t io_write_fn_ptr)
+.. doxygenfunction:: register_mmio_emulation_handler
+   :project: Project ACRN
 
-   /* Register a MMIO handler. */
-   int register_mmio_emulation_handler(struct vm *vm, hv_mem_io_handler_t read_write,
-                                       uint64_t start, uint64_t end, void *handler_private_data)
-
-   /* Unregister a MMIO handler.*/
-   void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start, uint64_t end)
-
-.. note:: change these to reference API material from ioreq.h
+.. doxygenfunction:: unregister_mmio_emulation_handler
+   :project: Project ACRN
 
 I/O Emulation
 =============
 
 The following APIs are provided for I/O emulation at runtime:
 
-.. code-block:: c
+.. doxygenfunction:: emulate_io
+   :project: Project ACRN
 
-   /* Emulate the given I/O access for vcpu. */
-   int32_t emulate_io(struct vcpu *vcpu, struct io_request *io_req)
+.. doxygenfunction:: acrn_insert_request_wait
+   :project: Project ACRN
 
-   /* Deliver io_req to SOS and suspend vcpu till its completion. */
-   int32_t acrn_insert_request_wait(struct vcpu *vcpu, struct io_request *io_req)
+.. doxygenfunction:: emulate_io_post
+   :project: Project ACRN
 
-   /* General post-work for port I/O emulation. */
-   void emulate_io_post(struct vcpu *vcpu)
+.. doxygenfunction:: emulate_mmio_post
+   :project: Project ACRN
 
-   /* General post-work for MMIO emulation. */
-   void emulate_mmio_post(struct vcpu *vcpu, struct io_request *io_req)
+.. doxygenfunction:: dm_emulate_mmio_post
+   :project: Project ACRN
 
-   /* Post-work of I/O requests for MMIO. */
-   void dm_emulate_mmio_post(struct vcpu *vcpu)
-
-   /* The handler of VM exits on I/O instructions. */
-   int32_t pio_instr_vmexit_handler(struct vcpu *vcpu)
-
-.. note:: change these to reference API material from ioreq.h
+.. doxygenfunction:: pio_instr_vmexit_handler
+   :project: Project ACRN

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -55,11 +55,15 @@ static void acrn_print_request(uint16_t vcpu_id, const struct vhm_request *req)
 	}
 }
 
-/*
+/**
+ * @brief Deliver \p io_req to SOS and suspend \p vcpu till its completion
+ *
+ * @param vcpu The virtual CPU that triggers the MMIO access
+ * @param io_req The I/O request holding the details of the MMIO access
+ *
  * @pre vcpu != NULL && io_req != NULL
  */
-int32_t
-acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req)
+int32_t acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req)
 {
 	union vhm_request_buffer *req_buf = NULL;
 	struct vhm_request *vhm_req;

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -10,24 +10,41 @@
 #include <types.h>
 #include <acrn_common.h>
 
+/**
+ * @brief I/O Emulation
+ *
+ * @defgroup ioemul ACRN I/O Emulation
+ * @{
+ */
+
 /* The return value of emulate_io() indicating the I/O request is delivered to
  * VHM but not finished yet. */
 #define IOREQ_PENDING	1
 
-/* Internal representation of a I/O request. */
+/**
+ * @brief Internal representation of a I/O request.
+ */
 struct io_request {
-	/** Type of the request (PIO, MMIO, etc). Refer to vhm_request. */
+	/**
+	 * @brief Type of the request (PIO, MMIO, etc).
+	 *
+	 * Refer to vhm_request for detailed description of I/O request types.
+	 */
 	uint32_t type;
 
-	/** Details of this request in the same format as vhm_request. */
+	/**
+	 * @brief Details of this request in the same format as vhm_request.
+	 */
 	union vhm_io_request reqs;
 };
 
-/* Definition of a IO port range */
+/**
+ * @brief Definition of a IO port range
+ */
 struct vm_io_range {
-	uint16_t base;		/* IO port base */
-	uint16_t len;		/* IO port range */
-	uint32_t flags;		/* IO port attributes */
+	uint16_t base;		/**< IO port base */
+	uint16_t len;		/**< IO port range */
+	uint32_t flags;		/**< IO port attributes */
 };
 
 struct vm_io_handler;
@@ -40,15 +57,23 @@ uint32_t (*io_read_fn_t)(struct vm *vm, uint16_t port, size_t size);
 typedef
 void (*io_write_fn_t)(struct vm *vm, uint16_t port, size_t size, uint32_t val);
 
-/* Describes a single IO handler description entry. */
+/**
+ * @brief Describes a single IO handler description entry.
+ */
 struct vm_io_handler_desc {
 
-	/** The base address of the IO range for this description. */
+	/**
+	 * @brief The base address of the IO range for this description.
+	 */
 	uint16_t addr;
-	/** The number of bytes covered by this description. */
+
+	/**
+	 * @brief The number of bytes covered by this description.
+	 */
 	size_t len;
 
-	/** A pointer to the "read" function.
+	/**
+	 * @brief A pointer to the "read" function.
 	 *
 	 * The read function is called from the hypervisor whenever
 	 * a read access to a range described in "ranges" occur.
@@ -62,9 +87,10 @@ struct vm_io_handler_desc {
 	 *
 	 * If the pointer is null, a read of 1's is assumed.
 	 */
-
 	io_read_fn_t io_read;
-	/** A pointer to the "write" function.
+
+	/**
+	 * @brief A pointer to the "write" function.
 	 *
 	 * The write function is called from the hypervisor code
 	 * whenever a write access to a range described in "ranges"
@@ -78,8 +104,7 @@ struct vm_io_handler_desc {
 	 * The implementation must write the value to the port.
 	 *
 	 * If the pointer is null, the write access is ignored.
-    */
-
+	 */
 	io_write_fn_t io_write;
 };
 
@@ -96,38 +121,194 @@ struct vm_io_handler {
 struct mmio_request;
 typedef int (*hv_mem_io_handler_t)(struct io_request *io_req, void *handler_private_data);
 
-/* Structure for MMIO handler node */
+/**
+ * @brief Structure for MMIO handler node
+ */
 struct mem_io_node {
+	/**
+	 * @brief A pointer to the handler
+	 *
+	 * The function for handling MMIO accesses to the specified range.
+	 */
 	hv_mem_io_handler_t read_write;
+
+	/**
+	 * @brief Private data used by the handler
+	 *
+	 * The pointer to any data specified at registration. This pointer is
+	 * passed to the handler whenever the handler is called.
+	 */
 	void *handler_private_data;
+
+	/**
+	 * @brief The struct to make a bi-directional linked list
+	 */
 	struct list_head list;
+
+	/**
+	 * @brief The starting address
+	 *
+	 * This member is used in pair with \p range_end. See the documentation
+	 * of \p range_end for details.
+	 */
 	uint64_t range_start;
+
+	/**
+	 * @brief The ending address
+	 *
+	 * \p range_start (inclusive) and \p range_end (exclusive) together
+	 * specify the address range that this handler is expected to
+	 * emulate. Note that the bytes to be accessed shall completely fall in
+	 * the range before the handler is called to emulate that access, or
+	 * more specifically
+	 *
+	 *    \p range_start <= address < address + size <= \p end
+	 *
+	 * where address and size are the starting address of the MMIO access
+	 * and the number of bytes to be accessed, respectively. Otherwise the
+	 * behavior is undefined.
+	 */
 	uint64_t range_end;
 };
 
 /* External Interfaces */
+
+/**
+ * @brief The handler of VM exits on I/O instructions
+ *
+ * @param vcpu The virtual CPU which triggers the VM exit on I/O instruction
+ */
 int32_t pio_instr_vmexit_handler(struct vcpu *vcpu);
+
+/**
+ * @brief Initialize the I/O bitmap for \p vm
+ *
+ * @param vm The VM whose I/O bitmaps are to be initialized
+ */
 void   setup_io_bitmap(struct vm *vm);
+
+/**
+ * @brief Free I/O bitmaps and port I/O handlers of \p vm
+ *
+ * @param vm The VM whose I/O bitmaps and handlers are to be freed
+ */
 void   free_io_emulation_resource(struct vm *vm);
+
+/**
+ * @brief Allow a VM to access a port I/O range
+ *
+ * This API enables direct access from the given \p vm to the port I/O space
+ * starting from \p port_address to \p port_address + \p nbytes - 1.
+ *
+ * @param vm The VM whose port I/O access permissions is to be changed
+ * @param port_address The start address of the port I/O range
+ * @param nbytes The size of the range, in bytes
+ */
 void   allow_guest_pio_access(struct vm *vm, uint16_t port_address,
 		uint32_t nbytes);
+
+/**
+ * @brief Register a port I/O handler
+ *
+ * @param vm The VM to which the port I/O handlers are registered
+ * @param range The port I/O range that the given handlers can emulate
+ * @param io_read_fn_ptr The handler for emulating reads from the given range
+ * @param io_write_fn_ptr The handler for emulating writes to the given range
+ */
 void   register_io_emulation_handler(struct vm *vm, const struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr);
 
+/**
+ * @brief Register a MMIO handler
+ *
+ * This API registers a MMIO handler to \p vm before it is launched.
+ *
+ * @param vm The VM to which the MMIO handler is registered
+ * @param read_write The handler for emulating accesses to the given range
+ * @param start The base address of the range \p read_write can emulate
+ * @param end The end of the range (exclusive) \p read_write can emulate
+ * @param handler_private_data Handler-specific data which will be passed to \p read_write when called
+ *
+ * @return 0 - Registration succeeds
+ * @return -EINVAL - \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
+ */
 int register_mmio_emulation_handler(struct vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
 	uint64_t end, void *handler_private_data);
+
+/**
+ * @brief Unregister a MMIO handler
+ *
+ * @param vm The VM from which MMIO handlers are unregistered
+ * @param start The base address of the range the to-be-unregistered handler is for
+ * @param end The end of the range (exclusive) the to-be-unregistered handler is for
+ */
 void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
         uint64_t end);
+
+/**
+ * @brief General post-work for MMIO emulation
+ *
+ * @param vcpu The virtual CPU that triggers the MMIO access
+ * @param io_req The I/O request holding the details of the MMIO access
+ *
+ * @pre io_req->type == REQ_MMIO
+ *
+ * @remark This function must be called when \p io_req is completed, after
+ * either a previous call to emulate_io() returning 0 or the corresponding VHM
+ * request transferring to the COMPLETE state.
+ */
 void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req);
+
+/**
+ * @brief Post-work of VHM requests for MMIO emulation
+ *
+ * @param vcpu The virtual CPU that triggers the MMIO access
+ *
+ * @pre vcpu->req.type == REQ_MMIO
+ *
+ * @remark This function must be called after the VHM request corresponding to
+ * \p vcpu being transferred to the COMPLETE state.
+ */
 void dm_emulate_mmio_post(struct vcpu *vcpu);
 
+/**
+ * @brief Emulate \p io_req for \p vcpu
+ *
+ * Handle an I/O request by either invoking a hypervisor-internal handler or
+ * deliver to VHM.
+ *
+ * @param vcpu The virtual CPU that triggers the MMIO access
+ * @param io_req The I/O request holding the details of the MMIO access
+ *
+ * @return 0       - Successfully emulated by registered handlers.
+ * @return IOREQ_PENDING - The I/O request is delivered to VHM.
+ * @return -EIO    - The request spans multiple devices and cannot be emulated.
+ * @return -EINVAL - \p io_req has an invalid type.
+ * @return Negative on other errors during emulation.
+ */
 int32_t emulate_io(struct vcpu *vcpu, struct io_request *io_req);
+
+/**
+ * @brief General post-work for all kinds of VHM requests for I/O emulation
+ *
+ * @param vcpu The virtual CPU that triggers the MMIO access
+ */
 void emulate_io_post(struct vcpu *vcpu);
-/*
+
+/**
+ * @brief Deliver \p io_req to SOS and suspend \p vcpu till its completion
+ *
+ * @param vcpu The virtual CPU that triggers the MMIO access
+ * @param io_req The I/O request holding the details of the MMIO access
+ *
  * @pre vcpu != NULL && io_req != NULL
  */
 int32_t acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req);
+
+/**
+ * @}
+ */
 
 #endif /* IOREQ_H */


### PR DESCRIPTION
This patch series adds the structure and API documentation to header and C
sources in doxygen style and replace the hard-coded API docs with
doxygen-generated ones.

Tracked-On: #1595