### PR TITLE
hv: porting security patch from master branch to apl_sdc_stable branch

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -248,9 +248,14 @@ void enable_smap(void)
  */
 void hv_access_memory_region_update(uint64_t base, uint64_t size)
 {
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (base & PDE_MASK),
-		((size + PDE_SIZE - 1UL) & PDE_MASK), 0UL, PAGE_USER,
-		&ppt_mem_ops, MR_MODIFY);
+	uint64_t region_end = base + size;
+
+	/*rounddown base to 2MBytes aligned.*/
+	base = round_pde_down(base);
+	size = region_end - base;
+
+	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, base, round_pde_up(size),
+		0UL, PAGE_USER,	&ppt_mem_ops, MR_MODIFY);
 }
 
 void init_paging(void)
@@ -269,7 +274,7 @@ void init_paging(void)
 	pr_dbg("HV MMU Initialization");
 
 	/* align to 2MB */
-	high64_max_ram = (p_e820_mem_info->mem_top + PDE_SIZE - 1UL) & PDE_MASK;
+	high64_max_ram = round_pde_up(p_e820_mem_info->mem_top);
 	if ((high64_max_ram > (CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)) ||
 			(high64_max_ram < (1UL << 32U))) {
 		panic("Please configure HV_ADDRESS_SPACE correctly!\n");
@@ -294,7 +299,7 @@ void init_paging(void)
 		}
 	}
 
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, 0UL, (low32_max_ram + PDE_SIZE - 1UL) & PDE_MASK,
+	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, 0UL, round_pde_up(low32_max_ram),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK, &ppt_mem_ops, MR_MODIFY);
 
 	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (1UL << 32U), high64_max_ram - (1UL << 32U),
@@ -311,20 +316,18 @@ void init_paging(void)
 
 	size = ((uint64_t)&ld_text_end - CONFIG_HV_RAM_START);
 	text_end = hv_hpa + size;
-	/*round up 'text_end' to 2MB aligned.*/
-	text_end = (text_end + PDE_SIZE - 1UL) & PDE_MASK;
 	/*
 	 * remove 'NX' bit for pages that contain hv code section, as by default XD bit is set for
 	 * all pages, including pages for guests.
 	 */
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, hv_hpa & PDE_MASK,
-			text_end - (hv_hpa & PDE_MASK), 0UL, PAGE_NX, &ppt_mem_ops, MR_MODIFY);
+	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, round_pde_down(hv_hpa),
+			round_pde_up(text_end) - round_pde_down(hv_hpa), 0UL,
+			PAGE_NX, &ppt_mem_ops, MR_MODIFY);
 
 	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (uint64_t)get_reserve_sworld_memory_base(),
 			TRUSTY_RAM_SIZE * (CONFIG_MAX_VM_NUM - 1U), PAGE_USER, 0UL, &ppt_mem_ops, MR_MODIFY);
 
-#ifdef CONFIG_EFI_STUB
-	/*Hypvervisor need access below memory region on UEFI platform.*/
+#ifdef CONFIG_DMAR_PARSE_ENABLED
 	for (i = 0U; i < entries_count; i++) {
 		entry = p_e820 + i;
 		if (entry->type == E820_TYPE_ACPI_RECLAIM) {

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -706,12 +706,12 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 		goto out;
 	}
 
-	status = atoi(argv[1]);
+	status = strtol_deci(argv[1]);
 	if (status < 0) {
 		goto out;
 	}
 	vm_id = (uint16_t)status;
-	vcpu_id = (uint16_t)atoi(argv[2]);
+	vcpu_id = (uint16_t)strtol_deci(argv[2]);
 
 	vm = get_vm_from_vmid(vm_id);
 	if (vm == NULL) {
@@ -757,7 +757,7 @@ static int32_t shell_dumpmem(int32_t argc, char **argv)
 	}
 
 	addr = strtoul_hex(argv[1]);
-	length = (uint32_t)atoi(argv[2]);
+	length = (uint32_t)strtol_deci(argv[2]);
 	if (length > MAX_MEMDUMP_LEN) {
 		shell_puts("over max length, round back\r\n");
 		length = MAX_MEMDUMP_LEN;
@@ -799,7 +799,7 @@ static int32_t shell_to_sos_console(__unused int32_t argc, __unused char **argv)
 	struct vm_description *vm_desc;
 
 	if (argc == 2U) {
-		guest_no = atoi(argv[1]);
+		guest_no = strtol_deci(argv[1]);
 	}
 
 	vuart_vmid = guest_no;
@@ -1083,7 +1083,7 @@ static int32_t shell_show_vioapic_info(int32_t argc, char **argv)
 	if (argc != 2) {
 		return -EINVAL;
 	}
-	ret = atoi(argv[1]);
+	ret = strtol_deci(argv[1]);
 	if (ret >= 0) {
 		vmid = (uint16_t) ret;
 		get_vioapic_info(shell_log_buf, SHELL_LOG_BUF_SIZE, vmid);
@@ -1180,13 +1180,13 @@ static int32_t shell_loglevel(int32_t argc, char **argv)
 
 	switch (argc) {
 	case 4:
-		npk_loglevel = (uint16_t)atoi(argv[3]);
+		npk_loglevel = (uint16_t)strtol_deci(argv[3]);
 		/* falls through */
 	case 3:
-		mem_loglevel = (uint16_t)atoi(argv[2]);
+		mem_loglevel = (uint16_t)strtol_deci(argv[2]);
 		/* falls through */
 	case 2:
-		console_loglevel = (uint16_t)atoi(argv[1]);
+		console_loglevel = (uint16_t)strtol_deci(argv[1]);
 		break;
 	case 1:
 		snprintf(str, MAX_STR_SIZE, "console_loglevel: %u, "

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -45,6 +45,7 @@
 
 #include <cpu.h>
 #include <page.h>
+#include <pgtable.h>
 
 /* Define cache line size (in bytes) */
 #define CACHE_LINE_SIZE		64U
@@ -63,6 +64,16 @@ static inline uint64_t round_page_up(uint64_t addr)
 static inline uint64_t round_page_down(uint64_t addr)
 {
 	return (addr & PAGE_MASK);
+}
+
+static inline uint64_t round_pde_up(uint64_t val)
+{
+	return (((val + (uint64_t)PDE_SIZE) - 1UL) & PDE_MASK);
+}
+
+static inline uint64_t round_pde_down(uint64_t val)
+{
+	return (val & PDE_MASK);
 }
 
 /**

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -29,7 +29,6 @@ char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
 void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
-int32_t atoi(const char *str);
 long strtol_deci(const char *nptr);
 uint64_t strtoul_hex(const char *nptr);
 char *strstr_s(const char *str1, size_t maxlen1,

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -157,11 +157,6 @@ uint64_t strtoul_hex(const char *nptr)
 	return acc;
 }
 
-int32_t atoi(const char *str)
-{
-	return (int32_t)strtol_deci(str);
-}
-
 char *strchr(char *s_arg, char ch)
 {
 	char *s = s_arg;


### PR DESCRIPTION
porting security patch from master branch to apl_sdc_stable branch

HV: [v2] bugfix in 'hv_access_memory_region_update()' :
Tracked-On: #2056
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>

hv: remove the usage of 'atoi()' :
Tracked-On: #2187 
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>