### PR TITLE
hv: reset VM ioreqs in reset_vm

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -255,6 +255,7 @@ int reset_vm(struct acrn_vm *vm)
 		(void )vm_sw_loader(vm);
 	}
 
+	reset_vm_ioreqs(vm);
 	vioapic_reset(vm_ioapic(vm));
 	destroy_secure_world(vm, false);
 	vm->sworld_control.flag.active = 0UL;

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -56,6 +56,25 @@ static void acrn_print_request(uint16_t vcpu_id, const struct vhm_request *req)
 }
 
 /**
+ * @brief Reset all IO requests status of the VM
+ *
+ * @param vm The VM whose IO requests to be reset
+ *
+ * @return N/A
+ */
+void reset_vm_ioreqs(struct acrn_vm *vm)
+{
+	uint16_t i;
+	union vhm_request_buffer *req_buf;
+
+	req_buf = vm->sw.io_shared_page;
+	for (i = 0U; i < VHM_REQUEST_MAX; i++) {
+		req_buf->req_queue[i].valid = 0U;
+		atomic_store32(&req_buf->req_queue[i].processed, REQ_STATE_FREE);
+	}
+}
+
+/**
  * @brief Deliver \p io_req to SOS and suspend \p vcpu till its completion
  *
  * @param vcpu The virtual CPU that triggers the MMIO access

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -288,6 +288,15 @@ void emulate_io_post(struct acrn_vcpu *vcpu);
 int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request *io_req);
 
 /**
+ * @brief Reset all IO requests status of the VM
+ *
+ * @param vm The VM whose IO requests to be reset
+ *
+ * @return N/A
+ */
+void reset_vm_ioreqs(struct acrn_vm *vm);
+
+/**
  * @}
  */
 


### PR DESCRIPTION
ioreqs acrossing VM reset is meaningless. So we reset their status when
VM reset.
Please note, device model and service os need to handle various ioreqs
pending status in emergency reset condition carefully. Otherwises, the
post processing of such ioreqs might overwrite this reset.

Tracked-On: projectacrn#1821
Signed-off-by: Shuo Liu <shuo.a.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>