### PR TITLE
dm: pass mac seed not to use vm name

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -86,10 +86,12 @@ char *vsbl_file_name;
 char *kernel_file_name;
 char *elf_file_name;
 uint8_t trusty_enabled;
+char *mac_seed;
 bool stdio_in_use;
 
 static int virtio_msix = 1;
 static bool debugexit_enabled;
+static char mac_seed_str[50];
 
 static int acpi;
 
@@ -708,6 +710,7 @@ enum {
 	CMD_OPT_PART_INFO,
 	CMD_OPT_TRUSTY_ENABLE,
 	CMD_OPT_VIRTIO_POLL_ENABLE,
+	CMD_OPT_MAC_SEED,
 	CMD_OPT_PTDEV_NO_RESET,
 	CMD_OPT_DEBUGEXIT,
 	CMD_OPT_VMCFG,
@@ -745,6 +748,7 @@ static struct option long_options[] = {
 	{"enable_trusty",	no_argument,		0,
 					CMD_OPT_TRUSTY_ENABLE},
 	{"virtio_poll",		required_argument,	0, CMD_OPT_VIRTIO_POLL_ENABLE},
+	{"mac_seed",		required_argument,	0, CMD_OPT_MAC_SEED},
 	{"ptdev_no_reset",	no_argument,		0,
 		CMD_OPT_PTDEV_NO_RESET},
 	{"debugexit",		no_argument,		0, CMD_OPT_DEBUGEXIT},
@@ -875,6 +879,11 @@ dm_run(int argc, char *argv[])
 					optarg);
 				exit(1);
 			}
+			break;
+		case CMD_OPT_MAC_SEED:
+			strncpy(mac_seed_str, optarg, sizeof(mac_seed_str));
+			mac_seed_str[sizeof(mac_seed_str) - 1] = '\0';
+			mac_seed = mac_seed_str;
 			break;
 		case CMD_OPT_PTDEV_NO_RESET:
 			ptdev_no_reset(true);

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -818,7 +818,7 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	 */
 	if (!mac_provided) {
 		snprintf(nstr, sizeof(nstr), "%d-%d-%s", dev->slot,
-		    dev->func, vmname);
+		    dev->func, mac_seed);
 
 		MD5_Init(&mdctx);
 		MD5_Update(&mdctx, nstr, strlen(nstr));

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -42,6 +42,7 @@ extern char *kernel_file_name;
 extern char *elf_file_name;
 extern char *vmname;
 extern bool stdio_in_use;
+extern char *mac_seed;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,
 		       int *vcpu);

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -34,9 +34,9 @@ if [ ! -f "/data/$5/$5.img" ]; then
 fi
 
 #vm-name used to generate uos-mac address
-mac=$(cat /sys/class/net/en*/address)
+mac=$(cat /sys/class/net/e*/address)
 vm_name=vm$1
-vm_name=${vm_name}-${mac:9:8}
+mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
@@ -152,6 +152,7 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   -s 7,xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \
   -s 9,passthru,0/15/1 \
   $boot_cse_option \
+  --mac_seed $mac_seed \
   -s 27,passthru,0/1b/0 \
   $intr_storm_monitor \
   $boot_ipu_option      \
@@ -172,9 +173,9 @@ if [ ! -f "/data/$5/$5.img" ]; then
 fi
 
 #vm-name used to generate uos-mac address
-mac=$(cat /sys/class/net/en*/address)
+mac=$(cat /sys/class/net/e*/address)
 vm_name=vm$1
-vm_name=${vm_name}-${mac:9:8}
+mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
@@ -352,6 +353,7 @@ fi
    -s 11,wdt-i6300esb \
    $boot_audio_option \
    $boot_cse_option \
+   --mac_seed $mac_seed \
    -s 27,passthru,0/1b/0 \
    -s 24,passthru,0/18/0 \
    -s 18,passthru,3/0/0,keep_gsi \

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -2,8 +2,9 @@
 
 function launch_clear()
 {
+mac=$(cat /sys/class/net/e*/address)
 vm_name=vm$1
-
+mac_seed=${mac:9:8}-${vm_name}
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
@@ -22,6 +23,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 6,virtio-hyper_dmabuf \
   -s 3,virtio-blk,/home/clear/uos/clear-26200-kvm.img \
   -s 4,virtio-net,tap0 \
+  --mac_seed $mac_seed \
   -k /usr/lib/kernel/default-iot-lts2018 \
   -B "root=/dev/vda3 rw rootwait maxcpus=$2 nohpet console=tty0 console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \


### PR DESCRIPTION
Physical NIC mac address is used for generate UOS mac address.
This patch uses a new parameters to pass this information
instead of vm name.

Tracked-On: #1987

Signed-off-by: Jie Deng <jie.deng@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>