### PR TITLE
hv:Replace dynamic memory with static for sbuf

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -99,6 +99,10 @@ config STACK_SIZE
 	  The size of stacks used by physical cores. Each core uses one stack
 	  for normal operations and another three for specific exceptions.
 
+config LOG_BUF_SIZE
+	hex "Capacity of logbuf for each physical cpu"
+	default 0x40000
+
 config LOG_DESTINATION
 	int "Bitmap of consoles where logs are printed"
 	range 0 7

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -25,63 +25,6 @@ uint32_t sbuf_next_ptr(uint32_t pos_arg,
 	return pos;
 }
 
-static inline uint32_t sbuf_calculate_allocate_size(uint32_t ele_num,
-						uint32_t ele_size)
-{
-	uint64_t sbuf_allocate_size;
-
-	sbuf_allocate_size = ele_num * ele_size;
-	sbuf_allocate_size +=  SBUF_HEAD_SIZE;
-	if (sbuf_allocate_size > SBUF_MAX_SIZE) {
-		pr_err("%s, num=0x%x, size=0x%x exceed 0x%x",
-			__func__, ele_num, ele_size, SBUF_MAX_SIZE);
-		return 0;
-	}
-
-	return (uint32_t) sbuf_allocate_size;
-}
-
-struct shared_buf *sbuf_allocate(uint32_t ele_num, uint32_t ele_size)
-{
-	struct shared_buf *sbuf;
-	uint32_t sbuf_allocate_size;
-
-	if ((ele_num == 0U) || (ele_size == 0U)) {
-		pr_err("%s invalid parameter!", __func__);
-		return NULL;
-	}
-
-	sbuf_allocate_size = sbuf_calculate_allocate_size(ele_num, ele_size);
-	if (sbuf_allocate_size == 0U) {
-		return NULL;
-	}
-
-	sbuf = calloc(1U, sbuf_allocate_size);
-	if (sbuf == NULL) {
-		pr_err("%s no memory!", __func__);
-		return NULL;
-	}
-
-	sbuf->ele_num = ele_num;
-	sbuf->ele_size = ele_size;
-	sbuf->size = ele_num * ele_size;
-	sbuf->magic = SBUF_MAGIC;
-	pr_info("%s ele_num=0x%x, ele_size=0x%x allocated",
-			__func__, ele_num, ele_size);
-	return sbuf;
-}
-
-void sbuf_free(struct shared_buf *sbuf)
-{
-	if ((sbuf == NULL) || (sbuf->magic != SBUF_MAGIC)) {
-		pr_err("%s invalid parameter!", __func__);
-		return;
-	}
-
-	sbuf->magic = 0UL;
-	free(sbuf);
-}
-
 uint32_t sbuf_get(struct shared_buf *sbuf, uint8_t *data)
 {
 	const void *from;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -24,6 +24,9 @@ struct per_cpu_region {
 	uint8_t vmxon_region[CPU_PAGE_SIZE];
 #ifdef HV_DEBUG
 	uint64_t *sbuf[ACRN_SBUF_ID_MAX];
+	char logbuf[LOG_MESSAGE_MAX_SIZE];
+	bool is_early_logbuf;
+	char early_logbuf[CONFIG_LOG_BUF_SIZE];
 	uint64_t vmexit_cnt[64];
 	uint64_t vmexit_time[64];
 	uint32_t npk_log_ref;
@@ -31,7 +34,6 @@ struct per_cpu_region {
 	uint64_t irq_count[NR_IRQS];
 	uint64_t softirq_pending;
 	uint64_t spurious;
-	struct shared_buf *earlylog_sbuf;
 	void *vcpu;
 	void *ever_run_vcpu;
 #ifdef STACK_PROTECTOR
@@ -47,7 +49,6 @@ struct per_cpu_region {
 	uint8_t df_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t sf_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t stack[CONFIG_STACK_SIZE] __aligned(16);
-	char logbuf[LOG_MESSAGE_MAX_SIZE];
 	uint32_t lapic_id;
 	uint32_t lapic_ldr;
 	struct smp_call_info_data smp_call_info;

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -74,8 +74,6 @@ static inline void sbuf_add_flags(struct shared_buf *sbuf, uint64_t flags)
 	sbuf->flags |= flags;
 }
 
-struct shared_buf *sbuf_allocate(uint32_t ele_num, uint32_t ele_size);
-void sbuf_free(struct shared_buf *sbuf);
 /**
  *@pre sbuf != NULL
  *@pre data != NULL
@@ -106,18 +104,6 @@ static inline void sbuf_set_flags(
 static inline void sbuf_add_flags(
 		__unused struct shared_buf *sbuf,
 		__unused uint64_t flags)
-{
-}
-
-static inline struct shared_buf *sbuf_allocate(
-		__unused uint32_t ele_num,
-		__unused uint32_t ele_size)
-{
-	return NULL;
-}
-
-static inline void sbuf_free(
-		__unused struct shared_buf *sbuf)
 {
 }
 


### PR DESCRIPTION
--Config LOG_BUF_SIZE 256KB for per cpu
--Replace 'calloc' with static array for sbuf
--Rename 'alloc_earlylog_sbuf' to 'init_earlylog_sbuf'
--Remove deadcode sbuf_free

v2-->v3:
 -- put the buffer into per_cpu data structure
v1-->v2:
 -- add 'is_early_logbuf' in percpu data structure used for
    check if need to do 'do_copy_earlylog'

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Yan, Like <like.yan@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>