### PR TITLE
HV:treewide:rename data structure

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -442,7 +442,7 @@ static void ptdev_intr_handle_irq(struct vm *vm,
 
 void ptdev_softirq(uint16_t pcpu_id)
 {
-	struct vcpu *vcpu = (struct vcpu *)per_cpu(vcpu, pcpu_id);
+	struct acrn_vcpu *vcpu = (struct acrn_vcpu *)per_cpu(vcpu, pcpu_id);
 	struct vm *vm = vcpu->vm;
 
 	while (1) {

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -11,7 +11,7 @@ static inline struct vcpuid_entry *find_vcpuid_entry(const struct acrn_vcpu *vcp
 {
 	uint32_t i = 0U, nr, half;
 	struct vcpuid_entry *entry = NULL;
-	struct vm *vm = vcpu->vm;
+	struct acrn_vm *vm = vcpu->vm;
 	uint32_t leaf = leaf_arg;
 
 	nr = vm->vcpuid_entry_nr;
@@ -63,7 +63,7 @@ static inline struct vcpuid_entry *find_vcpuid_entry(const struct acrn_vcpu *vcp
 	return entry;
 }
 
-static inline int set_vcpuid_entry(struct vm *vm,
+static inline int set_vcpuid_entry(struct acrn_vm *vm,
 				const struct vcpuid_entry *entry)
 {
 	struct vcpuid_entry *tmp;
@@ -170,7 +170,7 @@ static void init_vcpuid_entry(uint32_t leaf, uint32_t subleaf,
 	}
 }
 
-int set_vcpuid_entries(struct vm *vm)
+int set_vcpuid_entries(struct acrn_vm *vm)
 {
 	int result;
 	struct vcpuid_entry entry;

--- a/hypervisor/arch/x86/cpuid.c
+++ b/hypervisor/arch/x86/cpuid.c
@@ -6,7 +6,7 @@
 
 #include <hypervisor.h>
 
-static inline struct vcpuid_entry *find_vcpuid_entry(const struct vcpu *vcpu,
+static inline struct vcpuid_entry *find_vcpuid_entry(const struct acrn_vcpu *vcpu,
 					uint32_t leaf_arg, uint32_t subleaf)
 {
 	uint32_t i = 0U, nr, half;
@@ -293,7 +293,7 @@ int set_vcpuid_entries(struct vm *vm)
 	return 0;
 }
 
-void guest_cpuid(struct vcpu *vcpu,
+void guest_cpuid(struct acrn_vcpu *vcpu,
 		uint32_t *eax, uint32_t *ebx,
 		uint32_t *ecx, uint32_t *edx)
 {

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -30,7 +30,7 @@ uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
 	void *eptp;
 	struct acrn_vcpu *vcpu = vcpu_from_pid(vm, get_cpu_id());
 
-	if ((vcpu != NULL) && (vcpu->arch_vcpu.cur_context == SECURE_WORLD)) {
+	if ((vcpu != NULL) && (vcpu->arch.cur_context == SECURE_WORLD)) {
 		eptp = vm->arch_vm.sworld_eptp;
 	} else {
 		eptp = vm->arch_vm.nworld_eptp;
@@ -80,7 +80,7 @@ int ept_violation_vmexit_handler(struct acrn_vcpu *vcpu)
 	struct mmio_request *mmio_req = &io_req->reqs.mmio;
 
 	/* Handle page fault from guest */
-	exit_qual = vcpu->arch_vcpu.exit_qualification;
+	exit_qual = vcpu->arch.exit_qualification;
 
 	io_req->type = REQ_MMIO;
 

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -28,7 +28,7 @@ uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
 	uint64_t hpa = INVALID_HPA;
 	uint64_t *pgentry, pg_size = 0UL;
 	void *eptp;
-	struct vcpu *vcpu = vcpu_from_pid(vm, get_cpu_id());
+	struct acrn_vcpu *vcpu = vcpu_from_pid(vm, get_cpu_id());
 
 	if ((vcpu != NULL) && (vcpu->arch_vcpu.cur_context == SECURE_WORLD)) {
 		eptp = vm->arch_vm.sworld_eptp;
@@ -71,7 +71,7 @@ uint64_t vm0_hpa2gpa(uint64_t hpa)
 	return hpa;
 }
 
-int ept_violation_vmexit_handler(struct vcpu *vcpu)
+int ept_violation_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int status = -EINVAL, ret;
 	uint64_t exit_qual;
@@ -158,7 +158,7 @@ out:
 	return status;
 }
 
-int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu)
+int ept_misconfig_vmexit_handler(__unused struct acrn_vcpu *vcpu)
 {
 	int status;
 
@@ -182,7 +182,7 @@ void ept_mr_add(struct vm *vm, uint64_t *pml4_page,
 	uint64_t hpa, uint64_t gpa, uint64_t size, uint64_t prot_orig)
 {
 	uint16_t i;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	uint64_t prot = prot_orig;
 
 	dev_dbg(ACRN_DBG_EPT, "%s, vm[%d] hpa: 0x%016llx gpa: 0x%016llx size: 0x%016llx prot: 0x%016x\n",
@@ -207,7 +207,7 @@ void ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
 		uint64_t gpa, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr)
 {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	uint16_t i;
 
 	dev_dbg(ACRN_DBG_EPT, "%s,vm[%d] gpa 0x%llx size 0x%llx\n", __func__, vm->vm_id, gpa, size);
@@ -223,7 +223,7 @@ void ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
  */
 void ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t size)
 {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	uint16_t i;
 
 	dev_dbg(ACRN_DBG_EPT, "%s,vm[%d] gpa 0x%llx size 0x%llx\n", __func__, vm->vm_id, gpa, size);

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -10,7 +10,7 @@
 
 #define ACRN_DBG_EPT	6U
 
-void destroy_ept(struct vm *vm)
+void destroy_ept(struct acrn_vm *vm)
 {
 	/* Destroy secure world */
 	if (vm->sworld_control.flag.active != 0UL) {
@@ -23,7 +23,7 @@ void destroy_ept(struct vm *vm)
 }
 
 /* using return value INVALID_HPA as error code */
-uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
+uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 {
 	uint64_t hpa = INVALID_HPA;
 	uint64_t *pgentry, pg_size = 0UL;
@@ -58,7 +58,7 @@ uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size)
 }
 
 /* using return value INVALID_HPA as error code */
-uint64_t gpa2hpa(struct vm *vm, uint64_t gpa)
+uint64_t gpa2hpa(struct acrn_vm *vm, uint64_t gpa)
 {
 	return local_gpa2hpa(vm, gpa, NULL);
 }
@@ -178,7 +178,7 @@ int ept_misconfig_vmexit_handler(__unused struct acrn_vcpu *vcpu)
 	return status;
 }
 
-void ept_mr_add(struct vm *vm, uint64_t *pml4_page,
+void ept_mr_add(struct acrn_vm *vm, uint64_t *pml4_page,
 	uint64_t hpa, uint64_t gpa, uint64_t size, uint64_t prot_orig)
 {
 	uint16_t i;
@@ -203,7 +203,7 @@ void ept_mr_add(struct vm *vm, uint64_t *pml4_page,
 	}
 }
 
-void ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
+void ept_mr_modify(struct acrn_vm *vm, uint64_t *pml4_page,
 		uint64_t gpa, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr)
 {
@@ -221,7 +221,7 @@ void ept_mr_modify(struct vm *vm, uint64_t *pml4_page,
 /**
  * @pre [gpa,gpa+size) has been mapped into host physical memory region
  */
-void ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t size)
+void ept_mr_del(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t size)
 {
 	struct acrn_vcpu *vcpu;
 	uint16_t i;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -32,7 +32,7 @@ struct page_walk_info {
 	bool is_smep_on;
 };
 
-uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
+uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask)
 {
 	uint16_t vcpu_id;
 	uint64_t dmask = 0UL;
@@ -327,7 +327,7 @@ int gva2gpa(struct acrn_vcpu *vcpu, uint64_t gva, uint64_t *gpa,
 	return ret;
 }
 
-static inline uint32_t local_copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
+static inline uint32_t local_copy_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa,
 	uint32_t size, uint32_t fix_pg_size, bool cp_from_vm)
 {
 	uint64_t hpa;
@@ -360,7 +360,7 @@ static inline uint32_t local_copy_gpa(struct vm *vm, void *h_ptr, uint64_t gpa,
 	return len;
 }
 
-static inline int copy_gpa(struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
+static inline int copy_gpa(struct acrn_vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
 	uint32_t size_arg, bool cp_from_vm)
 {
 	void *h_ptr = h_ptr_arg;
@@ -427,7 +427,7 @@ static inline int copy_gva(struct acrn_vcpu *vcpu, void *h_ptr_arg, uint64_t gva
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
+int copy_from_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 {
 	return copy_gpa(vm, h_ptr, gpa, size, 1);
 }
@@ -438,7 +438,7 @@ int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
+int copy_to_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 {
 	return copy_gpa(vm, h_ptr, gpa, size, 0);
 }
@@ -606,7 +606,7 @@ static void rebuild_vm0_e820(void)
  * @pre vm != NULL
  * @pre is_vm0(vm) == true
  */
-int prepare_vm0_memmap_and_e820(struct vm *vm)
+int prepare_vm0_memmap_and_e820(struct acrn_vm *vm)
 {
 	uint32_t i;
 	uint64_t attr_uc = (EPT_RWX | EPT_UNCACHED);

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -36,7 +36,7 @@ uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 {
 	uint16_t vcpu_id;
 	uint64_t dmask = 0UL;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
 		if (vdmask & (1U << vcpu_id)) {
@@ -48,7 +48,7 @@ uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask)
 	return dmask;
 }
 
-enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu)
+enum vm_paging_mode get_vcpu_paging_mode(struct acrn_vcpu *vcpu)
 {
 	enum vm_cpu_mode cpu_mode;
 
@@ -72,7 +72,7 @@ enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu)
 
 /* TODO: Add code to check for Revserved bits, SMAP and PKE when do translation
  * during page walk */
-static int local_gva2gpa_common(struct vcpu *vcpu, const struct page_walk_info *pw_info,
+static int local_gva2gpa_common(struct acrn_vcpu *vcpu, const struct page_walk_info *pw_info,
 	uint64_t gva, uint64_t *gpa, uint32_t *err_code)
 {
 	uint32_t i;
@@ -219,7 +219,7 @@ out:
 	return ret;
 }
 
-static int local_gva2gpa_pae(struct vcpu *vcpu, struct page_walk_info *pw_info,
+static int local_gva2gpa_pae(struct acrn_vcpu *vcpu, struct page_walk_info *pw_info,
 	uint64_t gva, uint64_t *gpa, uint32_t *err_code)
 {
 	int index;
@@ -269,7 +269,7 @@ out:
  * - Return -EFAULT for paging fault, and refer to err_code for paging fault
  *   error code.
  */
-int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa,
+int gva2gpa(struct acrn_vcpu *vcpu, uint64_t gva, uint64_t *gpa,
 	uint32_t *err_code)
 {
 	enum vm_paging_mode pm = get_vcpu_paging_mode(vcpu);
@@ -385,7 +385,7 @@ static inline int copy_gpa(struct vm *vm, void *h_ptr_arg, uint64_t gpa_arg,
 /*
  * @pre vcpu != NULL && err_code != NULL
  */
-static inline int copy_gva(struct vcpu *vcpu, void *h_ptr_arg, uint64_t gva_arg,
+static inline int copy_gva(struct acrn_vcpu *vcpu, void *h_ptr_arg, uint64_t gva_arg,
 	uint32_t size_arg, uint32_t *err_code, uint64_t *fault_addr,
 	bool cp_from_vm)
 {
@@ -443,13 +443,13 @@ int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size)
 	return copy_gpa(vm, h_ptr, gpa, size, 0);
 }
 
-int copy_from_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
+int copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr)
 {
 	return copy_gva(vcpu, h_ptr, gva, size, err_code, fault_addr, 1);
 }
 
-int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
+int copy_to_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr)
 {
 	return copy_gva(vcpu, h_ptr, gva, size, err_code, fault_addr, 0);

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1631,7 +1631,7 @@ static int vmm_emulate_instruction(struct instr_emul_ctxt *ctxt)
 static int vie_init(struct instr_emul_vie *vie, struct acrn_vcpu *vcpu)
 {
 	uint64_t guest_rip_gva = vcpu_get_rip(vcpu);
-	uint32_t inst_len = vcpu->arch_vcpu.inst_len;
+	uint32_t inst_len = vcpu->arch.inst_len;
 	uint32_t err_code;
 	uint64_t fault_addr;
 	int ret;

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -322,7 +322,7 @@ static uint32_t get_vmcs_field(enum cpu_reg_name ident)
  * @pre ((reg <= CPU_REG_LAST) && (reg >= CPU_REG_FIRST))
  * @pre ((reg != CPU_REG_CR2) && (reg != CPU_REG_IDTR) && (reg != CPU_REG_GDTR))
  */
-static uint64_t vm_get_register(const struct vcpu *vcpu, enum cpu_reg_name reg)
+static uint64_t vm_get_register(const struct acrn_vcpu *vcpu, enum cpu_reg_name reg)
 {
 	uint64_t reg_val = 0UL;
 	
@@ -349,7 +349,7 @@ static uint64_t vm_get_register(const struct vcpu *vcpu, enum cpu_reg_name reg)
  * @pre ((reg <= CPU_REG_LAST) && (reg >= CPU_REG_FIRST))
  * @pre ((reg != CPU_REG_CR2) && (reg != CPU_REG_IDTR) && (reg != CPU_REG_GDTR))
  */
-static void vm_set_register(struct vcpu *vcpu, enum cpu_reg_name reg,
+static void vm_set_register(struct acrn_vcpu *vcpu, enum cpu_reg_name reg,
 								uint64_t val)
 {
 
@@ -387,7 +387,7 @@ static void vm_get_seg_desc(enum cpu_reg_name seg, struct seg_desc *desc)
 	desc->access = exec_vmread32(tdesc.access_field);
 }
 
-static void get_guest_paging_info(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
+static void get_guest_paging_info(struct acrn_vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
 						uint32_t csar)
 {
 	uint8_t cpl;
@@ -492,7 +492,7 @@ static int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 	return 0;
 }
 
-static int mmio_read(const struct vcpu *vcpu, uint64_t *rval)
+static int mmio_read(const struct acrn_vcpu *vcpu, uint64_t *rval)
 {
 	if (vcpu == NULL) {
 		return -EINVAL;
@@ -502,7 +502,7 @@ static int mmio_read(const struct vcpu *vcpu, uint64_t *rval)
 	return 0;
 }
 
-static int mmio_write(struct vcpu *vcpu, uint64_t wval)
+static int mmio_write(struct acrn_vcpu *vcpu, uint64_t wval)
 {
 	if (vcpu == NULL) {
 		return -EINVAL;
@@ -538,7 +538,7 @@ static void vie_calc_bytereg(const struct instr_emul_vie *vie,
 	}
 }
 
-static uint8_t vie_read_bytereg(const struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static uint8_t vie_read_bytereg(const struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int lhbr;
 	uint64_t val;
@@ -561,7 +561,7 @@ static uint8_t vie_read_bytereg(const struct vcpu *vcpu, const struct instr_emul
 	return reg_val;
 }
 
-static void vie_write_bytereg(struct vcpu *vcpu, const struct instr_emul_vie *vie,
+static void vie_write_bytereg(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie,
 								uint8_t byte)
 {
 	uint64_t origval, val, mask;
@@ -591,7 +591,7 @@ static void vie_write_bytereg(struct vcpu *vcpu, const struct instr_emul_vie *vi
  * @pre ((reg <= CPU_REG_LAST) && (reg >= CPU_REG_FIRST))
  * @pre ((reg != CPU_REG_CR2) && (reg != CPU_REG_IDTR) && (reg != CPU_REG_GDTR))
  */
-static void vie_update_register(struct vcpu *vcpu, enum cpu_reg_name reg,
+static void vie_update_register(struct acrn_vcpu *vcpu, enum cpu_reg_name reg,
 					uint64_t val_arg, uint8_t size)
 {
 	uint64_t origval;
@@ -616,7 +616,7 @@ static void vie_update_register(struct vcpu *vcpu, enum cpu_reg_name reg,
 
 #define	RFLAGS_STATUS_BITS    (PSL_C | PSL_PF | PSL_AF | PSL_Z | PSL_N | PSL_V)
 
-static void vie_update_rflags(struct vcpu *vcpu, uint64_t rflags2, uint64_t psl)
+static void vie_update_rflags(struct acrn_vcpu *vcpu, uint64_t rflags2, uint64_t psl)
 {
 	uint8_t size;
 	uint64_t rflags;
@@ -664,7 +664,7 @@ static uint64_t getcc(uint8_t opsize, uint64_t x, uint64_t y)
 	}
 }
 
-static int emulate_mov(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_mov(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -780,7 +780,7 @@ static int emulate_mov(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_movx(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_movx(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -883,7 +883,7 @@ static int emulate_movx(struct vcpu *vcpu, const struct instr_emul_vie *vie)
  *
  * It's only used by MOVS/STO
  */
-static void get_gva_si_nocheck(const struct vcpu *vcpu, uint8_t addrsize,
+static void get_gva_si_nocheck(const struct acrn_vcpu *vcpu, uint8_t addrsize,
 		enum cpu_reg_name seg, uint64_t *gva)
 {
 	uint64_t val;
@@ -907,7 +907,7 @@ static void get_gva_si_nocheck(const struct vcpu *vcpu, uint8_t addrsize,
  *
  * It's only used by MOVS/STO
  */
-static int get_gva_di_check(struct vcpu *vcpu, struct instr_emul_vie *vie,
+static int get_gva_di_check(struct acrn_vcpu *vcpu, struct instr_emul_vie *vie,
 		uint8_t addrsize, uint64_t *gva)
 {
 	int ret;
@@ -980,7 +980,7 @@ exception_inject:
  * For MOVs instruction, we always check RDI during instruction decoding phase.
  * And access RSI without any check during instruction emulation phase.
  */
-static int emulate_movs(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_movs(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	uint64_t src_gva, gpa, val = 0UL;
 	uint64_t *dst_hva, *src_hva;
@@ -1067,7 +1067,7 @@ done:
 	return error;
 }
 
-static int emulate_stos(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_stos(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error, repeat;
 	uint8_t opsize = vie->opsize;
@@ -1121,7 +1121,7 @@ static int emulate_stos(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return 0;
 }
 
-static int emulate_test(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_test(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1187,7 +1187,7 @@ static int emulate_test(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_and(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_and(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1275,7 +1275,7 @@ static int emulate_and(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_or(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_or(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1366,7 +1366,7 @@ static int emulate_or(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_cmp(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_cmp(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1458,7 +1458,7 @@ static int emulate_cmp(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_sub(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_sub(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 	uint8_t size;
@@ -1512,7 +1512,7 @@ static int emulate_sub(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_group1(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_group1(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	int error;
 
@@ -1534,7 +1534,7 @@ static int emulate_group1(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 	return error;
 }
 
-static int emulate_bittest(struct vcpu *vcpu, const struct instr_emul_vie *vie)
+static int emulate_bittest(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	uint64_t val, rflags, bitmask;
 	int error;
@@ -1580,7 +1580,7 @@ static int emulate_bittest(struct vcpu *vcpu, const struct instr_emul_vie *vie)
 static int vmm_emulate_instruction(struct instr_emul_ctxt *ctxt)
 {
 	struct instr_emul_vie *vie = &ctxt->vie;
-	struct vcpu *vcpu = ctxt->vcpu;
+	struct acrn_vcpu *vcpu = ctxt->vcpu;
 	int error;
 
 	if (vie->decoded == 0U) {
@@ -1628,7 +1628,7 @@ static int vmm_emulate_instruction(struct instr_emul_ctxt *ctxt)
 	return error;
 }
 
-static int vie_init(struct instr_emul_vie *vie, struct vcpu *vcpu)
+static int vie_init(struct instr_emul_vie *vie, struct acrn_vcpu *vcpu)
 {
 	uint64_t guest_rip_gva = vcpu_get_rip(vcpu);
 	uint32_t inst_len = vcpu->arch_vcpu.inst_len;
@@ -2182,7 +2182,7 @@ static int local_decode_instruction(enum vm_cpu_mode cpu_mode,
 }
 
 /* for instruction MOVS/STO, check the gva gotten from DI/SI. */
-static int instr_check_di(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt)
+static int instr_check_di(struct acrn_vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt)
 {
 	int ret;
 	struct instr_emul_vie *vie = &emul_ctxt->vie;
@@ -2197,7 +2197,7 @@ static int instr_check_di(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt)
 	return 0;
 }
 
-static int instr_check_gva(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
+static int instr_check_gva(struct acrn_vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
 		enum vm_cpu_mode cpu_mode)
 {
 	int ret;
@@ -2283,7 +2283,7 @@ static int instr_check_gva(struct vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
 	return 0;
 }
 
-int decode_instruction(struct vcpu *vcpu)
+int decode_instruction(struct acrn_vcpu *vcpu)
 {
 	struct instr_emul_ctxt *emul_ctxt;
 	uint32_t csar;
@@ -2343,7 +2343,7 @@ int decode_instruction(struct vcpu *vcpu)
 	return (int)(emul_ctxt->vie.opsize);
 }
 
-int emulate_instruction(const struct vcpu *vcpu)
+int emulate_instruction(const struct acrn_vcpu *vcpu)
 {
 	struct instr_emul_ctxt *ctxt = &per_cpu(g_inst_ctxt, vcpu->pcpu_id);
 

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -190,10 +190,10 @@ struct vm_guest_paging {
 struct instr_emul_ctxt {
 	struct instr_emul_vie vie;
 	struct vm_guest_paging paging;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 };
 
-int emulate_instruction(const struct vcpu *vcpu);
-int decode_instruction(struct vcpu *vcpu);
+int emulate_instruction(const struct acrn_vcpu *vcpu);
+int decode_instruction(struct acrn_vcpu *vcpu);
 
 #endif

--- a/hypervisor/arch/x86/guest/mptable.c
+++ b/hypervisor/arch/x86/guest/mptable.c
@@ -288,7 +288,7 @@ static uint8_t mpt_compute_checksum(void *base, size_t len)
 	return (256U - sum);
 }
 
-int mptable_build(struct vm *vm)
+int mptable_build(struct acrn_vm *vm)
 {
 	char                    *startaddr;
 	char                    *curraddr;

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -6,7 +6,7 @@
 
 #include <hypervisor.h>
 
-int validate_pstate(const struct vm *vm, uint64_t perf_ctl)
+int validate_pstate(const struct acrn_vm *vm, uint64_t perf_ctl)
 {
 	const struct cpu_px_data *px_data;
 	int i, px_cnt;
@@ -31,7 +31,7 @@ int validate_pstate(const struct vm *vm, uint64_t perf_ctl)
 	return -1;
 }
 
-static void vm_setup_cpu_px(struct vm *vm)
+static void vm_setup_cpu_px(struct acrn_vm *vm)
 {
 	uint32_t px_data_size;
 
@@ -56,7 +56,7 @@ static void vm_setup_cpu_px(struct vm *vm)
 
 }
 
-static void vm_setup_cpu_cx(struct vm *vm)
+static void vm_setup_cpu_cx(struct acrn_vm *vm)
 {
 	uint32_t cx_data_size;
 
@@ -84,7 +84,7 @@ static void vm_setup_cpu_cx(struct vm *vm)
 
 }
 
-static inline void init_cx_port(struct vm *vm)
+static inline void init_cx_port(struct acrn_vm *vm)
 {
 	uint8_t cx_idx;
 
@@ -99,7 +99,7 @@ static inline void init_cx_port(struct vm *vm)
 	}
 }
 
-void vm_setup_cpu_state(struct vm *vm)
+void vm_setup_cpu_state(struct acrn_vm *vm)
 {
 	vm_setup_cpu_px(vm);
 	vm_setup_cpu_cx(vm);
@@ -109,7 +109,7 @@ void vm_setup_cpu_state(struct vm *vm)
 /* This function is for power management Sx state implementation,
  * VM need to load the Sx state data to implement S3/S5.
  */
-int vm_load_pm_s_state(struct vm *vm)
+int vm_load_pm_s_state(struct acrn_vm *vm)
 {
 #ifdef ACPI_INFO_VALIDATED
 	vm->pm.sx_state_data = (struct pm_s_state_data *)&host_pm_s_state;
@@ -132,7 +132,7 @@ static inline uint8_t get_slp_typx(uint32_t pm1_cnt)
 	return (uint8_t)((pm1_cnt & 0x1fffU) >> BIT_SLP_TYPx);
 }
 
-static uint32_t pm1ab_io_read(__unused struct vm *vm, uint16_t addr,
+static uint32_t pm1ab_io_read(__unused struct acrn_vm *vm, uint16_t addr,
 			size_t width)
 {
 	uint32_t val = pio_read(addr, width);
@@ -148,7 +148,7 @@ static uint32_t pm1ab_io_read(__unused struct vm *vm, uint16_t addr,
 	return val;
 }
 
-static void pm1ab_io_write(__unused struct vm *vm, uint16_t addr, size_t width,
+static void pm1ab_io_write(__unused struct acrn_vm *vm, uint16_t addr, size_t width,
 			uint32_t v)
 {
 	static uint32_t pm1a_cnt_ready = 0U;
@@ -187,7 +187,7 @@ static void pm1ab_io_write(__unused struct vm *vm, uint16_t addr, size_t width,
 }
 
 static void
-register_gas_io_handler(struct vm *vm, const struct acpi_generic_address *gas)
+register_gas_io_handler(struct acrn_vm *vm, const struct acpi_generic_address *gas)
 {
 	uint8_t io_len[5] = {0, 1, 2, 4, 8};
 	struct vm_io_range gas_io;
@@ -210,7 +210,7 @@ register_gas_io_handler(struct vm *vm, const struct acpi_generic_address *gas)
 			vm->vm_id, gas_io.base, gas_io.len);
 }
 
-void register_pm1ab_handler(struct vm *vm)
+void register_pm1ab_handler(struct acrn_vm *vm)
 {
 	struct pm_s_state_data *sx_data = vm->pm.sx_state_data;
 

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -32,7 +32,7 @@ static inline size_t get_ucode_data_size(const struct ucode_header *uhdr)
 	return ((uhdr->data_size != 0U) ? uhdr->data_size : 2000U);
 }
 
-void acrn_update_ucode(struct vcpu *vcpu, uint64_t v)
+void acrn_update_ucode(struct acrn_vcpu *vcpu, uint64_t v)
 {
 	uint64_t gva, fault_addr;
 	struct ucode_header uhdr;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -10,7 +10,7 @@
 
 vm_sw_loader_t vm_sw_loader;
 
-inline uint64_t vcpu_get_gpreg(const struct vcpu *vcpu, uint32_t reg)
+inline uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg)
 {
 	const struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -18,7 +18,7 @@ inline uint64_t vcpu_get_gpreg(const struct vcpu *vcpu, uint32_t reg)
 	return ctx->guest_cpu_regs.longs[reg];
 }
 
-inline void vcpu_set_gpreg(struct vcpu *vcpu, uint32_t reg, uint64_t val)
+inline void vcpu_set_gpreg(struct acrn_vcpu *vcpu, uint32_t reg, uint64_t val)
 {
 	struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -26,7 +26,7 @@ inline void vcpu_set_gpreg(struct vcpu *vcpu, uint32_t reg, uint64_t val)
 	ctx->guest_cpu_regs.longs[reg] = val;
 }
 
-inline uint64_t vcpu_get_rip(struct vcpu *vcpu)
+inline uint64_t vcpu_get_rip(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -37,13 +37,13 @@ inline uint64_t vcpu_get_rip(struct vcpu *vcpu)
 	return ctx->rip;
 }
 
-inline void vcpu_set_rip(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_rip(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.rip = val;
 	bitmap_set_lock(CPU_REG_RIP, &vcpu->reg_updated);
 }
 
-inline uint64_t vcpu_get_rsp(struct vcpu *vcpu)
+inline uint64_t vcpu_get_rsp(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -51,7 +51,7 @@ inline uint64_t vcpu_get_rsp(struct vcpu *vcpu)
 	return ctx->guest_cpu_regs.regs.rsp;
 }
 
-inline void vcpu_set_rsp(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_rsp(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -60,7 +60,7 @@ inline void vcpu_set_rsp(struct vcpu *vcpu, uint64_t val)
 	bitmap_set_lock(CPU_REG_RSP, &vcpu->reg_updated);
 }
 
-inline uint64_t vcpu_get_efer(struct vcpu *vcpu)
+inline uint64_t vcpu_get_efer(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -71,14 +71,14 @@ inline uint64_t vcpu_get_efer(struct vcpu *vcpu)
 	return ctx->ia32_efer;
 }
 
-inline void vcpu_set_efer(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_efer(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.ia32_efer
 		= val;
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
 }
 
-inline uint64_t vcpu_get_rflags(struct vcpu *vcpu)
+inline uint64_t vcpu_get_rflags(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
 		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
@@ -90,14 +90,14 @@ inline uint64_t vcpu_get_rflags(struct vcpu *vcpu)
 	return ctx->rflags;
 }
 
-inline void vcpu_set_rflags(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_rflags(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.rflags =
 		val;
 	bitmap_set_lock(CPU_REG_RFLAGS, &vcpu->reg_updated);
 }
 
-inline uint64_t vcpu_get_cr0(struct vcpu *vcpu)
+inline uint64_t vcpu_get_cr0(struct acrn_vcpu *vcpu)
 {
 	uint64_t mask;
 	struct run_context *ctx =
@@ -111,23 +111,23 @@ inline uint64_t vcpu_get_cr0(struct vcpu *vcpu)
 	return ctx->cr0;
 }
 
-inline void vcpu_set_cr0(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_cr0(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vmx_write_cr0(vcpu, val);
 }
 
-inline uint64_t vcpu_get_cr2(struct vcpu *vcpu)
+inline uint64_t vcpu_get_cr2(struct acrn_vcpu *vcpu)
 {
 	return vcpu->
 		arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.cr2;
 }
 
-inline void vcpu_set_cr2(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_cr2(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.cr2 = val;
 }
 
-inline uint64_t vcpu_get_cr4(struct vcpu *vcpu)
+inline uint64_t vcpu_get_cr4(struct acrn_vcpu *vcpu)
 {
 	uint64_t mask;
 	struct run_context *ctx =
@@ -141,29 +141,29 @@ inline uint64_t vcpu_get_cr4(struct vcpu *vcpu)
 	return ctx->cr4;
 }
 
-inline void vcpu_set_cr4(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_cr4(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vmx_write_cr4(vcpu, val);
 }
 
-inline uint64_t vcpu_get_pat_ext(const struct vcpu *vcpu)
+inline uint64_t vcpu_get_pat_ext(const struct acrn_vcpu *vcpu)
 {
 	return vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].
 		ext_ctx.ia32_pat;
 }
 
-inline void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val)
+inline void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx.ia32_pat
 		= val;
 }
 
-struct vcpu *get_ever_run_vcpu(uint16_t pcpu_id)
+struct acrn_vcpu *get_ever_run_vcpu(uint16_t pcpu_id)
 {
 	return per_cpu(ever_run_vcpu, pcpu_id);
 }
 
-static void set_vcpu_mode(struct vcpu *vcpu, uint32_t cs_attr, uint64_t ia32_efer,
+static void set_vcpu_mode(struct acrn_vcpu *vcpu, uint32_t cs_attr, uint64_t ia32_efer,
 		uint64_t cr0)
 {
 	if (ia32_efer & MSR_IA32_EFER_LMA_BIT) {
@@ -178,7 +178,7 @@ static void set_vcpu_mode(struct vcpu *vcpu, uint32_t cs_attr, uint64_t ia32_efe
 	}
 }
 
-void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs)
+void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs)
 {
 	struct ext_context *ectx;
 	struct run_context *ctx;
@@ -280,12 +280,12 @@ static struct acrn_vcpu_regs realmode_init_regs = {
 	.cr4 = 0UL,
 };
 
-void reset_vcpu_regs(struct vcpu *vcpu)
+void reset_vcpu_regs(struct acrn_vcpu *vcpu)
 {
 	set_vcpu_regs(vcpu, &realmode_init_regs);
 }
 
-void set_ap_entry(struct vcpu *vcpu, uint64_t entry)
+void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry)
 {
 	struct ext_context *ectx;
 
@@ -311,9 +311,9 @@ void set_ap_entry(struct vcpu *vcpu, uint64_t entry)
  *     for physical CPU 1 : vcpu->pcpu_id = 1, vcpu->vcpu_id = 1, vmid = 1;
  *
  ***********************************************************************/
-int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
+int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct acrn_vcpu **rtn_vcpu_handle)
 {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	uint16_t vcpu_id;
 
 	pr_info("Creating VCPU working on PCPU%hu", pcpu_id);
@@ -329,7 +329,7 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 	}
 	/* Allocate memory for VCPU */
 	vcpu = &(vm->hw.vcpu_array[vcpu_id]);
-	(void)memset((void *)vcpu, 0U, sizeof(struct vcpu));
+	(void)memset((void *)vcpu, 0U, sizeof(struct acrn_vcpu));
 
 	/* Initialize CPU ID for this VCPU */
 	vcpu->vcpu_id = vcpu_id;
@@ -387,7 +387,7 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle)
 /*
  *  @pre vcpu != NULL
  */
-int run_vcpu(struct vcpu *vcpu)
+int run_vcpu(struct acrn_vcpu *vcpu)
 {
 	uint32_t instlen, cs_attr;
 	uint64_t rip, ia32_efer, cr0;
@@ -487,7 +487,7 @@ int run_vcpu(struct vcpu *vcpu)
 	return status;
 }
 
-int shutdown_vcpu(__unused struct vcpu *vcpu)
+int shutdown_vcpu(__unused struct acrn_vcpu *vcpu)
 {
 	/* TODO : Implement VCPU shutdown sequence */
 
@@ -497,7 +497,7 @@ int shutdown_vcpu(__unused struct vcpu *vcpu)
 /*
  *  @pre vcpu != NULL
  */
-void offline_vcpu(struct vcpu *vcpu)
+void offline_vcpu(struct acrn_vcpu *vcpu)
 {
 	vlapic_free(vcpu);
 	per_cpu(ever_run_vcpu, vcpu->pcpu_id) = NULL;
@@ -508,7 +508,7 @@ void offline_vcpu(struct vcpu *vcpu)
 /* NOTE:
  * vcpu should be paused before call this function.
  */
-void reset_vcpu(struct vcpu *vcpu)
+void reset_vcpu(struct acrn_vcpu *vcpu)
 {
 	int i;
 	struct acrn_vlapic *vlapic;
@@ -546,7 +546,7 @@ void reset_vcpu(struct vcpu *vcpu)
 	reset_vcpu_regs(vcpu);
 }
 
-void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state)
+void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 {
 	uint16_t pcpu_id = get_cpu_id();
 
@@ -572,7 +572,7 @@ void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state)
 	}
 }
 
-void resume_vcpu(struct vcpu *vcpu)
+void resume_vcpu(struct acrn_vcpu *vcpu)
 {
 	pr_dbg("vcpu%hu resumed", vcpu->vcpu_id);
 
@@ -586,7 +586,7 @@ void resume_vcpu(struct vcpu *vcpu)
 	release_schedule_lock(vcpu->pcpu_id);
 }
 
-void schedule_vcpu(struct vcpu *vcpu)
+void schedule_vcpu(struct acrn_vcpu *vcpu)
 {
 	vcpu->state = VCPU_RUNNING;
 	pr_dbg("vcpu%hu scheduled", vcpu->vcpu_id);
@@ -601,7 +601,7 @@ void schedule_vcpu(struct vcpu *vcpu)
 int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 {
 	int ret = 0;
-	struct vcpu *vcpu = NULL;
+	struct acrn_vcpu *vcpu = NULL;
 
 	ret = create_vcpu(pcpu_id, vm, &vcpu);
 	if (ret != 0) {
@@ -619,7 +619,7 @@ int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
 	return ret;
 }
 
-void request_vcpu_pre_work(struct vcpu *vcpu, uint16_t pre_work_id)
+void request_vcpu_pre_work(struct acrn_vcpu *vcpu, uint16_t pre_work_id)
 {
 	bitmap_set_lock(pre_work_id, &vcpu->pending_pre_work);
 }
@@ -633,7 +633,7 @@ void vcpu_dumpreg(void *data)
 	uint64_t i, fault_addr, tmp[DUMPREG_SP_SIZE];
 	uint32_t err_code = 0;
 	struct vcpu_dump *dump = data;
-	struct vcpu *vcpu = dump->vcpu;
+	struct acrn_vcpu *vcpu = dump->vcpu;
 	char *str = dump->str;
 	size_t len, size = dump->str_max;
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -311,7 +311,7 @@ void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry)
  *     for physical CPU 1 : vcpu->pcpu_id = 1, vcpu->vcpu_id = 1, vmid = 1;
  *
  ***********************************************************************/
-int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct acrn_vcpu **rtn_vcpu_handle)
+int create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn_vcpu_handle)
 {
 	struct acrn_vcpu *vcpu;
 	uint16_t vcpu_id;
@@ -598,7 +598,7 @@ void schedule_vcpu(struct acrn_vcpu *vcpu)
 }
 
 /* help function for vcpu create */
-int prepare_vcpu(struct vm *vm, uint16_t pcpu_id)
+int prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 {
 	int ret = 0;
 	struct acrn_vcpu *vcpu = NULL;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -13,7 +13,7 @@ vm_sw_loader_t vm_sw_loader;
 inline uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg)
 {
 	const struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	return ctx->guest_cpu_regs.longs[reg];
 }
@@ -21,7 +21,7 @@ inline uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg)
 inline void vcpu_set_gpreg(struct acrn_vcpu *vcpu, uint32_t reg, uint64_t val)
 {
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	ctx->guest_cpu_regs.longs[reg] = val;
 }
@@ -29,7 +29,7 @@ inline void vcpu_set_gpreg(struct acrn_vcpu *vcpu, uint32_t reg, uint64_t val)
 inline uint64_t vcpu_get_rip(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	if (bitmap_test(CPU_REG_RIP, &vcpu->reg_updated) == 0 &&
 		bitmap_test_and_set_lock(CPU_REG_RIP, &vcpu->reg_cached) == 0)
@@ -39,14 +39,14 @@ inline uint64_t vcpu_get_rip(struct acrn_vcpu *vcpu)
 
 inline void vcpu_set_rip(struct acrn_vcpu *vcpu, uint64_t val)
 {
-	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.rip = val;
+	vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx.rip = val;
 	bitmap_set_lock(CPU_REG_RIP, &vcpu->reg_updated);
 }
 
 inline uint64_t vcpu_get_rsp(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	return ctx->guest_cpu_regs.regs.rsp;
 }
@@ -54,7 +54,7 @@ inline uint64_t vcpu_get_rsp(struct acrn_vcpu *vcpu)
 inline void vcpu_set_rsp(struct acrn_vcpu *vcpu, uint64_t val)
 {
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	ctx->guest_cpu_regs.regs.rsp = val;
 	bitmap_set_lock(CPU_REG_RSP, &vcpu->reg_updated);
@@ -63,7 +63,7 @@ inline void vcpu_set_rsp(struct acrn_vcpu *vcpu, uint64_t val)
 inline uint64_t vcpu_get_efer(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	if (bitmap_test(CPU_REG_EFER, &vcpu->reg_updated) == 0 &&
 		bitmap_test_and_set_lock(CPU_REG_EFER, &vcpu->reg_cached) == 0)
@@ -73,7 +73,7 @@ inline uint64_t vcpu_get_efer(struct acrn_vcpu *vcpu)
 
 inline void vcpu_set_efer(struct acrn_vcpu *vcpu, uint64_t val)
 {
-	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.ia32_efer
+	vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx.ia32_efer
 		= val;
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
 }
@@ -81,7 +81,7 @@ inline void vcpu_set_efer(struct acrn_vcpu *vcpu, uint64_t val)
 inline uint64_t vcpu_get_rflags(struct acrn_vcpu *vcpu)
 {
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	if (bitmap_test(CPU_REG_RFLAGS, &vcpu->reg_updated) == 0 &&
 		bitmap_test_and_set_lock(CPU_REG_RFLAGS,
@@ -92,7 +92,7 @@ inline uint64_t vcpu_get_rflags(struct acrn_vcpu *vcpu)
 
 inline void vcpu_set_rflags(struct acrn_vcpu *vcpu, uint64_t val)
 {
-	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.rflags =
+	vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx.rflags =
 		val;
 	bitmap_set_lock(CPU_REG_RFLAGS, &vcpu->reg_updated);
 }
@@ -101,7 +101,7 @@ inline uint64_t vcpu_get_cr0(struct acrn_vcpu *vcpu)
 {
 	uint64_t mask;
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	if (bitmap_test_and_set_lock(CPU_REG_CR0, &vcpu->reg_cached) == 0) {
 		mask = exec_vmread(VMX_CR0_MASK);
@@ -119,19 +119,19 @@ inline void vcpu_set_cr0(struct acrn_vcpu *vcpu, uint64_t val)
 inline uint64_t vcpu_get_cr2(struct acrn_vcpu *vcpu)
 {
 	return vcpu->
-		arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.cr2;
+		arch.contexts[vcpu->arch.cur_context].run_ctx.cr2;
 }
 
 inline void vcpu_set_cr2(struct acrn_vcpu *vcpu, uint64_t val)
 {
-	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx.cr2 = val;
+	vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx.cr2 = val;
 }
 
 inline uint64_t vcpu_get_cr4(struct acrn_vcpu *vcpu)
 {
 	uint64_t mask;
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	if (bitmap_test_and_set_lock(CPU_REG_CR4, &vcpu->reg_cached) == 0) {
 		mask = exec_vmread(VMX_CR4_MASK);
@@ -148,13 +148,13 @@ inline void vcpu_set_cr4(struct acrn_vcpu *vcpu, uint64_t val)
 
 inline uint64_t vcpu_get_pat_ext(const struct acrn_vcpu *vcpu)
 {
-	return vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].
+	return vcpu->arch.contexts[vcpu->arch.cur_context].
 		ext_ctx.ia32_pat;
 }
 
 inline void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val)
 {
-	vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx.ia32_pat
+	vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx.ia32_pat
 		= val;
 }
 
@@ -168,13 +168,13 @@ static void set_vcpu_mode(struct acrn_vcpu *vcpu, uint32_t cs_attr, uint64_t ia3
 {
 	if (ia32_efer & MSR_IA32_EFER_LMA_BIT) {
 		if (cs_attr & 0x2000)		/* CS.L = 1 */
-			vcpu->arch_vcpu.cpu_mode = CPU_MODE_64BIT;
+			vcpu->arch.cpu_mode = CPU_MODE_64BIT;
 		else
-			vcpu->arch_vcpu.cpu_mode = CPU_MODE_COMPATIBILITY;
+			vcpu->arch.cpu_mode = CPU_MODE_COMPATIBILITY;
 	} else if (cr0 & CR0_PE) {
-		vcpu->arch_vcpu.cpu_mode = CPU_MODE_PROTECTED;
+		vcpu->arch.cpu_mode = CPU_MODE_PROTECTED;
 	} else {
-		vcpu->arch_vcpu.cpu_mode = CPU_MODE_REAL;
+		vcpu->arch.cpu_mode = CPU_MODE_REAL;
 	}
 }
 
@@ -186,8 +186,8 @@ void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs)
 	struct segment_sel *seg;
 	uint32_t limit, attr;
 
-	ectx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx);
-	ctx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx);
+	ectx = &(vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx);
+	ctx = &(vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx);
 
 	/* NOTE:
 	 * This is to set the attr and limit to default value.
@@ -289,7 +289,7 @@ void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry)
 {
 	struct ext_context *ectx;
 
-	ectx = &(vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].ext_ctx);
+	ectx = &(vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx);
 	ectx->cs.selector = (uint16_t)((entry >> 4U) & 0xFFFFU);
 	ectx->cs.base = ectx->cs.selector << 4U;
 
@@ -353,13 +353,13 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct acrn_vcpu **rtn_vcpu_han
 			vcpu->pcpu_id, vcpu->vm->vm_id, vcpu->vcpu_id,
 			is_vcpu_bsp(vcpu) ? "PRIMARY" : "SECONDARY");
 
-	vcpu->arch_vcpu.vpid = allocate_vpid();
+	vcpu->arch.vpid = allocate_vpid();
 
 	/* Initialize exception field in VCPU context */
-	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
+	vcpu->arch.exception_info.exception = VECTOR_INVALID;
 
 	/* Initialize cur context */
-	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
+	vcpu->arch.cur_context = NORMAL_WORLD;
 
 	/* Create per vcpu vlapic */
 	vlapic_create(vcpu);
@@ -374,7 +374,7 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct acrn_vcpu **rtn_vcpu_han
 	vcpu->launched = false;
 	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
-	vcpu->arch_vcpu.nr_sipi = 0;
+	vcpu->arch.nr_sipi = 0;
 	vcpu->pending_pre_work = 0U;
 	vcpu->state = VCPU_INIT;
 
@@ -392,7 +392,7 @@ int run_vcpu(struct acrn_vcpu *vcpu)
 	uint32_t instlen, cs_attr;
 	uint64_t rip, ia32_efer, cr0;
 	struct run_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context].run_ctx;
+		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 	int64_t status = 0;
 
 	if (bitmap_test_and_clear_lock(CPU_REG_RIP, &vcpu->reg_updated))
@@ -409,8 +409,8 @@ int run_vcpu(struct acrn_vcpu *vcpu)
 		pr_info("VM %d Starting VCPU %hu",
 				vcpu->vm->vm_id, vcpu->vcpu_id);
 
-		if (vcpu->arch_vcpu.vpid)
-			exec_vmwrite16(VMX_VPID, vcpu->arch_vcpu.vpid);
+		if (vcpu->arch.vpid)
+			exec_vmwrite16(VMX_VPID, vcpu->arch.vpid);
 
 		/*
 		 * A power-up or a reset invalidates all linear mappings,
@@ -447,7 +447,7 @@ int run_vcpu(struct acrn_vcpu *vcpu)
 		/* This VCPU was already launched, check if the last guest
 		 * instruction needs to be repeated and resume VCPU accordingly
 		 */
-		instlen = vcpu->arch_vcpu.inst_len;
+		instlen = vcpu->arch.inst_len;
 		rip = vcpu_get_rip(vcpu);
 		exec_vmwrite(VMX_GUEST_RIP, ((rip+(uint64_t)instlen) &
 				0xFFFFFFFFFFFFFFFFUL));
@@ -467,17 +467,17 @@ int run_vcpu(struct acrn_vcpu *vcpu)
 	set_vcpu_mode(vcpu, cs_attr, ia32_efer, cr0);
 
 	/* Obtain current VCPU instruction length */
-	vcpu->arch_vcpu.inst_len = exec_vmread32(VMX_EXIT_INSTR_LEN);
+	vcpu->arch.inst_len = exec_vmread32(VMX_EXIT_INSTR_LEN);
 
 	ctx->guest_cpu_regs.regs.rsp = exec_vmread(VMX_GUEST_RSP);
 
 	/* Obtain VM exit reason */
-	vcpu->arch_vcpu.exit_reason = exec_vmread32(VMX_EXIT_REASON);
+	vcpu->arch.exit_reason = exec_vmread32(VMX_EXIT_REASON);
 
 	if (status != 0) {
 		/* refer to 64-ia32 spec section 24.9.1 volume#3 */
-		if (vcpu->arch_vcpu.exit_reason & VMX_VMENTRY_FAIL)
-			pr_fatal("vmentry fail reason=%lx", vcpu->arch_vcpu.exit_reason);
+		if (vcpu->arch.exit_reason & VMX_VMENTRY_FAIL)
+			pr_fatal("vmentry fail reason=%lx", vcpu->arch.exit_reason);
 		else
 			pr_fatal("vmexit fail err_inst=%x", exec_vmread32(VMX_INSTR_ERROR));
 
@@ -525,20 +525,20 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 	vcpu->launched = false;
 	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
-	vcpu->arch_vcpu.nr_sipi = 0;
+	vcpu->arch.nr_sipi = 0;
 	vcpu->pending_pre_work = 0U;
 
-	vcpu->arch_vcpu.exception_info.exception = VECTOR_INVALID;
-	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
-	vcpu->arch_vcpu.irq_window_enabled = 0;
-	vcpu->arch_vcpu.inject_event_pending = false;
-	(void)memset(vcpu->arch_vcpu.vmcs, 0U, CPU_PAGE_SIZE);
+	vcpu->arch.exception_info.exception = VECTOR_INVALID;
+	vcpu->arch.cur_context = NORMAL_WORLD;
+	vcpu->arch.irq_window_enabled = 0;
+	vcpu->arch.inject_event_pending = false;
+	(void)memset(vcpu->arch.vmcs, 0U, CPU_PAGE_SIZE);
 
 	for (i = 0; i < NR_WORLD; i++) {
-		(void)memset(&vcpu->arch_vcpu.contexts[i], 0U,
+		(void)memset(&vcpu->arch.contexts[i], 0U,
 			sizeof(struct run_context));
 	}
-	vcpu->arch_vcpu.cur_context = NORMAL_WORLD;
+	vcpu->arch.cur_context = NORMAL_WORLD;
 
 	vlapic = vcpu_vlapic(vcpu);
 	vlapic_reset(vlapic);

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -107,7 +107,7 @@ static void vlapic_timer_expired(void *data);
 static inline bool is_x2apic_enabled(const struct acrn_vlapic *vlapic);
 
 static struct acrn_vlapic *
-vm_lapic_from_vcpu_id(struct vm *vm, uint16_t vcpu_id)
+vm_lapic_from_vcpu_id(struct acrn_vm *vm, uint16_t vcpu_id)
 {
 	struct acrn_vcpu *vcpu;
 
@@ -116,7 +116,7 @@ vm_lapic_from_vcpu_id(struct vm *vm, uint16_t vcpu_id)
 	return vcpu_vlapic(vcpu);
 }
 
-static uint16_t vm_apicid2vcpu_id(struct vm *vm, uint8_t lapicid)
+static uint16_t vm_apicid2vcpu_id(struct acrn_vm *vm, uint8_t lapicid)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu;
@@ -134,7 +134,7 @@ static uint16_t vm_apicid2vcpu_id(struct vm *vm, uint8_t lapicid)
 }
 
 static uint64_t
-vm_active_cpus(const struct vm *vm)
+vm_active_cpus(const struct acrn_vm *vm)
 {
 	uint64_t dmask = 0UL;
 	uint16_t i;
@@ -1004,7 +1004,7 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t vector)
  * addressing specified by the (dest, phys, lowprio) tuple.
  */
 static void
-vlapic_calcdest(struct vm *vm, uint64_t *dmask, uint32_t dest,
+vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest,
 		bool phys, bool lowprio)
 {
 	struct acrn_vlapic *vlapic;
@@ -1118,7 +1118,7 @@ vlapic_calcdest(struct vm *vm, uint64_t *dmask, uint32_t dest,
 }
 
 	void
-calcvdest(struct vm *vm, uint64_t *dmask, uint32_t dest, bool phys)
+calcvdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys)
 {
 	vlapic_calcdest(vm, dmask, dest, phys, false);
 }
@@ -1797,7 +1797,7 @@ vlapic_set_apicbase(struct acrn_vlapic *vlapic, uint64_t new)
 }
 
 void
-vlapic_deliver_intr(struct vm *vm, bool level, uint32_t dest, bool phys,
+vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest, bool phys,
 		uint32_t delmode, uint32_t vec, bool rh)
 {
 	bool lowprio;
@@ -1968,7 +1968,7 @@ vlapic_set_intr(struct acrn_vcpu *vcpu, uint32_t vector, bool level)
  * @pre vm != NULL
  */
 int
-vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id_arg, uint32_t vector)
+vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vector)
 {
 	struct acrn_vlapic *vlapic;
 	uint64_t dmask = 0UL;
@@ -2011,7 +2011,7 @@ vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id_arg, uint32_t vector)
  * @pre vm != NULL
  */
 int
-vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg)
+vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg)
 {
 	uint32_t delmode, vec;
 	uint32_t dest;
@@ -2095,7 +2095,7 @@ static inline  uint32_t x2apic_msr_to_regoff(uint32_t msr)
  */
 
 static int
-vlapic_x2apic_pt_icr_access(struct vm *vm, uint64_t val)
+vlapic_x2apic_pt_icr_access(struct acrn_vm *vm, uint64_t val)
 {
 	uint64_t apic_id = (uint32_t) (val >> 32U);
 	uint32_t icr_low = val;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -11,7 +11,7 @@
 
 /* Local variables */
 
-static struct vm vm_array[CONFIG_MAX_VM_NUM] __aligned(CPU_PAGE_SIZE);
+static struct acrn_vm vm_array[CONFIG_MAX_VM_NUM] __aligned(CPU_PAGE_SIZE);
 
 static uint64_t vmid_bitmap;
 
@@ -30,7 +30,7 @@ static inline uint16_t alloc_vm_id(void)
 	return INVALID_VM_ID;
 }
 
-static inline void free_vm_id(const struct vm *vm)
+static inline void free_vm_id(const struct acrn_vm *vm)
 {
 	bitmap_clear_lock(vm->vm_id, &vmid_bitmap);
 }
@@ -43,7 +43,7 @@ static inline bool is_vm_valid(uint16_t vm_id)
 /* return a pointer to the virtual machine structure associated with
  * this VM ID
  */
-struct vm *get_vm_from_vmid(uint16_t vm_id)
+struct acrn_vm *get_vm_from_vmid(uint16_t vm_id)
 {
 	if (is_vm_valid(vm_id)) {
 		return &vm_array[vm_id];
@@ -55,9 +55,9 @@ struct vm *get_vm_from_vmid(uint16_t vm_id)
 /**
  * @pre vm_desc != NULL && rtn_vm != NULL
  */
-int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
+int create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm)
 {
-	struct vm *vm;
+	struct acrn_vm *vm;
 	int status;
 	uint16_t vm_id;
 
@@ -74,7 +74,7 @@ int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm)
 
 	/* Allocate memory for virtual machine */
 	vm = &vm_array[vm_id];
-	(void)memset((void *)vm, 0U, sizeof(struct vm));
+	(void)memset((void *)vm, 0U, sizeof(struct acrn_vm));
 	vm->vm_id = vm_id;
 #ifdef CONFIG_PARTITION_MODE
 	/* Map Virtual Machine to its VM Description */
@@ -185,7 +185,7 @@ err:
 /*
  * @pre vm != NULL
  */
-int shutdown_vm(struct vm *vm)
+int shutdown_vm(struct acrn_vm *vm)
 {
 	int status = 0;
 	uint16_t i;
@@ -233,7 +233,7 @@ int shutdown_vm(struct vm *vm)
 /**
  *  * @pre vm != NULL
  */
-int start_vm(struct vm *vm)
+int start_vm(struct acrn_vm *vm)
 {
 	struct acrn_vcpu *vcpu = NULL;
 
@@ -249,7 +249,7 @@ int start_vm(struct vm *vm)
 /**
  *  * @pre vm != NULL
  */
-int reset_vm(struct vm *vm)
+int reset_vm(struct acrn_vm *vm)
 {
 	int i;
 	struct acrn_vcpu *vcpu = NULL;
@@ -276,7 +276,7 @@ int reset_vm(struct vm *vm)
 /**
  *  * @pre vm != NULL
  */
-void pause_vm(struct vm *vm)
+void pause_vm(struct acrn_vm *vm)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu = NULL;
@@ -295,7 +295,7 @@ void pause_vm(struct vm *vm)
 /**
  *  * @pre vm != NULL
  */
-void resume_vm(struct vm *vm)
+void resume_vm(struct acrn_vm *vm)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu = NULL;
@@ -321,7 +321,7 @@ void resume_vm(struct vm *vm)
  *
  * @pre vm != NULL
  */
-void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec)
+void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 {
 	struct acrn_vcpu *bsp = vcpu_from_vid(vm, 0U);
 
@@ -344,7 +344,7 @@ int prepare_vm(uint16_t pcpu_id)
 {
 	int ret = 0;
 	uint16_t i;
-	struct vm *vm = NULL;
+	struct acrn_vm *vm = NULL;
 	struct vm_description *vm_desc = NULL;
 	bool is_vm_bsp;
 
@@ -385,7 +385,7 @@ int prepare_vm0(void)
 {
 	int err;
 	uint16_t i;
-	struct vm *vm = NULL;
+	struct acrn_vm *vm = NULL;
 	struct vm_description vm0_desc;
 
 	(void)memset((void *)&vm0_desc, 0U, sizeof(vm0_desc));

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -189,7 +189,7 @@ int shutdown_vm(struct vm *vm)
 {
 	int status = 0;
 	uint16_t i;
-	struct vcpu *vcpu = NULL;
+	struct acrn_vcpu *vcpu = NULL;
 
 	pause_vm(vm);
 
@@ -235,7 +235,7 @@ int shutdown_vm(struct vm *vm)
  */
 int start_vm(struct vm *vm)
 {
-	struct vcpu *vcpu = NULL;
+	struct acrn_vcpu *vcpu = NULL;
 
 	vm->state = VM_STARTED;
 
@@ -252,7 +252,7 @@ int start_vm(struct vm *vm)
 int reset_vm(struct vm *vm)
 {
 	int i;
-	struct vcpu *vcpu = NULL;
+	struct acrn_vcpu *vcpu = NULL;
 
 	if (vm->state != VM_PAUSED) {
 		return -1;
@@ -279,7 +279,7 @@ int reset_vm(struct vm *vm)
 void pause_vm(struct vm *vm)
 {
 	uint16_t i;
-	struct vcpu *vcpu = NULL;
+	struct acrn_vcpu *vcpu = NULL;
 
 	if (vm->state == VM_PAUSED) {
 		return;
@@ -298,7 +298,7 @@ void pause_vm(struct vm *vm)
 void resume_vm(struct vm *vm)
 {
 	uint16_t i;
-	struct vcpu *vcpu = NULL;
+	struct acrn_vcpu *vcpu = NULL;
 
 	foreach_vcpu(i, vm, vcpu) {
 		resume_vcpu(vcpu);
@@ -323,7 +323,7 @@ void resume_vm(struct vm *vm)
  */
 void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec)
 {
-	struct vcpu *bsp = vcpu_from_vid(vm, 0U);
+	struct acrn_vcpu *bsp = vcpu_from_vid(vm, 0U);
 
 	vm->state = VM_STARTED;
 

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -15,7 +15,7 @@
 int vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int32_t ret = -EACCES;
-	struct vm *vm = vcpu->vm;
+	struct acrn_vm *vm = vcpu->vm;
 	/* hypercall ID from guest*/
 	uint64_t hypcall_id = vcpu_get_gpreg(vcpu, CPU_REG_R8);
 	/* hypercall param1 from guest*/

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -12,7 +12,7 @@
  * This function should always return 0 since we shouldn't
  * deal with hypercall error in hypervisor.
  */
-int vmcall_vmexit_handler(struct vcpu *vcpu)
+int vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int32_t ret = -EACCES;
 	struct vm *vm = vcpu->vm;

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -261,7 +261,7 @@ int rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	}
 	case MSR_IA32_TSC_AUX:
 	{
-		v = vcpu->arch_vcpu.msr_tsc_aux;
+		v = vcpu->arch.msr_tsc_aux;
 		break;
 	}
 	case MSR_IA32_APIC_BASE:
@@ -398,7 +398,7 @@ int wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	}
 	case MSR_IA32_TSC_AUX:
 	{
-		vcpu->arch_vcpu.msr_tsc_aux = v;
+		vcpu->arch.msr_tsc_aux = v;
 		break;
 	}
 	case MSR_IA32_APIC_BASE:

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -132,7 +132,7 @@ static void intercept_x2apic_msrs(uint8_t *msr_bitmap_arg, enum rw_mode mode)
 	}
 }
 
-void init_msr_emulation(struct vcpu *vcpu)
+void init_msr_emulation(struct acrn_vcpu *vcpu)
 {
 	uint32_t i;
 	uint32_t msrs_count =  ARRAY_SIZE(emulated_msrs);
@@ -184,7 +184,7 @@ void init_msr_emulation(struct vcpu *vcpu)
 	pr_dbg("VMX_MSR_BITMAP: 0x%016llx ", value64);
 }
 
-int rdmsr_vmexit_handler(struct vcpu *vcpu)
+int rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int err = 0;
 	uint32_t msr;
@@ -297,7 +297,7 @@ int rdmsr_vmexit_handler(struct vcpu *vcpu)
 	return err;
 }
 
-int wrmsr_vmexit_handler(struct vcpu *vcpu)
+int wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int err = 0;
 	uint32_t msr;
@@ -428,7 +428,7 @@ int wrmsr_vmexit_handler(struct vcpu *vcpu)
 	return err;
 }
 
-void update_msr_bitmap_x2apic_apicv(struct vcpu *vcpu)
+void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu)
 {
 	uint8_t *msr_bitmap;
 
@@ -447,7 +447,7 @@ void update_msr_bitmap_x2apic_apicv(struct vcpu *vcpu)
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_SELF_IPI, READ);
 }
 
-void update_msr_bitmap_x2apic_passthru(struct vcpu *vcpu)
+void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu)
 {
 	uint32_t msr;
 	uint8_t *msr_bitmap;

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -361,11 +361,11 @@ int32_t pio_instr_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int32_t status;
 	uint64_t exit_qual;
-	int32_t cur_context_idx = vcpu->arch_vcpu.cur_context;
+	int32_t cur_context_idx = vcpu->arch.cur_context;
 	struct io_request *io_req = &vcpu->req;
 	struct pio_request *pio_req = &io_req->reqs.pio;
 
-	exit_qual = vcpu->arch_vcpu.exit_qualification;
+	exit_qual = vcpu->arch.exit_qualification;
 
 	io_req->type = REQ_PORTIO;
 	pio_req->size = vm_exit_io_instruction_size(exit_qual) + 1UL;

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -24,7 +24,7 @@ static void complete_ioreq(struct vhm_request *vhm_req)
  * request having transferred to the COMPLETE state.
  */
 static void
-emulate_pio_post(struct vcpu *vcpu, const struct io_request *io_req)
+emulate_pio_post(struct acrn_vcpu *vcpu, const struct io_request *io_req)
 {
 	const struct pio_request *pio_req = &io_req->reqs.pio;
 	uint64_t mask = 0xFFFFFFFFUL >> (32UL - 8UL * pio_req->size);
@@ -46,7 +46,7 @@ emulate_pio_post(struct vcpu *vcpu, const struct io_request *io_req)
  * @remark This function must be called after the VHM request corresponding to
  * \p vcpu being transferred to the COMPLETE state.
  */
-void dm_emulate_pio_post(struct vcpu *vcpu)
+void dm_emulate_pio_post(struct acrn_vcpu *vcpu)
 {
 	uint16_t cur = vcpu->vcpu_id;
 	union vhm_request_buffer *req_buf = NULL;
@@ -77,7 +77,7 @@ void dm_emulate_pio_post(struct vcpu *vcpu)
  * either a previous call to emulate_io() returning 0 or the corresponding VHM
  * request transferring to the COMPLETE state.
  */
-void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req)
+void emulate_mmio_post(const struct acrn_vcpu *vcpu, const struct io_request *io_req)
 {
 	const struct mmio_request *mmio_req = &io_req->reqs.mmio;
 
@@ -97,7 +97,7 @@ void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req)
  * @remark This function must be called after the VHM request corresponding to
  * \p vcpu being transferred to the COMPLETE state.
  */
-void dm_emulate_mmio_post(struct vcpu *vcpu)
+void dm_emulate_mmio_post(struct acrn_vcpu *vcpu)
 {
 	uint16_t cur = vcpu->vcpu_id;
 	struct io_request *io_req = &vcpu->req;
@@ -132,7 +132,7 @@ static void io_instr_dest_handler(struct io_request *io_req)
  *
  * @param vcpu The virtual CPU that triggers the MMIO access
  */
-void emulate_io_post(struct vcpu *vcpu)
+void emulate_io_post(struct acrn_vcpu *vcpu)
 {
 	union vhm_request_buffer *req_buf;
 	struct vhm_request *vhm_req;
@@ -191,7 +191,7 @@ void emulate_io_post(struct vcpu *vcpu)
  * @return -EIO    - The request spans multiple devices and cannot be emulated.
  */
 int32_t
-hv_emulate_pio(const struct vcpu *vcpu, struct io_request *io_req)
+hv_emulate_pio(const struct acrn_vcpu *vcpu, struct io_request *io_req)
 {
 	int32_t status = -ENODEV;
 	uint16_t port, size;
@@ -249,7 +249,7 @@ hv_emulate_pio(const struct vcpu *vcpu, struct io_request *io_req)
  * @return -EIO    - The request spans multiple devices and cannot be emulated.
  */
 static int32_t
-hv_emulate_mmio(struct vcpu *vcpu, struct io_request *io_req)
+hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
 {
 	int status = -ENODEV;
 	uint64_t address, size;
@@ -299,7 +299,7 @@ hv_emulate_mmio(struct vcpu *vcpu, struct io_request *io_req)
  * @return Negative on other errors during emulation.
  */
 int32_t
-emulate_io(struct vcpu *vcpu, struct io_request *io_req)
+emulate_io(struct acrn_vcpu *vcpu, struct io_request *io_req)
 {
 	int32_t status;
 
@@ -357,7 +357,7 @@ emulate_io(struct vcpu *vcpu, struct io_request *io_req)
  *
  * @param vcpu The virtual CPU which triggers the VM exit on I/O instruction
  */
-int32_t pio_instr_vmexit_handler(struct vcpu *vcpu)
+int32_t pio_instr_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int32_t status;
 	uint64_t exit_qual;

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -196,7 +196,7 @@ hv_emulate_pio(const struct acrn_vcpu *vcpu, struct io_request *io_req)
 	int32_t status = -ENODEV;
 	uint16_t port, size;
 	uint32_t mask;
-	struct vm *vm = vcpu->vm;
+	struct acrn_vm *vm = vcpu->vm;
 	struct pio_request *pio_req = &io_req->reqs.pio;
 	struct vm_io_handler *handler;
 
@@ -394,7 +394,7 @@ int32_t pio_instr_vmexit_handler(struct acrn_vcpu *vcpu)
 	return status;
 }
 
-static void register_io_handler(struct vm *vm, struct vm_io_handler *hdlr)
+static void register_io_handler(struct acrn_vm *vm, struct vm_io_handler *hdlr)
 {
 	if (vm->arch_vm.io_handler != NULL) {
 		hdlr->next = vm->arch_vm.io_handler;
@@ -403,7 +403,7 @@ static void register_io_handler(struct vm *vm, struct vm_io_handler *hdlr)
 	vm->arch_vm.io_handler = hdlr;
 }
 
-static void empty_io_handler_list(struct vm *vm)
+static void empty_io_handler_list(struct acrn_vm *vm)
 {
 	struct vm_io_handler *handler = vm->arch_vm.io_handler;
 	struct vm_io_handler *tmp;
@@ -421,7 +421,7 @@ static void empty_io_handler_list(struct vm *vm)
  *
  * @param vm The VM whose I/O bitmaps and handlers are to be freed
  */
-void free_io_emulation_resource(struct vm *vm)
+void free_io_emulation_resource(struct acrn_vm *vm)
 {
 	empty_io_handler_list(vm);
 }
@@ -436,7 +436,7 @@ void free_io_emulation_resource(struct vm *vm)
  * @param port_address The start address of the port I/O range
  * @param nbytes The size of the range, in bytes
  */
-void allow_guest_pio_access(struct vm *vm, uint16_t port_address,
+void allow_guest_pio_access(struct acrn_vm *vm, uint16_t port_address,
 		uint32_t nbytes)
 {
 	uint16_t address = port_address;
@@ -450,7 +450,7 @@ void allow_guest_pio_access(struct vm *vm, uint16_t port_address,
 	}
 }
 
-static void deny_guest_pio_access(struct vm *vm, uint16_t port_address,
+static void deny_guest_pio_access(struct acrn_vm *vm, uint16_t port_address,
 		uint32_t nbytes)
 {
 	uint16_t address = port_address;
@@ -490,7 +490,7 @@ static struct vm_io_handler *create_io_handler(uint32_t port, uint32_t len,
  *
  * @param vm The VM whose I/O bitmap is to be initialized
  */
-void setup_io_bitmap(struct vm *vm)
+void setup_io_bitmap(struct acrn_vm *vm)
 {
 	if (is_vm0(vm)) {
 		(void)memset(vm->arch_vm.io_bitmap, 0x00U, CPU_PAGE_SIZE * 2);
@@ -508,7 +508,7 @@ void setup_io_bitmap(struct vm *vm)
  * @param io_read_fn_ptr The handler for emulating reads from the given range
  * @param io_write_fn_ptr The handler for emulating writes to the given range
  */
-void register_io_emulation_handler(struct vm *vm, const struct vm_io_range *range,
+void register_io_emulation_handler(struct acrn_vm *vm, const struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr)
 {
@@ -543,7 +543,7 @@ void register_io_emulation_handler(struct vm *vm, const struct vm_io_range *rang
  * @return 0 - Registration succeeds
  * @return -EINVAL - \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
  */
-int register_mmio_emulation_handler(struct vm *vm,
+int register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
 	uint64_t end, void *handler_private_data)
 {
@@ -600,7 +600,7 @@ int register_mmio_emulation_handler(struct vm *vm,
  * @param start The base address of the range the to-be-unregistered handler is for
  * @param end The end of the range (exclusive) the to-be-unregistered handler is for
  */
-void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
+void unregister_mmio_emulation_handler(struct acrn_vm *vm, uint64_t start,
 	uint64_t end)
 {
 	struct list_head *pos, *tmp;

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -384,7 +384,7 @@ void dispatch_exception(struct intr_excp_ctx *ctx)
 void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx)
 {
 	uint8_t vr = ctx->vector;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	/*
 	 * There is no vector and APIC ID remapping for VMs in

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -168,7 +168,7 @@ void flush_vpid_global(void)
 	local_invvpid(VMX_VPID_TYPE_ALL_CONTEXT, 0U, 0UL);
 }
 
-void invept(const struct vcpu *vcpu)
+void invept(const struct acrn_vcpu *vcpu)
 {
 	struct invept_desc desc = {0};
 

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -291,7 +291,7 @@ void init_paging(void)
 	sanitize_pte((uint64_t *)sanitized_page);
 }
 
-bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg)
+bool check_continuous_hpa(struct acrn_vm *vm, uint64_t gpa_arg, uint64_t size_arg)
 {
 	uint64_t curr_hpa;
 	uint64_t next_hpa;

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -125,7 +125,7 @@ void init_mtrr(struct acrn_vcpu *vcpu)
 	}
 }
 
-static uint32_t update_ept(struct vm *vm, uint64_t start,
+static uint32_t update_ept(struct acrn_vm *vm, uint64_t start,
 	uint64_t size, uint8_t type)
 {
 	uint64_t attr;

--- a/hypervisor/arch/x86/mtrr.c
+++ b/hypervisor/arch/x86/mtrr.c
@@ -63,23 +63,23 @@ get_subrange_start_of_fixed_mtrr(uint32_t index, uint32_t subrange_id)
 		get_subrange_size_of_fixed_mtrr(index));
 }
 
-static inline bool is_mtrr_enabled(const struct vcpu *vcpu)
+static inline bool is_mtrr_enabled(const struct acrn_vcpu *vcpu)
 {
 	return (vcpu->mtrr.def_type.bits.enable != 0U);
 }
 
-static inline bool is_fixed_range_mtrr_enabled(const struct vcpu *vcpu)
+static inline bool is_fixed_range_mtrr_enabled(const struct acrn_vcpu *vcpu)
 {
 	return ((vcpu->mtrr.cap.bits.fix != 0U) &&
 		(vcpu->mtrr.def_type.bits.fixed_enable != 0U));
 }
 
-static inline uint8_t get_default_memory_type(const struct vcpu *vcpu)
+static inline uint8_t get_default_memory_type(const struct acrn_vcpu *vcpu)
 {
 	return (uint8_t)(vcpu->mtrr.def_type.bits.type);
 }
 
-void init_mtrr(struct vcpu *vcpu)
+void init_mtrr(struct acrn_vcpu *vcpu)
 {
 	union mtrr_cap_reg cap = {0};
 	uint32_t i;
@@ -154,7 +154,7 @@ static uint32_t update_ept(struct vm *vm, uint64_t start,
 	return attr;
 }
 
-static void update_ept_mem_type(const struct vcpu *vcpu)
+static void update_ept_mem_type(const struct acrn_vcpu *vcpu)
 {
 	uint8_t type;
 	uint64_t start, size;
@@ -193,7 +193,7 @@ static void update_ept_mem_type(const struct vcpu *vcpu)
 	}
 }
 
-void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value)
+void mtrr_wrmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t value)
 {
 	uint32_t index;
 
@@ -236,7 +236,7 @@ void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value)
 	}
 }
 
-uint64_t mtrr_rdmsr(const struct vcpu *vcpu, uint32_t msr)
+uint64_t mtrr_rdmsr(const struct acrn_vcpu *vcpu, uint32_t msr)
 {
 	const struct mtrr_state *mtrr = &vcpu->mtrr;
 	uint64_t ret = 0UL;

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -135,7 +135,7 @@ static inline struct page *ept_get_pt_page(const union pgtable_pages_info *info,
 	return page;
 }
 
-void init_ept_mem_ops(struct vm *vm)
+void init_ept_mem_ops(struct acrn_vm *vm)
 {
 	uint16_t vm_id = vm->vm_id;
 	if (vm_id != 0U) {

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -87,7 +87,7 @@ static uint32_t acpi_gas_read(const struct acpi_generic_address *gas)
 	return ret;
 }
 
-void do_acpi_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+void do_acpi_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 	uint32_t pm1b_cnt_val)
 {
 	uint32_t s1, s2;
@@ -123,7 +123,7 @@ void do_acpi_s3(struct vm *vm, uint32_t pm1a_cnt_val,
 	}
 }
 
-int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+int enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 	uint32_t pm1b_cnt_val)
 {
 	uint64_t pmain_entry_saved;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -181,7 +181,7 @@ void  destroy_secure_world(struct vm *vm, bool need_clr_mem)
 
 }
 
-static void save_world_ctx(struct vcpu *vcpu, struct ext_context *ext_ctx)
+static void save_world_ctx(struct acrn_vcpu *vcpu, struct ext_context *ext_ctx)
 {
 	/* cache on-demand run_context for efer/rflags/rsp/rip */
 	(void)vcpu_get_efer(vcpu);
@@ -235,7 +235,7 @@ static void save_world_ctx(struct vcpu *vcpu, struct ext_context *ext_ctx)
 			: : "r" (ext_ctx->fxstore_guest_area) : "memory");
 }
 
-static void load_world_ctx(struct vcpu *vcpu, const struct ext_context *ext_ctx)
+static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext_ctx)
 {
 	/* mark to update on-demand run_context for efer/rflags/rsp */
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
@@ -291,7 +291,7 @@ static void copy_smc_param(const struct run_context *prev_ctx,
 	next_ctx->guest_cpu_regs.regs.rbx = prev_ctx->guest_cpu_regs.regs.rbx;
 }
 
-void switch_world(struct vcpu *vcpu, int next_world)
+void switch_world(struct acrn_vcpu *vcpu, int next_world)
 {
 	struct vcpu_arch *arch_vcpu = &vcpu->arch_vcpu;
 
@@ -327,7 +327,7 @@ void switch_world(struct vcpu *vcpu, int next_world)
 /* Put key_info and trusty_startup_param in the first Page of Trusty
  * runtime memory
  */
-static bool setup_trusty_info(struct vcpu *vcpu,
+static bool setup_trusty_info(struct acrn_vcpu *vcpu,
 			uint32_t mem_size, uint64_t mem_base_hpa)
 {
 	uint32_t i;
@@ -381,7 +381,7 @@ static bool setup_trusty_info(struct vcpu *vcpu,
  * RIP, RSP and RDI are specified below, other GP registers are leaved
  * as 0.
  */
-static bool init_secure_world_env(struct vcpu *vcpu,
+static bool init_secure_world_env(struct acrn_vcpu *vcpu,
 				uint64_t entry_gpa,
 				uint64_t base_hpa,
 				uint32_t size)
@@ -398,7 +398,7 @@ static bool init_secure_world_env(struct vcpu *vcpu,
 	return setup_trusty_info(vcpu, size, base_hpa);
 }
 
-bool initialize_trusty(struct vcpu *vcpu, uint64_t param)
+bool initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
 {
 	uint64_t trusty_entry_gpa, trusty_base_gpa, trusty_base_hpa;
 	uint32_t trusty_mem_size;
@@ -477,7 +477,7 @@ void trusty_set_dseed(const void *dseed, uint8_t dseed_num)
 			dseed, sizeof(struct seed_info) * dseed_num);
 }
 
-void save_sworld_context(struct vcpu *vcpu)
+void save_sworld_context(struct acrn_vcpu *vcpu)
 {
 	(void)memcpy_s(&vcpu->vm->sworld_snapshot,
 			sizeof(struct cpu_context),
@@ -485,7 +485,7 @@ void save_sworld_context(struct vcpu *vcpu)
 			sizeof(struct cpu_context));
 }
 
-void restore_sworld_context(struct vcpu *vcpu)
+void restore_sworld_context(struct acrn_vcpu *vcpu)
 {
 	struct secure_world_control *sworld_ctl =
 		&vcpu->vm->sworld_control;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -57,7 +57,7 @@ static struct trusty_key_info g_key_info = {
  * @param gpa_rebased gpa rebased to offset xxx (511G_OFFSET)
  *
  */
-static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
+static void create_secure_world_ept(struct acrn_vm *vm, uint64_t gpa_orig,
 		uint64_t size, uint64_t gpa_rebased)
 {
 	uint64_t nworld_pml4e;
@@ -68,7 +68,7 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	uint64_t table_present = EPT_RWX;
 	uint64_t pdpte, *dest_pdpte_p, *src_pdpte_p;
 	void *sub_table_addr, *pml4_base;
-	struct vm *vm0 = get_vm_from_vmid(0U);
+	struct acrn_vm *vm0 = get_vm_from_vmid(0U);
 	uint16_t i;
 
 	if ((vm->sworld_control.flag.supported == 0UL)
@@ -148,9 +148,9 @@ static void create_secure_world_ept(struct vm *vm, uint64_t gpa_orig,
 	vm->sworld_control.sworld_memory.length = size;
 }
 
-void  destroy_secure_world(struct vm *vm, bool need_clr_mem)
+void  destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem)
 {
-	struct vm *vm0 = get_vm_from_vmid(0U);
+	struct acrn_vm *vm0 = get_vm_from_vmid(0U);
 	uint64_t hpa = vm->sworld_control.sworld_memory.base_hpa;
 	uint64_t gpa_sos = vm->sworld_control.sworld_memory.base_gpa_in_sos;
 	uint64_t gpa_uos = vm->sworld_control.sworld_memory.base_gpa_in_uos;
@@ -402,7 +402,7 @@ bool initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
 {
 	uint64_t trusty_entry_gpa, trusty_base_gpa, trusty_base_hpa;
 	uint32_t trusty_mem_size;
-	struct vm *vm = vcpu->vm;
+	struct acrn_vm *vm = vcpu->vm;
 	struct trusty_boot_param boot_param;
 
 	(void)memset(&boot_param, 0U, sizeof(boot_param));

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -150,7 +150,7 @@ static int vcpu_inject_vlapic_int(struct acrn_vcpu *vcpu)
 
 static int vcpu_do_pending_extint(const struct acrn_vcpu *vcpu)
 {
-	struct vm *vm;
+	struct acrn_vm *vm;
 	struct acrn_vcpu *primary;
 	uint32_t vector;
 

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -12,8 +12,8 @@
  */
 #define NR_VMX_EXIT_REASONS	65U
 
-static int unhandled_vmexit_handler(struct vcpu *vcpu);
-static int xsetbv_vmexit_handler(struct vcpu *vcpu);
+static int unhandled_vmexit_handler(struct acrn_vcpu *vcpu);
+static int xsetbv_vmexit_handler(struct acrn_vcpu *vcpu);
 
 /* VM Dispatch table for Exit condition handling */
 static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
@@ -151,7 +151,7 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 		.handler = unhandled_vmexit_handler}
 };
 
-int vmexit_handler(struct vcpu *vcpu)
+int vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	struct vm_exit_dispatch *dispatch = NULL;
 	uint16_t basic_exit_reason;
@@ -227,7 +227,7 @@ int vmexit_handler(struct vcpu *vcpu)
 	return ret;
 }
 
-static int unhandled_vmexit_handler(struct vcpu *vcpu)
+static int unhandled_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	pr_fatal("Error: Unhandled VM exit condition from guest at 0x%016llx ",
 			exec_vmread(VMX_GUEST_RIP));
@@ -242,7 +242,7 @@ static int unhandled_vmexit_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int cpuid_vmexit_handler(struct vcpu *vcpu)
+int cpuid_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	uint64_t rax, rbx, rcx, rdx;
 
@@ -262,7 +262,7 @@ int cpuid_vmexit_handler(struct vcpu *vcpu)
 	return 0;
 }
 
-int cr_access_vmexit_handler(struct vcpu *vcpu)
+int cr_access_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	uint64_t reg;
 	uint32_t idx;
@@ -317,7 +317,7 @@ int cr_access_vmexit_handler(struct vcpu *vcpu)
  * XSETBV instruction set's the XCR0 that is used to tell for which
  * components states can be saved on a context switch using xsave.
  */
-static int xsetbv_vmexit_handler(struct vcpu *vcpu)
+static int xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int idx;
 	uint64_t val64;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -762,7 +762,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
 	uint64_t value64;
-	struct vm *vm = vcpu->vm;
+	struct acrn_vm *vm = vcpu->vm;
 
 	/* Log messages to show initializing VMX execution controls */
 	pr_dbg("*****************************");

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -102,7 +102,7 @@ void exec_vmxon_instr(uint16_t pcpu_id)
 	vmxon_region_pa = hva2hpa(vmxon_region_va);
 	exec_vmxon(&vmxon_region_pa);
 
-	vmcs_pa = hva2hpa(vcpu->arch_vcpu.vmcs);
+	vmcs_pa = hva2hpa(vcpu->arch.vmcs);
 	exec_vmptrld(&vmcs_pa);
 }
 
@@ -112,7 +112,7 @@ void vmx_off(uint16_t pcpu_id)
 	struct acrn_vcpu *vcpu = get_ever_run_vcpu(pcpu_id);
 	uint64_t vmcs_pa;
 
-	vmcs_pa = hva2hpa(vcpu->arch_vcpu.vmcs);
+	vmcs_pa = hva2hpa(vcpu->arch.vmcs);
 	exec_vmclear((void *)&vmcs_pa);
 
 	asm volatile ("vmxoff" : : : "memory");
@@ -549,7 +549,7 @@ static void init_guest_vmx(struct acrn_vcpu *vcpu, uint64_t cr0, uint64_t cr3,
 	uint64_t cr4)
 {
 	struct cpu_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
+		&vcpu->arch.contexts[vcpu->arch.cur_context];
 	struct ext_context *ectx = &ctx->ext_ctx;
 
 	vcpu_set_cr4(vcpu, cr4);
@@ -593,7 +593,7 @@ static void init_guest_vmx(struct acrn_vcpu *vcpu, uint64_t cr0, uint64_t cr3,
 static void init_guest_state(struct acrn_vcpu *vcpu)
 {
 	struct cpu_context *ctx =
-		&vcpu->arch_vcpu.contexts[vcpu->arch_vcpu.cur_context];
+		&vcpu->arch.contexts[vcpu->arch.cur_context];
 
 	init_guest_vmx(vcpu, ctx->run_ctx.cr0, ctx->ext_ctx.cr3,
 			ctx->run_ctx.cr4 & ~CR4_VMXE);
@@ -825,7 +825,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 			VMX_PROCBASED_CTLS2_UNRESTRICT|
 			VMX_PROCBASED_CTLS2_VAPIC_REGS);
 
-	if (vcpu->arch_vcpu.vpid != 0U) {
+	if (vcpu->arch.vpid != 0U) {
 		value32 |= VMX_PROCBASED_CTLS2_VPID;
 	} else {
 		value32 &= ~VMX_PROCBASED_CTLS2_VPID;
@@ -1038,10 +1038,10 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 
 	/* Obtain the VM Rev ID from HW and populate VMCS page with it */
 	vmx_rev_id = msr_read(MSR_IA32_VMX_BASIC);
-	(void)memcpy_s(vcpu->arch_vcpu.vmcs, 4U, (void *)&vmx_rev_id, 4U);
+	(void)memcpy_s(vcpu->arch.vmcs, 4U, (void *)&vmx_rev_id, 4U);
 
 	/* Execute VMCLEAR on current VMCS */
-	vmcs_pa = hva2hpa(vcpu->arch_vcpu.vmcs);
+	vmcs_pa = hva2hpa(vcpu->arch.vmcs);
 	exec_vmclear((void *)&vmcs_pa);
 
 	/* Load VMCS pointer */

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1240,7 +1240,7 @@ int init_iommu(void)
 	return ret;
 }
 
-void init_iommu_vm0_domain(struct vm *vm0)
+void init_iommu_vm0_domain(struct acrn_vm *vm0)
 {
 	uint16_t bus;
 	uint16_t devfun;

--- a/hypervisor/boot/sbl/abl_seed_parse.c
+++ b/hypervisor/boot/sbl/abl_seed_parse.c
@@ -105,7 +105,7 @@ fail:
  * return value:
  *    true if parse successfully, otherwise false.
  */
-bool abl_seed_parse(struct vm *vm, char *cmdline, char *out_arg, uint32_t out_len)
+bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len)
 {
 	char *arg, *arg_end;
 	char *param;

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -17,7 +17,7 @@
 #define MAX_BOOT_PARAMS_LEN 64U
 
 #ifdef CONFIG_PARTITION_MODE
-int init_vm_boot_info(struct vm *vm)
+int init_vm_boot_info(struct acrn_vm *vm)
 {
 	struct multiboot_module *mods = NULL;
 	struct multiboot_info *mbi = NULL;
@@ -72,7 +72,7 @@ int init_vm_boot_info(struct vm *vm)
 static char kernel_cmdline[MEM_2K];
 
 /* now modules support: FIRMWARE & RAMDISK & SeedList */
-static void parse_other_modules(struct vm *vm,
+static void parse_other_modules(struct acrn_vm *vm,
 	const struct multiboot_module *mods, uint32_t mods_count)
 {
 	uint32_t i;
@@ -164,7 +164,7 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
  * @pre vm != NULL
  * @pre is_vm0(vm) == true
  */
-int init_vm_boot_info(struct vm *vm)
+int init_vm_boot_info(struct acrn_vm *vm)
 {
 	struct multiboot_module *mods = NULL;
 	struct multiboot_info *mbi = NULL;

--- a/hypervisor/boot/sbl/sbl_seed_parse.c
+++ b/hypervisor/boot/sbl/sbl_seed_parse.c
@@ -132,7 +132,7 @@ fail:
  * return value:
  *    true if parse successfully, otherwise false.
  */
-bool sbl_seed_parse(struct vm *vm, char *cmdline, char *out_arg, uint32_t out_len)
+bool sbl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len)
 {
 	char *arg, *arg_end;
 	char *param;

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -17,7 +17,7 @@ static int efi_initialized;
 
 void efi_spurious_handler(int vector)
 {
-	struct vcpu* vcpu;
+	struct acrn_vcpu* vcpu;
 	int ret;
 
 	if (get_cpu_id() != 0)
@@ -39,7 +39,7 @@ void efi_spurious_handler(int vector)
 int uefi_sw_loader(struct vm *vm)
 {
 	int ret = 0;
-	struct vcpu *vcpu = get_primary_vcpu(vm);
+	struct acrn_vcpu *vcpu = get_primary_vcpu(vm);
 	struct acrn_vcpu_regs *vcpu_regs = &vm0_boot_context;
 
 	ASSERT(vm != NULL, "Incorrect argument");

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -36,7 +36,7 @@ void efi_spurious_handler(int vector)
 	return;
 }
 
-int uefi_sw_loader(struct vm *vm)
+int uefi_sw_loader(struct acrn_vm *vm)
 {
 	int ret = 0;
 	struct acrn_vcpu *vcpu = get_primary_vcpu(vm);

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -89,7 +89,7 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 		vmexit_begin = rdtsc();
 #endif
 
-		vcpu->arch_vcpu.nrexits++;
+		vcpu->arch.nrexits++;
 		/* Save guest TSC_AUX */
 		cpu_msr_read(MSR_IA32_TSC_AUX, &vcpu->msr_tsc_aux_guest);
 		/* Restore native TSC_AUX */
@@ -98,7 +98,7 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 		CPU_IRQ_ENABLE();
 		/* Dispatch handler */
 		ret = vmexit_handler(vcpu);
-		basic_exit_reason = vcpu->arch_vcpu.exit_reason & 0xFFFFU;
+		basic_exit_reason = vcpu->arch.exit_reason & 0xFFFFU;
 		if (ret < 0) {
 			pr_fatal("dispatch VM exit handler failed for reason"
 				" %d, ret = %d!", basic_exit_reason, ret);

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -8,7 +8,7 @@
 #include <schedule.h>
 #include <softirq.h>
 
-static void run_vcpu_pre_work(struct vcpu *vcpu)
+static void run_vcpu_pre_work(struct acrn_vcpu *vcpu)
 {
 	uint64_t *pending_pre_work = &vcpu->pending_pre_work;
 
@@ -17,7 +17,7 @@ static void run_vcpu_pre_work(struct vcpu *vcpu)
 	}
 }
 
-void vcpu_thread(struct vcpu *vcpu)
+void vcpu_thread(struct acrn_vcpu *vcpu)
 {
 #ifdef HV_DEBUG
 	uint64_t vmexit_begin = 0UL, vmexit_end = 0UL;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -30,7 +30,7 @@ bool is_hypercall_from_ring0(void)
  */
 int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid)
 {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	int i;
 
 	pr_info("sos offline cpu with lapicid %lld", lapicid);
@@ -198,7 +198,7 @@ int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param)
 {
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 	struct acrn_set_vcpu_regs vcpu_regs;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	if ((target_vm == NULL) || (param == 0U) || is_vm0(target_vm)) {
 		return -1;
@@ -326,7 +326,7 @@ int32_t hcall_set_ioreq_buffer(struct vm *vm, uint16_t vmid, uint64_t param)
 
 int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	struct vm *target_vm = get_vm_from_vmid(vmid);
 
 	/* make sure we have set req_buf */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -28,7 +28,7 @@ bool is_hypercall_from_ring0(void)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid)
+int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid)
 {
 	struct acrn_vcpu *vcpu;
 	int i;
@@ -53,7 +53,7 @@ int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_get_api_version(struct vm *vm, uint64_t param)
+int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param)
 {
 	struct hc_api_version version;
 
@@ -71,10 +71,10 @@ int32_t hcall_get_api_version(struct vm *vm, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_create_vm(struct vm *vm, uint64_t param)
+int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param)
 {
 	int32_t ret;
-	struct vm *target_vm = NULL;
+	struct acrn_vm *target_vm = NULL;
 	struct acrn_create_vm cv;
 	struct vm_description vm_desc;
 
@@ -110,7 +110,7 @@ int32_t hcall_create_vm(struct vm *vm, uint64_t param)
 int32_t hcall_destroy_vm(uint16_t vmid)
 {
 	int32_t ret;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -123,7 +123,7 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 int32_t hcall_start_vm(uint16_t vmid)
 {
 	int32_t ret;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -139,7 +139,7 @@ int32_t hcall_start_vm(uint16_t vmid)
 
 int32_t hcall_pause_vm(uint16_t vmid)
 {
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -153,12 +153,12 @@ int32_t hcall_pause_vm(uint16_t vmid)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_create_vcpu(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret;
 	uint16_t pcpu_id;
 	struct acrn_create_vcpu cv;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if ((target_vm == NULL) || (param == 0U)) {
 		return -1;
@@ -182,7 +182,7 @@ int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param)
 
 int32_t hcall_reset_vm(uint16_t vmid)
 {
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if ((target_vm == NULL) || is_vm0(target_vm)) {
 		return -1;
@@ -194,9 +194,9 @@ int32_t hcall_reset_vm(uint16_t vmid)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	struct acrn_set_vcpu_regs vcpu_regs;
 	struct acrn_vcpu *vcpu;
 
@@ -228,11 +228,11 @@ int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
+int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 				const struct acrn_irqline_ops *ops)
 {
 	uint32_t irq_pic;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -EINVAL;
@@ -261,11 +261,11 @@ int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_inject_msi(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_inject_msi(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret;
 	struct acrn_msi_entry msi;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -284,11 +284,11 @@ int32_t hcall_inject_msi(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_ioreq_buffer(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	uint64_t hpa;
 	struct acrn_set_ioreq_buffer iobuf;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	union vhm_request_buffer *req_buf;
 	uint16_t i;
 
@@ -327,7 +327,7 @@ int32_t hcall_set_ioreq_buffer(struct vm *vm, uint16_t vmid, uint64_t param)
 int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 {
 	struct acrn_vcpu *vcpu;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	/* make sure we have set req_buf */
 	if ((target_vm == NULL) || (target_vm->sw.io_shared_page == NULL)) {
@@ -353,8 +353,8 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 /**
  *@pre Pointer vm shall point to VM0
  */
-static int32_t local_set_vm_memory_region(struct vm *vm,
-	struct vm *target_vm, const struct vm_memory_region *region)
+static int32_t local_set_vm_memory_region(struct acrn_vm *vm,
+	struct acrn_vm *target_vm, const struct vm_memory_region *region)
 {
 	uint64_t hpa, base_paddr, gpa_end;
 	uint64_t prot;
@@ -433,10 +433,10 @@ static int32_t local_set_vm_memory_region(struct vm *vm,
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_vm_memory_region(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_set_vm_memory_region(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	struct vm_memory_region region;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -EINVAL;
@@ -461,11 +461,11 @@ int32_t hcall_set_vm_memory_region(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param)
+int32_t hcall_set_vm_memory_regions(struct acrn_vm *vm, uint64_t param)
 {
 	struct set_regions set_regions;
 	struct vm_memory_region *regions;
-	struct vm *target_vm;
+	struct acrn_vm *target_vm;
 	uint32_t idx;
 
 
@@ -505,7 +505,7 @@ int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-static int32_t write_protect_page(struct vm *vm,const struct wp_data *wp)
+static int32_t write_protect_page(struct acrn_vm *vm,const struct wp_data *wp)
 {
 	uint64_t hpa, base_paddr;
 	uint64_t prot_set;
@@ -540,10 +540,10 @@ static int32_t write_protect_page(struct vm *vm,const struct wp_data *wp)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_write_protect_page(struct vm *vm, uint16_t vmid, uint64_t wp_gpa)
+int32_t hcall_write_protect_page(struct acrn_vm *vm, uint16_t vmid, uint64_t wp_gpa)
 {
 	struct wp_data wp;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -EINVAL;
@@ -567,11 +567,11 @@ int32_t hcall_write_protect_page(struct vm *vm, uint16_t vmid, uint64_t wp_gpa)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_gpa_to_hpa(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret = 0;
 	struct vm_gpa2hpa v_gpa2hpa;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -600,11 +600,11 @@ int32_t hcall_gpa_to_hpa(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_assign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret;
 	uint16_t bdf;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		pr_err("%s, vm is null\n", __func__);
@@ -641,11 +641,11 @@ int32_t hcall_assign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_deassign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret = 0;
 	uint16_t bdf;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -664,11 +664,11 @@ int32_t hcall_deassign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret;
 	struct hc_ptdev_irq irq;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -705,11 +705,11 @@ int32_t hcall_set_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
  *@pre Pointer vm shall point to VM0
  */
 int32_t
-hcall_reset_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
+hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret = 0;
 	struct hc_ptdev_irq irq;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -751,7 +751,7 @@ hcall_reset_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
+int32_t hcall_setup_sbuf(struct acrn_vm *vm, uint64_t param)
 {
 	struct sbuf_setup_param ssp;
 	uint64_t *hva;
@@ -772,7 +772,7 @@ int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param)
 	return sbuf_share_setup(ssp.pcpu_id, ssp.sbuf_id, hva);
 }
 #else
-int32_t hcall_setup_sbuf(__unused struct vm *vm, __unused uint64_t param)
+int32_t hcall_setup_sbuf(__unused struct acrn_vm *vm, __unused uint64_t param)
 {
 	return -ENODEV;
 }
@@ -782,7 +782,7 @@ int32_t hcall_setup_sbuf(__unused struct vm *vm, __unused uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param)
+int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, uint64_t param)
 {
 	struct hv_npk_log_param npk_param;
 
@@ -803,7 +803,7 @@ int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param)
 	return 0;
 }
 #else
-int32_t hcall_setup_hv_npk_log(__unused struct vm *vm, __unused uint64_t param)
+int32_t hcall_setup_hv_npk_log(__unused struct acrn_vm *vm, __unused uint64_t param)
 {
 	return -ENODEV;
 }
@@ -812,10 +812,10 @@ int32_t hcall_setup_hv_npk_log(__unused struct vm *vm, __unused uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param)
+int32_t hcall_get_cpu_pm_state(struct acrn_vm *vm, uint64_t cmd, uint64_t param)
 {
 	uint16_t target_vm_id;
-	struct vm *target_vm;
+	struct acrn_vm *target_vm;
 
 	target_vm_id = (uint16_t)((cmd & PMCMD_VMID_MASK) >> PMCMD_VMID_SHIFT);
 	target_vm = get_vm_from_vmid(target_vm_id);
@@ -910,11 +910,11 @@ int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param)
+int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	struct acrn_intr_monitor *intr_hdr;
 	uint64_t hpa;
-	struct vm *target_vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
 		return -1;
@@ -955,7 +955,7 @@ int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param)
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_set_callback_vector(const struct vm *vm, uint64_t param)
+int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param)
 {
 	if (!is_vm0(vm)) {
 		pr_err("%s: Targeting to service vm", __func__);

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -15,7 +15,7 @@ static void fire_vhm_interrupt(void)
 	 * use vLAPIC to inject vector to SOS vcpu 0 if vlapic is enabled
 	 * otherwise, send IPI hardcoded to BOOT_CPU_ID
 	 */
-	struct vm *vm0;
+	struct acrn_vm *vm0;
 	struct acrn_vcpu *vcpu;
 
 	vm0 = get_vm_from_vmid(0U);

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -16,7 +16,7 @@ static void fire_vhm_interrupt(void)
 	 * otherwise, send IPI hardcoded to BOOT_CPU_ID
 	 */
 	struct vm *vm0;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	vm0 = get_vm_from_vmid(0U);
 
@@ -63,7 +63,7 @@ static void acrn_print_request(uint16_t vcpu_id, const struct vhm_request *req)
  *
  * @pre vcpu != NULL && io_req != NULL
  */
-int32_t acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req)
+int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request *io_req)
 {
 	union vhm_request_buffer *req_buf = NULL;
 	struct vhm_request *vhm_req;

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -45,7 +45,7 @@ static void ptdev_intr_delay_callback(void *data)
 }
 
 struct ptdev_remapping_info*
-ptdev_dequeue_softirq(struct vm *vm)
+ptdev_dequeue_softirq(struct acrn_vm *vm)
 {
 	uint64_t rflags;
 	struct ptdev_remapping_info *entry = NULL;
@@ -75,7 +75,7 @@ ptdev_dequeue_softirq(struct vm *vm)
 
 /* require ptdev_lock protect */
 struct ptdev_remapping_info *
-alloc_entry(struct vm *vm, uint32_t intr_type)
+alloc_entry(struct acrn_vm *vm, uint32_t intr_type)
 {
 	struct ptdev_remapping_info *entry;
 
@@ -120,7 +120,7 @@ release_entry(struct ptdev_remapping_info *entry)
 
 /* require ptdev_lock protect */
 static void
-release_all_entries(const struct vm *vm)
+release_all_entries(const struct acrn_vm *vm)
 {
 	struct ptdev_remapping_info *entry;
 	struct list_head *pos, *tmp;
@@ -204,7 +204,7 @@ void ptdev_init(void)
 	register_softirq(SOFTIRQ_PTDEV, ptdev_softirq);
 }
 
-void ptdev_release_all_entries(const struct vm *vm)
+void ptdev_release_all_entries(const struct acrn_vm *vm)
 {
 	/* VM already down */
 	spinlock_obtain(&ptdev_lock);
@@ -212,7 +212,7 @@ void ptdev_release_all_entries(const struct vm *vm)
 	spinlock_release(&ptdev_lock);
 }
 
-uint32_t get_vm_ptdev_intr_data(const struct vm *target_vm, uint64_t *buffer,
+uint32_t get_vm_ptdev_intr_data(const struct acrn_vm *target_vm, uint64_t *buffer,
 	uint32_t buffer_cnt)
 {
 	uint32_t index = 0U;

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -74,7 +74,7 @@ int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
 
 int64_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu)
 {
-	struct vm *vm = vcpu->vm;
+	struct acrn_vm *vm = vcpu->vm;
 
 	if (vm->sworld_control.flag.supported == 0UL) {
 		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -12,7 +12,7 @@
 /* this hcall is only come from trusty enabled vcpu itself, and cannot be
  * called from other vcpus
  */
-int32_t hcall_world_switch(struct vcpu *vcpu)
+int32_t hcall_world_switch(struct acrn_vcpu *vcpu)
 {
 	int32_t next_world_id = !(vcpu->arch_vcpu.cur_context);
 
@@ -42,7 +42,7 @@ int32_t hcall_world_switch(struct vcpu *vcpu)
 /* this hcall is only come from trusty enabled vcpu itself, and cannot be
  * called from other vcpus
  */
-int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param)
+int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
 {
 	if (vcpu->vm->sworld_control.flag.supported == 0UL) {
 		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
@@ -72,7 +72,7 @@ int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param)
 	return 0;
 }
 
-int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu)
+int64_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu)
 {
 	struct vm *vm = vcpu->vm;
 

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -14,7 +14,7 @@
  */
 int32_t hcall_world_switch(struct acrn_vcpu *vcpu)
 {
-	int32_t next_world_id = !(vcpu->arch_vcpu.cur_context);
+	int32_t next_world_id = !(vcpu->arch.cur_context);
 
 	if (next_world_id >= NR_WORLD) {
 		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
@@ -56,7 +56,7 @@ int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
 		return -EPERM;
 	}
 
-	if (vcpu->arch_vcpu.cur_context != NORMAL_WORLD) {
+	if (vcpu->arch.cur_context != NORMAL_WORLD) {
 		dev_dbg(ACRN_DBG_TRUSTY_HYCALL,
 			"%s, must initialize Trusty from Normal World!\n",
 			__func__);

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -111,7 +111,7 @@ int general_sw_loader(struct vm *vm)
 	struct zero_page *zeropage;
 	struct sw_linux *sw_linux = &(vm->sw.linux_info);
 	struct sw_kernel_info *sw_kernel = &(vm->sw.kernel_info);
-	struct vcpu *vcpu = get_primary_vcpu(vm);
+	struct acrn_vcpu *vcpu = get_primary_vcpu(vm);
 
 	pr_dbg("Loading guest to run-time location");
 

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -38,7 +38,7 @@ static uint32_t create_e820_table(struct e820_entry *param_e820)
 }
 #endif
 
-static void prepare_bsp_gdt(struct vm *vm)
+static void prepare_bsp_gdt(struct acrn_vm *vm)
 {
 	size_t gdt_len;
 	uint64_t gdt_base_hpa;
@@ -57,7 +57,7 @@ static void prepare_bsp_gdt(struct vm *vm)
 	return;
 }
 
-static uint64_t create_zero_page(struct vm *vm)
+static uint64_t create_zero_page(struct acrn_vm *vm)
 {
 	struct zero_page *zeropage;
 	struct sw_linux *sw_linux = &(vm->sw.linux_info);
@@ -102,7 +102,7 @@ static uint64_t create_zero_page(struct vm *vm)
 	return gpa;
 }
 
-int general_sw_loader(struct vm *vm)
+int general_sw_loader(struct acrn_vm *vm)
 {
 	int32_t ret = 0;
 	void *hva;

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -121,7 +121,7 @@ int general_sw_loader(struct vm *vm)
 	/* calculate the kernel entry point */
 	zeropage = (struct zero_page *)sw_kernel->kernel_src_addr;
 	kernel_entry_offset = (uint32_t)(zeropage->hdr.setup_sects + 1U) * 512U;
-	if (vcpu->arch_vcpu.cpu_mode == CPU_MODE_64BIT) {
+	if (vcpu->arch.cpu_mode == CPU_MODE_64BIT) {
 		/* 64bit entry is the 512bytes after the start */
 		kernel_entry_offset += 512U;
 	}

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -54,7 +54,7 @@ static const char *const excp_names[32] = {
  */
 struct intr_excp_ctx *crash_ctx;
 
-static void dump_guest_reg(struct vcpu *vcpu)
+static void dump_guest_reg(struct acrn_vcpu *vcpu)
 {
 	printf("\n\n================================================");
 	printf("================================\n\n");
@@ -101,7 +101,7 @@ static void dump_guest_reg(struct vcpu *vcpu)
 	printf("\r\n");
 }
 
-static void dump_guest_stack(struct vcpu *vcpu)
+static void dump_guest_stack(struct acrn_vcpu *vcpu)
 {
 	uint32_t i;
 	uint64_t tmp[DUMP_STACK_SIZE], fault_addr;
@@ -126,7 +126,7 @@ static void dump_guest_stack(struct vcpu *vcpu)
 	printf("\r\n");
 }
 
-static void show_guest_call_trace(struct vcpu *vcpu)
+static void show_guest_call_trace(struct acrn_vcpu *vcpu)
 {
 	uint64_t bp;
 	uint64_t count = 0UL;
@@ -170,7 +170,7 @@ static void show_guest_call_trace(struct vcpu *vcpu)
 
 static void dump_guest_context(uint16_t pcpu_id)
 {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	vcpu = per_cpu(vcpu, pcpu_id);
 	if (vcpu != NULL) {

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -62,7 +62,7 @@ static void dump_guest_reg(struct acrn_vcpu *vcpu)
 	printf("=	VM ID %d ==== vCPU ID %hu ===  pCPU ID %d ===="
 			"world %d =============\r\n",
 			vcpu->vm->vm_id, vcpu->vcpu_id, vcpu->pcpu_id,
-			vcpu->arch_vcpu.cur_context);
+			vcpu->arch.cur_context);
 	printf("=	RIP=0x%016llx  RSP=0x%016llx "
 			"RFLAGS=0x%016llx\r\n",
 			vcpu_get_rip(vcpu),

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -14,7 +14,7 @@
 /**
  *@pre Pointer vm shall point to VM0
  */
-int32_t hcall_profiling_ops(struct vm *vm, uint64_t cmd, uint64_t param)
+int32_t hcall_profiling_ops(struct acrn_vm *vm, uint64_t cmd, uint64_t param)
 {
 	int32_t ret;
 	switch (cmd) {

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -842,7 +842,7 @@ int32_t profiling_msr_ops_all_cpus(struct vm *vm, uint64_t addr)
 int32_t profiling_vm_list_info(struct vm *vm, uint64_t addr)
 {
 	struct vm *tmp_vm;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	int32_t vm_idx;
 	uint16_t i, j;
 	struct profiling_vm_info_list vm_info_list;
@@ -1291,7 +1291,7 @@ void profiling_ipi_handler(__unused void *data)
 /*
  * Save the VCPU info on vmenter
  */
-void profiling_vmenter_handler(__unused struct vcpu *vcpu)
+void profiling_vmenter_handler(__unused struct acrn_vcpu *vcpu)
 {
 	if (((get_cpu_var(profiling_info.sep_state).pmu_state == PMU_RUNNING) &&
 			((sep_collection_switch &
@@ -1307,7 +1307,7 @@ void profiling_vmenter_handler(__unused struct vcpu *vcpu)
 /*
  * Save the VCPU info on vmexit
  */
-void profiling_vmexit_handler(struct vcpu *vcpu, uint64_t exit_reason)
+void profiling_vmexit_handler(struct acrn_vcpu *vcpu, uint64_t exit_reason)
 {
 	per_cpu(profiling_info.sep_state, vcpu->pcpu_id).total_vmexit_count++;
 

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -806,7 +806,7 @@ void profiling_stop_pmu(void)
 /*
  * Performs MSR operations on all the CPU's
  */
-int32_t profiling_msr_ops_all_cpus(struct vm *vm, uint64_t addr)
+int32_t profiling_msr_ops_all_cpus(struct acrn_vm *vm, uint64_t addr)
 {
 	uint16_t i;
 	struct profiling_msr_ops_list msr_list[phys_cpu_num];
@@ -839,9 +839,9 @@ int32_t profiling_msr_ops_all_cpus(struct vm *vm, uint64_t addr)
 /*
  * Generate VM info list
  */
-int32_t profiling_vm_list_info(struct vm *vm, uint64_t addr)
+int32_t profiling_vm_list_info(struct acrn_vm *vm, uint64_t addr)
 {
-	struct vm *tmp_vm;
+	struct acrn_vm *tmp_vm;
 	struct acrn_vcpu *vcpu;
 	int32_t vm_idx;
 	uint16_t i, j;
@@ -905,7 +905,7 @@ int32_t profiling_vm_list_info(struct vm *vm, uint64_t addr)
 /*
  * Sep/socwatch profiling version
  */
-int32_t profiling_get_version_info(struct vm *vm, uint64_t addr)
+int32_t profiling_get_version_info(struct acrn_vm *vm, uint64_t addr)
 {
 	struct profiling_version_info ver_info;
 
@@ -939,7 +939,7 @@ int32_t profiling_get_version_info(struct vm *vm, uint64_t addr)
 /*
  * Gets type of profiling - sep/socwatch
  */
-int32_t profiling_get_control(struct vm *vm, uint64_t addr)
+int32_t profiling_get_control(struct acrn_vm *vm, uint64_t addr)
 {
 	struct profiling_control prof_control;
 
@@ -977,7 +977,7 @@ int32_t profiling_get_control(struct vm *vm, uint64_t addr)
 /*
  * Update the profiling type based on control switch
  */
-int32_t profiling_set_control(struct vm *vm, uint64_t addr)
+int32_t profiling_set_control(struct acrn_vm *vm, uint64_t addr)
 {
 	uint64_t old_switch;
 	uint64_t new_switch;
@@ -1092,7 +1092,7 @@ int32_t profiling_set_control(struct vm *vm, uint64_t addr)
 /*
  * Configure PMI on all cpus
  */
-int32_t profiling_configure_pmi(struct vm *vm, uint64_t addr)
+int32_t profiling_configure_pmi(struct acrn_vm *vm, uint64_t addr)
 {
 	uint16_t i;
 	struct profiling_pmi_config pmi_config;
@@ -1169,7 +1169,7 @@ int32_t profiling_configure_pmi(struct vm *vm, uint64_t addr)
 /*
  * Configure for VM-switch data on all cpus
  */
-int32_t profiling_configure_vmsw(struct vm *vm, uint64_t addr)
+int32_t profiling_configure_vmsw(struct acrn_vm *vm, uint64_t addr)
 {
 	uint16_t i;
 	int32_t ret = 0;
@@ -1233,7 +1233,7 @@ int32_t profiling_configure_vmsw(struct vm *vm, uint64_t addr)
 /*
  * Get the physical cpu id
  */
-int32_t profiling_get_pcpu_id(struct vm *vm, uint64_t addr)
+int32_t profiling_get_pcpu_id(struct acrn_vm *vm, uint64_t addr)
 {
 	struct profiling_pcpuid pcpuid;
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -526,7 +526,7 @@ static int shell_cmd_help(__unused int argc, __unused char **argv)
 static int shell_list_vm(__unused int argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
-	struct vm *vm;
+	struct acrn_vm *vm;
 	uint16_t idx;
 	char state[32];
 
@@ -568,7 +568,7 @@ static int shell_list_vm(__unused int argc, __unused char **argv)
 static int shell_list_vcpu(__unused int argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
-	struct vm *vm;
+	struct acrn_vm *vm;
 	struct acrn_vcpu *vcpu;
 	char state[32];
 	uint16_t i;
@@ -623,7 +623,7 @@ static int shell_vcpu_dumpreg(int argc, char **argv)
 	int status = 0;
 	uint16_t vm_id;
 	uint16_t vcpu_id;
-	struct vm *vm;
+	struct acrn_vm *vm;
 	struct acrn_vcpu *vcpu;
 	uint64_t mask = 0UL;
 	struct vcpu_dump dump;
@@ -722,7 +722,7 @@ static int shell_to_sos_console(__unused int argc, __unused char **argv)
 	char temp_str[TEMP_STR_SIZE];
 	uint16_t guest_no = 0U;
 
-	struct vm *vm;
+	struct acrn_vm *vm;
 	struct acrn_vuart *vu;
 #ifdef CONFIG_PARTITION_MODE
 	struct vm_description *vm_desc;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -569,7 +569,7 @@ static int shell_list_vcpu(__unused int argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
 	struct vm *vm;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	char state[32];
 	uint16_t i;
 	uint16_t idx;
@@ -624,7 +624,7 @@ static int shell_vcpu_dumpreg(int argc, char **argv)
 	uint16_t vm_id;
 	uint16_t vcpu_id;
 	struct vm *vm;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	uint64_t mask = 0UL;
 	struct vcpu_dump dump;
 

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -154,7 +154,7 @@ static void vuart_toggle_intr(const struct acrn_vuart *vu)
 	vioapic_set_irq(vu->vm, COM1_IRQ, operation);
 }
 
-static void vuart_write(struct vm *vm, uint16_t offset_arg,
+static void vuart_write(struct acrn_vm *vm, uint16_t offset_arg,
 			__unused size_t width, uint32_t value)
 {
 	uint16_t offset = offset_arg;
@@ -240,7 +240,7 @@ done:
 	vuart_unlock(vu);
 }
 
-static uint32_t vuart_read(struct vm *vm, uint16_t offset_arg,
+static uint32_t vuart_read(struct acrn_vm *vm, uint16_t offset_arg,
 			__unused size_t width)
 {
 	uint16_t offset = offset_arg;
@@ -319,7 +319,7 @@ done:
 	return (uint32_t)reg;
 }
 
-static void vuart_register_io_handler(struct vm *vm)
+static void vuart_register_io_handler(struct acrn_vm *vm)
 {
 	struct vm_io_range range = {
 		.flags = IO_ATTR_RW,
@@ -370,7 +370,7 @@ void vuart_console_rx_chars(struct acrn_vuart *vu)
 struct acrn_vuart *vuart_console_active(void)
 {
 #ifdef CONFIG_PARTITION_MODE
-	struct vm *vm;
+	struct acrn_vm *vm;
 
 	if (vuart_vmid == -1) {
 		return NULL;
@@ -378,7 +378,7 @@ struct acrn_vuart *vuart_console_active(void)
 
 	vm = get_vm_from_vmid(vuart_vmid);
 #else
-	struct vm *vm = get_vm_from_vmid(0U);
+	struct acrn_vm *vm = get_vm_from_vmid(0U);
 #endif
 
 	if (vm != NULL) {
@@ -391,7 +391,7 @@ struct acrn_vuart *vuart_console_active(void)
 	return NULL;
 }
 
-void vuart_init(struct vm *vm)
+void vuart_init(struct acrn_vm *vm)
 {
 	uint32_t divisor;
 	struct acrn_vuart *vu = vm_vuart(vm);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -126,7 +126,7 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint16_t pin, uint32_t level)
  * @return void
  */
 void
-vioapic_set_irq_nolock(struct vm *vm, uint32_t irq, uint32_t operation)
+vioapic_set_irq_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic;
 	uint16_t pin = (uint16_t)irq;
@@ -169,7 +169,7 @@ vioapic_set_irq_nolock(struct vm *vm, uint32_t irq, uint32_t operation)
  * @return void
  */
 void
-vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation)
+vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic = vm_ioapic(vm);
 
@@ -448,7 +448,7 @@ vioapic_mmio_rw(struct acrn_vioapic *vioapic, uint64_t gpa,
 }
 
 void
-vioapic_process_eoi(struct vm *vm, uint32_t vector)
+vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
 {
 	struct acrn_vioapic *vioapic;
 	uint32_t pin, pincount = vioapic_pincount(vm);
@@ -509,7 +509,7 @@ vioapic_reset(struct acrn_vioapic *vioapic)
 }
 
 void
-vioapic_init(struct vm *vm)
+vioapic_init(struct acrn_vm *vm)
 {
 	vm->arch_vm.vioapic.vm = vm;
 	spinlock_init(&(vm->arch_vm.vioapic.mtx));
@@ -532,7 +532,7 @@ vioapic_cleanup(const struct acrn_vioapic *vioapic)
 }
 
 uint32_t
-vioapic_pincount(const struct vm *vm)
+vioapic_pincount(const struct acrn_vm *vm)
 {
 	if (is_vm0(vm)) {
 		return REDIR_ENTRIES_HW;
@@ -543,7 +543,7 @@ vioapic_pincount(const struct vm *vm)
 
 int vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private_data)
 {
-	struct vm *vm = (struct vm *)handler_private_data;
+	struct acrn_vm *vm = (struct acrn_vm *)handler_private_data;
 	struct acrn_vioapic *vioapic;
 	struct mmio_request *mmio = &io_req->reqs.mmio;
 	uint64_t gpa = mmio->address;
@@ -575,7 +575,7 @@ int vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private
  * @pre vm->arch_vm.vioapic != NULL
  * @pre rte != NULL
  */
-void vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte)
+void vioapic_get_rte(struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte)
 {
 	struct acrn_vioapic *vioapic;
 
@@ -591,7 +591,7 @@ void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 	union ioapic_rte rte;
 	uint32_t delmode, vector, dest;
 	bool level, phys, remote_irr, mask;
-	struct vm *vm = get_vm_from_vmid(vmid);
+	struct acrn_vm *vm = get_vm_from_vmid(vmid);
 	uint32_t pin, pincount;
 
 	if (vm == NULL) {

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -183,7 +183,7 @@ vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation)
  * configuration.
  */
 void
-vioapic_update_tmr(struct vcpu *vcpu)
+vioapic_update_tmr(struct acrn_vcpu *vcpu)
 {
 	struct acrn_vioapic *vioapic;
 	struct acrn_vlapic *vlapic;
@@ -370,7 +370,7 @@ vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr,
 		 */
 		if ((changed & NEED_TMR_UPDATE) != 0UL) {
 			uint16_t i;
-			struct vcpu *vcpu;
+			struct acrn_vcpu *vcpu;
 
 			dev_dbg(ACRN_DBG_IOAPIC,
 			"ioapic pin%hhu: recalculate vlapic trigger-mode reg",

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -43,7 +43,7 @@ static int vmsi_remap(struct pci_vdev *vdev, bool enable)
 {
 	struct ptdev_msi_info info;
 	union pci_bdf pbdf = vdev->pdev.bdf;
-	struct vm *vm = vdev->vpci->vm;
+	struct acrn_vm *vm = vdev->vpci->vm;
 	uint32_t capoff = vdev->msi.capoff;
 	uint32_t msgctrl, msgdata;
 	uint32_t addrlo, addrhi;

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -49,7 +49,7 @@ static struct pci_vdev *partition_mode_find_vdev(struct vpci *vpci, union pci_bd
 	return NULL;
 }
 
-static int partition_mode_vpci_init(struct vm *vm)
+static int partition_mode_vpci_init(struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
 	struct vpci *vpci = &vm->vpci;
@@ -73,7 +73,7 @@ static int partition_mode_vpci_init(struct vm *vm)
 	return 0;
 }
 
-static void partition_mode_vpci_deinit(struct vm *vm)
+static void partition_mode_vpci_deinit(struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
 	struct pci_vdev *vdev;

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -56,7 +56,7 @@ static int vdev_pt_init_validate(struct pci_vdev *vdev)
 static int vdev_pt_init(struct pci_vdev *vdev)
 {
 	int ret;
-	struct vm *vm = vdev->vpci->vm;
+	struct acrn_vm *vm = vdev->vpci->vm;
 	uint16_t pci_command;
 
 	ret = vdev_pt_init_validate(vdev);
@@ -89,7 +89,7 @@ static int vdev_pt_init(struct pci_vdev *vdev)
 static int vdev_pt_deinit(struct pci_vdev *vdev)
 {
 	int ret;
-	struct vm *vm = vdev->vpci->vm;
+	struct acrn_vm *vm = vdev->vpci->vm;
 
 	ret = unassign_iommu_device(vm->iommu, vdev->pdev.bdf.bits.b,
 		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
@@ -119,7 +119,7 @@ static int vdev_pt_cfgread(struct pci_vdev *vdev, uint32_t offset,
 static void vdev_pt_remap_bar(struct pci_vdev *vdev, uint32_t idx,
 	uint32_t new_base)
 {
-	struct vm *vm = vdev->vpci->vm;
+	struct acrn_vm *vm = vdev->vpci->vm;
 
 	if (vdev->bar[idx].base != 0UL) {
 		ept_mr_del(vm, (uint64_t *)vm->arch_vm.nworld_eptp,

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -104,7 +104,7 @@ static void sharing_mode_cfgwrite(__unused struct vpci *vpci, union pci_bdf bdf,
 	}
 }
 
-static struct pci_vdev *alloc_pci_vdev(struct vm *vm, union pci_bdf bdf)
+static struct pci_vdev *alloc_pci_vdev(struct acrn_vm *vm, union pci_bdf bdf)
 {
 	struct pci_vdev *vdev;
 
@@ -124,7 +124,7 @@ static struct pci_vdev *alloc_pci_vdev(struct vm *vm, union pci_bdf bdf)
 
 static void enumerate_pci_dev(uint16_t pbdf, void *cb_data)
 {
-	struct vm *vm = (struct vm *)cb_data;
+	struct acrn_vm *vm = (struct acrn_vm *)cb_data;
 	struct pci_vdev *vdev;
 
 	vdev = alloc_pci_vdev(vm, (union pci_bdf)pbdf);
@@ -133,7 +133,7 @@ static void enumerate_pci_dev(uint16_t pbdf, void *cb_data)
 	}
 }
 
-static int sharing_mode_vpci_init(struct vm *vm)
+static int sharing_mode_vpci_init(struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i, j;
@@ -165,7 +165,7 @@ static int sharing_mode_vpci_init(struct vm *vm)
 	return 0;
 }
 
-static void sharing_mode_vpci_deinit(__unused struct vm *vm)
+static void sharing_mode_vpci_deinit(__unused struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i, j;
@@ -201,7 +201,7 @@ struct vpci_ops sharing_mode_vpci_ops = {
 	.cfgwrite = sharing_mode_cfgwrite,
 };
 
-void vpci_set_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf)
+void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
 {
 	struct pci_vdev *vdev;
 
@@ -218,10 +218,10 @@ void vpci_set_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf
 	vdev->pdev.bdf.value = pbdf;
 }
 
-void vpci_reset_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf)
+void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
 {
 	struct pci_vdev *vdev;
-	struct vm *vm;
+	struct acrn_vm *vm;
 
 	vdev = sharing_mode_find_vdev((union pci_bdf)pbdf);
 	if (vdev == NULL) {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -48,7 +48,7 @@ static void pci_cfg_clear_cache(struct pci_addr_info *pi)
 	pi->cached_enable = 0U;
 }
 
-static uint32_t pci_cfg_io_read(struct vm *vm, uint16_t addr, size_t bytes)
+static uint32_t pci_cfg_io_read(struct acrn_vm *vm, uint16_t addr, size_t bytes)
 {
 	uint32_t val = 0xFFFFFFFFU;
 	struct vpci *vpci = &vm->vpci;
@@ -82,7 +82,7 @@ static uint32_t pci_cfg_io_read(struct vm *vm, uint16_t addr, size_t bytes)
 	return val;
 }
 
-static void pci_cfg_io_write(struct vm *vm, uint16_t addr, size_t bytes,
+static void pci_cfg_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes,
 			uint32_t val)
 {
 	struct vpci *vpci = &vm->vpci;
@@ -114,7 +114,7 @@ static void pci_cfg_io_write(struct vm *vm, uint16_t addr, size_t bytes,
 	}
 }
 
-void vpci_init(struct vm *vm)
+void vpci_init(struct acrn_vm *vm)
 {
 	struct vpci *vpci = &vm->vpci;
 	struct vm_io_range pci_cfg_range = {
@@ -137,7 +137,7 @@ void vpci_init(struct vm *vm)
 	}
 }
 
-void vpci_cleanup(struct vm *vm)
+void vpci_cleanup(struct acrn_vm *vm)
 {
 	struct vpci *vpci = &vm->vpci;
 

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -448,7 +448,7 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
  *
  * @return void
  */
-void vpic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation)
+void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
 {
 	struct acrn_vpic *vpic;
 	struct i8259_reg_state *i8259;
@@ -501,7 +501,7 @@ vpic_pincount(void)
  * @pre vm->vpic != NULL
  * @pre irq < NR_VPIC_PINS_TOTAL
  */
-void vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
+void vpic_get_irq_trigger(struct acrn_vm *vm, uint32_t irq,
 		enum vpic_trigger *trigger)
 {
 	struct acrn_vpic *vpic;
@@ -524,7 +524,7 @@ void vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
  *
  * @return void.
  */
-void vpic_pending_intr(struct vm *vm, uint32_t *vecptr)
+void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr)
 {
 	struct acrn_vpic *vpic;
 	struct i8259_reg_state *i8259;
@@ -587,7 +587,7 @@ static void vpic_pin_accepted(struct i8259_reg_state *i8259, uint8_t pin)
  *
  * @pre vm != NULL
  */
-void vpic_intr_accepted(struct vm *vm, uint32_t vector)
+void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector)
 {
 	struct acrn_vpic *vpic;
 	uint8_t pin;
@@ -699,7 +699,7 @@ static int vpic_write(struct acrn_vpic *vpic, struct i8259_reg_state *i8259,
 	return error;
 }
 
-static int vpic_master_handler(struct vm *vm, bool in, uint16_t port,
+static int vpic_master_handler(struct acrn_vm *vm, bool in, uint16_t port,
 		size_t bytes, uint32_t *eax)
 {
 	struct acrn_vpic *vpic;
@@ -719,7 +719,7 @@ static int vpic_master_handler(struct vm *vm, bool in, uint16_t port,
 	return vpic_write(vpic, i8259, port, eax);
 }
 
-static uint32_t vpic_master_io_read(struct vm *vm, uint16_t addr, size_t width)
+static uint32_t vpic_master_io_read(struct acrn_vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0U;
 
@@ -730,7 +730,7 @@ static uint32_t vpic_master_io_read(struct vm *vm, uint16_t addr, size_t width)
 	return val;
 }
 
-static void vpic_master_io_write(struct vm *vm, uint16_t addr, size_t width,
+static void vpic_master_io_write(struct acrn_vm *vm, uint16_t addr, size_t width,
 				uint32_t v)
 {
 	uint32_t val = v;
@@ -741,7 +741,7 @@ static void vpic_master_io_write(struct vm *vm, uint16_t addr, size_t width,
 	}
 }
 
-static int vpic_slave_handler(struct vm *vm, bool in, uint16_t port,
+static int vpic_slave_handler(struct acrn_vm *vm, bool in, uint16_t port,
 		size_t bytes, uint32_t *eax)
 {
 	struct acrn_vpic *vpic;
@@ -761,7 +761,7 @@ static int vpic_slave_handler(struct vm *vm, bool in, uint16_t port,
 	return vpic_write(vpic, i8259, port, eax);
 }
 
-static uint32_t vpic_slave_io_read(struct vm *vm, uint16_t addr, size_t width)
+static uint32_t vpic_slave_io_read(struct acrn_vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0U;
 
@@ -772,7 +772,7 @@ static uint32_t vpic_slave_io_read(struct vm *vm, uint16_t addr, size_t width)
 	return val;
 }
 
-static void vpic_slave_io_write(struct vm *vm, uint16_t addr, size_t width,
+static void vpic_slave_io_write(struct acrn_vm *vm, uint16_t addr, size_t width,
 				uint32_t v)
 {
 	uint32_t val = v;
@@ -783,7 +783,7 @@ static void vpic_slave_io_write(struct vm *vm, uint16_t addr, size_t width,
 	}
 }
 
-static int vpic_elc_handler(struct vm *vm, bool in, uint16_t port, size_t bytes,
+static int vpic_elc_handler(struct acrn_vm *vm, bool in, uint16_t port, size_t bytes,
 		uint32_t *eax)
 {
 	struct acrn_vpic *vpic;
@@ -827,7 +827,7 @@ static int vpic_elc_handler(struct vm *vm, bool in, uint16_t port, size_t bytes,
 	return 0;
 }
 
-static uint32_t vpic_elc_io_read(struct vm *vm, uint16_t addr, size_t width)
+static uint32_t vpic_elc_io_read(struct acrn_vm *vm, uint16_t addr, size_t width)
 {
 	uint32_t val = 0U;
 
@@ -837,7 +837,7 @@ static uint32_t vpic_elc_io_read(struct vm *vm, uint16_t addr, size_t width)
 	return val;
 }
 
-static void vpic_elc_io_write(struct vm *vm, uint16_t addr, size_t width,
+static void vpic_elc_io_write(struct acrn_vm *vm, uint16_t addr, size_t width,
 				uint32_t v)
 {
 	uint32_t val = v;
@@ -848,7 +848,7 @@ static void vpic_elc_io_write(struct vm *vm, uint16_t addr, size_t width,
 	}
 }
 
-static void vpic_register_io_handler(struct vm *vm)
+static void vpic_register_io_handler(struct acrn_vm *vm)
 {
 	struct vm_io_range master_range = {
 		.flags = IO_ATTR_RW,
@@ -874,7 +874,7 @@ static void vpic_register_io_handler(struct vm *vm)
 			&vpic_elc_io_read, &vpic_elc_io_write);
 }
 
-void vpic_init(struct vm *vm)
+void vpic_init(struct acrn_vm *vm)
 {
 	struct acrn_vpic *vpic = vm_pic(vm);
 	vpic_register_io_handler(vm);

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -189,7 +189,7 @@ static void vpic_notify_intr(struct acrn_vpic *vpic)
 		 */
 		i8259->intr_raised = true;
 		if (vpic->vm->wire_mode == VPIC_WIRE_INTR) {
-			struct vcpu *vcpu = vcpu_from_vid(vpic->vm, 0U);
+			struct acrn_vcpu *vcpu = vcpu_from_vid(vpic->vm, 0U);
 			vcpu_inject_extint(vcpu);
 		} else {
 			vlapic_set_local_intr(vpic->vm, BROADCAST_CPU_ID, APIC_LVT_LINT0);

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -42,7 +42,7 @@ static uint8_t cmos_get_reg_val(uint8_t addr)
 	return reg;
 }
 
-static uint32_t vrtc_read(struct vm *vm, uint16_t addr, __unused size_t width)
+static uint32_t vrtc_read(struct acrn_vm *vm, uint16_t addr, __unused size_t width)
 {
 	uint8_t reg;
 	uint8_t offset;
@@ -57,7 +57,7 @@ static uint32_t vrtc_read(struct vm *vm, uint16_t addr, __unused size_t width)
 	return reg;
 }
 
-static void vrtc_write(struct vm *vm, uint16_t addr, size_t width,
+static void vrtc_write(struct acrn_vm *vm, uint16_t addr, size_t width,
 			uint32_t value)
 {
 
@@ -69,7 +69,7 @@ static void vrtc_write(struct vm *vm, uint16_t addr, size_t width,
 	}
 }
 
-void vrtc_init(struct vm *vm)
+void vrtc_init(struct acrn_vm *vm)
 {
 	struct vm_io_range range = {
 	.flags = IO_ATTR_RW, .base = CMOS_ADDR_PORT, .len = 2U};

--- a/hypervisor/include/arch/x86/abl_seed_parse.h
+++ b/hypervisor/include/arch/x86/abl_seed_parse.h
@@ -7,6 +7,6 @@
 #ifndef ABL_SEED_PARSE_H_
 #define ABL_SEED_PARSE_H_
 
-bool abl_seed_parse(struct vm *vm, char *cmdline, char *out_arg, uint32_t out_len);
+bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len);
 
 #endif /* ABL_SEED_PARSE_H_ */

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -9,18 +9,18 @@
 
 #include <ptdev.h>
 
-void ptdev_intx_ack(struct vm *vm, uint8_t virt_pin,
+void ptdev_intx_ack(struct acrn_vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
-int ptdev_msix_remap(struct vm *vm, uint16_t virt_bdf,
+int ptdev_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,
 		uint16_t entry_nr, struct ptdev_msi_info *info);
-int ptdev_intx_pin_remap(struct vm *vm, uint8_t virt_pin,
+int ptdev_intx_pin_remap(struct acrn_vm *vm, uint8_t virt_pin,
 		enum ptdev_vpin_source vpin_src);
-int ptdev_add_intx_remapping(struct vm *vm, uint8_t virt_pin, uint8_t phys_pin,
+int ptdev_add_intx_remapping(struct acrn_vm *vm, uint8_t virt_pin, uint8_t phys_pin,
 		bool pic_pin);
-void ptdev_remove_intx_remapping(const struct vm *vm, uint8_t virt_pin, bool pic_pin);
-int ptdev_add_msix_remapping(struct vm *vm, uint16_t virt_bdf,
+void ptdev_remove_intx_remapping(const struct acrn_vm *vm, uint8_t virt_pin, bool pic_pin);
+int ptdev_add_msix_remapping(struct acrn_vm *vm, uint16_t virt_bdf,
 	uint16_t phys_bdf, uint32_t vector_count);
-void ptdev_remove_msix_remapping(const struct vm *vm, uint16_t virt_bdf,
+void ptdev_remove_msix_remapping(const struct acrn_vm *vm, uint16_t virt_bdf,
 		uint32_t vector_count);
 
 #endif /* ASSIGN_H */

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -132,7 +132,7 @@ static inline void cpuid_subleaf(uint32_t leaf, uint32_t subleaf,
 }
 
 int set_vcpuid_entries(struct vm *vm);
-void guest_cpuid(struct vcpu *vcpu,
+void guest_cpuid(struct acrn_vcpu *vcpu,
 			uint32_t *eax, uint32_t *ebx,
 			uint32_t *ecx, uint32_t *edx);
 

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -131,7 +131,7 @@ static inline void cpuid_subleaf(uint32_t leaf, uint32_t subleaf,
 	asm_cpuid(eax, ebx, ecx, edx);
 }
 
-int set_vcpuid_entries(struct vm *vm);
+int set_vcpuid_entries(struct acrn_vm *vm);
 void guest_cpuid(struct acrn_vcpu *vcpu,
 			uint32_t *eax, uint32_t *ebx,
 			uint32_t *ecx, uint32_t *edx);

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -87,7 +87,7 @@ struct e820_mem_params {
 	uint64_t max_ram_blk_size;
 };
 
-int prepare_vm0_memmap_and_e820(struct vm *vm);
+int prepare_vm0_memmap_and_e820(struct acrn_vm *vm);
 uint64_t e820_alloc_low_memory(uint32_t size_arg);
 
 /* Definition for a mem map lookup */
@@ -110,7 +110,7 @@ enum vm_paging_mode {
 /*
  * VM related APIs
  */
-uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
+uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask);
 
 int gva2gpa(struct acrn_vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
 
@@ -142,9 +142,9 @@ void init_msr_emulation(struct acrn_vcpu *vcpu);
 struct run_context;
 int vmx_vmrun(struct run_context *context, int ops, int ibrs);
 
-int general_sw_loader(struct vm *vm);
+int general_sw_loader(struct acrn_vm *vm);
 
-typedef int (*vm_sw_loader_t)(struct vm *vm);
+typedef int (*vm_sw_loader_t)(struct acrn_vm *vm);
 extern vm_sw_loader_t vm_sw_loader;
 /**
  * @brief Data transfering between hypervisor and VM
@@ -170,7 +170,7 @@ extern vm_sw_loader_t vm_sw_loader;
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+int copy_from_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
 /**
  * @brief Copy data from HV address space to VM GPA space
  *
@@ -189,7 +189,7 @@ int copy_from_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
  *   continuous
  * @pre Pointer vm is non-NULL
  */
-int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
+int copy_to_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
 /**
  * @brief Copy data from VM GVA space to HV address space
  *

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -112,9 +112,9 @@ enum vm_paging_mode {
  */
 uint64_t vcpumask2pcpumask(struct vm *vm, uint64_t vdmask);
 
-int gva2gpa(struct vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
+int gva2gpa(struct acrn_vcpu *vcpu, uint64_t gva, uint64_t *gpa, uint32_t *err_code);
 
-enum vm_paging_mode get_vcpu_paging_mode(struct vcpu *vcpu);
+enum vm_paging_mode get_vcpu_paging_mode(struct acrn_vcpu *vcpu);
 
 void init_e820(void);
 void obtain_e820_mem_info(void);
@@ -135,9 +135,9 @@ extern const struct e820_entry e820_default_entries[NUM_E820_ENTRIES];
 extern uint32_t boot_regs[2];
 extern struct e820_mem_params e820_mem;
 
-int rdmsr_vmexit_handler(struct vcpu *vcpu);
-int wrmsr_vmexit_handler(struct vcpu *vcpu);
-void init_msr_emulation(struct vcpu *vcpu);
+int rdmsr_vmexit_handler(struct acrn_vcpu *vcpu);
+int wrmsr_vmexit_handler(struct acrn_vcpu *vcpu);
+void init_msr_emulation(struct acrn_vcpu *vcpu);
 
 struct run_context;
 int vmx_vmrun(struct run_context *context, int ops, int ibrs);
@@ -203,7 +203,7 @@ int copy_to_gpa(struct vm *vm, void *h_ptr, uint64_t gpa, uint32_t size);
  * @param[out] err_code The page fault flags
  * @param[out] fault_addr The GVA address that causes a page fault
  */
-int copy_from_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
+int copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 /**
  * @brief Copy data from HV address space to VM GVA space
@@ -218,7 +218,7 @@ int copy_from_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
  * @param[out] err_code The page fault flags
  * @param[out] fault_addr The GVA address that causes a page fault
  */
-int copy_to_gva(struct vcpu *vcpu, void *h_ptr, uint64_t gva,
+int copy_to_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
 extern struct acrn_vcpu_regs vm0_boot_context;
 /**

--- a/hypervisor/include/arch/x86/guest/guest_pm.h
+++ b/hypervisor/include/arch/x86/guest/guest_pm.h
@@ -7,9 +7,9 @@
 #ifndef GUEST_PM_H
 #define GUEST_PM_H
 
-void vm_setup_cpu_state(struct vm *vm);
-int vm_load_pm_s_state(struct vm *vm);
-int validate_pstate(const struct vm *vm, uint64_t perf_ctl);
-void register_pm1ab_handler(struct vm *vm);
+void vm_setup_cpu_state(struct acrn_vm *vm);
+int vm_load_pm_s_state(struct acrn_vm *vm);
+int validate_pstate(const struct acrn_vm *vm, uint64_t perf_ctl);
+void register_pm1ab_handler(struct acrn_vm *vm);
 
 #endif /* PM_H */

--- a/hypervisor/include/arch/x86/guest/mptable.h
+++ b/hypervisor/include/arch/x86/guest/mptable.h
@@ -26,6 +26,6 @@ struct mptable_info;
 extern struct mptable_info mptable_vm1;
 extern struct mptable_info mptable_vm2;
 
-int mptable_build(struct vm *vm);
+int mptable_build(struct acrn_vm *vm);
 
 #endif /* MPTABLE_H */

--- a/hypervisor/include/arch/x86/guest/ucode.h
+++ b/hypervisor/include/arch/x86/guest/ucode.h
@@ -20,7 +20,7 @@ struct ucode_header {
 	uint32_t	reserved[3];
 };
 
-void acrn_update_ucode(struct vcpu *vcpu, uint64_t v);
+void acrn_update_ucode(struct acrn_vcpu *vcpu, uint64_t v);
 uint64_t get_microcode_version(void);
 
 #endif /* UCODE_H */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -219,13 +219,13 @@ struct acrn_vcpu_arch {
 
 } __aligned(CPU_PAGE_SIZE);
 
-struct vm;
+struct acrn_vm;
 struct acrn_vcpu {
 	/* Architecture specific definitions for this VCPU */
 	struct acrn_vcpu_arch arch;
 	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */
 	uint16_t vcpu_id;	/* virtual identifier for VCPU */
-	struct vm *vm;		/* Reference to the VM this VCPU belongs to */
+	struct acrn_vm *vm;		/* Reference to the VM this VCPU belongs to */
 
 	/* State of this VCPU before suspend */
 	volatile enum vcpu_state prev_state;
@@ -514,7 +514,7 @@ struct acrn_vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
  *
  * @return 0: vcpu created successfully, other values failed.
  */
-int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct acrn_vcpu **rtn_vcpu_handle);
+int create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn_vcpu_handle);
 
 /**
  * @brief run into non-root mode based on vcpu setting
@@ -586,7 +586,7 @@ void schedule_vcpu(struct acrn_vcpu *vcpu);
  * @param[inout] vm pointer to vm data structure
  * @param[in] pcpu_id which the vcpu will be mapped 
  */
-int prepare_vcpu(struct vm *vm, uint16_t pcpu_id);
+int prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id);
 
 void request_vcpu_pre_work(struct acrn_vcpu *vcpu, uint16_t pre_work_id);
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -176,7 +176,7 @@ struct cpu_context {
 	struct ext_context ext_ctx;
 };
 
-struct vcpu_arch {
+struct acrn_vcpu_arch {
 	/* vmcs region for this vcpu, MUST be 4KB-aligned */
 	uint8_t vmcs[CPU_PAGE_SIZE];
 	/* per vcpu lapic */
@@ -222,7 +222,7 @@ struct vcpu_arch {
 struct vm;
 struct acrn_vcpu {
 	/* Architecture specific definitions for this VCPU */
-	struct vcpu_arch arch_vcpu;
+	struct acrn_vcpu_arch arch;
 	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */
 	uint16_t vcpu_id;	/* virtual identifier for VCPU */
 	struct vm *vm;		/* Reference to the VM this VCPU belongs to */
@@ -272,13 +272,13 @@ static inline bool is_vcpu_bsp(const struct acrn_vcpu *vcpu)
 /* do not update Guest RIP for next VM Enter */
 static inline void vcpu_retain_rip(struct acrn_vcpu *vcpu)
 {
-	(vcpu)->arch_vcpu.inst_len = 0U;
+	(vcpu)->arch.inst_len = 0U;
 }
 
 static inline struct acrn_vlapic *
 vcpu_vlapic(struct acrn_vcpu *vcpu)
 {
-	return &(vcpu->arch_vcpu.vlapic);
+	return &(vcpu->arch.vlapic);
 }
 
 /* External Interfaces */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -220,7 +220,7 @@ struct vcpu_arch {
 } __aligned(CPU_PAGE_SIZE);
 
 struct vm;
-struct vcpu {
+struct acrn_vcpu {
 	/* Architecture specific definitions for this VCPU */
 	struct vcpu_arch arch_vcpu;
 	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */
@@ -259,24 +259,24 @@ struct vcpu {
 } __aligned(CPU_PAGE_SIZE);
 
 struct vcpu_dump {
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 	char *str;
 	uint32_t str_max;
 };
 
-static inline bool is_vcpu_bsp(const struct vcpu *vcpu)
+static inline bool is_vcpu_bsp(const struct acrn_vcpu *vcpu)
 {
 	return (vcpu->vcpu_id == BOOT_CPU_ID);
 }
 
 /* do not update Guest RIP for next VM Enter */
-static inline void vcpu_retain_rip(struct vcpu *vcpu)
+static inline void vcpu_retain_rip(struct acrn_vcpu *vcpu)
 {
 	(vcpu)->arch_vcpu.inst_len = 0U;
 }
 
 static inline struct acrn_vlapic *
-vcpu_vlapic(struct vcpu *vcpu)
+vcpu_vlapic(struct acrn_vcpu *vcpu)
 {
 	return &(vcpu->arch_vcpu.vlapic);
 }
@@ -293,7 +293,7 @@ vcpu_vlapic(struct vcpu *vcpu)
  *
  * @return the value of the register.
  */
-uint64_t vcpu_get_gpreg(const struct vcpu *vcpu, uint32_t reg);
+uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg);
 
 /**
  * @brief set vcpu register value
@@ -304,7 +304,7 @@ uint64_t vcpu_get_gpreg(const struct vcpu *vcpu, uint32_t reg);
  * @param[in] reg register of the vcpu
  * @param[in] val the value set the register of the vcpu
  */
-void vcpu_set_gpreg(struct vcpu *vcpu, uint32_t reg, uint64_t val);
+void vcpu_set_gpreg(struct acrn_vcpu *vcpu, uint32_t reg, uint64_t val);
 
 /**
  * @brief get vcpu RIP value
@@ -315,7 +315,7 @@ void vcpu_set_gpreg(struct vcpu *vcpu, uint32_t reg, uint64_t val);
  *
  * @return the value of RIP.
  */
-uint64_t vcpu_get_rip(struct vcpu *vcpu);
+uint64_t vcpu_get_rip(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu RIP value
@@ -325,7 +325,7 @@ uint64_t vcpu_get_rip(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set RIP
  */
-void vcpu_set_rip(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_rip(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get vcpu RSP value
@@ -336,7 +336,7 @@ void vcpu_set_rip(struct vcpu *vcpu, uint64_t val);
  *
  * @return the value of RSP.
  */
-uint64_t vcpu_get_rsp(struct vcpu *vcpu);
+uint64_t vcpu_get_rsp(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu RSP value
@@ -346,7 +346,7 @@ uint64_t vcpu_get_rsp(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set RSP
  */
-void vcpu_set_rsp(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_rsp(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get vcpu EFER value
@@ -357,7 +357,7 @@ void vcpu_set_rsp(struct vcpu *vcpu, uint64_t val);
  *
  * @return the value of EFER.
  */
-uint64_t vcpu_get_efer(struct vcpu *vcpu);
+uint64_t vcpu_get_efer(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu EFER value
@@ -367,7 +367,7 @@ uint64_t vcpu_get_efer(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set EFER
  */
-void vcpu_set_efer(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_efer(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get vcpu RFLAG value
@@ -378,7 +378,7 @@ void vcpu_set_efer(struct vcpu *vcpu, uint64_t val);
  *
  * @return the value of RFLAGS.
  */
-uint64_t vcpu_get_rflags(struct vcpu *vcpu);
+uint64_t vcpu_get_rflags(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu RFLAGS value
@@ -388,7 +388,7 @@ uint64_t vcpu_get_rflags(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set RFLAGS
  */
-void vcpu_set_rflags(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_rflags(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get vcpu CR0 value
@@ -399,7 +399,7 @@ void vcpu_set_rflags(struct vcpu *vcpu, uint64_t val);
  *
  * @return the value of CR0.
  */
-uint64_t vcpu_get_cr0(struct vcpu *vcpu);
+uint64_t vcpu_get_cr0(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu CR0 value
@@ -409,7 +409,7 @@ uint64_t vcpu_get_cr0(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set CR0
  */
-void vcpu_set_cr0(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_cr0(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get vcpu CR2 value
@@ -420,7 +420,7 @@ void vcpu_set_cr0(struct vcpu *vcpu, uint64_t val);
  *
  * @return the value of CR2.
  */
-uint64_t vcpu_get_cr2(struct vcpu *vcpu);
+uint64_t vcpu_get_cr2(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu CR2 value
@@ -430,7 +430,7 @@ uint64_t vcpu_get_cr2(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set CR2
  */
-void vcpu_set_cr2(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_cr2(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get vcpu CR4 value
@@ -441,7 +441,7 @@ void vcpu_set_cr2(struct vcpu *vcpu, uint64_t val);
  *
  * @return the value of CR4.
  */
-uint64_t vcpu_get_cr4(struct vcpu *vcpu);
+uint64_t vcpu_get_cr4(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu CR4 value
@@ -451,10 +451,10 @@ uint64_t vcpu_get_cr4(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] val the value set CR4
  */
-void vcpu_set_cr4(struct vcpu *vcpu, uint64_t val);
+void vcpu_set_cr4(struct acrn_vcpu *vcpu, uint64_t val);
 
-uint64_t vcpu_get_pat_ext(const struct vcpu *vcpu);
-void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
+uint64_t vcpu_get_pat_ext(const struct acrn_vcpu *vcpu);
+void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief set all the vcpu registers
@@ -464,7 +464,7 @@ void vcpu_set_pat_ext(struct vcpu *vcpu, uint64_t val);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] vcpu_regs all the registers' value
  */
-void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
+void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 
 /**
  * @brief reset all the vcpu registers
@@ -473,7 +473,7 @@ void set_vcpu_regs(struct vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  */
-void reset_vcpu_regs(struct vcpu *vcpu);
+void reset_vcpu_regs(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set the vcpu AP entry
@@ -483,24 +483,24 @@ void reset_vcpu_regs(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] entry the entry value for AP
  */
-void set_ap_entry(struct vcpu *vcpu, uint64_t entry);
+void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry);
 
-static inline bool is_long_mode(struct vcpu *vcpu)
+static inline bool is_long_mode(struct acrn_vcpu *vcpu)
 {
 	return (vcpu_get_efer(vcpu) & MSR_IA32_EFER_LMA_BIT) != 0UL;
 }
 
-static inline bool is_paging_enabled(struct vcpu *vcpu)
+static inline bool is_paging_enabled(struct acrn_vcpu *vcpu)
 {
 	return (vcpu_get_cr0(vcpu) & CR0_PG) != 0UL;
 }
 
-static inline bool is_pae(struct vcpu *vcpu)
+static inline bool is_pae(struct acrn_vcpu *vcpu)
 {
 	return (vcpu_get_cr4(vcpu) & CR4_PAE) != 0UL;
 }
 
-struct vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
+struct acrn_vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
 
 /**
  * @brief create a vcpu for the target vm
@@ -514,7 +514,7 @@ struct vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
  *
  * @return 0: vcpu created successfully, other values failed.
  */
-int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle);
+int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct acrn_vcpu **rtn_vcpu_handle);
 
 /**
  * @brief run into non-root mode based on vcpu setting
@@ -527,9 +527,9 @@ int create_vcpu(uint16_t pcpu_id, struct vm *vm, struct vcpu **rtn_vcpu_handle);
  *
  * @return 0: vcpu run successfully, other values failed.
  */
-int run_vcpu(struct vcpu *vcpu);
+int run_vcpu(struct acrn_vcpu *vcpu);
 
-int shutdown_vcpu(struct vcpu *vcpu);
+int shutdown_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief unmap the vcpu with pcpu and free its vlapic
@@ -539,7 +539,7 @@ int shutdown_vcpu(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @pre vcpu != NULL
  */
-void offline_vcpu(struct vcpu *vcpu);
+void offline_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief reset vcpu state and values
@@ -548,7 +548,7 @@ void offline_vcpu(struct vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  */
-void reset_vcpu(struct vcpu *vcpu);
+void reset_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief pause the vcpu and set new state
@@ -558,7 +558,7 @@ void reset_vcpu(struct vcpu *vcpu);
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] new_state the state to set vcpu
  */
-void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state);
+void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state);
 
 /**
  * @brief resume the vcpu
@@ -567,7 +567,7 @@ void pause_vcpu(struct vcpu *vcpu, enum vcpu_state new_state);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  */
-void resume_vcpu(struct vcpu *vcpu);
+void resume_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set the vcpu to running state, then it will be scheculed.
@@ -576,7 +576,7 @@ void resume_vcpu(struct vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  */
-void schedule_vcpu(struct vcpu *vcpu);
+void schedule_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief create a vcpu for the vm and mapped to the pcpu.
@@ -588,7 +588,7 @@ void schedule_vcpu(struct vcpu *vcpu);
  */
 int prepare_vcpu(struct vm *vm, uint16_t pcpu_id);
 
-void request_vcpu_pre_work(struct vcpu *vcpu, uint16_t pre_work_id);
+void request_vcpu_pre_work(struct acrn_vcpu *vcpu, uint16_t pre_work_id);
 
 void vcpu_dumpreg(void *data);
 

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -46,7 +46,7 @@
 #define STATE_BITMAP_SIZE	INT_DIV_ROUNDUP(REDIR_ENTRIES_HW, 64U)
 
 struct acrn_vioapic {
-	struct vm	*vm;
+	struct acrn_vm	*vm;
 	spinlock_t	mtx;
 	uint32_t	id;
 	uint32_t	ioregsel;
@@ -55,7 +55,7 @@ struct acrn_vioapic {
 	uint64_t pin_state[STATE_BITMAP_SIZE];
 };
 
-void    vioapic_init(struct vm *vm);
+void    vioapic_init(struct acrn_vm *vm);
 void	vioapic_cleanup(const struct acrn_vioapic *vioapic);
 void	vioapic_reset(struct acrn_vioapic *vioapic);
 
@@ -79,7 +79,7 @@ void	vioapic_reset(struct acrn_vioapic *vioapic);
  *
  * @return void
  */
-void	vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 
 /**
  * @brief Set vIOAPIC IRQ line status.
@@ -95,12 +95,12 @@ void	vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
  * @pre irq < vioapic_pincount(vm)
  * @return void
  */
-void	vioapic_set_irq_nolock(struct vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irq_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
-uint32_t	vioapic_pincount(const struct vm *vm);
-void	vioapic_process_eoi(struct vm *vm, uint32_t vector);
-void	vioapic_get_rte(struct vm *vm, uint32_t pin, union ioapic_rte *rte);
+uint32_t	vioapic_pincount(const struct acrn_vm *vm);
+void	vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector);
+void	vioapic_get_rte(struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte);
 int		vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 
 #ifdef HV_DEBUG

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -96,7 +96,7 @@ void	vioapic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
  * @return void
  */
 void	vioapic_set_irq_nolock(struct vm *vm, uint32_t irq, uint32_t operation);
-void	vioapic_update_tmr(struct vcpu *vcpu);
+void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
 uint32_t	vioapic_pincount(const struct vm *vm);
 void	vioapic_process_eoi(struct vm *vm, uint32_t vector);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -70,7 +70,7 @@ struct acrn_vlapic {
 	struct vlapic_pir_desc	pir_desc;
 
 	struct vm		*vm;
-	struct vcpu		*vcpu;
+	struct acrn_vcpu		*vcpu;
 
 	uint32_t		esr_pending;
 	int			esr_firing;
@@ -177,16 +177,16 @@ void vlapic_post_intr(uint16_t dest_pcpu_id);
  *
  * @pre vcpu != NULL
  */
-uint64_t apicv_get_pir_desc_paddr(struct vcpu *vcpu);
+uint64_t apicv_get_pir_desc_paddr(struct acrn_vcpu *vcpu);
 
-int vlapic_rdmsr(struct vcpu *vcpu, uint32_t msr, uint64_t *rval);
-int vlapic_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t wval);
+int vlapic_rdmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *rval);
+int vlapic_wrmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t wval);
 
 /*
  * Signals to the LAPIC that an interrupt at 'vector' needs to be generated
  * to the 'cpu', the state is recorded in IRR.
  */
-int vlapic_set_intr(struct vcpu *vcpu, uint32_t vector, bool level);
+int vlapic_set_intr(struct acrn_vcpu *vcpu, uint32_t vector, bool level);
 
 #define	LAPIC_TRIG_LEVEL	true
 #define	LAPIC_TRIG_EDGE		false
@@ -200,7 +200,7 @@ int vlapic_set_intr(struct vcpu *vcpu, uint32_t vector, bool level);
  * @return -EINVAL on error that vector is invalid or vcpu is NULL.
  */
 static inline int
-vlapic_intr_level(struct vcpu *vcpu, uint32_t vector)
+vlapic_intr_level(struct acrn_vcpu *vcpu, uint32_t vector)
 {
 	return vlapic_set_intr(vcpu, vector, LAPIC_TRIG_LEVEL);
 }
@@ -215,7 +215,7 @@ vlapic_intr_level(struct vcpu *vcpu, uint32_t vector)
  * @return -EINVAL on error that vector is invalid or vcpu is NULL.
  */
 static inline int
-vlapic_intr_edge(struct vcpu *vcpu, uint32_t vector)
+vlapic_intr_edge(struct acrn_vcpu *vcpu, uint32_t vector)
 {
 	return vlapic_set_intr(vcpu, vector, LAPIC_TRIG_EDGE);
 }
@@ -265,11 +265,11 @@ void vlapic_set_tmr_one_vec(struct acrn_vlapic *vlapic, uint32_t delmode,
 
 void vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
 uint32_t vlapic_get_apicid(struct acrn_vlapic *vlapic);
-int vlapic_create(struct vcpu *vcpu);
+int vlapic_create(struct acrn_vcpu *vcpu);
 /*
  *  @pre vcpu != NULL
  */
-void vlapic_free(struct vcpu *vcpu);
+void vlapic_free(struct acrn_vcpu *vcpu);
 void vlapic_init(struct acrn_vlapic *vlapic);
 void vlapic_reset(struct acrn_vlapic *vlapic);
 void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs);
@@ -277,10 +277,10 @@ bool vlapic_enabled(const struct acrn_vlapic *vlapic);
 uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);
 void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);
-int apic_access_vmexit_handler(struct vcpu *vcpu);
-int apic_write_vmexit_handler(struct vcpu *vcpu);
-int veoi_vmexit_handler(struct vcpu *vcpu);
-int tpr_below_threshold_vmexit_handler(__unused struct vcpu *vcpu);
+int apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
+int apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
+int veoi_vmexit_handler(struct acrn_vcpu *vcpu);
+int tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
 void calcvdest(struct vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 
 /**

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -69,7 +69,7 @@ struct acrn_vlapic {
 	struct lapic_regs	apic_page;
 	struct vlapic_pir_desc	pir_desc;
 
-	struct vm		*vm;
+	struct acrn_vm		*vm;
 	struct acrn_vcpu		*vcpu;
 
 	uint32_t		esr_pending;
@@ -233,7 +233,7 @@ vlapic_intr_edge(struct acrn_vcpu *vcpu, uint32_t vector)
  *
  * @pre vm != NULL
  */
-int vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id_arg, uint32_t vector);
+int vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vector);
 
 /**
  * @brief Inject MSI to target VM.
@@ -247,9 +247,9 @@ int vlapic_set_local_intr(struct vm *vm, uint16_t vcpu_id_arg, uint32_t vector);
  *
  * @pre vm != NULL
  */
-int vlapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg);
+int vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg);
 
-void vlapic_deliver_intr(struct vm *vm, bool level, uint32_t dest,
+void vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest,
 		bool phys, uint32_t delmode, uint32_t vec, bool rh);
 
 /* Reset the trigger-mode bits for all vectors to be edge-triggered */
@@ -281,7 +281,7 @@ int apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
 int apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int veoi_vmexit_handler(struct acrn_vcpu *vcpu);
 int tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
-void calcvdest(struct vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
+void calcvdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -130,7 +130,7 @@ struct vcpuid_entry {
 	uint32_t padding;
 };
 
-struct vm {
+struct acrn_vm {
 	struct vm_arch arch_vm; /* Reference to this VM's arch information */
 	struct vm_hw_info hw;	/* Reference to this VM's HW information */
 	struct vm_sw_info sw;	/* Reference to SW associated with this VM */
@@ -197,7 +197,7 @@ struct vm_description {
 #endif
 };
 
-static inline bool is_vm0(const struct vm *vm)
+static inline bool is_vm0(const struct acrn_vm *vm)
 {
 	return (vm->vm_id) == 0U;
 }
@@ -205,7 +205,7 @@ static inline bool is_vm0(const struct vm *vm)
 /*
  * @pre vcpu_id < CONFIG_MAX_VCPUS_PER_VM
  */
-static inline struct acrn_vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
+static inline struct acrn_vcpu *vcpu_from_vid(struct acrn_vm *vm, uint16_t vcpu_id)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu;
@@ -218,7 +218,7 @@ static inline struct acrn_vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 	return vcpu;
 }
 
-static inline struct acrn_vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
+static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_id)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu;
@@ -232,7 +232,7 @@ static inline struct acrn_vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
 	return NULL;
 }
 
-static inline struct acrn_vcpu *get_primary_vcpu(struct vm *vm)
+static inline struct acrn_vcpu *get_primary_vcpu(struct acrn_vm *vm)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu;
@@ -247,37 +247,37 @@ static inline struct acrn_vcpu *get_primary_vcpu(struct vm *vm)
 }
 
 static inline struct acrn_vuart*
-vm_vuart(struct vm *vm)
+vm_vuart(struct acrn_vm *vm)
 {
 	return &(vm->vuart);
 }
 
 static inline struct acrn_vpic *
-vm_pic(struct vm *vm)
+vm_pic(struct acrn_vm *vm)
 {
 	return (struct acrn_vpic *)&(vm->arch_vm.vpic);
 }
 
 static inline struct acrn_vioapic *
-vm_ioapic(struct vm *vm)
+vm_ioapic(struct acrn_vm *vm)
 {
 	return (struct acrn_vioapic *)&(vm->arch_vm.vioapic);
 }
 
-int shutdown_vm(struct vm *vm);
-void pause_vm(struct vm *vm);
-void resume_vm(struct vm *vm);
-void resume_vm_from_s3(struct vm *vm, uint32_t wakeup_vec);
-int start_vm(struct vm *vm);
-int reset_vm(struct vm *vm);
-int create_vm(struct vm_description *vm_desc, struct vm **rtn_vm);
+int shutdown_vm(struct acrn_vm *vm);
+void pause_vm(struct acrn_vm *vm);
+void resume_vm(struct acrn_vm *vm);
+void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);
+int start_vm(struct acrn_vm *vm);
+int reset_vm(struct acrn_vm *vm);
+int create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm);
 int prepare_vm(uint16_t pcpu_id);
 
 #ifdef CONFIG_PARTITION_MODE
 const struct vm_description_array *get_vm_desc_base(void);
 #endif
 
-struct vm *get_vm_from_vmid(uint16_t vm_id);
+struct acrn_vm *get_vm_from_vmid(uint16_t vm_id);
 
 #ifdef CONFIG_PARTITION_MODE
 struct vm_description_array {
@@ -291,6 +291,6 @@ struct pcpu_vm_desc_mapping {
 };
 extern const struct pcpu_vm_desc_mapping pcpu_vm_desc_map[];
 
-void vrtc_init(struct vm *vm);
+void vrtc_init(struct acrn_vm *vm);
 #endif
 #endif /* VM_H_ */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -23,7 +23,7 @@ enum vm_privilege_level {
 
 struct vm_hw_info {
 	/* vcpu array of this VM */
-	struct vcpu vcpu_array[CONFIG_MAX_VCPUS_PER_VM];
+	struct acrn_vcpu vcpu_array[CONFIG_MAX_VCPUS_PER_VM];
 	uint16_t created_vcpus;	/* Number of created vcpus */
 	uint64_t gpa_lowtop;    /* top lowmem gpa of this VM */
 } __aligned(CPU_PAGE_SIZE);
@@ -205,10 +205,10 @@ static inline bool is_vm0(const struct vm *vm)
 /*
  * @pre vcpu_id < CONFIG_MAX_VCPUS_PER_VM
  */
-static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
+static inline struct acrn_vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 {
 	uint16_t i;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (vcpu->vcpu_id == vcpu_id) {
@@ -218,10 +218,10 @@ static inline struct vcpu *vcpu_from_vid(struct vm *vm, uint16_t vcpu_id)
 	return vcpu;
 }
 
-static inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
+static inline struct acrn_vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
 {
 	uint16_t i;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (vcpu->pcpu_id == pcpu_id) {
@@ -232,10 +232,10 @@ static inline struct vcpu *vcpu_from_pid(struct vm *vm, uint16_t pcpu_id)
 	return NULL;
 }
 
-static inline struct vcpu *get_primary_vcpu(struct vm *vm)
+static inline struct acrn_vcpu *get_primary_vcpu(struct vm *vm)
 {
 	uint16_t i;
-	struct vcpu *vcpu;
+	struct acrn_vcpu *vcpu;
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (is_vcpu_bsp(vcpu)) {

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -121,12 +121,12 @@ struct i8259_reg_state {
 };
 
 struct acrn_vpic {
-	struct vm		*vm;
+	struct acrn_vm		*vm;
 	spinlock_t	lock;
 	struct i8259_reg_state	i8259[2];
 };
 
-void vpic_init(struct vm *vm);
+void vpic_init(struct acrn_vm *vm);
 
 /**
  * @brief virtual PIC
@@ -145,7 +145,7 @@ void vpic_init(struct vm *vm);
  *
  * @return void
  */
-void vpic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
+void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
@@ -156,7 +156,7 @@ void vpic_set_irq(struct vm *vm, uint32_t irq, uint32_t operation);
  *
  * @return void.
  */
-void vpic_pending_intr(struct vm *vm, uint32_t *vecptr);
+void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
 
 /**
  * @brief Accept virtual interrupt for vPIC.
@@ -168,8 +168,8 @@ void vpic_pending_intr(struct vm *vm, uint32_t *vecptr);
  *
  * @pre vm != NULL
  */
-void vpic_intr_accepted(struct vm *vm, uint32_t vector);
-void vpic_get_irq_trigger(struct vm *vm, uint32_t irq,
+void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector);
+void vpic_get_irq_trigger(struct acrn_vm *vm, uint32_t irq,
 	enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
 

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -13,8 +13,8 @@ extern struct pm_s_state_data host_pm_s_state;
 
 extern uint8_t host_enter_s3_success;
 
-int enter_s3(struct vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
-extern void asm_enter_s3(struct vm *vm, uint32_t pm1a_cnt_val,
+int enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
+extern void asm_enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 		uint32_t pm1b_cnt_val);
 extern void restore_s3_context(void);
 

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -48,14 +48,14 @@ struct vm_io_range {
 };
 
 struct vm_io_handler;
-struct vm;
+struct acrn_vm;
 struct acrn_vcpu;
 
 typedef
-uint32_t (*io_read_fn_t)(struct vm *vm, uint16_t port, size_t size);
+uint32_t (*io_read_fn_t)(struct acrn_vm *vm, uint16_t port, size_t size);
 
 typedef
-void (*io_write_fn_t)(struct vm *vm, uint16_t port, size_t size, uint32_t val);
+void (*io_write_fn_t)(struct acrn_vm *vm, uint16_t port, size_t size, uint32_t val);
 
 /**
  * @brief Describes a single IO handler description entry.
@@ -185,14 +185,14 @@ int32_t pio_instr_vmexit_handler(struct acrn_vcpu *vcpu);
  *
  * @param vm The VM whose I/O bitmaps are to be initialized
  */
-void   setup_io_bitmap(struct vm *vm);
+void   setup_io_bitmap(struct acrn_vm *vm);
 
 /**
  * @brief Free I/O bitmaps and port I/O handlers of \p vm
  *
  * @param vm The VM whose I/O bitmaps and handlers are to be freed
  */
-void   free_io_emulation_resource(struct vm *vm);
+void   free_io_emulation_resource(struct acrn_vm *vm);
 
 /**
  * @brief Allow a VM to access a port I/O range
@@ -204,7 +204,7 @@ void   free_io_emulation_resource(struct vm *vm);
  * @param port_address The start address of the port I/O range
  * @param nbytes The size of the range, in bytes
  */
-void   allow_guest_pio_access(struct vm *vm, uint16_t port_address,
+void   allow_guest_pio_access(struct acrn_vm *vm, uint16_t port_address,
 		uint32_t nbytes);
 
 /**
@@ -215,7 +215,7 @@ void   allow_guest_pio_access(struct vm *vm, uint16_t port_address,
  * @param io_read_fn_ptr The handler for emulating reads from the given range
  * @param io_write_fn_ptr The handler for emulating writes to the given range
  */
-void   register_io_emulation_handler(struct vm *vm, const struct vm_io_range *range,
+void   register_io_emulation_handler(struct acrn_vm *vm, const struct vm_io_range *range,
 		io_read_fn_t io_read_fn_ptr,
 		io_write_fn_t io_write_fn_ptr);
 
@@ -233,7 +233,7 @@ void   register_io_emulation_handler(struct vm *vm, const struct vm_io_range *ra
  * @return 0 - Registration succeeds
  * @return -EINVAL - \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
  */
-int register_mmio_emulation_handler(struct vm *vm,
+int register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
 	uint64_t end, void *handler_private_data);
 
@@ -244,7 +244,7 @@ int register_mmio_emulation_handler(struct vm *vm,
  * @param start The base address of the range the to-be-unregistered handler is for
  * @param end The end of the range (exclusive) the to-be-unregistered handler is for
  */
-void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
+void unregister_mmio_emulation_handler(struct acrn_vm *vm, uint64_t start,
         uint64_t end);
 
 /**

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -49,7 +49,7 @@ struct vm_io_range {
 
 struct vm_io_handler;
 struct vm;
-struct vcpu;
+struct acrn_vcpu;
 
 typedef
 uint32_t (*io_read_fn_t)(struct vm *vm, uint16_t port, size_t size);
@@ -178,7 +178,7 @@ struct mem_io_node {
  *
  * @param vcpu The virtual CPU which triggers the VM exit on I/O instruction
  */
-int32_t pio_instr_vmexit_handler(struct vcpu *vcpu);
+int32_t pio_instr_vmexit_handler(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Initialize the I/O bitmap for \p vm
@@ -259,7 +259,7 @@ void unregister_mmio_emulation_handler(struct vm *vm, uint64_t start,
  * either a previous call to emulate_io() returning 0 or the corresponding VHM
  * request transferring to the COMPLETE state.
  */
-void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req);
+void emulate_mmio_post(const struct acrn_vcpu *vcpu, const struct io_request *io_req);
 
 /**
  * @brief Post-work of VHM requests for MMIO emulation
@@ -271,7 +271,7 @@ void emulate_mmio_post(const struct vcpu *vcpu, const struct io_request *io_req)
  * @remark This function must be called after the VHM request corresponding to
  * \p vcpu being transferred to the COMPLETE state.
  */
-void dm_emulate_mmio_post(struct vcpu *vcpu);
+void dm_emulate_mmio_post(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Emulate \p io_req for \p vcpu
@@ -288,14 +288,14 @@ void dm_emulate_mmio_post(struct vcpu *vcpu);
  * @return -EINVAL - \p io_req has an invalid type.
  * @return Negative on other errors during emulation.
  */
-int32_t emulate_io(struct vcpu *vcpu, struct io_request *io_req);
+int32_t emulate_io(struct acrn_vcpu *vcpu, struct io_request *io_req);
 
 /**
  * @brief General post-work for all kinds of VHM requests for I/O emulation
  *
  * @param vcpu The virtual CPU that triggers the MMIO access
  */
-void emulate_io_post(struct vcpu *vcpu);
+void emulate_io_post(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Deliver \p io_req to SOS and suspend \p vcpu till its completion
@@ -305,7 +305,7 @@ void emulate_io_post(struct vcpu *vcpu);
  *
  * @pre vcpu != NULL && io_req != NULL
  */
-int32_t acrn_insert_request_wait(struct vcpu *vcpu, const struct io_request *io_req);
+int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request *io_req);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -141,7 +141,7 @@ uint32_t irq_to_vector(uint32_t irq);
  *
  * @pre vcpu != NULL
  */
-int vcpu_queue_exception(struct vcpu *vcpu, uint32_t vector, uint32_t err_code);
+int vcpu_queue_exception(struct acrn_vcpu *vcpu, uint32_t vector, uint32_t err_code);
 
 /**
  * @brief Inject external interrupt to guest.
@@ -152,7 +152,7 @@ int vcpu_queue_exception(struct vcpu *vcpu, uint32_t vector, uint32_t err_code);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_extint(struct vcpu *vcpu);
+void vcpu_inject_extint(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Inject NMI to guest.
@@ -163,7 +163,7 @@ void vcpu_inject_extint(struct vcpu *vcpu);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_nmi(struct vcpu *vcpu);
+void vcpu_inject_nmi(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Inject general protection exeception(GP) to guest.
@@ -175,7 +175,7 @@ void vcpu_inject_nmi(struct vcpu *vcpu);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code);
+void vcpu_inject_gp(struct acrn_vcpu *vcpu, uint32_t err_code);
 
 /**
  * @brief Inject page fault exeception(PF) to guest.
@@ -188,7 +188,7 @@ void vcpu_inject_gp(struct vcpu *vcpu, uint32_t err_code);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code);
+void vcpu_inject_pf(struct acrn_vcpu *vcpu, uint64_t addr, uint32_t err_code);
 
 /**
  * @brief Inject invalid opcode exeception(UD) to guest.
@@ -199,7 +199,7 @@ void vcpu_inject_pf(struct vcpu *vcpu, uint64_t addr, uint32_t err_code);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_ud(struct vcpu *vcpu);
+void vcpu_inject_ud(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Inject alignment check exeception(AC) to guest.
@@ -210,7 +210,7 @@ void vcpu_inject_ud(struct vcpu *vcpu);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_ac(struct vcpu *vcpu);
+void vcpu_inject_ac(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Inject stack fault exeception(SS) to guest.
@@ -221,16 +221,16 @@ void vcpu_inject_ac(struct vcpu *vcpu);
  *
  * @pre vcpu != NULL
  */
-void vcpu_inject_ss(struct vcpu *vcpu);
-void vcpu_make_request(struct vcpu *vcpu, uint16_t eventid);
+void vcpu_inject_ss(struct acrn_vcpu *vcpu);
+void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid);
 
 /*
  * @pre vcpu != NULL
  */
-int exception_vmexit_handler(struct vcpu *vcpu);
-int interrupt_window_vmexit_handler(struct vcpu *vcpu);
-int external_interrupt_vmexit_handler(struct vcpu *vcpu);
-int acrn_handle_pending_request(struct vcpu *vcpu);
+int exception_vmexit_handler(struct acrn_vcpu *vcpu);
+int interrupt_window_vmexit_handler(struct acrn_vcpu *vcpu);
+int external_interrupt_vmexit_handler(struct acrn_vcpu *vcpu);
+int acrn_handle_pending_request(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Initialize the interrupt
@@ -241,7 +241,7 @@ int acrn_handle_pending_request(struct vcpu *vcpu);
  */
 void interrupt_init(uint16_t pcpu_id);
 
-void cancel_event_injection(struct vcpu *vcpu);
+void cancel_event_injection(struct acrn_vcpu *vcpu);
 
 #ifdef HV_DEBUG
 /**

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -149,7 +149,7 @@ void flush_vpid_global(void);
  *
  * @return None
  */
-void invept(const struct vcpu *vcpu);
+void invept(const struct acrn_vcpu *vcpu);
 /**
  * @brief Host-physical address continous checking
  *
@@ -302,7 +302,7 @@ void ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
  * @return -EINVAL - fail to handle the EPT violation
  * @return 0 - Success to handle the EPT violation
  */
-int ept_violation_vmexit_handler(struct vcpu *vcpu);
+int ept_violation_vmexit_handler(struct acrn_vcpu *vcpu);
 /**
  * @brief EPT misconfiguration handling
  *
@@ -311,7 +311,7 @@ int ept_violation_vmexit_handler(struct vcpu *vcpu);
  * @return -EINVAL - fail to handle the EPT misconfig
  * @return 0 - Success to handle the EPT misconfig
  */
-int ept_misconfig_vmexit_handler(__unused struct vcpu *vcpu);
+int ept_misconfig_vmexit_handler(__unused struct acrn_vcpu *vcpu);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -160,7 +160,7 @@ void invept(const struct acrn_vcpu *vcpu);
  * @return true - The HPA of the guest memory region is continuous
  * @return false - The HPA of the guest memory region is non-continuous
  */
-bool check_continuous_hpa(struct vm *vm, uint64_t gpa_arg, uint64_t size_arg);
+bool check_continuous_hpa(struct acrn_vm *vm, uint64_t gpa_arg, uint64_t size_arg);
 /**
  *@pre (pml4_page != NULL) && (pg_size != NULL)
  */
@@ -214,7 +214,7 @@ static inline void clflush(volatile void *p)
  *
  * @return None
  */
-void destroy_ept(struct vm *vm);
+void destroy_ept(struct acrn_vm *vm);
 /**
  * @brief Translating from guest-physical address to host-physcial address
  *
@@ -224,7 +224,7 @@ void destroy_ept(struct vm *vm);
  * @return INVALID_HPA - the HPA of parameter gpa is unmapping
  * @return hpa - the HPA of parameter gpa is hpa
  */
-uint64_t gpa2hpa(struct vm *vm, uint64_t gpa);
+uint64_t gpa2hpa(struct acrn_vm *vm, uint64_t gpa);
 /**
  * @brief Translating from guest-physical address to host-physcial address
  *
@@ -236,7 +236,7 @@ uint64_t gpa2hpa(struct vm *vm, uint64_t gpa);
  * @return INVALID_HPA - the HPA of parameter gpa is unmapping
  * @return hpa - the HPA of parameter gpa is hpa
  */
-uint64_t local_gpa2hpa(struct vm *vm, uint64_t gpa, uint32_t *size);
+uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size);
 /**
  * @brief Translating from host-physical address to guest-physical address for VM0
  *
@@ -260,7 +260,7 @@ uint64_t vm0_hpa2gpa(uint64_t hpa);
  *
  * @return None
  */
-void ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
+void ept_mr_add(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t hpa,
 		uint64_t gpa, uint64_t size, uint64_t prot_orig);
 /**
  * @brief Guest-physical memory page access right or memory type updating
@@ -277,7 +277,7 @@ void ept_mr_add(struct vm *vm, uint64_t *pml4_page, uint64_t hpa,
  *
  * @return None
  */
-void ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
+void ept_mr_modify(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size, uint64_t prot_set, uint64_t prot_clr);
 /**
  * @brief Guest-physical memory region unmapping
@@ -292,7 +292,7 @@ void ept_mr_modify(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
  *
  * @pre [gpa,gpa+size) has been mapped into host physical memory region
  */
-void ept_mr_del(struct vm *vm, uint64_t *pml4_page, uint64_t gpa,
+void ept_mr_del(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size);
 /**
  * @brief EPT violation handling

--- a/hypervisor/include/arch/x86/mtrr.h
+++ b/hypervisor/include/arch/x86/mtrr.h
@@ -62,7 +62,7 @@ struct mtrr_state {
  *
  * @return None
  */
-void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value);
+void mtrr_wrmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t value);
 /**
  * @brief Virtual MTRR MSR read
  *
@@ -71,7 +71,7 @@ void mtrr_wrmsr(struct vcpu *vcpu, uint32_t msr, uint64_t value);
  *
  * @return unsigned long integer - The specified virtual MTRR MSR value
  */
-uint64_t mtrr_rdmsr(const struct vcpu *vcpu, uint32_t msr);
+uint64_t mtrr_rdmsr(const struct acrn_vcpu *vcpu, uint32_t msr);
 /**
  * @brief Virtual MTRR initialization
  *
@@ -79,7 +79,7 @@ uint64_t mtrr_rdmsr(const struct vcpu *vcpu, uint32_t msr);
  *
  * @return None
  */
-void init_mtrr(struct vcpu *vcpu);
+void init_mtrr(struct acrn_vcpu *vcpu);
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/multiboot.h
+++ b/hypervisor/include/arch/x86/multiboot.h
@@ -79,5 +79,5 @@ struct multiboot_module {
 };
 
 int parse_hv_cmdline(void);
-int init_vm_boot_info(struct vm *vm);
+int init_vm_boot_info(struct acrn_vm *vm);
 #endif

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -60,6 +60,6 @@ struct memory_ops {
 };
 
 extern const struct memory_ops ppt_mem_ops;
-void init_ept_mem_ops(struct vm *vm);
+void init_ept_mem_ops(struct acrn_vm *vm);
 
 #endif /* PAGE_H */

--- a/hypervisor/include/arch/x86/sbl_seed_parse.h
+++ b/hypervisor/include/arch/x86/sbl_seed_parse.h
@@ -7,6 +7,6 @@
 #ifndef SBL_SEED_PARSE_H_
 #define SBL_SEED_PARSE_H_
 
-bool sbl_seed_parse(struct vm *vm, char *cmdline, char *out_arg, uint32_t out_len);
+bool sbl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len);
 
 #endif /* SBL_SEED_PARSE_H_ */

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -130,7 +130,7 @@ struct trusty_startup_param {
 
 void switch_world(struct acrn_vcpu *vcpu, int next_world);
 bool initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param);
-void destroy_secure_world(struct vm *vm, bool need_clr_mem);
+void destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem);
 void save_sworld_context(struct acrn_vcpu *vcpu);
 void restore_sworld_context(struct acrn_vcpu *vcpu);
 void trusty_set_dseed(const void *dseed, uint8_t dseed_num);

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -128,11 +128,11 @@ struct trusty_startup_param {
 	uint8_t padding[4];
 };
 
-void switch_world(struct vcpu *vcpu, int next_world);
-bool initialize_trusty(struct vcpu *vcpu, uint64_t param);
+void switch_world(struct acrn_vcpu *vcpu, int next_world);
+bool initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param);
 void destroy_secure_world(struct vm *vm, bool need_clr_mem);
-void save_sworld_context(struct vcpu *vcpu);
-void restore_sworld_context(struct vcpu *vcpu);
+void save_sworld_context(struct acrn_vcpu *vcpu);
+void restore_sworld_context(struct acrn_vcpu *vcpu);
 void trusty_set_dseed(const void *dseed, uint8_t dseed_num);
 
 #endif /* TRUSTY_H_ */

--- a/hypervisor/include/arch/x86/vmexit.h
+++ b/hypervisor/include/arch/x86/vmexit.h
@@ -8,14 +8,14 @@
 #define VMEXIT_H_
 
 struct vm_exit_dispatch {
-	int (*handler)(struct vcpu *);
+	int (*handler)(struct acrn_vcpu *);
 	uint32_t need_exit_qualification;
 };
 
-int vmexit_handler(struct vcpu *vcpu);
-int vmcall_vmexit_handler(struct vcpu *vcpu);
-int cpuid_vmexit_handler(struct vcpu *vcpu);
-int cr_access_vmexit_handler(struct vcpu *vcpu);
+int vmexit_handler(struct acrn_vcpu *vcpu);
+int vmcall_vmexit_handler(struct acrn_vcpu *vcpu);
+int cpuid_vmexit_handler(struct acrn_vcpu *vcpu);
+int cr_access_vmexit_handler(struct acrn_vcpu *vcpu);
 extern void vm_exit(void);
 static inline uint64_t
 vm_exit_qualification_bit_mask(uint64_t exit_qual, uint32_t msb, uint32_t lsb)

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -451,22 +451,22 @@ void exec_vmwrite32(uint32_t field, uint32_t value);
 void exec_vmwrite64(uint32_t field_full, uint64_t value);
 #define exec_vmwrite exec_vmwrite64
 
-void init_vmcs(struct vcpu *vcpu);
+void init_vmcs(struct acrn_vcpu *vcpu);
 
 void vmx_off(uint16_t pcpu_id);
 
 void exec_vmclear(void *addr);
 void exec_vmptrld(void *addr);
 
-uint64_t vmx_rdmsr_pat(const struct vcpu *vcpu);
-int vmx_wrmsr_pat(struct vcpu *vcpu, uint64_t value);
+uint64_t vmx_rdmsr_pat(const struct acrn_vcpu *vcpu);
+int vmx_wrmsr_pat(struct acrn_vcpu *vcpu, uint64_t value);
 
-void vmx_write_cr0(struct vcpu *vcpu, uint64_t cr0);
-void vmx_write_cr4(struct vcpu *vcpu, uint64_t cr4);
+void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0);
+void vmx_write_cr4(struct acrn_vcpu *vcpu, uint64_t cr4);
 bool is_vmx_disabled(void);
-void switch_apicv_mode_x2apic(struct vcpu *vcpu);
+void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu);
 
-static inline enum vm_cpu_mode get_vcpu_mode(const struct vcpu *vcpu)
+static inline enum vm_cpu_mode get_vcpu_mode(const struct acrn_vcpu *vcpu)
 {
 	return vcpu->arch_vcpu.cpu_mode;
 }

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -468,7 +468,7 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu);
 
 static inline enum vm_cpu_mode get_vcpu_mode(const struct acrn_vcpu *vcpu)
 {
-	return vcpu->arch_vcpu.cpu_mode;
+	return vcpu->arch.cpu_mode;
 }
 
 static inline bool cpu_has_vmx_unrestricted_guest_cap(void)

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -610,7 +610,7 @@ int init_iommu(void);
  * @remark to reduce boot time & memory cost, a config IOMMU_INIT_BUS_LIMIT, which limit the bus number.
  *
  */
-void init_iommu_vm0_domain(struct vm *vm0);
+void init_iommu_vm0_domain(struct acrn_vm *vm0);
 
 /**
   * @}

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -405,7 +405,7 @@ int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param);
  * @return 0 on success, non-zero on error.
  */
 
-int32_t hcall_world_switch(struct vcpu *vcpu);
+int32_t hcall_world_switch(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Initialize environment for Trusty-OS on a vCPU.
@@ -421,7 +421,7 @@ int32_t hcall_world_switch(struct vcpu *vcpu);
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param);
+int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param);
 
 /**
  * @brief Save/Restore Context of Secure World.
@@ -430,7 +430,7 @@ int32_t hcall_initialize_trusty(struct vcpu *vcpu, uint64_t param);
  *
  * @return 0 on success, non-zero on error.
  */
-int64_t hcall_save_restore_sworld_ctx(struct vcpu *vcpu);
+int64_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu);
 
 /**
  * @}

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -35,7 +35,7 @@ bool is_hypercall_from_ring0(void);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid);
+int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid);
 
 /**
  * @brief Get hypervisor api version
@@ -49,7 +49,7 @@ int32_t hcall_sos_offline_cpu(struct vm *vm, uint64_t lapicid);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_get_api_version(struct vm *vm, uint64_t param);
+int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param);
 
 /**
  * @brief create virtual machine
@@ -65,7 +65,7 @@ int32_t hcall_get_api_version(struct vm *vm, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_create_vm(struct vm *vm, uint64_t param);
+int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param);
 
 /**
  * @brief destroy virtual machine
@@ -134,7 +134,7 @@ int32_t hcall_pause_vm(uint16_t vmid);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_create_vcpu(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief set vcpu regs
@@ -150,7 +150,7 @@ int32_t hcall_create_vcpu(struct vm *vm, uint16_t vmid, uint64_t param);
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief set or clear IRQ line
@@ -166,7 +166,7 @@ int32_t hcall_set_vcpu_regs(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
+int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 				const struct acrn_irqline_ops *ops);
 /**
  * @brief inject MSI interrupt
@@ -181,7 +181,7 @@ int32_t hcall_set_irqline(const struct vm *vm, uint16_t vmid,
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_inject_msi(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_inject_msi(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief set ioreq shared buffer
@@ -197,7 +197,7 @@ int32_t hcall_inject_msi(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_ioreq_buffer(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief notify request done
@@ -223,7 +223,7 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_vm_memory_region(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_set_vm_memory_region(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief setup ept memory mapping for multi regions
@@ -235,7 +235,7 @@ int32_t hcall_set_vm_memory_region(struct vm *vm, uint16_t vmid, uint64_t param)
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param);
+int32_t hcall_set_vm_memory_regions(struct acrn_vm *vm, uint64_t param);
 
 /**
  * @brief change guest memory page write permission
@@ -248,7 +248,7 @@ int32_t hcall_set_vm_memory_regions(struct vm *vm, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_write_protect_page(struct vm *vm, uint16_t vmid, uint64_t wp_gpa);
+int32_t hcall_write_protect_page(struct acrn_vm *vm, uint16_t vmid, uint64_t wp_gpa);
 
 /**
  * @brief translate guest physical address to host physical address
@@ -263,7 +263,7 @@ int32_t hcall_write_protect_page(struct vm *vm, uint16_t vmid, uint64_t wp_gpa);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_gpa_to_hpa(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief Assign one passthrough dev to VM.
@@ -276,7 +276,7 @@ int32_t hcall_gpa_to_hpa(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_assign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief Deassign one passthrough dev from VM.
@@ -289,7 +289,7 @@ int32_t hcall_assign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_deassign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief Set interrupt mapping info of ptdev.
@@ -302,7 +302,7 @@ int32_t hcall_deassign_ptdev(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @brief Clear interrupt mapping info of ptdev.
@@ -315,7 +315,7 @@ int32_t hcall_set_ptdev_intr_info(struct vm *vm, uint16_t vmid, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_reset_ptdev_intr_info(struct vm *vm, uint16_t vmid,
+int32_t hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid,
 	uint64_t param);
 
 /**
@@ -328,7 +328,7 @@ int32_t hcall_reset_ptdev_intr_info(struct vm *vm, uint16_t vmid,
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
+int32_t hcall_setup_sbuf(struct acrn_vm *vm, uint64_t param);
 
 /**
   * @brief Setup the hypervisor NPK log.
@@ -340,7 +340,7 @@ int32_t hcall_setup_sbuf(struct vm *vm, uint64_t param);
   * @pre Pointer vm shall point to VM0
   * @return 0 on success, non-zero on error.
   */
-int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param);
+int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, uint64_t param);
 
 /**
  * @brief Execute profiling operation
@@ -353,7 +353,7 @@ int32_t hcall_setup_hv_npk_log(struct vm *vm, uint64_t param);
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_profiling_ops(struct vm *vm, uint64_t cmd, uint64_t param);
+int32_t hcall_profiling_ops(struct acrn_vm *vm, uint64_t cmd, uint64_t param);
 
 /**
  * @brief Get VCPU Power state.
@@ -366,7 +366,7 @@ int32_t hcall_profiling_ops(struct vm *vm, uint64_t cmd, uint64_t param);
  * @return 0 on success, non-zero on error.
  */
 
-int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param);
+int32_t hcall_get_cpu_pm_state(struct acrn_vm *vm, uint64_t cmd, uint64_t param);
 
 /**
  * @brief Get VCPU a VM's interrupt count data.
@@ -379,7 +379,7 @@ int32_t hcall_get_cpu_pm_state(struct vm *vm, uint64_t cmd, uint64_t param);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_vm_intr_monitor(struct vm *vm, uint16_t vmid, uint64_t param);
+int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
  * @defgroup trusty_hypercall Trusty Hypercalls
@@ -450,7 +450,7 @@ int64_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu);
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_callback_vector(const struct vm *vm, uint64_t param);
+int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param);
 
 /**
  * @}

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -55,7 +55,7 @@ struct ptdev_remapping_info {
 	uint32_t intr_type;
 	union source_id phys_sid;
 	union source_id virt_sid;
-	struct vm *vm;
+	struct acrn_vm *vm;
 	uint32_t active;	/* 1=active, 0=inactive and to free*/
 	uint32_t allocated_pirq;
 	uint32_t polarity; /* 0=active high, 1=active low*/
@@ -72,10 +72,10 @@ extern spinlock_t ptdev_lock;
 
 void ptdev_softirq(uint16_t pcpu_id);
 void ptdev_init(void);
-void ptdev_release_all_entries(const struct vm *vm);
+void ptdev_release_all_entries(const struct acrn_vm *vm);
 
-struct ptdev_remapping_info *ptdev_dequeue_softirq(struct vm *vm);
-struct ptdev_remapping_info *alloc_entry(struct vm *vm,
+struct ptdev_remapping_info *ptdev_dequeue_softirq(struct acrn_vm *vm);
+struct ptdev_remapping_info *alloc_entry(struct acrn_vm *vm,
 		uint32_t intr_type);
 void release_entry(struct ptdev_remapping_info *entry);
 void ptdev_activate_entry(
@@ -87,7 +87,7 @@ void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
 void get_ptdev_info(char *str_arg, size_t str_max);
 #endif /* HV_DEBUG */
 
-uint32_t get_vm_ptdev_intr_data(const struct vm *target_vm, uint64_t *buffer,
+uint32_t get_vm_ptdev_intr_data(const struct acrn_vm *target_vm, uint64_t *buffer,
 	uint32_t buffer_cnt);
 
 #endif /* PTDEV_H */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -14,7 +14,7 @@ struct sched_context {
 	spinlock_t runqueue_lock;
 	struct list_head runqueue;
 	uint64_t flags;
-	struct vcpu *curr_vcpu;
+	struct acrn_vcpu *curr_vcpu;
 	spinlock_t scheduler_lock;
 };
 
@@ -26,18 +26,18 @@ void set_pcpu_used(uint16_t pcpu_id);
 uint16_t allocate_pcpu(void);
 void free_pcpu(uint16_t pcpu_id);
 
-void add_vcpu_to_runqueue(struct vcpu *vcpu);
-void remove_vcpu_from_runqueue(struct vcpu *vcpu);
+void add_vcpu_to_runqueue(struct acrn_vcpu *vcpu);
+void remove_vcpu_from_runqueue(struct acrn_vcpu *vcpu);
 
 void default_idle(void);
 
-void make_reschedule_request(const struct vcpu *vcpu);
+void make_reschedule_request(const struct acrn_vcpu *vcpu);
 int need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
 int need_offline(uint16_t pcpu_id);
 
 void schedule(void);
 
-void vcpu_thread(struct vcpu *vcpu);
+void vcpu_thread(struct acrn_vcpu *vcpu);
 #endif /* SCHEDULE_H */
 

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -11,14 +11,14 @@
 
 #include <profiling_internal.h>
 
-void profiling_vmenter_handler(struct vcpu *vcpu);
-void profiling_vmexit_handler(struct vcpu *vcpu, uint64_t exit_reason);
+void profiling_vmenter_handler(struct acrn_vcpu *vcpu);
+void profiling_vmexit_handler(struct acrn_vcpu *vcpu, uint64_t exit_reason);
 void profiling_setup(void);
 
 #else
 
-static inline void profiling_vmenter_handler(__unused struct vcpu *vcpu) {}
-static inline void profiling_vmexit_handler(__unused struct vcpu *vcpu,
+static inline void profiling_vmenter_handler(__unused struct acrn_vcpu *vcpu) {}
+static inline void profiling_vmexit_handler(__unused struct acrn_vcpu *vcpu,
 	__unused uint64_t exit_reason) {}
 static inline void profiling_setup(void) {}
 

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -22,7 +22,7 @@ static inline void profiling_vmexit_handler(__unused struct acrn_vcpu *vcpu,
 	__unused uint64_t exit_reason) {}
 static inline void profiling_setup(void) {}
 
-static inline int32_t hcall_profiling_ops(__unused struct vm *vm,
+static inline int32_t hcall_profiling_ops(__unused struct acrn_vm *vm,
 	__unused uint64_t cmd, __unused uint64_t param)
 {
 	return -ENODEV;

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -292,14 +292,14 @@ struct profiling_info_wrapper {
 	struct sw_msr_op_info	sw_msr_op_info;
 } __aligned(8);
 
-int32_t profiling_get_version_info(struct vm *vm, uint64_t addr);
-int32_t profiling_get_pcpu_id(struct vm *vm, uint64_t addr);
-int32_t profiling_msr_ops_all_cpus(struct vm *vm, uint64_t addr);
-int32_t profiling_vm_list_info(struct vm *vm, uint64_t addr);
-int32_t profiling_get_control(struct vm *vm, uint64_t addr);
-int32_t profiling_set_control(struct vm *vm, uint64_t addr);
-int32_t profiling_configure_pmi(struct vm *vm, uint64_t addr);
-int32_t profiling_configure_vmsw(struct vm *vm, uint64_t addr);
+int32_t profiling_get_version_info(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_get_pcpu_id(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_msr_ops_all_cpus(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_vm_list_info(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_get_control(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_set_control(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_configure_pmi(struct acrn_vm *vm, uint64_t addr);
+int32_t profiling_configure_vmsw(struct acrn_vm *vm, uint64_t addr);
 void profiling_ipi_handler(void *data);
 
 #endif

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -62,7 +62,7 @@ struct acrn_vuart {
 #endif
 	bool thre_int_pending;	/* THRE interrupt pending */
 	bool active;
-	struct vm *vm;
+	struct acrn_vm *vm;
 	spinlock_t lock;	/* protects all softc elements */
 };
 #ifdef CONFIG_PARTITION_MODE
@@ -70,13 +70,13 @@ extern int8_t vuart_vmid;
 #endif
 #ifdef HV_DEBUG
 #define COM1_IRQ		6U
-void vuart_init(struct vm *vm);
+void vuart_init(struct acrn_vm *vm);
 struct acrn_vuart *vuart_console_active(void);
 void vuart_console_tx_chars(struct acrn_vuart *vu);
 void vuart_console_rx_chars(struct acrn_vuart *vu);
 #else
 #define COM1_IRQ		0xFFU
-static inline void vuart_init(__unused struct vm *vm)
+static inline void vuart_init(__unused struct acrn_vm *vm)
 {
 }
 static inline struct acrn_vuart *vuart_console_active(void)

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -124,8 +124,8 @@ struct pci_addr_info {
 };
 
 struct vpci_ops {
-	int (*init)(struct vm *vm);
-	void (*deinit)(struct vm *vm);
+	int (*init)(struct acrn_vm *vm);
+	void (*deinit)(struct acrn_vm *vm);
 	void (*cfgread)(struct vpci *vpci, union pci_bdf vbdf, uint32_t offset,
 		uint32_t bytes, uint32_t *val);
 	void (*cfgwrite)(struct vpci *vpci, union pci_bdf vbdf, uint32_t offset,
@@ -134,7 +134,7 @@ struct vpci_ops {
 
 
 struct vpci {
-	struct vm *vm;
+	struct acrn_vm *vm;
 	struct pci_addr_info addr_info;
 	struct vpci_ops *ops;
 };
@@ -142,9 +142,9 @@ struct vpci {
 extern struct pci_vdev_ops pci_ops_vdev_hostbridge;
 extern struct pci_vdev_ops pci_ops_vdev_pt;
 
-void vpci_init(struct vm *vm);
-void vpci_cleanup(struct vm *vm);
-void vpci_set_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf);
-void vpci_reset_ptdev_intr_info(struct vm *target_vm, uint16_t vbdf, uint16_t pbdf);
+void vpci_init(struct acrn_vm *vm);
+void vpci_cleanup(struct acrn_vm *vm);
+void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
+void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 
 #endif /* VPCI_H_ */

--- a/hypervisor/include/hypervisor.h
+++ b/hypervisor/include/hypervisor.h
@@ -38,12 +38,12 @@
 
 #ifndef ASSEMBLER
 /* gpa --> hpa -->hva */
-static inline void *gpa2hva(struct vm *vm, uint64_t x)
+static inline void *gpa2hva(struct acrn_vm *vm, uint64_t x)
 {
 	return hpa2hva(gpa2hpa(vm, x));
 }
 
-static inline uint64_t hva2gpa(struct vm *vm, void *x)
+static inline uint64_t hva2gpa(struct acrn_vm *vm, void *x)
 {
 	return (is_vm0(vm)) ? vm0_hpa2gpa(hva2hpa(x)) : INVALID_GPA;
 }


### PR DESCRIPTION
In the hypervisor, some names of data structure type is
identical with variable name in the same scope. This is
a MISRA C  violation.

This patch is to fix these naming MISRA C violation.

Tracked-On: #861