### PR TITLE
hv: emulate IA32_TSC_ADJUST MSR

### DIFF
--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -167,6 +167,7 @@ static void save_world_ctx(struct acrn_vcpu *vcpu, struct ext_context *ext_ctx)
 	(void)vcpu_get_rip(vcpu);
 
 	/* VMCS GUEST field */
+	ext_ctx->tsc_offset = exec_vmread(VMX_TSC_OFFSET_FULL);
 	ext_ctx->vmx_cr0 = exec_vmread(VMX_GUEST_CR0);
 	ext_ctx->vmx_cr4 = exec_vmread(VMX_GUEST_CR4);
 	ext_ctx->vmx_cr0_read_shadow = exec_vmread(VMX_CR0_READ_SHADOW);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -165,7 +165,7 @@ struct ext_context {
 #define NORMAL_WORLD	0
 #define SECURE_WORLD	1
 
-#define NUM_WORLD_MSRS		1U
+#define NUM_WORLD_MSRS		2U
 #define NUM_COMMON_MSRS		6U
 #define NUM_GUEST_MSRS		(NUM_WORLD_MSRS + NUM_COMMON_MSRS)
 


### PR DESCRIPTION
Intercept IA32_TSC_ADJUST MSR so that writing IA32_TSC_ADJUST from the
guests won't impact the TSC in root mode or potentially other vCPUs in
the same pCPU.

- MSR TSC_ADJUST needs to be isolated between normal and secure world,
  so it's included in NUM_WORLD_MSRS.
- Upon writing to either IA32_TSC_ADJUST or IA32_TSC from the guests,
  don't write to physical MSRS so it won't impact the host side, but
  update the TSC offset VM-execution control.
- don't need to intercept rdmsr for IA32_TIME_STAMP_COUNTER.
- add the missing statement in save_world_ctx() to save the tsc_offset
  during world switch.

Tracked-On: #1867
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>