### PR TITLE
hv: hv_main: clean up HV_DEBUG usage

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -29,7 +29,6 @@ static int shell_show_cpu_int(__unused int argc, __unused char **argv);
 static int shell_show_ptdev_info(__unused int argc, __unused char **argv);
 static int shell_show_vioapic_info(int argc, char **argv);
 static int shell_show_ioapic_info(__unused int argc, __unused char **argv);
-static int shell_show_vmexit_profile(__unused int argc, __unused char **argv);
 static int shell_dump_logbuf(int argc, char **argv);
 static int shell_loglevel(int argc, char **argv);
 static int shell_cpuid(int argc, char **argv);
@@ -95,12 +94,6 @@ static struct shell_cmd shell_cmds[] = {
 		.cmd_param	= SHELL_CMD_IOAPIC_PARAM,
 		.help_str	= SHELL_CMD_IOAPIC_HELP,
 		.fcn		= shell_show_ioapic_info,
-	},
-	{
-		.str		= SHELL_CMD_VMEXIT,
-		.cmd_param	= SHELL_CMD_VMEXIT_PARAM,
-		.help_str	= SHELL_CMD_VMEXIT_HELP,
-		.fcn		= shell_show_vmexit_profile,
 	},
 	{
 		.str		= SHELL_CMD_LOGDUMP,
@@ -805,14 +798,6 @@ static int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 	shell_puts(shell_log_buf);
 
 	return err;
-}
-
-static int shell_show_vmexit_profile(__unused int argc, __unused char **argv)
-{
-	get_vmexit_profile(shell_log_buf, SHELL_LOG_BUF_SIZE);
-	shell_puts(shell_log_buf);
-
-	return 0;
 }
 
 static int shell_dump_logbuf(int argc, char **argv)

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -78,10 +78,6 @@ struct shell {
 #define SHELL_CMD_VIOAPIC_PARAM		"<vm id>"
 #define SHELL_CMD_VIOAPIC_HELP		"show vioapic info"
 
-#define SHELL_CMD_VMEXIT		"vmexit"
-#define SHELL_CMD_VMEXIT_PARAM		NULL
-#define SHELL_CMD_VMEXIT_HELP		"show vmexit profiling"
-
 #define SHELL_CMD_LOGDUMP		"logdump"
 #define SHELL_CMD_LOGDUMP_PARAM		"<pcpu id>"
 #define SHELL_CMD_LOGDUMP_HELP		"log buffer dump"

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -27,8 +27,6 @@ struct per_cpu_region {
 	char logbuf[LOG_MESSAGE_MAX_SIZE];
 	bool is_early_logbuf;
 	char early_logbuf[CONFIG_LOG_BUF_SIZE];
-	uint64_t vmexit_cnt[64];
-	uint64_t vmexit_time[64];
 	uint32_t npk_log_ref;
 #endif
 	uint64_t irq_count[NR_IRQS];


### PR DESCRIPTION
- Remove the usage of HV_DEBUG in hv_main.c
The usage of HV_DEBUG in hv_main.c is for the shell command 'vmexit'.
Since vmexit info has been captured by acrntrace, there is no need to
keep this duplicated feature in shell command.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>