### PR TITLE
modularization for scheduler

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -160,6 +160,8 @@ void init_cpu_post(uint16_t pcpu_id)
 			pr_fatal("Please apply the latest CPU uCode patch!");
 		}
 
+		init_scheduler();
+
 		/* Initialize interrupts */
 		interrupt_init(BOOT_CPU_ID);
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -573,7 +573,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 
 	if (atomic_load32(&vcpu->running) == 1U) {
 		remove_from_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
-		make_reschedule_request(vcpu);
+		make_reschedule_request(vcpu->pcpu_id);
 		release_schedule_lock(vcpu->pcpu_id);
 
 		if (vcpu->pcpu_id != pcpu_id) {
@@ -595,7 +595,7 @@ void resume_vcpu(struct acrn_vcpu *vcpu)
 
 	if (vcpu->state == VCPU_RUNNING) {
 		add_to_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
-		make_reschedule_request(vcpu);
+		make_reschedule_request(vcpu->pcpu_id);
 	}
 	release_schedule_lock(vcpu->pcpu_id);
 }
@@ -607,7 +607,7 @@ void schedule_vcpu(struct acrn_vcpu *vcpu)
 
 	get_schedule_lock(vcpu->pcpu_id);
 	add_to_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
-	make_reschedule_request(vcpu);
+	make_reschedule_request(vcpu->pcpu_id);
 	release_schedule_lock(vcpu->pcpu_id);
 }
 

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -69,7 +69,7 @@ static void enter_guest_mode(uint16_t pcpu_id)
 	}
 #endif
 
-	default_idle();
+	switch_to_idle(default_idle);
 
 	/* Control should not come here */
 	cpu_dead();

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -51,12 +51,6 @@ static void init_passthru(void)
 }
 
 /*TODO: move into guest-vcpu module */
-static void init_guest(void)
-{
-	init_scheduler();
-}
-
-/*TODO: move into guest-vcpu module */
 static void enter_guest_mode(uint16_t pcpu_id)
 {
 	vmx_on();
@@ -81,8 +75,6 @@ static void init_primary_cpu_post(void)
 	init_bsp();
 
 	init_debug_pre();
-
-	init_guest();
 
 	init_cpu_post(BOOT_CPU_ID);
 

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -106,13 +106,13 @@ static struct acrn_vcpu *select_next_vcpu(uint16_t pcpu_id)
 	return vcpu;
 }
 
-void make_reschedule_request(const struct acrn_vcpu *vcpu)
+void make_reschedule_request(uint16_t pcpu_id)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, vcpu->pcpu_id);
+	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 
 	bitmap_set_lock(NEED_RESCHEDULE, &ctx->flags);
-	if (get_cpu_id() != vcpu->pcpu_id) {
-		send_single_ipi(vcpu->pcpu_id, VECTOR_NOTIFY_VCPU);
+	if (get_cpu_id() != pcpu_id) {
+		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
 	}
 }
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -264,7 +264,7 @@ struct acrn_vcpu {
 	volatile enum vcpu_state dbg_req_state;
 	uint64_t sync;	/*hold the bit events*/
 
-	struct list_head run_list; /* inserted to schedule runqueue */
+	struct sched_object sched_obj;
 	uint64_t pending_pre_work; /* any pre work pending? */
 	bool launched; /* Whether the vcpu is launched on target pcpu */
 	uint32_t paused_cnt; /* how many times vcpu is paused */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -299,6 +299,9 @@ vcpu_vlapic(struct acrn_vcpu *vcpu)
 	return &(vcpu->arch.vlapic);
 }
 
+void default_idle(struct sched_object *obj);
+void vcpu_thread(struct sched_object *obj);
+
 /* External Interfaces */
 
 /**

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -19,6 +19,7 @@
 #include <vmtrr.h>
 #include <timer.h>
 #include <vlapic.h>
+#include <schedule.h>
 #include <vcpu.h>
 #include <trusty.h>
 #include <guest_pm.h>

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -10,19 +10,26 @@
 #define	NEED_RESCHEDULE		(1U)
 #define	NEED_OFFLINE		(2U)
 
+struct sched_object;
+typedef void (*run_thread_t)(struct sched_object *obj);
+typedef void (*prepare_switch_t)(struct sched_object *obj);
 struct sched_object {
 	struct list_head run_list;
+	run_thread_t thread;
+	prepare_switch_t prepare_switch_out;
+	prepare_switch_t prepare_switch_in;
 };
 
 struct sched_context {
 	spinlock_t runqueue_lock;
 	struct list_head runqueue;
 	uint64_t flags;
-	struct acrn_vcpu *curr_vcpu;
+	struct sched_object *curr_obj;
 	spinlock_t scheduler_lock;
 };
 
 void init_scheduler(void);
+void switch_to_idle(run_thread_t idle_thread);
 void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);
 
@@ -33,15 +40,11 @@ void free_pcpu(uint16_t pcpu_id);
 void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
 void remove_from_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
 
-void default_idle(void);
-
 void make_reschedule_request(uint16_t pcpu_id);
 int32_t need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
 int32_t need_offline(uint16_t pcpu_id);
 
 void schedule(void);
-
-void vcpu_thread(struct acrn_vcpu *vcpu);
 #endif /* SCHEDULE_H */
 

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -35,7 +35,7 @@ void remove_from_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
 
 void default_idle(void);
 
-void make_reschedule_request(const struct acrn_vcpu *vcpu);
+void make_reschedule_request(uint16_t pcpu_id);
 int32_t need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
 int32_t need_offline(uint16_t pcpu_id);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -10,6 +10,10 @@
 #define	NEED_RESCHEDULE		(1U)
 #define	NEED_OFFLINE		(2U)
 
+struct sched_object {
+	struct list_head run_list;
+};
+
 struct sched_context {
 	spinlock_t runqueue_lock;
 	struct list_head runqueue;
@@ -26,8 +30,8 @@ void set_pcpu_used(uint16_t pcpu_id);
 uint16_t allocate_pcpu(void);
 void free_pcpu(uint16_t pcpu_id);
 
-void add_vcpu_to_runqueue(struct acrn_vcpu *vcpu);
-void remove_vcpu_from_runqueue(struct acrn_vcpu *vcpu);
+void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
+void remove_from_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
 
 void default_idle(void);
 


### PR DESCRIPTION
this patch series reshuffle scheduler functions, it make basic scheduler
functions to be based on struct sched_object, and make it as a field in
struct vcpu to specify vcpu schedule related operations.

Tracked-On: #1842
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <edide.dong@intel.com>
