### PR TITLE
hv: vtd: fix the pre-allocated context table number

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -299,12 +299,12 @@ config RELOC
 	  wherever appropriate. Without relocation the bootloader must put the
 	  image to RAM_START, otherwise the hypervisor will not start up.
 
-config IOMMU_INIT_BUS_LIMIT
+config IOMMU_BUS_NUM
 	hex "Limit of PCI bus on IOMMU initialization"
-	default 0xf if PLATFORM_SBL
-	default 0xff if PLATFORM_UEFI
+	default 0x10 if PLATFORM_SBL
+	default 0x100 if PLATFORM_UEFI
 	help
-	  Any BDF with a bus ID smaller than or equal to this limit is mapped to
+	  Any BDF with a bus ID smaller than this number is mapped to
 	  the IOMMU domain of the first VM.
 
 config MAX_PCI_DEV_NUM

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -134,7 +134,7 @@ struct iommu_domain {
 };
 
 struct context_table {
-	struct page buses[CONFIG_IOMMU_INIT_BUS_LIMIT];
+	struct page buses[CONFIG_IOMMU_BUS_NUM];
 };
 
 static struct page root_tables[CONFIG_MAX_IOMMU_NUM] __aligned(CPU_PAGE_SIZE);
@@ -1250,7 +1250,7 @@ void init_iommu_vm0_domain(struct acrn_vm *vm0)
 
 	vm0_domain = (struct iommu_domain *) vm0->iommu;
 
-	for (bus = 0U; bus <= CONFIG_IOMMU_INIT_BUS_LIMIT; bus++) {
+	for (bus = 0U; bus < CONFIG_IOMMU_BUS_NUM; bus++) {
 		for (devfun = 0U; devfun <= 255U; devfun++) {
 			add_iommu_device(vm0_domain, 0U,
 				(uint8_t)bus, (uint8_t)devfun);


### PR DESCRIPTION
In current code, there is an out of range access to the array buses defined in struct struct context_table.
This patch defines CONFIG_IOMMU_BUS_NUM to replace CONFIG_IOMMU_INIT_BUS_LIMIT, which is clearer.
CONFIG_IOMMU_BUS_NUM equals to (CONFIG_IOMMU_INIT_BUS_LIMIT + 1).

Tracked-On: #1807
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>