### PR TITLE
HV: io: obsolete the valid field in vhm requests

### DIFF
--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -10,7 +10,6 @@
 
 static void complete_ioreq(struct vhm_request *vhm_req)
 {
-	vhm_req->valid = 0;
 	atomic_store32(&vhm_req->processed, REQ_STATE_FREE);
 }
 
@@ -140,8 +139,7 @@ void emulate_io_post(struct acrn_vcpu *vcpu)
 	req_buf = (union vhm_request_buffer *)vcpu->vm->sw.io_shared_page;
 	vhm_req = &req_buf->req_queue[vcpu->vcpu_id];
 
-	if ((vhm_req->valid == 0) ||
-		(atomic_load32(&vhm_req->processed) != REQ_STATE_COMPLETE)) {
+	if (atomic_load32(&vhm_req->processed) != REQ_STATE_COMPLETE) {
 		return;
 	}
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -261,7 +261,7 @@ union vhm_io_request {
  */
 struct vhm_request {
 	/**
-	 * Type of this request.
+	 * @brief Type of this request.
 	 *
 	 * Byte offset: 0.
 	 */
@@ -275,14 +275,16 @@ struct vhm_request {
 	uint32_t completion_polling;
 
 	/**
-	 * Reserved.
+	 * @brief Reserved.
 	 *
 	 * Byte offset: 8.
 	 */
 	uint32_t reserved0[14];
 
 	/**
-	 * Details about this request. For REQ_PORTIO, this has type
+	 * @brief Details about this request.
+	 *
+	 * For REQ_PORTIO, this has type
 	 * pio_request. For REQ_MMIO and REQ_WP, this has type mmio_request. For
 	 * REQ_PCICFG, this has type pci_request.
 	 *
@@ -291,25 +293,25 @@ struct vhm_request {
 	union vhm_io_request reqs;
 
 	/**
-	 * Whether this request is valid for processing. ACRN write, VHM read
-	 * only.
-	 *
-	 * Warning; this field is obsolete and will be removed soon.
+	 * @brief Reserved.
 	 *
 	 * Byte offset: 128.
 	 */
-	int32_t valid;
+	uint32_t reserved1;
 
 	/**
-	 * The client which is distributed to handle this request. Accessed by
-	 * VHM only.
+	 * @brief The client which is distributed to handle this request.
+	 *
+	 * Accessed by VHM only.
 	 *
 	 * Byte offset: 132.
 	 */
 	int32_t client;
 
 	/**
-	 * The status of this request, taking REQ_STATE_xxx as values.
+	 * @brief The status of this request.
+	 *
+	 * Taking REQ_STATE_xxx as values.
 	 *
 	 * Byte offset: 136.
 	 */


### PR DESCRIPTION
As SOS has already adapted to the new state transition of VHM requests for a
month, the old `valid` field can now be safely obsoleted.

This patch changes the `valid` field as reserved and drops all the code that
reads or modifies this field for backward compatibility. The embedded comments
are updated accordingly, following the doxygen style.

Tracked-On: #875
Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>