### PR TITLE
hv:refine prepare_vm0 api

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -177,7 +177,7 @@ int32_t hcall_destroy_vm(uint16_t vmid)
  */
 int32_t hcall_start_vm(uint16_t vmid)
 {
-	int32_t ret;
+	int32_t ret = 0;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (target_vm == NULL) {
@@ -185,7 +185,7 @@ int32_t hcall_start_vm(uint16_t vmid)
 	} else if (target_vm->sw.io_shared_page == NULL) {
 		ret = -1;
 	} else {
-		ret = start_vm(target_vm);
+		start_vm(target_vm);
 	}
 
 	return ret;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -262,7 +262,7 @@ int32_t shutdown_vm(struct acrn_vm *vm);
 void pause_vm(struct acrn_vm *vm);
 void resume_vm(struct acrn_vm *vm);
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);
-int32_t start_vm(struct acrn_vm *vm);
+void start_vm(struct acrn_vm *vm);
 int32_t reset_vm(struct acrn_vm *vm);
 int32_t create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm);
 int32_t prepare_vm(uint16_t pcpu_id);


### PR DESCRIPTION
-- fix MISRA-C violation "procedure has more than one exit point"
   for this api
-- change start_vm to void type since it is always return 0

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>