### PR TITLE
HV: Refine memset and memcpy_s

### DIFF
--- a/hypervisor/include/arch/x86/cpufeatures.h
+++ b/hypervisor/include/arch/x86/cpufeatures.h
@@ -71,6 +71,7 @@
 /* Intel-defined CPU features, CPUID level 0x00000007 (EBX)*/
 #define X86_FEATURE_TSC_ADJ	((FEAT_7_0_EBX << 5U) +  1U)
 #define X86_FEATURE_SMEP	((FEAT_7_0_EBX << 5U) +  7U)
+#define X86_FEATURE_ERMS	((FEAT_7_0_EBX << 5U) +  9U)
 #define X86_FEATURE_INVPCID	((FEAT_7_0_EBX << 5U) + 10U)
 #define X86_FEATURE_SMAP	((FEAT_7_0_EBX << 5U) + 20U)
 

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -402,6 +402,9 @@
 #define PAT_MEM_TYPE_WB				0x06UL	/* writeback */
 #define PAT_MEM_TYPE_UCM			0x07UL	/* uncached minus */
 
+/* MISC_ENABLE bits: architectural */
+#define MSR_IA32_MISC_ENABLE_FAST_STRING	(1U << 0U)
+
 #ifndef ASSEMBLER
 static inline bool pat_mem_type_invalid(uint64_t x)
 {

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -28,7 +28,7 @@ char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg);
 char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
-void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen_arg);
+void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
 int32_t atoi(const char *str);
 long strtol_deci(const char *nptr);
 uint64_t strtoul_hex(const char *nptr);


### PR DESCRIPTION
1) ACRN will use enhanced rep fast-string operation by default. So check this capability  at the very beginning.
2) Use enhanced rep fast-string operation to refine memset/memcpy_s.

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>