### PR TITLE
Fix some USB virtualization issues

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -66,6 +66,8 @@
 #include "vmcfg.h"
 #include "tpm.h"
 #include "virtio.h"
+#include "usb.h"
+#include "xhci.h"
 
 #define GUEST_NIO_PORT		0x488	/* guest upcalls via i/o port */
 
@@ -631,6 +633,7 @@ vm_suspend_resume(struct vmctx *ctx)
 
 	vm_stop_watchdog(ctx);
 	wait_for_resume(ctx);
+	wait_for_xhci_resume();
 
 	pm_backto_wakeup(ctx);
 	vm_reset_watchdog(ctx);

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -485,6 +485,24 @@ static struct pci_xhci_option_elem xhci_option_table[] = {
 	{"cap", pci_xhci_parse_extcap}
 };
 
+void
+wait_for_xhci_resume()
+{
+	/* The reason of waiting for resuming is USB virtualization
+	 * needs do TWO PASS SEQUENTIAL enumerations: one for SOS and
+	 * the other for UOS after SOS USB resuming work is completely
+	 * done. So, theoretically, virtual USB resuming MUST use more
+	 * time than its native counterpart.
+	 */
+
+	/* FIXME: will substitute it by dynamic way. The thought is
+	 * waiting time is calculated by the number of USB devices
+	 * attached. More devices, more waiting time, no device no
+	 * waiting.
+	 */
+	sleep(5);
+}
+
 static int
 pci_xhci_get_free_vport(struct pci_xhci_vdev *xdev,
 		struct usb_native_devinfo *di)

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2862,8 +2862,9 @@ retry:
 	}
 
 	err = USB_TO_XHCI_ERR(err);
-	if ((err == XHCI_TRB_ERROR_SUCCESS) ||
-	    (err == XHCI_TRB_ERROR_SHORT_PKT)) {
+	if (err == XHCI_TRB_ERROR_SUCCESS ||
+			err == XHCI_TRB_ERROR_SHORT_PKT ||
+			err == XHCI_TRB_ERROR_STALL) {
 		err = pci_xhci_xfer_complete(xdev, xfer, slot, epid, &do_intr);
 		if (err != XHCI_TRB_ERROR_SUCCESS)
 			do_retry = 0;

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1262,8 +1262,15 @@ pci_xhci_portregs_write(struct pci_xhci_vdev *xdev,
 		case 3: /* U3 */
 			if (oldpls != newpls) {
 				p->portsc &= ~XHCI_PS_PLS_MASK;
-				p->portsc |= XHCI_PS_PLS_SET(newpls) |
-					     XHCI_PS_PLC;
+				p->portsc |= XHCI_PS_PLS_SET(newpls);
+
+				/*
+				 * TODO:
+				 * Should check if this is exactly
+				 * consistent with xHCI spec.
+				 */
+				if (newpls == 0)
+					p->portsc |= XHCI_PS_PLC;
 
 				if (oldpls != 0 && newpls == 0) {
 					pci_xhci_set_evtrb(&evtrb, port,

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -836,6 +836,7 @@ pci_xhci_native_usb_dev_disconn_cb(void *hci_data, void *dev_data)
 		edev->dev_slotstate = XHCI_ST_DISABLED;
 		xdev->devices[vport] = NULL;
 		xdev->slots[slot] = NULL;
+		xdev->slot_allocated[slot] = false;
 		pci_xhci_dev_destroy(edev);
 		need_intr = 0;
 		return 0;

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2937,6 +2937,9 @@ pci_xhci_device_doorbell(struct pci_xhci_vdev *xdev,
 	}
 
 	dev = XHCI_SLOTDEV_PTR(xdev, slot);
+	if (!dev)
+		return;
+
 	devep = &dev->eps[epid];
 	dev_ctx = pci_xhci_get_dev_ctx(xdev, slot);
 	if (!dev_ctx)

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <unistd.h>
 #include "usb.h"
 #include "usbdi.h"
 #include "usb_pmapper.h"
@@ -1112,10 +1113,16 @@ static void *
 usb_dev_sys_thread(void *arg)
 {
 	struct timeval t = {1, 0};
+	int rc = 0;
 
-	while (g_ctx.thread_exit == 0 &&
-		libusb_handle_events_timeout(g_ctx.libusb_ctx, &t) >= 0)
-		; /* nothing */
+	while (g_ctx.thread_exit == 0) {
+		rc = libusb_handle_events_timeout(g_ctx.libusb_ctx, &t);
+		if (rc < 0)
+			/* TODO: maybe one second as interval is too long which
+			 * may result of slower USB enumeration process.
+			 */
+			sleep(1);
+	}
 
 	UPRINTF(LINF, "poll thread exit\n\r");
 	return NULL;

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -377,4 +377,6 @@ struct xhci_event_ring_seg {
 	volatile uint32_t	dwEvrsReserved;
 };
 
+void wait_for_xhci_resume();
+
 #endif /* _XHCI_H_ */


### PR DESCRIPTION
1. Losing USB device(s) after resuming from S3;
2. Fail to enumerate USB device after many times of suspending and resuming;
3. Long dalay (~20 seconds) for USB headset enumeration.
Tracked-On: #1894,#1893,#1895
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>