### PR TITLE
doc: add Makefile option for singlehtml

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,6 +56,9 @@ html: doxy content kconfig
 	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> doc.log 2>&1
 	$(Q)./scripts/filter-doc-log.sh doc.log
 
+singlehtml: doxy content kconfig
+	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b singlehtml -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> doc.log 2>&1
+	$(Q)./scripts/filter-doc-log.sh doc.log
 
 # Remove generated content (Sphinx and doxygen)
 


### PR DESCRIPTION
Sphinx supports making a single (large) html file instead of a
full website with a collection of html pages.  This ``make singlehtml``
option provides the basis for creating a Word document (for example)
via a cut-and-paste of a section of the documentation (not easily
possible when the docs are in multiple HTML files.)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>