### PR TITLE
dm: add OVMF booting support

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -118,6 +118,7 @@ SRCS += core/monitor.c
 SRCS += core/sw_load_common.c
 SRCS += core/sw_load_bzimage.c
 SRCS += core/sw_load_vsbl.c
+SRCS += core/sw_load_ovmf.c
 SRCS += core/sw_load_elf.c
 SRCS += core/smbiostbl.c
 SRCS += core/mevent.c

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -237,6 +237,14 @@ virtio_uses_msix(void)
 	return virtio_msix;
 }
 
+size_t
+high_bios_size(void)
+{
+	size_t size = 0;
+
+	return roundup2(size, 2 * MB);
+}
+
 static void *
 start_thread(void *param)
 {

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -239,6 +239,8 @@ acrn_sw_load(struct vmctx *ctx)
 {
 	if (vsbl_file_name)
 		return acrn_sw_load_vsbl(ctx);
+	else if (ovmf_file_name)
+		return acrn_sw_load_ovmf(ctx);
 	else if (kernel_file_name)
 		return acrn_sw_load_bzimage(ctx);
 	else if (elf_file_name)

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -117,15 +117,32 @@ get_bootargs(void)
 }
 
 int
-check_image(char *path)
+check_image(char *path, size_t size_limit, size_t *size)
 {
 	FILE *fp;
+	long len;
 
 	fp = fopen(path, "r");
-	if (fp == NULL)
+
+	if (fp == NULL) {
+		fprintf(stderr,
+			"SW_LOAD ERR: image file failed to open\n");
 		return -1;
+	}
+
+	fseek(fp, 0, SEEK_END);
+	len = ftell(fp);
+
+	if (len == 0 || (size_limit && len > size_limit)) {
+		fprintf(stderr,
+			"SW_LOAD ERR: file is %s\n",
+			len ? "too large" : "empty");
+		fclose(fp);
+		return -1;
+	}
 
 	fclose(fp);
+	*size = len;
 	return 0;
 }
 

--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -96,10 +96,11 @@ int
 acrn_parse_elf(char *arg)
 {
 	size_t len = strnlen(arg, STR_LEN);
+	size_t elfsz;
 
 	if (len < STR_LEN) {
 		strncpy(elf_path, arg, len + 1);
-		assert(check_image(elf_path) == 0);
+		assert(check_image(elf_path, 0, &elfsz) == 0);
 
 		elf_file_name = elf_path;
 

--- a/devicemodel/core/sw_load_ovmf.c
+++ b/devicemodel/core/sw_load_ovmf.c
@@ -1,0 +1,158 @@
+/*-
+ * Copyright (c) 2018 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "dm.h"
+#include "vmmapi.h"
+#include "sw_load.h"
+
+
+/*                 ovmf binary layout:
+ *
+ * +--------------------------------------------------+ <--OVMF Top
+ * |             |offset: Top - 0x10 (reset vector)   |
+ * + SECFV       |------------------------------------+
+ * |             |other                               |
+ * +--------------------------------------------------+
+ * |                                                  |
+ * + FVMAIN_COMPACT                                   +
+ * |                                                  |
+ * +--------------------------------------------------+
+ * |                                                  |
+ * + NV data storage                                  +
+ * |                                                  |
+ * +--------------------------------------------------+
+ */
+
+/* ovmf real entry is reset vector, which is (OVMF_TOP - 16) */
+#define	OVMF_TOP(ctx)		(4*GB)
+
+static char ovmf_path[STR_LEN];
+static size_t ovmf_size;
+
+extern int init_cmos_vrpmb(struct vmctx *ctx);
+
+size_t
+ovmf_image_size(void)
+{
+	return ovmf_size;
+}
+
+int
+acrn_parse_ovmf(char *arg)
+{
+	int error;
+	size_t len = strlen(arg);
+
+	if (len < STR_LEN) {
+		strncpy(ovmf_path, arg, len + 1);
+		error = check_image(ovmf_path, 2 * MB, &ovmf_size);
+		assert(!error);
+
+		ovmf_file_name = ovmf_path;
+		printf("SW_LOAD: get ovmf path %s, size 0x%lx\n",
+		       ovmf_path, ovmf_size);
+		return 0;
+	} else
+		return -1;
+}
+
+static int
+acrn_prepare_ovmf(struct vmctx *ctx)
+{
+	FILE *fp;
+	size_t read;
+
+	fp = fopen(ovmf_path, "r");
+	if (fp == NULL) {
+		fprintf(stderr,
+			"SW_LOAD ERR: could not open ovmf file: %s\n",
+			ovmf_path);
+		return -1;
+	}
+
+	fseek(fp, 0, SEEK_END);
+
+	if (ftell(fp) != ovmf_size) {
+		fprintf(stderr,
+			"SW_LOAD ERR: ovmf file changed\n");
+		fclose(fp);
+		return -1;
+	}
+
+	fseek(fp, 0, SEEK_SET);
+	read = fread(ctx->baseaddr + OVMF_TOP(ctx) - ovmf_size,
+		sizeof(char), ovmf_size, fp);
+
+	if (read < ovmf_size) {
+		fprintf(stderr,
+			"SW_LOAD ERR: could not read whole partition blob\n");
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+	printf("SW_LOAD: partition blob %s size %lu copy to guest 0x%lx\n",
+		ovmf_path, ovmf_size, OVMF_TOP(ctx) - ovmf_size);
+
+	return 0;
+}
+
+int
+acrn_sw_load_ovmf(struct vmctx *ctx)
+{
+	int ret;
+
+	init_cmos_vrpmb(ctx);
+
+	ret = acrn_prepare_ovmf(ctx);
+
+	if (ret)
+		return ret;
+
+	printf("SW_LOAD: ovmf_entry 0x%lx\n", OVMF_TOP(ctx) - 16);
+
+	/* set guest bsp state. Will call hypercall set bsp state
+	 * after bsp is created.
+	 */
+	memset(&ctx->bsp_regs, 0, sizeof(struct acrn_set_vcpu_regs));
+	ctx->bsp_regs.vcpu_id = 0;
+
+	/* CR0_ET | CR0_NE */
+	ctx->bsp_regs.vcpu_regs.cr0 = 0x30U;
+	ctx->bsp_regs.vcpu_regs.cs_ar = 0x009FU;
+	ctx->bsp_regs.vcpu_regs.cs_sel = 0xF000U;
+	ctx->bsp_regs.vcpu_regs.cs_limit = 0xFFFFU;
+	ctx->bsp_regs.vcpu_regs.cs_base = (OVMF_TOP(ctx) - 16) & 0xFFFF0000UL;
+	ctx->bsp_regs.vcpu_regs.rip = (OVMF_TOP(ctx) - 16) & 0xFFFFUL;
+
+	return 0;
+}

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -292,6 +292,8 @@ vm_setup_memory(struct vmctx *ctx, size_t memsize)
 		ctx->highmem = 0;
 	}
 
+	ctx->biosmem = high_bios_size();
+
 	return hugetlb_setup_memory(ctx);
 }
 

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -58,6 +58,7 @@ int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,
  */
 void *paddr_guest2host(struct vmctx *ctx, uintptr_t gaddr, size_t len);
 int  virtio_uses_msix(void);
+size_t high_bios_size(void);
 void ptdev_no_reset(bool enable);
 void init_debugexit(void);
 void deinit_debugexit(void);

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -38,6 +38,7 @@ extern int guest_ncpus;
 extern char *guest_uuid_str;
 extern uint8_t trusty_enabled;
 extern char *vsbl_file_name;
+extern char *ovmf_file_name;
 extern char *kernel_file_name;
 extern char *elf_file_name;
 extern char *vmname;

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -55,11 +55,14 @@ struct e820_entry {
 extern const struct e820_entry e820_default_entries[NUM_E820_ENTRIES];
 extern int with_bootargs;
 
+size_t ovmf_image_size(void);
+
 int acrn_parse_kernel(char *arg);
 int acrn_parse_ramdisk(char *arg);
 int acrn_parse_bootargs(char *arg);
 int acrn_parse_gvtargs(char *arg);
 int acrn_parse_vsbl(char *arg);
+int acrn_parse_ovmf(char *arg);
 int acrn_parse_elf(char *arg);
 int acrn_parse_guest_part_info(char *arg);
 char *get_bootargs(void);
@@ -73,6 +76,7 @@ int add_e820_entry(struct e820_entry *e820, int len, uint64_t start,
 int acrn_sw_load_bzimage(struct vmctx *ctx);
 int acrn_sw_load_elf(struct vmctx *ctx);
 int acrn_sw_load_vsbl(struct vmctx *ctx);
+int acrn_sw_load_ovmf(struct vmctx *ctx);
 int acrn_sw_load(struct vmctx *ctx);
 #endif
 

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -65,7 +65,7 @@ int acrn_parse_guest_part_info(char *arg);
 char *get_bootargs(void);
 void vsbl_set_bdf(int bnum, int snum, int fnum);
 
-int check_image(char *path);
+int check_image(char *path, size_t size_limit, size_t *size);
 uint32_t acrn_create_e820_table(struct vmctx *ctx, struct e820_entry *e820);
 int add_e820_entry(struct e820_entry *e820, int len, uint64_t start,
 	uint64_t size, uint32_t type);

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -53,10 +53,11 @@ struct vmctx {
 	int     ioreq_client;
 	uint32_t lowmem_limit;
 	size_t  lowmem;
+	size_t  biosmem;
 	size_t  highmem;
 	char    *baseaddr;
 	char    *name;
-	uuid_t	vm_uuid;
+	uuid_t  vm_uuid;
 
 	/* fields to track virtual devices */
 	void *atkbdc_base;

--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -53,7 +53,8 @@ options:
 
    acrn-dm [-abehuwxACHPSTWY] [-c vcpus] [-g <gdb port>] [-l <lpc>]
                [-m mem] [-p vcpu:hostcpu] [-s <pci>] [-U uuid]
-               [--vsbl vsbl_file_name] [--part_info part_info_name]
+               [--vsbl vsbl_file_path] [--ovmf ovmf_file_path]
+               [--part_info part_info_name]
                [--enable_trusty] [--intr_monitor param_setting] <vm>
 
        -a: local apic is in xAPIC mode (deprecated)
@@ -84,6 +85,7 @@ options:
        -v: version
        -i: ioc boot parameters
        --vsbl: vsbl file path
+       --ovmf: ovmf file path
        --part_info: guest partition info file path
        --enable_trusty: enable trusty for guest
        --ptdev_no_reset: disable reset check for ptdev
@@ -96,6 +98,7 @@ configuration options.
 Here's an example showing how to run a VM with:
 
 -  Build ACPI table
+-  vSBL as the boot ROM
 -  UART device on PCI 00:01.0
 -  GPU device on PCI 00:02.0
 -  Virtio-block device on PCI 00:03.0

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -213,6 +213,19 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
        uses ``/usr/share/acrn/bios/VSBL.bin`` as the vSBL image
 
+   * - :kbd:`--ovmf <ovmf_file_path>`
+     - Open Virtual Machine Firmware (OVMF) is an EDK II based project to enable
+       UEFI support for Virtual Machines.
+
+       ACRN currently does not support off-the-shelf OVMF builds targeted for
+       QEMU and KVM. This feature is still under development.
+
+       usage::
+
+          --ovmf <path to OVMF.fd>
+
+       uses ``OVMF.fd`` as the OVMF image
+
    * - :kbd:`-W, --virtio_msix`
      - This option forces virtio to use single-vector MSI.
        By default, any virtio-based devices will use MSI-X as its interrupt


### PR DESCRIPTION
Add support for loading OVMF into the High BIOS area and booting it from acrn-dm.
Use generic code for BIOS/ROM image loading at High BIOS region.

Tracked-On: #1832
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>