### PR TITLE
HV/DM: Unify the usage of aligned for structure definition with align…

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -101,7 +101,7 @@ static cpuset_t cpumask;
 
 static void vm_loop(struct vmctx *ctx);
 
-static char vhm_request_page[4096] __attribute__ ((aligned(4096)));
+static char vhm_request_page[4096] __aligned(4096);
 
 static struct vhm_request *vhm_req_buf =
 				(struct vhm_request *)&vhm_request_page;

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -346,7 +346,7 @@ struct acrn_set_vcpu_regs {
 
 	/** the structure to hold vcpu state */
 	struct acrn_vcpu_regs vcpu_regs;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 /**
  * @brief Info to set ioreq buffer for a created VM
@@ -477,14 +477,14 @@ struct acpi_generic_address {
 	uint8_t 	bit_offset;
 	uint8_t 	access_size;
 	uint64_t	address;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 struct cpu_cx_data {
 	struct acpi_generic_address cx_reg;
 	uint8_t 	type;
 	uint32_t	latency;
 	uint64_t	power;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 struct cpu_px_data {
 	uint64_t core_frequency;	/* megahertz */
@@ -493,7 +493,7 @@ struct cpu_px_data {
 	uint64_t bus_master_latency;	/* microseconds */
 	uint64_t control;		/* control value */
 	uint64_t status;		/* success indicator */
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 /**
  * @brief Info PM command from DM/VHM.

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -217,7 +217,7 @@ struct xhci_dev_ctx {
 		struct xhci_slot_ctx	u_slot;
 		struct xhci_endp_ctx	u_ep[XHCI_MAX_ENDPOINTS];
 	} ctx_dev_slep;
-} __attribute__((aligned(XHCI_DEV_CTX_ALIGN)));
+} __aligned(XHCI_DEV_CTX_ALIGN);
 #define	ctx_slot	ctx_dev_slep.u_slot
 #define	ctx_ep		ctx_dev_slep.u_ep
 
@@ -364,7 +364,7 @@ struct xhci_trb {
 #define	XHCI_TRB_ERROR_INVALID_SID	0x22
 #define	XHCI_TRB_ERROR_SEC_BW		0x23
 #define	XHCI_TRB_ERROR_SPLIT_XACT	0x24
-} __attribute__((aligned(4)));
+} __aligned(8);
 
 struct xhci_dev_endpoint_trbs {
 	struct xhci_trb		trb[(XHCI_MAX_STREAMS *

--- a/efi-stub/multiboot.h
+++ b/efi-stub/multiboot.h
@@ -38,6 +38,7 @@
 #define _MULTIBOOT_H
 
 #include <stdint.h>
+#include <types.h>
 
 struct multiboot_info;
 extern struct multiboot_info mbi;
@@ -144,7 +145,7 @@ struct multiboot_info {
 	uint32_t		unused_mi_vbe_interface_seg;
 	uint32_t		unused_mi_vbe_interface_off;
 	uint32_t	unused_mi_vbe_interface_len;
-}__attribute__((aligned(8)));
+}__aligned(8);
 
 
 /*

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -34,7 +34,7 @@ struct trace_entry {
 		} fields_64;
 		char str[16];
 	} payload;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 static inline bool trace_check(uint16_t cpu_id)
 {

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -444,7 +444,7 @@ struct acrn_set_vcpu_regs {
 
 	/** the structure to hold vcpu state */
 	struct acrn_vcpu_regs vcpu_regs;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 /**
  * @brief Info to set ioreq buffer for a created VM
@@ -562,14 +562,14 @@ struct acpi_generic_address {
 	uint8_t 	bit_offset;
 	uint8_t 	access_size;
 	uint64_t	address;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 struct cpu_cx_data {
 	struct acpi_generic_address cx_reg;
 	uint8_t 	type;
 	uint32_t	latency;
 	uint64_t	power;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 struct cpu_px_data {
 	uint64_t core_frequency;	/* megahertz */
@@ -578,13 +578,13 @@ struct cpu_px_data {
 	uint64_t bus_master_latency;	/* microseconds */
 	uint64_t control;		/* control value */
 	uint64_t status;		/* success indicator */
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 struct acpi_sx_pkg {
 	uint8_t		val_pm1a;
 	uint8_t		val_pm1b;
 	uint16_t	reserved;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 struct pm_s_state_data {
 	struct acpi_generic_address pm1a_evt;
@@ -595,7 +595,7 @@ struct pm_s_state_data {
 	struct acpi_sx_pkg s5_pkg;
 	uint32_t *wake_vector_32;
 	uint64_t *wake_vector_64;
-}__attribute__((aligned(8)));
+} __aligned(8);
 
 /**
  * @brief Info PM command from DM/VHM.

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -150,7 +150,7 @@ struct set_regions {
 	 * the max buffer size is one page.
 	 */
 	uint64_t regions_gpa;
-} __attribute__((aligned(8)));
+} __aligned(8);
 
 /**
  * @brief Info to change guest one page write protect permission


### PR DESCRIPTION
…ment

Now one macro is added to define the alignment requirement.
>#define __aligned(x) __attribute__((aligned(x)))

Some code uses the __aligned(x) to define the alignment while the other
code uses the original alignment definition.
So they are unified.

Tracked-On: projectacrn/acrn-hypervisor#2131
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>