### PR TITLE
doc: add CSS for non-compliant code examples

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -61,6 +61,10 @@ div.rst-other-versions dl {
     color: #000000;
 }
 
+div.non-compliant-code div.highlight {
+   background: #f7d7d7;
+}
+
 /* Make the version number more visible */
 .wy-side-nav-search>div.version {
     color: rgba(255,255,255,1);


### PR DESCRIPTION
Coding guidelines have examples for compliant and non-compliant code,
but they look the same when rendered as HTML.  Add a CSS style for
non-compliant-code examples with a red-tinted background.

Usage is:
```
.. rst-class:: non-compliant-code

   .. code-block:: c

      a=b=c=0;
```
or, for example:

```
.. rst-class:: non-compliant-code

   Here's an example of non-compliant code::

      a=b=c=0;
```

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>