### PR TITLE
hv: fix "Procedure has more than one exit point"

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -156,11 +156,9 @@ uint16_t allocate_vpid(void)
 
 void flush_vpid_single(uint16_t vpid)
 {
-	if (vpid == 0U) {
-		return;
+	if (vpid != 0U) {
+		local_invvpid(VMX_VPID_TYPE_SINGLE_CONTEXT, vpid, 0UL);
 	}
-
-	local_invvpid(VMX_VPID_TYPE_SINGLE_CONTEXT, vpid, 0UL);
 }
 
 void flush_vpid_global(void)

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -111,6 +111,5 @@ void setup_posted_intr_notification(void)
 			posted_intr_notification,
 			NULL, IRQF_NONE) < 0) {
 		pr_err("Failed to setup posted-intr notification");
-		return;
 	}
 }

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -131,66 +131,66 @@ void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
 
 	/* We assume enter s3 success by default */
 	host_enter_s3_success = 1U;
-	if (vm->pm.sx_state_data == NULL) {
+	if (vm->pm.sx_state_data != NULL) {
+		pause_vm(vm);	/* pause vm0 before suspend system */
+
+		pcpu_id = get_cpu_id();
+
+		/* Save the wakeup vec set by guest. Will return to guest
+		 * with this wakeup vec as entry.
+		 */
+		guest_wakeup_vec32 = *vm->pm.sx_state_data->wake_vector_32;
+
+		/* set ACRN wakeup vec instead */
+		*vm->pm.sx_state_data->wake_vector_32 =
+			(uint32_t) trampoline_start16_paddr;
+
+		/* offline all APs */
+		stop_cpus();
+
+		/* Save default main entry and we will restore it after
+		 * back from S3. So the AP online could jmp to correct
+		 * main entry.
+		 */
+		pmain_entry_saved = read_trampoline_sym(main_entry);
+
+		/* Set the main entry for resume from S3 state */
+		write_trampoline_sym(main_entry, (uint64_t)restore_s3_context);
+
+		CPU_IRQ_DISABLE();
+		vmx_off(pcpu_id);
+
+		suspend_console();
+		suspend_ioapic();
+		suspend_iommu();
+		suspend_lapic();
+
+		asm_enter_s3(vm, pm1a_cnt_val, pm1b_cnt_val);
+
+		/* release the lock aquired in trampoline code */
+		spinlock_release(&trampoline_spinlock);
+
+		resume_lapic();
+		resume_iommu();
+		resume_ioapic();
+		resume_console();
+
+		exec_vmxon_instr(pcpu_id);
+		CPU_IRQ_ENABLE();
+
+		/* restore the default main entry */
+		write_trampoline_sym(main_entry, pmain_entry_saved);
+
+		/* online all APs again */
+		start_cpus();
+
+		/* jump back to vm */
+		resume_vm_from_s3(vm, guest_wakeup_vec32);
+	} else {
 		pr_err("No Sx state info avaiable. No Sx support");
 		host_enter_s3_success = 0U;
-		return;
 	}
 
-	pause_vm(vm);	/* pause vm0 before suspend system */
-
-	pcpu_id = get_cpu_id();
-
-	/* Save the wakeup vec set by guest. Will return to guest
-	 * with this wakeup vec as entry.
-	 */
-	guest_wakeup_vec32 = *vm->pm.sx_state_data->wake_vector_32;
-
-	/* set ACRN wakeup vec instead */
-	*vm->pm.sx_state_data->wake_vector_32 =
-		(uint32_t) trampoline_start16_paddr;
-
-	/* offline all APs */
-	stop_cpus();
-
-	/* Save default main entry and we will restore it after
-	 * back from S3. So the AP online could jmp to correct
-	 * main entry.
-	 */
-	pmain_entry_saved = read_trampoline_sym(main_entry);
-
-	/* Set the main entry for resume from S3 state */
-	write_trampoline_sym(main_entry, (uint64_t)restore_s3_context);
-
-	CPU_IRQ_DISABLE();
-	vmx_off(pcpu_id);
-
-	suspend_console();
-	suspend_ioapic();
-	suspend_iommu();
-	suspend_lapic();
-
-	asm_enter_s3(vm, pm1a_cnt_val, pm1b_cnt_val);
-
-	/* release the lock aquired in trampoline code */
-	spinlock_release(&trampoline_spinlock);
-
-	resume_lapic();
-	resume_iommu();
-	resume_ioapic();
-	resume_console();
-
-	exec_vmxon_instr(pcpu_id);
-	CPU_IRQ_ENABLE();
-
-	/* restore the default main entry */
-	write_trampoline_sym(main_entry, pmain_entry_saved);
-
-	/* online all APs again */
-	start_cpus();
-
-	/* jump back to vm */
-	resume_vm_from_s3(vm, guest_wakeup_vec32);
 
 	return;
 }

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -81,13 +81,15 @@ static inline void pio_write(uint32_t v, uint16_t addr, size_t sz)
 
 static inline uint32_t pio_read(uint16_t addr, size_t sz)
 {
+	uint32_t ret;
 	if (sz == 1U) {
-		return pio_read8(addr);
+		ret = pio_read8(addr);
+	} else if (sz == 2U) {
+		ret = pio_read16(addr);
+	} else {
+		ret = pio_read32(addr);
 	}
-	if (sz == 2U) {
-		return pio_read16(addr);
-	}
-	return pio_read32(addr);
+	return ret;
 }
 
 /** Writes a 64 bit value to a memory mapped IO device.

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -78,11 +78,12 @@ static inline uint16_t fls64(uint64_t value)
 {
 	uint64_t ret = 0UL;
 	if (value == 0UL) {
-		return (INVALID_BIT_INDEX);
-	}
-	asm volatile("bsrq %1,%0"
+	        ret = (INVALID_BIT_INDEX);
+	} else {
+		asm volatile("bsrq %1,%0"
 			: "=r" (ret)
 			: "rm" (value));
+	}
 	return (uint16_t)ret;
 }
 


### PR DESCRIPTION
hv: fix "Procedure has more than one exit point"
    
    IEC 61508,ISO 26262 standards highly recommend single-exit rule.
    
    Reduce the count of the "return entries".
    Fix the violations which is comply with the cases list below:
    1.Function has 2 return entries.
    2.The first return entry is used to return the error code of
    checking variable whether is valid.
    
    Fix the violations in "if else" format.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
     

