### PR TITLE
HV: replace dynamic memory with static for crypto library

### DIFF
--- a/hypervisor/lib/crypto/crypto_api.c
+++ b/hypervisor/lib/crypto/crypto_api.c
@@ -52,8 +52,8 @@ int hmac_sha256(uint8_t *out_key,
 	}
 
 	if (mbedtls_md_hmac(md,
-			salt, salt_len,
 			secret, secret_len,
+			salt, salt_len,
 			out_key) != 0) {
 		return 0;
 	}

--- a/hypervisor/lib/crypto/mbedtls/hkdf.c
+++ b/hypervisor/lib/crypto/mbedtls/hkdf.c
@@ -121,7 +121,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
 
     mbedtls_md_init( &ctx );
 
-    if( (ret = mbedtls_md_setup( &ctx, md, 1) ) != 0 )
+    if( (ret = mbedtls_md_setup( &ctx, md) ) != 0 )
     {
         goto exit;
     }

--- a/hypervisor/lib/crypto/mbedtls/md.c
+++ b/hypervisor/lib/crypto/mbedtls/md.c
@@ -59,18 +59,8 @@ void mbedtls_md_init( mbedtls_md_context_t *ctx )
 
 void mbedtls_md_free( mbedtls_md_context_t *ctx )
 {
-    if( ctx == NULL || ctx->md_info == NULL )
+    if( ctx == NULL )
         return;
-
-    if( ctx->md_ctx != NULL )
-        ctx->md_info->ctx_free_func( ctx->md_ctx );
-
-    if( ctx->hmac_ctx != NULL )
-    {
-        mbedtls_platform_zeroize( ctx->hmac_ctx,
-                                  2 * ctx->md_info->block_size );
-        mbedtls_free( ctx->hmac_ctx );
-    }
 
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_md_context_t ) );
 }
@@ -90,23 +80,10 @@ int mbedtls_md_clone( mbedtls_md_context_t *dst,
     return( 0 );
 }
 
-int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac )
+int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info )
 {
     if( md_info == NULL || ctx == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
-
-    if( ( ctx->md_ctx = md_info->ctx_alloc_func() ) == NULL )
-        return( MBEDTLS_ERR_MD_ALLOC_FAILED );
-
-    if( hmac != 0 )
-    {
-        ctx->hmac_ctx = mbedtls_calloc( 2, md_info->block_size );
-        if( ctx->hmac_ctx == NULL )
-        {
-            md_info->ctx_free_func( ctx->md_ctx );
-            return( MBEDTLS_ERR_MD_ALLOC_FAILED );
-        }
-    }
 
     ctx->md_info = md_info;
 
@@ -254,7 +231,7 @@ int mbedtls_md_hmac( const mbedtls_md_info_t *md_info,
 
     mbedtls_md_init( &ctx );
 
-    if( ( ret = mbedtls_md_setup( &ctx, md_info, 1 ) ) != 0 )
+    if( ( ret = mbedtls_md_setup( &ctx, md_info ) ) != 0 )
         goto cleanup;
 
     if( ( ret = mbedtls_md_hmac_starts( &ctx, key, keylen ) ) != 0 )

--- a/hypervisor/lib/crypto/mbedtls/md_internal.h
+++ b/hypervisor/lib/crypto/mbedtls/md_internal.h
@@ -62,12 +62,6 @@ struct mbedtls_md_info_t
     int (*digest_func)( const unsigned char *input, size_t ilen,
                         unsigned char *output );
 
-    /** Allocate a new context */
-    void * (*ctx_alloc_func)( void );
-
-    /** Free the given context */
-    void (*ctx_free_func)( void *ctx );
-
     /** Clone state from a context */
     void (*clone_func)( void *dst, const void *src );
 

--- a/hypervisor/lib/crypto/mbedtls/md_wrap.c
+++ b/hypervisor/lib/crypto/mbedtls/md_wrap.c
@@ -45,22 +45,6 @@ static int sha256_finish_wrap( void *ctx, unsigned char *output )
                                        output ) );
 }
 
-static void *sha256_ctx_alloc( void )
-{
-    void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_sha256_context ) );
-
-    if( ctx != NULL )
-        mbedtls_sha256_init( (mbedtls_sha256_context *) ctx );
-
-    return( ctx );
-}
-
-static void sha256_ctx_free( void *ctx )
-{
-    mbedtls_sha256_free( (mbedtls_sha256_context *) ctx );
-    mbedtls_free( ctx );
-}
-
 static void sha256_clone_wrap( void *dst, const void *src )
 {
     mbedtls_sha256_clone( (mbedtls_sha256_context *) dst,
@@ -93,8 +77,6 @@ const mbedtls_md_info_t mbedtls_sha256_info = {
     sha256_update_wrap,
     sha256_finish_wrap,
     sha256_wrap,
-    sha256_ctx_alloc,
-    sha256_ctx_free,
     sha256_clone_wrap,
     sha256_process_wrap,
 };


### PR DESCRIPTION
Remove dynamic memory allocation in crypto lib, use array to
replace them.

Tracked-On: #1900
Reviewed-by: Bing Zhu <bing.zhu@intel.com>
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>