### PR TITLE
snprintf: Remove the %o and %p support

### DIFF
--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -508,19 +508,6 @@ void do_print(const char *fmt_arg, struct print_param *param,
 						uint32_t));
 				}
 			}
-			/* octal number */
-			else if (ch == 'o') {
-				if ((param->vars.flags &
-					PRINT_FLAG_LONG_LONG) != 0U) {
-					print_pow2(param,
-						__builtin_va_arg(args,
-						uint64_t), 3U);
-				} else {
-					print_pow2(param,
-						__builtin_va_arg(args,
-						uint32_t), 3U);
-				}
-			}
 			/* hexadecimal number */
 			else if ((ch == 'X') || (ch == 'x')) {
 				if (ch == 'X') {
@@ -545,12 +532,6 @@ void do_print(const char *fmt_arg, struct print_param *param,
 					s = "(null)";
 				}
 				print_string(param, s);
-			}
-			/* pointer argument */
-			else if (ch == 'p') {
-				param->vars.flags |= PRINT_FLAG_ALTERNATE_FORM;
-				print_pow2(param, (uint64_t)
-					__builtin_va_arg(args, void *), 4U);
 			}
 			/* single character argument */
 			else if (ch == 'c') {


### PR DESCRIPTION
%x could be used to replace the %o print option.
%x could be used to replace the %p print option also.

Tracked-On: #1656
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>