### PR TITLE
coding style: refine memory.c

### DIFF
--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -21,7 +21,6 @@ union u_qword {
 
 /* Function prototypes */
 void udelay(uint32_t us);
-void *memchr(const void *void_s, int32_t c, size_t n);
 int32_t strcmp(const char *s1_arg, const char *s2_arg);
 int32_t strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg);
 char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg);

--- a/hypervisor/lib/memory.c
+++ b/hypervisor/lib/memory.c
@@ -259,21 +259,6 @@ void free(const void *ptr)
 	}
 }
 
-void *memchr(const void *void_s, int32_t c, size_t n)
-{
-	uint8_t val = (uint8_t)c;
-	uint8_t *ptr = (uint8_t *)void_s;
-	uint8_t *end = ptr + n;
-
-	while (ptr < end) {
-		if (*ptr == val) {
-			return ((void *)ptr);
-		}
-		ptr++;
-	}
-	return NULL;
-}
-
 static inline void memcpy_erms(void *d, const void *s, size_t slen)
 {
 	asm volatile ("rep; movsb"


### PR DESCRIPTION
hv: coding style: refine memory.c

 1) Variable names shall start with a lower-case letter.
 2) Multiplication and division come before addition and subtraction.
Everything else should be in parentheses.

Tracked-On: #861
 Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>