### PR TITLE
security: remove gcc flags Wformat Wformat-security in HV

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -51,7 +51,7 @@ CFLAGS += -fsigned-char
 CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -nostdinc -nostdlib -fno-common
-CFLAGS += -Wformat -Wformat-security -Werror
+CFLAGS += -Werror
 ifeq (y, $(CONFIG_RELOC))
 CFLAGS += -fpie
 else


### PR DESCRIPTION
We have used the option --ffreestanding to assert hypervisor
is a freestanding environment, and hypervisor does not include
standard library.

"-Wformat/-Wformat-security"
Check calls to the standard library functions printf and scanf, etc.,
to make sure that the arguments supplied have types appropriate to
the format string specified, and that the conversions specified in
the format string make sense. these flags disabled by -ffreestanding
or -fno-builtin.

Tracked-On: #1122
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>