### PR TITLE
Update 'launch_uos.sh' script for UEFI platforms

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -22,7 +22,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 6,virtio-hyper_dmabuf \
   -s 3,virtio-blk,/root/clear-26200-kvm.img \
   -s 4,virtio-net,tap0 \
-  -k /usr/lib/kernel/org.clearlinux.iot-lts2018.4.19.0-19 \
+  -k /usr/lib/kernel/default-iot-lts2018 \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 \

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -359,6 +359,12 @@ Set up Reference UOS
       name on the second line highlighted (check the exact name to be used using:
       ``ls /usr/lib/kernel/org.clearlinux*-standard*``).
 
+   .. note::
+      The script uses ``/usr/lib/kernel/default-iot-lts2018`` which is a symlink
+      to the latest ``*-iot-lts2018`` installed on the system. This provides a
+      sane default but double-check the version in case things do not work as
+      expected.
+
    By default, the script is located in the ``/usr/share/acrn/samples/nuc/``
    directory. You can edit it there, and then run it to launch the User OS:
 


### PR DESCRIPTION
Update the 'launch_uos.sh' script for UEFI platforms to point at the latest
iot-lts2018 kernel installed by means of the
/usr/lib/kernel/default-default-iot-lts2018 symlink which is set-up by the
kernel-iot-lts2018 bundle.

Update the Getting Started Guide to reflect this minor change.

Tracked-On: #1927
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>