### PR TITLE
Refine acrntrace acrnlog

### DIFF
--- a/tools/acrntrace/acrntrace.h
+++ b/tools/acrntrace/acrntrace.h
@@ -42,8 +42,8 @@
 #define FLAG_TO_REL		(1UL << 0)
 #define FLAG_CLEAR_BUF		(1UL << 1)
 
-#define foreach_cpu(cpu)                                       \
-        for ((cpu) = 0; (cpu) < (pcpu_num); (cpu)++)
+#define foreach_dev(dev_id)                                       \
+        for ((dev_id) = 0; (dev_id) < (dev_cnt); (dev_id)++)
 
 typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;
@@ -71,7 +71,7 @@ typedef struct {
 } trace_ev_t;
 
 typedef struct {
-	uint32_t cpuid;
+	uint32_t devid;
 	int exit_flag;
 	int trace_fd;
 	shared_buf_t *sbuf;


### PR DESCRIPTION
If module acrn_trace is configured as "m" and we don't insert it before
launching acrntrace tool, acrntrace will run normally instead of throw
out an error in current implementation. And no trace files are generated.
It will cause confusing here.

So, this patch throw out an error massage to user about the absence of acrn
trace devices.

BTW, this patch replaces cpuid/num related concept to devid/cnt which is more
suitable for /dev/acrn_trace_xxx.

Tracked-On: #1975
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>