### PR TITLE
hv: fixes related to unused API and uninitialized variable

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -1335,7 +1335,7 @@ static int emulate_or(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 
 static int emulate_cmp(struct acrn_vcpu *vcpu, const struct instr_emul_vie *vie)
 {
-	int error;
+	int error = 0;
 	uint8_t size;
 	uint64_t regop, memop, op1, op2, rflags2;
 	enum cpu_reg_name reg;

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -74,12 +74,6 @@ struct smp_call_info_data {
 };
 
 void smp_call_function(uint64_t mask, smp_call_func_t func, void *data);
-int handle_level_interrupt_common(struct irq_desc *desc,
-	__unused void *handler_data);
-int common_handler_edge(struct irq_desc *desc, __unused void *handler_data);
-int common_dev_handler_level(struct irq_desc *desc,
-	__unused void *handler_data);
-int quick_handler_nolock(struct irq_desc *desc, __unused void *handler_data);
 
 void init_default_irqs(uint16_t cpu_id);
 

--- a/hypervisor/include/arch/x86/vmexit.h
+++ b/hypervisor/include/arch/x86/vmexit.h
@@ -84,8 +84,4 @@ static inline uint64_t vm_exit_io_instruction_port_number(uint64_t exit_qual)
 	return (vm_exit_qualification_bit_mask(exit_qual, 31U, 16U) >> 16U);
 }
 
-#ifdef HV_DEBUG
-void get_vmexit_profile(char *str_arg, size_t str_max);
-#endif /* HV_DEBUG */
-
 #endif /* VMEXIT_H_ */

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -48,7 +48,6 @@ void asm_assert(int32_t line, const char *file, const char *txt);
 #endif /* HV_DEBUG */
 
 void init_logmsg(uint32_t flags);
-void print_logmsg_buffer(uint16_t pcpu_id);
 void do_logmsg(uint32_t severity, const char *fmt, ...);
 
 /** The well known printf() function.

--- a/hypervisor/release/logmsg.c
+++ b/hypervisor/release/logmsg.c
@@ -8,6 +8,5 @@
 
 void init_logmsg(__unused uint32_t flags) {}
 void do_logmsg(__unused uint32_t severity, __unused const char *fmt, ...) {}
-void print_logmsg_buffer(__unused uint16_t pcpu_id) {}
 void printf(__unused const char *fmt, ...) {}
 void vprintf(__unused const char *fmt, __unused va_list args) {}


### PR DESCRIPTION
This patch does:
- remove the unused API declaration
- fix use of uninitialized variable in instr_emul.c

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>