### PR TITLE
hv: x2APICv support on platforms w/o APICv reg virtualization

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -869,6 +869,11 @@ bool is_ept_supported(void)
 	return (cpu_caps.ept_features != 0U);
 }
 
+bool is_apicv_reg_virtualization_supported(void)
+{
+	return ((cpu_caps.apicv_features & VAPIC_FEATURE_VIRT_REG) != 0U);
+}
+
 bool is_apicv_intr_delivery_supported(void)
 {
 	return ((cpu_caps.apicv_features & VAPIC_FEATURE_INTR_DELIVERY) != 0U);

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -311,6 +311,7 @@ extern struct cpuinfo_x86 boot_cpu_data;
 void cpu_do_idle(void);
 void cpu_dead(uint16_t pcpu_id);
 void trampoline_start16(void);
+bool is_apicv_reg_virtualization_supported(void);
 bool is_apicv_intr_delivery_supported(void);
 bool is_apicv_posted_intr_supported(void);
 bool is_ept_supported(void);


### PR DESCRIPTION
On platforms, that do not support APICv register virtualization, all the
x2APIC MSRs need to intercepted by ACRN for emulation.

Tracked-On: #1973
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>