### PR TITLE
Misrac fix

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -57,7 +57,7 @@ static uint64_t legacy_irq_trigger_mode[NR_LEGACY_IRQ] = {
 	IOAPIC_RTE_TRGREDG, /* IRQ15*/
 };
 
-uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN] = {
+const uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN] = {
 	2U, /* pin0*/
 	1U, /* pin1*/
 	0U, /* pin2*/

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -262,13 +262,15 @@ uint8_t irq_to_pin(uint32_t irq)
 uint32_t pin_to_irq(uint8_t pin)
 {
 	uint32_t i;
+	uint32_t irq = IRQ_INVALID;
 
 	for (i = 0U; i < nr_gsi; i++) {
 		if (gsi_table[i].pin == pin) {
-			return i;
+			irq = i;
+			break;
 		}
 	}
-	return IRQ_INVALID;
+	return irq;
 }
 
 static void

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -68,6 +68,6 @@ struct gsi_table {
 
 extern struct gsi_table gsi_table[NR_MAX_GSI];
 extern uint32_t nr_gsi;
-extern uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
+extern const uint8_t pic_ioapic_pin_map[NR_LEGACY_PIN];
 
 #endif /* IOAPIC_H */


### PR DESCRIPTION
IEC 61508, ISO 26262 standards highly recommand single-exit rule.

Tracked-On: #861
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>