### PR TITLE
Optimize trusty logic to meet MISRA-C rules

### DIFF
--- a/hypervisor/include/arch/x86/trusty.h
+++ b/hypervisor/include/arch/x86/trusty.h
@@ -127,7 +127,7 @@ struct trusty_startup_param {
 };
 
 void switch_world(struct acrn_vcpu *vcpu, int32_t next_world);
-bool initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param);
+bool initialize_trusty(struct acrn_vcpu *vcpu, const struct trusty_boot_param *boot_param);
 void destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem);
 void save_sworld_context(struct acrn_vcpu *vcpu);
 void restore_sworld_context(struct acrn_vcpu *vcpu);


### PR DESCRIPTION
v2-v3:
1) Split the semantics change from MISRAC change.
2) minor change about not only the function to meet only  one exit but also the coding style not too ugly

v1-v2:
Split the patch into three small one.

Fix procedure has more than one exit point

Tracked-On: #2120
Signed-off-by: Li, Fei1 <fei1.li@intel.com>