### PR TITLE
hv: MISRA-C fix "identifier reuse" in vpci code

### DIFF
--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -353,7 +353,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 	uint32_t msgctrl;
 	uint32_t table_info, i;
 	uint64_t addr_hi, addr_lo;
-	struct msix *msix = &vdev->msix;
+	struct pci_msix *msix = &vdev->msix;
 	int32_t ret;
 
 	msgctrl = pci_pdev_read_cfg(vdev->pdev.bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -32,7 +32,7 @@
 #include <hypervisor.h>
 #include "pci_priv.h"
 
-static struct pci_vdev *partition_mode_find_vdev(struct vpci *vpci, union pci_bdf vbdf)
+static struct pci_vdev *partition_mode_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf)
 {
 	struct vpci_vdev_array *vdev_array;
 	struct pci_vdev *vdev;
@@ -52,7 +52,7 @@ static struct pci_vdev *partition_mode_find_vdev(struct vpci *vpci, union pci_bd
 static int32_t partition_mode_vpci_init(struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_vdev *vdev;
 	int32_t i;
 
@@ -91,7 +91,7 @@ static void partition_mode_vpci_deinit(struct acrn_vm *vm)
 	}
 }
 
-static void partition_mode_cfgread(struct vpci *vpci, union pci_bdf vbdf,
+static void partition_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	struct pci_vdev *vdev = partition_mode_find_vdev(vpci, vbdf);
@@ -101,7 +101,7 @@ static void partition_mode_cfgread(struct vpci *vpci, union pci_bdf vbdf,
 	}
 }
 
-static void partition_mode_cfgwrite(struct vpci *vpci, union pci_bdf vbdf,
+static void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	struct pci_vdev *vdev = partition_mode_find_vdev(vpci, vbdf);

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -47,7 +47,7 @@ struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf)
 	return NULL;
 }
 
-static void sharing_mode_cfgread(__unused struct vpci *vpci, union pci_bdf bdf,
+static void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	struct pci_vdev *vdev;
@@ -75,7 +75,7 @@ static void sharing_mode_cfgread(__unused struct vpci *vpci, union pci_bdf bdf,
 	}
 }
 
-static void sharing_mode_cfgwrite(__unused struct vpci *vpci, union pci_bdf bdf,
+static void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	struct pci_vdev *vdev;

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -40,7 +40,7 @@ static void pci_cfg_clear_cache(struct pci_addr_info *pi)
 static uint32_t pci_cfgaddr_io_read(struct acrn_vm *vm, uint16_t addr, size_t bytes)
 {
 	uint32_t val = ~0U;
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 
 	if ((addr == (uint16_t)PCI_CONFIG_ADDR) && (bytes == 4U)) {
@@ -57,7 +57,7 @@ static uint32_t pci_cfgaddr_io_read(struct acrn_vm *vm, uint16_t addr, size_t by
 
 static void pci_cfgaddr_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes, uint32_t val)
 {
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 
 	if ((addr == (uint16_t)PCI_CONFIG_ADDR) && (bytes == 4U)) {
@@ -69,7 +69,7 @@ static void pci_cfgaddr_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes
 
 static uint32_t pci_cfgdata_io_read(struct acrn_vm *vm, uint16_t addr, size_t bytes)
 {
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 	uint16_t offset = addr - PCI_CONFIG_DATA;
 	uint32_t val = ~0U;
@@ -86,7 +86,7 @@ static uint32_t pci_cfgdata_io_read(struct acrn_vm *vm, uint16_t addr, size_t by
 
 static void pci_cfgdata_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes, uint32_t val)
 {
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 	uint16_t offset = addr - PCI_CONFIG_DATA;
 
@@ -100,7 +100,7 @@ static void pci_cfgdata_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes
 
 void vpci_init(struct acrn_vm *vm)
 {
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 
 	struct vm_io_range pci_cfgaddr_range = {
 		.flags = IO_ATTR_RW,
@@ -139,7 +139,7 @@ void vpci_init(struct acrn_vm *vm)
 
 void vpci_cleanup(struct acrn_vm *vm)
 {
-	struct vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vm->vpci;
 
 	if ((vpci->ops != NULL) && (vpci->ops->deinit != NULL)) {
 		vpci->ops->deinit(vm);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -151,7 +151,7 @@ struct acrn_vm {
 
 	uint32_t vcpuid_entry_nr, vcpuid_level, vcpuid_xlevel;
 	struct vcpuid_entry vcpuid_entries[MAX_VM_VCPUID_ENTRIES];
-	struct vpci vpci;
+	struct acrn_vpci vpci;
 #ifdef CONFIG_PARTITION_MODE
 	struct vm_description	*vm_desc;
 	uint8_t vrtc_offset;

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -66,13 +66,13 @@ struct pci_pdev {
 };
 
 /* MSI capability structure */
-struct msi {
+struct pci_msi {
 	uint32_t  capoff;
 	uint32_t  caplen;
 };
 
 /* MSI-X capability structure */
-struct msix {
+struct pci_msix {
 	struct msix_table_entry tables[CONFIG_MAX_MSIX_TABLE_NUM];
 	uint64_t  mmio_gpa;
 	uint64_t  mmio_hva;
@@ -86,7 +86,7 @@ struct msix {
 	uint32_t  table_count;
 };
 
-union cfgdata {
+union pci_cfgdata {
 	uint8_t data_8[PCI_REGMAX + 1U];
 	uint16_t data_16[(PCI_REGMAX + 1U) >> 2U];
 	uint32_t data_32[(PCI_REGMAX + 1U) >> 4U];
@@ -101,20 +101,20 @@ struct pci_vdev {
 	struct pci_vdev_ops *ops;
 #endif
 
-	struct vpci *vpci;
+	struct acrn_vpci *vpci;
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf vbdf;
 
 	struct pci_pdev pdev;
 
-	union cfgdata cfgdata;
+	union pci_cfgdata cfgdata;
 
 	/* The bar info of the virtual PCI device. */
 	struct pci_bar bar[PCI_BAR_COUNT];
 
 #ifndef CONFIG_PARTITION_MODE
-	struct msi msi;
-	struct msix msix;
+	struct pci_msi msi;
+	struct pci_msix msix;
 #endif
 };
 
@@ -127,14 +127,14 @@ struct pci_addr_info {
 struct vpci_ops {
 	int32_t (*init)(struct acrn_vm *vm);
 	void (*deinit)(struct acrn_vm *vm);
-	void (*cfgread)(struct vpci *vpci, union pci_bdf vbdf, uint32_t offset,
+	void (*cfgread)(struct acrn_vpci *vpci, union pci_bdf vbdf, uint32_t offset,
 		uint32_t bytes, uint32_t *val);
-	void (*cfgwrite)(struct vpci *vpci, union pci_bdf vbdf, uint32_t offset,
+	void (*cfgwrite)(struct acrn_vpci *vpci, union pci_bdf vbdf, uint32_t offset,
 		uint32_t bytes, uint32_t val);
 };
 
 
-struct vpci {
+struct acrn_vpci {
 	struct acrn_vm *vm;
 	struct pci_addr_info addr_info;
 	struct vpci_ops *ops;


### PR DESCRIPTION
13X: Identifier reuse: tag vs component.
A tag name shall be a unique identifier

Change the following names:
  struct msi --> struct pci_msi
  struct msix --> struct pci_msix
  struct vpci --> struct acrn_vpci
  union cfgdata -> union pci_cfgdata

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>