### PR TITLE
hv:fix MISRA-C const violation for vm_desc

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -58,7 +58,7 @@ struct acrn_vm *get_vm_from_vmid(uint16_t vm_id)
 /**
  * @pre vm_desc != NULL && rtn_vm != NULL
  */
-int32_t create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm)
+int32_t create_vm(const struct vm_description *vm_desc, struct acrn_vm **rtn_vm)
 {
 	struct acrn_vm *vm = NULL;
 	int32_t status = 0;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -265,7 +265,7 @@ void resume_vm(struct acrn_vm *vm);
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);
 void start_vm(struct acrn_vm *vm);
 int32_t reset_vm(struct acrn_vm *vm);
-int32_t create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm);
+int32_t create_vm(const struct vm_description *vm_desc, struct acrn_vm **rtn_vm);
 int32_t prepare_vm(uint16_t pcpu_id);
 
 #ifdef CONFIG_PARTITION_MODE


### PR DESCRIPTION
MISRA-C require pointer param should be declared pointer
to const, the const qualifier should be applied to pointer parameters
data not subject to change.

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>