### PR TITLE
Doc: Upload the tutorial of "Build UOS from Clear Linux"

### DIFF
--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -82,7 +82,7 @@ follow these steps to build a UOS image from Clear Linux:
       ``"Version": "latest"`` for example.
       
    Here we will use ``"Version": 26550`` for example, 
-   and the image of UOS called ``uos.img`` will be generated 
+   and the UOS image called ``uos.img`` will be generated 
    after successful installation. An example output log is:
    
    .. code-block:: none

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -44,7 +44,7 @@ please follow these steps in Clear Linux native:
                                   "type" : "EFI" },
                                 { "disk" : "uos.img",
                                   "partition" : 2,
-                                  "size" : "32M",
+                                  "size" : "1G",
                                   "type" : "swap" },
                                 { "disk" : "uos.img",
                                   "partition" : 3,

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -126,7 +126,7 @@ Start the User OS (UOS)
 
    .. code-block:: none
 
-      # losetup -f -P --show ~/uos.img
+      # losetup -r -f -P --show ~/uos.img
       # mount /dev/loop0p3 /mnt
 
       # ls -l /mnt/usr/lib/kernel/

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -12,15 +12,15 @@ Build UOS image in Clear Linux native
 In order to build out the image of UOS, 
 please follow these steps in Clear Linux native:
 
-#. In Clear Linxu native, please install ``ister`` at first, 
-   ``ister`` is a template based installer for linux, 
-   which is inclued in the bundle ``os-installer`` in Clear Linux.
+#. In Clear Linux native, install ``ister`` (a template-based
+   installer for Linux) inclued in the Clear Linux bundle 
+   ``os-installer``.
    For more information about ``ister``, 
    please visit https://github.com/bryteise/ister.
 
    .. code-block:: none
 
-      # sudo swupd bundle-add os-installer
+      $ sudo swupd bundle-add os-installer
    
 #. After installation is complete, use ``ister.py`` to 
    generate the image for UOS with the configuration in 
@@ -28,8 +28,8 @@ please follow these steps in Clear Linux native:
 
    .. code-block:: none
    
-      # cd ~   
-      # sudo ister.py -t uos-image.json
+      $ cd ~   
+      $ sudo ister.py -t uos-image.json
       
    An example of the configuration file ``uos-image.json`` 
    is shown as below:
@@ -81,6 +81,8 @@ please follow these steps in Clear Linux native:
       To generate the image with a specified version, 
       please modify with the ``"Version"`` argument, 
       and we can set ``"Version": 26550`` for example.
+      If you want to build out the latest, please 
+      set ``"Version": "latest"`` here.
 
    Here we will use ``"Version": 26550`` for example, 
    and the image of UOS called ``uos.img`` will be generated 
@@ -138,7 +140,7 @@ Start the User OS (UOS)
       install.d
       org.clearlinux.iot-lts2018.4.19.0-26
    
-#. And you need to adjust the ``/usr/share/acrn/samples/nuc/launch_uos.sh`` 
+#. Adjust the ``/usr/share/acrn/samples/nuc/launch_uos.sh`` 
    script to match your installation. 
    These are the couple of lines you need to modify:
 
@@ -148,13 +150,13 @@ Start the User OS (UOS)
       -k /mnt/usr/lib/kernel/default-iot-lts2018  \
 
    .. note::
-      UOS image ``uos.img`` stored in the directory ``~/``
-      and UOS kernel ``default-iot-lts2018`` stored ``/mnt/usr/lib/kernel/``.
+      UOS image ``uos.img`` is in the directory ``~/``
+      and UOS kernel ``default-iot-lts2018`` is in ``/mnt/usr/lib/kernel/``.
    
 #. You are now all set to start the User OS (UOS):
 
    .. code-block:: none
    
-      sudo /usr/share/acrn/samples/nuc/launch_uos.sh
+      $ sudo /usr/share/acrn/samples/nuc/launch_uos.sh
       
    You are now watching the User OS booting up!

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -31,8 +31,7 @@ please follow these steps in Clear Linux native:
       $ cd ~   
       $ sudo ister.py -t uos-image.json
       
-   An example of the configuration file ``uos-image.json`` 
-   is shown as below:
+   An example of the configuration file ``uos-image.json``:
 
    .. code-block:: none
    
@@ -78,14 +77,13 @@ please follow these steps in Clear Linux native:
 
    .. note::
       To generate the image with a specified version, 
