### PR TITLE
dm: virtio: refine header file

### DIFF
--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -206,7 +206,7 @@ vhost_vq_register_eventfd(struct vhost_dev *vdev,
 	}
 
 	/* register ioeventfd for kick */
-	if (base->device_caps & ACRN_VIRTIO_F_VERSION_1) {
+	if (base->device_caps & (1UL << VIRTIO_F_VERSION_1)) {
 		/*
 		 * in the current implementation, if virtio 1.0 with pio
 		 * notity, its bar idx should be set to non-zero
@@ -234,7 +234,7 @@ vhost_vq_register_eventfd(struct vhost_dev *vdev,
 	} else {
 		bar = &vdev->base->dev->bar[base->legacy_pio_bar_idx];
 		ioeventfd.data = vdev->vq_idx + idx;
-		ioeventfd.addr = bar->addr + VIRTIO_CR_QNOTIFY;
+		ioeventfd.addr = bar->addr + VIRTIO_PCI_QUEUE_NOTIFY;
 		ioeventfd.len = 2;
 		ioeventfd.flags |= (ACRN_IOEVENTFD_FLAG_DATAMATCH |
 			ACRN_IOEVENTFD_FLAG_PIO);
@@ -677,7 +677,7 @@ vhost_dev_start(struct vhost_dev *vdev)
 		goto fail;
 	}
 
-	if ((vdev->base->status & VIRTIO_CR_STATUS_DRIVER_OK) == 0) {
+	if ((vdev->base->status & VIRTIO_CONFIG_S_DRIVER_OK) == 0) {
 		WPRINTF("status error 0x%x\n", vdev->base->status);
 		goto fail;
 	}

--- a/devicemodel/hw/pci/virtio/virtio_audio.c
+++ b/devicemodel/hw/pci/virtio/virtio_audio.c
@@ -224,7 +224,7 @@ virtio_audio_k_set_status(void *base, uint64_t status)
 	nvq = virt_audio->base.vops->nvq;
 
 	if (virt_audio->vbs_k.kstatus == VIRTIO_DEV_INIT_SUCCESS &&
-	    (status & VIRTIO_CR_STATUS_DRIVER_OK)) {
+	    (status & VIRTIO_CONFIG_S_DRIVER_OK)) {
 		/* time to kickoff VBS-K side */
 		/* init vdev first */
 		rc = virtio_audio_kernel_dev_set(

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -67,7 +67,7 @@
 	(VIRTIO_BLK_F_SEG_MAX |						    \
 	VIRTIO_BLK_F_BLK_SIZE |						    \
 	VIRTIO_BLK_F_TOPOLOGY |						    \
-	ACRN_VIRTIO_RING_F_INDIRECT_DESC)	/* indirect descriptors */
+	(1 << VIRTIO_RING_F_INDIRECT_DESC))	/* indirect descriptors */
 
 /*
  * Writeback cache bits
@@ -230,7 +230,7 @@ virtio_blk_proc(struct virtio_blk *blk, struct virtio_vq_info *vq)
 	assert(n >= 2 && n <= BLOCKIF_IOV_MAX + 2);
 
 	io = &blk->ios[idx];
-	assert((flags[0] & ACRN_VRING_DESC_F_WRITE) == 0);
+	assert((flags[0] & VRING_DESC_F_WRITE) == 0);
 	assert(iov[0].iov_len == sizeof(struct virtio_blk_hdr));
 	vbh = iov[0].iov_base;
 	memcpy(&io->req.iov, &iov[1], sizeof(struct iovec) * (n - 2));
@@ -238,7 +238,7 @@ virtio_blk_proc(struct virtio_blk *blk, struct virtio_vq_info *vq)
 	io->req.offset = vbh->sector * DEV_BSIZE;
 	io->status = iov[--n].iov_base;
 	assert(iov[n].iov_len == 1);
-	assert(flags[n] & ACRN_VRING_DESC_F_WRITE);
+	assert(flags[n] & VRING_DESC_F_WRITE);
 
 	/*
 	 * XXX
@@ -257,7 +257,7 @@ virtio_blk_proc(struct virtio_blk *blk, struct virtio_vq_info *vq)
 		 * therefore test the inverse of the descriptor bit
 		 * to the op.
 		 */
-		assert(((flags[i] & ACRN_VRING_DESC_F_WRITE) == 0) == writeop);
+		assert(((flags[i] & VRING_DESC_F_WRITE) == 0) == writeop);
 		iolen += iov[i].iov_len;
 	}
 	io->req.resid = iolen;

--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -405,7 +405,7 @@ virtio_console_notify_rx(void *vdev, struct virtio_vq_info *vq)
 
 	if (!port->rx_ready) {
 		port->rx_ready = 1;
-		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
 	}
 }
 

