### PR TITLE
 hv: decouple IO completion polling from idle thread

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -301,7 +301,7 @@ void stop_cpus(void)
 
 void cpu_do_idle(void)
 {
-	__asm __volatile("pause" ::: "memory");
+	asm_pause();
 }
 
 /**
@@ -325,7 +325,7 @@ void cpu_dead(void)
 
 		/* Halt the CPU */
 		do {
-			hlt_cpu();
+			asm_hlt();
 		} while (halt != 0);
 	} else {
 		pr_err("pcpu%hu already dead", pcpu_id);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -578,7 +578,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 
 		if (vcpu->pcpu_id != pcpu_id) {
 			while (atomic_load32(&vcpu->running) == 1U)
-				__asm__ __volatile("pause" ::: "memory");
+				asm_pause();
 		}
 	} else {
 		remove_from_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -256,7 +256,7 @@ static inline void dmar_wait_completion(const struct dmar_drhd_rt *dmar_unit, ui
 		}
 		ASSERT(((rdtsc() - start) < CYCLES_PER_MS),
 			"DMAR OP Timeout!");
-		pause_cpu();
+		asm_pause();
 	}
 }
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -45,7 +45,7 @@ void vcpu_thread(struct sched_object *obj)
 			continue;
 		}
 
-		if (need_reschedule(vcpu->pcpu_id) != 0) {
+		if (need_reschedule(vcpu->pcpu_id)) {
 			/*
 			 * In extrem case, schedule() could return. Which
 			 * means the vcpu resume happens before schedule()
@@ -95,7 +95,7 @@ void default_idle(__unused struct sched_object *obj)
 	uint16_t pcpu_id = get_cpu_id();
 
 	while (1) {
-		if (need_reschedule(pcpu_id) != 0) {
+		if (need_reschedule(pcpu_id)) {
 			schedule();
 		} else if (need_offline(pcpu_id) != 0) {
 			cpu_dead();

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -101,7 +101,6 @@ void default_idle(__unused struct sched_object *obj)
 			cpu_dead();
 		} else {
 			CPU_IRQ_ENABLE();
-			handle_complete_ioreq(pcpu_id);
 			cpu_do_idle();
 			CPU_IRQ_DISABLE();
 		}

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -79,29 +79,6 @@ static inline bool has_complete_ioreq(const struct acrn_vcpu *vcpu)
 }
 
 /**
- * @brief Handle completed ioreq if any one pending
- *
- * @param pcpu_id The physical cpu id of vcpu whose IO request to be checked
- *
- * @return None
- */
-void handle_complete_ioreq(uint16_t pcpu_id)
-{
-	struct acrn_vcpu *vcpu = get_ever_run_vcpu(pcpu_id);
-	struct acrn_vm *vm;
-
-	if (vcpu != NULL) {
-		vm = vcpu->vm;
-		if (vm->sw.is_completion_polling) {
-			if (has_complete_ioreq(vcpu)) {
-				/* we have completed ioreq pending */
-				emulate_io_post(vcpu);
-			}
-		}
-	}
-}
-
-/**
  * @brief Deliver \p io_req to SOS and suspend \p vcpu till its completion
  *
  * @param vcpu The virtual CPU that triggers the MMIO access
@@ -113,6 +90,7 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 {
 	union vhm_request_buffer *req_buf = NULL;
 	struct vhm_request *vhm_req;
+	bool is_polling = false;
 	uint16_t cur;
 
 	if (vcpu->vm->sw.io_shared_page == NULL) {
@@ -133,14 +111,17 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 		&io_req->reqs, sizeof(union vhm_io_request));
 	if (vcpu->vm->sw.is_completion_polling) {
 		vhm_req->completion_polling = 1U;
+		is_polling = true;
 	}
 	clac();
 
-	/* pause vcpu, wait for VHM to handle the MMIO request.
+	/* pause vcpu in notification mode , wait for VHM to handle the MMIO request.
 	 * TODO: when pause_vcpu changed to switch vcpu out directlly, we
 	 * should fix the race issue between req.processed update and vcpu pause
 	 */
-	pause_vcpu(vcpu, VCPU_PAUSED);
+	if (!is_polling) {
+		pause_vcpu(vcpu, VCPU_PAUSED);
+	}
 
 	/* Must clear the signal before we mark req as pending
 	 * Once we mark it pending, VHM may process req and signal us
@@ -157,6 +138,24 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 
 	/* signal VHM */
 	fire_vhm_interrupt();
+
+	/* Polling completion of the request in polling mode */
+	if (is_polling) {
+		/*
+		 * Now, we only have one case that will schedule out this vcpu
+		 * from IO completion polling status, it's pause_vcpu to VCPU_ZOMBIE.
+		 * In this case, we cannot come back to polling status again. Currently,
+		 * it's OK as we needn't handle IO completion in zombie status.
+		 */
+		while (!need_reschedule(vcpu->pcpu_id)) {
+			if (has_complete_ioreq(vcpu)) {
+				/* we have completed ioreq pending */
+				emulate_io_post(vcpu);
+				break;
+			}
+			asm_pause();
+		}
+	}
 
 	return 0;
 }

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -247,7 +247,7 @@ void asm_assert(int32_t line, const char *file, const char *txt)
 	show_host_call_trace(rsp, rbp, pcpu_id);
 	dump_guest_context(pcpu_id);
 	do {
-		pause_cpu();
+		asm_pause();
 	} while (1);
 }
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -306,12 +306,12 @@ static inline void cpu_msr_write(uint32_t reg, uint64_t msr_val)
 	asm volatile (" wrmsr " : : "c" (reg), "a" ((uint32_t)msr_val), "d" ((uint32_t)(msr_val >> 32U)));
 }
 
