### PR TITLE
Trusty

### DIFF
--- a/doc/developer-guides/hld/hv-memmgt.rst
+++ b/doc/developer-guides/hld/hv-memmgt.rst
@@ -445,9 +445,6 @@ Address Space Translation
 .. doxygenfunction:: vm0_hpa2gpa
    :project: Project ACRN
 
-.. doxygenfunction:: check_continuous_hpa
-   :project: Project ACRN
-
 EPT
 ---
 

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -267,8 +267,8 @@ config HV_RAM_START
 
 config HV_RAM_SIZE
 	hex "Size of the RAM region used by the hypervisor"
-	default 0x04800000 if PLATFORM_SBL
-	default 0x08000000 if PLATFORM_UEFI
+	default 0x07800000 if PLATFORM_SBL
+	default 0x0b000000 if PLATFORM_UEFI
 	help
 	  A 64-bit integer indicating the size of RAM used by the hypervisor.
 	  It is ensured at link time that the footprint of the hypervisor

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -275,14 +275,19 @@ void init_paging(void)
 	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (1UL << 32U), high64_max_ram - (1UL << 32U),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK, &ppt_mem_ops, MR_MODIFY);
 
-	/* set the paging-structure entries' U/S flag
-	 * to supervisor-mode for hypervisor owned memroy.
+	/*
+	 * set the paging-structure entries' U/S flag to supervisor-mode for hypervisor owned memroy.
+	 * (exclude the memory reserve for trusty)
 	 */
 	hv_hpa = get_hv_image_base();
 	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, hv_hpa & PDE_MASK,
-		CONFIG_HV_RAM_SIZE + (((hv_hpa & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
+			CONFIG_HV_RAM_SIZE + (((hv_hpa & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER,
 			&ppt_mem_ops, MR_MODIFY);
+
+	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (uint64_t)get_reserve_sworld_memory_base(),
+			TRUSTY_RAM_SIZE * (CONFIG_MAX_VM_NUM - 1U),
+			PAGE_USER, 0UL, &ppt_mem_ops, MR_MODIFY);
 
 	/* Enable paging */
 	enable_paging();

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -295,27 +295,3 @@ void init_paging(void)
 	/* set ptep in sanitized_page point to itself */
 	sanitize_pte((uint64_t *)sanitized_page);
 }
-
-bool check_continuous_hpa(struct acrn_vm *vm, uint64_t gpa_arg, uint64_t size_arg)
-{
-	uint64_t curr_hpa;
-	uint64_t next_hpa;
-	uint64_t gpa = gpa_arg;
-	uint64_t size = size_arg;
-
-	/* if size <= PAGE_SIZE_4K, it is continuous,no need check
-	 * if size > PAGE_SIZE_4K, need to fetch next page
-	 */
-	while (size > PAGE_SIZE_4K) {
-		curr_hpa = gpa2hpa(vm, gpa);
-		gpa += PAGE_SIZE_4K;
-		next_hpa = gpa2hpa(vm, gpa);
-		if ((curr_hpa == INVALID_HPA) || (next_hpa == INVALID_HPA)
-			|| (next_hpa != (curr_hpa + PAGE_SIZE_4K))) {
-			return false;
-		}
-		size -= PAGE_SIZE_4K;
-	}
-	return true;
-
-}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -119,8 +119,7 @@ int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param)
 	}
 
 	(void)memset(&vm_desc, 0U, sizeof(vm_desc));
-	vm_desc.sworld_supported =
-		((cv.vm_flag & (SECURE_WORLD_ENABLED)) != 0U);
+	vm_desc.sworld_supported = ((cv.vm_flag & (SECURE_WORLD_ENABLED)) != 0U);
 	(void)memcpy_s(&vm_desc.GUID[0], 16U, &cv.GUID[0], 16U);
 	ret = create_vm(&vm_desc, &target_vm);
 
@@ -515,11 +514,10 @@ static int32_t set_vm_memory_region(struct acrn_vm *vm,
 	}
 
 	gpa_end = region->gpa + region->size;
-	if ((gpa_end > vm->arch_vm.ept_mem_ops.info->ept.top_address_space) &&
-		(region->gpa < TRUSTY_EPT_REBASE_GPA)) {
+	if (gpa_end > vm->arch_vm.ept_mem_ops.info->ept.top_address_space) {
 			pr_err("%s, invalid gpa: 0x%llx, size: 0x%llx, top_address_space: 0x%llx", __func__,
 				region->gpa, region->size, vm->arch_vm.ept_mem_ops.info->ept.top_address_space);
-			return -EINVAL;
+			return 0;
 	}
 
 	dev_dbg(ACRN_DBG_HYCALL,

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -151,17 +151,6 @@ void flush_vpid_global(void);
  */
 void invept(const struct acrn_vcpu *vcpu);
 /**
- * @brief Host-physical address continous checking
- *
- * @param[in] vm the pointer that points the VM data structure
- * @param[in] gpa_arg the start GPA address of the guest memory region
- * @param[in] size_arg the size of the guest memory region
- *
- * @retval true The HPA of the guest memory region is continuous
- * @retval false The HPA of the guest memory region is non-continuous
- */
-bool check_continuous_hpa(struct acrn_vm *vm, uint64_t gpa_arg, uint64_t size_arg);
-/**
  *@pre (pml4_page != NULL) && (pg_size != NULL)
  */
 uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -46,6 +46,7 @@ union pgtable_pages_info {
 		struct page *nworld_pd_base;
 		struct page *nworld_pt_base;
 		struct page *sworld_pgtable_base;
+		struct page *sworld_memory_base;
 	} ept;
 };
 
@@ -57,9 +58,11 @@ struct memory_ops {
 	struct page *(*get_pdpt_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	struct page *(*get_pd_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	struct page *(*get_pt_page)(const union pgtable_pages_info *info, uint64_t gpa);
+	void *(*get_sworld_memory_base)(const union pgtable_pages_info *info);
 };
 
 extern const struct memory_ops ppt_mem_ops;
 void init_ept_mem_ops(struct acrn_vm *vm);
+void *get_reserve_sworld_memory_base(void);
 
 #endif /* PAGE_H */

--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -94,8 +94,6 @@ struct trusty_key_info {
 };
 
 struct secure_world_memory {
-	/* The secure world base address of GPA in SOS */
-	uint64_t base_gpa_in_sos;
 	/* The original secure world base address allocated by bootloader */
 	uint64_t base_gpa_in_uos;
 	/* The secure world base address of HPA */


### PR DESCRIPTION
v1-v2:
1) Detail the comments
2) Add restore the memory allocated to trusty back to normal world when destroying trusty world

v1:
The previous SOS would reserve memory for trusty. However, there would no
continue 16 MB memory available any more after running a long time. Then
the memory allocation for trusty would failed. Now Move trusty memory reserve
to ACRN. It would never fail again.

Tracked-On: #1942
Signed-off-by: Li, Fei1 <fei1.li@intel.com>