### PR TITLE
 improvement for “interrupt storm mitigation”: expose the params setting in DM

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -157,7 +157,9 @@ usage(int code)
 		"       --part_info: guest partition info file path\n"
 		"       --enable_trusty: enable trusty for guest\n"
 		"       --ptdev_no_reset: disable reset check for ptdev\n"
-		"       --debugexit: enable debug exit function\n",
+		"       --debugexit: enable debug exit function\n"
+		"       --intr_monitor: enable interrupt storm monitor\n"
+		"............its params: threshold/s,probe-period(s),delay_time(ms),delay_duration(ms)\n",
 		progname, (int)strlen(progname), "", (int)strlen(progname), "",
 		(int)strlen(progname), "");
 
@@ -701,6 +703,7 @@ enum {
 	CMD_OPT_DEBUGEXIT,
 	CMD_OPT_VMCFG,
 	CMD_OPT_DUMP,
+	CMD_OPT_INTR_MONITOR,
 };
 
 static struct option long_options[] = {
@@ -734,6 +737,7 @@ static struct option long_options[] = {
 	{"ptdev_no_reset",	no_argument,		0,
 		CMD_OPT_PTDEV_NO_RESET},
 	{"debugexit",		no_argument,		0, CMD_OPT_DEBUGEXIT},
+	{"intr_monitor",	required_argument,	0, CMD_OPT_INTR_MONITOR},
 	{0,			0,			0,  0  },
 };
 
@@ -858,6 +862,12 @@ dm_run(int argc, char *argv[])
 			break;
 		case CMD_OPT_DEBUGEXIT:
 			debugexit_enabled = true;
+			break;
+		case CMD_OPT_INTR_MONITOR:
+			if (acrn_parse_intr_monitor(optarg) != 0) {
+				errx(EX_USAGE, "invalid intr-monitor params %s", optarg);
+				exit(1);
+			}
 			break;
 		case 'h':
 			usage(0);

--- a/devicemodel/include/monitor.h
+++ b/devicemodel/include/monitor.h
@@ -33,4 +33,5 @@ int monitor_register_vm_ops(struct monitor_vm_ops *ops, void *arg,
 /* helper functions for vm_ops callback developer */
 unsigned get_wakeup_reason(void);
 int set_wakeup_timer(time_t t);
+int acrn_parse_intr_monitor(const char *opt);
 #endif

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -122,6 +122,9 @@ else
   boot_image_option="--vsbl /usr/share/acrn/bios/VSBL.bin"
 fi
 
+#interrupt storm monitor for pass-through devices, params order: 
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
 
 acrn-dm --help 2>&1 | grep 'GVT args'
 if [ $? == 0 ];then
@@ -143,6 +146,7 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   -s 9,passthru,0/15/1 \
   $boot_cse_option \
   -s 27,passthru,0/1b/0 \
+  $intr_storm_monitor \
   $boot_ipu_option      \
   -i /run/acrn/ioc_$vm_name,0x20 \
   -l com2,/run/acrn/ioc_$vm_name \
@@ -311,6 +315,10 @@ image, it should be kept using 3 as fixed value for Android Guest on Gordon_peak
 ACRN project
 '
 
+#interrupt storm monitor for pass-through devices, params order: 
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
+
 acrn-dm --help 2>&1 | grep 'GVT args'
 if [ $? == 0 ];then
   GVT_args=$3
@@ -334,6 +342,7 @@ fi
    -s 27,passthru,0/1b/0 \
    -s 24,passthru,0/18/0 \
    -s 18,passthru,3/0/0,keep_gsi \
+   $intr_storm_monitor \
    $boot_ipu_option      \
    -i /run/acrn/ioc_$vm_name,0x20 \
    -l com2,/run/acrn/ioc_$vm_name \


### PR DESCRIPTION
expose the params setting in DM; so it is easy for user to adjust the params in launch-uos script.

Tracked-On: #1724
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>