### PR TITLE
HV: replace dynamic memory with static for crypto library

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -52,7 +52,7 @@ ptdev_lookup_entry_by_vpin(struct acrn_vm *vm, uint8_t virt_pin, bool pic_pin)
 	return entry;
 }
 
-#ifdef HV_DEBUG
+#ifdef CONFIG_COM_IRQ
 static bool ptdev_hv_owned_intx(const struct acrn_vm *vm, const union source_id *virt_sid)
 {
 	/* vm0 vuart pin is owned by hypervisor under debug version */
@@ -62,7 +62,7 @@ static bool ptdev_hv_owned_intx(const struct acrn_vm *vm, const union source_id 
 		return false;
 	}
 }
-#endif
+#endif /* CONFIG_COM_IRQ */
 
 static uint64_t calculate_logical_dest_mask(uint64_t pdmask)
 {
@@ -645,11 +645,12 @@ int ptdev_intx_pin_remap(struct acrn_vm *vm, uint8_t virt_pin,
 	 */
 
 	/* no remap for hypervisor owned intx */
-#ifdef HV_DEBUG
+#ifdef CONFIG_COM_IRQ
 	if (ptdev_hv_owned_intx(vm, &virt_sid)) {
 		goto END;
 	}
-#endif
+#endif /* CONFIG_COM_IRQ */
+
 	/* query if we have virt to phys mapping */
 	spinlock_obtain(&ptdev_lock);
 	entry = ptdev_lookup_entry_by_vpin(vm, virt_pin, pic_pin);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -611,10 +611,6 @@ int prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		return ret;
 	}
 
-	/* init_vmcs is delayed to vcpu vmcs launch first time */
-	/* initialize the vcpu tsc aux */
-	vcpu->msr_tsc_aux_guest = vcpu->vcpu_id;
-
 	set_pcpu_used(pcpu_id);
 
 	INIT_LIST_HEAD(&vcpu->run_list);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -31,7 +31,7 @@
 #include <reloc.h>
 
 static void *ppt_mmu_pml4_addr;
-static void *sanitized_page[CPU_PAGE_SIZE];
+static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);
 
 static struct vmx_capability {
 	uint32_t ept;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -956,7 +956,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	exec_vmwrite(VMX_CR3_TARGET_3, 0UL);
 }
 
-static void init_entry_ctrl(__unused const struct acrn_vcpu *vcpu)
+static void init_entry_ctrl(const struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
 
@@ -985,7 +985,8 @@ static void init_entry_ctrl(__unused const struct acrn_vcpu *vcpu)
 	 * MSRs on load from memory on VM entry from mem address provided by
 	 * VM-entry MSR load address field
 	 */
-	exec_vmwrite32(VMX_ENTRY_MSR_LOAD_COUNT, 0U);
+	exec_vmwrite32(VMX_ENTRY_MSR_LOAD_COUNT, MSR_AREA_COUNT);
+	exec_vmwrite64(VMX_ENTRY_MSR_LOAD_ADDR_FULL, (uint64_t)vcpu->arch.msr_area.guest);
 
 	/* Set up VM entry interrupt information field pg 2909 24.8.3 */
 	exec_vmwrite32(VMX_ENTRY_INT_INFO_FIELD, 0U);
@@ -997,7 +998,7 @@ static void init_entry_ctrl(__unused const struct acrn_vcpu *vcpu)
 	exec_vmwrite32(VMX_ENTRY_INSTR_LENGTH, 0U);
 }
 
-static void init_exit_ctrl(void)
+static void init_exit_ctrl(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
 
@@ -1029,8 +1030,10 @@ static void init_exit_ctrl(void)
 	 * The 64 bit VM-exit MSR store and load address fields provide the
 	 * corresponding addresses
 	 */
-	exec_vmwrite32(VMX_EXIT_MSR_STORE_COUNT, 0U);
-	exec_vmwrite32(VMX_EXIT_MSR_LOAD_COUNT, 0U);
+	exec_vmwrite32(VMX_EXIT_MSR_STORE_COUNT, MSR_AREA_COUNT);
+	exec_vmwrite32(VMX_EXIT_MSR_LOAD_COUNT, MSR_AREA_COUNT);
+	exec_vmwrite64(VMX_EXIT_MSR_STORE_ADDR_FULL, (uint64_t)vcpu->arch.msr_area.guest);
+	exec_vmwrite64(VMX_EXIT_MSR_LOAD_ADDR_FULL, (uint64_t)vcpu->arch.msr_area.host);
 }
 
 /**
@@ -1061,7 +1064,7 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 	init_exec_ctrl(vcpu);
 	init_guest_state(vcpu);
 	init_entry_ctrl(vcpu);
-	init_exit_ctrl();
+	init_exit_ctrl(vcpu);
 }
 
 #ifndef CONFIG_PARTITION_MODE

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -20,7 +20,6 @@ static void run_vcpu_pre_work(struct acrn_vcpu *vcpu)
 void vcpu_thread(struct acrn_vcpu *vcpu)
 {
 	uint32_t basic_exit_reason = 0U;
-	uint64_t tsc_aux_hyp_cpu = (uint64_t) vcpu->pcpu_id;
 	int32_t ret = 0;
 
 	/* If vcpu is not launched, we need to do init_vmcs first */
