### PR TITLE
Init modulization upstream

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -127,6 +127,9 @@ S_SRCS += arch/x86/boot/cpu_save_boot_ctx.S
 S_SRCS += arch/x86/boot/trampoline.S
 C_SRCS += boot/reloc.c
 
+# initilization component
+C_SRCS += arch/x86/init.c
+
 C_SRCS += boot/acpi.c
 C_SRCS += boot/dmar_parse.c
 S_SRCS += arch/x86/idt.S

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -45,8 +45,6 @@ static struct cpu_capability cpu_caps;
 
 struct cpuinfo_x86 boot_cpu_data;
 
-static void bsp_boot_post(void);
-static void cpu_secondary_post(void);
 static void cpu_cap_detect(void);
 static void cpu_xsave_init(void);
 static void set_current_cpu_id(uint16_t pcpu_id);
@@ -54,16 +52,6 @@ static void print_hv_banner(void);
 static uint16_t get_cpu_id_from_lapic_id(uint32_t lapic_id);
 int32_t ibrs_type;
 static uint64_t start_tsc __attribute__((__section__(".bss_noinit")));
-
-/* Push sp magic to top of stack for call trace */
-#define SWITCH_TO(rsp, to)                                              \
-{                                                                       \
-	asm volatile ("movq %0, %%rsp\n"                                \
-			"pushq %1\n"                                    \
-			"call *%2\n"                                    \
-			 :                                              \
-			 : "r"(rsp), "rm"(SP_BOTTOM_MAGIC), "a"(to));   \
-}
 
 bool cpu_has_cap(uint32_t bit)
 {
@@ -379,63 +367,6 @@ static bool check_cpu_security_config(void)
 	return true;
 }
 
