### PR TITLE
hv: partition mode also needs free vm id when shutdown vm

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -210,10 +210,8 @@ int shutdown_vm(struct acrn_vm *vm)
 		destroy_iommu_domain(vm->iommu);
 	}
 
-#ifndef CONFIG_PARTITION_MODE
 	/* Free vm id */
 	free_vm_id(vm);
-#endif
 
 	vpci_cleanup(vm);
 


### PR DESCRIPTION
Even in partition mode, we also need to clear vmid in vmid_bitmap to
indicate the VM is not present.

Tracked-On: projectacrn#1821
Signed-off-by: Shuo Liu <shuo.a.liu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>