### PR TITLE
doc: add 0.4 to doc version menu

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,6 +189,7 @@ else:
 html_context = {
    'current_version': current_version,
    'versions': ( ("latest", "/latest/"),
+                 ("0.4", "/0.4/"),
                  ("0.3", "/0.3/"),
                  ("0.2", "/0.2/"),
                  ("0.1", "/0.1/"),


### PR DESCRIPTION
With the 0.4 release, we can now add the 0.4 doc version menu option

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>