### PR TITLE
minimize the case of "identifier reuse"

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <acpi.h>
 #include <schedule.h>
 #include <version.h>
 #include <trampoline.h>
@@ -269,18 +270,6 @@ static int hardware_detect_support(void)
 
 	pr_acrnlog("hardware support HV");
 	return 0;
-}
-
-uint16_t __attribute__((weak)) parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM])
-{
-	static const uint32_t lapic_id[] = {0U, 2U, 4U, 6U};
-	uint32_t i;
-
-	for (i = 0U; i < ARRAY_SIZE(lapic_id); i++) {
-		lapic_id_array[i] = lapic_id[i];
-	}
-
-	return ((uint16_t)ARRAY_SIZE(lapic_id));
 }
 
 static void init_percpu_lapic_id(void)

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -30,23 +30,23 @@ static inline uint64_t ppt_pgentry_present(uint64_t pte)
 
 static inline struct page *ppt_get_pml4_page(const union pgtable_pages_info *info)
 {
-	struct page *page = info->ppt.pml4_base;
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	struct page *pml4_page = info->ppt.pml4_base;
+	(void)memset(pml4_page, 0U, PAGE_SIZE);
+	return pml4_page;
 }
 
 static inline struct page *ppt_get_pdpt_page(const union pgtable_pages_info *info, uint64_t gpa)
 {
-	struct page *page = info->ppt.pdpt_base + (gpa >> PML4E_SHIFT);
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	struct page *pdpt_page = info->ppt.pdpt_base + (gpa >> PML4E_SHIFT);
+	(void)memset(pdpt_page, 0U, PAGE_SIZE);
+	return pdpt_page;
 }
 
 static inline struct page *ppt_get_pd_page(const union pgtable_pages_info *info, uint64_t gpa)
 {
-	struct page *page = info->ppt.pd_base + (gpa >> PDPTE_SHIFT);
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	struct page *pd_page = info->ppt.pd_base + (gpa >> PDPTE_SHIFT);
+	(void)memset(pd_page, 0U, PAGE_SIZE);
+	return pd_page;
 }
 
 const struct memory_ops ppt_mem_ops = {
@@ -103,43 +103,43 @@ static inline uint64_t ept_pgentry_present(uint64_t pte)
 
 static inline struct page *ept_get_pml4_page(const union pgtable_pages_info *info)
 {
-	struct page *page = info->ept.nworld_pml4_base;
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	struct page *pml4_page = info->ept.nworld_pml4_base;
+	(void)memset(pml4_page, 0U, PAGE_SIZE);
+	return pml4_page;
 }
 
 static inline struct page *ept_get_pdpt_page(const union pgtable_pages_info *info, uint64_t gpa)
 {
-	struct page *page = info->ept.nworld_pdpt_base + (gpa >> PML4E_SHIFT);
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	struct page *pdpt_page = info->ept.nworld_pdpt_base + (gpa >> PML4E_SHIFT);
+	(void)memset(pdpt_page, 0U, PAGE_SIZE);
+	return pdpt_page;
 }
 
 static inline struct page *ept_get_pd_page(const union pgtable_pages_info *info, uint64_t gpa)
 {
-	struct page *page;
+	struct page *pd_page;
 	if (gpa < TRUSTY_EPT_REBASE_GPA) {
-		page = info->ept.nworld_pd_base + (gpa >> PDPTE_SHIFT);
+		pd_page = info->ept.nworld_pd_base + (gpa >> PDPTE_SHIFT);
 	} else {
-		page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
+		pd_page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
 			TRUSTY_PDPT_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) + ((gpa - TRUSTY_EPT_REBASE_GPA) >> PDPTE_SHIFT);
 	}
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	(void)memset(pd_page, 0U, PAGE_SIZE);
+	return pd_page;
 }
 
 static inline struct page *ept_get_pt_page(const union pgtable_pages_info *info, uint64_t gpa)
 {
-	struct page *page;
+	struct page *pt_page;
 	if (gpa < TRUSTY_EPT_REBASE_GPA) {
-		page = info->ept.nworld_pt_base + (gpa >> PDE_SHIFT);
+		pt_page = info->ept.nworld_pt_base + (gpa >> PDE_SHIFT);
 	} else {
-		page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
+		pt_page = info->ept.sworld_pgtable_base + TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
 			TRUSTY_PDPT_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) + TRUSTY_PD_PAGE_NUM(TRUSTY_EPT_REBASE_GPA) +
 			((gpa - TRUSTY_EPT_REBASE_GPA) >> PDE_SHIFT);
 	}
