### PR TITLE
dm: pass mac seed not to use vm name on UP2

### DIFF
--- a/devicemodel/samples/up2/launch_uos.sh
+++ b/devicemodel/samples/up2/launch_uos.sh
@@ -36,7 +36,7 @@ fi
 #vm-name used to generate uos-mac address
 mac=$(cat /sys/class/net/en*/address)
 vm_name=vm$1
-vm_name=${vm_name}-${mac:9:8}
+mac_seed=${mac:9:8}-${vm_name} 
 
 # create a unique tap device for each VM
 tap=tap_$6
@@ -156,6 +156,7 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   $boot_ipu_option      \
   -i /run/acrn/ioc_$vm_name,0x20 \
   -l com2,/run/acrn/ioc_$vm_name \
+  --mac_seed $mac_seed \ 
   -B "root=/dev/vda2 rw rootwait maxcpus=$2 nohpet console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 i915.enable_guc_loading=0 \
@@ -173,7 +174,7 @@ fi
 #vm-name used to generate uos-mac address
 mac=$(cat /sys/class/net/en*/address)
 vm_name=vm$1
-vm_name=${vm_name}-${mac:9:8}
+mac_seed=${mac:9:8}-${vm_name} 
 
 # create a unique tap device for each VM
 tap=tap_$6
@@ -342,6 +343,7 @@ fi
    $boot_cse_option \
    $intr_storm_monitor \
    $boot_ipu_option      \
+   --mac_seed $mac_seed \ 
    -i /run/acrn/ioc_$vm_name,0x20 \
    -l com2,/run/acrn/ioc_$vm_name \
    $boot_image_option \


### PR DESCRIPTION
Physical NIC mac address is used for generate UOS mac address.
This patch uses a new parameters to pass this information
instead of vm name.

Tracked-On: #1987
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Jie Deng <jie.deng@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>