### PR TITLE
script: fix launch_uos script issue due to unseen character

### DIFF
--- a/devicemodel/samples/up2/launch_uos.sh
+++ b/devicemodel/samples/up2/launch_uos.sh
@@ -156,7 +156,7 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   $boot_ipu_option      \
   -i /run/acrn/ioc_$vm_name,0x20 \
   -l com2,/run/acrn/ioc_$vm_name \
-  --mac_seed $mac_seed \ 
+  --mac_seed $mac_seed \
   -B "root=/dev/vda2 rw rootwait maxcpus=$2 nohpet console=hvc0 \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 i915.enable_guc_loading=0 \
@@ -343,7 +343,7 @@ fi
    $boot_cse_option \
    $intr_storm_monitor \
    $boot_ipu_option      \
-   --mac_seed $mac_seed \ 
+   --mac_seed $mac_seed \
    -i /run/acrn/ioc_$vm_name,0x20 \
    -l com2,/run/acrn/ioc_$vm_name \
    $boot_image_option \


### PR DESCRIPTION
Space is tampered with unseen characters.

Tracked-On: #1995
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Signed-off-by: Tw <wei.tan@intel.com>