### PR TITLE
Profiling: fix the profiling tool crash by page faults

### DIFF
--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -70,6 +70,8 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 
 		vcpu->arch.nrexits++;
 
+		profiling_pre_vmexit_handler(vcpu);
+
 		CPU_IRQ_ENABLE();
 		/* Dispatch handler */
 		ret = vmexit_handler(vcpu);
@@ -83,6 +85,6 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 
 		TRACE_2L(TRACE_VM_EXIT, basic_exit_reason, vcpu_get_rip(vcpu));
 
-		profiling_vmexit_handler(vcpu, basic_exit_reason);
+		profiling_post_vmexit_handler(vcpu);
 	} while (1);
 }

--- a/hypervisor/include/debug/profiling.h
+++ b/hypervisor/include/debug/profiling.h
@@ -12,7 +12,8 @@
 #endif
 
 void profiling_vmenter_handler(struct acrn_vcpu *vcpu);
-void profiling_vmexit_handler(struct acrn_vcpu *vcpu, uint64_t exit_reason);
+void profiling_pre_vmexit_handler(struct acrn_vcpu *vcpu);
+void profiling_post_vmexit_handler(struct acrn_vcpu *vcpu);
 void profiling_setup(void);
 
 #endif /* PROFILING_H */

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -291,6 +291,7 @@ struct profiling_info_wrapper {
 	struct vm_switch_trace	vm_switch_trace;
 	socwatch_state			soc_state;
 	struct sw_msr_op_info	sw_msr_op_info;
+	spinlock_t		sw_lock;
 } __aligned(8);
 
 int32_t profiling_get_version_info(struct acrn_vm *vm, uint64_t addr);

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -7,5 +7,6 @@
 #include <hypervisor.h>
 
 void profiling_vmenter_handler(__unused struct acrn_vcpu *vcpu) {}
-void profiling_vmexit_handler(__unused struct acrn_vcpu *vcpu, __unused uint64_t exit_reason) {}
+void profiling_pre_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}
+void profiling_post_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}
 void profiling_setup(void) {}


### PR DESCRIPTION
Profiling tools are broken, which cause page faults during collection.
The issue happens by enabling SMAP recently. Therefore,
we use stac() and clac() to allow access to buffers allocated by guest vm.