### PR TITLE
hv: vpci: 2 MISRA-C violation fixes

### DIFF
--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -199,20 +199,20 @@ static int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t b
 static void vmsix_table_rw(struct pci_vdev *vdev, struct mmio_request *mmio, uint32_t offset)
 {
 	struct msix_table_entry *entry;
-	uint32_t vector_control, entry_offset, index;
+	uint32_t vector_control, entry_offset, table_offset, index;
 	bool message_changed = false;
 	bool unmasked;
 
 	/* Find out which entry it's accessing */
-	offset -= vdev->msix.table_offset;
-	index = offset / MSIX_TABLE_ENTRY_SIZE;
+	table_offset = offset - vdev->msix.table_offset;
+	index = table_offset / MSIX_TABLE_ENTRY_SIZE;
 	if (index >= vdev->msix.table_count) {
 		pr_err("%s, invalid arguments %llx - %llx", __func__, mmio->value, mmio->address);
 		return;
 	}
 
 	entry = &vdev->msix.tables[index];
-	entry_offset = offset % MSIX_TABLE_ENTRY_SIZE;
+	entry_offset = table_offset % MSIX_TABLE_ENTRY_SIZE;
 
 	if (mmio->direction == REQUEST_READ) {
 		(void)memcpy_s(&mmio->value, (size_t)mmio->size, (void *)entry + entry_offset, (size_t)mmio->size);

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -77,7 +77,7 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 
 void populate_msi_struct(struct pci_vdev *vdev);
 
-struct pci_vdev *sharing_mode_find_vdev(union pci_bdf vbdf);
+struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf);
 void add_vdev_handler(struct pci_vdev *vdev, struct pci_vdev_ops *ops);
 
 #endif /* PCI_PRIV_H_ */

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -178,6 +178,6 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
-void pci_scan_bus(pci_enumeration_cb cb, void *data);
+void pci_scan_bus(pci_enumeration_cb cb, void *cb_data);
 
 #endif /* PCI_H_ */


### PR DESCRIPTION
36D Prototype and definition name mismatch
  pci_scan_bus() and sharing_mode_find_vdev() wrong parameter in prototype.
14D Attempt to change parameter passed by value.
  vmsix_table_rw() uses function parameter as local viarable.

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>