@@ -62,12 +61,6 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 
 		profiling_vmenter_handler(vcpu);
 
-		/* Restore guest TSC_AUX */
-		if (vcpu->launched) {
-			cpu_msr_write(MSR_IA32_TSC_AUX,
-					vcpu->msr_tsc_aux_guest);
-		}
-
 		ret = run_vcpu(vcpu);
 		if (ret != 0) {
 			pr_fatal("vcpu resume failed");
@@ -76,10 +69,6 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 		}
 
 		vcpu->arch.nrexits++;
-		/* Save guest TSC_AUX */
-		cpu_msr_read(MSR_IA32_TSC_AUX, &vcpu->msr_tsc_aux_guest);
-		/* Restore native TSC_AUX */
-		cpu_msr_write(MSR_IA32_TSC_AUX, tsc_aux_hyp_cpu);
 
 		CPU_IRQ_ENABLE();
 		/* Dispatch handler */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -15,14 +15,17 @@
 bool is_hypercall_from_ring0(void)
 {
 	uint16_t cs_sel;
+	bool ret;
 
 	cs_sel = exec_vmread16(VMX_GUEST_CS_SEL);
 	/* cs_selector[1:0] is CPL */
 	if ((cs_sel & 0x3U) == 0U) {
-		return true;
+	        ret = true;
+	} else {
+		ret = false;
 	}
 
-	return false;
+	return ret;
 }
 
 /**
@@ -76,13 +79,16 @@ int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param)
 
 	version.major_version = HV_API_MAJOR_VERSION;
 	version.minor_version = HV_API_MINOR_VERSION;
+	int32_t ret;
 
 	if (copy_to_gpa(vm, &version, param, sizeof(version)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
-		return -1;
+		ret = -1;
+	} else {
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 
 /**

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -157,10 +157,11 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
-		return -1;
+		ret = -1;
+	} else {
+		ret = shutdown_vm(target_vm);
 	}
 
-	ret = shutdown_vm(target_vm);
 	return ret;
 }
 
@@ -181,9 +182,8 @@ int32_t hcall_start_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
-		return -1;
-	}
-	if (target_vm->sw.io_shared_page == NULL) {
+		ret = -1;
+	} else if (target_vm->sw.io_shared_page == NULL) {
 		ret = -1;
 	} else {
 		ret = start_vm(target_vm);
@@ -206,14 +206,16 @@ int32_t hcall_start_vm(uint16_t vmid)
 int32_t hcall_pause_vm(uint16_t vmid)
 {
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
+	int32_t ret;
 
 	if (target_vm == NULL) {
-		return -1;
+	        ret = -1;
+	} else {
+		pause_vm(target_vm);
+		ret = 0;
 	}
 
-	pause_vm(target_vm);
-
-	return 0;
+	return ret;
 }
 
 /**
@@ -273,12 +275,14 @@ int32_t hcall_create_vcpu(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 int32_t hcall_reset_vm(uint16_t vmid)
 {
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
+	int32_t ret;
 
 	if ((target_vm == NULL) || is_vm0(target_vm)) {
-		return -1;
+	        ret = -1;
+	} else {
+	        ret = reset_vm(target_vm);
 	}
-
-	return reset_vm(target_vm);
+	return ret;
 }
 
 /**

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -29,7 +29,6 @@ static int shell_show_cpu_int(__unused int argc, __unused char **argv);
 static int shell_show_ptdev_info(__unused int argc, __unused char **argv);
 static int shell_show_vioapic_info(int argc, char **argv);
 static int shell_show_ioapic_info(__unused int argc, __unused char **argv);
-static int shell_dump_logbuf(int argc, char **argv);
 static int shell_loglevel(int argc, char **argv);
 static int shell_cpuid(int argc, char **argv);
 static int shell_trigger_crash(int argc, char **argv);
@@ -94,12 +93,6 @@ static struct shell_cmd shell_cmds[] = {
 		.cmd_param	= SHELL_CMD_IOAPIC_PARAM,
 		.help_str	= SHELL_CMD_IOAPIC_HELP,
 		.fcn		= shell_show_ioapic_info,
-	},
-	{
-		.str		= SHELL_CMD_LOGDUMP,
-		.cmd_param	= SHELL_CMD_LOGDUMP_PARAM,
-		.help_str	= SHELL_CMD_LOGDUMP_HELP,
-		.fcn		= shell_dump_logbuf,
 	},
 	{
 		.str		= SHELL_CMD_LOG_LVL,
@@ -1179,23 +1172,6 @@ static int shell_show_ioapic_info(__unused int argc, __unused char **argv)
 	shell_puts(shell_log_buf);
 
 	return err;
-}
-
-static int shell_dump_logbuf(int argc, char **argv)
-{
-	uint16_t pcpu_id;
-	int val;
-
-	if (argc == 2) {
-		val = atoi(argv[1]);
-		if (val >= 0) {
-			pcpu_id = (uint16_t)val;
-			print_logmsg_buffer(pcpu_id);
-			return 0;
-		}
-	}
-
-	return -EINVAL;
 }
 
 static int shell_loglevel(int argc, char **argv)

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -78,10 +78,6 @@ struct shell {
 #define SHELL_CMD_VIOAPIC_PARAM		"<vm id>"
 #define SHELL_CMD_VIOAPIC_HELP		"show vioapic info"
 
-#define SHELL_CMD_LOGDUMP		"logdump"
-#define SHELL_CMD_LOGDUMP_PARAM		"<pcpu id>"
-#define SHELL_CMD_LOGDUMP_HELP		"log buffer dump"
-
 #define SHELL_CMD_LOG_LVL		"loglevel"
 #define SHELL_CMD_LOG_LVL_PARAM		"[<console_loglevel> [<mem_loglevel> " \
 					"[npk_loglevel]]]"

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -231,7 +231,7 @@ vlapic_intr_edge(struct acrn_vcpu *vcpu, uint32_t vector)
  *
  * @pre vm != NULL
  */
