### PR TITLE
hv: coding style: refine inline assembly use and one function one exit

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -344,9 +344,6 @@ $(VERSION):
 	echo "" >> $(VERSION); \
 	echo "#ifndef VERSION_H" >> $(VERSION); \
 	echo "#define VERSION_H" >> $(VERSION); \
-	echo "#define HV_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION);\
-	echo "#define HV_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION);\
-	echo "#define HV_EXTRA_VERSION "\"$(EXTRA_VERSION)\""" >> $(VERSION);\
 	echo "#define HV_FULL_VERSION "\"$(FULL_VERSION)\""" >> $(VERSION);\
 	echo "#define HV_API_MAJOR_VERSION $(API_MAJOR_VERSION)U" >> $(VERSION);\
 	echo "#define HV_API_MINOR_VERSION $(API_MINOR_VERSION)U" >> $(VERSION);\

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -292,22 +292,18 @@ static inline uint64_t sidt(void)
 }
 
 /* Read MSR */
-static inline void cpu_msr_read(uint32_t reg, uint64_t *msr_val_ptr)
+static inline uint64_t cpu_msr_read(uint32_t reg)
 {
 	uint32_t  msrl, msrh;
 
 	asm volatile (" rdmsr ":"=a"(msrl), "=d"(msrh) : "c" (reg));
-	*msr_val_ptr = ((uint64_t)msrh << 32U) | msrl;
+	return (((uint64_t)msrh << 32U) | msrl);
 }
 
 /* Write MSR */
 static inline void cpu_msr_write(uint32_t reg, uint64_t msr_val)
 {
-	uint32_t msrl, msrh;
-
-	msrl = (uint32_t)msr_val;
-	msrh = (uint32_t)(msr_val >> 32U);
-	asm volatile (" wrmsr " : : "c" (reg), "a" (msrl), "d" (msrh));
+	asm volatile (" wrmsr " : : "c" (reg), "a" ((uint32_t)msr_val), "d" ((uint32_t)(msr_val >> 32U)));
 }
 
 static inline void pause_cpu(void)
@@ -429,8 +425,7 @@ static inline uint64_t cpu_rsp_get(void)
 {
 	uint64_t ret;
 
-	asm volatile("movq %%rsp, %0"
-			:  "=r"(ret));
+	asm volatile("movq %%rsp, %0" :  "=r"(ret));
 	return ret;
 }
 
@@ -438,34 +433,23 @@ static inline uint64_t cpu_rbp_get(void)
 {
 	uint64_t ret;
 
-	asm volatile("movq %%rbp, %0"
-			:  "=r"(ret));
+	asm volatile("movq %%rbp, %0" :  "=r"(ret));
 	return ret;
 }
 
-static inline uint64_t
-msr_read(uint32_t reg_num)
+static inline uint64_t msr_read(uint32_t reg_num)
 {
-	uint64_t msr_val;
-
-	cpu_msr_read(reg_num, &msr_val);
-	return msr_val;
+	return cpu_msr_read(reg_num);
 }
 
-static inline void
-msr_write(uint32_t reg_num, uint64_t value64)
+static inline void msr_write(uint32_t reg_num, uint64_t value64)
 {
 	cpu_msr_write(reg_num, value64);
 }
 
-static inline void
-write_xcr(int32_t reg, uint64_t val)
+static inline void write_xcr(int32_t reg, uint64_t val)
 {
-	uint32_t low, high;
-
-	low = (uint32_t)val;
-	high = (uint32_t)(val >> 32U);
-	asm volatile("xsetbv" : : "c" (reg), "a" (low), "d" (high));
+	asm volatile("xsetbv" : : "c" (reg), "a" ((uint32_t)val), "d" ((uint32_t)(val >> 32U)));
 }
 
 static inline void stac(void)

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -216,29 +216,31 @@ static inline struct acrn_vcpu *vcpu_from_vid(struct acrn_vm *vm, uint16_t vcpu_
 static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_id)
 {
 	uint16_t i;
-	struct acrn_vcpu *vcpu;
+	struct acrn_vcpu *vcpu, *target_vcpu = NULL;
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (vcpu->pcpu_id == pcpu_id) {
-			return vcpu;
+			target_vcpu = vcpu;
+			break;
 		}
 	}
 
-	return NULL;
+	return target_vcpu;
 }
 
 static inline struct acrn_vcpu *get_primary_vcpu(struct acrn_vm *vm)
 {
 	uint16_t i;
-	struct acrn_vcpu *vcpu;
+	struct acrn_vcpu *vcpu, *target_vcpu = NULL;
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (is_vcpu_bsp(vcpu)) {
-			return vcpu;
+			target_vcpu = vcpu;
+			break;
 		}
 	}
 
-	return NULL;
+	return target_vcpu;
 }
 
 static inline struct acrn_vuart*

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -39,7 +39,7 @@
  **/
 #define INVALID_BIT_INDEX  0xffffU
 
