### PR TITLE
DM: sos_bootargs: split sos_bootargs into multiple lines

### DIFF
--- a/devicemodel/samples/apl-mrb/sos_bootargs_debug.txt
+++ b/devicemodel/samples/apl-mrb/sos_bootargs_debug.txt
@@ -1,1 +1,23 @@
-pci_devices_ignore=(0:18:2) module_blacklist=dwc3_pci console=tty0 console=ttyS2 i915.nuclear_pageflip=1 root=/dev/mmcblk1p1 rw rootwait quiet loglevel=3 no_timer_check consoleblank=0 i915.enable_initial_modeset=1 video=DP-1:d video=DP-2:d i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0x02 hvlog=2M@0x6de00000 reboot_panic=p,w cma=64M@0- memmap=0x400000$0x6da00000 ramoops.mem_address=0x6da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+pci_devices_ignore=(0:18:2)
+module_blacklist=dwc3_pci
+no_timer_check
+console=tty0
+console=ttyS2
+quiet loglevel=3
+consoleblank=0
+root=/dev/mmcblk1p1 rw rootwait
+i915.nuclear_pageflip=1
+i915.enable_initial_modeset=1
+i915.avail_planes_per_pipe=0x01010F
+i915.domain_plane_owners=0x011111110000
+i915.enable_gvt=1
+i915.enable_guc=0x02
+video=DP-1:d
+video=DP-2:d
+hvlog=2M@0x6de00000
+cma=64M@0-
+memmap=0x400000$0x6da00000
+ramoops.mem_address=0x6da00000
+ramoops.mem_size=0x400000
+ramoops.console_size=0x200000
+reboot_panic=p,w

--- a/devicemodel/samples/apl-mrb/sos_bootargs_release.txt
+++ b/devicemodel/samples/apl-mrb/sos_bootargs_release.txt
@@ -1,1 +1,16 @@
-console=tty0 console=ttyS2,115200n8 module_blacklist=dwc3_pci i915.nuclear_pageflip=1 root=/dev/mmcblk1p1 rw rootwait quiet loglevel=3 no_timer_check consoleblank=0 i915.enable_initial_modeset=1 video=DP-1:d video=DP-2:d i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0x02 cma=64M@0-
+module_blacklist=dwc3_pci
+no_timer_check
+console=tty0
+console=ttyS2,115200n8
+quiet loglevel=3
+consoleblank=0
+root=/dev/mmcblk1p1 rw rootwait
+i915.nuclear_pageflip=1
+i915.enable_initial_modeset=1
+i915.avail_planes_per_pipe=0x01010F
+i915.domain_plane_owners=0x011111110000
+i915.enable_gvt=1
+i915.enable_guc=0x02
+video=DP-1:d
+video=DP-2:d
+cma=64M@0-


### PR DESCRIPTION
Difficult to review the changes of sos_bootargs when the args is a single line.
Split sos boot args into multiple lines.

Tracked-On: #1730
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>