### PR TITLE
hv: Write Buffer Flush - VT-d

### DIFF
--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -129,11 +129,6 @@ static inline uint8_t iommu_cap_plmr(uint64_t cap)
 	return ((uint8_t)(cap >> 5U) & 1U);
 }
 
-static inline uint8_t iommu_cap_rwbf(uint64_t cap)
-{
-	return ((uint8_t)(cap >> 4U) & 1U);
-}
-
 static inline uint8_t iommu_cap_afl(uint64_t cap)
 {
 	return ((uint8_t)(cap >> 3U) & 1U);


### PR DESCRIPTION
This patch does the following changes
According to VT-d spec Section 6.8 "Write Buffer Flushing" DRAM write buffers
are flushed implicitly upon Remapping Hardware Caches Invalidation even on
platforms that set RWBF to 1 in capability register. So removed write buffer
flushing as current ACRN issues cache invalidation commands in all cases.

Tracked-On: #1855
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>