### PR TITLE
hv: fix '(void) missing for discarded return value'

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -513,7 +513,7 @@ static void bsp_boot_post(void)
 
 	exec_vmxon_instr(BOOT_CPU_ID);
 
-	prepare_vm(BOOT_CPU_ID);
+	(void)prepare_vm(BOOT_CPU_ID);
 
 	default_idle();
 
@@ -583,7 +583,7 @@ static void cpu_secondary_post(void)
 	exec_vmxon_instr(get_cpu_id());
 
 #ifdef CONFIG_PARTITION_MODE
-	prepare_vm(get_cpu_id());
+	(void)prepare_vm(get_cpu_id());
 #endif
 
 	default_idle();

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -2293,7 +2293,10 @@ int decode_instruction(struct acrn_vcpu *vcpu)
 			return retval;
 		}
 	} else {
-		instr_check_gva(vcpu, emul_ctxt, cpu_mode);
+		retval = instr_check_gva(vcpu, emul_ctxt, cpu_mode);
+		if (retval < 0) {
+			return retval;
+		}
 	}
 
 	return (int)(emul_ctxt->vie.opsize);

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -83,7 +83,7 @@ void emulate_mmio_post(const struct acrn_vcpu *vcpu, const struct io_request *io
 
 	if (mmio_req->direction == REQUEST_READ) {
 		/* Emulate instruction and update vcpu register set */
-		emulate_instruction(vcpu);
+		(void)emulate_instruction(vcpu);
 	}
 }
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -123,8 +123,7 @@ void do_acpi_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 	}
 }
 
-int enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
-	uint32_t pm1b_cnt_val)
+void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
 {
 	uint64_t pmain_entry_saved;
 	uint32_t guest_wakeup_vec32;
@@ -135,7 +134,7 @@ int enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 	if (vm->pm.sx_state_data == NULL) {
 		pr_err("No Sx state info avaiable. No Sx support");
 		host_enter_s3_success = 0U;
-		return -1;
+		return;
 	}
 
 	pause_vm(vm);	/* pause vm0 before suspend system */
@@ -193,5 +192,5 @@ int enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 	/* jump back to vm */
 	resume_vm_from_s3(vm, guest_wakeup_vec32);
 
-	return 0;
+	return;
 }

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -401,7 +401,7 @@ vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr,
 				((last.full & IOAPIC_RTE_INTMASK) == 0UL)) {
 			/* VM enable intr */
 			/* NOTE: only support max 256 pin */
-			ptdev_intx_pin_remap(vioapic->vm,
+			(void)ptdev_intx_pin_remap(vioapic->vm,
 					(uint8_t)pin, PTDEV_VPIN_IOAPIC);
 		}
 	}
@@ -516,7 +516,7 @@ vioapic_init(struct acrn_vm *vm)
 
 	vioapic_reset(vm_ioapic(vm));
 
-	register_mmio_emulation_handler(vm,
+	(void)register_mmio_emulation_handler(vm,
 			vioapic_mmio_access_handler,
 			(uint64_t)VIOAPIC_BASE,
 			(uint64_t)VIOAPIC_BASE + VIOAPIC_SIZE,

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -192,7 +192,11 @@ static void vpic_notify_intr(struct acrn_vpic *vpic)
 			struct acrn_vcpu *vcpu = vcpu_from_vid(vpic->vm, 0U);
 			vcpu_inject_extint(vcpu);
 		} else {
-			vlapic_set_local_intr(vpic->vm, BROADCAST_CPU_ID, APIC_LVT_LINT0);
+			/*
+			 * The input parameters here guarantee the return value of vlapic_set_local_intr is 0, means
+			 * success.
+			 */
+			(void)vlapic_set_local_intr(vpic->vm, BROADCAST_CPU_ID, APIC_LVT_LINT0);
 			/* notify vioapic pin0 if existing
 			 * For vPIC + vIOAPIC mode, vpic master irq connected
 			 * to vioapic pin0 (irq2)
@@ -321,7 +325,7 @@ static int vpic_ocw1(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259
 
 			virt_pin = (master_pic(vpic, i8259)) ?
 					pin : (pin + 8U);
-			ptdev_intx_pin_remap(vpic->vm,
+			(void)ptdev_intx_pin_remap(vpic->vm,
 					virt_pin, PTDEV_VPIN_PIC);
 		}
 		pin = (pin + 1U) & 0x7U;

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -13,7 +13,7 @@ extern struct pm_s_state_data host_pm_s_state;
 
 extern uint8_t host_enter_s3_success;
 
-int enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
+void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
 extern void asm_enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val,
 		uint32_t pm1b_cnt_val);
 extern void restore_s3_context(void);


### PR DESCRIPTION
MISRA-C requires that the function call in which the returned
value is discarded shall be clearly indicated using (void).

This patch fixes the violations related to the following
function calls.
- instr_check_gva
- vlapic_set_local_intr
- prepare_vm
- enter_s3
- emulate_instruction
- ptdev_intx_pin_remap
- register_mmio_emulation_handler

v1 -> v2:
 * discard the return value of enter_s3

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>