### PR TITLE
hv: fix mis-usage of "PAGE_SHIFT"

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -93,7 +93,7 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	bool phys;
 
 	/* get physical destination cpu mask */
-	dest = (uint32_t)(info->vmsi_addr >> PAGE_SHIFT) & 0xffU;
+	dest = (uint32_t)(info->vmsi_addr & MSI_ADDR_DEST) >> MSI_ADDR_DEST_SHIFT;
 	phys = ((info->vmsi_addr & MSI_ADDR_LOG) != MSI_ADDR_LOG);
 
 	calcvdest(vm, &vdmask, dest, phys);
@@ -114,7 +114,7 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	/* update physical dest mode & dest field */
 	info->pmsi_addr = info->vmsi_addr;
 	info->pmsi_addr &= ~0xFF00CU;
-	info->pmsi_addr |= (dest_mask << PAGE_SHIFT) | MSI_ADDR_RH | MSI_ADDR_LOG;
+	info->pmsi_addr |= (dest_mask << MSI_ADDR_DEST_SHIFT) | MSI_ADDR_RH | MSI_ADDR_LOG;
 
 	dev_dbg(ACRN_DBG_IRQ, "MSI addr:data = 0x%llx:%x(V) -> 0x%llx:%x(P)",
 		info->vmsi_addr, info->vmsi_data,

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -107,6 +107,9 @@ uint32_t irq_to_vector(uint32_t irq);
 #define	MSI_ADDR_BASE	0xfee00000UL
 #define	MSI_ADDR_RH	0x00000008UL	/* Redirection Hint */
 #define	MSI_ADDR_LOG	0x00000004UL	/* Destination Mode */
+#define	MSI_ADDR_DEST	0x000FF000UL	/* Destination Field */
+
+#define	MSI_ADDR_DEST_SHIFT	(12U)
 
 /* RFLAGS */
 #define HV_ARCH_VCPU_RFLAGS_IF              (1UL<<9U)


### PR DESCRIPTION
Replace PAGE_SHIFT with MSI_ADDR_DEST_SHIFT in ptirq_build_physical_msi(), since it's not correct in semantics.

Tracked-On: #2209
Signed-off-by: Yan, Like <like.yan@intel.com>