### PR TITLE
tools: acrn-crashlog: refine the log storage

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -124,6 +124,38 @@ static void watchdog_init(int timeout)
 	}
 }
 
+static int check_folder_space(struct sender_t *sender)
+{
+	size_t dsize;
+	int cfg_size;
+
+	if (dir_size(sender->outdir, sender->outdir_len, &dsize) == -1) {
+		LOGE("failed to check outdir size, drop ev\n");
+		return -1;
+	}
+
+	if (cfg_atoi(sender->foldersize, sender->foldersize_len,
+		     &cfg_size) == -1)
+		return -1;
+
+	if (dsize/MB >= (size_t)cfg_size) {
+		if (sender->suspending)
+			return -1;
+
+		LOGW("suspend (%s), since (%s: %ldM) meets quota (%dM)\n",
+		     sender->name, sender->outdir, dsize/MB, cfg_size);
+		sender->suspending = 1;
+		return -1;
+	}
+
+	if (!sender->suspending)
+		return 0;
+
+	LOGW("resume (%s), %s: left space %ldM for storage\n",
+	     sender->name, sender->outdir, cfg_size - dsize/MB);
+	return 0;
+}
+
 /**
  * Process each event in event queue.
  * Note that currently event handler is single threaded.
@@ -155,6 +187,9 @@ static void *event_handle(void *unused __attribute__((unused)))
 
 		for_each_sender(id, sender, conf) {
 			if (!sender)
+				continue;
+
+			if (check_folder_space(sender) == -1)
 				continue;
 
 			if (sender->send)

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -123,11 +123,14 @@ struct sender_t {
 	size_t		maxlines_len;
 	const char	*spacequota;
 	size_t		spacequota_len;
+	const char	*foldersize;
+	size_t		foldersize_len;
 	struct uptime_t *uptime;
 
 	void (*send)(struct event_t *);
 	char		*log_vmrecordid;
 	int		sw_updated; /* each sender has their own record */
+	int		suspending; /* drop all events while suspending */
 };
 
 struct conf_t {

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -36,6 +36,7 @@ static void print(void)
 		print_id_item(maxcrashdirs, sender, id);
 		print_id_item(maxlines, sender, id);
 		print_id_item(spacequota, sender, id);
+		print_id_item(foldersize, sender, id);
 
 		if (sender->uptime) {
 			print_id_item(uptime->name, sender, id);
@@ -678,6 +679,8 @@ static int parse_sender(xmlNodePtr cur, struct sender_t *sender)
 			res = load_cur_content(cur, sender, maxlines);
 		else if (name_is(cur, "spacequota"))
 			res = load_cur_content(cur, sender, spacequota);
+		else if (name_is(cur, "foldersize"))
+			res = load_cur_content(cur, sender, foldersize);
 		else if (name_is(cur, "uptime"))
 			res = parse_uptime(cur, sender);
 

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -40,7 +40,7 @@ struct mm_file_t {
 	char *path;
 	int fd;
 	char *begin;
-	int size;
+	ssize_t size;
 };
 
 struct ac_filter_data {
@@ -62,7 +62,7 @@ static inline int directory_exists(const char *path)
 	return (stat(path, &info) == 0 && S_ISDIR(info.st_mode));
 }
 
-static inline int get_file_size(const char *filepath)
+static inline ssize_t get_file_size(const char *filepath)
 {
 	struct stat info;
 
@@ -114,6 +114,7 @@ int dir_contains(const char *dir, const char *filename, size_t flen, int exact);
 int lsdir(const char *dir, char *fullname[], int limit);
 int find_file(const char *dir, size_t dlen, const char *target_file,
 		size_t tflen, int depth, char *path[], int limit);
+int dir_size(const char *dir, size_t dlen, size_t *size);
 int read_file(const char *path, unsigned long *size, void **data);
 int is_ac_filefmt(const char *file_fmt);
 int config_fmt_to_files(const char *file_fmt, char ***out);

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -7,6 +7,7 @@
 			<maxcrashdirs>1000</maxcrashdirs>
 			<maxlines>5000</maxlines>
 			<spacequota>90</spacequota>
+			<foldersize>200</foldersize>
 			<uptime>
 				<name>UPTIME</name>
 				<frequency>5</frequency>
@@ -16,6 +17,7 @@
 		<sender id="2" enable="true">
 			<name>telemd</name>
 			<outdir>/var/log/acrnprobe</outdir>
+			<foldersize>10</foldersize>
 			<uptime>
 				<name>UPTIME</name>
 				<frequency>5</frequency>
@@ -56,10 +58,9 @@
 			<name>VM1</name>
 			<channel>polling</channel>
 			<interval>60</interval>
-			<syncevent id="1">CRASH/TOMBSTONE</syncevent>
-			<syncevent id="2">CRASH/UIWDT</syncevent>
-			<syncevent id="3">CRASH/IPANIC</syncevent>
-			<syncevent id="4">REBOOT</syncevent>
+			<syncevent id="1">CRASH/UIWDT</syncevent>
+			<syncevent id="2">CRASH/IPANIC</syncevent>
+			<syncevent id="3">REBOOT</syncevent>
 		</vm>
 	</vms>
 


### PR DESCRIPTION
1. remove watching TOMBSTONE in AaaG.
2. add a configurable parameter "foldersize" in MB, sender will drop
   all events when the storaged log size exceeds this parameter.

Tracked-On:#1024
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Chen Gang <gang.c.chen@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>