### PR TITLE
Boot modulization

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -157,6 +157,7 @@ C_SRCS += arch/x86/mtrr.c
 C_SRCS += arch/x86/pm.c
 S_SRCS += arch/x86/wakeup.S
 C_SRCS += arch/x86/static_checks.c
+C_SRCS += arch/x86/trampoline.c
 C_SRCS += arch/x86/guest/vcpu.c
 C_SRCS += arch/x86/guest/vm.c
 C_SRCS += arch/x86/guest/vlapic.c

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include        <cpu.h>
-#include        <mmu.h>
-#include        <gdt.h>
 #include        <idt.h>
-#include        <msr.h>
 
 /* NOTE:
  *

--- a/hypervisor/arch/x86/boot/cpu_save_boot_ctx.S
+++ b/hypervisor/arch/x86/boot/cpu_save_boot_ctx.S
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <vm0_boot.h>
+#include <boot_context.h>
 
     .section    entry, "ax"
     .align      8
@@ -13,7 +13,7 @@
     .global     cpu_primary_save_32
 cpu_primary_save_32:
     /* save context from 32bit mode */
-    lea     vm0_boot_context, %eax
+    lea     boot_context, %eax
     sgdt    BOOT_CTX_GDT_OFFSET(%eax)
     sidt    BOOT_CTX_IDT_OFFSET(%eax)
     str     BOOT_CTX_TR_SEL_OFFSET(%eax)
@@ -50,7 +50,7 @@ cpu_primary_save_32:
     .global     cpu_primary_save_64
 cpu_primary_save_64:
     /* save context from 64bit mode */
-    lea     vm0_boot_context(%rip), %r8
+    lea     boot_context(%rip), %r8
     sgdt    BOOT_CTX_GDT_OFFSET(%r8)
     sidt    BOOT_CTX_IDT_OFFSET(%r8)
     str     BOOT_CTX_TR_SEL_OFFSET(%r8)
@@ -90,8 +90,8 @@ cpu_primary_save_64:
 
     .text
     .align  8
-    .global vm0_boot_context
-vm0_boot_context:
+    .global boot_context
+boot_context:
     .rept   SIZE_OF_BOOT_CTX
     .byte 0x00
     .endr

--- a/hypervisor/arch/x86/boot/idt.S
+++ b/hypervisor/arch/x86/boot/idt.S
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <gdt.h>
 #include <idt.h>
 
 .altmacro

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -15,10 +15,6 @@
  */
 
 #include        <spinlock.h>
-#include        <gdt.h>
-#include        <cpu.h>
-#include        <mmu.h>
-#include        <msr.h>
 
 /* NOTE:
  *
@@ -38,8 +34,6 @@
  */
 
     .extern     cpu_secondary_init
-    .extern     ld_bss_end
-    .extern     HOST_GDTR
 
     .section     .trampoline_reset,"ax"
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -7,7 +7,7 @@
 #include <hypervisor.h>
 #include <schedule.h>
 #include <version.h>
-#include <reloc.h>
+#include <trampoline.h>
 
 spinlock_t trampoline_spinlock = {
 	.head = 0U,

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -445,6 +445,14 @@ void init_default_irqs(uint16_t cpu_id)
 	}
 }
 
