### PR TITLE
 hv: fix "Procedure has more than one exit point"

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1462,12 +1462,10 @@ static int emulate_sub(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 		break;
 	}
 
-	if (error != 0) {
-		return error;
+	if (error == 0) {
+		rflags2 = getcc(size, val1, val2);
+		vie_update_rflags(vcpu, rflags2, RFLAGS_STATUS_BITS);
 	}
-
-	rflags2 = getcc(size, val1, val2);
-	vie_update_rflags(vcpu, rflags2, RFLAGS_STATUS_BITS);
 
 	return error;
 }
@@ -1494,11 +1492,12 @@ static int emulate_group1(struct acrn_vcpu *vcpu, const struct instr_emul_vie *v
 	return error;
 }
 
-static int emulate_bittest(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
+static int32_t emulate_bittest(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
 	uint64_t val, rflags, bitmask;
 	uint64_t bitoff;
 	uint8_t size;
+	int32_t ret;
 
 	/*
 	 * 0F BA is a Group 8 extended opcode.
@@ -1506,31 +1505,32 @@ static int emulate_bittest(struct acrn_vcpu *vcpu, const struct instr_emul_vie *
 	 * Currently we only emulate the 'Bit Test' instruction which is
 	 * identified by a ModR/M:reg encoding of 100b.
 	 */
-	if ((vie->reg & 7U) != 4U) {
-		return -EINVAL;
-	}
+	if ((vie->reg & 7U) == 4U) {
+		rflags = vm_get_register(vcpu, CPU_REG_RFLAGS);
 
-	rflags = vm_get_register(vcpu, CPU_REG_RFLAGS);
+		vie_mmio_read(vcpu, &val);
 
-	vie_mmio_read(vcpu, &val);
+		/*
+		 * Intel SDM, Vol 2, Table 3-2:
+		 * "Range of Bit Positions Specified by Bit Offset Operands"
+		 */
+		bitmask = ((uint64_t)vie->opsize * 8UL) - 1UL;
+		bitoff = (uint64_t)vie->immediate & bitmask;
 
-	/*
-	 * Intel SDM, Vol 2, Table 3-2:
-	 * "Range of Bit Positions Specified by Bit Offset Operands"
-	 */
-	bitmask = ((uint64_t)vie->opsize * 8UL) - 1UL;
-	bitoff = (uint64_t)vie->immediate & bitmask;
-
-	/* Copy the bit into the Carry flag in %rflags */
-	if ((val & (1UL << bitoff)) != 0U) {
-		rflags |= PSL_C;
+		/* Copy the bit into the Carry flag in %rflags */
+		if ((val & (1UL << bitoff)) != 0U) {
+			rflags |= PSL_C;
+		} else {
+			rflags &= ~PSL_C;
+		}
+		size = 8U;
+		vie_update_register(vcpu, CPU_REG_RFLAGS, rflags, size);
+		ret = 0;
 	} else {
-		rflags &= ~PSL_C;
+	        ret = -EINVAL;
 	}
-	size = 8U;
-	vie_update_register(vcpu, CPU_REG_RFLAGS, rflags, size);
 
-	return 0;
+	return ret;
 }
 
 static int vmm_emulate_instruction(struct instr_emul_ctxt *ctxt)
@@ -1539,48 +1539,50 @@ static int vmm_emulate_instruction(struct instr_emul_ctxt *ctxt)
 	struct acrn_vcpu *vcpu = ctxt->vcpu;
 	int error;
 
-	if (vie->decoded == 0U) {
-		return -EINVAL;
-	}
-	switch (vie->op.op_type) {
-	case VIE_OP_TYPE_GROUP1:
-		error = emulate_group1(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_CMP:
-		error = emulate_cmp(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_MOV:
-		error = emulate_mov(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_MOVSX:
-	case VIE_OP_TYPE_MOVZX:
-		error = emulate_movx(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_MOVS:
-		error = emulate_movs(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_STOS:
-		error = emulate_stos(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_AND:
-		error = emulate_and(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_TEST:
-		error = emulate_test(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_OR:
-		error = emulate_or(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_SUB:
-		error = emulate_sub(vcpu, vie);
-		break;
-	case VIE_OP_TYPE_BITTEST:
-		error = emulate_bittest(vcpu, vie);
-		break;
-	default:
+	if (vie->decoded != 0U) {
+		switch (vie->op.op_type) {
+		case VIE_OP_TYPE_GROUP1:
+			error = emulate_group1(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_CMP:
+			error = emulate_cmp(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_MOV:
+			error = emulate_mov(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_MOVSX:
+		case VIE_OP_TYPE_MOVZX:
+			error = emulate_movx(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_MOVS:
+			error = emulate_movs(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_STOS:
+			error = emulate_stos(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_AND:
+			error = emulate_and(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_TEST:
+			error = emulate_test(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_OR:
+			error = emulate_or(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_SUB:
+			error = emulate_sub(vcpu, vie);
+			break;
+		case VIE_OP_TYPE_BITTEST:
+			error = emulate_bittest(vcpu, vie);
+			break;
+		default:
+			error = -EINVAL;
+			break;
+		}
+	} else {
 		error = -EINVAL;
-		break;
 	}
+
 	return error;
 }
 
@@ -2138,19 +2140,21 @@ static int local_decode_instruction(enum vm_cpu_mode cpu_mode,
 }
 
 /* for instruction MOVS/STO, check the gva gotten from DI/SI. */
-static int instr_check_di(struct acrn_vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt)
+static int32_t instr_check_di(struct acrn_vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt)
 {
-	int ret;
+	int32_t ret;
 	struct instr_emul_vie *vie = &emul_ctxt->vie;
 	uint64_t gva;
 
 	ret = get_gva_di_check(vcpu, vie, vie->addrsize, &gva);
 
 	if (ret < 0) {
-		return -EFAULT;
+		ret = -EFAULT;
+	} else {
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int instr_check_gva(struct acrn_vcpu *vcpu, struct instr_emul_ctxt *emul_ctxt,
@@ -2302,14 +2306,17 @@ int decode_instruction(struct acrn_vcpu *vcpu)
 	return (int)(emul_ctxt->vie.opsize);
 }
 
-int emulate_instruction(const struct acrn_vcpu *vcpu)
+int32_t emulate_instruction(const struct acrn_vcpu *vcpu)
 {
 	struct instr_emul_ctxt *ctxt = &per_cpu(g_inst_ctxt, vcpu->pcpu_id);
+	int32_t ret;
 
 	if (ctxt == NULL) {
 		pr_err("%s: Failed to get instr_emul_ctxt", __func__);
-		return -1;
+		ret = -1;
+	} else {
+		ret = vmm_emulate_instruction(ctxt); 
 	}
 
-	return vmm_emulate_instruction(ctxt);
+	return ret;
 }

--- a/hypervisor/arch/x86/guest/instr_emul.h
+++ b/hypervisor/arch/x86/guest/instr_emul.h
@@ -193,7 +193,7 @@ struct instr_emul_ctxt {
 	struct acrn_vcpu *vcpu;
 };
 
-int emulate_instruction(const struct acrn_vcpu *vcpu);
+int32_t emulate_instruction(const struct acrn_vcpu *vcpu);
 int decode_instruction(struct acrn_vcpu *vcpu);
 
 #endif

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -162,17 +162,20 @@ static void *get_rsdp(void)
 	return rsdp;
 }
 
-static int
+static bool
 probe_table(uint64_t address, const char *sig)
 {
 	void *va =  hpa2hva(address);
 	struct acpi_table_header *table = (struct acpi_table_header *)va;
+	bool ret;
 
 	if (strncmp(table->signature, sig, ACPI_NAME_SIZE) != 0) {
-		return 0;
+	        ret = false;
+	} else {
+		ret = true;
 	}
 
-	return 1;
+	return ret;
 }
 
 static void *get_acpi_tbl(const char *sig)
@@ -198,7 +201,7 @@ static void *get_acpi_tbl(const char *sig)
 		    sizeof(uint64_t);
 
 		for (i = 0U; i < count; i++) {
-			if (probe_table(xsdt->table_offset_entry[i], sig) != 0) {
+			if (probe_table(xsdt->table_offset_entry[i], sig)) {
 				addr = xsdt->table_offset_entry[i];
 				break;
 			}
@@ -212,7 +215,7 @@ static void *get_acpi_tbl(const char *sig)
 			sizeof(uint32_t);
 
 		for (i = 0U; i < count; i++) {
-			if (probe_table(rsdt->table_offset_entry[i], sig) != 0) {
+			if (probe_table(rsdt->table_offset_entry[i], sig)) {
 				addr = rsdt->table_offset_entry[i];
 				break;
 			}

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -149,10 +149,10 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
 	 */
 	zeropage = (struct zero_page *)kernel_src_addr;
 	if (zeropage->hdr.relocatable_kernel != 0U) {
-		return (void *)zeropage->hdr.pref_addr;
+		zeropage = (void *)zeropage->hdr.pref_addr;
 	}
 
-	return kernel_src_addr;
+	return zeropage;
 }
 
 /**

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -86,26 +86,24 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint16_t pin, uint32_t level)
 	uint32_t old_lvl;
 	union ioapic_rte rte;
 
-	if (pin >= REDIR_ENTRIES_HW) {
-		return;
-	}
-
-	rte = vioapic->rtbl[pin];
-	old_lvl = (uint32_t)bitmap_test(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
-	if (level == 0U) {
-		/* clear pin_state and deliver interrupt according to polarity */
-		bitmap_clear_nolock(pin & 0x3FU,
-				&vioapic->pin_state[pin >> 6U]);
-		if (((rte.full & IOAPIC_RTE_INTPOL) != 0UL)
-			&& old_lvl != level) {
-			vioapic_send_intr(vioapic, pin);
-		}
-	} else {
-		/* set pin_state and deliver intrrupt according to polarity */
-		bitmap_set_nolock(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
-		if (((rte.full & IOAPIC_RTE_INTPOL) == 0UL)
-			&& old_lvl != level) {
-			vioapic_send_intr(vioapic, pin);
+	if (pin < REDIR_ENTRIES_HW) {
+		rte = vioapic->rtbl[pin];
+		old_lvl = (uint32_t)bitmap_test(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
+		if (level == 0U) {
+			/* clear pin_state and deliver interrupt according to polarity */
+			bitmap_clear_nolock(pin & 0x3FU,
+					&vioapic->pin_state[pin >> 6U]);
+			if (((rte.full & IOAPIC_RTE_INTPOL) != 0UL)
+				&& old_lvl != level) {
+				vioapic_send_intr(vioapic, pin);
+			}
+		} else {
+			/* set pin_state and deliver intrrupt according to polarity */
+			bitmap_set_nolock(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
+			if (((rte.full & IOAPIC_RTE_INTPOL) == 0UL)
+				&& old_lvl != level) {
+				vioapic_send_intr(vioapic, pin);
+			}
 		}
 	}
 }
@@ -260,16 +258,18 @@ static inline bool vioapic_need_intr(const struct acrn_vioapic *vioapic, uint16_
 {
 	uint32_t lvl;
 	union ioapic_rte rte;
+	bool ret;
 
 	if (pin >= REDIR_ENTRIES_HW) {
-		return false;
+		ret = false;
+	} else {
+		rte = vioapic->rtbl[pin];
+		lvl = (uint32_t)bitmap_test(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
+		ret = !!((((rte.full & IOAPIC_RTE_INTPOL) != 0UL) && lvl == 0U) ||
+			(((rte.full & IOAPIC_RTE_INTPOL) == 0UL) && lvl != 0U));
 	}
 
-	rte = vioapic->rtbl[pin];
-	lvl = (uint32_t)bitmap_test(pin & 0x3FU, &vioapic->pin_state[pin >> 6U]);
-
-	return !!((((rte.full & IOAPIC_RTE_INTPOL) != 0UL) && lvl == 0U) ||
-		(((rte.full & IOAPIC_RTE_INTPOL) == 0UL) && lvl != 0U));
+	return ret;
 }
 
 /*
@@ -525,11 +525,15 @@ vioapic_init(struct acrn_vm *vm)
 uint32_t
 vioapic_pincount(const struct acrn_vm *vm)
 {
+	uint32_t ret;
+
 	if (is_vm0(vm)) {
-		return REDIR_ENTRIES_HW;
+	        ret = REDIR_ENTRIES_HW;
 	} else {
-		return VIOAPIC_RTE_NUM;
+		ret = VIOAPIC_RTE_NUM;
 	}
+
+	return ret;
 }
 
 int vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private_data)

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -59,20 +59,19 @@ static void sharing_mode_cfgread(__unused struct vpci *vpci, union pci_bdf bdf,
 	/* vdev == NULL: Could be hit for PCI enumeration from guests */
 	if ((vdev == NULL) || ((bytes != 1U) && (bytes != 2U) && (bytes != 4U))) {
 		*val = ~0U;
-		return;
-	}
-
-	for (i = 0U; (i < vdev->nr_ops) && !handled; i++) {
-		if (vdev->ops[i].cfgread != NULL) {
-			if (vdev->ops[i].cfgread(vdev, offset, bytes, val) == 0) {
-				handled = true;
+	} else {
+		for (i = 0U; (i < vdev->nr_ops) && !handled; i++) {
+			if (vdev->ops[i].cfgread != NULL) {
+				if (vdev->ops[i].cfgread(vdev, offset, bytes, val) == 0) {
+					handled = true;
+				}
 			}
 		}
-	}
 
-	/* Not handled by any handlers. Passthru to physical device */
-	if (!handled) {
-		*val = pci_pdev_read_cfg(vdev->pdev.bdf, offset, bytes);
+		/* Not handled by any handlers. Passthru to physical device */
+		if (!handled) {
+			*val = pci_pdev_read_cfg(vdev->pdev.bdf, offset, bytes);
+		}
 	}
 }
 
@@ -83,23 +82,21 @@ static void sharing_mode_cfgwrite(__unused struct vpci *vpci, union pci_bdf bdf,
 	bool handled = false;
 	uint32_t i;
 
-	if ((bytes != 1U) && (bytes != 2U) && (bytes != 4U)) {
-		return;
-	}
-
-	vdev = sharing_mode_find_vdev(bdf);
-	if (vdev != NULL) {
-		for (i = 0U; (i < vdev->nr_ops) && !handled; i++) {
-			if (vdev->ops[i].cfgwrite != NULL) {
-				if (vdev->ops[i].cfgwrite(vdev, offset, bytes, val) == 0) {
-					handled = true;
+	if ((bytes == 1U) || (bytes == 2U) || (bytes == 4U)) {
+		vdev = sharing_mode_find_vdev(bdf);
+		if (vdev != NULL) {
+			for (i = 0U; (i < vdev->nr_ops) && !handled; i++) {
+				if (vdev->ops[i].cfgwrite != NULL) {
+					if (vdev->ops[i].cfgwrite(vdev, offset, bytes, val) == 0) {
+						handled = true;
+					}
 				}
 			}
-		}
 
-		/* Not handled by any handlers. Passthru to physical device */
-		if (!handled) {
-			pci_pdev_write_cfg(vdev->pdev.bdf, offset, bytes, val);
+			/* Not handled by any handlers. Passthru to physical device */
+			if (!handled) {
+				pci_pdev_write_cfg(vdev->pdev.bdf, offset, bytes, val);
+			}
 		}
 	}
 }
@@ -108,16 +105,16 @@ static struct pci_vdev *alloc_pci_vdev(struct acrn_vm *vm, union pci_bdf bdf)
 {
 	struct pci_vdev *vdev;
 
-	if (num_pci_vdev >= CONFIG_MAX_PCI_DEV_NUM) {
-		return NULL;
+	if (num_pci_vdev < CONFIG_MAX_PCI_DEV_NUM) {
+		vdev = &sharing_mode_vdev_array[num_pci_vdev++];
+
+		/* vbdf equals to pbdf otherwise remapped */
+		vdev->vbdf = bdf;
+		vdev->vpci = &vm->vpci;
+		vdev->pdev.bdf = bdf;
+	} else {
+		vdev = NULL;
 	}
-
-	vdev = &sharing_mode_vdev_array[num_pci_vdev++];
-
-	/* vbdf equals to pbdf otherwise remapped */
-	vdev->vbdf = bdf;
-	vdev->vpci = &vm->vpci;
-	vdev->pdev.bdf = bdf;
 
 	return vdev;
 }
@@ -133,36 +130,38 @@ static void enumerate_pci_dev(uint16_t pbdf, void *cb_data)
 	}
 }
 
-static int sharing_mode_vpci_init(struct acrn_vm *vm)
+static int32_t sharing_mode_vpci_init(struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i, j;
+	int32_t ret;
 
 	/*
 	 * Only setup IO bitmap for SOS.
 	 * IO/MMIO requests from non-vm0 guests will be injected to device model.
 	 */
 	if (!is_vm0(vm)) {
-		return -ENODEV;
-	}
+	        ret = -ENODEV;
+	} else {
+		/* Initialize PCI vdev array */
+		num_pci_vdev = 0U;
+		(void)memset((void *)sharing_mode_vdev_array, 0U, sizeof(sharing_mode_vdev_array));
 
-	/* Initialize PCI vdev array */
-	num_pci_vdev = 0U;
-	(void)memset((void *)sharing_mode_vdev_array, 0U, sizeof(sharing_mode_vdev_array));
+		/* build up vdev array for vm0 */
+		pci_scan_bus(enumerate_pci_dev, (void *)vm);
 
-	/* build up vdev array for vm0 */
-	pci_scan_bus(enumerate_pci_dev, (void *)vm);
-
-	for (i = 0U; i < num_pci_vdev; i++) {
-		vdev = &sharing_mode_vdev_array[i];
-		for (j = 0U; j < vdev->nr_ops; j++) {
-			if (vdev->ops[j].init != NULL) {
-				(void)vdev->ops[j].init(vdev);
+		for (i = 0U; i < num_pci_vdev; i++) {
+			vdev = &sharing_mode_vdev_array[i];
+			for (j = 0U; j < vdev->nr_ops; j++) {
+				if (vdev->ops[j].init != NULL) {
+					(void)vdev->ops[j].init(vdev);
+				}
 			}
 		}
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 
 static void sharing_mode_vpci_deinit(__unused struct acrn_vm *vm)
@@ -170,15 +169,13 @@ static void sharing_mode_vpci_deinit(__unused struct acrn_vm *vm)
 	struct pci_vdev *vdev;
 	uint32_t i, j;
 
-	if (!is_vm0(vm)) {
-		return;
-	}
-
-	for (i = 0U; i < num_pci_vdev; i++) {
-		vdev = &sharing_mode_vdev_array[i];
-		for (j = 0U; j < vdev->nr_ops; j++) {
-			if (vdev->ops[j].deinit != NULL) {
-				(void)vdev->ops[j].deinit(vdev);
+	if (is_vm0(vm)) {
+		for (i = 0U; i < num_pci_vdev; i++) {
+			vdev = &sharing_mode_vdev_array[i];
+			for (j = 0U; j < vdev->nr_ops; j++) {
+				if (vdev->ops[j].deinit != NULL) {
+					(void)vdev->ops[j].deinit(vdev);
+				}
 			}
 		}
 	}
@@ -188,10 +185,9 @@ void add_vdev_handler(struct pci_vdev *vdev, struct pci_vdev_ops *ops)
 {
 	if (vdev->nr_ops >= (MAX_VPCI_DEV_OPS - 1U)) {
 		pr_err("%s, adding too many handlers", __func__);
-		return;
+	} else {
+		vdev->ops[vdev->nr_ops++] = *ops;
 	}
-
-	vdev->ops[vdev->nr_ops++] = *ops;
 }
 
 struct vpci_ops sharing_mode_vpci_ops = {
@@ -209,13 +205,12 @@ void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t
 	if (vdev == NULL) {
 		pr_err("%s, can't find PCI device for vm%d, vbdf (0x%x) pbdf (0x%x)", __func__,
 			target_vm->vm_id, vbdf, pbdf);
-		return;
+	} else {
+		/* UOS may do BDF mapping */
+		vdev->vpci = &target_vm->vpci;
+		vdev->vbdf.value = vbdf;
+		vdev->pdev.bdf.value = pbdf;
 	}
-
-	/* UOS may do BDF mapping */
-	vdev->vpci = &target_vm->vpci;
-	vdev->vbdf.value = vbdf;
-	vdev->pdev.bdf.value = pbdf;
 }
 
 void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
@@ -227,12 +222,11 @@ void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16
 	if (vdev == NULL) {
 		pr_err("%s, can't find PCI device for vm%d, vbdf (0x%x) pbdf (0x%x)", __func__,
 			target_vm->vm_id, vbdf, pbdf);
-		return;
-	}
-
-	/* Return this PCI device to SOS */
-	if (vdev->vpci->vm == target_vm) {
-		vm = get_vm_from_vmid(0U);
-		vdev->vpci = &vm->vpci;
+	} else {
+		/* Return this PCI device to SOS */
+		if (vdev->vpci->vm == target_vm) {
+			vm = get_vm_from_vmid(0U);
+			vdev->vpci = &vm->vpci;
+		}
 	}
 }

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -147,12 +147,16 @@ static inline uint32_t pci_bar_offset(uint32_t idx)
 
 static inline bool pci_bar_access(uint32_t offset)
 {
+	bool ret;
+
 	if ((offset >= pci_bar_offset(0U))
 		&& (offset < pci_bar_offset(PCI_BAR_COUNT))) {
-		return true;
+		ret = true;
 	} else {
-		return false;
+	        ret = false;
 	}
+
+	return ret;
 }
 
 static inline uint8_t pci_bus(uint16_t bdf)

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -34,14 +34,14 @@
 
 struct pci_vdev;
 struct pci_vdev_ops {
-	int (*init)(struct pci_vdev *vdev);
+	int32_t (*init)(struct pci_vdev *vdev);
 
-	int (*deinit)(struct pci_vdev *vdev);
+	int32_t (*deinit)(struct pci_vdev *vdev);
 
 	int (*cfgwrite)(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t val);
 
-	int (*cfgread)(struct pci_vdev *vdev, uint32_t offset,
+	int32_t (*cfgread)(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t *val);
 };
 
@@ -125,7 +125,7 @@ struct pci_addr_info {
 };
 
 struct vpci_ops {
-	int (*init)(struct acrn_vm *vm);
+	int32_t (*init)(struct acrn_vm *vm);
 	void (*deinit)(struct acrn_vm *vm);
 	void (*cfgread)(struct vpci *vpci, union pci_bdf vbdf, uint32_t offset,
 		uint32_t bytes, uint32_t *val);


### PR DESCRIPTION
hv: vpic: fix "Procedure has more than one exit point"
    
    IEC 61508,ISO 26262 standards highly recommend single-exit rule.
    
    Reduce the count of the "return entries".
    Fix the violations which is comply with the cases list below:
    1.Function has 2 return entries.
    2.The first return entry is used to return the error code of
    checking variable whether is valid.
    
    Fix the violations in "if else" format.
    
Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
