### PR TITLE
tools: acrnctl: Fix path error when run "acrnctl add" cmd

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -223,6 +223,9 @@ static void _scan_added_vm(void)
 	char suffix[128];
 	int ret;
 
+	if (check_dir("/opt") || check_dir("/opt/acrn"))
+		return;
+
 	ret = check_dir(ACRNCTL_OPT_ROOT);
 	if (ret) {
 		pdebug();

--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -280,7 +280,7 @@ static int acrnctl_do_add(int argc, char *argv[])
 	}
 	system(cmd);
 
-	if (snprintf(cmd, sizeof(cmd), "bash %s%s >./%s.result", argv[1],
+	if (snprintf(cmd, sizeof(cmd), "bash %s%s > %s.result", argv[1],
 			args, argv[1]) >= sizeof(cmd)) {
 		printf("ERROR: cmd is truncated\n");
 		ret = -1 ;
@@ -290,7 +290,7 @@ static int acrnctl_do_add(int argc, char *argv[])
 	if (ret < 0)
 		goto get_vmname;
 
-	if (snprintf(cmd, sizeof(cmd), "grep -a \"acrnctl: \" ./%s.result",
+	if (snprintf(cmd, sizeof(cmd), "grep -a \"acrnctl: \" %s.result",
 			argv[1]) >= sizeof(cmd)) {
 		printf("ERROR: cmd is truncated\n");
 		ret = -1;
@@ -308,7 +308,7 @@ static int acrnctl_do_add(int argc, char *argv[])
 	ret = _get_vmname(cmd_out, vmname, sizeof(vmname));
 	if (ret < 0) {
 		/* failed to get vmname */
-		if (snprintf(cmd, sizeof(cmd), "cat ./%s.result", argv[1]) >= sizeof(cmd)) {
+		if (snprintf(cmd, sizeof(cmd), "cat %s.result", argv[1]) >= sizeof(cmd)) {
 			printf("ERROR: cmd is truncated\n");
 			goto get_vmname;
 		}
@@ -365,7 +365,7 @@ static int acrnctl_do_add(int argc, char *argv[])
 
  vm_exist:
  get_vmname:
-	if (snprintf(cmd, sizeof(cmd), "rm -f ./%s.result", argv[1]) >= sizeof(cmd)) {
+	if (snprintf(cmd, sizeof(cmd), "rm -f %s.result", argv[1]) >= sizeof(cmd)) {
 		printf("WARN: cmd is truncated\n");
 	} else
 		system(cmd);


### PR DESCRIPTION
There is a bug to run 'acrnctl add /[path]/script.sh', when the
launch script has an absolute path. Acrnctl will generate wrong path
for temp files and fail to add VM.

And message '/opt/acrn/conf: No such file or directory' always comes
out, until user once successfully run 'acrnctl add' cmd. That is reported
by _scan_added_vm(), because 'opt/acrn' is missing, only 'acrnctl add'
can create it, we should also check it in _scan_added_vm().

Tracked-On: #2013
Acked-by: Yan, Like <like.yan@intel.com>
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>