-int vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vector);
+int32_t vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vector);
 
 /**
  * @brief Inject MSI to target VM.
@@ -245,7 +245,7 @@ int vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t vec
  *
  * @pre vm != NULL
  */
-int vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg);
+int32_t vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg);
 
 void vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest,
 		bool phys, uint32_t delmode, uint32_t vec, bool rh);

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -25,8 +25,6 @@ struct per_cpu_region {
 #ifdef HV_DEBUG
 	uint64_t *sbuf[ACRN_SBUF_ID_MAX];
 	char logbuf[LOG_MESSAGE_MAX_SIZE];
-	bool is_early_logbuf;
-	char early_logbuf[CONFIG_LOG_BUF_SIZE];
 	uint32_t npk_log_ref;
 #endif
 	uint64_t irq_count[NR_IRQS];

--- a/hypervisor/lib/crypto/crypto_api.c
+++ b/hypervisor/lib/crypto/crypto_api.c
@@ -52,8 +52,8 @@ int hmac_sha256(uint8_t *out_key,
 	}
 
 	if (mbedtls_md_hmac(md,
-			salt, salt_len,
 			secret, secret_len,
+			salt, salt_len,
 			out_key) != 0) {
 		return 0;
 	}

--- a/hypervisor/lib/crypto/mbedtls/hkdf.c
+++ b/hypervisor/lib/crypto/mbedtls/hkdf.c
@@ -121,7 +121,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
 
     mbedtls_md_init( &ctx );
 
-    if( (ret = mbedtls_md_setup( &ctx, md, 1) ) != 0 )
+    if( (ret = mbedtls_md_setup( &ctx, md) ) != 0 )
     {
         goto exit;
     }

--- a/hypervisor/lib/crypto/mbedtls/md.c
+++ b/hypervisor/lib/crypto/mbedtls/md.c
@@ -59,18 +59,8 @@ void mbedtls_md_init( mbedtls_md_context_t *ctx )
 
 void mbedtls_md_free( mbedtls_md_context_t *ctx )
 {
-    if( ctx == NULL || ctx->md_info == NULL )
+    if( ctx == NULL )
         return;
-
-    if( ctx->md_ctx != NULL )
-        ctx->md_info->ctx_free_func( ctx->md_ctx );
-
-    if( ctx->hmac_ctx != NULL )
-    {
-        mbedtls_platform_zeroize( ctx->hmac_ctx,
-                                  2 * ctx->md_info->block_size );
-        mbedtls_free( ctx->hmac_ctx );
-    }
 
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_md_context_t ) );
 }
