### PR TITLE
dm: adjust the sequence of destroy client and wait for vm_loop exit

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -289,8 +289,8 @@ delete_cpu(struct vmctx *ctx, int vcpu)
 		exit(1);
 	}
 
-	pthread_join(mt_vmm_info[0].mt_thr, NULL);
 	vm_destroy_ioreq_client(ctx);
+	pthread_join(mt_vmm_info[0].mt_thr, NULL);
 
 	CPU_CLR_ATOMIC(vcpu, &cpumask);
 	return CPU_EMPTY(&cpumask);


### PR DESCRIPTION
To fix the issue that watchdog reset hang issue. At previous change,
we assume the reset comes from guest. But watchdog reset or dm killed
by signal is different. It's possible the vm_loop stick on ioreq
attaching.

The new fixing has two parts:
- fixing from kernel side to remove the race issue in ioreq attach,
  req_complete_notify and client destory.
- Move the client destroy before waiting of vm_loop exit.

Tracked-On: #1986
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Liu Shuo <shuo.a.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>