### PR TITLE
hv: reloc: define data structure when necessary

### DIFF
--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -8,21 +8,23 @@
 #include <reloc.h>
 #include <vm0_boot.h>
 
-struct Elf64_Dyn {
-	uint64_t d_tag;
-	uint64_t d_ptr;
-};
-
+#ifdef CONFIG_RELOC
 #define DT_NULL		0	/* end of .dynamic section */
 #define DT_RELA		7	/* relocation table */
 #define DT_RELASZ	8	/* size of reloc table */
 #define DT_RELAENT	9	/* size of one entry */
+
+struct Elf64_Dyn {
+	uint64_t d_tag;
+	uint64_t d_ptr;
+};
 
 struct Elf64_Rel {
 	uint64_t r_offset;
 	uint64_t r_info;
 	uint64_t reserved;
 };
+#endif
 
 static inline uint64_t elf64_r_type(uint64_t i)
 {


### PR DESCRIPTION
Some data structure are only used under some condition. This patch move data
structure definition under its corresponding contion. Otherwise, it would
violate MISRA-C 413 S "User type declared but not used in code analysed".

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>