### PR TITLE
DM:Check the device file of /dev/vbs_ipu to determine IPU mode

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -5,8 +5,8 @@ kernel_version=$(uname -r | awk -F. '{ printf("%d.%d", $1,$2) }')
 
 ipu_passthrough=0
 
-# this is the temporal solution before IPU is ready on 4.19
-if [ "$kernel_version" = "4.19" ]; then
+# Check the device file of /dev/vbs_ipu to determine the IPU mode
+if [ ! -f "/dev/vbs_ipu" ]; then
 ipu_passthrough=1
 fi
 


### PR DESCRIPTION
The /dev/vbs_ipu is used as the backend driver of IPU mediator on SOS kernel.
If the file of /dev/vbs_ipu exists, it indicates that IPU works in mediator mode.
Other it will fall back to the pass-through mode.

Tracked-on: https://github.com/projectacrn/acrn-hypervisor/issues/1373
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>