-static inline void pause_cpu(void)
+static inline void asm_pause(void)
 {
 	asm volatile ("pause" ::: "memory");
 }
 
-static inline void hlt_cpu(void)
+static inline void asm_hlt(void)
 {
 	asm volatile ("hlt");
 }

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -297,15 +297,6 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 void reset_vm_ioreqs(struct acrn_vm *vm);
 
 /**
- * @brief Handle completed ioreq if any one pending
- *
- * @param pcpu_id The physical cpu id of vcpu whose IO request to be checked
- *
- * @return None
- */
-void handle_complete_ioreq(uint16_t pcpu_id);
-
-/**
  * @brief Get the state of VHM request
  *
  * @param vm Target VM context

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -41,7 +41,7 @@ void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
 void remove_from_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
 
 void make_reschedule_request(uint16_t pcpu_id);
-int32_t need_reschedule(uint16_t pcpu_id);
+bool need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
 int32_t need_offline(uint16_t pcpu_id);
 

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -6,6 +6,7 @@
 
 #ifndef LOGMSG_H
 #define LOGMSG_H
+#include <cpu.h>
 
 /* Logging severity levels */
 #define LOG_FATAL		1U
@@ -116,6 +117,6 @@ void vprintf(const char *fmt, va_list args);
 #define panic(...) 							\
 	do { pr_fatal("PANIC: %s line: %d\n", __func__, __LINE__);	\
 		pr_fatal(__VA_ARGS__); 					\
-		while (1) { asm volatile ("pause" ::: "memory"); }; } while (0)
+		while (1) { asm_pause(); }; } while (0)
 
 #endif /* LOGMSG_H */


### PR DESCRIPTION
IO completion polling will access vcpu and vm structs. If doing it in idle
thread, there might be some race issues between vm destroying and idle
thread. They are running on different cores.
Got suggestion from Fengwei, decouple the polling action from idle thread
and just do it in vcpu thread, then we can guarantee idle thread in really idle
status.

Tracked-On: #1821 
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>