### PR TITLE
[backport stable] decouple IO completion polling from idle thread

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -412,7 +412,6 @@ handle_vmexit(struct vmctx *ctx, struct vhm_request *vhm_req, int vcpu)
 	}
 
 	(*handler[exitcode])(ctx, vhm_req, &vcpu);
-	atomic_store(&vhm_req->processed, REQ_STATE_COMPLETE);
 
 	/* We cannot notify the VHM/hypervisor on the request completion at this
 	 * point if the UOS is in suspend or system reset mode, as the VM is

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -386,6 +386,12 @@ vm_reset(struct vmctx *ctx)
 	ioctl(ctx->fd, IC_RESET_VM, &ctx->vmid);
 }
 
+void
+vm_clear_ioreq(struct vmctx *ctx)
+{
+	ioctl(ctx->fd, IC_CLEAR_VM_IOREQ, NULL);
+}
+
 static int suspend_mode = VM_SUSPEND_NONE;
 
 void

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -88,6 +88,7 @@
 #define IC_CREATE_IOREQ_CLIENT          _IC_ID(IC_ID, IC_ID_IOREQ_BASE + 0x02)
 #define IC_ATTACH_IOREQ_CLIENT          _IC_ID(IC_ID, IC_ID_IOREQ_BASE + 0x03)
 #define IC_DESTROY_IOREQ_CLIENT         _IC_ID(IC_ID, IC_ID_IOREQ_BASE + 0x04)
+#define IC_CLEAR_VM_IOREQ               _IC_ID(IC_ID, IC_ID_IOREQ_BASE + 0x05)
 
 /* Guest memory management */
 #define IC_ID_MEM_BASE                  0x40UL

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -98,6 +98,7 @@ int	vm_create_ioreq_client(struct vmctx *ctx);
 int	vm_destroy_ioreq_client(struct vmctx *ctx);
 int	vm_attach_ioreq_client(struct vmctx *ctx);
 int	vm_notify_request_done(struct vmctx *ctx, int vcpu);
+void	vm_clear_ioreq(struct vmctx *ctx);
 void	vm_set_suspend_mode(enum vm_suspend_how how);
 int	vm_get_suspend_mode(void);
 void	vm_destroy(struct vmctx *ctx);

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -152,7 +152,11 @@ void emulate_io_post(struct acrn_vcpu *vcpu)
 
 	switch (vcpu->req.type) {
 	case REQ_MMIO:
-		request_vcpu_pre_work(vcpu, ACRN_VCPU_MMIO_COMPLETE);
+		if (!vcpu->vm->sw.is_completion_polling) {
+			request_vcpu_pre_work(vcpu, ACRN_VCPU_MMIO_COMPLETE);
+		} else {
+			dm_emulate_mmio_post(vcpu);
+		}
 		break;
 
 	case REQ_PORTIO:
@@ -173,7 +177,10 @@ void emulate_io_post(struct acrn_vcpu *vcpu)
 		break;
 	}
 
-	resume_vcpu(vcpu);
+	if (!vcpu->vm->sw.is_completion_polling) {
+		resume_vcpu(vcpu);
+	}
+
 }
 
 /**

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -44,7 +44,7 @@ void vcpu_thread(struct acrn_vcpu *vcpu)
 			continue;
 		}
 
-		if (need_reschedule(vcpu->pcpu_id) != 0) {
+		if (need_reschedule(vcpu->pcpu_id)) {
 			/*
 			 * In extrem case, schedule() could return. Which
 			 * means the vcpu resume happens before schedule()

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -178,7 +178,6 @@ void default_idle(void)
 			cpu_dead();
 		} else {
 			CPU_IRQ_ENABLE();
-			handle_complete_ioreq(pcpu_id);
 			cpu_do_idle();
 			CPU_IRQ_DISABLE();
 		}

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -297,15 +297,6 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 void reset_vm_ioreqs(struct acrn_vm *vm);
 
 /**
- * @brief Handle completed ioreq if any one pending
- *
- * @param pcpu_id The physical cpu id of vcpu whose IO request to be checked
- *
- * @return None
- */
-void handle_complete_ioreq(uint16_t pcpu_id);
-
-/**
  * @brief Get the state of VHM request
  *
  * @param vm Target VM context

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -32,7 +32,7 @@ void remove_vcpu_from_runqueue(struct acrn_vcpu *vcpu);
 void default_idle(void);
 
 void make_reschedule_request(const struct acrn_vcpu *vcpu);
-int32_t need_reschedule(uint16_t pcpu_id);
+bool need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
 int32_t need_offline(uint16_t pcpu_id);
 


### PR DESCRIPTION
hv: decouple IO completion polling from idle thread
    
IO completion polling will access vcpu and vm structs. If doing it in
idle thread, there might be some race issues between vm destroying and
idle thread. They are running on different cores.
Got suggestion from Fengwei, decouple the polling action from idle
thread and just do it in vcpu thread, then we can guarantee idle thread
in really idle status.
    
Tracked-On: #1821
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>