-      please modify with the ``"Version"`` argument, 
-      and we can set ``"Version": 26550`` for example.
-      If you want to build out the latest, please 
-      set ``"Version": "latest"`` here.
-
+      please modify the ``"Version"`` argument, 
+      and we can set ``"Version": 26550`` instead of 
+      ``"Version: latest"`` for example.
+      
    Here we will use ``"Version": 26550`` for example, 
    and the image of UOS called ``uos.img`` will be generated 
-   after successful installation. It will output log as shown as below:
+   after successful installation. An example output log is:
    
    .. code-block:: none
    

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -1,0 +1,160 @@
+.. _build UOS from Clearlinux:
+
+Building UOS from Clear Linux
+##############################
+
+This document builds on the :ref:`getting_started`, 
+and explains how to build UOS from Clear Linux.
+      
+Build UOS image in Clear Linux native
+*************************************
+
+In order to build out the image of UOS, 
+please follow these steps in Clear Linux native:
+
+#. In Clear Linxu native, please install ``ister`` at first, 
+   ``ister`` is a template based installer for linux, 
+   which is inclued in the package ``os-installer`` in Clear Linux.
+   For more information about ``ister``, 
+   please visit https://github.com/bryteise/ister.
+
+   .. code-block:: none
+
+      # sudo swupd bundle-add os-installer
+   
+#. After installation is complete, use ``ister.py`` to 
+   generate the image for UOS with the configuration in 
+   ``uos-image.json``:
+
+   .. code-block:: none
+   
+      # cd ~   
+      # sudo ister.py -t uos-image.json
+      
+   An example of the configuration file ``uos-image.json`` 
+   is shown as below:
+
+   .. code-block:: none
+   
+      {
+          "DestinationType" : "virtual",
+          "PartitionLayout" : [ { "disk" : "uos.img",
+                                  "partition" : 1,
+                                  "size" : "512M",
+                                  "type" : "EFI" },
+                                { "disk" : "uos.img",
+                                  "partition" : 2,
+                                  "size" : "32M",
+                                  "type" : "swap" },
+                                { "disk" : "uos.img",
+                                  "partition" : 3,
+                                  "size" : "8G",
+                                  "type" : "linux" } ],
+          "FilesystemTypes" : [ { "disk" : "uos.img",
+                                  "partition" : 1,
+                                  "type" : "vfat" },
+                                { "disk" : "uos.img",
+                                  "partition" : 2,
+                                  "type" : "swap" },
+                                { "disk" : "uos.img",
+                                  "partition" : 3,
+                                  "type" : "ext4" } ],
+          "PartitionMountPoints" : [ { "disk" : "uos.img",
+                                       "partition" : 1,
+                                       "mount" : "/boot" },
+                                     { "disk" : "uos.img",
+                                       "partition" : 3,
+                                       "mount" : "/" } ],
+          "Version": "latest",
+          "Bundles": ["bootloader",
+                      "editors",
+                      "kernel-iot-lts2018",
+                      "network-basic",
+                      "os-core-update",
+                      "os-core",
+                      "openssh-server",
+                      "software-defined-cockpit",
+                      "sysadmin-basic"]
+       }
+
+   .. note::
+      To generate the image with a specified version, 
+      please modify with the ``"Version"`` argument, 
+      and ``"Version": 26550`` for example.
+
+   Here we will use ``"Version": 26550`` for example, 
+   and the image of UOS called ``uos.img`` will be generated 
+   after successful installation. It will output log as shown as below:
+   
+   .. code-block:: none
+   
+      Reading configuration
+      Validating configuration
+      Creating virtual disk
+      Creating partitions
+      Mapping loop device
+      Creating file systems
+      Setting up mount points
+      Starting swupd. May take several minutes
+      Installing 9 bundles (and dependencies)...
+      Verifying version 26550
+      Downloading packs...
+        
+      Extracting emacs pack for version 26550
+      
+      Extracting vim pack for version 26550
+      ...
+      Cleaning up
+      Successful installation
+      
+#. Reboot and select "The ACRN Service OS" to boot, as shown below:
+
+   .. code-block:: console
+      :emphasize-lines: 1
+      
+      => The ACRN Service OS
+      Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-4.19.0-19)
+      Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-sos-4.19.0-19)
+      Clear Linux OS for Intel Architecture (Clear-linux-native.4.19.1-654)
+      EFI Default Loader
+      Reboot Into Firmware Interface
+
+
+Start the User OS (UOS)
+***********************
+
+#. Mount the UOS image and check the UOS kernel:
+
+   .. code-block:: none
+
+      # losetup -f -P --show ~/uos.img
+      # mount /dev/loop0p3 /mnt
+
+      # ls -l /mnt/usr/lib/kernel/
+
+      cmdline-4.19.0-26.iot-lts2018
+      config-4.19.0-26.iot-lts2018
+      default-iot-lts2018 -> org.clearlinux.iot-lts2018.4.19.0-26
+      install.d
+      org.clearlinux.iot-lts2018.4.19.0-26
+   
+#. And you need to adjust the ``/usr/share/acrn/samples/nuc/launch_uos.sh`` 
+   script to match your installation. 
+   These are the couple of lines you need to modify:
+
+   .. code-block:: none
+   
+      -s 3,virtio-blk,~/uos.img \
+      -k /mnt/usr/lib/kernel/default-iot-lts2018  \
+
+   .. note::
+      UOS image ``uos.img`` stored in the directory ``~/``
+      and UOS kernel ``default-iot-lts2018`` stored ``/mnt/usr/lib/kernel/``.
+   
+#. You are now all set to start the User OS (UOS):
+
+   .. code-block:: none
+   
+      sudo /usr/share/acrn/samples/nuc/launch_uos.sh
+      
+   You are now watching the User OS booting up!

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -73,7 +73,6 @@ please follow these steps in Clear Linux native:
                       "os-core-update",
                       "os-core",
                       "openssh-server",