-	(void)memset(page, 0U, PAGE_SIZE);
-	return page;
+	(void)memset(pt_page, 0U, PAGE_SIZE);
+	return pt_page;
 }
 
 static inline void *ept_get_sworld_memory_base(const union pgtable_pages_info *info)

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -829,7 +829,7 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment, uint8
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_root_entry *root_table;
 	uint64_t context_table_addr;
-	struct dmar_context_entry *context_table;
+	struct dmar_context_entry *context;
 	struct dmar_root_entry *root_entry;
 	struct dmar_context_entry *context_entry;
 	uint64_t upper;
@@ -888,8 +888,8 @@ static int add_iommu_device(struct iommu_domain *domain, uint16_t segment, uint8
 
 	context_table_addr = context_table_addr << PAGE_SHIFT;
 
-	context_table = (struct dmar_context_entry *)hpa2hva(context_table_addr);
-	context_entry = context_table + devfun;
+	context = (struct dmar_context_entry *)hpa2hva(context_table_addr);
+	context_entry = context + devfun;
 
 	/* the context entry should not be present */
 	if (dmar_get_bitslice(context_entry->lower, CTX_ENTRY_LOWER_P_MASK, CTX_ENTRY_LOWER_P_POS) != 0UL) {
@@ -942,7 +942,7 @@ static int remove_iommu_device(const struct iommu_domain *domain, uint16_t segme
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_root_entry *root_table;
 	uint64_t context_table_addr;
-	struct dmar_context_entry *context_table;
+	struct dmar_context_entry *context;
 	struct dmar_root_entry *root_entry;
 	struct dmar_context_entry *context_entry;
 	uint16_t dom_id;
@@ -958,9 +958,9 @@ static int remove_iommu_device(const struct iommu_domain *domain, uint16_t segme
 
 	context_table_addr = dmar_get_bitslice(root_entry->lower,  ROOT_ENTRY_LOWER_CTP_MASK, ROOT_ENTRY_LOWER_CTP_POS);
 	context_table_addr = context_table_addr << PAGE_SHIFT;
-	context_table = (struct dmar_context_entry *)hpa2hva(context_table_addr);
+	context = (struct dmar_context_entry *)hpa2hva(context_table_addr);
 
-	context_entry = context_table + devfun;
+	context_entry = context + devfun;
 
 	dom_id = (uint16_t)dmar_get_bitslice(context_entry->upper, CTX_ENTRY_UPPER_DID_MASK, CTX_ENTRY_UPPER_DID_POS);
 	if (dom_id != vmid_to_domainid(domain->vm_id)) {

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -28,6 +28,7 @@
  */
 
 #include <hypervisor.h>
+#include "acpi_priv.h"
 #include "acpi.h"
 #include <vm0_boot.h>
 

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -163,14 +163,13 @@ static void *get_rsdp(void)
 	return rsdp;
 }
 
-static bool
-probe_table(uint64_t address, const char *sig)
+static bool probe_table(uint64_t address, const char *signature)
 {
 	void *va =  hpa2hva(address);
 	struct acpi_table_header *table = (struct acpi_table_header *)va;
 	bool ret;
 
-	if (strncmp(table->signature, sig, ACPI_NAME_SIZE) != 0) {
+	if (strncmp(table->signature, signature, ACPI_NAME_SIZE) != 0) {
 	        ret = false;
 	} else {
 		ret = true;
@@ -179,7 +178,7 @@ probe_table(uint64_t address, const char *sig)
 	return ret;
 }
 
-static void *get_acpi_tbl(const char *sig)
+static void *get_acpi_tbl(const char *signature)
 {
 	struct acpi_table_rsdp *rsdp;
 	struct acpi_table_rsdt *rsdt;
@@ -202,7 +201,7 @@ static void *get_acpi_tbl(const char *sig)
 		    sizeof(uint64_t);
 
 		for (i = 0U; i < count; i++) {
-			if (probe_table(xsdt->table_offset_entry[i], sig)) {
+			if (probe_table(xsdt->table_offset_entry[i], signature)) {
 				addr = xsdt->table_offset_entry[i];
 				break;
 			}
@@ -216,7 +215,7 @@ static void *get_acpi_tbl(const char *sig)
 			sizeof(uint32_t);
 
 		for (i = 0U; i < count; i++) {
-			if (probe_table(rsdt->table_offset_entry[i], sig)) {
+			if (probe_table(rsdt->table_offset_entry[i], signature)) {
 				addr = rsdt->table_offset_entry[i];
 				break;
 			}

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -8,7 +8,7 @@
 #include <hypervisor.h>
 #include "pci.h"
 #include "vtd.h"
-#include "acpi.h"
+#include "acpi_priv.h"
 
 enum acpi_dmar_type {
 	ACPI_DMAR_TYPE_HARDWARE_UNIT        = 0,

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -7,28 +7,6 @@
 #ifndef ACPI_H
 #define ACPI_H
 
-struct acpi_table_header {
-	/* ASCII table signature */
-	char                    signature[4];
-	/* Length of table in bytes, including this header */
-	uint32_t                length;
-	/* ACPI Specification minor version number */
-	uint8_t                 revision;
-	/* To make sum of entire table == 0 */
-	uint8_t                 checksum;
-	/* ASCII OEM identification */
-	char                    oem_id[6];
-	/* ASCII OEM table identification */
-	char                    oem_table_id[8];
-	/* OEM revision number */
-	uint32_t                oem_revision;
-	/* ASCII ASL compiler vendor ID */
-	char                    asl_compiler_id[4];
-	/* ASL compiler version */
-	uint32_t                asl_compiler_revision;
-};
-
 uint16_t parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM]);
 
-void *get_dmar_table(void);
 #endif /* !ACPI_H */

--- a/hypervisor/boot/include/acpi_priv.h
+++ b/hypervisor/boot/include/acpi_priv.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef ACPI_PRIV_H
+#define ACPI_PRIV_H
+
+struct acpi_table_header {
+	/* ASCII table signature */
+	char                    signature[4];
+	/* Length of table in bytes, including this header */
+	uint32_t                length;
+	/* ACPI Specification minor version number */
+	uint8_t                 revision;
+	/* To make sum of entire table == 0 */
+	uint8_t                 checksum;
+	/* ASCII OEM identification */
+	char                    oem_id[6];
+	/* ASCII OEM table identification */
+	char                    oem_table_id[8];
+	/* OEM revision number */
+	uint32_t                oem_revision;
+	/* ASCII ASL compiler vendor ID */
+	char                    asl_compiler_id[4];
+	/* ASL compiler version */
+	uint32_t                asl_compiler_revision;
+};
+
+void *get_dmar_table(void);
+#endif /* !ACPI_PRIV_H */

--- a/hypervisor/include/arch/x86/zeropage.h
+++ b/hypervisor/include/arch/x86/zeropage.h
@@ -33,7 +33,7 @@ struct zero_page {
 	} __packed hdr;
 
 	uint8_t pad3[0x68];	/* 0x268 */
-	struct e820_entry e820[0x80];	/* 0x2d0 */
+	struct e820_entry entries[0x80];	/* 0x2d0 */
 	uint8_t pad4[0x330];	/* 0xcd0 */
 } __packed;
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -468,7 +468,7 @@ struct acrn_set_ioreq_buffer {
  * the parameter for HC_SET_IRQLINE hypercall
  */
 struct acrn_irqline_ops {
-	uint32_t nr_gsi;
+	uint32_t gsi;
 	uint32_t op;
 } __aligned(8);
 


### PR DESCRIPTION
v1-v2:
Make clear which page table page used for which level, ie rename pgtable_page to pml4/pdpt/pd/pt_page.

v1:
Identifier reuse may arise confusion. So should minimize the case of it
as much as possible. This patch is try to do this except the PCI related
module.

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
