### PR TITLE
profiling: split profiling_vmexit_handler into two functions

### DIFF
--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -70,6 +70,8 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 
 		vcpu->arch.nrexits++;
 
+		profiling_pre_vmexit_handler(vcpu);
+
 		CPU_IRQ_ENABLE();
 		/* Dispatch handler */
 		ret = vmexit_handler(vcpu);
@@ -83,6 +85,6 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 
 		TRACE_2L(TRACE_VM_EXIT, basic_exit_reason, vcpu_get_rip(vcpu));
 
-		profiling_vmexit_handler(vcpu, basic_exit_reason);
+		profiling_post_vmexit_handler(vcpu);
 	} while (1);
 }

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -12,7 +12,8 @@
 #endif
 
 void profiling_vmenter_handler(struct acrn_vcpu *vcpu);
-void profiling_vmexit_handler(struct acrn_vcpu *vcpu, uint64_t exit_reason);
+void profiling_pre_vmexit_handler(struct acrn_vcpu *vcpu);
+void profiling_post_vmexit_handler(struct acrn_vcpu *vcpu);
 void profiling_setup(void);
 
 #endif /* PROFILING_H */

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -7,5 +7,6 @@
 #include <hypervisor.h>
 
 void profiling_vmenter_handler(__unused struct acrn_vcpu *vcpu) {}
-void profiling_vmexit_handler(__unused struct acrn_vcpu *vcpu, __unused uint64_t exit_reason) {}
+void profiling_pre_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}
+void profiling_post_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}
 void profiling_setup(void) {}


### PR DESCRIPTION
This patch fixes incorrect vm_id captured when sampling PMU data. Currently,
the vm_id gets attributed to ACRN hypervisor, rather than actual guest vm_id.

The issue is identified that the existing code captures the guest vm info
after vmexit_hander function is completed, in which the profiling module
points its context to VMM. When the vmexit happens by PMI, the guest context
should be captured so that the attribution to proper guest vm can happen.

This change will also allow to capture more accurate TSC when vmexit happens.

Tracked-On: #2043
Signed-off-by: Min Lim <min.yeol.lim@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>