### PR TITLE
hv: Remove the up_count_spinlock and use atomic for up_count

### DIFF
--- a/hypervisor/include/lib/atomic.h
+++ b/hypervisor/include/lib/atomic.h
@@ -41,6 +41,7 @@ static inline type name(const volatile type *ptr)	\
 			: "cc", "memory");		\
 	return ret;					\
 }
+build_atomic_load(atomic_load16, "w", uint16_t)
 build_atomic_load(atomic_load32, "l", uint32_t)
 build_atomic_load(atomic_load64, "q", uint64_t)
 
@@ -63,6 +64,7 @@ static inline void name(type *ptr)			\
 			: "=m" (*ptr)			\
 			:  "m" (*ptr));			\
 }
+build_atomic_inc(atomic_inc16, "w", uint16_t)
 build_atomic_inc(atomic_inc32, "l", uint32_t)
 build_atomic_inc(atomic_inc64, "q", uint64_t)
 


### PR DESCRIPTION
It's possible that the up_count_spinlock is not release during
system enter S3. The case is like following:

   BSP                                  AP
 stop_cpus                            cpu_dead
                                         cpu_set_current_state
                                            spinlock_abtain
                                                up_count--

   wait_for up_count == 1
 enter S3

                                            spinlock_release

Especially, considering the real spinlock release could be delayed
by cache.

Actually, the most content protected by up_count_spinlock is per
cpu data and could be changed without lock. Only left is up_count.
This patchset remove the up_count_spinlock and use atomic API
for up_count changing.

Tracked-On: #1691
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>