### PR TITLE
DM: xHCI: unbind slot id and ndevices relationship.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1433,7 +1433,8 @@ pci_xhci_get_dev_ctx(struct pci_xhci_vdev *xdev, uint32_t slot)
 	uint64_t devctx_addr;
 	struct xhci_dev_ctx *devctx;
 
-	assert(slot > 0 && slot <= xdev->ndevices);
+	assert(slot > 0 && slot <= XHCI_MAX_SLOTS &&
+			xdev->slot_allocated[slot]);
 	assert(xdev->opregs.dcbaa_p != NULL);
 
 	devctx_addr = xdev->opregs.dcbaa_p->dcba[slot];
@@ -2949,7 +2950,7 @@ pci_xhci_device_doorbell(struct pci_xhci_vdev *xdev,
 	UPRINTF(LDBG, "doorbell slot %u epid %u stream %u\r\n",
 		slot, epid, streamid);
 
-	if (slot == 0 || slot > xdev->ndevices) {
+	if (slot <= 0 || slot > XHCI_MAX_SLOTS || !xdev->slot_allocated[slot]) {
 		UPRINTF(LWRN, "invalid doorbell slot %u\r\n", slot);
 		return;
 	}


### PR DESCRIPTION
After mutiple usb devices send enable slot commnad and get slot id each
other, address device setup flow is not sorted by slot id. According to
current design, it will casue assert failure. This patch takes off this
restriction.

Tracked-On: #2017
Signed-off-by: Yang Liang <liang3.yang@intel.com>
Reviewed-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>