### PR TITLE
IOC mediator: Add VehicalSteeringWheelAngle signal to the whitelist

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -633,6 +633,7 @@ static struct wlist_signal wlist_tx_signal_table[] = {
 	{(uint16_t)CBC_SIG_ID_HVSSTT,	DEFAULT_WLIST_NODE},
 	{(uint16_t)CBC_SIG_ID_HRCAT,	DEFAULT_WLIST_NODE},
 	{(uint16_t)CBC_SIG_ID_HRASTT,	DEFAULT_WLIST_NODE},
+	{(uint16_t)CBC_SIG_ID_VSWA,	DEFAULT_WLIST_NODE},
 };
 
 static struct wlist_group wlist_rx_group_table[] = {


### PR DESCRIPTION
The signal is used to get camera right and left values.

Tracked-On: #1886
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>