### PR TITLE
HV: increase shell log buf size for debug build

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -445,8 +445,10 @@ int get_ioapic_info(char *str_arg, size_t str_max_len)
 	uint32_t irq;
 	size_t len, size = str_max_len;
 
-	len = snprintf(str, size,
-	"\r\nIRQ\tPIN\tRTE.HI32\tRTE.LO32\tVEC\tDST\tDM\tTM\tDELM\tIRR\tMASK");
+	len = snprintf(str, size, "\r\nIRQ\tPIN\tRTE.HI32\tRTE.LO32\tVEC\tDST\tDM\tTM\tDELM\tIRR\tMASK");
+	if (len >= size) {
+		goto overflow;
+	}
 	size -= len;
 	str += len;
 
@@ -463,24 +465,27 @@ int get_ioapic_info(char *str_arg, size_t str_max_len)
 		get_rte_info(rte, &mask, &irr, &phys, &delmode, &level,
 			&vector, &dest);
 
-		len = snprintf(str, size, "\r\n%03d\t%03hhu\t0x%08X\t0x%08X\t",
-			irq, pin, rte.u.hi_32, rte.u.lo_32);
+		len = snprintf(str, size, "\r\n%03d\t%03hhu\t0x%08X\t0x%08X\t", irq, pin, rte.u.hi_32, rte.u.lo_32);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
 
 		len = snprintf(str, size, "0x%02X\t0x%02X\t%s\t%s\t%u\t%d\t%d",
-			vector, dest, phys ? "phys" : "logic",
-			level ? "level" : "edge", delmode >> 8, irr, mask);
+			vector, dest, phys ? "phys" : "logic", level ? "level" : "edge", delmode >> 8, irr, mask);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
-
-		if (size < 2U) {
-			pr_err("\r\nsmall buffer for ioapic dump");
-			return -1;
-		}
 	}
 
 	snprintf(str, size, "\r\n");
+	return 0;
+
+overflow:
+	printf("buffer size could not be enough! please check!\n");
 	return 0;
 }
 #endif /* HV_DEBUG */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -411,10 +411,17 @@ void get_cpu_interrupt_info(char *str_arg, size_t str_max)
 	size_t len, size = str_max;
 
 	len = snprintf(str, size, "\r\nIRQ\tVECTOR");
+	if (len >= size) {
+		goto overflow;
+	}
 	size -= len;
 	str += len;
+
 	for (pcpu_id = 0U; pcpu_id < phys_cpu_num; pcpu_id++) {
 		len = snprintf(str, size, "\tCPU%d", pcpu_id);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
 	}
@@ -425,17 +432,27 @@ void get_cpu_interrupt_info(char *str_arg, size_t str_max)
 			irq_alloc_bitmap + (irq >> 6U))
 			&& (vector != VECTOR_INVALID)) {
 			len = snprintf(str, size, "\r\n%d\t0x%X", irq, vector);
+			if (len >= size) {
+				goto overflow;
+			}
 			size -= len;
 			str += len;
+
 			for (pcpu_id = 0U; pcpu_id < phys_cpu_num; pcpu_id++) {
-				len = snprintf(str, size, "\t%d",
-					per_cpu(irq_count, pcpu_id)[irq]);
+				len = snprintf(str, size, "\t%d", per_cpu(irq_count, pcpu_id)[irq]);
+				if (len >= size) {
+					goto overflow;
+				}
 				size -= len;
 				str += len;
 			}
 		}
 	}
 	snprintf(str, size, "\r\n");
+	return;
+
+overflow:
+	printf("buffer size could not be enough! please check!\n");
 }
 #endif /* HV_DEBUG */
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -123,33 +123,51 @@ void get_vmexit_profile(char *str_arg, size_t str_max)
 	uint16_t cpu, i;
 	size_t len, size = str_max;
 
-	len = snprintf(str, size, "\r\nNow(us) = %16lld\r\n",
-			ticks_to_us(rdtsc()));
+	len = snprintf(str, size, "\r\nNow(us) = %16lld\r\n", ticks_to_us(rdtsc()));
+	if (len >= size) {
+		goto overflow;
+	}
 	size -= len;
 	str += len;
 
 	len = snprintf(str, size, "\r\nREASON");
+	if (len >= size) {
+		goto overflow;
+	}
 	size -= len;
 	str += len;
 
 	for (cpu = 0U; cpu < phys_cpu_num; cpu++) {
 		len = snprintf(str, size, "\t      CPU%hu\t        US", cpu);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
 	}
 
 	for (i = 0U; i < 64U; i++) {
 		len = snprintf(str, size, "\r\n0x%x", i);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
 		for (cpu = 0U; cpu < phys_cpu_num; cpu++) {
-			len = snprintf(str, size, "\t%10lld\t%10lld",
-				per_cpu(vmexit_cnt, cpu)[i],
+			len = snprintf(str, size, "\t%10lld\t%10lld", per_cpu(vmexit_cnt, cpu)[i],
 				ticks_to_us(per_cpu(vmexit_time, cpu)[i]));
+			if (len >= size) {
+				goto overflow;
+			}
+
 			size -= len;
 			str += len;
 		}
 	}
 	snprintf(str, size, "\r\n");
+	return;
+
+overflow:
+	printf("buffer size could not be enough! please check!\n");
 }
 #endif /* HV_DEBUG */

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -11,7 +11,8 @@
 #define MAX_STR_SIZE		256U
 #define SHELL_PROMPT_STR	"ACRN:\\>"
 
