### PR TITLE
HV: [v2] bugfix in 'hv_access_memory_region_update()'

### DIFF
--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -45,6 +45,7 @@
 
 #include <cpu.h>
 #include <page.h>
+#include <pgtable.h>
 
 /* Define cache line size (in bytes) */
 #define CACHE_LINE_SIZE		64U
@@ -63,6 +64,16 @@ static inline uint64_t round_page_up(uint64_t addr)
 static inline uint64_t round_page_down(uint64_t addr)
 {
 	return (addr & PAGE_MASK);
+}
+
+static inline uint64_t round_pde_up(uint64_t val)
+{
+	return (((val + (uint64_t)PDE_SIZE) - 1UL) & PDE_MASK);
+}
+
+static inline uint64_t round_pde_down(uint64_t val)
+{
+	return (val & PDE_MASK);
 }
 
 /**


### PR DESCRIPTION
  - bugfix:the actual 'size' of memory region that
    to be updated is incorrect.

  - replace CONFIG_UEFI_STUB with DMAR_PARSE_ENABLED
    when update memory pages for ACPI_RECLAIM region,
    as DMAR_PARSE_ENABLED may be enabled on non-EFI
    platform.

V2 update:
    wrap roundup to 2M and rounddown to 2M inline
    functions.

Tracked-On: #2056
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>