### PR TITLE
hv: vMSR reshuffling: rearrange emulated MSR data structures

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -158,6 +158,27 @@ inline void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val)
 		= val;
 }
 
+uint64_t vcpu_get_guest_msr(const struct acrn_vcpu *vcpu, uint32_t msr)
+{
+	uint32_t index = vmsr_get_guest_msr_index(msr);
+	uint64_t val = 0UL;
+
+	if (index < NUM_GUEST_MSRS) {
+		val = vcpu->arch.guest_msrs[index];
+	}
+
+	return val;
+}
+
+void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val)
+{
+	uint32_t index = vmsr_get_guest_msr_index(msr);
+
+	if (index < NUM_GUEST_MSRS) {
+		vcpu->arch.guest_msrs[index] = val;
+	}
+}
+
 struct acrn_vcpu *get_ever_run_vcpu(uint16_t pcpu_id)
 {
 	return per_cpu(ever_run_vcpu, pcpu_id);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -146,18 +146,6 @@ inline void vcpu_set_cr4(struct acrn_vcpu *vcpu, uint64_t val)
 	vmx_write_cr4(vcpu, val);
 }
 
-inline uint64_t vcpu_get_pat_ext(const struct acrn_vcpu *vcpu)
-{
-	return vcpu->arch.contexts[vcpu->arch.cur_context].
-		ext_ctx.ia32_pat;
-}
-
-inline void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val)
-{
-	vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx.ia32_pat
-		= val;
-}
-
 uint64_t vcpu_get_guest_msr(const struct acrn_vcpu *vcpu, uint32_t msr)
 {
 	uint32_t index = vmsr_get_guest_msr_index(msr);

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -408,7 +408,7 @@ static uint64_t vlapic_get_tsc_deadline_msr(const struct acrn_vlapic *vlapic)
 		ret = 0UL;
 	} else {
 		ret = (vlapic->vtimer.timer.fire_tsc == 0UL) ? 0UL :
-			vlapic->vcpu->guest_msrs[IDX_TSC_DEADLINE];
+			vcpu_get_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE);
 	}
 
 	return ret;
@@ -422,7 +422,7 @@ static void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic,
 	uint64_t val = val_arg;
 
 	if (vlapic_lvtt_tsc_deadline(vlapic)) {
-		vlapic->vcpu->guest_msrs[IDX_TSC_DEADLINE] = val;
+		vcpu_set_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE, val);
 
 		timer = &vlapic->vtimer.timer;
 		del_timer(timer);

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -201,6 +201,24 @@ static const uint32_t x2apic_msrs[NUM_X2APIC_MSRS] = {
 	MSR_IA32_EXT_APIC_SELF_IPI,
 };
 
+/* emulated_guest_msrs[] shares same indexes with array vcpu->arch->guest_msrs[] */
+uint32_t vmsr_get_guest_msr_index(uint32_t msr)
+{
+	uint32_t index;
+
+	for (index = 0U; index < NUM_GUEST_MSRS; index++) {
+		if (emulated_guest_msrs[index] == msr) {
+			break;
+		}
+	}
+
+	if (index == NUM_GUEST_MSRS) {
+		pr_err("%s, MSR %x is not defined in array emulated_guest_msrs[]", __func__, msr);
+	}
+
+	return index;
+}
+
 static void enable_msr_interception(uint8_t *bitmap, uint32_t msr_arg, enum rw_mode mode)
 {
 	uint8_t *read_map;

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -260,11 +260,11 @@ static void init_cr0_cr4_host_mask(void)
 uint64_t vmx_rdmsr_pat(const struct acrn_vcpu *vcpu)
 {
 	/*
-	 * note: if context->cr0.CD is set, the actual value in guest's
+	 * note: if run_ctx->cr0.CD is set, the actual value in guest's
 	 * IA32_PAT MSR is PAT_ALL_UC_VALUE, which may be different from
-	 * the saved value saved_context->ia32_pat
+	 * the saved value guest_msrs[MSR_IA32_PAT]
 	 */
-	return vcpu_get_pat_ext(vcpu);
+	return vcpu_get_guest_msr(vcpu, MSR_IA32_PAT);
 }
 
 int vmx_wrmsr_pat(struct acrn_vcpu *vcpu, uint64_t value)
@@ -281,7 +281,7 @@ int vmx_wrmsr_pat(struct acrn_vcpu *vcpu, uint64_t value)
 		}
 	}
 
-	vcpu_set_pat_ext(vcpu, value);
+	vcpu_set_guest_msr(vcpu, MSR_IA32_PAT, value);
 
 	/*
 	 * If context->cr0.CD is set, we defer any further requests to write
@@ -430,7 +430,7 @@ void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0)
 			} else {
 				/* Restore IA32_PAT to enable cache again */
 				exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL,
-					vcpu_get_pat_ext(vcpu));
+					vcpu_get_guest_msr(vcpu, MSR_IA32_PAT));
 			}
 			vcpu_make_request(vcpu, ACRN_REQUEST_EPT_FLUSH);
 		}
