### PR TITLE
Documentation: adjust "Tracked-On" capitalization in documentation

### DIFF
--- a/doc/developer-guides/contribute_guidelines.rst
+++ b/doc/developer-guides/contribute_guidelines.rst
@@ -176,7 +176,7 @@ is set up correctly by using:
    git config --global user.name "David Developer"
    git config --global user.email "david.developer@company.com"
 
-Tracked-on
+Tracked-On
 ==========
 
 All commits must be mapped to a GitHub issue for a feature or bug. Add a


### PR DESCRIPTION
Update the capitalization of "Tracked-On" in the documentation.
"Tracked-on" should work but it throws a warning so it's better
to make the documentation focus on using "Tracked-On" only.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>