### PR TITLE
hv: add 'no-omit-frame-pointer' in debug version

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -237,7 +237,7 @@ endif
 
 C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(C_SRCS))
 ifneq ($(CONFIG_RELEASE),y)
-CFLAGS += -DHV_DEBUG -DPROFILING_ON
+CFLAGS += -DHV_DEBUG -DPROFILING_ON -fno-omit-frame-pointer
 endif
 S_OBJS := $(patsubst %.S,$(HV_OBJDIR)/%.o,$(S_SRCS))
 


### PR DESCRIPTION
Hypervisor uses '-O2' compiler option,
it will omit frame pointer by default for '-O2',
This patch add 'no-omit-frame-pointer' in debug version.

Tracked-On: #1979
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>