### PR TITLE
doc: fix doc misspellings

### DIFF
--- a/doc/developer-guides/hld/hld-power-management.rst
+++ b/doc/developer-guides/hld/hld-power-management.rst
@@ -86,7 +86,7 @@ Intercept Policy
 ================
 
 Hypervisor should be able to restrict guest's
-P/C-state request, with a user-customized poligy.
+P/C-state request, with a user-customized policy.
 
 Hypervisor should intercept guest P-state request and validate whether
 it is a valid P-state. Any invalid P-state (e.g. doesn't exist in CPU state

--- a/doc/developer-guides/hld/hld-virtio-devices.rst
+++ b/doc/developer-guides/hld/hld-virtio-devices.rst
@@ -377,7 +377,7 @@ Irqfd implementation
 
 The irqfd module is implemented in VHM, and can enhance an registered
 eventfd to inject an interrupt to a guest OS when the eventfd gets
-signalled. :numref:`irqfd-workflow` shows the general flow for irqfd.
+signaled. :numref:`irqfd-workflow` shows the general flow for irqfd.
 
 .. figure:: images/virtio-hld-image60.png
    :align: center

--- a/doc/developer-guides/hld/hld-vm-management.rst
+++ b/doc/developer-guides/hld/hld-vm-management.rst
@@ -102,7 +102,7 @@ IOC to keep doing this power cycle method, or change to another power
 cycle method. SOS-LCS heartbeat can also set RTC timer to IOC.
 
 SOS-LCS handles SHUTDOWN, SUSPEND, and REBOOT acrn-manager messages
-request from Acrnd. When these messages are received, SOS-LCS switchs IOC
+request from Acrnd. When these messages are received, SOS-LCS switches IOC
 power cycle method to shutdown, suspend, and reboot, respectively.
 
 SOS-LCS handles WAKEUP_REASON acrn-manager messages request from Acrnd.

--- a/doc/developer-guides/hld/virtio-blk.rst
+++ b/doc/developer-guides/hld/virtio-blk.rst
@@ -51,7 +51,7 @@ writethrough is set as the default mode, as it can make sure every write
 operation queued to the virtio-blk FE driver layer is submitted to
 hardware storage.
 
-During initialization, virito-blk will allocate 64 ioreq buffers in a
+During initialization, virtio-blk will allocate 64 ioreq buffers in a
 shared ring used to store the I/O requests.  The freeq, busyq, and pendq
 shown in :numref:`virtio-blk-be` are used to manage requests. Each
 virtio-blk device starts 8 worker threads to process request

--- a/doc/developer-guides/l1tf.rst
+++ b/doc/developer-guides/l1tf.rst
@@ -61,7 +61,7 @@ There are mainly three attack scenarios considered in ACRN:
 - Normal_world -> secure_world attack (Android specific)
 
 Malicious user space is not a concern to ACRN hypervisor, because
-every guest runs in VMX non-root. It is reponsibility of guest kernel
+every guest runs in VMX non-root. It is responsibility of guest kernel
 to protect itself from malicious user space attack.
 
 Intel® SGX/SMM related attacks are mitigated by using latest microcode.
@@ -197,7 +197,7 @@ guests and then put these virtual seeds into uncached memory,
 at the same time flush & erase physical seed.
 
 If all security data are identified and put in uncached
-meomry in a specific deployment, then it is not necessary to
+memory in a specific deployment, then it is not necessary to
 prevent guest -> hypervisor attack, since there is nothing
 useful to be attacked.
 
@@ -223,7 +223,7 @@ Core-based scheduling
 
 If Hyper-Threading is enabled, it's important to avoid running
 sensitive context (if containing security data which a given VM
-has no premission to access) on the same physical core that runs
+has no permission to access) on the same physical core that runs
 said VM. It requires scheduler enhancement to enable core-based
 scheduling policy, so all threads on the same core are always
 scheduled to the same VM. Also there are some further actions

--- a/doc/developer-guides/modularity.rst
+++ b/doc/developer-guides/modularity.rst
@@ -58,7 +58,7 @@ Measuring Complexity
 ====================
 
 ACRN uses the number of functions and the cyclomatic complexity [CC]_ of each
-function to measure the complexity of a module. Concrete criterias on complexity
+function to measure the complexity of a module. Concrete criteria on complexity
 will be determined while enhancing the modularity of the hypervisor. The current
 recommendation is to limit the cyclomatic complexity of a function under 20.
 

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -256,7 +256,7 @@ partition. Follow these steps:
 #. After booting up the ACRN hypervisor, the Service OS will be launched
    automatically by default, and the Clear Linux desktop will be showing with user "clear",
    (or you can login remotely with an "ssh" client).
-   If there is any issue which makes the GNOME desktop doens't show succesfully, then the system will go to 
+   If there is any issue which makes the GNOME desktop doesn't show successfully, then the system will go to 
    shell console.
 
 #. From ssh client, login as user "clear" using the password you set previously when
@@ -493,7 +493,7 @@ The build results are found in the ``build`` directory.
    artefacts, set the ``O`` (that is capital letter 'O') to the
    desired value. Example: ``make O=build-nuc BOARD=nuc6cayh``.
 
-Generating the documentation is decribed in details in the :ref:`acrn_doc`
+Generating the documentation is described in details in the :ref:`acrn_doc`
 tutorial.
 
 You can also build these components individually. The following

--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -60,7 +60,7 @@ Build kernel and modules for partition mode UOS
    `this Ubuntu tutorial <https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop>`_.
    The Ubuntu installer creates 3 disk partitions on the on-board eMMC memory.
    By default, the GRUB bootloader is installed on the ESP (EFI System Partition)
-   partition, which will be used to bootstrap the partiton mode ACRN hypervisor.
+   partition, which will be used to bootstrap the partition mode ACRN hypervisor.
 
 #. After installing the Ubuntu OS, power off the UP2 board, attach the SATA disk
    and the USB flash disk to the board. Power on the board and make sure 


### PR DESCRIPTION
Fix documentation misspellings missed during the regular review.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>