### PR TITLE
HV: update kernel name to kernel-org.clearlinux.iot-lts2018-sos.4.19.0-16

### DIFF
--- a/hypervisor/bsp/uefi/clearlinux/acrn.conf
+++ b/hypervisor/bsp/uefi/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title The ACRN Service OS
-linux   /EFI/org.clearlinux/kernel-org.clearlinux.pk414-sos.4.14.52-63
+linux   /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.0-16
 options pci_devices_ignore=(0:18:1) console=tty0 console=ttyS2 i915.nuclear_pageflip=1 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_initial_modeset=1 i915.enable_guc=0 hvlog=2M@0x1FE00000


### PR DESCRIPTION
updated kernel name  from kernel-org.clearlinux.pk414-sos.4.14.52-63 to kernel-org.clearlinux.iot-lts2018-sos.4.19.0-16 for v0.3 release

Signed-off-by: Ailun258 <ailin.yang@intel.com>