### PR TITLE
hv: fix 'Expression is not Boolean'

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -392,7 +392,7 @@ static void ptdev_intr_handle_irq(struct acrn_vm *vm,
 		}
 
 		if (trigger_lvl) {
-			if (entry->polarity) {
+			if (entry->polarity != 0U) {
 				vioapic_set_irq(vm, virt_sid->intx_id.pin,
 						GSI_SET_LOW);
 			} else {
@@ -400,7 +400,7 @@ static void ptdev_intr_handle_irq(struct acrn_vm *vm,
 						GSI_SET_HIGH);
 			}
 		} else {
-			if (entry->polarity) {
+			if (entry->polarity != 0U) {
 				vioapic_set_irq(vm, virt_sid->intx_id.pin,
 						GSI_FALLING_PULSE);
 			} else {
@@ -503,7 +503,7 @@ void ptdev_intx_ack(struct acrn_vm *vm, uint8_t virt_pin,
 	 */
 	switch (vpin_src) {
 	case PTDEV_VPIN_IOAPIC:
-		if (entry->polarity) {
+		if (entry->polarity != 0U) {
 			vioapic_set_irq(vm, virt_pin, GSI_SET_HIGH);
 		} else {
 			vioapic_set_irq(vm, virt_pin, GSI_SET_LOW);

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -39,7 +39,7 @@ uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask)
 	struct acrn_vcpu *vcpu;
 
 	for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
-		if (vdmask & (1U << vcpu_id)) {
+		if ((vdmask & (1UL << vcpu_id)) != 0UL) {
 			vcpu = vcpu_from_vid(vm, vcpu_id);
 			bitmap_set_lock(vcpu->pcpu_id, &dmask);
 		}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1039,7 +1039,7 @@ vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest,
 		*dmask = 0UL;
 		amask = vm_active_cpus(vm);
 		for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
-			if (amask & (1U << vcpu_id)) {
+			if ((amask & (1UL << vcpu_id)) != 0UL) {
 				vlapic = vm_lapic_from_vcpu_id(vm, vcpu_id);
 
 				if (is_x2apic_enabled(vlapic)){
@@ -1281,7 +1281,7 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
 	}
 
 	for (vcpu_id = 0U; vcpu_id < vlapic->vm->hw.created_vcpus; vcpu_id++) {
-		if (dmask & (1U << vcpu_id)) {
+		if ((dmask & (1UL << vcpu_id)) != 0UL) {
 			target_vcpu = vcpu_from_vid(vlapic->vm, vcpu_id);
 
 			if (mode == APIC_DELMODE_FIXED) {
@@ -1823,7 +1823,7 @@ vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest, bool phys,
 
 	for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
 		struct acrn_vlapic *vlapic;
-		if (dmask & (1U << vcpu_id)) {
+		if ((dmask & (1UL << vcpu_id)) != 0UL) {
 			target_vcpu = vcpu_from_vid(vm, vcpu_id);
 
 			/* only make request when vlapic enabled */
@@ -1986,7 +1986,7 @@ vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vector)
 	}
 	error = 0;
 	for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
-		if (dmask & (1U << vcpu_id)) {
+		if ((dmask & (1UL << vcpu_id)) != 0UL) {
 			vlapic = vm_lapic_from_vcpu_id(vm, vcpu_id);
 			error = vlapic_trigger_lvt(vlapic, vector);
 			if (error != 0) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -363,7 +363,7 @@ int prepare_vm(uint16_t pcpu_id)
 		for (i = 1U; i < vm_desc->vm_hw_num_cores; i++)
 			prepare_vcpu(vm, vm_desc->vm_pcpu_ids[i]);
 
-		if (!vm_sw_loader) {
+		if (vm_sw_loader == NULL) {
 			vm_sw_loader = general_sw_loader;
 		}
 
@@ -404,7 +404,7 @@ int prepare_vm0(void)
 		}
 	}
 
-	if (!vm_sw_loader) {
+	if (vm_sw_loader == NULL) {
 		vm_sw_loader = general_sw_loader;
 	}
 

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -247,8 +247,8 @@ void init_paging(void)
 	/* align to 2MB */
 	high64_max_ram = (e820_mem.mem_top + PDE_SIZE - 1UL) & PDE_MASK;
 
-	if (high64_max_ram > (CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE) ||
-			high64_max_ram < (1UL << 32U)) {
+	if ((high64_max_ram > (CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)) ||
+			(high64_max_ram < (1UL << 32U))) {
 		panic("Please configure HV_ADDRESS_SPACE correctly!\n");
 	}
 
@@ -262,7 +262,7 @@ void init_paging(void)
 		if (entry->type == E820_TYPE_RAM) {
 			if (entry->baseaddr < (1UL << 32U)) {
 				uint64_t end = entry->baseaddr + entry->length;
-				if (end < (1UL << 32U) && (end > low32_max_ram)) {
+				if ((end < (1UL << 32U)) && (end > low32_max_ram)) {
 					low32_max_ram = end;
 				}
 			}

--- a/hypervisor/boot/sbl/abl_seed_parse.c
+++ b/hypervisor/boot/sbl/abl_seed_parse.c
@@ -142,7 +142,7 @@ bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 	(void)memset((void *)arg, ' ', len);
 
 	/* Convert the param_addr to SOS GPA and copy to caller */
-	if (out_arg) {
+	if (out_arg != NULL) {
 		snprintf(out_arg, out_len, "%s0x%X ",
 			dev_sec_info_arg, hva2gpa(vm, param_addr));
 	}

--- a/hypervisor/boot/sbl/sbl_seed_parse.c
+++ b/hypervisor/boot/sbl/sbl_seed_parse.c
@@ -179,7 +179,7 @@ bool sbl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 	(void)memset((void *)arg, ' ', len);
 
 	/* Convert the param_addr to SOS GPA and copy to caller */
-	if (out_arg) {
+	if (out_arg != NULL) {
 		snprintf(out_arg, out_len, "%s0x%X ",
 			boot_params_arg, hva2gpa(vm, param_addr));
 	}

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -982,7 +982,7 @@ int32_t profiling_set_control(struct acrn_vm *vm, uint64_t addr)
 {
 	uint64_t old_switch;
 	uint64_t new_switch;
-	uint64_t i;
+	uint16_t i;
 
 	struct profiling_control prof_control;
 
@@ -1005,12 +1005,12 @@ int32_t profiling_set_control(struct acrn_vm *vm, uint64_t addr)
 			" old_switch: %llu sep_collection_switch: %llu!",
 			   old_switch, sep_collection_switch);
 
-		for (i = 0U; i < (uint64_t)MAX_SEP_FEATURE_ID; i++) {
-			if ((new_switch ^ old_switch) & (0x1U << i)) {
+		for (i = 0U; i < (uint16_t)MAX_SEP_FEATURE_ID; i++) {
+			if (((new_switch ^ old_switch) & (0x1UL << i)) != 0UL) {
 				switch (i) {
 				case CORE_PMU_SAMPLING:
 				case CORE_PMU_COUNTING:
-					if (new_switch & (0x1U << i)) {
+					if ((new_switch & (0x1UL << i)) != 0UL) {
 						profiling_start_pmu();
 					} else {
 						profiling_stop_pmu();
@@ -1042,8 +1042,8 @@ int32_t profiling_set_control(struct acrn_vm *vm, uint64_t addr)
 		if (socwatch_collection_switch != 0UL) {
 			dev_dbg(ACRN_DBG_PROFILING,
 			"%s: socwatch start collection invoked!", __func__);
-			for (i = 0U; i < (uint64_t)MAX_SOCWATCH_FEATURE_ID; i++) {
-				if (socwatch_collection_switch & (0x1U << i)) {
+			for (i = 0U; i < (uint16_t)MAX_SOCWATCH_FEATURE_ID; i++) {
+				if ((socwatch_collection_switch & (0x1UL << i)) != 0UL) {
 					switch (i) {
 					case SOCWATCH_COMMAND:
 						break;

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -169,7 +169,7 @@ static int vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes
 		/* Writing Message Control field? */
 		if ((offset - vdev->msix.capoff) == PCIR_MSIX_CTRL) {
 			if (((msgctrl ^ val) & PCIM_MSIXCTRL_MSIX_ENABLE) != 0U) {
-				if (val & PCIM_MSIXCTRL_MSIX_ENABLE) {
+				if ((val & PCIM_MSIXCTRL_MSIX_ENABLE) != 0U) {
 					(void)vmsix_remap(vdev, true);
 				} else {
 					(void)vmsix_remap(vdev, false);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -45,7 +45,7 @@ static void pci_cfg_clear_cache(struct pci_addr_info *pi)
 {
 	pi->cached_bdf.value = 0xFFFFU;
 	pi->cached_reg = 0U;
-	pi->cached_enable = 0U;
+	pi->cached_enable = false;
 }
 
 static uint32_t pci_cfg_io_read(struct acrn_vm *vm, uint16_t addr, size_t bytes)
@@ -96,8 +96,7 @@ static void pci_cfg_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes,
 			pi->cached_bdf.bits.f = (uint8_t)(val >> 8U) & PCI_FUNCMAX;
 
 			pi->cached_reg = val & PCI_REGMAX;
-			pi->cached_enable =
-			(val & PCI_CFG_ENABLE) == PCI_CFG_ENABLE;
+			pi->cached_enable = ((val & PCI_CFG_ENABLE) == PCI_CFG_ENABLE);
 		}
 	} else if (is_cfg_data(addr)) {
 		if (pi->cached_enable) {

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -411,7 +411,7 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
 
 	i8259 = &vpic->i8259[pin >> 3U];
 	old_lvl = i8259->pin_state[pin & 0x7U];
-	if (level) {
+	if (level != 0U) {
 		i8259->pin_state[pin & 0x7U] = 1U;
 	} else {
 		i8259->pin_state[pin & 0x7U] = 0U;
@@ -432,7 +432,7 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
 		}
 	} else {
 		dev_dbg(ACRN_DBG_PIC, "pic pin%hhu: %s, ignored\n",
-			pin, level ? "asserted" : "deasserted");
+			pin, (level != 0U) ? "asserted" : "deasserted");
 	}
 
 	vpic_notify_intr(vpic);

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -40,7 +40,6 @@ union source_id {
 struct ptdev_msi_info {
 	uint64_t vmsi_addr; /* virt msi_addr */
 	uint32_t vmsi_data; /* virt msi_data */
-	uint16_t vmsi_ctl; /* virt msi_ctl */
 	uint64_t pmsi_addr; /* phys msi_addr */
 	uint32_t pmsi_data; /* phys msi_data */
 	int is_msix;	/* 0-MSI, 1-MSIX */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -120,7 +120,8 @@ struct pci_vdev {
 
 struct pci_addr_info {
 	union pci_bdf cached_bdf;
-	uint32_t cached_reg, cached_enable;
+	uint32_t cached_reg;
+	bool cached_enable;
 };
 
 struct vpci_ops {


### PR DESCRIPTION
MISRA-C requires that the controlling expression of an if statement or
an iteration-statement shall be Boolean type.

v1 -> v2:
* update the U suffix of constant to let the type of operands
  to bit operations (&) is the same.
* update the type of 'i' from uint64_t to uint16_t in
  'profiling_set_control' since it is limited by phys_cpu_num,
  which is uint16_t.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>