### PR TITLE
fix "Casting operation to a pointer"

### DIFF
--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -6,12 +6,13 @@
 
 #include <hypervisor.h>
 
-static void charout(size_t cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
+static void
+charout(size_t cmd, const char *s_arg, uint32_t sz_arg, struct snprint_param *param)
 {
 	const char *s = s_arg;
 	uint32_t sz = sz_arg;
 	/* pointer to an integer to store the number of characters */
-	size_t *nchars = (size_t *)hnd;
+	size_t nchars = param->wrtn;
 	/* working pointer */
 	const char *p = s;
 	size_t len;
@@ -23,30 +24,29 @@ static void charout(size_t cmd, const char *s_arg, uint32_t sz_arg, void *hnd)
 			s += len;
 		}
 
-		*nchars += (s - p);
+		nchars += (s - p);
 	} else {
 		/* fill mode */
-		*nchars += sz;
+		nchars += sz;
 		while (sz != 0U) {
 			console_putc(s);
 			sz--;
 		}
 	}
-
+	param->wrtn = nchars;
 }
 
 void vprintf(const char *fmt, va_list args)
 {
 	/* struct to store all necessary parameters */
 	struct print_param param;
-
-	/* argument fo charout() */
-	size_t nchars = 0;
+	struct snprint_param snparam;
 
 	/* initialize parameters */
+	(void)memset(&snparam, 0U, sizeof(snparam));
 	(void)memset(&param, 0U, sizeof(param));
 	param.emit = charout;
-	param.data = &nchars;
+	param.data = &snparam;
 
 	/* execute the printf() */
 	do_print(fmt, &param, args);

--- a/hypervisor/include/lib/sprintf.h
+++ b/hypervisor/include/lib/sprintf.h
@@ -13,14 +13,24 @@
 /* Command for the emit function: fill output with first character. */
 #define PRINT_CMD_FILL			0x00000001U
 
+/** Structure used to call back emit lived in print_param */
+struct snprint_param {
+	/** The destination buffer. */
+	char *dst;
+	/** The size of the destination buffer. */
+	uint32_t sz;
+	/** Counter for written chars. */
+	uint32_t wrtn;
+};
+
 /* Structure used to parse parameters and variables to subroutines. */
 struct print_param {
 	/* A pointer to the function that is used to emit characters. */
-	void (*emit)(size_t, const char *, uint32_t, void *);
-	/* An opaque pointer that is passed as third argument to the emit
+	void (*emit)(size_t, const char *, uint32_t, struct snprint_param *);
+	/* An opaque pointer that is passed as forth argument to the emit
 	 * function.
 	 */
-	void *data;
+        struct snprint_param *data;
 	/* Contains variables which are recalculated for each argument. */
 	struct {
 		/* A bitfield with the parsed format flags. */

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -47,16 +47,6 @@
 /** The value is interpreted as unsigned. */
 #define PRINT_FLAG_UINT32		0x00000400U
 
-/** Structure used to save (v)snprintf() specific values */
-struct snprint_param {
-	/** The destination buffer. */
-	char *dst;
-	/** The size of the destination buffer. */
-	uint32_t sz;
-	/** Counter for written chars. */
-	uint32_t wrtn;
-};
-
 /** The characters to use for upper case hexadecimal conversion.
  *
  *  Note that this array is 17 bytes long. The first 16 characters
@@ -551,11 +541,10 @@ void do_print(const char *fmt_arg, struct print_param *param,
 
 }
 
-static void charmem(size_t cmd, const char *s_arg, uint32_t sz, void *hnd)
+static void
+charmem(size_t cmd, const char *s_arg, uint32_t sz, struct snprint_param *param)
 {
 	const char *s = s_arg;
-	/* pointer to the snprint parameter list */
-	struct snprint_param *param = (struct snprint_param *) hnd;
 	/* pointer to the destination */
 	char *p = param->dst + param->wrtn;
 	/* characters actually written */


### PR DESCRIPTION
The print_param struct's member emit who is used for callback,
the forth parameter of it is used for transmit the private data
of the "print_param".

The type translation between "void *" and private date broke the
violations.

Use the same type to fix it out.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Xu Anthony <anthony.xu@intel.com>