### PR TITLE
fix "Procedure is not pure assembler"

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -724,7 +724,7 @@ void cpu_dead(uint16_t pcpu_id)
 
 	/* Halt the CPU */
 	do {
-		asm volatile ("hlt");
+		hlt_cpu();
 	} while (halt != 0);
 }
 

--- a/hypervisor/arch/x86/gdt.c
+++ b/hypervisor/arch/x86/gdt.c
@@ -23,6 +23,11 @@ static void set_tss_desc(struct tss_64_descriptor *desc,
 	desc->high32_value = u2 | (type << 8U) | 0x8000U | u3;
 }
 
+static inline void load_gdt(struct host_gdt_descriptor *gdtr)
+{
+	asm volatile ("lgdt %0" ::"m"(*gdtr));
+}
+
 void load_gdtr_and_tr(void)
 {
 	struct host_gdt *gdt = &get_cpu_var(gdt);
@@ -48,7 +53,7 @@ void load_gdtr_and_tr(void)
 	gdtr.len = sizeof(struct host_gdt) - 1U;
 	gdtr.gdt = gdt;
 
-	asm volatile ("lgdt %0" ::"m"(gdtr));
+	load_gdt(&gdtr);
 
 	CPU_LTR_EXECUTE(HOST_GDT_RING0_CPU_TSS_SEL);
 }

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -123,7 +123,7 @@ static void init_tsc_deadline_timer(void)
 	val = VECTOR_TIMER;
 	val |= APIC_LVTT_TM_TSCDLT; /* TSC deadline and unmask */
 	msr_write(MSR_IA32_EXT_APIC_LVT_TIMER, val);
-	asm volatile("mfence" : : : "memory");
+	cpu_memory_barrier();
 
 	/* disarm timer */
 	msr_write(MSR_IA32_TSC_DEADLINE, 0UL);

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -264,7 +264,7 @@ dmar_wait_completion(const struct dmar_drhd_rt *dmar_uint, uint32_t offset,
 		}
 		ASSERT(((rdtsc() - start) < CYCLES_PER_MS),
 			"DMAR OP Timeout!");
-		asm volatile ("pause" ::: "memory");
+		pause_cpu();
 	}
 }
 

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -243,7 +243,7 @@ void asm_assert(int32_t line, const char *file, const char *txt)
 	show_host_call_trace(rsp, rbp, pcpu_id);
 	dump_guest_context(pcpu_id);
 	do {
-		asm volatile ("pause" ::: "memory");
+		pause_cpu();
 	} while (1);
 }
 

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -477,10 +477,6 @@ static inline bool cpu_has_vmx_unrestricted_guest_cap(void)
 									!= 0UL);
 }
 
-typedef struct _descriptor_table_{
-	uint16_t limit;
-	uint64_t base;
-}__attribute__((packed)) descriptor_table;
 #endif /* ASSEMBLER */
 
 #endif /* VMX_H_ */


### PR DESCRIPTION
Misra C reqires assembly code should comply with
the rules list below:
  The assembly code's functionality should match the function's
name.If not,pls encapsulate the assembly code and give a suitable
name for describing the functionality.
V1->V2:
    1.remove the dead code
    2.update detail comment

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>