### PR TITLE
x2APIC support for ACRN guests

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -28,8 +28,6 @@ static uint64_t startup_paddr = 0UL;
 /* physical cpu active bitmap, support up to 64 cpus */
 uint64_t pcpu_active_bitmap = 0UL;
 
-/* X2APIC mode is disabled by default. */
-bool x2apic_enabled = false;
 static bool skip_l1dfl_vmentry;
 static uint64_t x86_arch_capabilities;
 

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -360,6 +360,9 @@ void guest_cpuid(struct vcpu *vcpu,
 
 	case 0x0bU:
 		/* Patching X2APIC */
+#ifdef CONFIG_PARTITION_MODE
+		cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
+#else
 		if (is_vm0(vcpu->vm)) {
 			cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
 		} else {
@@ -388,6 +391,7 @@ void guest_cpuid(struct vcpu *vcpu,
 			break;
 			}
 		}
+#endif
 		break;
 
 	case 0x0dU:

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -327,10 +327,10 @@ void guest_cpuid(struct vcpu *vcpu,
 	case 0x01U:
 	{
 		cpuid(leaf, eax, ebx, ecx, edx);
-		uint32_t apicid = vlapic_get_id(vcpu_vlapic(vcpu));
+		uint32_t apicid = vlapic_get_apicid(vcpu_vlapic(vcpu));
 		/* Patching initial APIC ID */
 		*ebx &= ~APIC_ID_MASK;
-		*ebx |= (apicid & APIC_ID_MASK);
+		*ebx |= (apicid <<  APIC_ID_SHIFT);
 
 #ifndef CONFIG_MTRR_ENABLED
 		/* mask mtrr */

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1718,6 +1718,7 @@ vlapic_set_apicbase(struct acrn_vlapic *vlapic, uint64_t new)
 		if ((new & APICBASE_X2APIC) == APICBASE_X2APIC) {
 			vlapic->msr_apicbase = new;
 			vlapic_build_x2apic_id(vlapic);
+			switch_apicv_mode_x2apic(vlapic->vcpu);
 			return 0;
 		}
 	}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -148,17 +148,16 @@ vm_active_cpus(const struct vm *vm)
 }
 
 uint32_t
-vlapic_get_id(const struct acrn_vlapic *vlapic)
+vlapic_get_apicid(struct acrn_vlapic *vlapic)
 {
-	uint32_t id = vlapic->apic_page.id.v;
-	return id;
-}
+	uint32_t apicid;
+	if (is_x2apic_enabled(vlapic)) {
+		apicid = vlapic->apic_page.id.v;
+	} else {
+		apicid = (vlapic->apic_page.id.v) >> APIC_ID_SHIFT;
+	}
 
-uint8_t
-vlapic_get_apicid(const struct acrn_vlapic *vlapic)
-{
-	uint32_t apicid = (vlapic->apic_page.id.v) >> APIC_ID_SHIFT;
-	return (uint8_t)apicid;
+	return apicid;
 }
 
 static inline uint32_t

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -80,6 +80,6 @@
 #define APIC_OFFSET_TIMER_ICR	0x380U	/* Timer's Initial Count	*/
 #define APIC_OFFSET_TIMER_CCR	0x390U	/* Timer's Current Count	*/
 #define APIC_OFFSET_TIMER_DCR	0x3E0U	/* Timer's Divide Configuration	*/
-
+#define APIC_OFFSET_SELF_IPI    0x3F0U  /* Self IPI Register */
 
 #endif /* VLAPIC_PRIV_H */

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -446,3 +446,17 @@ void update_msr_bitmap_x2apic_apicv(struct vcpu *vcpu)
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_EOI, READ);
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_SELF_IPI, READ);
 }
+
+void update_msr_bitmap_x2apic_passthru(struct vcpu *vcpu)
+{
+	uint32_t msr;
+	uint8_t *msr_bitmap;
+
+	msr_bitmap = vcpu->vm->arch_vm.msr_bitmap;
+	for (msr = MSR_IA32_EXT_XAPICID;
+			msr <= MSR_IA32_EXT_APIC_SELF_IPI; msr++) {
+		enable_msr_interception(msr_bitmap, msr, DISABLE);
+	}
+	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_ICR, WRITE);
+	enable_msr_interception(msr_bitmap, MSR_IA32_TSC_DEADLINE, DISABLE);
+}

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -26,6 +26,8 @@ static uint64_t cr4_host_mask;
 static uint64_t cr4_always_on_mask;
 static uint64_t cr4_always_off_mask;
 
