### PR TITLE
hv: fix MISRA-C violations "Pointer param should be declared pointer to const."

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -547,7 +547,7 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	return err;
 }
 
-void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu)
+void update_msr_bitmap_x2apic_apicv(const struct acrn_vcpu *vcpu)
 {
 	uint8_t *msr_bitmap;
 
@@ -576,7 +576,7 @@ void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu)
 	}
 }
 
-void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu)
+void update_msr_bitmap_x2apic_passthru(const struct acrn_vcpu *vcpu)
 {
 	uint32_t msr;
 	uint8_t *msr_bitmap;

--- a/hypervisor/dm/vpci/core.c
+++ b/hypervisor/dm/vpci/core.c
@@ -30,7 +30,7 @@
 #include <hypervisor.h>
 #include "pci_priv.h"
 
-uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
+uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
 {
 	uint32_t val;
 

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -89,7 +89,7 @@ static int32_t vdev_hostbridge_deinit(__unused struct pci_vdev *vdev)
 	return 0;
 }
 
-static int32_t vdev_hostbridge_cfgread(struct pci_vdev *vdev, uint32_t offset,
+static int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	/* Assumption: access needed to be aligned on 1/2/4 bytes */

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -30,7 +30,7 @@
 #include <hypervisor.h>
 #include "pci_priv.h"
 
-static inline bool msicap_access(struct pci_vdev *vdev, uint32_t offset)
+static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 {
 	bool ret;
 	if (vdev->msi.capoff == 0U) {
@@ -42,7 +42,7 @@ static inline bool msicap_access(struct pci_vdev *vdev, uint32_t offset)
 	return ret;
 }
 
-static int32_t vmsi_remap(struct pci_vdev *vdev, bool enable)
+static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 {
 	struct ptirq_msi_info info;
 	union pci_bdf pbdf = vdev->pdev.bdf;
@@ -99,7 +99,7 @@ static int32_t vmsi_remap(struct pci_vdev *vdev, bool enable)
 	return ret;
 }
 
-static int32_t vmsi_cfgread(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+static int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret;
 	/* For PIO access, we emulate Capability Structures only */

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -30,7 +30,7 @@
 #include <hypervisor.h>
 #include "pci_priv.h"
 
-static inline bool msixcap_access(struct pci_vdev *vdev, uint32_t offset)
+static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)
 {
 	bool ret;
 
@@ -43,12 +43,12 @@ static inline bool msixcap_access(struct pci_vdev *vdev, uint32_t offset)
 	return ret;
 }
 
-static inline bool msixtable_access(struct pci_vdev *vdev, uint32_t offset)
+static inline bool msixtable_access(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return in_range(offset, vdev->msix.table_offset, vdev->msix.table_count * MSIX_TABLE_ENTRY_SIZE);
 }
 
-static int32_t vmsix_remap_entry(struct pci_vdev *vdev, uint32_t index, bool enable)
+static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bool enable)
 {
 	struct msix_table_entry *pentry;
 	struct ptirq_msi_info info;
@@ -82,7 +82,7 @@ static int32_t vmsix_remap_entry(struct pci_vdev *vdev, uint32_t index, bool ena
 	return ret;
 }
 
-static inline void enable_disable_msix(struct pci_vdev *vdev, bool enable)
+static inline void enable_disable_msix(const struct pci_vdev *vdev, bool enable)
 {
 	uint32_t msgctrl;
 
@@ -96,7 +96,7 @@ static inline void enable_disable_msix(struct pci_vdev *vdev, bool enable)
 }
 
 /* Do MSI-X remap for all MSI-X table entries in the target device */
-static int32_t vmsix_remap(struct pci_vdev *vdev, bool enable)
+static int32_t vmsix_remap(const struct pci_vdev *vdev, bool enable)
 {
 	uint32_t index;
 	int32_t ret = 0;
@@ -123,7 +123,7 @@ static int32_t vmsix_remap(struct pci_vdev *vdev, bool enable)
 }
 
 /* Do MSI-X remap for one MSI-X table entry only */
-static int32_t vmsix_remap_one_entry(struct pci_vdev *vdev, uint32_t index, bool enable)
+static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index, bool enable)
 {
 	uint32_t msgctrl;
 	int32_t ret;
@@ -148,7 +148,7 @@ static int32_t vmsix_remap_one_entry(struct pci_vdev *vdev, uint32_t index, bool
 	return ret;
 }
 
-static int32_t vmsix_cfgread(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+static int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret;
 	/* For PIO access, we emulate Capability Structures only */

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -37,17 +37,17 @@ static inline bool in_range(uint32_t value, uint32_t lower, uint32_t len)
 	return ((value >= lower) && (value < (lower + len)));
 }
 
-static inline uint8_t pci_vdev_read_cfg_u8(struct pci_vdev *vdev, uint32_t offset)
+static inline uint8_t pci_vdev_read_cfg_u8(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return vdev->cfgdata.data_8[offset];
 }
 
-static inline uint16_t pci_vdev_read_cfg_u16(struct pci_vdev *vdev, uint32_t offset)
+static inline uint16_t pci_vdev_read_cfg_u16(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return vdev->cfgdata.data_16[offset >> 1U];
 }
 
-static inline uint32_t pci_vdev_read_cfg_u32(struct pci_vdev *vdev, uint32_t offset)
+static inline uint32_t pci_vdev_read_cfg_u32(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return vdev->cfgdata.data_32[offset >> 2U];
 }
@@ -72,7 +72,7 @@ extern struct vpci_ops sharing_mode_vpci_ops;
 extern struct pci_vdev_ops pci_ops_vdev_msi;
 extern struct pci_vdev_ops pci_ops_vdev_msix;
 
-uint32_t pci_vdev_read_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
+uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
 void populate_msi_struct(struct pci_vdev *vdev);

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -97,7 +97,7 @@ static int32_t vdev_pt_deinit(struct pci_vdev *vdev)
 	return ret;
 }
 
-static int32_t vdev_pt_cfgread(struct pci_vdev *vdev, uint32_t offset,
+static int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	/* Assumption: access needed to be aligned on 1/2/4 bytes */

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -200,7 +200,7 @@ struct vpci_ops sharing_mode_vpci_ops = {
 	.cfgwrite = sharing_mode_cfgwrite,
 };
 
-void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
+void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
 {
 	struct pci_vdev *vdev;
 
@@ -210,13 +210,13 @@ void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t
 			target_vm->vm_id, vbdf, pbdf);
 	} else {
 		/* UOS may do BDF mapping */
-		vdev->vpci = &target_vm->vpci;
+		vdev->vpci = (struct acrn_vpci *)&(target_vm->vpci);
 		vdev->vbdf.value = vbdf;
 		vdev->pdev.bdf.value = pbdf;
 	}
 }
 
-void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
+void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
 {
 	struct pci_vdev *vdev;
 	struct acrn_vm *vm;

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -104,8 +104,8 @@ void init_msr_emulation(struct acrn_vcpu *vcpu);
 
 uint32_t vmsr_get_guest_msr_index(uint32_t msr);
 
-void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu);
-void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu);
+void update_msr_bitmap_x2apic_apicv(const struct acrn_vcpu *vcpu);
+void update_msr_bitmap_x2apic_passthru(const struct acrn_vcpu *vcpu);
 
 struct run_context;
 int32_t vmx_vmrun(struct run_context *context, int32_t ops, int32_t ibrs);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -41,7 +41,7 @@ struct pci_vdev_ops {
 	int32_t (*cfgwrite)(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t val);
 
-	int32_t (*cfgread)(struct pci_vdev *vdev, uint32_t offset,
+	int32_t (*cfgread)(const struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t *val);
 };
 
@@ -145,7 +145,7 @@ extern struct pci_vdev_ops pci_ops_vdev_pt;
 
 void vpci_init(struct acrn_vm *vm);
 void vpci_cleanup(struct acrn_vm *vm);
-void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
-void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
+void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
+void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 
 #endif /* VPCI_H_ */


### PR DESCRIPTION

MIRSA-C requires the const qualifier should be applied to pointer parameters
that address data not subject to change in rule 120D.

Tracked-On #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>