--- a/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
+++ b/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
@@ -213,7 +213,7 @@ virtio_hyper_dmabuf_set_status(void *base, uint64_t status)
 	nvq = hyper_dmabuf->base.vops->nvq;
 
 	if (kstatus == VIRTIO_DEV_INIT_SUCCESS &&
-	    (status & VIRTIO_CR_STATUS_DRIVER_OK)) {
+	    (status & VIRTIO_CONFIG_S_DRIVER_OK)) {
 		/* time to kickoff VBS-K side */
 		/* init vdev first */
 		rc = virtio_hyper_dmabuf_k_dev_set(

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -47,7 +47,7 @@ static int virtio_input_debug;
 /*
  * Host capabilities
  */
-#define VIRTIO_INPUT_S_HOSTCAPS		(ACRN_VIRTIO_F_VERSION_1)
+#define VIRTIO_INPUT_S_HOSTCAPS		(1UL << VIRTIO_F_VERSION_1)
 
 enum virtio_input_config_select {
 	VIRTIO_INPUT_CFG_UNSET		= 0x00,
@@ -170,7 +170,7 @@ virtio_input_set_status(void *vdev, uint64_t status)
 {
 	struct virtio_input *vi = vdev;
 
-	if (status & VIRTIO_CR_STATUS_DRIVER_OK) {
+	if (status & VIRTIO_CONFIG_S_DRIVER_OK) {
 		if (!vi->ready)
 			vi->ready = true;
 	}

--- a/devicemodel/hw/pci/virtio/virtio_ipu.c
+++ b/devicemodel/hw/pci/virtio/virtio_ipu.c
@@ -234,7 +234,7 @@ virtio_ipu_set_status(void *base, uint64_t status)
 	ipu = (struct virtio_ipu *) base;
 	nvq = ipu->base.vops->nvq;
 	if (ipu->vbs_k.ipu_kstatus == VIRTIO_DEV_INIT_SUCCESS &&
-	    (status & VIRTIO_CR_STATUS_DRIVER_OK)) {
+	    (status & VIRTIO_CONFIG_S_DRIVER_OK)) {
 		/* time to kickoff VBS-K side */
 		/* init vdev first */
 		rc = virtio_ipu_k_dev_set(

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -1583,7 +1583,7 @@ vmei_notify_tx(void *data, struct virtio_vq_info *vq)
 
 	pthread_mutex_lock(&vmei->tx_mutex);
 	DPRINTF("TX: New OUT buffer available!\n");
-	vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
+	vq->used->flags |= VRING_USED_F_NO_NOTIFY;
 	pthread_mutex_unlock(&vmei->tx_mutex);
 
 	while (vq_has_descs(vq))
@@ -1899,7 +1899,7 @@ static void *vmei_rx_thread(void *param)
 			if (err || vmei->status == VMEI_STST_DEINIT)
 				goto out;
 		}
-		vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
+		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
 
 		do {
 			vmei->rx_need_sched = vmei_proc_rx(vmei, vq);
@@ -1926,7 +1926,7 @@ vmei_notify_rx(void *data, struct virtio_vq_info *vq)
 	/* Signal the rx thread for processing */
 	pthread_mutex_lock(&vmei->rx_mutex);
 	DPRINTF("RX: New IN buffer available!\n");
-	vq->used->flags |= ACRN_VRING_USED_F_NO_NOTIFY;
+	vq->used->flags |= VRING_USED_F_NO_NOTIFY;
 	pthread_cond_signal(&vmei->rx_cond);
 	pthread_mutex_unlock(&vmei->rx_mutex);
 }

--- a/devicemodel/hw/pci/virtio/virtio_rnd.c
+++ b/devicemodel/hw/pci/virtio/virtio_rnd.c
@@ -141,7 +141,7 @@ virtio_rnd_k_set_status(void *base, uint64_t status)
 	nvq = rnd->base.vops->nvq;
 
 	if (rnd->vbs_k.status == VIRTIO_DEV_INIT_SUCCESS &&
-	    (status & VIRTIO_CR_STATUS_DRIVER_OK)) {
+	    (status & VIRTIO_CONFIG_S_DRIVER_OK)) {
 		/* time to kickoff VBS-K side */
 		/* init vdev first */
 		rc = virtio_rnd_kernel_dev_set(&rnd->vbs_k.dev,


### PR DESCRIPTION
Reuse linux common virtio header file and remove the repetitive
definition.

Tracked-On: #2145
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>