### PR TITLE
doc: add doyxgen alias for easy reST inclusion

### DIFF
--- a/doc/acrn.doxyfile
+++ b/doc/acrn.doxyfile
@@ -238,7 +238,9 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+# Allow for rst directives and advanced functions e.g. grid tables
+ALIASES  = "rst=\verbatim embed:rst:leading-asterisk"
+ALIASES += "endrst=\endverbatim"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
Tracked-on: #1595

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>