### PR TITLE
hv: hypercall: fix "Procedure has more than one exit point"

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -15,14 +15,17 @@
 bool is_hypercall_from_ring0(void)
 {
 	uint16_t cs_sel;
+	bool ret;
 
 	cs_sel = exec_vmread16(VMX_GUEST_CS_SEL);
 	/* cs_selector[1:0] is CPL */
 	if ((cs_sel & 0x3U) == 0U) {
-		return true;
+	        ret = true;
+	} else {
+		ret = false;
 	}
 
-	return false;
+	return ret;
 }
 
 /**
@@ -76,13 +79,16 @@ int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param)
 
 	version.major_version = HV_API_MAJOR_VERSION;
 	version.minor_version = HV_API_MINOR_VERSION;
+	int32_t ret;
 
 	if (copy_to_gpa(vm, &version, param, sizeof(version)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
-		return -1;
+		ret = -1;
+	} else {
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 
 /**

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -157,10 +157,11 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
-		return -1;
+		ret = -1;
+	} else {
+		ret = shutdown_vm(target_vm);
 	}
 
-	ret = shutdown_vm(target_vm);
 	return ret;
 }
 
@@ -181,9 +182,8 @@ int32_t hcall_start_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
-		return -1;
-	}
-	if (target_vm->sw.io_shared_page == NULL) {
+		ret = -1;
+	} else if (target_vm->sw.io_shared_page == NULL) {
 		ret = -1;
 	} else {
 		ret = start_vm(target_vm);
@@ -206,14 +206,16 @@ int32_t hcall_start_vm(uint16_t vmid)
 int32_t hcall_pause_vm(uint16_t vmid)
 {
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
+	int32_t ret;
 
 	if (target_vm == NULL) {
-		return -1;
+	        ret = -1;
+	} else {
+		pause_vm(target_vm);
+		ret = 0;
 	}
 
-	pause_vm(target_vm);
-
-	return 0;
+	return ret;
 }
 
 /**
@@ -273,12 +275,14 @@ int32_t hcall_create_vcpu(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 int32_t hcall_reset_vm(uint16_t vmid)
 {
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
+	int32_t ret;
 
 	if ((target_vm == NULL) || is_vm0(target_vm)) {
-		return -1;
+	        ret = -1;
+	} else {
+	        ret = reset_vm(target_vm);
 	}
-
-	return reset_vm(target_vm);
+	return ret;
 }
 
 /**


### PR DESCRIPTION
IEC 61508,ISO 26262 standards highly recommend single-exit rule.
    
    Reduce the count of the "return entries".
    Fix the violations which is comply with the cases list below:
    1.Function has 2 return entries.
    2.The first return entry is used to return the error code of
    checking variable whether is valid.
    
    Fix the violations in "if else" format.
    V1->V2:
        update the git comment to describe why comply with the
    single-exit rule.
    
    V2->V3:
        update the git comment title to give a scope declaration of this
    patch.
Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
