### PR TITLE
hv[v2]: enable NX in hypervisor

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -76,7 +76,6 @@ ASFLAGS += -m64 -nostdinc -nostdlib
 
 LDFLAGS += -Wl,--gc-sections -nostartfiles -nostdlib
 LDFLAGS += -Wl,-n,-z,max-page-size=0x1000
-LDFLAGS += -Wl,-z,noexecstack
 
 ifeq (y, $(CONFIG_RELOC))
 # on X86_64, when build with "-pie", GCC fails on linking R_X86_64_32

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -107,6 +107,13 @@ trampoline_fixup_target:
     orl     $0x00000100, %eax
     wrmsr
 
+    /* 0xc0000080 = MSR_IA32_EFER */
+    movl    $0xc0000080, %ecx
+    rdmsr
+    /* 0x00000800 = MSR_IA32_EFER_NXE_BIT */
+    orl     $0x00000800, %eax
+    wrmsr
+
     /* Enable paging, protection, numeric error and co-processor
        monitoring in CR0 to enter long mode */
 

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -31,6 +31,10 @@ SECTIONS
         *(.retpoline_thunk)
     } > ram
 
+     /*Align text top boundary to 2MBytes.*/
+     . = ALIGN(0x200000);
+     ld_text_end = . ;
+
     .rodata :
     {
         *(.rodata*) ;

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -53,6 +53,8 @@
 #define IA32E_REF_MASK		\
 		(boot_cpu_data.physical_address_mask)
 
+extern uint8_t ld_text_end;
+
 static inline uint64_t round_page_up(uint64_t addr)
 {
 	return (((addr + (uint64_t)PAGE_SIZE) - 1UL) & PAGE_MASK);


### PR DESCRIPTION
- enable NX feature in hypervisor:
  1. Set 'XD' bit for all pages, including pages for guests
     when initialize MMU tables in hypervisor.
  2. remove 'XD' bit for pages that contain hypervisor instructions.
  3. enable MSR EFER.NXE,which will enable page access restriction by
     preventing instruction fetches form pages with XD bit set.

- remove "-Wl -z noexecstack" GCC flag option in hypervisor
  Makefile as it would not affect stack attribute in hyervisor,
  which setup stack itself, instead of by loader.

  v2 update:
    1) move variable(_ld_text_end) declaration from cpu.h to mmu.h
    2) add more comments

Tracked-On: #1122
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>