### PR TITLE
hv: clean up function definitions in sbuf.h

### DIFF
--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -58,13 +58,7 @@ struct shared_buf {
 	uint32_t padding[6];
 };
 
-#ifdef HV_DEBUG
 
-/**
- *@pre sbuf != NULL
- *@pre data != NULL
- */
-uint32_t sbuf_get(struct shared_buf *sbuf, uint8_t *data);
 /**
  *@pre sbuf != NULL
  *@pre data != NULL
@@ -72,30 +66,5 @@ uint32_t sbuf_get(struct shared_buf *sbuf, uint8_t *data);
 uint32_t sbuf_put(struct shared_buf *sbuf, uint8_t *data);
 int sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva);
 uint32_t sbuf_next_ptr(uint32_t pos, uint32_t span, uint32_t scope);
-
-#else /* HV_DEBUG */
-
-static inline int sbuf_get(
-		__unused struct shared_buf *sbuf,
-		__unused uint8_t *data)
-{
-	return 0;
-}
-
-static inline int sbuf_put(
-		__unused struct shared_buf *sbuf,
-		__unused uint8_t *data)
-{
-	return 0;
-}
-
-static inline int sbuf_share_setup(
-		__unused uint16_t pcpu_id,
-		__unused uint32_t sbuf_id,
-		__unused uint64_t *hva)
-{
-	return -1;
-}
-#endif /* HV_DEBUG */
 
 #endif /* SHARED_BUFFER_H */


### PR DESCRIPTION
separate the function definitions into debug/release directories
to better distinguish debug/release libraries

v1 -> v2:
 - sbuf_get is defined in 'debug/sbuf.c' but not used anywhere.
   remove the declaration in 'include/debug/sbuf.h' and keep the
   definition in 'debug/sbuf.c' in case it will used later.
 - sbuf_put and sbuf_share_setup is not used under RELEASE version.
   remove the file 'release/sbuf.c'.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>