@@ -90,23 +80,10 @@ int mbedtls_md_clone( mbedtls_md_context_t *dst,
     return( 0 );
 }
 
-int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac )
+int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info )
 {
     if( md_info == NULL || ctx == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
-
-    if( ( ctx->md_ctx = md_info->ctx_alloc_func() ) == NULL )
-        return( MBEDTLS_ERR_MD_ALLOC_FAILED );
-
-    if( hmac != 0 )
-    {
-        ctx->hmac_ctx = mbedtls_calloc( 2, md_info->block_size );
-        if( ctx->hmac_ctx == NULL )
-        {
-            md_info->ctx_free_func( ctx->md_ctx );
-            return( MBEDTLS_ERR_MD_ALLOC_FAILED );
-        }
-    }
 
     ctx->md_info = md_info;
 
@@ -254,7 +231,7 @@ int mbedtls_md_hmac( const mbedtls_md_info_t *md_info,
 
     mbedtls_md_init( &ctx );
 
-    if( ( ret = mbedtls_md_setup( &ctx, md_info, 1 ) ) != 0 )
+    if( ( ret = mbedtls_md_setup( &ctx, md_info ) ) != 0 )
         goto cleanup;
 
     if( ( ret = mbedtls_md_hmac_starts( &ctx, key, keylen ) ) != 0 )

--- a/hypervisor/lib/crypto/mbedtls/md_internal.h
+++ b/hypervisor/lib/crypto/mbedtls/md_internal.h
@@ -62,12 +62,6 @@ struct mbedtls_md_info_t
     int (*digest_func)( const unsigned char *input, size_t ilen,
                         unsigned char *output );
 
-    /** Allocate a new context */
-    void * (*ctx_alloc_func)( void );
-
-    /** Free the given context */
-    void (*ctx_free_func)( void *ctx );
-
     /** Clone state from a context */
     void (*clone_func)( void *dst, const void *src );
 

--- a/hypervisor/lib/crypto/mbedtls/md_wrap.c
+++ b/hypervisor/lib/crypto/mbedtls/md_wrap.c
@@ -45,22 +45,6 @@ static int sha256_finish_wrap( void *ctx, unsigned char *output )
                                        output ) );
 }
 
-static void *sha256_ctx_alloc( void )
-{
-    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_sha256_context ) );
-
-    if( ctx != NULL )
-        mbedtls_sha256_init( (mbedtls_sha256_context *) ctx );
-
-    return( ctx );
-}
-
-static void sha256_ctx_free( void *ctx )
-{
-    mbedtls_sha256_free( (mbedtls_sha256_context *) ctx );
-    mbedtls_free( ctx );
-}
-
 static void sha256_clone_wrap( void *dst, const void *src )
 {
     mbedtls_sha256_clone( (mbedtls_sha256_context *) dst,
@@ -93,8 +77,6 @@ const mbedtls_md_info_t mbedtls_sha256_info = {
     sha256_update_wrap,
     sha256_finish_wrap,
     sha256_wrap,
-    sha256_ctx_alloc,
-    sha256_ctx_free,
     sha256_clone_wrap,
     sha256_process_wrap,
 };

--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -124,6 +124,38 @@ static void watchdog_init(int timeout)
 	}
 }
 
