### PR TITLE
DM: Fix the typo error in checking the /dev/vbs_ipu file

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -6,7 +6,7 @@ kernel_version=$(uname -r | awk -F. '{ printf("%d.%d", $1,$2) }')
 ipu_passthrough=0
 
 # Check the device file of /dev/vbs_ipu to determine the IPU mode
-if [ ! -f "/dev/vbs_ipu" ]; then
+if [ ! -e "/dev/vbs_ipu" ]; then
 ipu_passthrough=1
 fi
 


### PR DESCRIPTION
The /dev/vbs_ipu is used by the backend driver of IPU mediator on SOS kernel
If the file of /dev/vbs_ipu exists, it indicates that IPU works in mediator mode.
Other it will fall back to the pass-through mode.
But the commit 969f7cf071 doesn't check the file of /dev/vbs_ipu correctly.
It should be -e instead of -f.

Tracked-on: https://github.com/projectacrn/acrn-hypervisor/issues/1373
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: Wu, BinBin <binbin.wu@intel.com>