### PR TITLE
HV: handle adding ptdev entry failure cases

### DIFF
--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -77,9 +77,7 @@ struct ptdev_remapping_info *ptdev_dequeue_softirq(struct acrn_vm *vm);
 struct ptdev_remapping_info *alloc_entry(struct acrn_vm *vm,
 		uint32_t intr_type);
 void release_entry(struct ptdev_remapping_info *entry);
-void ptdev_activate_entry(
-		struct ptdev_remapping_info *entry,
-		uint32_t phys_irq);
+int32_t ptdev_activate_entry(struct ptdev_remapping_info *entry, uint32_t phys_irq);
 void ptdev_deactivate_entry(struct ptdev_remapping_info *entry);
 
 #ifdef HV_DEBUG


### PR DESCRIPTION
handle adding pass-through device entry failure cases,
instead of calling ASSERT, to avoid hypervisor crash.

Tracked-On: #1860
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>