### PR TITLE
hv:Replace dynamic memory with static for MMIO

### DIFF
--- a/doc/developer-guides/hld/hv-io-emulation.rst
+++ b/doc/developer-guides/hld/hv-io-emulation.rst
@@ -322,9 +322,6 @@ I/O bitmaps and register or unregister I/O handlers:
 .. doxygenfunction:: register_mmio_emulation_handler
    :project: Project ACRN
 
-.. doxygenfunction:: unregister_mmio_emulation_handler
-   :project: Project ACRN
-
 I/O Emulation
 =============
 

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -86,6 +86,11 @@ config MAX_PCPU_NUM
 	range 1 8
 	default 8
 
+config MAX_EMULATED_MMIO_REGIONS
+	int "Maximum number of emulated mmio regions"
+	range 0 128
+	default 16
+
 config MAX_IOMMU_NUM
 	int "Maximum number of IOMMU devices"
 	range 1 2

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -80,9 +80,8 @@ int create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm)
 	/* Map Virtual Machine to its VM Description */
 	vm->vm_desc = vm_desc;
 #endif
-	/* Init mmio list */
-	INIT_LIST_HEAD(&vm->mmio_list);
 	vm->hw.created_vcpus = 0U;
+	vm->emul_mmio_regions = 0U;
 
 	/* gpa_lowtop are used for system start up */
 	vm->hw.gpa_lowtop = 0UL;
@@ -173,8 +172,6 @@ int create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm)
 
 err:
 
-	vioapic_cleanup(vm_ioapic(vm));
-
 	if (vm->arch_vm.nworld_eptp != NULL) {
 		(void)memset(vm->arch_vm.nworld_eptp, 0U, CPU_PAGE_SIZE);
 	}
@@ -204,9 +201,6 @@ int shutdown_vm(struct acrn_vm *vm)
 	}
 
 	ptdev_release_all_entries(vm);
-
-	/* cleanup vioapic */
-	vioapic_cleanup(vm_ioapic(vm));
 
 	/* Free EPT allocated resources assigned to VM */
 	destroy_ept(vm);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -523,14 +523,6 @@ vioapic_init(struct acrn_vm *vm)
 			vm);
 }
 
-void
-vioapic_cleanup(const struct acrn_vioapic *vioapic)
-{
-	unregister_mmio_emulation_handler(vioapic->vm,
-		(uint64_t)VIOAPIC_BASE,
-		(uint64_t)VIOAPIC_BASE + VIOAPIC_SIZE);
-}
-
 uint32_t
 vioapic_pincount(const struct acrn_vm *vm)
 {

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -387,11 +387,7 @@ static int vmsix_init(struct pci_vdev *vdev)
 
 static int vmsix_deinit(struct pci_vdev *vdev)
 {
-	if (vdev->msix.intercepted_size != 0UL) {
-		unregister_mmio_emulation_handler(vdev->vpci->vm, vdev->msix.intercepted_gpa,
-			vdev->msix.intercepted_gpa + vdev->msix.intercepted_size);
-		vdev->msix.intercepted_size = 0U;
-	}
+	vdev->msix.intercepted_size = 0U;
 
 	if (vdev->msix.table_count != 0U) {
 		ptdev_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, vdev->msix.table_count);

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -56,7 +56,6 @@ struct acrn_vioapic {
 };
 
 void    vioapic_init(struct acrn_vm *vm);
-void	vioapic_cleanup(const struct acrn_vioapic *vioapic);
 void	vioapic_reset(struct acrn_vioapic *vioapic);
 
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -134,9 +134,8 @@ struct acrn_vm {
 	struct iommu_domain *iommu;	/* iommu domain of this VM */
 	spinlock_t spinlock;	/* Spin-lock used to protect VM modifications */
 
-	struct list_head mmio_list; /* list for mmio. This list is not updated
-				     * when vm is active. So no lock needed
-				     */
+	uint16_t emul_mmio_regions; /* Number of emulated mmio regions */
+	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
 
 	unsigned char GUID[16];
 	struct secure_world_control sworld_control;

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -228,16 +228,6 @@ int register_mmio_emulation_handler(struct acrn_vm *vm,
 	uint64_t end, void *handler_private_data);
 
 /**
- * @brief Unregister a MMIO handler
- *
- * @param vm The VM from which MMIO handlers are unregistered
- * @param start The base address of the range the to-be-unregistered handler is for
- * @param end The end of the range (exclusive) the to-be-unregistered handler is for
- */
-void unregister_mmio_emulation_handler(struct acrn_vm *vm, uint64_t start,
-        uint64_t end);
-
-/**
  * @brief General post-work for MMIO emulation
  *
  * @param vcpu The virtual CPU that triggers the MMIO access


### PR DESCRIPTION
-- Config MAX_EMULATED_MMIO_REGIONS 16 in Kconfig
-- Add emulated mmio array and emulated mmio regions
   in vm structure
-- Remove mmio list in vm structure
-- Remove unregister_mmio_emulation_handler and
   vioapic_cleanup APIs

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>