-/**
+/*
  *
  * fls32 - Find the Last (most significant) bit Set in value and
  *       return the bit index of that bit.
@@ -61,33 +61,30 @@
  * when 'value' was zero, bit operations function can't find bit
  * set and return the invalid bit index directly.
  *
- * **/
+ */
 static inline uint16_t fls32(uint32_t value)
 {
-	uint32_t ret = 0U;
-	if (value == 0U) {
-		return (INVALID_BIT_INDEX);
-	}
-	asm volatile("bsrl %1,%0"
-			: "=r" (ret)
-			: "rm" (value));
+	uint32_t ret;
+	asm volatile("bsrl %1,%0\n\t"
+			"jnz 1f\n\t"
+			"mov %2,%0\n"
+			"1:" : "=r" (ret)
+			: "rm" (value), "i" (INVALID_BIT_INDEX));
 	return (uint16_t)ret;
 }
 
 static inline uint16_t fls64(uint64_t value)
 {
 	uint64_t ret = 0UL;
-	if (value == 0UL) {
-	        ret = (INVALID_BIT_INDEX);
-	} else {
-		asm volatile("bsrq %1,%0"
-			: "=r" (ret)
-			: "rm" (value));
-	}
+	asm volatile("bsrq %1,%0\n\t"
+			"jnz 1f\n\t"
+			"mov %2,%0\n"
+			"1:" : "=r" (ret)
+			: "rm" (value), "i" (INVALID_BIT_INDEX));
 	return (uint16_t)ret;
 }
 
-/**
+/*
  *
  * ffs64 - Find the First (least significant) bit Set in value(Long type)
  * and return the index of that bit.
@@ -111,16 +108,15 @@ static inline uint16_t fls64(uint64_t value)
  * when 'value' was zero, bit operations function can't find bit
  * set and return the invalid bit index directly.
  *
- * **/
+ */
 static inline uint16_t ffs64(uint64_t value)
 {
-	uint64_t ret = 0UL;
-	if (value == 0UL) {
-		return (INVALID_BIT_INDEX);
-	}
-	asm volatile("bsfq %1,%0"
-			: "=r" (ret)
-			: "rm" (value));
+	uint64_t ret;
+	asm volatile("bsfq %1,%0\n\t"
+			"jnz 1f\n\t"
+			"mov %2,%0\n"
+			"1:" : "=r" (ret)
+			: "rm" (value), "i" (INVALID_BIT_INDEX));
 	return (uint16_t)ret;
 }
 
@@ -147,7 +143,7 @@ static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
 
 	return size;
 }
-/**
+/*
  * Counts leading zeros.
  *
  * The number of leading zeros is defined as the number of
@@ -171,7 +167,7 @@ static inline uint16_t clz(uint32_t value)
 	}
 }
 
-/**
+/*
  * Counts leading zeros (64 bit version).
  *
  * @param value:The 64 bit value to count the number of leading zeros.
@@ -232,26 +228,22 @@ build_bitmap_clear(bitmap32_clear_lock, "l", uint32_t, BUS_LOCK)
  * Note:Input parameter nr shall be less than 64. If nr>=64, it will
  * be truncated.
  */
-static inline bool bitmap_test(uint16_t nr_arg, const volatile uint64_t *addr)
+static inline bool bitmap_test(uint16_t nr, const volatile uint64_t *addr)
 {
-	uint16_t nr;
 	int32_t ret = 0;
-	nr = nr_arg & 0x3fU;
 	asm volatile("btq %q2,%1\n\tsbbl %0, %0"
 			: "=r" (ret)
-			: "m" (*addr), "r" ((uint64_t)nr)
+			: "m" (*addr), "r" ((uint64_t)(nr & 0x3fU))
 			: "cc", "memory");
 	return (ret != 0);
 }
 
-static inline bool bitmap32_test(uint16_t nr_arg, const volatile uint32_t *addr)
+static inline bool bitmap32_test(uint16_t nr, const volatile uint32_t *addr)
 {
-	uint16_t nr;
 	int32_t ret = 0;
-	nr = nr_arg & 0x1fU;
 	asm volatile("btl %2,%1\n\tsbbl %0, %0"
 			: "=r" (ret)
-			: "m" (*addr), "r" ((uint32_t)nr)
+			: "m" (*addr), "r" ((uint32_t)(nr & 0x1fU))
 			: "cc", "memory");
 	return (ret != 0);
 }

--- a/hypervisor/include/lib/bits.h
+++ b/hypervisor/include/lib/bits.h
@@ -133,15 +133,17 @@ static inline uint16_t ffz64(uint64_t value)
  */
 static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
 {
+	uint64_t ret = size;
 	uint64_t idx;
 
 	for (idx = 0UL; (idx << 6U) < size; idx++) {
 		if (addr[idx] != ~0UL) {
-			return (idx << 6U) + ffz64(addr[idx]);
+			ret = (idx << 6U) + ffz64(addr[idx]);
+			break;
 		}
 	}
 
-	return size;
+	return ret;
 }
 /*
  * Counts leading zeros.
@@ -160,11 +162,7 @@ static inline uint64_t ffz64_ex(const uint64_t *addr, uint64_t size)
  */
 static inline uint16_t clz(uint32_t value)
 {
-	if (value == 0U) {
-		return 32U;
-	} else {
-		return (31U - fls32(value));
-	}
+	return ((value != 0U) ? (31U - fls32(value)) : 32U);
 }
 
 /*
@@ -176,11 +174,7 @@ static inline uint16_t clz(uint32_t value)
  */
 static inline uint16_t clz64(uint64_t value)
 {
-	if (value == 0UL) {
-		return 64U;
-	} else {
-		return (63U - fls64(value));
-	}
+	return ((value != 0UL) ? (63U - fls64(value)) : 64U);
 }
 
 /*


### PR DESCRIPTION
1) Try to minimize the C code in inline assembly function. Now only
construct data structure and return a value is permitted.
2) Refine the remaining functions in the head file to one exit point

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>