### PR TITLE
 hv: virq: refine hypervisor/arch/x86/virq.c for MISRA C standards 

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -253,7 +253,7 @@ static int32_t vcpu_inject_hi_exception(struct acrn_vcpu *vcpu)
 	uint32_t vector = vcpu->arch.exception_info.exception;
 	int32_t ret;
 
-	if (vector == IDT_MC || vector == IDT_BP || vector == IDT_DB) {
+	if ((vector == IDT_MC) || (vector == IDT_BP) || (vector == IDT_DB)) {
 		vcpu_inject_exception(vcpu, vector);
 		ret = 1;
 	} else {


### PR DESCRIPTION
hv: virq: refine vcpu_inject_hi_exception()
The MISRA-C Standards suggests use brackets to clarify the precedence order of logical conjunctions.

hv: virq: refine vcpu_inject_vlapic_int() has more than one exit point
The MISRA-C Standards suggests procedures to be single exit.

 Tracked-On: #861
 Acked-by: Eddie Dong <eddie.dong@intel.com>
 Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>