### PR TITLE
acrn-dm: wait for monitor thread canceling finish

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -183,7 +183,10 @@ static void start_intr_storm_monitor(struct vmctx *ctx)
 static void stop_intr_storm_monitor(void)
 {
 	if (intr_storm_monitor_pid) {
+		void *ret;
+
 		pthread_cancel(intr_storm_monitor_pid);
+		pthread_join(intr_storm_monitor_pid, &ret);
 		intr_storm_monitor_pid = 0;
 	}
 }


### PR DESCRIPTION
When thread_cancel() is called to exit pthread, we can't know
when the thread exit done unless pthread_join() is used to
wait for thread exit.

Tracked-On: #1868
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>