### PR TITLE
dm: set correct thread name

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -175,6 +175,7 @@ static void start_intr_storm_monitor(struct vmctx *ctx)
 			printf("failed %s %d\n", __func__, __LINE__);
 			intr_storm_monitor_pid = 0;
 		}
+		pthread_setname_np(intr_storm_monitor_pid, "storm_monitor");
 
 		printf("start monitor interrupt data...\n");
 	}

--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -504,6 +504,7 @@ int init_tpm_crb(struct vmctx *ctx)
 		WPRINTF("Failed init request thread!\n");
 		goto fail_thread;
 	}
+	pthread_setname_np(tpm_vdev->request_thread, "tpm_crb_deli");
 
 	return 0;
 

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1250,6 +1250,8 @@ usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
 				native_disconn_handle);
 		goto errout;
 	}
+	pthread_setname_np(g_ctx.thread, "usb_dev_sys");
+
 	return 0;
 
 errout:

--- a/tools/acrn-manager/acrn_mngr.c
+++ b/tools/acrn-manager/acrn_mngr.c
@@ -340,6 +340,7 @@ static int create_new_server(const char *name)
 		pdebug();
 		goto listen_err;
 	}
+	pthread_setname_np(mfd->listen_thread, "mngr_listen");
 
 	/* create a poll_thread */
 	mfd->polling = 1;
@@ -348,6 +349,7 @@ static int create_new_server(const char *name)
 		pdebug();
 		goto poll_err;
 	}
+	pthread_setname_np(mfd->poll_thread, "mngr_pull");
 
 	mfd->desc = mfd->fd;
 	/* add this to mngr_fd_head */


### PR DESCRIPTION
When issue happen, we could identify which thread is impacted.
This could help stability issue debugging.

Tracked-On: #2037
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>