### PR TITLE
hv: unify the function pointer assignment

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -131,8 +131,7 @@ void vpci_init(struct acrn_vm *vm)
 #endif
 
 	if ((vpci->ops->init != NULL) && (vpci->ops->init(vm) == 0)) {
-		register_io_emulation_handler(vm, PCI_PIO_IDX, &pci_cfg_range,
-			&pci_cfg_io_read, &pci_cfg_io_write);
+		register_io_emulation_handler(vm, PCI_PIO_IDX, &pci_cfg_range, pci_cfg_io_read, pci_cfg_io_write);
 		/* This is a tmp solution to avoid sos reboot failure, it need pass-thru IO port CF9 for Reset Control
 		 * register.
 		 */

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -867,11 +867,11 @@ static void vpic_register_io_handler(struct acrn_vm *vm)
 	};
 
 	register_io_emulation_handler(vm, PIC_MASTER_PIO_IDX, &master_range,
-			&vpic_master_io_read, &vpic_master_io_write);
+			vpic_master_io_read, vpic_master_io_write);
 	register_io_emulation_handler(vm, PIC_SLAVE_PIO_IDX, &slave_range,
-			&vpic_slave_io_read, &vpic_slave_io_write);
+			vpic_slave_io_read, vpic_slave_io_write);
 	register_io_emulation_handler(vm, PIC_ELC_PIO_IDX, &elcr_range,
-			&vpic_elc_io_read, &vpic_elc_io_write);
+			vpic_elc_io_read, vpic_elc_io_write);
 }
 
 void vpic_init(struct acrn_vm *vm)


### PR DESCRIPTION
Assign function pointer without the unary & operator.

Take 'register_io_emulation_handler' as an example:
void register_io_emulation_handler(struct acrn_vm *vm,
                const struct vm_io_range *range,
                io_read_fn_t io_read_fn_ptr,
                io_write_fn_t io_write_fn_ptr)

The last two parameters are function pointer.
Sometimes we use function designator directly, while sometimes
with the unary & operator, as shown below.
 - without &
   register_io_emulation_handler(vm, &range, vuart_read, vuart_write);
 - with &
   register_io_emulation_handler(vm, &pci_cfg_range,
                   &pci_cfg_io_read, &pci_cfg_io_write);

To unify the coding style, we will go with the first way.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>