+static void set_idt(struct host_idt_descriptor *idtd)
+{
+
+	asm volatile ("   lidtq %[idtd]\n" :	/* no output parameters */
+		      :		/* input parameters */
+		      [idtd] "m"(*idtd));
+}
+
 void interrupt_init(uint16_t pcpu_id)
 {
 	struct host_idt_descriptor *idtd = &HOST_IDTR;

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <hypervisor.h>
-#include <reloc.h>
+#include <trampoline.h>
 
 struct cpu_context cpu_ctx;
 

--- a/hypervisor/arch/x86/static_checks.c
+++ b/hypervisor/arch/x86/static_checks.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <hypervisor.h>
-#include <vm0_boot.h>
+#include <boot_context.h>
 
 #define CAT__(A,B) A ## B
 #define CAT_(A,B) CAT__(A,B)

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <hypervisor.h>
+#include <reloc.h>
+#include <trampoline.h>
+#include <vm0_boot.h>
+
+uint64_t trampoline_start16_paddr;
+
+/*
+ * Because trampoline code is relocated in different way, if HV code
+ * accesses trampoline using relative addressing, it needs to take
+ * out the HV relocation delta
+ *
+ * This function is valid if:
+ *  - The hpa of HV code is always higher than trampoline code
+ *  - The HV code is always relocated to higher address, compared
+ *    with CONFIG_HV_RAM_START
+ */
+static uint64_t trampoline_relo_addr(const void *addr)
+{
+	return (uint64_t)addr - get_hv_image_delta();
+}
+
+uint64_t read_trampoline_sym(const void *sym)
+{
+	uint64_t *hva;
+
+	hva = hpa2hva(trampoline_start16_paddr) + trampoline_relo_addr(sym);
+	return *hva;
+}
+
+void write_trampoline_sym(const void *sym, uint64_t val)
+{
+	uint64_t *hva;
+
+	hva = hpa2hva(trampoline_start16_paddr) + trampoline_relo_addr(sym);
+	*hva = val;
+	clflush(hva);
+}
+
+static void update_trampoline_code_refs(uint64_t dest_pa)
+{
+	void *ptr;
+	uint64_t val;
+	int i;
+
+	/*
+	 * calculate the fixup CS:IP according to fixup target address
+	 * dynamically.
+	 *
+	 * trampoline code starts in real mode,
+	 * so the target addres is HPA
+	 */
+	val = dest_pa + trampoline_relo_addr(&trampoline_fixup_target);
+
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_fixup_cs));
+	*(uint16_t *)(ptr) = (uint16_t)((val >> 4U) & 0xFFFFU);
+
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_fixup_ip));
+	*(uint16_t *)(ptr) = (uint16_t)(val & 0xfU);
+
+	/* Update temporary page tables */
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&cpu_boot_page_tables_ptr));
+	*(uint32_t *)(ptr) += (uint32_t)dest_pa;
+
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&cpu_boot_page_tables_start));
+	*(uint64_t *)(ptr) += dest_pa;
+
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_pdpt_addr));
+	for (i = 0; i < 4; i++) {
+		*(uint64_t *)(ptr + sizeof(uint64_t) * i) += dest_pa;
+	}
+
+	/* update the gdt base pointer with relocated offset */
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_gdt_ptr));
+	*(uint64_t *)(ptr + 2) += dest_pa;
+
+	/* update trampoline jump pointer with relocated offset */
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_start64_fixup));
+	*(uint32_t *)ptr += (uint32_t)dest_pa;
+
+	/* update trampoline's main entry pointer */
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(main_entry));
+	*(uint64_t *)ptr += get_hv_image_delta();
+
+	/* update trampoline's spinlock pointer */
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_spinlock_ptr));
+	*(uint64_t *)ptr += get_hv_image_delta();
+}
+
+uint64_t prepare_trampoline(void)
+{
+	uint64_t size, dest_pa, i;
+
+	size = (uint64_t)(&ld_trampoline_end - &ld_trampoline_start);
+#ifndef CONFIG_EFI_STUB
+	dest_pa = e820_alloc_low_memory(CONFIG_LOW_RAM_SIZE);
+#else
+	dest_pa = (uint64_t)get_ap_trampoline_buf();
+#endif
+
+	pr_dbg("trampoline code: %llx size %x", dest_pa, size);
+
+	/* Copy segment for AP initialization code below 1MB */
+	(void)memcpy_s(hpa2hva(dest_pa), (size_t)size, &ld_trampoline_load,
+			(size_t)size);
+	update_trampoline_code_refs(dest_pa);
+
+	for (i = 0UL; i < size; i = i + CACHE_LINE_SIZE) {
+		clflush(hpa2hva(dest_pa + i));
+	}
+
+	trampoline_start16_paddr = dest_pa;
+
+	return dest_pa;
+}

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -9,30 +9,12 @@
 extern void relocate(void);
 extern uint64_t get_hv_image_delta(void);
 extern uint64_t get_hv_image_base(void);
-extern uint64_t read_trampoline_sym(const void *sym);
-extern void write_trampoline_sym(const void *sym, uint64_t val);
-extern uint64_t prepare_trampoline(void);
 
 /* external symbols that are helpful for relocation */
 extern uint8_t		_DYNAMIC[1];
