### PR TITLE
hv: fix MISRA-C violations in dm/vpci

### DIFF
--- a/hypervisor/dm/hw/pci.c
+++ b/hypervisor/dm/hw/pci.c
@@ -54,18 +54,18 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes)
 	addr = pci_pdev_calc_address(bdf, offset);
 
 	/* Write address to ADDRESS register */
-	pio_write32(addr, PCI_CONFIG_ADDR);
+	pio_write32(addr, (uint16_t)PCI_CONFIG_ADDR);
 
 	/* Read result from DATA register */
 	switch (bytes) {
 	case 1U:
-		val = (uint32_t)pio_read8(PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
+		val = (uint32_t)pio_read8((uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
 		break;
 	case 2U:
-		val = (uint32_t)pio_read16(PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
+		val = (uint32_t)pio_read16((uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
 		break;
 	default:
-		val = pio_read32(PCI_CONFIG_DATA);
+		val = pio_read32((uint16_t)PCI_CONFIG_DATA);
 		break;
 	}
 	spinlock_release(&pci_device_lock);
@@ -82,18 +82,18 @@ void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes,	uint
 	addr = pci_pdev_calc_address(bdf, offset);
 
 	/* Write address to ADDRESS register */
-	pio_write32(addr, PCI_CONFIG_ADDR);
+	pio_write32(addr, (uint16_t)PCI_CONFIG_ADDR);
 
 	/* Write value to DATA register */
 	switch (bytes) {
 	case 1U:
-		pio_write8((uint8_t)val, PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
+		pio_write8((uint8_t)val, (uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
 		break;
 	case 2U:
-		pio_write16((uint16_t)val, PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
+		pio_write16((uint16_t)val, (uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
 		break;
 	default:
-		pio_write32(val, PCI_CONFIG_DATA);
+		pio_write32(val, (uint16_t)PCI_CONFIG_DATA);
 		break;
 	}
 	spinlock_release(&pci_device_lock);

--- a/hypervisor/dm/vpci/core.c
+++ b/hypervisor/dm/vpci/core.c
@@ -30,7 +30,7 @@
 #include <hypervisor.h>
 #include "pci_priv.h"
 
-inline uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
+uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
 {
 	uint32_t val;
 
@@ -49,7 +49,7 @@ inline uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev, uint32_t offset, uint32
 	return val;
 }
 
-inline void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	switch (bytes) {
 	case 1U:

--- a/hypervisor/dm/vpci/core.c
+++ b/hypervisor/dm/vpci/core.c
@@ -53,10 +53,10 @@ inline void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t 
 {
 	switch (bytes) {
 	case 1U:
-		pci_vdev_write_cfg_u8(vdev, offset, val);
+		pci_vdev_write_cfg_u8(vdev, offset, (uint8_t)val);
 		break;
 	case 2U:
-		pci_vdev_write_cfg_u16(vdev, offset, val);
+		pci_vdev_write_cfg_u16(vdev, offset, (uint16_t)val);
 		break;
 	default:
 		pci_vdev_write_cfg_u32(vdev, offset, val);

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -40,46 +40,46 @@
 static int vdev_hostbridge_init(struct pci_vdev *vdev)
 {
 	/* PCI config space */
-	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, 0x8086U);
-	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, 0x5af0U);
+	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
+	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x5af0U);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, 0xbU);
+	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xbU);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, PCIM_HDRTYPE_NORMAL
+	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)PCIM_HDRTYPE_NORMAL
 		| PCIM_MFDEV);
-	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, PCIC_BRIDGE);
-	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, PCIS_BRIDGE_HOST);
+	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
+	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_HOST);
 
-	pci_vdev_write_cfg_u8(vdev, 0x34U, 0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0x3cU, 0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0x48U, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0x4aU, 0xd1U);
-	pci_vdev_write_cfg_u8(vdev, 0x4bU, 0xfeU);
-	pci_vdev_write_cfg_u8(vdev, 0x50U, 0xc1U);
-	pci_vdev_write_cfg_u8(vdev, 0x51U, 0x2U);
-	pci_vdev_write_cfg_u8(vdev, 0x54U, 0x33U);
-	pci_vdev_write_cfg_u8(vdev, 0x58U, 0x7U);
-	pci_vdev_write_cfg_u8(vdev, 0x5aU, 0xf0U);
-	pci_vdev_write_cfg_u8(vdev, 0x5bU, 0x7fU);
-	pci_vdev_write_cfg_u8(vdev, 0x60U, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0x63U, 0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0xabU, 0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xacU, 0x2U);
-	pci_vdev_write_cfg_u8(vdev, 0xb0U, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xb3U, 0x7cU);
-	pci_vdev_write_cfg_u8(vdev, 0xb4U, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xb6U, 0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xb7U, 0x7bU);
-	pci_vdev_write_cfg_u8(vdev, 0xb8U, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xbbU, 0x7bU);
-	pci_vdev_write_cfg_u8(vdev, 0xbcU, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xbfU, 0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xe0U, 0x9U);
-	pci_vdev_write_cfg_u8(vdev, 0xe2U, 0xcU);
-	pci_vdev_write_cfg_u8(vdev, 0xe3U, 0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xf5U, 0xfU);
-	pci_vdev_write_cfg_u8(vdev, 0xf6U, 0x1cU);
-	pci_vdev_write_cfg_u8(vdev, 0xf7U, 0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x34U, (uint8_t)0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0x3cU, (uint8_t)0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0x48U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x4aU, (uint8_t)0xd1U);
+	pci_vdev_write_cfg_u8(vdev, 0x4bU, (uint8_t)0xfeU);
+	pci_vdev_write_cfg_u8(vdev, 0x50U, (uint8_t)0xc1U);
+	pci_vdev_write_cfg_u8(vdev, 0x51U, (uint8_t)0x2U);
+	pci_vdev_write_cfg_u8(vdev, 0x54U, (uint8_t)0x33U);
+	pci_vdev_write_cfg_u8(vdev, 0x58U, (uint8_t)0x7U);
+	pci_vdev_write_cfg_u8(vdev, 0x5aU, (uint8_t)0xf0U);
+	pci_vdev_write_cfg_u8(vdev, 0x5bU, (uint8_t)0x7fU);
+	pci_vdev_write_cfg_u8(vdev, 0x60U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x63U, (uint8_t)0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0xabU, (uint8_t)0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xacU, (uint8_t)0x2U);
+	pci_vdev_write_cfg_u8(vdev, 0xb0U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xb3U, (uint8_t)0x7cU);
+	pci_vdev_write_cfg_u8(vdev, 0xb4U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xb6U, (uint8_t)0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xb7U, (uint8_t)0x7bU);
+	pci_vdev_write_cfg_u8(vdev, 0xb8U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xbbU, (uint8_t)0x7bU);
+	pci_vdev_write_cfg_u8(vdev, 0xbcU, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xbfU, (uint8_t)0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xe0U, (uint8_t)0x9U);
+	pci_vdev_write_cfg_u8(vdev, 0xe2U, (uint8_t)0xcU);
+	pci_vdev_write_cfg_u8(vdev, 0xe3U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
+	pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
+	pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
 
 	return 0;
 }

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -121,7 +121,7 @@ static int vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 struct pci_vdev_ops pci_ops_vdev_hostbridge = {
 	.init = vdev_hostbridge_init,
 	.deinit = vdev_hostbridge_deinit,
-	.cfgread = vdev_hostbridge_cfgread,
 	.cfgwrite = vdev_hostbridge_cfgwrite,
+	.cfgread = vdev_hostbridge_cfgread,
 };
 

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -223,7 +223,6 @@ static int vmsi_deinit(struct pci_vdev *vdev)
 }
 
 struct pci_vdev_ops pci_ops_vdev_msi = {
-	.init = NULL,
 	.deinit = vmsi_deinit,
 	.cfgwrite = vmsi_cfgwrite,
 	.cfgread = vmsi_cfgread,

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -216,7 +216,7 @@ void populate_msi_struct(struct pci_vdev *vdev)
 static int vmsi_deinit(struct pci_vdev *vdev)
 {
 	if (vdev->msi.capoff != 0U) {
-		ptdev_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1);
+		ptdev_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);
 	}
 
 	return 0;

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -242,14 +242,14 @@ static int vmsix_table_mmio_access_handler(struct io_request *io_req, void *hand
 {
 	struct mmio_request *mmio = &io_req->reqs.mmio;
 	struct pci_vdev *vdev;
-	uint32_t offset;
+	uint64_t offset;
 	uint64_t hva;
 
 	vdev = (struct pci_vdev *)handler_private_data;
-	offset = (uint32_t)(mmio->address - vdev->msix.mmio_gpa);
+	offset = mmio->address - vdev->msix.mmio_gpa;
 
-	if (msixtable_access(vdev, offset)) {
-		vmsix_table_rw(vdev, mmio, offset);
+	if (msixtable_access(vdev, (uint32_t)offset)) {
+		vmsix_table_rw(vdev, mmio, (uint32_t)offset);
 	} else {
 		hva = vdev->msix.mmio_hva + offset;
 

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -63,7 +63,7 @@ static int partition_mode_vpci_init(struct acrn_vm *vm)
 		vdev->vpci = vpci;
 
 		if ((vdev->ops != NULL) && (vdev->ops->init != NULL)) {
-			if (vdev->ops->init(vdev) != 0U) {
+			if (vdev->ops->init(vdev) != 0) {
 				pr_err("%s() failed at PCI device (bdf %x)!", __func__,
 					vdev->vbdf);
 			}
@@ -84,7 +84,7 @@ static void partition_mode_vpci_deinit(struct acrn_vm *vm)
 	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
 		vdev = &vdev_array->vpci_vdev_list[i];
 		if ((vdev->ops != NULL) && (vdev->ops->deinit != NULL)) {
-			if (vdev->ops->deinit(vdev) != 0U) {
+			if (vdev->ops->deinit(vdev) != 0) {
 				pr_err("vdev->ops->deinit failed!");
 			}
 		}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -198,7 +198,7 @@ static int vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 struct pci_vdev_ops pci_ops_vdev_pt = {
 	.init = vdev_pt_init,
 	.deinit = vdev_pt_deinit,
-	.cfgread = vdev_pt_cfgread,
 	.cfgwrite = vdev_pt_cfgwrite,
+	.cfgread = vdev_pt_cfgread,
 };
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -41,7 +41,7 @@ static int vdev_pt_init_validate(struct pci_vdev *vdev)
 {
 	uint32_t idx;
 
-	for (idx = 0; idx < (uint32_t)PCI_BAR_COUNT; idx++) {
+	for (idx = 0U; idx < PCI_BAR_COUNT; idx++) {
 		if ((vdev->bar[idx].base != 0x0UL)
 			|| ((vdev->bar[idx].size & 0xFFFUL) != 0x0UL)
 			|| ((vdev->bar[idx].type != PCIBAR_MEM32)

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -75,10 +75,10 @@ static int vdev_pt_init(struct pci_vdev *vdev)
 			hva2hpa(vm->arch_vm.nworld_eptp), 48U);
 	}
 
-	ret = assign_iommu_device(vm->iommu, vdev->pdev.bdf.bits.b,
+	ret = assign_iommu_device(vm->iommu, (uint8_t)vdev->pdev.bdf.bits.b,
 		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
 
-	pci_command = pci_pdev_read_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U);
+	pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U);
 	/* Disable INTX */
 	pci_command |= 0x400U;
 	pci_pdev_write_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U, pci_command);
@@ -91,7 +91,7 @@ static int vdev_pt_deinit(struct pci_vdev *vdev)
 	int ret;
 	struct acrn_vm *vm = vdev->vpci->vm;
 
-	ret = unassign_iommu_device(vm->iommu, vdev->pdev.bdf.bits.b,
+	ret = unassign_iommu_device(vm->iommu, (uint8_t)vdev->pdev.bdf.bits.b,
 		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
 
 	return ret;

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -137,7 +137,7 @@ void vpci_init(struct acrn_vm *vm)
 		 * register.
 		 */
 		if (is_vm0(vm)) {
-			allow_guest_pio_access(vm, 0xCF9U, 1);
+			allow_guest_pio_access(vm, (uint16_t)0xCF9U, 1U);
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -91,10 +91,7 @@ static void pci_cfg_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes,
 	if (is_cfg_addr(addr)) {
 		/* TODO: handling the non 4 bytes access */
 		if (bytes == 4U) {
-			pi->cached_bdf.bits.b = (uint8_t)(val >> 16U) & PCI_BUSMAX;
-			pi->cached_bdf.bits.d = (uint8_t)(val >> 11U) & PCI_SLOTMAX;
-			pi->cached_bdf.bits.f = (uint8_t)(val >> 8U) & PCI_FUNCMAX;
-
+			pi->cached_bdf.value = (uint16_t)(val >> 8U);
 			pi->cached_reg = val & PCI_REGMAX;
 			pi->cached_enable = ((val & PCI_CFG_ENABLE) == PCI_CFG_ENABLE);
 		}


### PR DESCRIPTION
This patch series fixes all MISRA-C violations in dm/vpci except for two
instances found from runtest-tailored.sh. 

msi.c: 227   Function pointer is of wrong type. : No. of formal parameters differ;
pci_ops_vdev_msi.deinit: 1, vmsi_cfgwrite: 4
MISRA-C:1998 105

msi.c: 228  Function pointer is of wrong type. : Types of parameter 4 differ;
pci_ops_vdev_msi.cfgwrite: unsigned int, vmsi_cfgread: unsigned int
MISRA-C:1998 105

The code in question is in dm/vpci.msi.c:

struct pci_vdev_ops pci_ops_vdev_msi = {
    .deinit = vmsi_deinit,
    .cfgwrite = vmsi_cfgwrite,
    .cfgread = vmsi_cfgread,
};

I can 'fix' this violation with the following code, which doesn't make sense
to me. So I leave these violations open for now.

+ static int vmsi_init(struct pci_vdev *vdev)
+ {
+    return 0;
+ }

struct pci_vdev_ops pci_ops_vdev_msi = {
+   .init = vmsi_init,
    .deinit = vmsi_deinit,
    .cfgwrite = vmsi_cfgwrite,
    .cfgread = vmsi_cfgread,
};

BTW, this doesn't help: ".init = NULL,"
