### PR TITLE
Replace function like macro with inline function

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -579,7 +579,7 @@ int ptdev_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,
 	entry->msi = *info;
 
 	dev_dbg(ACRN_DBG_IRQ, "PCI %x:%x.%x MSI VR[%d] 0x%x->0x%x assigned to vm%d",
-		PCI_BUS(virt_bdf), PCI_SLOT(virt_bdf), PCI_FUNC(virt_bdf), entry_nr,
+		pci_bus(virt_bdf), pci_slot(virt_bdf), pci_func(virt_bdf), entry_nr,
 		info->vmsi_data & 0xFFU, irq_to_vector(entry->allocated_pirq), entry->vm->vm_id);
 END:
 	return 0;

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -748,9 +748,9 @@ static void fault_record_analysis(__unused uint64_t low, uint64_t high)
 	pr_info("%s, Reason: 0x%x, SID: %x.%x.%x @0x%llx",
 		(dma_frcd_up_t(high) != 0U) ? "Read/Atomic" : "Write",
 		dma_frcd_up_fr(high),
-		dma_frcd_up_sid(high) >> 8U,
-		(dma_frcd_up_sid(high) >> 3U) & 0x1fUL,
-		dma_frcd_up_sid(high) & 0x7UL,
+		pci_bus(dma_frcd_up_sid(high)),
+		pci_slot(dma_frcd_up_sid(high)),
+		pci_func(dma_frcd_up_sid(high)),
 		low);
 #if DBG_IOMMU
 	if (iommu_ecap_dt(dmar_uint->ecap)i != 0U) {
@@ -930,13 +930,13 @@ static int add_iommu_device(const struct iommu_domain *domain, uint16_t segment,
 	dmar_uint = device_to_dmaru(segment, bus, devfun);
 	if (dmar_uint == NULL) {
 		pr_err("no dmar unit found for device:0x%x:%x.%x",
-			bus, devfun >> 3U, devfun & 0x7U);
+			bus, pci_slot(devfun), pci_func(devfun));
 		return 1;
 	}
 
 	if (dmar_uint->drhd->ignore) {
 		dev_dbg(ACRN_DBG_IOMMU, "device is ignored :0x%x:%x.%x",
-			bus, devfun >> 3U, devfun & 0x7U);
+			bus, pci_slot(devfun), pci_func(devfun));
 		return 0;
 	}
 
@@ -992,7 +992,7 @@ static int add_iommu_device(const struct iommu_domain *domain, uint16_t segment,
 		pr_err("%s: context entry@0x%llx (Lower:%x) ",
 				__func__, context_entry, context_entry->lower);
 		pr_err("already present for %x:%x.%x",
-				bus, devfun >> 3U, devfun & 0x7U);
+				bus, pci_slot(devfun), pci_func(devfun));
 		return 1;
 	}
 

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -430,9 +430,9 @@ static inline bool dma_frcd_up_priv(uint64_t up_priv)
 	return (((up_priv >> 29U) & 1UL) == 1UL);
 }
 
-static inline uint32_t dma_frcd_up_sid(uint64_t up_sid)
+static inline uint16_t dma_frcd_up_sid(uint64_t up_sid)
 {
-	return ((uint32_t)up_sid & 0xffffU);
+	return ((uint16_t)up_sid & 0xffffU);
 }
 
 #define DMAR_CONTEXT_TRANSLATION_TYPE_TRANSLATED 0x00U

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -49,10 +49,6 @@
 #define PCI_BAR_COUNT         0x6U
 #define PCI_REGMAX            0xFFU
 
-#define PCI_BUS(bdf)          (((bdf) >> 8U) & 0xFFU)
-#define PCI_SLOT(bdf)         (((bdf) & 0xFFU) >> 3U)
-#define PCI_FUNC(bdf)         ((bdf) & 0x7U)
-
 /* I/O ports */
 #define PCI_CONFIG_ADDR       0xCF8U
 #define PCI_CONFIG_DATA       0xCFCU
@@ -157,6 +153,21 @@ static inline bool pci_bar_access(uint32_t offset)
 	} else {
 		return false;
 	}
+}
+
+static inline uint8_t pci_bus(uint16_t bdf)
+{
+	return (uint8_t)((bdf >> 8U) & 0xFFU);
+}
+
+static inline uint8_t pci_slot(uint16_t bdf)
+{
+	return (uint8_t)((bdf >> 3U) & 0x1FU);
+}
+
+static inline uint8_t pci_func(uint16_t bdf)
+{
+	return (uint8_t)(bdf & 0x7U);
 }
 
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);


### PR DESCRIPTION
According to MISRA-C, function like should be replaced with inline function.
And use the predefined inline function for bdf calculation.

Tracked-on: #1747 
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
