### PR TITLE
hv: remove duplicated `is_vmx_disabled`

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -305,6 +305,7 @@ void init_cpu_model_name(void)
 static inline bool is_vmx_disabled(void)
 {
 	uint64_t msr_val;
+	bool ret = false;
 
 	/* Read Feature ControL MSR */
 	msr_val = msr_read(MSR_IA32_FEATURE_CONTROL);
@@ -312,9 +313,10 @@ static inline bool is_vmx_disabled(void)
 	/* Check if feature control is locked and vmx cannot be enabled */
 	if (((msr_val & MSR_IA32_FEATURE_CONTROL_LOCK) != 0U) &&
 		((msr_val & MSR_IA32_FEATURE_CONTROL_VMX_NO_SMX) == 0U)) {
-		return true;
+		ret = true;
 	}
-	return false;
+
+	return ret;
 }
 
 static inline bool cpu_has_vmx_unrestricted_guest_cap(void)

--- a/hypervisor/arch/x86/vmcs.c
+++ b/hypervisor/arch/x86/vmcs.c
@@ -14,23 +14,6 @@ static uint64_t cr0_always_off_mask;
 static uint64_t cr4_always_on_mask;
 static uint64_t cr4_always_off_mask;
 
-bool is_vmx_disabled(void)
-{
-	uint64_t msr_val;
-	bool ret = false;
-
-	/* Read Feature ControL MSR */
-	msr_val = msr_read(MSR_IA32_FEATURE_CONTROL);
-
-	/* Check if feature control is locked and vmx cannot be enabled */
-	if (((msr_val & MSR_IA32_FEATURE_CONTROL_LOCK) != 0U) &&
-		((msr_val & MSR_IA32_FEATURE_CONTROL_VMX_NO_SMX) == 0U)) {
-		ret = true;
-	}
-
-	return ret;
-}
-
 static void init_cr0_cr4_host_mask(void)
 {
 	static bool inited = false;


### PR DESCRIPTION
This patch fixes the duplicated functions introduced by cpu caps
modularization.

In cpu caps modularization, function `is_vmx_disabled` was supposed
to be moved from `arch/x86/vmcs.c` to`arch/x86/cpu_caps.c`,
but the original one was not removed.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>