-/*TODO: move into debug module */
-static void init_debug_pre(void)
-{
-	/* Initialize console */
-	console_init();
-
-	/* Enable logging */
-	init_logmsg(CONFIG_LOG_DESTINATION);
-}
-
-/*TODO: move into debug module */
-static void init_debug_post(uint16_t pcpu_id)
-{
-	if (pcpu_id == BOOT_CPU_ID) {
-		/* Initialize the shell */
-		shell_init();
-		console_setup_timer();
-	}
-
-	profiling_setup();
-}
-
-/*TODO: move into pass-thru module */
-static void init_passthru(void)
-{
-	if (init_iommu() != 0) {
-		panic("failed to initialize iommu!");
-	}
-
-	ptdev_init();
-}
-
-/*TODO: move into guest-vcpu module */
-static void init_guest(void)
-{
-	init_scheduler();
-}
-
-/*TODO: move into guest-vcpu module */
-static void enter_guest_mode(uint16_t pcpu_id)
-{
-	exec_vmxon_instr(pcpu_id);
-
-#ifdef CONFIG_PARTITION_MODE
-	(void)prepare_vm(pcpu_id);
-#else
-	if (pcpu_id == BOOT_CPU_ID) {
-		(void)prepare_vm(pcpu_id);
-	}
-#endif
-
-	default_idle();
-
-	/* Control should not come here */
-	cpu_dead(pcpu_id);
-}
-
 void init_cpu_pre(uint16_t pcpu_id)
 {
 	if (pcpu_id == BOOT_CPU_ID) {
@@ -551,72 +482,6 @@ void init_cpu_post(uint16_t pcpu_id)
 		/* Wait for boot processor to signal all secondary cores to continue */
 		wait_sync_change(&pcpu_sync, 0UL);
 	}
-}
-
-static void bsp_boot_post(void)
-{
-	/* Perform any necessary BSP initialization */
-	init_bsp();
-
-	init_debug_pre();
-
-	init_guest();
-
-	init_cpu_post(BOOT_CPU_ID);
-
-	init_debug_post(BOOT_CPU_ID);
-
-	init_passthru();
-
-	enter_guest_mode(BOOT_CPU_ID);
-}
-
-/* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
- * it will switch to runtime stack.
- */
-void bsp_boot_init(void)
-{
-	uint64_t rsp;
-
-	init_cpu_pre(BOOT_CPU_ID);
-
-	/* Switch to run-time stack */
-	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
-	rsp &= ~(CPU_STACK_ALIGN - 1UL);
-	SWITCH_TO(rsp, bsp_boot_post);
-}
-
-static void cpu_secondary_post(void)
-{
-	uint16_t pcpu_id;
-
-	/* Release secondary boot spin-lock to allow one of the next CPU(s) to
-	 * perform this common initialization
-	 */
-	spinlock_release(&trampoline_spinlock);
-
-	pcpu_id = get_cpu_id();
-
-	init_cpu_post(pcpu_id);
-
-	init_debug_post(pcpu_id);
-
-	enter_guest_mode(pcpu_id);
-}
-
-/* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
- * it will switch to runtime stack.
- */
-void cpu_secondary_init(void)
-{
-	uint64_t rsp;
-
-	init_cpu_pre(INVALID_CPU_ID);
-
-	/* Switch to run-time stack */
-	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
-	rsp &= ~(CPU_STACK_ALIGN - 1UL);
-	SWITCH_TO(rsp, cpu_secondary_post);
 }
 
 static uint16_t get_cpu_id_from_lapic_id(uint32_t lapic_id)

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <init.h>
+#include <hypervisor.h>
+#include <schedule.h>
+
+/* Push sp magic to top of stack for call trace */
+#define SWITCH_TO(rsp, to)                                              \
+{                                                                       \
+	asm volatile ("movq %0, %%rsp\n"                                \
+			"pushq %1\n"                                    \
+			"call *%2\n"                                    \
+			 :                                              \
+			 : "r"(rsp), "rm"(SP_BOTTOM_MAGIC), "a"(to));   \
+}
+
+/*TODO: move into debug module */
+static void init_debug_pre(void)
+{
+	/* Initialize console */
+	console_init();
+
+	/* Enable logging */
+	init_logmsg(CONFIG_LOG_DESTINATION);
+}
+
+/*TODO: move into debug module */
+static void init_debug_post(uint16_t pcpu_id)
+{
+	if (pcpu_id == BOOT_CPU_ID) {
+		/* Initialize the shell */
+		shell_init();
+		console_setup_timer();
+	}
+
+	profiling_setup();
+}
+
+/*TODO: move into pass-thru module */
+static void init_passthru(void)
+{
+	if (init_iommu() != 0) {
+		panic("failed to initialize iommu!");
+	}
+
+	ptdev_init();
+}
+
+/*TODO: move into guest-vcpu module */
+static void init_guest(void)
+{
+	init_scheduler();
+}
+
+/*TODO: move into guest-vcpu module */
+static void enter_guest_mode(uint16_t pcpu_id)
+{
+	exec_vmxon_instr(pcpu_id);
+
+#ifdef CONFIG_PARTITION_MODE
+	(void)prepare_vm(pcpu_id);
+#else
+	if (pcpu_id == BOOT_CPU_ID) {
+		(void)prepare_vm(pcpu_id);
+	}
+#endif
+
+	default_idle();
+
+	/* Control should not come here */
+	cpu_dead(pcpu_id);
+}
+
+static void bsp_boot_post(void)
+{
+	/* Perform any necessary BSP initialization */
+	init_bsp();
+
+	init_debug_pre();
+
+	init_guest();
+
+	init_cpu_post(BOOT_CPU_ID);
+
+	init_debug_post(BOOT_CPU_ID);
+
+	init_passthru();
+
+	enter_guest_mode(BOOT_CPU_ID);
+}
+
+/* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
+ * it will switch to runtime stack.
+ */
+void bsp_boot_init(void)
+{
+	uint64_t rsp;
+
+	init_cpu_pre(BOOT_CPU_ID);
+
+	/* Switch to run-time stack */
+	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
+	rsp &= ~(CPU_STACK_ALIGN - 1UL);
+	SWITCH_TO(rsp, bsp_boot_post);
+}
+
+static void cpu_secondary_post(void)
+{
+	uint16_t pcpu_id;
+
+	/* Release secondary boot spin-lock to allow one of the next CPU(s) to
+	 * perform this common initialization
+	 */
+	spinlock_release(&trampoline_spinlock);
+
+	pcpu_id = get_cpu_id();
+
+	init_cpu_post(pcpu_id);
+
+	init_debug_post(pcpu_id);
+
+	enter_guest_mode(pcpu_id);
+}
+
+/* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
+ * it will switch to runtime stack.
+ */
+void cpu_secondary_init(void)
+{
+	uint64_t rsp;
+
+	init_cpu_pre(INVALID_CPU_ID);
+
+	/* Switch to run-time stack */
+	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
+	rsp &= ~(CPU_STACK_ALIGN - 1UL);
+	SWITCH_TO(rsp, cpu_secondary_post);
+}

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <init.h>
 
 #define CALL_TRACE_HIERARCHY_MAX    20U
 #define DUMP_STACK_SIZE 0x200U

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -127,9 +127,6 @@
 /* Boot CPU ID */
 #define BOOT_CPU_ID             0U
 
-/* hypervisor stack bottom magic('intl') */
-#define SP_BOTTOM_MAGIC    0x696e746cUL
-
 /* type of speculation control
  * 0 - no speculation control support
  * 1 - raw IBRS + IPBP support
@@ -317,8 +314,8 @@ bool is_apicv_posted_intr_supported(void);
 bool is_ept_supported(void);
 bool cpu_has_cap(uint32_t bit);
 void load_cpu_state_data(void);
-void bsp_boot_init(void);
-void cpu_secondary_init(void);
+void init_cpu_pre(uint16_t pcpu_id);
+void init_cpu_post(uint16_t pcpu_id);
 void start_cpus(void);
 void stop_cpus(void);
 void wait_sync_change(uint64_t *sync, uint64_t wake_sync);

--- a/hypervisor/include/arch/x86/init.h
+++ b/hypervisor/include/arch/x86/init.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) <2018> Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef	INIT_H
+
+/* hypervisor stack bottom magic('intl') */
+#define SP_BOTTOM_MAGIC    0x696e746cUL
+
+void bsp_boot_init(void);
+void cpu_secondary_init(void);
+
+#endif /* INIT_H*/


### PR DESCRIPTION
reorg both init functions, separate the initilization of different
components.

v2:
- separate into 2 patches, 1 for reorg, 1 for pure move.

Tracked-On: #1842
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Xu, Anthony <anthony.xu@intel.com>