-extern const uint8_t	ld_trampoline_load;
-extern uint8_t		ld_trampoline_start;
 extern uint8_t		ld_trampoline_end;
-extern const uint64_t	ld_trampoline_size;
 
 extern uint8_t		cpu_primary_start_32;
 extern uint8_t		cpu_primary_start_64;
-
-extern uint8_t		trampoline_fixup_cs;
-extern uint8_t		trampoline_fixup_ip;
-extern uint8_t		trampoline_fixup_target;
-extern uint8_t		cpu_boot_page_tables_start;
-extern uint8_t		cpu_boot_page_tables_ptr;
-extern uint8_t		trampoline_pdpt_addr;
-extern uint8_t		trampoline_gdt_ptr;
-extern uint8_t		trampoline_start64_fixup;
-extern uint8_t		trampoline_spinlock_ptr;
-
-extern uint64_t		trampoline_start16_paddr;
 
 #endif /* RELOCATE_H */

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
 #include <reloc.h>
-#include <vm0_boot.h>
 
 #ifdef CONFIG_RELOC
 #define DT_NULL		0	/* end of .dynamic section */
@@ -33,8 +32,6 @@ static inline uint64_t elf64_r_type(uint64_t i)
 
 #define R_X86_64_RELATIVE	8UL
 
-uint64_t trampoline_start16_paddr;
-
 /* get the delta between CONFIG_HV_RAM_START and the actual load address */
 uint64_t get_hv_image_delta(void)
 {
@@ -55,21 +52,6 @@ uint64_t get_hv_image_delta(void)
 uint64_t get_hv_image_base(void)
 {
 	return (get_hv_image_delta() + CONFIG_HV_RAM_START);
-}
-
-/*
- * Because trampoline code is relocated in different way, if HV code
- * accesses trampoline using relative addressing, it needs to take
- * out the HV relocation delta
- *
- * This function is valid if:
- *  - The hpa of HV code is always higher than trampoline code
- *  - The HV code is always relocated to higher address, compared
- *    with CONFIG_HV_RAM_START
- */
-static uint64_t trampoline_relo_addr(const void *addr)
-{
-	return (uint64_t)addr - get_hv_image_delta();
 }
 
 void relocate(void)
@@ -143,98 +125,4 @@ void relocate(void)
 		start = (struct Elf64_Rel *)((char *)start + size);
 	}
 #endif
-}
-
-uint64_t read_trampoline_sym(const void *sym)
-{
-	uint64_t *hva;
-
-	hva = hpa2hva(trampoline_start16_paddr) + trampoline_relo_addr(sym);
-	return *hva;
-}
-
-void write_trampoline_sym(const void *sym, uint64_t val)
-{
-	uint64_t *hva;
-
-	hva = hpa2hva(trampoline_start16_paddr) + trampoline_relo_addr(sym);
-	*hva = val;
-	clflush(hva);
-}
-
-static void update_trampoline_code_refs(uint64_t dest_pa)
-{
-	void *ptr;
-	uint64_t val;
-	int i;
-
-	/*
-	 * calculate the fixup CS:IP according to fixup target address
-	 * dynamically.
-	 *
-	 * trampoline code starts in real mode,
-	 * so the target addres is HPA
-	 */
-	val = dest_pa + trampoline_relo_addr(&trampoline_fixup_target);
-
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_fixup_cs));
-	*(uint16_t *)(ptr) = (uint16_t)((val >> 4U) & 0xFFFFU);
-
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_fixup_ip));
-	*(uint16_t *)(ptr) = (uint16_t)(val & 0xfU);
-
-	/* Update temporary page tables */
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&cpu_boot_page_tables_ptr));
-	*(uint32_t *)(ptr) += (uint32_t)dest_pa;
-
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&cpu_boot_page_tables_start));
-	*(uint64_t *)(ptr) += dest_pa;
-
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_pdpt_addr));
-	for (i = 0; i < 4; i++) {
-		*(uint64_t *)(ptr + sizeof(uint64_t) * i) += dest_pa;
-	}
-
-	/* update the gdt base pointer with relocated offset */
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_gdt_ptr));
-	*(uint64_t *)(ptr + 2) += dest_pa;
-
-	/* update trampoline jump pointer with relocated offset */
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_start64_fixup));
-	*(uint32_t *)ptr += (uint32_t)dest_pa;
-
-	/* update trampoline's main entry pointer */
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(main_entry));
-	*(uint64_t *)ptr += get_hv_image_delta();
-
-	/* update trampoline's spinlock pointer */
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_spinlock_ptr));
-	*(uint64_t *)ptr += get_hv_image_delta();
-}
-
-uint64_t prepare_trampoline(void)
-{
-	uint64_t size, dest_pa, i;
-
-	size = (uint64_t)(&ld_trampoline_end - &ld_trampoline_start);
-#ifndef CONFIG_EFI_STUB
-	dest_pa = e820_alloc_low_memory(CONFIG_LOW_RAM_SIZE);
-#else
-	dest_pa = (uint64_t)get_ap_trampoline_buf();
-#endif
-
-	pr_dbg("trampoline code: %llx size %x", dest_pa, size);
-
-	/* Copy segment for AP initialization code below 1MB */
-	(void)memcpy_s(hpa2hva(dest_pa), (size_t)size, &ld_trampoline_load,
-			(size_t)size);
-	update_trampoline_code_refs(dest_pa);
-
-	for (i = 0UL; i < size; i = i + CACHE_LINE_SIZE) {
-		clflush(hpa2hva(dest_pa + i));
-	}
-
-	trampoline_start16_paddr = dest_pa;
-
-	return dest_pa;
 }

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -6,6 +6,7 @@
 
 #include <hypervisor.h>
 #include <multiboot.h>
