### PR TITLE
Remove vtd dynamic allocation

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -479,7 +479,9 @@ static void bsp_boot_post(void)
 	/* Initialize interrupts */
 	interrupt_init(BOOT_CPU_ID);
 
-	init_iommu();
+	if (init_iommu() != 0) {
+		panic("failed to initialize iommu!");
+	}
 
 	timer_init();
 	profiling_setup();

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -324,8 +324,9 @@ int parse_dmar_table(void)
  */
 struct dmar_info *get_dmar_info(void)
 {
-	parse_dmar_table();
+	if (dmar_info_parsed.drhd_count == 0) {
+		parse_dmar_table();
+	}
 	return &dmar_info_parsed;
 }
-
 #endif

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -71,6 +71,10 @@ enum _page_table_level {
 #define PAGE_SIZE_2M	MEM_2M
 #define PAGE_SIZE_1G	MEM_1G
 
+struct cpu_page {
+	uint8_t contents[CPU_PAGE_SIZE];
+};
+
 uint64_t get_paging_pml4(void);
 void *alloc_paging_struct(void);
 void free_paging_struct(void *ptr);

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -480,7 +480,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id,
 	uint64_t translation_table, uint32_t addr_width);
 
 /* Destroy the iommu domain */
-void destroy_iommu_domain(const struct iommu_domain *domain);
+void destroy_iommu_domain(struct iommu_domain *domain);
 
 /* Enable translation of iommu*/
 void enable_iommu(void);

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -495,7 +495,7 @@ void suspend_iommu(void);
 void resume_iommu(void);
 
 /* iommu initialization */
-void init_iommu(void);
+int init_iommu(void);
 void init_iommu_vm0_domain(struct vm *vm0);
 
 #endif


### PR DESCRIPTION
v6 since v5:
	- remove dom_id field.
	- remove dmar_hdrh_unit_count.
	- export cpu_page structure and redefine
iommu_root_table&iommu_ctx_table

v5 since v4:
	- remove the new api for retrieving dmar count.
	- fix a potential bug in dmar looping.
	- check init_iommu()

v4 since v3:
    - remove domain id dynamic allocation.
    - export a new api for retrieving the dmar number.
    - fix a minor bug in v3 when memclr domain structure.

v3 since v2:
    - move iommu number check into hardware_detect_support()
    - more comments on domain index.

v2 since v1:
    - use predefine macros in Kconfig instead of defining a new one.
    - remove unnecessary bus_no and dmar_index check.
    - add a new patch for stripping iommu_domain dynamic allocations.

Tw (3):
  hv: vtd: remove dynamic page allocation for root&ctx table
  hv: vtd: remove dynamic allocation for dmar_drhd_rt
  hv: vtd: remove dynamic allocation for iommu_domain

Tracked-On: #861
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
