### PR TITLE
hv: change the param type of mmio_write**

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -85,7 +85,7 @@ static void *map_ioapic(uint64_t ioapic_paddr)
 }
 
 static inline uint32_t
-ioapic_read_reg32(const void *ioapic_base, const uint32_t offset)
+ioapic_read_reg32(void *ioapic_base, const uint32_t offset)
 {
 	uint32_t v;
 	uint64_t rflags;
@@ -102,8 +102,7 @@ ioapic_read_reg32(const void *ioapic_base, const uint32_t offset)
 }
 
 static inline void
-ioapic_write_reg32(const void *ioapic_base,
-		const uint32_t offset, const uint32_t value)
+ioapic_write_reg32(void *ioapic_base, const uint32_t offset, const uint32_t value)
 {
 	uint64_t rflags;
 

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -70,11 +70,11 @@ static int vmsix_remap_entry(struct pci_vdev *vdev, uint32_t index, bool enable)
 		 * fields with a single QWORD write, but some hardware can accept 32 bits
 		 * write only
 		 */
-		mmio_write32((uint32_t)(info.pmsi_addr), (const void *)&(pentry->addr));
-		mmio_write32((uint32_t)(info.pmsi_addr >> 32U), (const void *)((char *)&(pentry->addr) + 4U));
+		mmio_write32((uint32_t)(info.pmsi_addr), (void *)&(pentry->addr));
+		mmio_write32((uint32_t)(info.pmsi_addr >> 32U), (void *)((char *)&(pentry->addr) + 4U));
 
-		mmio_write32(info.pmsi_data, (const void *)&(pentry->data));
-		mmio_write32(vdev->msix.tables[index].vector_control, (const void *)&(pentry->vector_control));
+		mmio_write32(info.pmsi_data, (void *)&(pentry->data));
+		mmio_write32(vdev->msix.tables[index].vector_control, (void *)&(pentry->vector_control));
 	}
 
 	return ret;
@@ -289,9 +289,9 @@ static int vmsix_table_mmio_access_handler(struct io_request *io_req, void *hand
 		} else {
 			/* mmio->size is either 4U or 8U */
 			if (mmio->size == 4U) {
-				mmio_write32((uint32_t)(mmio->value), (const void *)hva);
+				mmio_write32((uint32_t)(mmio->value), (void *)hva);
 			} else {
-				mmio_write64(mmio->value, (const void *)hva);
+				mmio_write64(mmio->value, (void *)hva);
 			}
 		}
 	}

--- a/hypervisor/include/arch/x86/io.h
+++ b/hypervisor/include/arch/x86/io.h
@@ -97,7 +97,7 @@ static inline uint32_t pio_read(uint16_t addr, size_t sz)
  *  @param value The 64 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write64(uint64_t value, const void *addr)
+static inline void mmio_write64(uint64_t value, void *addr)
 {
 	volatile uint64_t *addr64 = (volatile uint64_t *)addr;
 	*addr64 = value;
@@ -108,7 +108,7 @@ static inline void mmio_write64(uint64_t value, const void *addr)
  *  @param value The 32 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write32(uint32_t value, const void *addr)
+static inline void mmio_write32(uint32_t value, void *addr)
 {
 	volatile uint32_t *addr32 = (volatile uint32_t *)addr;
 	*addr32 = value;
@@ -119,7 +119,7 @@ static inline void mmio_write32(uint32_t value, const void *addr)
  *  @param value The 16 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write16(uint16_t value, const void *addr)
+static inline void mmio_write16(uint16_t value, void *addr)
 {
 	volatile uint16_t *addr16 = (volatile uint16_t *)addr;
 	*addr16 = value;
@@ -130,7 +130,7 @@ static inline void mmio_write16(uint16_t value, const void *addr)
  *  @param value The 8 bit value to write.
  *  @param addr The memory address to write to.
  */
-static inline void mmio_write8(uint8_t value, const void *addr)
+static inline void mmio_write8(uint8_t value, void *addr)
 {
 	volatile uint8_t *addr8 = (volatile uint8_t *)addr;
 	*addr8 = value;
@@ -187,7 +187,7 @@ static inline uint8_t mmio_read8(const void *addr)
  * @param mask    The mask to apply to the value read.
  * @param value   The 64 bit value to write.
  */
-static inline void set64(const void *addr, uint64_t mask, uint64_t value)
+static inline void set64(void *addr, uint64_t mask, uint64_t value)
 {
 	uint64_t temp_val;
 
@@ -202,7 +202,7 @@ static inline void set64(const void *addr, uint64_t mask, uint64_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 32 bit value to write.
  */
-static inline void set32(const void *addr, uint32_t mask, uint32_t value)
+static inline void set32(void *addr, uint32_t mask, uint32_t value)
 {
 	uint32_t temp_val;
 
@@ -217,7 +217,7 @@ static inline void set32(const void *addr, uint32_t mask, uint32_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 16 bit value to write.
  */
-static inline void set16(const void *addr, uint16_t mask, uint16_t value)
+static inline void set16(void *addr, uint16_t mask, uint16_t value)
 {
 	uint16_t temp_val;
 
@@ -232,7 +232,7 @@ static inline void set16(const void *addr, uint16_t mask, uint16_t value)
  * @param mask    The mask to apply to the value read.
  * @param value   The 8 bit value to write.
  */
-static inline void set8(const void *addr, uint8_t mask, uint8_t value)
+static inline void set8(void *addr, uint8_t mask, uint8_t value)
 {
 	uint8_t temp_val;
 


### PR DESCRIPTION
Input parameter of mmio_write64/mmio_write32/mmio_write16/mmio_write8
should be 'void *addr' rather than 'const void *addr' since the object
pointed by 'addr' is modified in these operations.

This patch change the param type of mmio_write** and update its usage
accordingly.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>