-char shell_log_buf[CPU_PAGE_SIZE*2];
+#define SHELL_LOG_BUF_SIZE		(CPU_PAGE_SIZE * CONFIG_MAX_PCPU_NUM / 2U)
+static char shell_log_buf[SHELL_LOG_BUF_SIZE];
 
 /* Input Line Other - Switch to the "other" input line (there are only two
  * input lines total).
@@ -657,7 +658,7 @@ static int shell_vcpu_dumpreg(int argc, char **argv)
 	vcpu = vcpu_from_vid(vm, vcpu_id);
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
-	dump.str_max = CPU_PAGE_SIZE;
+	dump.str_max = SHELL_LOG_BUF_SIZE;
 	if (vcpu->pcpu_id == get_cpu_id()) {
 		vcpu_dumpreg(&dump);
 	} else {
@@ -764,14 +765,14 @@ static int shell_to_sos_console(__unused int argc, __unused char **argv)
 
 static int shell_show_cpu_int(__unused int argc, __unused char **argv)
 {
-	get_cpu_interrupt_info(shell_log_buf, CPU_PAGE_SIZE);
+	get_cpu_interrupt_info(shell_log_buf, SHELL_LOG_BUF_SIZE);
 	shell_puts(shell_log_buf);
 	return 0;
 }
 
 static int shell_show_ptdev_info(__unused int argc, __unused char **argv)
 {
-	get_ptdev_info(shell_log_buf, CPU_PAGE_SIZE);
+	get_ptdev_info(shell_log_buf, SHELL_LOG_BUF_SIZE);
 	shell_puts(shell_log_buf);
 
 	return 0;
@@ -789,7 +790,7 @@ static int shell_show_vioapic_info(int argc, char **argv)
 	ret = atoi(argv[1]);
 	if (ret >= 0) {
 		vmid = (uint16_t) ret;
-		get_vioapic_info(shell_log_buf, CPU_PAGE_SIZE, vmid);
+		get_vioapic_info(shell_log_buf, SHELL_LOG_BUF_SIZE, vmid);
 		shell_puts(shell_log_buf);
 		return 0;
 	}
@@ -801,7 +802,7 @@ static int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 {
 	int err = 0;
 
-	err = get_ioapic_info(shell_log_buf, 2 * CPU_PAGE_SIZE);
+	err = get_ioapic_info(shell_log_buf, SHELL_LOG_BUF_SIZE);
 	shell_puts(shell_log_buf);
 
 	return err;
@@ -809,7 +810,7 @@ static int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 
 static int shell_show_vmexit_profile(__unused int argc, __unused char **argv)
 {
-	get_vmexit_profile(shell_log_buf, 2*CPU_PAGE_SIZE);
+	get_vmexit_profile(shell_log_buf, SHELL_LOG_BUF_SIZE);
 	shell_puts(shell_log_buf);
 
 	return 0;

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -586,15 +586,19 @@ void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 	uint32_t pin, pincount;
 
 	if (vm == NULL) {
-		len = snprintf(str, size,
-			"\r\nvm is not exist for vmid %hu", vmid);
+		len = snprintf(str, size, "\r\nvm is not exist for vmid %hu", vmid);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
 		goto END;
 	}
 
-	len = snprintf(str, size,
-		"\r\nPIN\tVEC\tDM\tDEST\tTM\tDELM\tIRR\tMASK");
+	len = snprintf(str, size, "\r\nPIN\tVEC\tDM\tDEST\tTM\tDELM\tIRR\tMASK");
+	if (len >= size) {
+		goto overflow;
+	}
 	size -= len;
 	str += len;
 
@@ -610,15 +614,20 @@ void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 		vector = rte.u.lo_32 & IOAPIC_RTE_LOW_INTVEC;
 		dest = (uint32_t)(rte.full >> IOAPIC_RTE_DEST_SHIFT);
 
-		len = snprintf(str, size,
-				"\r\n%hhu\t0x%X\t%s\t0x%X\t%s\t%u\t%d\t%d",
-				pin, vector, phys ? "phys" : "logic",
-				dest, level ? "level" : "edge",
+		len = snprintf(str, size, "\r\n%hhu\t0x%X\t%s\t0x%X\t%s\t%u\t%d\t%d",
+				pin, vector, phys ? "phys" : "logic", dest, level ? "level" : "edge",
 				delmode >> 8U, remote_irr, mask);
+		if (len >= size) {
+			goto overflow;
+		}
 		size -= len;
 		str += len;
 	}
 END:
 	snprintf(str, size, "\r\n");
+	return;
+
+overflow:
+	printf("buffer size could not be enough! please check!\n");
 }
 #endif /* HV_DEBUG */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -245,7 +245,7 @@ struct vcpu {
 struct vcpu_dump {
 	struct vcpu *vcpu;
 	char *str;
-	int str_max;
+	uint32_t str_max;
 };
 
 static inline bool is_vcpu_bsp(const struct vcpu *vcpu)


### PR DESCRIPTION
on KBL-NUC when input "vmexit" in hypervisor console,
the console or HV/SOS could be hung, the root cause is:
the log buffer is overflow for 8 CPU cores info.

for the command just used in debug build, so to resolve
this bug in a simple way, just increase shell log buffer
size from 2 pages to 6 pages, it should be enough for more
CPU core info (like 12 cores or more).

Tracked-On: #1587
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>