### PR TITLE
doc: fix inconsistency and format in comments on return values

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1644,7 +1644,7 @@ pci_msix_enabled(struct pci_vdev *dev)
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index MSIx table entry index.
  *
- * @return N/A
+ * @return None
  */
 void
 pci_generate_msix(struct pci_vdev *dev, int index)
@@ -1673,7 +1673,7 @@ pci_generate_msix(struct pci_vdev *dev, int index)
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index Message data index.
  *
- * @return N/A
+ * @return None
  */
 void
 pci_generate_msi(struct pci_vdev *dev, int index)
@@ -1781,7 +1781,7 @@ pci_lintr_route(struct pci_vdev *dev)
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  *
- * @return N/A
+ * @return None
  */
 void
 pci_lintr_assert(struct pci_vdev *dev)
@@ -1804,7 +1804,7 @@ pci_lintr_assert(struct pci_vdev *dev)
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  *
- * @return N/A
+ * @return None
  */
 void
 pci_lintr_deassert(struct pci_vdev *dev)

--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -55,7 +55,7 @@
  * @param dev Pointer to struct pci_vdev which emulates a PCI device.
  * @param queues Pointer to struct virtio_vq_info, normally an array.
  *
- * @return NULL
+ * @return None
  */
 void
 virtio_linkup(struct virtio_base *base, struct virtio_ops *vops,
@@ -89,7 +89,7 @@ virtio_linkup(struct virtio_base *base, struct virtio_ops *vops,
  *
  * @param base Pointer to struct virtio_base.
  *
- * @return N/A
+ * @return None
  */
 void
 virtio_reset_dev(struct virtio_base *base)
@@ -133,7 +133,7 @@ virtio_reset_dev(struct virtio_base *base)
  * @param base Pointer to struct virtio_base.
  * @param barnum Which BAR[0..5] to use.
  *
- * @return N/A
+ * @return None
  */
 void
 virtio_set_io_bar(struct virtio_base *base, int barnum)
@@ -1078,7 +1078,7 @@ virtio_set_modern_bar(struct virtio_base *base, bool use_notify_pio)
  *
  * @param base Pointer to struct virtio_base.
  *
- * @return N/A
+ * @return None
  */
 void
 virtio_dev_error(struct virtio_base *base)
@@ -1716,7 +1716,7 @@ virtio_pci_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  * @param size Access range in bytes.
  * @param value Data value to be written into register.
  *
- * @return N/A
+ * @return None
  */
 void
 virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,

--- a/devicemodel/include/dm_string.h
+++ b/devicemodel/include/dm_string.h
@@ -16,8 +16,8 @@
  * @param base Base: 8, 10, 16...
  * @param val Long integer convert from string.
  *
- * @return -1 error.
- * @return 0  no error.
+ * @retval -1 error.
+ * @retval 0  no error.
  */
 
 int dm_strtol(const char *s, char **end, unsigned int base, long *val);
@@ -30,8 +30,8 @@ int dm_strtol(const char *s, char **end, unsigned int base, long *val);
  * @param base Base: 8, 10, 16...
  * @param val Integer convert from string.
  *
- * @return -1 error.
- * @return 0  no error.
+ * @retval -1 error.
+ * @retval 0  no error.
  */
 
 int dm_strtoi(const char *s, char **end, unsigned int base, int *val);
@@ -44,8 +44,8 @@ int dm_strtoi(const char *s, char **end, unsigned int base, int *val);
  * @param base Base: 8, 10, 16...
  * @param val Unsigned long integer convert from string.
  *
- * @return -1 error.
- * @return 0  no error.
+ * @retval -1 error.
+ * @retval 0  no error.
  */
 
 int dm_strtoul(const char *s, char **end, unsigned int base, unsigned long *val);
@@ -58,8 +58,8 @@ int dm_strtoul(const char *s, char **end, unsigned int base, unsigned long *val)
  * @param base Base: 8, 10, 16...
  * @param val Unsigned integer convert from string.
  *
- * @return -1 error.
- * @return 0  no error.
+ * @retval -1 error.
+ * @retval 0  no error.
  */
 
 int dm_strtoui(const char *s, char **end, unsigned int base, unsigned int *val);

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -259,7 +259,7 @@ int	pci_emul_add_pciecap(struct pci_vdev *pi, int pcie_device_type);
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index Message data index.
  *
- * @return N/A
+ * @return None
  */
 void	pci_generate_msi(struct pci_vdev *dev, int index);
 
@@ -269,7 +269,7 @@ void	pci_generate_msi(struct pci_vdev *dev, int index);
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  * @param index MSIs table entry index.
  *
- * @return N/A
+ * @return None
  */
 void	pci_generate_msix(struct pci_vdev *dev, int index);
 
@@ -278,7 +278,7 @@ void	pci_generate_msix(struct pci_vdev *dev, int index);
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  *
- * @return N/A
+ * @return None
  */
 void	pci_lintr_assert(struct pci_vdev *dev);
 
@@ -287,7 +287,7 @@ void	pci_lintr_assert(struct pci_vdev *dev);
  *
  * @param dev Pointer to struct pci_vdev representing virtual PCI device.
  *
- * @return N/A
+ * @return None
  */
 void	pci_lintr_deassert(struct pci_vdev *dev);
 
@@ -324,7 +324,7 @@ void	pciaccess_cleanup(void);
  * @param offset Offset in configuration space.
  * @param val Value in 1 byte.
  *
- * @return N/A
+ * @return None
  */
 static inline void
 pci_set_cfgdata8(struct pci_vdev *dev, int offset, uint8_t val)
@@ -340,7 +340,7 @@ pci_set_cfgdata8(struct pci_vdev *dev, int offset, uint8_t val)
  * @param offset Offset in configuration space.
  * @param val Value in 2 bytes.
  *
- * @return N/A
+ * @return None
  */
 static inline void
 pci_set_cfgdata16(struct pci_vdev *dev, int offset, uint16_t val)
@@ -356,7 +356,7 @@ pci_set_cfgdata16(struct pci_vdev *dev, int offset, uint16_t val)
  * @param offset Offset in configuration space.
  * @param val Value in 4 bytes.
  *
- * @return N/A
+ * @return None
  */
 static inline void
 pci_set_cfgdata32(struct pci_vdev *dev, int offset, uint32_t val)

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -648,7 +648,7 @@ vq_has_descs(struct virtio_vq_info *vq)
  * @param vb Pointer to struct virtio_base.
  * @param vq Pointer to struct virtio_vq_info.
  *
- * @return NULL
+ * @return None
  */
 static inline void
 vq_interrupt(struct virtio_base *vb, struct virtio_vq_info *vq)
@@ -671,7 +671,7 @@ vq_interrupt(struct virtio_base *vb, struct virtio_vq_info *vq)
  *
  * @param vb Pointer to struct virtio_base.
  *
- * @return NULL.
+ * @return None
  */
 static inline void
 virtio_config_changed(struct virtio_base *vb)
@@ -704,7 +704,7 @@ struct iovec;
  * @param dev Pointer to struct pci_vdev which emulates a PCI device.
  * @param queues Pointer to struct virtio_vq_info, normally an array.
  *
- * @return NULL
+ * @return None
  */
 void virtio_linkup(struct virtio_base *base, struct virtio_ops *vops,
 		   void *pci_virtio_dev, struct pci_vdev *dev,
@@ -751,7 +751,7 @@ int virtio_intr_init(struct virtio_base *base, int barnum, int use_msix);
  *
  * @param base Pointer to struct virtio_base.
  *
- * @return N/A
+ * @return None
  */
 void virtio_reset_dev(struct virtio_base *base);
 
@@ -761,7 +761,7 @@ void virtio_reset_dev(struct virtio_base *base);
  * @param base Pointer to struct virtio_base.
  * @param barnum Which BAR[0..5] to use.
  *
- * @return N/A
+ * @return None
  */
 void virtio_set_io_bar(struct virtio_base *base, int barnum);
 
@@ -787,7 +787,7 @@ int vq_getchain(struct virtio_vq_info *vq, uint16_t *pidx,
  *
  * @param vq Pointer to struct virtio_vq_info.
  *
- * @return N/A
+ * @return None
  */
 void vq_retchain(struct virtio_vq_info *vq);
 
@@ -799,7 +799,7 @@ void vq_retchain(struct virtio_vq_info *vq);
  * @param idx Pointer to available ring position, returned by vq_getchain().
  * @param iolen Number of data bytes to be returned to frontend.
  *
- * @return N/A
+ * @return None
  */
 void vq_relchain(struct virtio_vq_info *vq, uint16_t idx, uint32_t iolen);
 
@@ -812,7 +812,7 @@ void vq_relchain(struct virtio_vq_info *vq, uint16_t idx, uint32_t iolen);
  * @param vq Pointer to struct virtio_vq_info.
  * @param used_all_avail Flag indicating if driver used all available chains.
  *
- * @return N/A
+ * @return None
  */
 void vq_endchains(struct virtio_vq_info *vq, int used_all_avail);
 
@@ -848,7 +848,7 @@ uint64_t virtio_pci_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  * @param size Access range in bytes.
  * @param value Data value to be written into register.
  *
- * @return N/A
+ * @return None
  */
 void virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 		      int baridx, uint64_t offset, int size, uint64_t value);
@@ -862,7 +862,7 @@ void virtio_pci_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
  *
  * @param base Pointer to struct virtio_base.
  *
- * @return N/A
+ * @return None
  */
 void virtio_dev_error(struct virtio_base *base);
 

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -601,7 +601,7 @@ static void rebuild_vm0_e820(void)
 /**
  * @param[inout] vm pointer to a vm descriptor
  *
- * @return 0 - on success
+ * @retval 0 on success
  *
  * @pre vm != NULL
  * @pre is_vm0(vm) == true

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1314,8 +1314,8 @@ vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *               with eligible vector if any.
  *
- * @return 0 - There is no eligible pending vector.
- * @return 1 - There is pending vector.
+ * @retval 0 There is no eligible pending vector.
+ * @retval 1 There is pending vector.
  *
  * @remark The vector does not automatically transition to the ISR as a
  *	   result of calling this function.
@@ -1954,8 +1954,8 @@ vlapic_set_intr(struct acrn_vcpu *vcpu, uint32_t vector, bool level)
  *			   interrupt to all vCPUs.
  * @param[in] vector       Vector to be fired.
  *
- * @return 0 on success.
- * @return -EINVAL on error that vcpu_id_arg or vector is invalid.
+ * @retval 0 on success.
+ * @retval -EINVAL on error that vcpu_id_arg or vector is invalid.
  *
  * @pre vm != NULL
  */
@@ -1997,8 +1997,8 @@ vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vector)
  * @param[in] addr MSI address.
  * @param[in] msg  MSI data.
  *
- * @return 0 on success.
- * @return non-zero on error that addr is invalid.
+ * @retval 0 on success.
+ * @retval -1 on error that addr is invalid.
  *
  * @pre vm != NULL
  */

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -540,7 +540,7 @@ vlapic_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
  *
  * @param[in] dest_pcpu_id Target CPU ID.
  *
- * @return void
+ * @return None
  */
 void vlapic_post_intr(uint16_t dest_pcpu_id)
 {
@@ -1363,7 +1363,7 @@ vlapic_pending_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr)
  * @param[in] vlapic Pointer to target vLAPIC data structure
  * @param[in] vector Target virtual interrupt vector
  *
- * @return void
+ * @return None
  *
  * @pre vlapic != NULL
  */

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -186,9 +186,9 @@ void emulate_io_post(struct acrn_vcpu *vcpu)
  *
  * @pre io_req->type == REQ_PORTIO
  *
- * @return 0       - Successfully emulated by registered handlers.
- * @return -ENODEV - No proper handler found.
- * @return -EIO    - The request spans multiple devices and cannot be emulated.
+ * @retval 0 Successfully emulated by registered handlers.
+ * @retval -ENODEV No proper handler found.
+ * @retval -EIO The request spans multiple devices and cannot be emulated.
  */
 int32_t
 hv_emulate_pio(const struct acrn_vcpu *vcpu, struct io_request *io_req)
@@ -236,9 +236,9 @@ hv_emulate_pio(const struct acrn_vcpu *vcpu, struct io_request *io_req)
  *
  * @pre io_req->type == REQ_MMIO
  *
- * @return 0       - Successfully emulated by registered handlers.
- * @return -ENODEV - No proper handler found.
- * @return -EIO    - The request spans multiple devices and cannot be emulated.
+ * @retval 0 Successfully emulated by registered handlers.
+ * @retval -ENODEV No proper handler found.
+ * @retval -EIO The request spans multiple devices and cannot be emulated.
  */
 static int32_t
 hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
@@ -285,11 +285,11 @@ hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
  * @param vcpu The virtual CPU that triggers the MMIO access
  * @param io_req The I/O request holding the details of the MMIO access
  *
- * @return 0       - Successfully emulated by registered handlers.
- * @return IOREQ_PENDING - The I/O request is delivered to VHM.
- * @return -EIO    - The request spans multiple devices and cannot be emulated.
- * @return -EINVAL - \p io_req has an invalid type.
- * @return Negative on other errors during emulation.
+ * @retval 0 Successfully emulated by registered handlers.
+ * @retval IOREQ_PENDING The I/O request is delivered to VHM.
+ * @retval -EIO The request spans multiple devices and cannot be emulated.
+ * @retval -EINVAL \p io_req has an invalid type.
+ * @retval <0 on other errors during emulation.
  */
 int32_t
 emulate_io(struct acrn_vcpu *vcpu, struct io_request *io_req)
@@ -474,8 +474,8 @@ void register_io_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
  * @param end The end of the range (exclusive) \p read_write can emulate
  * @param handler_private_data Handler-specific data which will be passed to \p read_write when called
  *
- * @return 0 - Registration succeeds
- * @return -EINVAL - \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
+ * @retval 0 Registration succeeds
+ * @retval -EINVAL \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
  */
 int register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -158,8 +158,8 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
 /**
  * @param[inout] vm pointer to a vm descriptor
  *
- * @return 0		- on success
- * @return -EINVAL	- on invalid parameters
+ * @retval 0 on success
+ * @retval -EINVAL on invalid parameters
  *
  * @pre vm != NULL
  * @pre is_vm0(vm) == true

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -60,7 +60,7 @@ static void acrn_print_request(uint16_t vcpu_id, const struct vhm_request *req)
  *
  * @param vm The VM whose IO requests to be reset
  *
- * @return N/A
+ * @return None
  */
 void reset_vm_ioreqs(struct acrn_vm *vm)
 {
@@ -100,7 +100,7 @@ static bool has_complete_ioreq(struct acrn_vcpu *vcpu)
  *
  * @param pcpu_id The physical cpu id of vcpu whose IO request to be checked
  *
- * @return N/A
+ * @return None
  */
 void handle_complete_ioreq(uint16_t pcpu_id)
 {

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -123,7 +123,7 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint16_t pin, uint32_t level)
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @pre irq < vioapic_pincount(vm)
- * @return void
+ * @return None
  */
 void
 vioapic_set_irq_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
@@ -166,7 +166,7 @@ vioapic_set_irq_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
  *
  * @pre irq < vioapic_pincount(vm)
  *
- * @return void
+ * @return None
  */
 void
 vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation)

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -448,7 +448,7 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @return void
+ * @return None
  */
 void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
 {
@@ -525,7 +525,7 @@ void vpic_get_irq_trigger(struct acrn_vm *vm, uint32_t irq,
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *			with eligible vector if any.
  *
- * @return void.
+ * @return None
  */
 void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr)
 {
@@ -586,7 +586,7 @@ static void vpic_pin_accepted(struct i8259_reg_state *i8259, uint8_t pin)
  * @param[in] vm     Pointer to target VM
  * @param[in] vector Target virtual interrupt vector
  *
- * @return void
+ * @return None
  *
  * @pre vm != NULL
  */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -512,7 +512,7 @@ struct acrn_vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
  * @param[in] vm pointer to vm data structure, this vcpu will owned by this vm.
  * @param[out] rtn_vcpu_handle pointer to the created vcpu
  *
- * @return 0: vcpu created successfully, other values failed.
+ * @retval 0 vcpu created successfully, other values failed.
  */
 int create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn_vcpu_handle);
 
@@ -525,7 +525,7 @@ int create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn_vcp
  * @param[inout] vcpu pointer to vcpu data structure
  * @pre vcpu != NULL
  *
- * @return 0: vcpu run successfully, other values failed.
+ * @retval 0 vcpu run successfully, other values failed.
  */
 int run_vcpu(struct acrn_vcpu *vcpu);
 
@@ -584,7 +584,7 @@ void schedule_vcpu(struct acrn_vcpu *vcpu);
  * Create a vcpu for the vm, and mapped to the pcpu.
  *
  * @param[inout] vm pointer to vm data structure
- * @param[in] pcpu_id which the vcpu will be mapped 
+ * @param[in] pcpu_id which the vcpu will be mapped
  */
 int prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id);
 

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -76,7 +76,7 @@ void	vioapic_reset(struct acrn_vioapic *vioapic);
  *
  * @pre irq < vioapic_pincount(vm)
  *
- * @return void
+ * @return None
  */
 void	vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 
@@ -92,7 +92,7 @@ void	vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @pre irq < vioapic_pincount(vm)
- * @return void
+ * @return None
  */
 void	vioapic_set_irq_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 void	vioapic_update_tmr(struct acrn_vcpu *vcpu);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -145,7 +145,7 @@ int vlapic_pending_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
  * @param[in] vlapic Pointer to target vLAPIC data structure
  * @param[in] vector Target virtual interrupt vector
  *
- * @return void
+ * @return None
  *
  * @pre vlapic != NULL
  */
@@ -161,7 +161,7 @@ void vlapic_intr_accepted(struct acrn_vlapic *vlapic, uint32_t vector);
  *
  * @param[in] dest_pcpu_id Target CPU ID.
  *
- * @return void
+ * @return None
  */
 void vlapic_post_intr(uint16_t dest_pcpu_id);
 

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -126,8 +126,8 @@ uint64_t vlapic_get_cr8(const struct acrn_vlapic *vlapic);
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *               with eligible vector if any.
  *
- * @return 0 - There is no eligible pending vector.
- * @return 1 - There is pending vector.
+ * @retval 0 There is no eligible pending vector.
+ * @retval 1 There is pending vector.
  *
  * @remark The vector does not automatically transition to the ISR as a
  *	   result of calling this function.
@@ -226,8 +226,8 @@ vlapic_intr_edge(struct acrn_vcpu *vcpu, uint32_t vector)
  *			   interrupt to all vCPUs.
  * @param[in] vector       Vector to be fired.
  *
- * @return 0 on success.
- * @return -EINVAL on error that vcpu_id_arg or vector is invalid.
+ * @retval 0 on success.
+ * @retval -EINVAL on error that vcpu_id_arg or vector is invalid.
  *
  * @pre vm != NULL
  */
@@ -240,8 +240,8 @@ int vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vec
  * @param[in] addr MSI address.
  * @param[in] msg  MSI data.
  *
- * @return 0 on success.
- * @return non-zero on error that addr is invalid.
+ * @retval 0 on success.
+ * @retval -1 on error that addr is invalid.
  *
  * @pre vm != NULL
  */

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -143,7 +143,7 @@ void vpic_init(struct acrn_vm *vm);
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @return void
+ * @return None
  */
 void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 
@@ -154,7 +154,7 @@ void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *			with eligible vector if any.
  *
- * @return void.
+ * @return None
  */
 void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
 
@@ -164,7 +164,7 @@ void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
  * @param[in] vm     Pointer to target VM
  * @param[in] vector Target virtual interrupt vector
  *
- * @return void
+ * @return None
  *
  * @pre vm != NULL
  */

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -292,7 +292,7 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
  *
  * @param vm The VM whose IO requests to be reset
  *
- * @return N/A
+ * @return None
  */
 void reset_vm_ioreqs(struct acrn_vm *vm);
 
@@ -301,7 +301,7 @@ void reset_vm_ioreqs(struct acrn_vm *vm);
  *
  * @param pcpu_id The physical cpu id of vcpu whose IO request to be checked
  *
- * @return N/A
+ * @return None
  */
 void handle_complete_ioreq(uint16_t pcpu_id);
 

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -220,8 +220,8 @@ void   register_io_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
  * @param end The end of the range (exclusive) \p read_write can emulate
  * @param handler_private_data Handler-specific data which will be passed to \p read_write when called
  *
- * @return 0 - Registration succeeds
- * @return -EINVAL - \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
+ * @retval 0 Registration succeeds
+ * @retval -EINVAL \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
  */
 int register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
@@ -262,11 +262,11 @@ void dm_emulate_mmio_post(struct acrn_vcpu *vcpu);
  * @param vcpu The virtual CPU that triggers the MMIO access
  * @param io_req The I/O request holding the details of the MMIO access
  *
- * @return 0       - Successfully emulated by registered handlers.
- * @return IOREQ_PENDING - The I/O request is delivered to VHM.
- * @return -EIO    - The request spans multiple devices and cannot be emulated.
- * @return -EINVAL - \p io_req has an invalid type.
- * @return Negative on other errors during emulation.
+ * @retval 0       Successfully emulated by registered handlers.
+ * @retval IOREQ_PENDING The I/O request is delivered to VHM.
+ * @retval -EIO    The request spans multiple devices and cannot be emulated.
+ * @retval -EINVAL \p io_req has an invalid type.
+ * @retval <0 on other errors during emulation.
  */
 int32_t emulate_io(struct acrn_vcpu *vcpu, struct io_request *io_req);
 

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -136,8 +136,8 @@ uint32_t irq_to_vector(uint32_t irq);
  * @param[in] vector   Vector of the exeception.
  * @param[in] err_code Error Code to be injected.
  *
- * @return 0 on success
- * @return -EINVAL on error that vector is invalid.
+ * @retval 0 on success
+ * @retval -EINVAL on error that vector is invalid.
  *
  * @pre vcpu != NULL
  */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -148,7 +148,7 @@ int vcpu_queue_exception(struct acrn_vcpu *vcpu, uint32_t vector, uint32_t err_c
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */
@@ -159,7 +159,7 @@ void vcpu_inject_extint(struct acrn_vcpu *vcpu);
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */
@@ -171,7 +171,7 @@ void vcpu_inject_nmi(struct acrn_vcpu *vcpu);
  * @param[in] vcpu     Pointer to vCPU.
  * @param[in] err_code Error Code to be injected.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */
@@ -184,7 +184,7 @@ void vcpu_inject_gp(struct acrn_vcpu *vcpu, uint32_t err_code);
  * @param[in] addr     Address that result in PF.
  * @param[in] err_code Error Code to be injected.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */
@@ -195,7 +195,7 @@ void vcpu_inject_pf(struct acrn_vcpu *vcpu, uint64_t addr, uint32_t err_code);
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */
@@ -206,7 +206,7 @@ void vcpu_inject_ud(struct acrn_vcpu *vcpu);
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */
@@ -217,7 +217,7 @@ void vcpu_inject_ac(struct acrn_vcpu *vcpu);
  *
  * @param[in] vcpu Pointer to vCPU.
  *
- * @return void
+ * @return None
  *
  * @pre vcpu != NULL
  */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -117,15 +117,15 @@ void mmu_modify_or_del(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
 /**
  * @brief EPT and VPID capability checking
  *
- * @return 0 - on success
- * @return -ENODEV - Don't support EPT or VPID capability
+ * @retval 0 on success
+ * @retval -ENODEV Don't support EPT or VPID capability
  */
 int check_vmx_mmu_cap(void);
 /**
  * @brief VPID allocation
  *
- * @return 0 - VPID overflow
- * @return more than 0 - the valid VPID
+ * @retval 0 VPID overflow
+ * @retval >0 the valid VPID
  */
 uint16_t allocate_vpid(void);
 /**
@@ -157,8 +157,8 @@ void invept(const struct acrn_vcpu *vcpu);
  * @param[in] gpa_arg the start GPA address of the guest memory region
  * @param[in] size_arg the size of the guest memory region
  *
- * @return true - The HPA of the guest memory region is continuous
- * @return false - The HPA of the guest memory region is non-continuous
+ * @retval true The HPA of the guest memory region is continuous
+ * @retval false The HPA of the guest memory region is non-continuous
  */
 bool check_continuous_hpa(struct acrn_vm *vm, uint64_t gpa_arg, uint64_t size_arg);
 /**
@@ -221,8 +221,8 @@ void destroy_ept(struct acrn_vm *vm);
  * @param[in] vm the pointer that points to VM data structure
  * @param[in] gpa the specified guest-physical address
  *
- * @return INVALID_HPA - the HPA of parameter gpa is unmapping
- * @return hpa - the HPA of parameter gpa is hpa
+ * @retval hpa the host physical address mapping to the \p gpa
+ * @retval INVALID_HPA the HPA of parameter gpa is unmapping
  */
 uint64_t gpa2hpa(struct acrn_vm *vm, uint64_t gpa);
 /**
@@ -233,8 +233,8 @@ uint64_t gpa2hpa(struct acrn_vm *vm, uint64_t gpa);
  * @param[out] size the pointer that returns the page size of
  *                  the page in which the gpa is
  *
- * @return INVALID_HPA - the HPA of parameter gpa is unmapping
- * @return hpa - the HPA of parameter gpa is hpa
+ * @retval hpa the host physical address mapping to the \p gpa
+ * @retval INVALID_HPA the HPA of parameter gpa is unmapping
  */
 uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size);
 /**
@@ -299,8 +299,8 @@ void ept_mr_del(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
  *
  * @param[in] vcpu the pointer that points to vcpu data structure
  *
- * @return -EINVAL - fail to handle the EPT violation
- * @return 0 - Success to handle the EPT violation
+ * @retval -EINVAL fail to handle the EPT violation
+ * @retval 0 Success to handle the EPT violation
  */
 int ept_violation_vmexit_handler(struct acrn_vcpu *vcpu);
 /**
@@ -308,8 +308,8 @@ int ept_violation_vmexit_handler(struct acrn_vcpu *vcpu);
  *
  * @param[in] vcpu the pointer that points to vcpu data structure
  *
- * @return -EINVAL - fail to handle the EPT misconfig
- * @return 0 - Success to handle the EPT misconfig
+ * @retval -EINVAL fail to handle the EPT misconfig
+ * @retval 0 Success to handle the EPT misconfig
  */
 int ept_misconfig_vmexit_handler(__unused struct acrn_vcpu *vcpu);
 

--- a/hypervisor/include/arch/x86/mtrr.h
+++ b/hypervisor/include/arch/x86/mtrr.h
@@ -69,7 +69,7 @@ void mtrr_wrmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t value);
  * @param[in] vcpu The pointer that points VCPU data structure
  * @param[in] msr Virtual MTRR MSR Address
  *
- * @return unsigned long integer - The specified virtual MTRR MSR value
+ * @return The specified virtual MTRR MSR value
  */
 uint64_t mtrr_rdmsr(const struct acrn_vcpu *vcpu, uint32_t msr);
 /**

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -82,7 +82,7 @@
  *
  * @param[in] x The specified host-physical address
  *
- * @return void pointer - The host-virtual address
+ * @return The translated host-virtual address
  */
 static inline void *hpa2hva(uint64_t x)
 {
@@ -93,7 +93,7 @@ static inline void *hpa2hva(uint64_t x)
  *
  * @param[in] x The specified host-virtual address
  *
- * @return unsigned long integer - The host-physical address
+ * @return The translated host-physical address
  */
 static inline uint64_t hva2hpa(void *x)
 {

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -496,8 +496,8 @@ struct iommu_domain;
  * @param[in]    bus the 8-bit bus number of the device
  * @param[in]    devfun the 8-bit device(5-bit):function(3-bit) of the device
  *
- * @return 0 - on success.
- * @return 1 - fail to unassign the device
+ * @retval 0 on success.
+ * @retval 1 fail to unassign the device
  *
  * @pre domain != NULL
  *
@@ -513,8 +513,8 @@ int assign_iommu_device(struct iommu_domain *domain, uint8_t bus, uint8_t devfun
  * @param[in]    bus the 8-bit bus number of the device
  * @param[in]    devfun the 8-bit device(5-bit):function(3-bit) of the device
  *
- * @return 0 - on success.
- * @return 1 - fail to unassign the device
+ * @retval 0 on success.
+ * @retval 1 fail to unassign the device
  *
  * @pre domain != NULL
  *
@@ -530,8 +530,10 @@ int unassign_iommu_device(const struct iommu_domain *domain, uint8_t bus, uint8_
  * @param[in] translation_table the physcial address of EPT table of the VM specified by the vm_id
  * @param[in] addr_width address width of the VM
  *
- * @return Pointer pointer to iommu_domain
- * @return NULL if translation_table is 0
+ * @return Pointer to the created iommu_domain
+ *
+ * @retval NULL when \p translation_table is 0
+ * @retval !NULL when \p translation_table is not 0
  *
  * @pre vm_id is valid
  * @pre translation_table != 0
@@ -586,10 +588,12 @@ void resume_iommu(void);
 /**
  * @brief Init IOMMUs.
  *
- * Register DMAR units on the platform according to the pre-parsed information or DMAR table.
+ * Register DMAR units on the platform according to the pre-parsed information
+ * or DMAR table. IOMMU is a must have feature, if init_iommu failed, the system
+ * should not continue booting.
  *
- * @return 0 - on success
- * @return non-zero - iommu is a must have feature, if init_iommu failed, the system should not continue booting
+ * @retval 0 on success
+ * @retval <0 on failure
  *
  */
 int init_iommu(void);
@@ -614,8 +618,8 @@ void init_iommu_vm0_domain(struct acrn_vm *vm0);
  *
  * @param[in] vm pointer to VM to check
  *
- * @return true - support
- * @return false - not support
+ * @retval true support
+ * @retval false not support
  *
  */
 bool iommu_snoop_supported(struct acrn_vm *vm);

--- a/hypervisor/include/common/irq.h
+++ b/hypervisor/include/common/irq.h
@@ -50,8 +50,8 @@ struct irq_desc {
  *			IRQF_LEVEL - 1: level trigger; 0: edge trigger;
  *    			IRQF_PT    - 1: for passthrough dev
  *
- * @return valid irq num - on success
- * @return IRQ_INVALID - on failure
+ * @retval >=0 on success
+ * @retval IRQ_INVALID on failure
  */
 int32_t request_irq(uint32_t req_irq, irq_action_t action_fn, void *priv_data,
 			uint32_t flags);


### PR DESCRIPTION
This series fixes the following issues reported by @gvancuts.

1. Absence of return values are stated in inconsistent ways in the doxygen-style comments.
1. Adjacent `@return`s are not joined by breathe, causing multiple `Return` sections in the generated doc.

Tracked-On: #1595
Signed-off-by: Junjie Mao <junjie.mao@intel.com>