### PR TITLE
hv:disable Executable attribute for hypervisor stack

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -76,7 +76,6 @@ ASFLAGS += -m64 -nostdinc -nostdlib
 
 LDFLAGS += -Wl,--gc-sections -nostartfiles -nostdlib
 LDFLAGS += -Wl,-n,-z,max-page-size=0x1000
-LDFLAGS += -Wl,-z,noexecstack
 
 ifeq (y, $(CONFIG_RELOC))
 # on X86_64, when build with "-pie", GCC fails on linking R_X86_64_32

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -76,12 +76,13 @@ SECTIONS
 
     .bss (NOLOAD):
     {
-        . = ALIGN(4) ;
+	/*2Mbytes alignment */
+        . = ALIGN(0x200000) ;
         ld_bss_start = . ;
         *(.bss) ;
         *(.bss*) ;
         *(COMMON) ;
-        . = ALIGN(4) ;
+        . = ALIGN(0x200000) ;
         ld_bss_end = . ;
     } > ram
 


### PR DESCRIPTION
- remove "-Wl -z noexecstack" GCC flag option in hypervisor
  Makefile as it would not affect stack attribute in hyervisor,
  which setup stack itself, instead of by loader.
- Stack in hypervisor is setup based on per-CPU global data,
  which is in BSS section, this patch will set NX bit for
  BSS Page entries.
- Align the boundaries of BSS section to 2M bytes.
- Enable MSR EFER.NXE in hypvervisor.

Tracked-On: #1122
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>