### PR TITLE
tools: acrn-manager: set MAX_NAME_LEN to 32

### DIFF
--- a/tools/acrn-manager/acrnctl.h
+++ b/tools/acrn-manager/acrnctl.h
@@ -11,7 +11,7 @@
 #define ACRNCTL_OPT_ROOT        "/opt/acrn/conf"
 #define ACRN_DM_SOCK_ROOT       "/run/acrn/mngr"
 
-#define MAX_NAME_LEN            (16)
+#define MAX_NAME_LEN            (32)
 
 enum vm_state {
 	VM_STATE_UNKNOWN = 0,


### PR DESCRIPTION
I am currently using Yocto build and deploy UOS images, it would be
much more convenient to let the VMs to have the same names with when
they are being built. For instance, a typical image name in Yocto is
like: uos-image-weston, but it can not show the name completely with
'acrnctl list', since the length limit is 16.

Increasing the limit to 32 would fix this problem.

Tracked-On: #1837
Signed-off-by: Ming Liu <liu.ming50@gmail.com>