### PR TITLE
hv: vcpuid: cpuid leaf 07h has subleaf

### DIFF
--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -88,6 +88,8 @@
 #define CPUID_EBX_PQM           (1U<<12U)
 /* CPUID.07H:EBX.PQE */
 #define CPUID_EBX_PQE           (1U<<15U)
+/* CPUID.07H:EBX.INTEL_PROCESSOR_TRACE */
+#define CPUID_EBX_PROC_TRC      (1U<<25U)
 /* CPUID.01H:ECX.PCID*/
 #define CPUID_ECX_PCID          (1U<<17U)
 


### PR DESCRIPTION
Two changes:

1. cpuid leaf 07h has subleaf:
According to SDM 3-194 Vol.2A, Table 3-8, cpuid leaf 07h has sub-leaves.
cpuid.07.eax reports the maximum input for sub-leaves.
Since there is no definition for subleaf > 0 in SDM, hv only supports subleaf 0.

2. In currently hv code, cpuid leaf function 14h is disabled,
CPUID.07H:EBX.INTEL_PROCESSOR_TRACE should be disabled as well.

Tracked-On: #2198
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>