### PR TITLE
hv: fix integer violations

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -35,12 +35,12 @@ static uint64_t x86_arch_capabilities;
 
 /* TODO: add more capability per requirement */
 /* APICv features */
-#define VAPIC_FEATURE_VIRT_ACCESS		(1U << 0)
-#define VAPIC_FEATURE_VIRT_REG			(1U << 1)
-#define VAPIC_FEATURE_INTR_DELIVERY		(1U << 2)
-#define VAPIC_FEATURE_TPR_SHADOW		(1U << 3)
-#define VAPIC_FEATURE_POST_INTR		(1U << 4)
-#define VAPIC_FEATURE_VX2APIC_MODE		(1U << 5)
+#define VAPIC_FEATURE_VIRT_ACCESS		(1U << 0U)
+#define VAPIC_FEATURE_VIRT_REG			(1U << 1U)
+#define VAPIC_FEATURE_INTR_DELIVERY		(1U << 2U)
+#define VAPIC_FEATURE_TPR_SHADOW		(1U << 3U)
+#define VAPIC_FEATURE_POST_INTR			(1U << 4U)
+#define VAPIC_FEATURE_VX2APIC_MODE		(1U << 5U)
 
 struct cpu_capability {
 	uint8_t apicv_features;

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1077,7 +1077,7 @@ remove_iommu_device(const struct iommu_domain *domain, uint16_t segment,
 	context_table_addr = dmar_get_bitslice(root_entry->lower,
 					       ROOT_ENTRY_LOWER_CTP_MASK,
 					       ROOT_ENTRY_LOWER_CTP_POS);
-	context_table_addr = context_table_addr << 12;
+	context_table_addr = context_table_addr << CPU_PAGE_SHIFT;
 	context_table =
 		(struct dmar_context_entry *)hpa2hva(context_table_addr);
 

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -145,12 +145,12 @@ static uint8_t get_secondary_bus(uint8_t bus, uint8_t dev, uint8_t func)
 {
 	uint32_t data;
 
-	pio_write32(PCI_CFG_ENABLE | (bus << 16) | (dev << 11) |
-		(func << 8) | 0x18, PCI_CONFIG_ADDR);
+	pio_write32(PCI_CFG_ENABLE | (bus << 16U) | (dev << 11U) |
+		(func << 8U) | 0x18U, PCI_CONFIG_ADDR);
 
 	data = pio_read32(PCI_CONFIG_DATA);
 
-	return (data >> 8) & 0xff;
+	return (data >> 8U) & 0xffU;
 }
 
 static uint16_t
@@ -173,7 +173,7 @@ dmar_path_bdf(int path_len, int busno,
 		dev = path[i].device;
 		fun = path[i].function;
 	}
-	return (bus << 8 | DEVFUN(dev, fun));
+	return (bus << 8U | DEVFUN(dev, fun));
 }
 
 
@@ -267,8 +267,8 @@ handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd,
 
 		consumed = handle_dmar_devscope(dev_scope, cp, remaining);
 
-		if (((drhd->segment << 16) |
-		     (dev_scope->bus << 8) |
+		if (((drhd->segment << 16U) |
+		     (dev_scope->bus << 8U) |
 		     dev_scope->devfun) == CONFIG_GPU_SBDF) {
 			ASSERT(dev_count == 1, "no dedicated iommu for gpu");
 			drhd->ignore = true;

--- a/hypervisor/bsp/uefi/efi/boot.h
+++ b/hypervisor/bsp/uefi/efi/boot.h
@@ -63,7 +63,7 @@
 	uint32_t msrl, msrh;                                 \
 	asm volatile ("rdmsr" : "=a"(msrl),                 \
 		"=d"(msrh) : "c" (reg));            \
-	*msr_val_ptr = ((uint64_t)msrh<<32) | msrl;           \
+	*msr_val_ptr = ((uint64_t)msrh << 32U) | msrl;           \
 }
 
 EFI_STATUS get_pe_section(CHAR8 *base, char *section, UINTN *vaddr, UINTN *size);

--- a/hypervisor/bsp/uefi/efi/efilinux.h
+++ b/hypervisor/bsp/uefi/efi/efilinux.h
@@ -45,8 +45,8 @@
 #define EFILINUX_VERSION_MAJOR 1
 #define EFILINUX_VERSION_MINOR 0
 
-#define MEM_ADDR_1MB (1 << 20)
-#define MEM_ADDR_4GB (0xFFFFFFFF)
+#define MEM_ADDR_1MB (1U << 20U)
+#define MEM_ADDR_4GB (0xFFFFFFFFU)
 
 
 extern EFI_SYSTEM_TABLE *sys_table;

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -10,7 +10,7 @@
 #include <spinlock.h>
 
 #define SHELL_CMD_MAX_LEN		100U
-#define SHELL_STRING_MAX_LEN		(CPU_PAGE_SIZE << 2)
+#define SHELL_STRING_MAX_LEN		(CPU_PAGE_SIZE << 2U)
 
 /* Shell Command Function */
 typedef int (*shell_cmd_fn_t)(int argc, char **argv);

--- a/hypervisor/debug/uart16550.h
+++ b/hypervisor/debug/uart16550.h
@@ -52,12 +52,12 @@
 /*enable/disable receive data read request interrupt*/
 
 /* definition for LCR */
-#define LCR_DLAB	(1U << 7) /*DLAB THR/RBR&IER or DLL&DLM= Bit 7*/
-#define LCR_SB		(1U << 6) /*break control on/off= Bit 6*/
-#define LCR_SP		(1U << 5) /*Specifies the operation of parity bit*/
-#define LCR_EPS		(1U << 4) /*Specifies the logic of a parity bit*/
-#define LCR_PEN		(1U << 3) /*Specifies whether to add a parity bit*/
-#define LCR_STB		(1U << 2) /*stop bit length*/
+#define LCR_DLAB	(1U << 7U) /*DLAB THR/RBR&IER or DLL&DLM= Bit 7*/
+#define LCR_SB		(1U << 6U) /*break control on/off= Bit 6*/
+#define LCR_SP		(1U << 5U) /*Specifies the operation of parity bit*/
+#define LCR_EPS		(1U << 4U) /*Specifies the logic of a parity bit*/
+#define LCR_PEN		(1U << 3U) /*Specifies whether to add a parity bit*/
+#define LCR_STB		(1U << 2U) /*stop bit length*/
 #define LCR_WL8		(0x03U) /*number of bits of serial data*/
 #define LCR_WL7		(0x02U) /*number of bits of serial data*/
 #define LCR_WL6		(0x01U) /*number of bits of serial data*/
@@ -70,32 +70,32 @@
 
 /* bit definitions for LSR */
 /* at least one error in data within fifo */
-#define LSR_ERR		(1U << 7)
+#define LSR_ERR		(1U << 7U)
 /* Transmit data Present */
-#define LSR_TEMT	(1U << 6)
+#define LSR_TEMT	(1U << 6U)
 /* Transmit data write request present */
-#define LSR_THRE	(1U << 5)
+#define LSR_THRE	(1U << 5U)
 /* Break interrupt data Present */
-#define LSR_BI		(1U << 4)
+#define LSR_BI		(1U << 4U)
 /* Framing Error Occurred */
-#define LSR_FE		(1U << 3)
+#define LSR_FE		(1U << 3U)
 /* Parity Error Occurred */
-#define LSR_PE		(1U << 2)
+#define LSR_PE		(1U << 2U)
 /* Overrun error */
-#define LSR_OE		(1U << 1)
+#define LSR_OE		(1U << 1U)
 /* Readable received data is present */
-#define LSR_DR		(1U << 0)
+#define LSR_DR		(1U << 0U)
 
 /* definition for MCR */
-#define MCR_RTS		(1U << 1) /* Request to Send */
-#define MCR_DTR		(1U << 0) /* Data Terminal Ready */
+#define MCR_RTS		(1U << 1U) /* Request to Send */
+#define MCR_DTR		(1U << 0U) /* Data Terminal Ready */
 
 /* definition for FCR */
 #define FCR_RX_MASK	0xc0U
-#define FCR_DMA		(1U << 3)
-#define FCR_TFR		(1U << 2) /* Reset Transmit Fifo */
-#define FCR_RFR		(1U << 1) /* Reset Receive Fifo */
-#define FCR_FIFOE	(1U << 0) /* Fifo Enable */
+#define FCR_DMA		(1U << 3U)
+#define FCR_TFR		(1U << 2U) /* Reset Transmit Fifo */
+#define FCR_RFR		(1U << 1U) /* Reset Receive Fifo */
+#define FCR_FIFOE	(1U << 0U) /* Fifo Enable */
 
 #define UART_IER_DISABLE_ALL	0x00000000U
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -47,7 +47,7 @@
 #endif
 
 /* Generic VM flags from guest OS */
-#define SECURE_WORLD_ENABLED    (1UL<<0U)  /* Whether secure world is enabled */
+#define SECURE_WORLD_ENABLED    (1UL << 0U)  /* Whether secure world is enabled */
 
 /**
  * @brief Hypercall


### PR DESCRIPTION
The operands to shift operations (<<, >>) shall be unsigned integers.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>