### PR TITLE
doc: hide doxygen duplicate definition warnings

### DIFF
--- a/doc/.known-issues/doc/dupdecl.conf
+++ b/doc/.known-issues/doc/dupdecl.conf
@@ -1,5 +1,5 @@
 #
-# Emulated devices
+# HLD warnings
 #
-#
-^(?P<filename>[-._/\w]+/hld/hv-io-emulation.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+#^(?P<filename>[-._/\w]+/hld/hv-cpu-virt.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.


### PR DESCRIPTION
Sphinx/Breathe have a known problem with processing unnamed nested
structs and unions that cause a "Duplicate definition" warning.

Use our .known-issues filter to hide these in the HLD content.

Tracked-on: #1706
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>