### PR TITLE
Documentation: update uos config of partition mode on up2

### DIFF
--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -14,7 +14,7 @@ Build kernel and modules for partition mode guest
 
      git clone https://github.com/projectacrn/acrn-kernel.git
      cd ~/acrn-kernel
-     cp kernel_config_partition_os .config
+     cp kernel_config_uos .config
      make oldconfig
      make
 


### PR DESCRIPTION
kernel patch "kernel: Remove kernel_config_partition_os"
and "kernel: Compile in USB XHCI drivers (default modules)" has
porting partition mode related config to kernel_config_uos and
remove the kernel_config_partition_os.

This patch update the tutorials about using_partition_mode_on_up2.rst
accordingly.

Tracked-On: #1756
Signed-off-by: Kaige Fu <kaige.fu@intel.com>