### PR TITLE
hv: remove the usage of 'atoi()'

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -707,12 +707,12 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 		goto out;
 	}
 
-	status = atoi(argv[1]);
+	status = strtol_deci(argv[1]);
 	if (status < 0) {
 		goto out;
 	}
 	vm_id = (uint16_t)status;
-	vcpu_id = (uint16_t)atoi(argv[2]);
+	vcpu_id = (uint16_t)strtol_deci(argv[2]);
 
 	vm = get_vm_from_vmid(vm_id);
 	if (vm == NULL) {
@@ -758,7 +758,7 @@ static int32_t shell_dumpmem(int32_t argc, char **argv)
 	}
 
 	addr = strtoul_hex(argv[1]);
-	length = (uint32_t)atoi(argv[2]);
+	length = (uint32_t)strtol_deci(argv[2]);
 	if (length > MAX_MEMDUMP_LEN) {
 		shell_puts("over max length, round back\r\n");
 		length = MAX_MEMDUMP_LEN;
@@ -800,7 +800,7 @@ static int32_t shell_to_sos_console(__unused int32_t argc, __unused char **argv)
 	struct vm_description *vm_desc;
 
 	if (argc == 2U) {
-		guest_no = atoi(argv[1]);
+		guest_no = strtol_deci(argv[1]);
 	}
 
 	vuart_vmid = guest_no;
@@ -1084,7 +1084,7 @@ static int32_t shell_show_vioapic_info(int32_t argc, char **argv)
 	if (argc != 2) {
 		return -EINVAL;
 	}
-	ret = atoi(argv[1]);
+	ret = strtol_deci(argv[1]);
 	if (ret >= 0) {
 		vmid = (uint16_t) ret;
 		get_vioapic_info(shell_log_buf, SHELL_LOG_BUF_SIZE, vmid);
@@ -1188,13 +1188,13 @@ static int32_t shell_loglevel(int32_t argc, char **argv)
 
 	switch (argc) {
 	case 4:
-		npk_loglevel = (uint16_t)atoi(argv[3]);
+		npk_loglevel = (uint16_t)strtol_deci(argv[3]);
 		/* falls through */
 	case 3:
-		mem_loglevel = (uint16_t)atoi(argv[2]);
+		mem_loglevel = (uint16_t)strtol_deci(argv[2]);
 		/* falls through */
 	case 2:
-		console_loglevel = (uint16_t)atoi(argv[1]);
+		console_loglevel = (uint16_t)strtol_deci(argv[1]);
 		break;
 	case 1:
 		snprintf(str, MAX_STR_SIZE, "console_loglevel: %u, "

--- a/hypervisor/debug/string.c
+++ b/hypervisor/debug/string.c
@@ -84,8 +84,3 @@ int64_t strtol_deci(const char *nptr)
 	}
 	return (long)acc;
 }
-
-int32_t atoi(const char *str)
-{
-	return (int32_t)strtol_deci(str);
-}

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -38,7 +38,6 @@ char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
 void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
-int32_t atoi(const char *str);
 int64_t strtol_deci(const char *nptr);
 uint64_t strtoul_hex(const char *nptr);
 char *strstr_s(const char *str1, size_t maxlen1,


### PR DESCRIPTION
  this function is not from libc but has the same name,
  atoi() in libc is unbounded and not safe.

  replace this function with 'strtol_deci()' in this case.

Tracked-On: #2187
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>