### PR TITLE
hv:fix possible buffer overflow in 'ptirq_get_intr_data()'

### DIFF
--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -229,7 +229,7 @@ uint32_t ptirq_get_intr_data(const struct acrn_vm *target_vm, uint64_t *buffer, 
 			buffer[index + 1U] = entry->intr_count;
 
 			index += 2U;
-			if (index >= buffer_cnt) {
+			if (index > (buffer_cnt - 2U)) {
 				break;
 			}
 		}


### PR DESCRIPTION
 - 'buffer'with size of 'buffer_cnt',  will overflow in
    next loop if 'index == buffer_cnt - 1'.

Tracked-On: #1252
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>