+static int check_folder_space(struct sender_t *sender)
+{
+	size_t dsize;
+	int cfg_size;
+
+	if (dir_size(sender->outdir, sender->outdir_len, &dsize) == -1) {
+		LOGE("failed to check outdir size, drop ev\n");
+		return -1;
+	}
+
+	if (cfg_atoi(sender->foldersize, sender->foldersize_len,
+		     &cfg_size) == -1)
+		return -1;
+
+	if (dsize/MB >= (size_t)cfg_size) {
+		if (sender->suspending)
+			return -1;
+
+		LOGW("suspend (%s), since (%s: %ldM) meets quota (%dM)\n",
+		     sender->name, sender->outdir, dsize/MB, cfg_size);
+		sender->suspending = 1;
+		return -1;
+	}
+
+	if (!sender->suspending)
+		return 0;
+
+	LOGW("resume (%s), %s: left space %ldM for storage\n",
+	     sender->name, sender->outdir, cfg_size - dsize/MB);
+	return 0;
+}
+
 /**
  * Process each event in event queue.
  * Note that currently event handler is single threaded.
@@ -155,6 +187,9 @@ static void *event_handle(void *unused __attribute__((unused)))
 
 		for_each_sender(id, sender, conf) {
 			if (!sender)
+				continue;
+
+			if (check_folder_space(sender) == -1)
 				continue;
 
 			if (sender->send)

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -123,11 +123,14 @@ struct sender_t {
 	size_t		maxlines_len;
 	const char	*spacequota;
 	size_t		spacequota_len;
+	const char	*foldersize;
+	size_t		foldersize_len;
 	struct uptime_t *uptime;
 
 	void (*send)(struct event_t *);
 	char		*log_vmrecordid;
 	int		sw_updated; /* each sender has their own record */
+	int		suspending; /* drop all events while suspending */
 };
 
 struct conf_t {

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -36,6 +36,7 @@ static void print(void)
 		print_id_item(maxcrashdirs, sender, id);
 		print_id_item(maxlines, sender, id);
 		print_id_item(spacequota, sender, id);
+		print_id_item(foldersize, sender, id);
 
 		if (sender->uptime) {
 			print_id_item(uptime->name, sender, id);
@@ -678,6 +679,8 @@ static int parse_sender(xmlNodePtr cur, struct sender_t *sender)
 			res = load_cur_content(cur, sender, maxlines);
 		else if (name_is(cur, "spacequota"))
 			res = load_cur_content(cur, sender, spacequota);
+		else if (name_is(cur, "foldersize"))
+			res = load_cur_content(cur, sender, foldersize);
 		else if (name_is(cur, "uptime"))
 			res = parse_uptime(cur, sender);
 

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -40,7 +40,7 @@ struct mm_file_t {
 	char *path;
 	int fd;
 	char *begin;
-	int size;
+	ssize_t size;
 };
 
 struct ac_filter_data {
@@ -62,7 +62,7 @@ static inline int directory_exists(const char *path)
 	return (stat(path, &info) == 0 && S_ISDIR(info.st_mode));
 }
 
-static inline int get_file_size(const char *filepath)
+static inline ssize_t get_file_size(const char *filepath)
 {
 	struct stat info;
 
@@ -114,6 +114,7 @@ int dir_contains(const char *dir, const char *filename, size_t flen, int exact);
 int lsdir(const char *dir, char *fullname[], int limit);
 int find_file(const char *dir, size_t dlen, const char *target_file,
 		size_t tflen, int depth, char *path[], int limit);
+int dir_size(const char *dir, size_t dlen, size_t *size);
 int read_file(const char *path, unsigned long *size, void **data);
 int is_ac_filefmt(const char *file_fmt);
 int config_fmt_to_files(const char *file_fmt, char ***out);

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -7,6 +7,7 @@
 			<maxcrashdirs>1000</maxcrashdirs>
 			<maxlines>5000</maxlines>
 			<spacequota>90</spacequota>
+			<foldersize>200</foldersize>
 			<uptime>
 				<name>UPTIME</name>
 				<frequency>5</frequency>
@@ -16,6 +17,7 @@
 		<sender id="2" enable="true">
 			<name>telemd</name>
 			<outdir>/var/log/acrnprobe</outdir>
+			<foldersize>10</foldersize>
 			<uptime>
 				<name>UPTIME</name>
 				<frequency>5</frequency>
@@ -56,10 +58,9 @@
 			<name>VM1</name>
 			<channel>polling</channel>
 			<interval>60</interval>
-			<syncevent id="1">CRASH/TOMBSTONE</syncevent>
-			<syncevent id="2">CRASH/UIWDT</syncevent>
-			<syncevent id="3">CRASH/IPANIC</syncevent>
-			<syncevent id="4">REBOOT</syncevent>
+			<syncevent id="1">CRASH/UIWDT</syncevent>
+			<syncevent id="2">CRASH/IPANIC</syncevent>
+			<syncevent id="3">REBOOT</syncevent>
 		</vm>
 	</vms>
 


### PR DESCRIPTION
Remove dynamic memory allocation in crypto lib, use array to
replace them.

Tracked-On: #1900
Reviewed-by: Bing Zhu <bing.zhu@intel.com>
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>