### PR TITLE
doc: vertical align table content to top

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -109,9 +109,12 @@ table.hlist {
     width: 95% !important;
 }
 
-/*  override rtd theme white-space no-wrap in table heading and content  */
+/*  override rtd theme white-space no-wrap in table heading and content
+ *  and top align for content too (not middle)
+ */
 th,td {
     white-space: normal !important;
+    vertical-align: top !important;
 }
 
 /* dbk tweak for doxygen-generated API headings (for RTD theme) */


### PR DESCRIPTION
Default vertical alignment of "middle" doesn't look good on large
tables, so override to be "top" of the cell.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>