### PR TITLE
tools: acrn-manager: Fix acrnctl mistake displaying suspended to paused

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -23,6 +23,7 @@ const char *state_str[] = {
 	[VM_CREATED] = "stopped",
 	[VM_STARTED] = "started",
 	[VM_PAUSED] = "paused",
+	[VM_SUSPENDED] = "suspended",
 	[VM_UNTRACKED] = "untracked",
 };
 
@@ -174,7 +175,7 @@ static void _scan_alive_vm(void)
 				vm->state = VM_STARTED;
 				break;
 			case VM_SUSPEND_SUSPEND:
-				vm->state = VM_PAUSED;
+				vm->state = VM_SUSPENDED;
 				break;
 			default:
 				vm->state = VM_STATE_UNKNOWN;

--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -574,7 +574,7 @@ static int acrnctl_do_resume(int argc, char *argv[])
 		printf("No wake up reason, use 0x%x\n", reason);
 
 	switch (s->state) {
-		case VM_PAUSED:
+		case VM_SUSPENDED:
 			resume_vm(argv[1], reason);
 			printf("resume %s reason(0x%x\n", argv[1], reason);
 			break;
@@ -627,7 +627,7 @@ static int acrnctl_do_reset(int argc, char *argv[])
 				start_vm(argv[i]);
 				break;
 			case VM_STARTED:
-			case VM_PAUSED:
+			case VM_SUSPENDED:
 				stop_vm(argv[i]);
 				if (wait_vm_stop(argv[i], STOP_TIMEOUT)) {
 					printf("Failed to stop %s in %u sec\n",

--- a/tools/acrn-manager/acrnctl.h
+++ b/tools/acrn-manager/acrnctl.h
@@ -18,6 +18,7 @@ enum vm_state {
 	VM_CREATED,		/* VM created / awaiting start (boot) */
 	VM_STARTED,		/* VM started (booted) */
 	VM_PAUSED,		/* VM paused */
+	VM_SUSPENDED,		/* VM suspended */
 	VM_UNTRACKED,		/* VM not created by acrnctl, or its launch script can change vm name */
 };
 

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -135,7 +135,7 @@ void acrnd_vm_timer_func(struct work_arg *arg)
 	case VM_CREATED:
 		acrnd_run_vm(arg->name);
 		break;
-	case VM_PAUSED:
+	case VM_SUSPENDED:
 		resume_vm(arg->name, CBC_WK_RSN_RTC);
 		break;
 	default:
@@ -251,7 +251,7 @@ static int active_all_vms(void)
 			if (!pid)
 				acrnd_run_vm(vm->name);
 			break;
-		case VM_PAUSED:
+		case VM_SUSPENDED:
 			reason = get_sos_wakeup_reason();
 			ret += resume_vm(vm->name, reason);
 			break;
@@ -288,7 +288,7 @@ static int wakeup_suspended_vms(unsigned wakeup_reason)
 	vmmngr_update();
 
 	LIST_FOREACH(vm, &vmmngr_head, list) {
-		if (vm->state == VM_PAUSED)
+		if (vm->state == VM_SUSPENDED)
 			ret += resume_vm(vm->name, wakeup_reason);
 	}
 
@@ -466,7 +466,7 @@ static int wait_for_stop(unsigned int timeout)
 			return SHUTDOWN;
 		}
 
-		if (check_vms_status(VM_PAUSED) == 0) {
+		if (check_vms_status(VM_SUSPENDED) == 0) {
 			printf("All vms have entered S3 state successfully\n");
 			return SUSPEND;
 		}


### PR DESCRIPTION
When UOS is sleeping, 'acrnctl list' command show it is 'paused', not
'suspended'. That is not correct. Because pausing an UOS means to block
its VCPUs immediately, otherwise suspending an UOS means to put it to
sleep.

Tracked-On: #1910 
Acked-by: Yan, Like <like.yan@intel.com>
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>