### PR TITLE
[v3]Patch for modularising ioapic.[c/h] and related files.

### DIFF
--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -4,6 +4,7 @@
  */
 #include <hypervisor.h>
 #include <trampoline.h>
+#include <ioapic.h>
 
 struct cpu_context cpu_ctx;
 

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -29,6 +29,7 @@
  */
 
 #include <hypervisor.h>
+#include <ioapic.h>
 
 #include "uart16550.h"
 

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -11,7 +11,6 @@
 #include <gdt.h>
 #include <idt.h>
 #include <apicreg.h>
-#include <ioapic.h>
 #include <lapic.h>
 #include <msr.h>
 #include <io.h>

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -9,26 +9,19 @@
 
 #include <bsp_extern.h>
 
-/*
- * IOAPIC_MAX_LINES is architecturally defined.
- * The usable RTEs may be a subset of the total on a per IO APIC basis.
- */
-#define IOAPIC_MAX_LINES	120U
 #define NR_LEGACY_IRQ		16U
 #define NR_LEGACY_PIN		NR_LEGACY_IRQ
-#define NR_MAX_GSI		(NR_IOAPICS * IOAPIC_MAX_LINES)
+void ioapic_setup_irqs(void);
 
-void setup_ioapic_irqs(void);
-
-bool irq_is_gsi(uint32_t irq);
-uint8_t irq_to_pin(uint32_t irq);
+bool ioapic_irq_is_gsi(uint32_t irq);
+uint8_t ioapic_irq_to_pin(uint32_t irq);
 
 /**
  * @brief Get irq num from pin num
  *
  * @param[in]	pin The pin number
  */
-uint32_t pin_to_irq(uint8_t pin);
+uint32_t ioapic_pin_to_irq(uint8_t pin);
 
 /**
  * @brief Set the redirection table entry
@@ -55,8 +48,8 @@ void ioapic_get_rte(uint32_t irq, union ioapic_rte *rte);
 void suspend_ioapic(void);
 void resume_ioapic(void);
 
-void gsi_mask_irq(uint32_t irq);
-void gsi_unmask_irq(uint32_t irq);
+void ioapic_gsi_mask_irq(uint32_t irq);
+void ioapic_gsi_unmask_irq(uint32_t irq);
 
 void ioapic_get_rte_entry(void *ioapic_addr, uint8_t pin, union ioapic_rte *rte);
 
@@ -66,8 +59,9 @@ struct gsi_table {
 	void  *addr;
 };
 
-extern struct gsi_table gsi_table[NR_MAX_GSI];
-extern uint32_t nr_gsi;
-extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
+void *ioapic_get_gsi_irq_addr(uint32_t irq_num);
+uint32_t ioapic_get_nr_gsi(void);
+uint8_t get_ioapic_pin_from_pic_pin(uint8_t pin_index);
+bool ioapic_is_pin_valid(uint8_t pin);
 
 #endif /* IOAPIC_H */


### PR DESCRIPTION
This adds few functions to access the daata structures
defined inside ioapic.c. Removes the same data structures
from ioapic.h
Also this modifies some of the names of existing APIs to
conform to the ioapic module name.
Made some changes to conform to MISRA C standards.

Tracked-On: #1842
Signed-off-by: Arindam Roy <arindam.roy@intel.com>