### PR TITLE
DM USB: xHCI: Fix banned API issue.

### DIFF
--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -82,6 +82,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include "usb_core.h"
+#include "dm_string.h"
 
 SET_DECLARE(usb_emu_set, struct usb_devemu);
 int usb_log_level;
@@ -205,7 +206,13 @@ usb_native_is_port_existed(uint8_t bus_num, uint8_t port_num)
 		return 0;
 	}
 
-	native_port_cnt = atoi(cnt);
+	rc = dm_strtoi(cnt, (char **)&cnt, 10, &native_port_cnt);
+	if (rc) {
+		UPRINTF(LWRN, "fail to get maxchild number\r\n");
+		close(fd);
+		return 0;
+	}
+
 	if (port_num > native_port_cnt || port_num < 0) {
 		UPRINTF(LWRN, "invalid port_num %d, max port count %d\r\n",
 				port_num, native_port_cnt);
@@ -269,6 +276,7 @@ int
 usb_get_hub_port_num(struct usb_devpath *path)
 {
 	int rc, fd;
+	int icnt;
 	char buf[128];
 	char cnt[8];
 
@@ -296,5 +304,12 @@ usb_get_hub_port_num(struct usb_devpath *path)
 	}
 
 	close(fd);
-	return atoi(cnt);
+
+	rc = dm_strtoi(cnt, (char **)&cnt, 10, &icnt);
+	if (rc) {
+		UPRINTF(LWRN, "fail to get maxchild\r\n");
+		return -1;
+	}
+
+	return icnt;
 }


### PR DESCRIPTION
In USB mediator, sscanf, strtok and atoi API is banned, so replace them
with permitted API function.

Tracked-On: #1254
Signed-off-by: Yang Liang <liang3.yang@intel.com>
Reviewed-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Shuo Liu <shuo.a.liu@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>