### PR TITLE
hv: fix misra violations

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -387,7 +387,7 @@ int prepare_vm(uint16_t pcpu_id)
 #else
 
 /* Create vm/vcpu for vm0 */
-int prepare_vm0(void)
+static int prepare_vm0(void)
 {
 	int err;
 	uint16_t i;

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -211,12 +211,12 @@ hv_emulate_pio(const struct acrn_vcpu *vcpu, struct io_request *io_req)
 		}
 
 		if (pio_req->direction == REQUEST_WRITE) {
-			if (handler->io_write) {
+			if (handler->io_write != NULL) {
 				handler->io_write(vm, port, size, pio_req->value & mask);
 			}
 			pr_dbg("IO write on port %04x, data %08x", port, pio_req->value & mask);
 		} else {
-			if (handler->io_read) {
+			if (handler->io_read != NULL) {
 				pio_req->value = handler->io_read(vm, port, size);
 			}
 			pr_dbg("IO read on port %04x, data %08x", port, pio_req->value);
@@ -264,7 +264,7 @@ hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
 			return -EIO;
 		} else {
 			/* Handle this MMIO operation */
-			if (mmio_handler->read_write) {
+			if (mmio_handler->read_write != NULL) {
 				status = mmio_handler->read_write(io_req, mmio_handler->handler_private_data);
 				break;
 			}

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -45,7 +45,7 @@ emulate_pio_post(struct acrn_vcpu *vcpu, const struct io_request *io_req)
  * @remark This function must be called after the VHM request corresponding to
  * \p vcpu being transferred to the COMPLETE state.
  */
-void dm_emulate_pio_post(struct acrn_vcpu *vcpu)
+static void dm_emulate_pio_post(struct acrn_vcpu *vcpu)
 {
 	uint16_t cur = vcpu->vcpu_id;
 	union vhm_request_buffer *req_buf = NULL;
@@ -188,7 +188,7 @@ void emulate_io_post(struct acrn_vcpu *vcpu)
  * @retval -ENODEV No proper handler found.
  * @retval -EIO The request spans multiple devices and cannot be emulated.
  */
-int32_t
+static int32_t
 hv_emulate_pio(const struct acrn_vcpu *vcpu, struct io_request *io_req)
 {
 	int32_t status = -ENODEV;

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -64,7 +64,7 @@ uint32_t alloc_irq_num(uint32_t req_irq)
  * @pre: irq is not in irq_static_mappings
  * free irq num allocated via alloc_irq_num()
  */
-void free_irq_num(uint32_t irq)
+static void free_irq_num(uint32_t irq)
 {
 	uint64_t rflags;
 
@@ -130,7 +130,7 @@ uint32_t alloc_irq_vector(uint32_t irq)
 }
 
 /* free the vector allocated via alloc_irq_vector() */
-void free_irq_vector(uint32_t irq)
+static void free_irq_vector(uint32_t irq)
 {
 	struct irq_desc *desc;
 	uint32_t vr;

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -326,7 +326,7 @@ static bool derive_aek(uint8_t *attkb_key)
 	uint32_t ikm_len;
 	uint32_t max_svn_idx;
 
-	if ((!attkb_key) || (g_key_info.num_seeds == 0U) ||
+	if ((attkb_key == NULL) || (g_key_info.num_seeds == 0U) ||
 			(g_key_info.num_seeds > BOOTLOADER_SEED_MAX_ENTRIES)) {
 		return false;
 	}

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -175,23 +175,6 @@ static int vcpu_do_pending_extint(const struct acrn_vcpu *vcpu)
 	return 0;
 }
 
-/* please keep this for interrupt debug:
- * 1. Timer alive or not
- * 2. native LAPIC interrupt pending/EOI status
- * 3. CPU stuck or not
- */
-static void dump_lapic(void)
-{
-	dev_dbg(ACRN_DBG_INTR,
-		"LAPIC: TIME %08x, init=0x%x cur=0x%x ISR=0x%x IRR=0x%x",
-		msr_read(MSR_IA32_EXT_APIC_LVT_TIMER),
-		msr_read(MSR_IA32_EXT_APIC_INIT_COUNT),
-		msr_read(MSR_IA32_EXT_APIC_CUR_COUNT),
-		msr_read(MSR_IA32_EXT_APIC_ISR7),
-		msr_read(MSR_IA32_EXT_APIC_IRR7)
-		);
-}
-
 /* SDM Vol3 -6.15, Table 6-4 - interrupt and exception classes */
 static int get_excep_class(uint32_t vector)
 {

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -180,7 +180,7 @@ static int vcpu_do_pending_extint(const struct acrn_vcpu *vcpu)
  * 2. native LAPIC interrupt pending/EOI status
  * 3. CPU stuck or not
  */
-void dump_lapic(void)
+static void dump_lapic(void)
 {
 	dev_dbg(ACRN_DBG_INTR,
 		"LAPIC: TIME %08x, init=0x%x cur=0x%x ISR=0x%x IRR=0x%x",

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -710,7 +710,7 @@ reconfig:
 /*
  * Initialize sep state and enable PMU counters
  */
-void profiling_start_pmu(void)
+static void profiling_start_pmu(void)
 {
 	uint16_t i;
 
@@ -751,7 +751,7 @@ void profiling_start_pmu(void)
 /*
  * Reset sep state and Disable all the PMU counters
  */
-void profiling_stop_pmu(void)
+static void profiling_stop_pmu(void)
 {
 	uint16_t i;
 


### PR DESCRIPTION
fix following violations:
  1."Expression is not boolean"
  2."No prototype for non-static function"
  3.dead code
Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>