### PR TITLE
DM: updating launch_uos.sh

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -20,7 +20,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \
   -s 5,virtio-console,@pty:pty_port \
   -s 6,virtio-hyper_dmabuf \
-  -s 3,virtio-blk,/root/clear-26200-kvm.img \
+  -s 3,virtio-blk,/home/clear/uos/clear-26200-kvm.img \
   -s 4,virtio-net,tap0 \
   -k /usr/lib/kernel/default-iot-lts2018 \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \


### PR DESCRIPTION
this patch is for updating path of the UOS image in launch_uos.sh script to adapt latest getting started guide, 

Tracked-On: #2003 
Signed-off-by: Ailun258 <ailin.yang@intel.com>