### PR TITLE
hv: vPCI needs to handle reset IO port CF9 differently

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -134,6 +134,12 @@ void vpci_init(struct vm *vm)
 	if ((vpci->ops->init != NULL) && (vpci->ops->init(vm) == 0)) {
 		register_io_emulation_handler(vm, &pci_cfg_range,
 			&pci_cfg_io_read, &pci_cfg_io_write);
+		/* This is a tmp solution to avoid sos reboot failure, it need pass-thru IO port CF9 for Reset Control
+		 * register.
+		 */
+		if (is_vm0(vm)) {
+			allow_guest_pio_access(vm, 0xCF9U, 1);
+		}
 	}
 }
 


### PR DESCRIPTION
Currently vpci treats IO port CF9 as a regular PCI CONFIG_ADDRESS port,
so that SOS can't do system reboot through port CF9.

This patch handles port CF9 in this way:
- SOS (vm0): it is allowed to actually access the physical IO port for byte
  accesses.
- UOS (non-vm0) or partitioning guests: any accesses to port CF9 are
  ignored.

Tracked-On: #1568
Signed-off-by: Zide Chen zide.chen@intel.com
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>