@@ -592,7 +592,7 @@ static void init_guest_vmx(struct acrn_vcpu *vcpu, uint64_t cr0, uint64_t cr3,
 	exec_vmwrite32(VMX_GUEST_INTERRUPTIBILITY_INFO, 0U);
 	exec_vmwrite32(VMX_GUEST_ACTIVITY_STATE, 0U);
 	exec_vmwrite32(VMX_GUEST_SMBASE, 0U);
-	vcpu_set_pat_ext(vcpu, PAT_POWER_ON_VALUE);
+	vcpu_set_guest_msr(vcpu, MSR_IA32_PAT, PAT_POWER_ON_VALUE);
 	exec_vmwrite(VMX_GUEST_IA32_PAT_FULL, PAT_POWER_ON_VALUE);
 	exec_vmwrite(VMX_GUEST_DR7, DR7_INIT_VALUE);
 }

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -28,15 +28,6 @@
 		(idx)++, vcpu = &(vm->hw.vcpu_array[(idx)])) \
 		if (vcpu->state != VCPU_OFFLINE)
 
-/* the index is matched with emulated msrs array*/
-#define IDX_TSC_DEADLINE		0U
-#define IDX_BIOS_UPDT_TRIG		(IDX_TSC_DEADLINE + 1U)
-#define IDX_BIOS_SIGN_ID		(IDX_BIOS_UPDT_TRIG + 1U)
-#define IDX_TSC		(IDX_BIOS_SIGN_ID + 1U)
-#define IDX_PAT		(IDX_TSC + 1U)
-#define IDX_APIC_BASE	(IDX_PAT + 1U)
-#define IDX_MAX_MSR	(IDX_APIC_BASE + 1U)
-
 /*
  * VCPU related APIs
  */
@@ -138,6 +129,8 @@ extern struct e820_mem_params e820_mem;
 int rdmsr_vmexit_handler(struct acrn_vcpu *vcpu);
 int wrmsr_vmexit_handler(struct acrn_vcpu *vcpu);
 void init_msr_emulation(struct acrn_vcpu *vcpu);
+
+uint32_t vmsr_get_guest_msr_index(uint32_t msr);
 
 struct run_context;
 int vmx_vmrun(struct run_context *context, int ops, int ibrs);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -141,7 +141,6 @@ struct ext_context {
 	uint64_t ia32_kernel_gs_base;
 
 	uint64_t ia32_pat;
-	uint64_t vmx_ia32_pat;
 	uint32_t ia32_sysenter_cs;
 	uint64_t ia32_sysenter_esp;
 	uint64_t ia32_sysenter_eip;
@@ -469,9 +468,6 @@ uint64_t vcpu_get_cr4(struct acrn_vcpu *vcpu);
  * @param[in] val the value set CR4
  */
 void vcpu_set_cr4(struct acrn_vcpu *vcpu, uint64_t val);
-
-uint64_t vcpu_get_pat_ext(const struct acrn_vcpu *vcpu);
-void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val);
 
 /**
  * @brief get guest emulated MSR

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -268,7 +268,6 @@ struct acrn_vcpu {
 
 	struct io_request req; /* used by io/ept emulation */
 
-	uint64_t guest_msrs[IDX_MAX_MSR];
 #ifdef CONFIG_MTRR_ENABLED
 	struct mtrr_state mtrr;
 #endif /* CONFIG_MTRR_ENABLED */
@@ -473,6 +472,30 @@ void vcpu_set_cr4(struct acrn_vcpu *vcpu, uint64_t val);
 
 uint64_t vcpu_get_pat_ext(const struct acrn_vcpu *vcpu);
 void vcpu_set_pat_ext(struct acrn_vcpu *vcpu, uint64_t val);
+
+/**
+ * @brief get guest emulated MSR
+ *
+ * Get the content of emulated guest MSR
+ *
+ * @param[in] vcpu pointer to vcpu data structure
+ * @param[in] msr the guest MSR
+ *
+ * @return the value of emulated MSR.
+ */
+uint64_t vcpu_get_guest_msr(const struct acrn_vcpu *vcpu, uint32_t msr);
+
+/**
+ * @brief set guest emulated MSR
+ *
+ * Update the content of emulated guest MSR
+ *
+ * @param[in] vcpu pointer to vcpu data structure
+ * @param[in] msr the guest MSR
+ * @param[in] val the value to set the target MSR
+ *
+ */
+void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val);
 
 /**
  * @brief set all the vcpu registers

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -166,6 +166,10 @@ struct ext_context {
 #define NORMAL_WORLD	0
 #define SECURE_WORLD	1
 
+#define NUM_WORLD_MSRS		1U
+#define NUM_COMMON_MSRS		6U
+#define NUM_GUEST_MSRS		(NUM_WORLD_MSRS + NUM_COMMON_MSRS)
+
 struct event_injection_info {
 	uint32_t intr_info;
 	uint32_t error_code;
@@ -174,6 +178,9 @@ struct event_injection_info {
 struct cpu_context {
 	struct run_context run_ctx;
 	struct ext_context ext_ctx;
+
+	/* per world MSRs, need isolation between secure and normal world */
+	uint32_t world_msrs[NUM_WORLD_MSRS];
 };
 
 /* Intel SDM 24.8.2, the address must be 16-byte aligned */
@@ -200,6 +207,9 @@ struct acrn_vcpu_arch {
 	struct acrn_vlapic vlapic;
 	int cur_context;
 	struct cpu_context contexts[NR_WORLD];
+
+	/* common MSRs, world_msrs[] is a subset of it */
+	uint64_t guest_msrs[NUM_GUEST_MSRS];
 
 	uint16_t vpid;
 


### PR DESCRIPTION
 - moved guest_msrs[] from struct acrn_vcpu to struct acrn_vcpu_arch
 - create per world world_msrs[] to help emulate MSRs that need world isolation
 - cleanup IA32_PAT and TSC_DEADLINE code according new data structure
Tracked-On: #1867
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>