### PR TITLE
Debug: Add one hypercall to quary hardware info

### DIFF
--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -123,6 +123,34 @@ static int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, uint64_t param)
 }
 
 /**
+ * @brief Get hardware related info
+ *
+ * @param vm Pointer to vm data structure
+ * @param param Guest physical address pointing to struct acrn_hw_info
+ *
+ * @pre vm shall point to VM0
+ * @pre param shall be a valid physical address
+ *
+ * @retval 0 on success
+ * @retval -1 in case of error
+ */
+static int32_t hcall_get_hw_info(struct acrn_vm *vm, uint64_t param)
+{
+	int32_t ret = 0;
+	struct acrn_hw_info hw_info;
+
+	(void)memset((void *)&hw_info, 0U, sizeof(hw_info));
+
+	hw_info.cpu_num = phys_cpu_num;
+	ret = copy_to_gpa(vm, &hw_info, param, sizeof(hw_info));
+	if (ret != 0) {
+		pr_err("%s: Unable to copy param to vm", __func__);
+	}
+
+	return ret;
+}
+
+/**
   * @brief Setup hypervisor debug infrastructure, such as share buffer, NPK log and profiling.
   *
   * @param vm Pointer to VM data structure
@@ -149,6 +177,10 @@ int32_t hcall_debug(struct acrn_vm *vm, uint64_t param1, uint64_t param2, uint64
 
 	case HC_PROFILING_OPS:
 		ret = hcall_profiling_ops(vm, param1, param2);
+		break;
+
+	case HC_GET_HW_INFO:
+		ret = hcall_get_hw_info(vm, param1);
 		break;
 
 	default:

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -69,6 +69,7 @@
 #define HC_SETUP_SBUF               BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x00UL)
 #define HC_SETUP_HV_NPK_LOG         BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x01UL)
 #define HC_PROFILING_OPS            BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x02UL)
+#define HC_GET_HW_INFO              BASE_HC_ID(HC_ID, HC_ID_DBG_BASE + 0x03UL)
 
 /* Trusty */
 #define HC_ID_TRUSTY_BASE           0x70UL
@@ -207,6 +208,14 @@ struct hv_npk_log_param {
 
 	/** the MMIO address for the hypervisor NPK log */
 	uint64_t mmio_addr;
+} __aligned(8);
+
+/**
+ * the parameter for HC_GET_HW_INFO hypercall
+ */
+struct acrn_hw_info {
+	uint16_t cpu_num; /* Physical CPU number */
+	uint16_t reserved[3];
 } __aligned(8);
 
 /**


### PR DESCRIPTION
acrntrace/log kernel modules will use this hypercall to fetch
pcpu num of hardware platform. Then, initialize driver accordingly.

Tracked-On: #1775;#1776
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Reviewed-by: Yan, Like <like.yan@intel.com>