+void update_msr_bitmap_x2apic_apicv(struct vcpu *vcpu);
+
 bool is_vmx_disabled(void)
 {
 	uint64_t msr_val;
@@ -1051,4 +1053,14 @@ void init_vmcs(struct vcpu *vcpu)
 	init_guest_state(vcpu);
 	init_entry_ctrl(vcpu);
 	init_exit_ctrl();
+}
+
+void switch_apicv_mode_x2apic(struct vcpu *vcpu)
+{
+	uint32_t value32;
+	value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS2);
+	value32 &= ~VMX_PROCBASED_CTLS2_VAPIC;
+	value32 |= VMX_PROCBASED_CTLS2_VX2APIC;
+	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS2, value32);
+	update_msr_bitmap_x2apic_apicv(vcpu);
 }

--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -72,7 +72,7 @@ struct lapic_regs {			 /*OFFSET(Hex)*/
 	struct lapic_reg	ccr_timer;/*390*/
 	struct lapic_reg	rsv3[4];
 	struct lapic_reg	dcr_timer;/*3E0*/
-	struct lapic_reg	rsv4;
+	struct lapic_reg	self_ipi; /*3F0*/
 
 	/*roundup sizeof current struct to 4KB*/
 	struct lapic_reg	rsv5[192]; /*400 -- FF0*/

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -171,8 +171,7 @@ void vlapic_set_tmr_one_vec(struct acrn_vlapic *vlapic, uint32_t delmode,
 		uint32_t vector, bool level);
 
 void vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
-uint32_t vlapic_get_id(const struct acrn_vlapic *vlapic);
-uint8_t vlapic_get_apicid(const struct acrn_vlapic *vlapic);
+uint32_t vlapic_get_apicid(struct acrn_vlapic *vlapic);
 int vlapic_create(struct vcpu *vcpu);
 /*
  *  @pre vcpu != NULL

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -190,6 +190,7 @@ struct vm_description {
 	bool			vm_vuart;
 	const char		*bootargs;
 	struct vpci_vdev_array  *vpci_vdev_array;
+	bool	lapic_pt;
 #endif
 };
 

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -529,6 +529,18 @@ static inline bool pat_mem_type_invalid(uint64_t x)
 		(x != PAT_MEM_TYPE_WT) && (x != PAT_MEM_TYPE_WP) &&
 		(x != PAT_MEM_TYPE_WB) && (x != PAT_MEM_TYPE_UCM));
 }
+
+static inline bool is_x2apic_msr(uint32_t msr)
+{
+	bool ret = false;
+	/*
+	 * if msr is in the range of x2APIC MSRs
+	 */
+	if ((msr >= MSR_IA32_EXT_XAPICID) && (msr <= MSR_IA32_EXT_APIC_SELF_IPI)) {
+		ret = true;
+	}
+	return ret;
+}
 #endif /* ASSEMBLER */
 
 /* 5 high-order bits in every field are reserved */

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -541,6 +541,31 @@ static inline bool is_x2apic_msr(uint32_t msr)
 	}
 	return ret;
 }
+
+static inline bool is_x2apic_read_only_msr(uint32_t msr)
+{
+	bool ret = false;
+
+	if ((msr == MSR_IA32_EXT_XAPICID) ||
+			(msr == MSR_IA32_EXT_APIC_VERSION) ||
+			(msr == MSR_IA32_EXT_APIC_PPR) ||
+			(msr == MSR_IA32_EXT_APIC_LDR) ||
+			((msr >= MSR_IA32_EXT_APIC_ISR0) &&
+				(msr <= MSR_IA32_EXT_APIC_IRR7)) ||
+			(msr == MSR_IA32_EXT_APIC_CUR_COUNT)) {
+		ret = true;
+	}
+	return ret;
+}
+
+static inline bool is_x2apic_write_only_msr(uint32_t msr)
+{
+	bool ret = false;
+	if ((msr == MSR_IA32_EXT_APIC_EOI) || (msr == MSR_IA32_EXT_APIC_SELF_IPI)) {
+		ret = true;
+	}
+	return ret;
+}
 #endif /* ASSEMBLER */
 
 /* 5 high-order bits in every field are reserved */

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -464,6 +464,7 @@ int vmx_wrmsr_pat(struct vcpu *vcpu, uint64_t value);
 void vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0);
 void vmx_write_cr4(struct vcpu *vcpu, uint64_t cr4);
 bool is_vmx_disabled(void);
+void switch_apicv_mode_x2apic(struct vcpu *vcpu);
 
 static inline enum vm_cpu_mode get_vcpu_mode(const struct vcpu *vcpu)
 {

--- a/hypervisor/partition/vm_description.c
+++ b/hypervisor/partition/vm_description.c
@@ -183,6 +183,7 @@ struct vm_description_array vm_desc_partition = {
 						consoleblank=0 tsc=reliable xapic_phys",
 				.vpci_vdev_array = &vpci_vdev_array2,
 				.mptable = &mptable_vm2,
+				.lapic_pt = true,
 			},
 		}
 };


### PR DESCRIPTION
This patch series adds x2APIC support for ACRN guests. Also adds support for LAPIC pass-thru for guests running using partition mode of ACRN.

Tracked-On: #1626
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Reviewed-by: Xu Anthony <anthony.xu@intel.com>