### PR TITLE
hv: switch IA32_TSC_AUX between host/guest through VM Controls

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -611,10 +611,6 @@ int prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		return ret;
 	}
 
-	/* init_vmcs is delayed to vcpu vmcs launch first time */
-	/* initialize the vcpu tsc aux */
-	vcpu->msr_tsc_aux_guest = vcpu->vcpu_id;
-
 	set_pcpu_used(pcpu_id);
 
 	INIT_LIST_HEAD(&vcpu->run_list);

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -956,7 +956,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	exec_vmwrite(VMX_CR3_TARGET_3, 0UL);
 }
 
-static void init_entry_ctrl(__unused const struct acrn_vcpu *vcpu)
+static void init_entry_ctrl(const struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
 
@@ -985,7 +985,8 @@ static void init_entry_ctrl(__unused const struct acrn_vcpu *vcpu)
 	 * MSRs on load from memory on VM entry from mem address provided by
 	 * VM-entry MSR load address field
 	 */
-	exec_vmwrite32(VMX_ENTRY_MSR_LOAD_COUNT, 0U);
+	exec_vmwrite32(VMX_ENTRY_MSR_LOAD_COUNT, MSR_AREA_COUNT);
+	exec_vmwrite64(VMX_ENTRY_MSR_LOAD_ADDR_FULL, (uint64_t)vcpu->arch.msr_area.guest);
 
 	/* Set up VM entry interrupt information field pg 2909 24.8.3 */
 	exec_vmwrite32(VMX_ENTRY_INT_INFO_FIELD, 0U);
@@ -997,7 +998,7 @@ static void init_entry_ctrl(__unused const struct acrn_vcpu *vcpu)
 	exec_vmwrite32(VMX_ENTRY_INSTR_LENGTH, 0U);
 }
 
-static void init_exit_ctrl(void)
+static void init_exit_ctrl(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
 
@@ -1029,8 +1030,10 @@ static void init_exit_ctrl(void)
 	 * The 64 bit VM-exit MSR store and load address fields provide the
 	 * corresponding addresses
 	 */
-	exec_vmwrite32(VMX_EXIT_MSR_STORE_COUNT, 0U);
-	exec_vmwrite32(VMX_EXIT_MSR_LOAD_COUNT, 0U);
+	exec_vmwrite32(VMX_EXIT_MSR_STORE_COUNT, MSR_AREA_COUNT);
+	exec_vmwrite32(VMX_EXIT_MSR_LOAD_COUNT, MSR_AREA_COUNT);
+	exec_vmwrite64(VMX_EXIT_MSR_STORE_ADDR_FULL, (uint64_t)vcpu->arch.msr_area.guest);
+	exec_vmwrite64(VMX_EXIT_MSR_LOAD_ADDR_FULL, (uint64_t)vcpu->arch.msr_area.host);
 }
 
 /**
@@ -1061,7 +1064,7 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 	init_exec_ctrl(vcpu);
 	init_guest_state(vcpu);
 	init_entry_ctrl(vcpu);
-	init_exit_ctrl();
+	init_exit_ctrl(vcpu);
 }
 
 #ifndef CONFIG_PARTITION_MODE

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -20,7 +20,6 @@ static void run_vcpu_pre_work(struct acrn_vcpu *vcpu)
 void vcpu_thread(struct acrn_vcpu *vcpu)
 {
 	uint32_t basic_exit_reason = 0U;
-	uint64_t tsc_aux_hyp_cpu = (uint64_t) vcpu->pcpu_id;
 	int32_t ret = 0;
 
 	/* If vcpu is not launched, we need to do init_vmcs first */
@@ -62,12 +61,6 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 
 		profiling_vmenter_handler(vcpu);
 
-		/* Restore guest TSC_AUX */
-		if (vcpu->launched) {
-			cpu_msr_write(MSR_IA32_TSC_AUX,
-					vcpu->msr_tsc_aux_guest);
-		}
-
 		ret = run_vcpu(vcpu);
 		if (ret != 0) {
 			pr_fatal("vcpu resume failed");
@@ -76,10 +69,6 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 		}
 
 		vcpu->arch.nrexits++;
-		/* Save guest TSC_AUX */
-		cpu_msr_read(MSR_IA32_TSC_AUX, &vcpu->msr_tsc_aux_guest);
-		/* Restore native TSC_AUX */
-		cpu_msr_write(MSR_IA32_TSC_AUX, tsc_aux_hyp_cpu);
 
 		CPU_IRQ_ENABLE();
 		/* Dispatch handler */


### PR DESCRIPTION
Currently guest IA32_TSC_AUX MSR is loaded manually right before VM
entry, and saved right after VM exit.

This patch enables VM-Entry Control and VM-Exit Control to switch
MSR IA32_TSC_AUX between host and guest automatically. This helps to
keep vcpu_thread() function and struct acrn_vcpu cleaner.

Also it removes the dead code of intercepting IA32_TSC_AUX.

Tracked-On: #1867
Signed-off-by: Zide Chen <zide.chen@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>