### PR TITLE
dm: add "break" removed by mistake.

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -881,6 +881,7 @@ dm_run(int argc, char *argv[])
 			break;
 		case CMD_OPT_DEBUGEXIT:
 			debugexit_enabled = true;
+			break;
 		case CMD_OPT_VTPM2:
 			if (acrn_parse_vtpm2(optarg) != 0) {
 				errx(EX_USAGE, "invalid vtpm2 param %s", optarg);


### PR DESCRIPTION
The tpm patch delete the "break" for CMD_OPT_DEBUGEXIT branch.

Tracked-On: #1978
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>