### PR TITLE
remove check_tsc and refine cpu_dead

### DIFF
--- a/doc/developer-guides/hld/hv-timer.rst
+++ b/doc/developer-guides/hld/hv-timer.rst
@@ -42,9 +42,6 @@ Interfaces Design
 .. doxygenfunction:: timer_init
    :project: Project ACRN
 
-.. doxygenfunction:: check_tsc
-   :project: Project ACRN
-
 .. doxygenfunction:: calibrate_tsc
    :project: Project ACRN
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -429,9 +429,6 @@ void init_cpu_post(uint16_t pcpu_id)
 
 	enable_smap();
 
-	/* Make sure rdtsc is enabled */
-	check_tsc();
-
 	cpu_xsave_init();
 
 	if (pcpu_id == BOOT_CPU_ID) {

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -598,12 +598,16 @@ void cpu_do_idle(void)
 	__asm __volatile("pause" ::: "memory");
 }
 
-void cpu_dead(uint16_t pcpu_id)
+/**
+ * only run on current pcpu
+ */
+void cpu_dead(void)
 {
 	/* For debug purposes, using a stack variable in the while loop enables
 	 * us to modify the value using a JTAG probe and resume if needed.
 	 */
 	int32_t halt = 1;
+	uint16_t pcpu_id = get_cpu_id();
 
 	if (bitmap_test_and_clear_lock(pcpu_id, &pcpu_active_bitmap)) {
 		/* clean up native stuff */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -72,7 +72,7 @@ static void enter_guest_mode(uint16_t pcpu_id)
 	default_idle();
 
 	/* Control should not come here */
-	cpu_dead(pcpu_id);
+	cpu_dead();
 }
 
 static void bsp_boot_post(void)

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -376,7 +376,7 @@ void dispatch_exception(struct intr_excp_ctx *ctx)
 	spinlock_release(&exception_spinlock);
 
 	/* Halt the CPU */
-	cpu_dead(pcpu_id);
+	cpu_dead();
 }
 
 #ifdef CONFIG_PARTITION_MODE

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -189,15 +189,6 @@ void timer_init(void)
 	}
 }
 
-void check_tsc(void)
-{
-	uint64_t temp64;
-
-	/* Ensure time-stamp timer is turned on for each CPU */
-	CPU_CR_READ(cr4, &temp64);
-	CPU_CR_WRITE(cr4, (temp64 & ~CR4_TSD));
-}
-
 static uint64_t pit_calibrate_tsc(uint32_t cal_ms_arg)
 {
 #define PIT_TICK_RATE	1193182U

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -175,7 +175,7 @@ void default_idle(void)
 		if (need_reschedule(pcpu_id) != 0) {
 			schedule();
 		} else if (need_offline(pcpu_id) != 0) {
-			cpu_dead(pcpu_id);
+			cpu_dead();
 		} else {
 			CPU_IRQ_ENABLE();
 			handle_complete_ioreq(pcpu_id);

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -306,7 +306,7 @@ extern struct cpuinfo_x86 boot_cpu_data;
 
 /* Function prototypes */
 void cpu_do_idle(void);
-void cpu_dead(uint16_t pcpu_id);
+void cpu_dead(void);
 void trampoline_start16(void);
 bool is_apicv_reg_virtualization_supported(void);
 bool is_apicv_intr_delivery_supported(void);

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -117,11 +117,6 @@ void del_timer(struct hv_timer *timer);
 void timer_init(void);
 
 /**
- * @brief Check tsc to make sure rdtsc is enabled.
- */
-void check_tsc(void);
-
-/**
  * @brief Calibrate tsc.
  *
  * @return None


### PR DESCRIPTION
these two patches removed check_tsc function and refined cpu_dead function.
Tracked-On: #1842
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>