### PR TITLE
hv: vcpuid: leaf 02h has no subleaf

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -211,26 +211,6 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 			}
 
 			switch (i) {
-			case 0x02U:
-			{
-				uint32_t times;
-
-				init_vcpuid_entry(i, 0U, CPUID_CHECK_SUBLEAF, &entry);
-				result = set_vcpuid_entry(vm, &entry);
-				if (result == 0) {
-					times = entry.eax & 0xffUL;
-					for (j = 1U; j < times; j++) {
-						init_vcpuid_entry(i, j, CPUID_CHECK_SUBLEAF, &entry);
-						result = set_vcpuid_entry(vm, &entry);
-						if (result != 0) {
-							/* wants to break out of switch */
-							break;
-						}
-					}
-				}
-				break;
-			}
-
 			case 0x04U:
 				for (j = 0U; ; j++) {
 					init_vcpuid_entry(i, j, CPUID_CHECK_SUBLEAF, &entry);

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -253,10 +253,6 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 			default:
 				init_vcpuid_entry(i, 0U, 0U, &entry);
 				result = set_vcpuid_entry(vm, &entry);
-				if (result != 0) {
-					/* break out of switch */
-					break;
-				}
 				break;
 			}
 


### PR DESCRIPTION
According to SDM Vol. 2A 3-191 & Vol. 2A 3-213, leaf 02h has no subleaf.
This patch removes the un-needed code.

Tracked-On: #861
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>