### PR TITLE
modify makefile to save debug files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ devicemodel-install:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install
 
 tools-install:
-	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) install
+	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) install

--- a/efi-stub/Makefile
+++ b/efi-stub/Makefile
@@ -89,6 +89,10 @@ all: $(EFIBIN)
 install: $(EFIBIN) install-conf
 	install -D $(EFIBIN) $(DESTDIR)/usr/lib/acrn/$(HV_FILE).efi
 
+install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
+	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).efi.out
+	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).efi.map
+
 $(EFIBIN): $(BOOT)
 
 $(EFI_OBJDIR)/boot.efi: $(EFI_OBJDIR)/boot.so

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -282,6 +282,10 @@ all: lib $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 ifeq ($(CONFIG_PLATFORM_SBL),y)
 install: lib $(HV_OBJDIR)/$(HV_FILE).32.out
 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).sbl
+
+install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
+	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).sbl.out
+	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).sbl.map
 endif
 
 .PHONY: header


### PR DESCRIPTION
modify makefile to save debug files; so it when meet issues in the release build, it is easy to use the debug files to find some info.

Alek Du (1):
  Makefile: keep files used for debug target

Miguel Bernal Marin (1):
  Makefile: add RELEASE variable to make command

Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
