### PR TITLE
hv: vpci: fix MISRA-C violations related to variable declarations

### DIFF
--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -118,7 +118,7 @@ static int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-struct pci_vdev_ops pci_ops_vdev_hostbridge = {
+const struct pci_vdev_ops pci_ops_vdev_hostbridge = {
 	.init = vdev_hostbridge_init,
 	.deinit = vdev_hostbridge_deinit,
 	.cfgwrite = vdev_hostbridge_cfgwrite,

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -151,6 +151,21 @@ static int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t by
 	return ret;
 }
 
+static int32_t vmsi_deinit(struct pci_vdev *vdev)
+{
+	if (vdev->msi.capoff != 0U) {
+		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);
+	}
+
+	return 0;
+}
+
+static const struct pci_vdev_ops pci_ops_vdev_msi = {
+	.deinit = vmsi_deinit,
+	.cfgwrite = vmsi_cfgwrite,
+	.cfgread = vmsi_cfgread,
+};
+
 void populate_msi_struct(struct pci_vdev *vdev)
 {
 	uint8_t ptr, cap;
@@ -216,17 +231,3 @@ void populate_msi_struct(struct pci_vdev *vdev)
 	}
 }
 
-static int32_t vmsi_deinit(struct pci_vdev *vdev)
-{
-	if (vdev->msi.capoff != 0U) {
-		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);
-	}
-
-	return 0;
-}
-
-struct pci_vdev_ops pci_ops_vdev_msi = {
-	.deinit = vmsi_deinit,
-	.cfgwrite = vmsi_cfgwrite,
-	.cfgread = vmsi_cfgread,
-};

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -425,7 +425,7 @@ static int32_t vmsix_deinit(struct pci_vdev *vdev)
 	return 0;
 }
 
-struct pci_vdev_ops pci_ops_vdev_msix = {
+const struct pci_vdev_ops pci_ops_vdev_msix = {
 	.init = vmsix_init,
 	.deinit = vmsix_deinit,
 	.cfgwrite = vmsix_cfgwrite,

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -111,7 +111,7 @@ static void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
 	}
 }
 
-struct vpci_ops partition_mode_vpci_ops = {
+const struct vpci_ops partition_mode_vpci_ops = {
 	.init = partition_mode_vpci_init,
 	.deinit = partition_mode_vpci_deinit,
 	.cfgread = partition_mode_cfgread,

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -67,10 +67,12 @@ static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset
 	vdev->cfgdata.data_32[offset >> 2U] = val;
 }
 
-extern struct vpci_ops partition_mode_vpci_ops;
-extern struct vpci_ops sharing_mode_vpci_ops;
-extern struct pci_vdev_ops pci_ops_vdev_msi;
-extern struct pci_vdev_ops pci_ops_vdev_msix;
+#ifdef CONFIG_PARTITION_MODE
+extern const struct vpci_ops partition_mode_vpci_ops;
+#else
+extern const struct vpci_ops sharing_mode_vpci_ops;
+extern const struct pci_vdev_ops pci_ops_vdev_msix;
+#endif
 
 uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
@@ -78,6 +80,6 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 void populate_msi_struct(struct pci_vdev *vdev);
 
 struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf);
-void add_vdev_handler(struct pci_vdev *vdev, struct pci_vdev_ops *ops);
+void add_vdev_handler(struct pci_vdev *vdev, const struct pci_vdev_ops *ops);
 
 #endif /* PCI_PRIV_H_ */

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -195,7 +195,7 @@ static int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-struct pci_vdev_ops pci_ops_vdev_pt = {
+const struct pci_vdev_ops pci_ops_vdev_pt = {
 	.init = vdev_pt_init,
 	.deinit = vdev_pt_deinit,
 	.cfgwrite = vdev_pt_cfgwrite,

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -183,7 +183,7 @@ static void sharing_mode_vpci_deinit(__unused struct acrn_vm *vm)
 	}
 }
 
-void add_vdev_handler(struct pci_vdev *vdev, struct pci_vdev_ops *ops)
+void add_vdev_handler(struct pci_vdev *vdev, const struct pci_vdev_ops *ops)
 {
 	if (vdev->nr_ops >= (MAX_VPCI_DEV_OPS - 1U)) {
 		pr_err("%s, adding too many handlers", __func__);
@@ -193,7 +193,7 @@ void add_vdev_handler(struct pci_vdev *vdev, struct pci_vdev_ops *ops)
 	}
 }
 
-struct vpci_ops sharing_mode_vpci_ops = {
+const struct vpci_ops sharing_mode_vpci_ops = {
 	.init = sharing_mode_vpci_init,
 	.deinit = sharing_mode_vpci_deinit,
 	.cfgread = sharing_mode_cfgread,

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -98,7 +98,7 @@ struct pci_vdev {
 	struct pci_vdev_ops ops[MAX_VPCI_DEV_OPS];
 	uint32_t nr_ops;
 #else
-	struct pci_vdev_ops *ops;
+	const struct pci_vdev_ops *ops;
 #endif
 
 	struct acrn_vpci *vpci;
@@ -137,11 +137,13 @@ struct vpci_ops {
 struct acrn_vpci {
 	struct acrn_vm *vm;
 	struct pci_addr_info addr_info;
-	struct vpci_ops *ops;
+	const struct vpci_ops *ops;
 };
 
-extern struct pci_vdev_ops pci_ops_vdev_hostbridge;
-extern struct pci_vdev_ops pci_ops_vdev_pt;
+#ifdef CONFIG_PARTITION_MODE
+extern const struct pci_vdev_ops pci_ops_vdev_hostbridge;
+extern const struct pci_vdev_ops pci_ops_vdev_pt;
+#endif
 
 void vpci_init(struct acrn_vm *vm);
 void vpci_cleanup(struct acrn_vm *vm);


### PR DESCRIPTION
78D: Global variable should be declared const.

Global variables should be declared constant wherever possible to
avoid unintentional modification.

27D: Variable should be declared static
  pci_ops_vdev_msi is not accessed by other files. Remove the declaration
  from the header and define it with the static qualifier; Because it's
  referenced by populate_msi_struct(), so move the define statements forward.

33D: No real declaration for external variable
  certain variables are available in sharing mode or partition mode only,
  so that the declarations in header files must be enclosed with
  CONFIG_PARTITION_MODE

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>