+#include <boot_context.h>
 #include <vm0_boot.h>
 
 #ifdef CONFIG_EFI_STUB
@@ -36,7 +37,7 @@ int uefi_sw_loader(struct acrn_vm *vm)
 {
 	int ret = 0;
 	struct acrn_vcpu *vcpu = get_primary_vcpu(vm);
-	struct acrn_vcpu_regs *vcpu_regs = &vm0_boot_context;
+	struct acrn_vcpu_regs *vcpu_regs = &boot_context;
 
 	ASSERT(vm != NULL, "Incorrect argument");
 
@@ -47,8 +48,8 @@ int uefi_sw_loader(struct acrn_vm *vm)
 	/* For UEFI platform, the bsp init regs come from two places:
 	 * 1. saved in efi_boot: gpregs, rip
 	 * 2. saved when HV started: other registers
-	 * We copy the info saved in efi_boot to vm0_boot_context and
-	 * init bsp with vm0_boot_context.
+	 * We copy the info saved in efi_boot to boot_context and
+	 * init bsp with boot_context.
 	 */
 	memcpy_s(&(vcpu_regs->gprs), sizeof(struct acrn_gp_regs),
 		&(efi_ctx->vcpu_regs.gprs), sizeof(struct acrn_gp_regs));

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -6,6 +6,7 @@
 
 #include <hypervisor.h>
 #include <zeropage.h>
+#include <boot_context.h>
 
 #ifdef CONFIG_PARTITION_MODE
 static uint32_t create_e820_table(struct e820_entry *param_e820)
@@ -44,14 +45,14 @@ static void prepare_bsp_gdt(struct acrn_vm *vm)
 	uint64_t gdt_base_hpa;
 	void *gdt_base_hva;
 
-	gdt_base_hpa = gpa2hpa(vm, vm0_boot_context.gdt.base);
-	if (vm0_boot_context.gdt.base == gdt_base_hpa) {
+	gdt_base_hpa = gpa2hpa(vm, boot_context.gdt.base);
+	if (boot_context.gdt.base == gdt_base_hpa) {
 		return;
 	} else {
 		gdt_base_hva = hpa2hva(gdt_base_hpa);
-		gdt_len = ((size_t)vm0_boot_context.gdt.limit + 1U)/sizeof(uint8_t);
+		gdt_len = ((size_t)boot_context.gdt.limit + 1U)/sizeof(uint8_t);
 
-		(void )memcpy_s(gdt_base_hva, gdt_len, hpa2hva(vm0_boot_context.gdt.base), gdt_len);
+		(void )memcpy_s(gdt_base_hva, gdt_len, hpa2hva(boot_context.gdt.base), gdt_len);
 	}
 
 	return;
@@ -116,7 +117,7 @@ int general_sw_loader(struct acrn_vm *vm)
 	pr_dbg("Loading guest to run-time location");
 
 	prepare_bsp_gdt(vm);
-	set_vcpu_regs(vcpu, &vm0_boot_context);
+	set_vcpu_regs(vcpu, &boot_context);
 
 	/* calculate the kernel entry point */
 	zeropage = (struct zero_page *)sw_kernel->kernel_src_addr;

--- a/hypervisor/include/arch/x86/boot/boot_context.h
+++ b/hypervisor/include/arch/x86/boot/boot_context.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef BOOT_CTX_H
+#define BOOT_CTX_H
+
+#ifdef ASSEMBLER
+#define BOOT_CTX_CR0_OFFSET         176
+#define BOOT_CTX_CR3_OFFSET         192
+#define BOOT_CTX_CR4_OFFSET         184
+#define BOOT_CTX_IDT_OFFSET         144
+#define BOOT_CTX_GDT_OFFSET         128
+#define BOOT_CTX_LDT_SEL_OFFSET     280
+#define BOOT_CTX_TR_SEL_OFFSET      282
+#define BOOT_CTX_CS_SEL_OFFSET      268
+#define BOOT_CTX_SS_SEL_OFFSET      270
+#define BOOT_CTX_DS_SEL_OFFSET      272
+#define BOOT_CTX_ES_SEL_OFFSET      274
+#define BOOT_CTX_FS_SEL_OFFSET      276
+#define BOOT_CTX_GS_SEL_OFFSET      278
+#define BOOT_CTX_CS_AR_OFFSET       248
+#define BOOT_CTX_CS_LIMIT_OFFSET    252
+#define BOOT_CTX_EFER_LOW_OFFSET    200
+#define BOOT_CTX_EFER_HIGH_OFFSET   204
+#define SIZE_OF_BOOT_CTX            296
+#else
+#define BOOT_CTX_CR0_OFFSET         176U
+#define BOOT_CTX_CR3_OFFSET         192U
+#define BOOT_CTX_CR4_OFFSET         184U
+#define BOOT_CTX_IDT_OFFSET         144U
+#define BOOT_CTX_GDT_OFFSET         128U
+#define BOOT_CTX_LDT_SEL_OFFSET     280U
+#define BOOT_CTX_TR_SEL_OFFSET      282U
+#define BOOT_CTX_CS_SEL_OFFSET      268U
+#define BOOT_CTX_SS_SEL_OFFSET      270U
+#define BOOT_CTX_DS_SEL_OFFSET      272U
+#define BOOT_CTX_ES_SEL_OFFSET      274U
+#define BOOT_CTX_FS_SEL_OFFSET      276U
+#define BOOT_CTX_GS_SEL_OFFSET      278U
+#define BOOT_CTX_CS_AR_OFFSET       248U
+#define BOOT_CTX_CS_LIMIT_OFFSET    252U
+#define BOOT_CTX_EFER_LOW_OFFSET    200U
+#define BOOT_CTX_EFER_HIGH_OFFSET   204U
+#define SIZE_OF_BOOT_CTX            296U
+struct acrn_vcpu_regs;
+extern struct acrn_vcpu_regs boot_context;
+#endif /* ASSEMBLER */
+#endif /* BOOT_CTX_H */

--- a/hypervisor/include/arch/x86/boot/idt.h
+++ b/hypervisor/include/arch/x86/boot/idt.h
@@ -74,14 +74,6 @@ struct host_idt_descriptor {
 extern struct host_idt HOST_IDT;
 extern struct host_idt_descriptor HOST_IDTR;
 
-static inline void set_idt(struct host_idt_descriptor *idtd)
-{
-
-	asm volatile ("   lidtq %[idtd]\n" :	/* no output parameters */
-		      :		/* input parameters */
-		      [idtd] "m"(*idtd));
-}
-
 #endif /* end #ifndef ASSEMBLER */
 
 #endif /* IDT_H */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -220,7 +220,6 @@ int copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
  */
 int copy_to_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
-extern struct acrn_vcpu_regs vm0_boot_context;
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/guest/vm0_boot.h
+++ b/hypervisor/include/arch/x86/guest/vm0_boot.h
@@ -7,45 +7,6 @@
 #ifndef VM0_BOOT_H
 #define VM0_BOOT_H
 
-#ifdef ASSEMBLER
-#define BOOT_CTX_CR0_OFFSET         176
-#define BOOT_CTX_CR3_OFFSET         192
-#define BOOT_CTX_CR4_OFFSET         184
-#define BOOT_CTX_IDT_OFFSET         144
-#define BOOT_CTX_GDT_OFFSET         128
-#define BOOT_CTX_LDT_SEL_OFFSET     280
-#define BOOT_CTX_TR_SEL_OFFSET      282
-#define BOOT_CTX_CS_SEL_OFFSET      268
-#define BOOT_CTX_SS_SEL_OFFSET      270
-#define BOOT_CTX_DS_SEL_OFFSET      272
-#define BOOT_CTX_ES_SEL_OFFSET      274
-#define BOOT_CTX_FS_SEL_OFFSET      276
-#define BOOT_CTX_GS_SEL_OFFSET      278
-#define BOOT_CTX_CS_AR_OFFSET       248
-#define BOOT_CTX_CS_LIMIT_OFFSET    252
-#define BOOT_CTX_EFER_LOW_OFFSET    200
-#define BOOT_CTX_EFER_HIGH_OFFSET   204
-#define SIZE_OF_BOOT_CTX            296
-#else
-#define BOOT_CTX_CR0_OFFSET         176U
-#define BOOT_CTX_CR3_OFFSET         192U
-#define BOOT_CTX_CR4_OFFSET         184U
-#define BOOT_CTX_IDT_OFFSET         144U
-#define BOOT_CTX_GDT_OFFSET         128U
-#define BOOT_CTX_LDT_SEL_OFFSET     280U
-#define BOOT_CTX_TR_SEL_OFFSET      282U
-#define BOOT_CTX_CS_SEL_OFFSET      268U
-#define BOOT_CTX_SS_SEL_OFFSET      270U
-#define BOOT_CTX_DS_SEL_OFFSET      272U
-#define BOOT_CTX_ES_SEL_OFFSET      274U
-#define BOOT_CTX_FS_SEL_OFFSET      276U
-#define BOOT_CTX_GS_SEL_OFFSET      278U
-#define BOOT_CTX_CS_AR_OFFSET       248U
-#define BOOT_CTX_CS_LIMIT_OFFSET    252U
-#define BOOT_CTX_EFER_LOW_OFFSET    200U
-#define BOOT_CTX_EFER_HIGH_OFFSET   204U
-#define SIZE_OF_BOOT_CTX            296U
-
 #ifdef CONFIG_EFI_STUB
 struct efi_context {
 	struct acrn_vcpu_regs vcpu_regs;
@@ -56,5 +17,5 @@ struct efi_context {
 void *get_rsdp_from_uefi(void);
 void *get_ap_trampoline_buf(void);
 #endif
-#endif /* ASSEMBLER */
+
 #endif /* VM0_BOOT_H */

--- a/hypervisor/include/arch/x86/trampoline.h
+++ b/hypervisor/include/arch/x86/trampoline.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TRAMPOLINE_H
+#define TRAMPOLINE_H
+
+extern uint64_t read_trampoline_sym(const void *sym);
+extern void write_trampoline_sym(const void *sym, uint64_t val);
+extern uint64_t prepare_trampoline(void);
+
+/* external symbols that are helpful for relocation */
+extern const uint8_t	ld_trampoline_load;
+extern uint8_t		ld_trampoline_start;
+
+extern uint8_t		trampoline_fixup_cs;
+extern uint8_t		trampoline_fixup_ip;
+extern uint8_t		trampoline_fixup_target;
+extern uint8_t		cpu_boot_page_tables_start;
+extern uint8_t		cpu_boot_page_tables_ptr;
+extern uint8_t		trampoline_pdpt_addr;
+extern uint8_t		trampoline_gdt_ptr;
+extern uint8_t		trampoline_start64_fixup;
+extern uint8_t		trampoline_spinlock_ptr;
+
+extern uint64_t		trampoline_start16_paddr;
+
+#endif /* TRAMPOLINE_H */


### PR DESCRIPTION
Boot component prepares the very basic platform boot env. It finally call
into platform initilization entries:

- bsp_boot_init & cpu_secondary_init for start up
- or restore_s3_context for wakeup

this patch move functions for AP trampoline into trampoline.c from reloc.c
Tracked-On: #1842
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>