-                      "software-defined-cockpit",
                       "sysadmin-basic"]
        }
 

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -1,7 +1,7 @@
 .. _build UOS from Clearlinux:
 
 Building UOS from Clear Linux
-##############################
+#############################
 
 This document builds on the :ref:`getting_started`, 
 and explains how to build UOS from Clear Linux.
@@ -14,7 +14,7 @@ please follow these steps in Clear Linux native:
 
 #. In Clear Linxu native, please install ``ister`` at first, 
    ``ister`` is a template based installer for linux, 
-   which is inclued in the package ``os-installer`` in Clear Linux.
+   which is inclued in the bundle ``os-installer`` in Clear Linux.
    For more information about ``ister``, 
    please visit https://github.com/bryteise/ister.
 
@@ -80,7 +80,7 @@ please follow these steps in Clear Linux native:
    .. note::
       To generate the image with a specified version, 
       please modify with the ``"Version"`` argument, 
-      and ``"Version": 26550`` for example.
+      and we can set ``"Version": 26550`` for example.
 
    Here we will use ``"Version": 26550`` for example, 
    and the image of UOS called ``uos.img`` will be generated 

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -10,10 +10,10 @@ Build UOS image in Clear Linux native
 *************************************
 
 In order to build out the image of UOS, 
-please follow these steps in Clear Linux native:
+follow these steps to build a UOS image from Clear Linux:
 
 #. In Clear Linux native, install ``ister`` (a template-based
-   installer for Linux) inclued in the Clear Linux bundle 
+   installer for Linux) included in the Clear Linux bundle 
    ``os-installer``.
    For more information about ``ister``, 
    please visit https://github.com/bryteise/ister.
@@ -79,7 +79,7 @@ please follow these steps in Clear Linux native:
       To generate the image with a specified version, 
       please modify the ``"Version"`` argument, 
       and we can set ``"Version": 26550`` instead of 
-      ``"Version: latest"`` for example.
+      ``"Version": "latest"`` for example.
       
    Here we will use ``"Version": 26550`` for example, 
    and the image of UOS called ``uos.img`` will be generated 
@@ -106,7 +106,7 @@ please follow these steps in Clear Linux native:
       Cleaning up
       Successful installation
       
-#. Reboot and select "The ACRN Service OS" to boot, as shown below:
+#. On your target device, boot the system and select "The ACRN Service OS", as shown below:
 
    .. code-block:: console
       :emphasize-lines: 1


### PR DESCRIPTION
Upload the tutorial of "Build UOS from Clear Linux"

1.  Introduce how to use "uos-image.json" to set configuration for building UOS image and kernel together
2.  No more 
"$ cp -r ~/uos-kernel-build/usr/lib/modules/4.19.0-22.iot-lts2018/ /mnt/lib/modules/
$ cp -r ~/uos-kernel-build/usr/lib/kernel /lib/modules" 
needed when use the image built by "ister";

Signed-off-by: Xie, zhengtian zhengtian.xie@intel.com