### PR TITLE
vmx: tiny fix for MACRO name and print format

### DIFF
--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -625,29 +625,29 @@ static void init_host_state(void)
 	 * GS), * Task Register (TR), * Local Descriptor Table Register (LDTR)
 	 *
 	 ***************************************************/
-	CPU_SEG_WRITE(es, value16);
+	CPU_SEG_READ(es, &value16);
 	exec_vmwrite16(VMX_HOST_ES_SEL, value16);
-	pr_dbg("VMX_HOST_ES_SEL: 0x%hu ", value16);
+	pr_dbg("VMX_HOST_ES_SEL: 0x%hx ", value16);
 
-	CPU_SEG_WRITE(cs, value16);
+	CPU_SEG_READ(cs, &value16);
 	exec_vmwrite16(VMX_HOST_CS_SEL, value16);
-	pr_dbg("VMX_HOST_CS_SEL: 0x%hu ", value16);
+	pr_dbg("VMX_HOST_CS_SEL: 0x%hx ", value16);
 
-	CPU_SEG_WRITE(ss, value16);
+	CPU_SEG_READ(ss, &value16);
 	exec_vmwrite16(VMX_HOST_SS_SEL, value16);
-	pr_dbg("VMX_HOST_SS_SEL: 0x%hu ", value16);
+	pr_dbg("VMX_HOST_SS_SEL: 0x%hx ", value16);
 
-	CPU_SEG_WRITE(ds, value16);
+	CPU_SEG_READ(ds, &value16);
 	exec_vmwrite16(VMX_HOST_DS_SEL, value16);
-	pr_dbg("VMX_HOST_DS_SEL: 0x%hu ", value16);
+	pr_dbg("VMX_HOST_DS_SEL: 0x%hx ", value16);
 
-	CPU_SEG_WRITE(fs, value16);
+	CPU_SEG_READ(fs, &value16);
 	exec_vmwrite16(VMX_HOST_FS_SEL, value16);
-	pr_dbg("VMX_HOST_FS_SEL: 0x%hu ", value16);
+	pr_dbg("VMX_HOST_FS_SEL: 0x%hx ", value16);
 
-	CPU_SEG_WRITE(gs, value16);
+	CPU_SEG_READ(gs, &value16);
 	exec_vmwrite16(VMX_HOST_GS_SEL, value16);
-	pr_dbg("VMX_HOST_GS_SEL: 0x%hu ", value16);
+	pr_dbg("VMX_HOST_GS_SEL: 0x%hx ", value16);
 
 	exec_vmwrite16(VMX_HOST_TR_SEL, HOST_GDT_RING0_CPU_TSS_SEL);
 	pr_dbg("VMX_HOST_TR_SEL: 0x%hx ", HOST_GDT_RING0_CPU_TSS_SEL);

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -331,9 +331,9 @@ void stop_cpus(void);
 void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 void cpu_l1d_flush(void);
 
-#define CPU_SEG_WRITE(seg, value16)						\
+#define CPU_SEG_READ(seg, result_ptr)						\
 {										\
-	asm volatile ("mov %%" STRINGIFY(seg) ", %%ax": "=a" (value16));	\
+	asm volatile ("mov %%" STRINGIFY(seg) ", %0": "=r" (*(result_ptr)));	\
 }
 
 /* Read control register */


### PR DESCRIPTION
1. CPU_SEG_WRITE->CPU_SEG_READ: it's actually seg read
2. 0x%hu -> 0x%x: it need print hex format

Tracked-On: #1833
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>