### PR TITLE
hv: hypercall: remove hcall_set_vm_memory_region

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -106,11 +106,6 @@ int vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 			(uint16_t)param2);
 		break;
 
-	case HC_VM_SET_MEMORY_REGION:
-		/* param1: vmid */
-		ret = hcall_set_vm_memory_region(vm, (uint16_t)param1, param2);
-		break;
-
 	case HC_VM_SET_MEMORY_REGIONS:
 		ret = hcall_set_vm_memory_regions(vm, param1);
 		break;

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -213,19 +213,6 @@ int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, uint16_t vmid, uint64_t param
 int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id);
 
 /**
- * @brief setup ept memory mapping
- *
- * @param vm Pointer to VM data structure
- * @param vmid ID of the VM
- * @param param guest physical address. This gpa points to
- *              struct vm_set_memmap
- *
- * @pre Pointer vm shall point to VM0
- * @return 0 on success, non-zero on error.
- */
-int32_t hcall_set_vm_memory_region(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
-
-/**
  * @brief setup ept memory mapping for multi regions
  *
  * @param vm Pointer to VM data structure

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -52,7 +52,6 @@
 
 /* Guest memory management */
 #define HC_ID_MEM_BASE              0x40UL
-#define HC_VM_SET_MEMORY_REGION     BASE_HC_ID(HC_ID, HC_ID_MEM_BASE + 0x00UL)
 #define HC_VM_GPA2HPA               BASE_HC_ID(HC_ID, HC_ID_MEM_BASE + 0x01UL)
 #define HC_VM_SET_MEMORY_REGIONS    BASE_HC_ID(HC_ID, HC_ID_MEM_BASE + 0x02UL)
 #define HC_VM_WRITE_PROTECT_PAGE    BASE_HC_ID(HC_ID, HC_ID_MEM_BASE + 0x03UL)


### PR DESCRIPTION
Since it's discarded.

Tracked-On: #1124
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>