### PR TITLE
Documentation: add a README.rst to the tools/ folder

### DIFF
--- a/tools/README.rst
+++ b/tools/README.rst
@@ -1,0 +1,19 @@
+ACRN tools
+##########
+
+The open source `Project ACRN`_ defines a device hypervisor reference stack and
+an architecture for running multiple software subsystems, managed securely, on
+a consolidated system by means of a virtual machine manager. It also defines a
+reference framework implementation for virtual device emulation, called the
+“ACRN Device Model”.
+
+This folder holds the source to a number of tools that facilitate the
+management, debugging, profiling, and logging of a mutli-OS systems based on
+ACRN.
+
+You can find out more about Project ACRN and its set of tools on the
+`Project ACRN documentation`_ website.
+
+.. _`Project ACRN`: https://projectacrn.org
+.. _`Project ACRN documentation`: https://projectacrn.github.io/
+


### PR DESCRIPTION
Add a basic README.rst file to the tools/ folder to give a very brief
introduction and redirect the reader to the online documentation for more
details.

Tracked-On: #1896
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>