### PR TITLE
DM: update clear Linux version to 26120 in guest os launch script 

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -20,9 +20,9 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
-  -s 3,virtio-blk,/root/clear-23690-kvm.img \
+  -s 3,virtio-blk,/root/clear-26120-kvm.img \
   -s 4,virtio-net,tap0 \
-  -k /usr/lib/kernel/org.clearlinux.pk414-standard.4.14.52-63 \
+  -k /usr/lib/kernel/org.clearlinux.iot-lts2018.4.19.0-16 \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \


### PR DESCRIPTION
1, update Clear Linux version to 26120 
2, update kernel name to *iot-lts2018* 


Signed-off-by: Ailun258 <ailin.yang@intel.com>