### PR TITLE
hv: refine a few functions to only one exit point

### DIFF
--- a/hypervisor/arch/x86/guest/vmtrr.c
+++ b/hypervisor/arch/x86/guest/vmtrr.c
@@ -44,10 +44,11 @@ static uint32_t get_index_of_fixed_mtrr(uint32_t msr)
 
 	for (i = 0U; i < FIXED_RANGE_MTRR_NUM; i++) {
 		if (fixed_mtrr_map[i].msr == msr) {
-			return i;
+			break;
 		}
 	}
-	return FIXED_MTRR_INVALID_INDEX;
+
+	return (i < FIXED_RANGE_MTRR_NUM) ? i : FIXED_MTRR_INVALID_INDEX;
 }
 
 static uint32_t


### PR DESCRIPTION
IEC 61508,ISO 26262 standards highly recommend single-exit rule.
7C: Procedure has more than one exit point.

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>