### PR TITLE
profiling: fix the profiling tool crash by page faults

### DIFF
--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -291,6 +291,7 @@ struct profiling_info_wrapper {
 	struct vm_switch_trace	vm_switch_trace;
 	socwatch_state			soc_state;
 	struct sw_msr_op_info	sw_msr_op_info;
+	spinlock_t		sw_lock;
 } __aligned(8);
 
 int32_t profiling_get_version_info(struct acrn_vm *vm, uint64_t addr);


### PR DESCRIPTION
Profiling tools are broken, which cause page faults during collection.
The issue happens by enabling SMAP recently. Therefore,
we use stac() and clac() to allow access to buffers allocated by guest.

Tacked-On: #2157
Signed-off-by: Min Lim <min.yeol.lim@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>