### PR TITLE
HV: Use parameter directly to pass bdf for hcall_assign/deassign_ptdev

### DIFF
--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -270,8 +270,9 @@ int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  *
  * @param vm Pointer to VM data structure
  * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to
- *              physical BDF of the assigning ptdev
+ * @param param the physical BDF of the assigning ptdev
+ *              To keep the compatibility it still can be the guest physical address that
+ *              points to the physical BDF of the assigning ptdev.(Depreciated)
  *
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.
@@ -283,8 +284,9 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  *
  * @param vm Pointer to VM data structure
  * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to
- *              physical BDF of the deassigning ptdev
+ * @param param the physical BDF of the deassigning ptdev
+ *              To keep the compatibility it still can be the guest physical address that
+ *              points to the physical BDF of the deassigning ptdev.(Depreciated)
  *
  * @pre Pointer vm shall point to VM0
  * @return 0 on success, non-zero on error.


### PR DESCRIPTION
The the bdf(bus/dev/func) is used to determine which pass-through device should
be assigned/released. Now the hypervisor parses the corresponding bdf from the guest
physical address when hcall_assign_ptdev/hcall_deassign_ptdev is called.
As it is only uint16_t, it is unnecessary to use the GPA to pass the bdf parameter.
Instead the parameter can be used as the bdf directly.

In order to keep the compatibility, it still can get the bdf by using
copy_from_gpa when SOS passes the parameter based on the buffer. But this will
be depreciated.
This is based on the assumption that the GPA in SOS is greater than 0x10000
when one buffer is allocated to pass the corresponding hypercall parameter.
After the SOS uses the bdf to pass the hypercall paremeter, we can remove the code
that gets the bdf by using copy_from_gpa.

V1->V2: Add some comments for hcall_assign_ptdev/hcall_deassign_ptdev.

Tracked-on: #1751
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>