### PR TITLE
hv: ptdev: fix MISRAC violations

### DIFF
--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -68,7 +68,7 @@ struct ptirq_remapping_info {
 	struct hv_timer intr_delay_timer; /* used for delay intr injection */
 };
 
-extern struct ptirq_remapping_info ptirq_entries[];
+extern struct ptirq_remapping_info ptirq_entries[CONFIG_MAX_PT_IRQ_ENTRIES];
 extern spinlock_t ptdev_lock;
 
 bool is_entry_active(const struct ptirq_remapping_info *entry);


### PR DESCRIPTION
This patch fixs MISRAC violations in common/ptdev.c and include/common/ptdev.h

Tracked-On: #861
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>