### PR TITLE
hv: fix type conversion violations

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -317,7 +317,7 @@ set_expiration(struct acrn_vlapic *vlapic)
 	if ((tmicr == 0U) || (divisor_shift > 8U)) {
 		ret = false;
 	} else {
-		delta = tmicr << divisor_shift;
+		delta = (uint64_t)tmicr << divisor_shift;
 		timer = &vtimer->timer;
 
 		if (vlapic_lvtt_period(vlapic)) {
@@ -1163,7 +1163,7 @@ vlapic_get_cr8(const struct acrn_vlapic *vlapic)
 	uint32_t tpr;
 
 	tpr = vlapic_get_tpr(vlapic);
-	return (uint64_t)(tpr >> 4U);
+	return ((uint64_t)tpr >> 4UL);
 }
 
 static void

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -189,7 +189,7 @@ create_rte_for_gsi_irq(uint32_t irq, uint32_t vr)
 		rte.full |= IOAPIC_RTE_INTAHI;
 
 		/* Dest field */
-		rte.full |= ((uint64_t)ALL_CPUS_MASK << IOAPIC_RTE_DEST_SHIFT);
+		rte.full |= (ALL_CPUS_MASK << IOAPIC_RTE_DEST_SHIFT);
 	}
 
 	return rte;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -120,7 +120,7 @@ static void create_secure_world_ept(struct acrn_vm *vm, uint64_t gpa_orig,
 	 */
 	dest_pdpte_p = pml4e_page_vaddr(sworld_pml4e);
 	src_pdpte_p = pml4e_page_vaddr(nworld_pml4e);
-	for (i = 0U; i < (PTRS_PER_PDPTE - 1UL); i++) {
+	for (i = 0U; i < (uint16_t)(PTRS_PER_PDPTE - 1UL); i++) {
 		pdpte = get_pgentry(src_pdpte_p);
 		if ((pdpte & table_present) != 0UL) {
 			pdpte &= ~EPT_EXE;
@@ -162,7 +162,7 @@ void destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem)
 
 	if (need_clr_mem) {
 		/* clear trusty memory space */
-		(void)memset(hpa2hva(hpa), 0U, size);
+		(void)memset(hpa2hva(hpa), 0U, (size_t)size);
 	}
 
 	ept_mr_del(vm, vm->arch_vm.sworld_eptp, gpa_uos, size);
@@ -361,7 +361,7 @@ static bool derive_aek(uint8_t *attkb_key)
 	max_svn_idx = get_max_svn_index();
 	ikm = g_key_info.dseed_list[max_svn_idx].seed;
 	/* only the low 32 bits of seed are valid */
-	ikm_len = 32;
+	ikm_len = 32U;
 
 	if (hmac_sha256(attkb_key, ikm, ikm_len,
 			(const uint8_t *)salt, sizeof(salt)) != 1) {

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -924,7 +924,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	value64 = hva2hpa(vm->arch_vm.io_bitmap);
 	exec_vmwrite64(VMX_IO_BITMAP_A_FULL, value64);
 	pr_dbg("VMX_IO_BITMAP_A: 0x%016llx ", value64);
-	value64 = hva2hpa(&(vm->arch_vm.io_bitmap[CPU_PAGE_SIZE]));
+	value64 = hva2hpa((void *)&(vm->arch_vm.io_bitmap[CPU_PAGE_SIZE]));
 	exec_vmwrite64(VMX_IO_BITMAP_B_FULL, value64);
 	pr_dbg("VMX_IO_BITMAP_B: 0x%016llx ", value64);
 

--- a/hypervisor/boot/sbl/sbl_seed_parse.c
+++ b/hypervisor/boot/sbl/sbl_seed_parse.c
@@ -94,7 +94,7 @@ static void parse_seed_list_sbl(struct seed_list_hob *seed_hob)
 			dseed_index++;
 
 			/* erase original seed in seed entry */
-			(void)memset(entry->seed, 0U, sizeof(struct seed_info));
+			(void)memset((void *)entry->seed, 0U, sizeof(struct seed_info));
 		}
 
 		entry = (struct seed_entry *)((uint8_t *)entry +

--- a/hypervisor/dm/hw/pci.c
+++ b/hypervisor/dm/hw/pci.c
@@ -123,8 +123,8 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable)
 void pci_scan_bus(pci_enumeration_cb cb_func, void *cb_data)
 {
 	union pci_bdf pbdf;
-	uint8_t hdr_type, secondary_bus;
-	uint32_t bus, dev, func, val;
+	uint8_t hdr_type, secondary_bus, dev, func;
+	uint32_t bus, val;
 	uint8_t bus_to_scan[PCI_BUSMAX + 1] = { BUS_SCAN_SKIP };
 
 	/* start from bus 0 */
@@ -136,7 +136,7 @@ void pci_scan_bus(pci_enumeration_cb cb_func, void *cb_data)
 		}
 
 		bus_to_scan[bus] = BUS_SCAN_COMPLETE;
-		pbdf.bits.b = bus;
+		pbdf.bits.b = (uint8_t)bus;
 
 		for (dev = 0U; dev <= PCI_SLOTMAX; dev++) {
 			pbdf.bits.d = dev;

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -50,7 +50,7 @@
 
 #define DEFAULT_DEST_MODE	IOAPIC_RTE_DESTLOG
 #define DEFAULT_DELIVERY_MODE	IOAPIC_RTE_DELLOPRI
-#define ALL_CPUS_MASK		((1U << phys_cpu_num) - 1U)
+#define ALL_CPUS_MASK		((1UL << (uint64_t)phys_cpu_num) - 1UL)
 
 #define IRQ_ALLOC_BITMAP_SIZE	INT_DIV_ROUNDUP(NR_IRQS, 64U)
 

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -8,7 +8,7 @@
 #define PAGE_H
 
 #define PAGE_SHIFT	12U
-#define PAGE_SIZE	(1UL << PAGE_SHIFT)
+#define PAGE_SIZE	(1U << PAGE_SHIFT)
 
 /* size of the low MMIO address space: 2GB */
 #define PLATFORM_LO_MMIO_SIZE	0x80000000UL

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -291,7 +291,7 @@ static inline uint8_t iommu_ecap_pds(uint64_t ecap)
 #define DMA_CCMD_DEVICE_INVL (3UL << 61U)
 static inline uint64_t dma_ccmd_fm(uint8_t fm)
 {
-	return (((uint64_t)(fm & 0x3U)) << 32U);
+	return (((uint64_t)fm & 0x3UL) << 32UL);
 }
 
 #define DMA_CCMD_MASK_NOBIT 0UL
@@ -300,7 +300,7 @@ static inline uint64_t dma_ccmd_fm(uint8_t fm)
 #define DMA_CCMD_MASK_3BIT 3UL
 static inline uint64_t dma_ccmd_sid(uint16_t sid)
 {
-	return (((uint64_t)(sid & 0xffffU)) << 16U);
+	return (((uint64_t)sid & 0xffffUL) << 16UL);
 }
 
 static inline uint16_t dma_ccmd_did(uint16_t did)
@@ -324,7 +324,7 @@ static inline uint8_t dma_ccmd_get_caig_32(uint32_t gaig)
 #define DMA_IOTLB_DW				(((uint64_t)1UL) << 48U)
 static inline uint64_t dma_iotlb_did(uint16_t did)
 {
-	return (((uint64_t)(did & 0xffffU)) << 32U);
+	return (((uint64_t)did & 0xffffUL) << 32UL);
 }
 
 static inline uint8_t dma_iotlb_get_iaig_32(uint32_t iai)


### PR DESCRIPTION
This patch fixes the following violations:
 1. Implicit conversion: actual to formal param
 2. Value is not of appropriate type
 3. No cast for widening complex int expression
 4. Widening cast on complex integer expression
 5. Narrower int conversion without cast.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>