### PR TITLE
DM USB: xHCI: change log level of some logs for S3 online debugging

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -777,7 +777,7 @@ pci_xhci_native_usb_dev_conn_cb(void *hci_data, void *dev_data)
 		return 0;
 	}
 
-	UPRINTF(LDBG, "%04x:%04x %d-%s belong to this vm.\r\n", di->vid,
+	UPRINTF(LINF, "%04x:%04x %d-%s belong to this vm.\r\n", di->vid,
 			di->pid, di->path.bus, usb_dev_path(&di->path));
 
 	for (i = 0; xdev->vbdp_dev_num && i < XHCI_MAX_VIRT_PORTS; ++i) {
@@ -903,6 +903,9 @@ pci_xhci_native_usb_dev_disconn_cb(void *hci_data, void *dev_data)
 		 * we do nothing here for device that is in the middle of
 		 * S3 resuming process.
 		 */
+		UPRINTF(LINF, "disconnect device %d-%s on vport %d with "
+				"state %d and return.\r\n", di->path.bus,
+				usb_dev_path(&di->path), vport, state);
 		return 0;
 	}
 


### PR DESCRIPTION
S3 emulation is complicated and greatly dependent on system timing,
hence this patch changes log level for some important logs to help
online debugging (could output log by modifing launch_uos.sh and
without re-compiling)

Tracked-On: #1893
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Liang Yang <liang3.yang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>