### PR TITLE
HV:fix "Recursion in procedure calls found"

### DIFF
--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -434,8 +434,6 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
 		dev_dbg(ACRN_DBG_PIC, "pic pin%hhu: %s, ignored\n",
 			pin, level ? "asserted" : "deasserted");
 	}
-
-	vpic_notify_intr(vpic);
 }
 
 /**
@@ -488,6 +486,7 @@ void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
 		 */
 		break;
 	}
+	vpic_notify_intr(vpic);
 	spinlock_release(&(vpic->lock));
 }
 


### PR DESCRIPTION
Functions shall not call themselves, either directly or indirectly.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
