### PR TITLE
In device-model, sscanf, strlen and sprintf API is banned, so replace them with permitted API.

### DIFF
--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -2307,7 +2307,7 @@ pci_ahci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts, int atapi)
 	char bident[16];
 	struct blockif_ctxt *bctxt;
 	struct pci_ahci_vdev *ahci_dev;
-	int ret, slots;
+	int ret, slots, rc;
 	uint8_t p;
 	MD5_CTX mdctx;
 	u_char digest[16];
@@ -2378,9 +2378,12 @@ pci_ahci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts, int atapi)
 		MD5_Init(&mdctx);
 		MD5_Update(&mdctx, opts, strlen(opts));
 		MD5_Final(digest, &mdctx);
-		sprintf(ahci_dev->port[p].ident,
+		rc = snprintf(ahci_dev->port[p].ident,
+			sizeof(ahci_dev->port[p].ident),
 			"ACRN--%02X%02X-%02X%02X-%02X%02X", digest[0],
 			digest[1], digest[2], digest[3], digest[4], digest[5]);
+		if (rc > sizeof(ahci_dev->port[p].ident))
+			WPRINTF("%s: digest is longer than ident\n", __func__);
 
 		/*
 		 * Allocate blockif request structures and add them

--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -2315,6 +2315,7 @@ pci_ahci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts, int atapi)
 
 	ret = 0;
 
+#define MAX_OPTS_LEN 256
 #ifdef AHCI_DEBUG
 	dbg = fopen("/tmp/log", "w+");
 #endif
@@ -2376,7 +2377,7 @@ pci_ahci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts, int atapi)
 		 * Use parts of the md5 sum of the filename
 		 */
 		MD5_Init(&mdctx);
-		MD5_Update(&mdctx, opts, strlen(opts));
+		MD5_Update(&mdctx, opts, strnlen(opts, MAX_OPTS_LEN));
 		MD5_Final(digest, &mdctx);
 		rc = snprintf(ahci_dev->port[p].ident,
 			sizeof(ahci_dev->port[p].ident),

--- a/devicemodel/hw/pci/gsi_sharing.c
+++ b/devicemodel/hw/pci/gsi_sharing.c
@@ -84,7 +84,7 @@ check_msi_capability(char *dev_name)
 	struct pci_device *phys_dev;
 
 	/* only check the MSI/MSI-x capability for PCI device */
-	if (sscanf(dev_name, "%x:%x.%x", &bus, &slot, &func) != 3)
+	if (parse_bdf(dev_name, &bus, &slot, &func, 16) != 0)
 		return 0;
 
 	phys_dev = pci_device_find_by_slot(0, bus, slot, func);
@@ -168,7 +168,7 @@ update_pt_info(uint16_t phys_bdf)
 	LIST_FOREACH(group, &gsg_head, gsg_list) {
 		for (i = 0; i < (group->shared_dev_num); i++) {
 			name = group->dev[i].dev_name;
-			if (sscanf(name, "%x:%x.%x", &bus, &slot, &func) != 3)
+			if (parse_bdf(name, &bus, &slot, &func, 16) != 0)
 				continue;
 
 			if (phys_bdf == (PCI_BDF(bus, slot, func)))

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -52,8 +52,8 @@ int guest_domid = 1;
 int
 acrn_parse_gvtargs(char *arg)
 {
-	if (sscanf(arg, " %d %d %d", &gvt_low_gm_sz,
-			&gvt_high_gm_sz, &gvt_fence_sz) != 3) {
+	if (parse_bdf(arg, &gvt_low_gm_sz, &gvt_high_gm_sz,
+				&gvt_fence_sz, 10) != 0) {
 		return -1;
 	}
 	printf("passed gvt-g optargs low_gm %d, high_gm %d, fence %d\n",

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -89,6 +89,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <string.h>
 
 #include "dm.h"
 #include "vmmapi.h"
@@ -226,7 +227,9 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 	/* traverse the driver folder, and try to find the NPK BDF# */
 	while ((dent = readdir(dir)) != NULL) {
-		if (sscanf(dent->d_name, "0000:%x:%x.%x", &b, &s, &f) != 3)
+		if (strncmp(dent->d_name, "0000:", 5) != 0 ||
+				parse_bdf((dent->d_name + 5),
+					&b, &s, &f, 10) != 0)
 			continue;
 		else
 			break;

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -178,7 +178,7 @@ static inline int valid_param(uint32_t m_off, uint32_t m_num)
  */
 static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
-	int i, b, s, f, fd, ret, error = -1;
+	int i, b, s, f, fd, ret, rc, error = -1;
 	DIR *dir;
 	struct dirent *dent;
 	char name[PATH_MAX];
@@ -239,7 +239,10 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	}
 
 	/* read the host NPK configuration space */
-	sprintf(name, "%s/%s/config", NPK_DRV_SYSFS_PATH, dent->d_name);
+	rc = snprintf(name, PATH_MAX, "%s/%s/config", NPK_DRV_SYSFS_PATH,
+			dent->d_name);
+	if (rc > PATH_MAX)
+		WPRINTF(("NPK device name too long\n"));
 	fd = open(name, O_RDONLY);
 	if (fd == -1) {
 		WPRINTF(("Cannot open host NPK config\n"));

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -1003,7 +1003,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	}
 
 	opt = strsep(&opts, ",");
-	if (sscanf(opt, "%x/%x/%x", &bus, &slot, &func) != 3) {
+	if (parse_bdf(opt, &bus, &slot, &func, 16) != 0) {
 		warnx("Invalid passthru BDF options:%s", opt);
 		return -EINVAL;
 	}

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -2182,7 +2182,7 @@ vmei_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	int i, rc;
 	char *endptr = NULL;
 	char *opt;
-	unsigned int bus = 0, slot = 0, func = 0;
+	int bus = 0, slot = 0, func = 0;
 	char name[DEV_NAME_SIZE + 1];
 
 	vmei_debug = 0;
@@ -2191,7 +2191,7 @@ vmei_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		goto init;
 
 	while ((opt = strsep(&opts, ",")) != NULL) {
-		if (sscanf(opt, "%x/%x/%x", &bus, &slot, &func) == 3)
+		if (parse_bdf(opt, &bus, &slot, &func, 16) == 0)
 			continue;
 		if (!strncmp(opt, "d", 1)) {
 			vmei_debug = strtoul(opt + 1, &endptr, 10);

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -1006,7 +1006,7 @@ basl_make_templates(void)
 			tmpdir = _PATH_TMP;
 	}
 
-	len = strlen(tmpdir);
+	len = strnlen(tmpdir, MAXPATHLEN);
 
 	if ((len + sizeof(ASL_TEMPLATE) + 1) < MAXPATHLEN) {
 		strncpy(basl_template, tmpdir, len + 1);

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -316,6 +316,8 @@ void	update_pt_info(uint16_t phys_bdf);
 int	check_gsi_sharing_violation(void);
 int	pciaccess_init(void);
 void	pciaccess_cleanup(void);
+int	parse_bdf(char *s, int *bus, int *dev, int *func, int base);
+
 
 /**
  * @brief Set virtual PCI device's configuration space in 1 byte width


### PR DESCRIPTION
Replace banned functions with permitted string APi in device-model hw directory.

        1.Replace sscanf with permitted string API
        2.Replace strlen with strnlen
        3.Replace sprintf with snprintf

Tracked-On: #2079
Signed-off-by: Long Liu <long.liu@intel.com>
Reviewed-by: Shuo A Liu <shuo.a.liu@intel.com>
Reviewed-by: <yonghua.huang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com