### PR TITLE
security: remove cflag _FORTIFY_SOURCE in hypervisor

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -51,7 +51,6 @@ CFLAGS += -fsigned-char
 CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -nostdinc -nostdlib -fno-common
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security -Werror
 ifeq (y, $(CONFIG_RELOC))
 CFLAGS += -fpie


### PR DESCRIPTION
_FORTIFY_SOURCE is a Glibc feature which adds memory
and string function protection, this flag is only for
Glibc. The _FORTIFY_SOURCE is not used by hypervisor
because hypervisor is not include Glibc.

Tracked-On: #1122
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>