### PR TITLE
Makefile: Add UP2 related stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ BOARD ?= apl-mrb
 else ifeq ($(PLATFORM),uefi)
 BOARD ?= apl-nuc
 endif
+undefine PLATFORM
 
 ifndef BOARD
 $(error BOARD must be set (apl-mrb, apl-nuc, cb2_dnv, nuc6cayh)
@@ -47,7 +48,7 @@ all: hypervisor devicemodel tools
 hypervisor:
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) clean
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
-ifeq ($(PLATFORM),uefi)
+ifeq ($(FIRMWARE),uefi)
 	echo "building hypervisor as EFI executable..."
 	make -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT)
 endif
@@ -78,10 +79,10 @@ clean:
 install: hypervisor-install devicemodel-install tools-install
 
 hypervisor-install:
-ifeq ($(PLATFORM),sbl)
+ifeq ($(FIRMWARE),sbl)
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
 endif
-ifeq ($(PLATFORM),uefi)
+ifeq ($(FIRMWARE),uefi)
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
 	make -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT) all install
 endif

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ifeq ($(FIRMWARE),uefi)
 endif
 
 sbl-hypervisor-install:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) install
 
 devicemodel-install:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -156,6 +156,7 @@ PROGRAM := acrn-dm
 
 SAMPLES_NUC := $(wildcard samples/nuc/*)
 SAMPLES_MRB := $(wildcard samples/apl-mrb/*)
+SAMPLES_UP2 := $(wildcard samples/up2/*)
 
 BIOS_BIN := $(wildcard bios/*)
 
@@ -209,6 +210,9 @@ $(DM_OBJDIR)/%.o: %.c $(HEADERS)
 
 install: $(DM_OBJDIR)/$(PROGRAM) install-samples-nuc install-samples-mrb install-bios install-vmcfg
 	install -D --mode=0755 $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)/usr/bin/$(PROGRAM)
+
+install-samples-up2: $(SAMPLES_UP2)
+	install -D -t $(DESTDIR)/usr/share/acrn/samples/up2 $^
 
 install-samples-nuc: $(SAMPLES_NUC)
 	install -D -t $(DESTDIR)/usr/share/acrn/samples/nuc $^


### PR DESCRIPTION
This patch fix a bug due to use of deprecated PLATFORM and add `install-samples-up2` rule.

Tracked-On: #1995
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
