### PR TITLE
hv: fix sprintf and hypercall violations

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -895,37 +895,35 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct hc_ptdev_irq irq;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (target_vm == NULL) {
-		return -1;
-	}
+	if (target_vm != NULL) {
+		(void)memset((void *)&irq, 0U, sizeof(irq));
 
-	(void)memset((void *)&irq, 0U, sizeof(irq));
+		if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
+			pr_err("%s: Unable copy param to vm\n", __func__);
+			ret = -1;
+		} else if (irq.type == IRQ_INTX) {
+			ptirq_remove_intx_remapping(target_vm,
+					irq.is.intx.virt_pin,
+					irq.is.intx.pic_pin);
+		} else if ((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) {
 
-	if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
-		pr_err("%s: Unable copy param to vm\n", __func__);
-		return -1;
-	}
-
-	if (irq.type == IRQ_INTX) {
-		ptirq_remove_intx_remapping(target_vm,
-				irq.is.intx.virt_pin,
-				irq.is.intx.pic_pin);
-	} else if ((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) {
-
-		/*
-		 * Inform vPCI about the interupt info changes
-		 * TODO: Need to add bdf info for IRQ_INTX type in devicemodel
-		 */
+			/*
+			 * Inform vPCI about the interupt info changes
+			 * TODO: Need to add bdf info for IRQ_INTX type in devicemodel
+			 */
 #ifndef CONFIG_PARTITION_MODE
-		vpci_reset_ptdev_intr_info(target_vm, irq.virt_bdf, irq.phys_bdf);
+			vpci_reset_ptdev_intr_info(target_vm, irq.virt_bdf, irq.phys_bdf);
 #endif
 
-		ptirq_remove_msix_remapping(target_vm,
-				irq.virt_bdf,
-				irq.is.msix.vector_cnt);
+			ptirq_remove_msix_remapping(target_vm,
+					irq.virt_bdf,
+					irq.is.msix.vector_cnt);
+		} else {
+			pr_err("%s: Invalid irq type: %u\n", __func__, irq.type);
+			ret = -1;
+		}
 	} else {
-		pr_err("%s: Invalid irq type: %u\n", __func__, irq.type);
-		ret = -1;
+	        ret = -1;
 	}
 
 	return ret;
@@ -1117,17 +1115,18 @@ int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
  */
 int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param)
 {
+	int32_t ret;
+
 	if (!is_vm0(vm)) {
 		pr_err("%s: Targeting to service vm", __func__);
-		return -EPERM;
-	}
-
-	if ((param > NR_MAX_VECTOR) || (param < VECTOR_DYNAMIC_START)) {
+	        ret = -EPERM;
+	} else if ((param > NR_MAX_VECTOR) || (param < VECTOR_DYNAMIC_START)) {
 		pr_err("%s: Invalid passed vector\n");
-		return -EINVAL;
+		ret = -EINVAL;
+	} else {
+		acrn_vhm_vector = (uint32_t)param;
+		ret = 0;
 	}
 
-	acrn_vhm_vector = (uint32_t)param;
-
-	return 0;
+	return ret;
 }

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -15,9 +15,7 @@ static void prepare_bsp_gdt(struct acrn_vm *vm)
 	uint64_t gdt_base_hpa;
 
 	gdt_base_hpa = gpa2hpa(vm, boot_context.gdt.base);
-	if (boot_context.gdt.base == gdt_base_hpa) {
-		return;
-	} else {
+	if (boot_context.gdt.base != gdt_base_hpa) {
 		gdt_len = ((size_t)boot_context.gdt.limit + 1U) / sizeof(uint8_t);
 		(void)copy_to_gpa(vm, hpa2hva(boot_context.gdt.base), boot_context.gdt.base, gdt_len);
 	}

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -86,7 +86,7 @@ static const char *get_param(const char *s_arg, uint32_t *x)
 	/* parse uint32_teger */
 	while ((*s >= '0') && (*s <= '9')) {
 		char delta = *s - '0';
-		*x = *x * 10U + (uint32_t)delta;
+		*x = ((*x) * 10U) + (uint32_t)delta;
 		s++;
 	}
 
@@ -97,7 +97,7 @@ static const char *get_flags(const char *s_arg, uint32_t *flags)
 {
 	const char *s = s_arg;
 	/* contains the flag characters */
-	static const char flagchars[] = "#0- +";
+	static const char flagchars[5] = "#0- +";
 	/* contains the numeric flags for the characters above */
 	static const uint32_t fl[sizeof(flagchars)] = {
 		PRINT_FLAG_ALTERNATE_FORM,	/* # */


### PR DESCRIPTION
Fix the violations list below:
1.Procedure has more than one exit point.
2.Use of sizeof on an array parameter.
3.Expression needs brackets.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>