### PR TITLE
hv: add brackets to make operator expression more readable

### DIFF
--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -259,9 +259,9 @@ hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
 		base = mmio_handler->range_start;
 		end = mmio_handler->range_end;
 
-		if ((address + size <= base) || (address >= end)) {
+		if (((address + size) <= base) || (address >= end)) {
 			continue;
-		} else if (!((address >= base) && (address + size <= end))) {
+		} else if (!((address >= base) && ((address + size) <= end))) {
 			pr_fatal("Err MMIO, address:0x%llx, size:%x", address, size);
 			return -EIO;
 		} else {

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -118,7 +118,7 @@ static void create_secure_world_ept(struct acrn_vm *vm, uint64_t gpa_orig,
 	 */
 	dest_pdpte_p = pml4e_page_vaddr(sworld_pml4e);
 	src_pdpte_p = pml4e_page_vaddr(nworld_pml4e);
-	for (i = 0U; i < PTRS_PER_PDPTE - 1; i++) {
+	for (i = 0U; i < (PTRS_PER_PDPTE - 1UL); i++) {
 		pdpte = get_pgentry(src_pdpte_p);
 		if ((pdpte & table_present) != 0UL) {
 			pdpte &= ~EPT_EXE;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -652,9 +652,9 @@ static int32_t write_protect_page(struct acrn_vm *vm,const struct wp_data *wp)
 			vm->vm_id, wp->gpa, hpa);
 
 	base_paddr = get_hv_image_base();
-	if (((hpa <= base_paddr) && (hpa + CPU_PAGE_SIZE > base_paddr)) ||
+	if (((hpa <= base_paddr) && ((hpa + CPU_PAGE_SIZE) > base_paddr)) ||
 			((hpa >= base_paddr) &&
-			(hpa < base_paddr + CONFIG_HV_RAM_SIZE))) {
+			(hpa < (base_paddr + CONFIG_HV_RAM_SIZE)))) {
 		pr_err("%s: overlap the HV memory region.", __func__);
 		return -EINVAL;
 	}

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -278,7 +278,7 @@ static int profiling_sbuf_put_variable(struct shared_buf *sbuf,
 		/* 2nd part */
 		to = (void *)sbuf + SBUF_HEAD_SIZE;
 
-		if (size - offset > 0U) {
+		if ((size - offset) > 0U) {
 			(void)memcpy_s(to, size - offset,
 				data + offset, size - offset);
 		}
@@ -372,12 +372,12 @@ static int profiling_generate_data(int32_t collector, uint32_t type)
 				return 0;
 			}
 
-			for (i = 0U; i < ((DATA_HEADER_SIZE - 1U) / SEP_BUF_ENTRY_SIZE + 1U); i++) {
+			for (i = 0U; i < (((DATA_HEADER_SIZE - 1U) / SEP_BUF_ENTRY_SIZE) + 1U); i++) {
 				(void)sbuf_put((struct shared_buf *)sbuf,
 					(uint8_t *)&pkt_header + i * SEP_BUF_ENTRY_SIZE);
 			}
 
-			for (i = 0U; i < ((payload_size - 1U) / SEP_BUF_ENTRY_SIZE + 1U); i++) {
+			for (i = 0U; i < (((payload_size - 1U) / SEP_BUF_ENTRY_SIZE) + 1U); i++) {
 				(void)sbuf_put((struct shared_buf *)sbuf,
 					(uint8_t *)payload + i * SEP_BUF_ENTRY_SIZE);
 			}

--- a/hypervisor/lib/crypto/mbedtls/hkdf.c
+++ b/hypervisor/lib/crypto/mbedtls/hkdf.c
@@ -167,7 +167,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
             goto exit;
         }
 
-        num_to_copy = i != n ? hash_len : okm_len - where;
+        num_to_copy = (i != n) ? hash_len : (okm_len - where);
         memcpy_s( okm + where, num_to_copy, t, num_to_copy );
         where += hash_len;
         t_len = hash_len;

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -567,7 +567,7 @@ charmem(size_t cmd, const char *s_arg, uint32_t sz, struct snprint_param *param)
 	}
 	/* fill mode */
 	else {
-		n = (sz < param->sz - param->wrtn) ? sz : 0U;
+		n = (sz < (param->sz - param->wrtn)) ? sz : 0U;
 		param->wrtn += sz;
 		(void)memset(p, (uint8_t)*s, n);
 	}


### PR DESCRIPTION
v1-v2:
Bypass this case:
When binary arithmetic operators of different precedence (e.g. '+'
and '*') are mixed in an expression, parentheses are added to the
sub-expressions using the operator with a higher precedence.

v1:
The operator precedence rules are complicated and it is easy to make a mistake.
So add brackets to make operator expression more readable.

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>