### PR TITLE
doc: tweak CSS for doxygen API usability

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -134,6 +134,13 @@ th,td {
   padding-left: 0 !important;
 }
 
+/* doxygenXX item color tweaks, light blue background with dark blue top border */
+.rst-content dl:not(.docutils) dl dt {
+  background: #e7f2fa !important;
+  border-top: solid 3px #2980B9 !important;
+  border-left: none !important; */
+}
+
 /* tweak display of option tables to make first column wider */
 col.option {
   width: 25%;


### PR DESCRIPTION
Change background colors of API elements to improve readability and
match configuration documentation look.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>