### PR TITLE
hv: fix branch addressing syntax warning

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -58,7 +58,7 @@ static uint64_t start_tsc __attribute__((__section__(".bss_noinit")));
 {                                                                       \
 	asm volatile ("movq %0, %%rsp\n"                                \
 			"pushq %1\n"                                    \
-			"call %2\n"                                     \
+			"call *%2\n"                                    \
 			 :                                              \
 			 : "r"(rsp), "rm"(SP_BOTTOM_MAGIC), "a"(to));   \
 }

--- a/hypervisor/arch/x86/trampoline.S
+++ b/hypervisor/arch/x86/trampoline.S
@@ -165,7 +165,7 @@ trampoline_start64:
 
     /* Jump to C entry */
     movq    main_entry(%rip), %rax
-    jmp     %rax
+    jmp     *%rax
 
 
 /* main entry */


### PR DESCRIPTION
Branch addressing using registers or memory operands must be prefixed by
a '*' in AT&T ASM language.

This change is to fix these warnings:

arch/x86/cpu.c:409: Warning: indirect call without `*'
arch/x86/cpu.c:553: Warning: indirect call without `*'
arch/x86/trampoline.S:168: Warning: indirect jmp without `*'

Ref: https://csiflabs.cs.ucdavis.edu/~ssdavis/50/att-syntax.htm
Tracked-On: #1764
Signed-off-by: Xinyun Liu <xinyun.liu@intel.com>
Reviewed-By: Yin Fengwei <fengwei.yin@intel.com>