### PR TITLE
hv: vmsr: fix MISRA_C violations

### DIFF
--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -27,9 +27,6 @@ static uint64_t cr4_host_mask;
 static uint64_t cr4_always_on_mask;
 static uint64_t cr4_always_off_mask;
 
-void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu);
-void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu);
-
 bool is_vmx_disabled(void)
 {
 	uint64_t msr_val;

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -104,6 +104,9 @@ void init_msr_emulation(struct acrn_vcpu *vcpu);
 
 uint32_t vmsr_get_guest_msr_index(uint32_t msr);
 
+void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu);
+void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu);
+
 struct run_context;
 int32_t vmx_vmrun(struct run_context *context, int32_t ops, int32_t ibrs);
 


### PR DESCRIPTION
106D No prototype for non-static function.
  2 functions missing prototyle declarations in header file.

120S Use of bit operator on signed type.
123S Use of underlying enum representation value.
  enum values are treated like unsigned integer in vmsr.c

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>