### PR TITLE
 improve uart/vuart to support one binary on UEFI HW && refine cmdline cod

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -54,22 +54,6 @@ ptirq_lookup_entry_by_vpin(struct acrn_vm *vm, uint8_t virt_pin, bool pic_pin)
 	return entry;
 }
 
-#ifdef CONFIG_COM_IRQ
-static bool ptdev_hv_owned_intx(const struct acrn_vm *vm, const union source_id *virt_sid)
-{
-	bool ret;
-
-	/* vm0 vuart pin is owned by hypervisor under debug version */
-	if (is_vm0(vm) && (virt_sid->intx_id.pin == CONFIG_COM_IRQ)) {
-		ret = true;
-	} else {
-	        ret = false;
-	}
-
-	return ret;
-}
-#endif /* CONFIG_COM_IRQ */
-
 static uint64_t calculate_logical_dest_mask(uint64_t pdmask)
 {
 	uint64_t dest_mask = 0UL;
@@ -625,11 +609,9 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint8_t virt_pin, uint8_t vpin_
 	 */
 
 	/* no remap for hypervisor owned intx */
-#ifdef CONFIG_COM_IRQ
-	if (ptdev_hv_owned_intx(vm, &virt_sid)) {
+	if (is_vm0(vm) && hv_used_dbg_intx(virt_sid.intx_id.pin)) {
 		status = -ENODEV;
 	}
-#endif /* CONFIG_COM_IRQ */
 
 	if (status || (pic_pin && (virt_pin >= NR_VPIC_PINS_TOTAL))) {
 		status = -EINVAL;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -149,14 +149,16 @@ int32_t create_vm(struct vm_description *vm_desc, struct acrn_vm **rtn_vm)
 					register_pm1ab_handler(vm);
 				}
 
-				/* Create virtual uart */
-				vuart_init(vm);
+				/* Create virtual uart; just when uart enabled, vuart can work */
+				if (is_dbg_uart_enabled()) {
+					vuart_init(vm);
+				}
 			}
 			vpic_init(vm);
 
 #ifdef CONFIG_PARTITION_MODE
-			/* Create virtual uart */
-			if (vm_desc->vm_vuart) {
+			/* Create virtual uart; just when uart enabled, vuart can work */
+			if (vm_desc->vm_vuart && is_dbg_uart_enabled()) {
 				vuart_init(vm);
 			}
 			vrtc_init(vm);

--- a/hypervisor/bsp/uefi/cmdline.c
+++ b/hypervisor/bsp/uefi/cmdline.c
@@ -7,66 +7,7 @@
 #include <hypervisor.h>
 #include <multiboot.h>
 
-#define MAX_PORT			0x10000  /* port 0 - 64K */
-#define DEFAULT_UART_PORT	0x3F8
-
 #define ACRN_DBG_PARSE		6
-
-#define MAX_CMD_LEN		64
-
-static const char * const cmd_list[] = {
-	"uart=disabled",	/* to disable uart */
-	"uart=port@",		/* like uart=port@0x3F8 */
-	"uart=bdf@",	/*like: uart=bdf@0:18.2, it is for ttyS2 */
-
-	/* format: vuart=ttySx@irqN, like vuart=ttyS1@irq6; better to unify
-	 * uart & vuart & SOS console the same one, and irq same with the native.
-	 * ttySx range (0-3), irqN (0-255)
-	 */
-	"vuart=ttyS",
-};
-
-enum IDX_CMD {
-	IDX_DISABLE_UART,
-	IDX_PORT_UART,
-	IDX_PCI_UART,
-	IDX_SET_VUART,
-
-	IDX_MAX_CMD,
-};
-
-static void handle_cmd(const char *cmd, int32_t len)
-{
-	int32_t i;
-
-	for (i = 0; i < IDX_MAX_CMD; i++) {
-		int32_t tmp = strnlen_s(cmd_list[i], MAX_CMD_LEN);
-
-		/*cmd prefix should be same with one in cmd_list */
-		if (len < tmp)
-			continue;
-
-		if (strncmp(cmd_list[i], cmd, tmp) != 0)
-			continue;
-
-		if (i == IDX_DISABLE_UART) {
-			/* set uart disabled*/
-			uart16550_set_property(false, false, 0UL);
-		} else if (i == IDX_PORT_UART) {
-			uint64_t addr = strtoul_hex(cmd + tmp);
-			if (addr > MAX_PORT) {
-				addr = DEFAULT_UART_PORT;
-			}
-
-			uart16550_set_property(true, true, addr);
-
-		} else if (i == IDX_PCI_UART) {
-			uart16550_set_property(true, false, (uint64_t)(cmd+tmp));
-		} else if (i == IDX_SET_VUART) {
-			vuart_set_property(cmd+tmp);
-		}
-	}
-}
 
 int32_t parse_hv_cmdline(void)
 {
@@ -98,7 +39,9 @@ int32_t parse_hv_cmdline(void)
 		while (*end != ' ' && *end)
 			end++;
 
-		handle_cmd(start, end - start);
+		if (!handle_dbg_cmd(start, end - start)) {
+			/* if not handled by handle_dbg_cmd, it can be handled further */
+		}
 		start = end + 1;
 
 	} while (*end && *start);

--- a/hypervisor/bsp/uefi/cmdline.c
+++ b/hypervisor/bsp/uefi/cmdline.c
@@ -18,12 +18,19 @@ static const char * const cmd_list[] = {
 	"uart=disabled",	/* to disable uart */
 	"uart=port@",		/* like uart=port@0x3F8 */
 	"uart=bdf@",	/*like: uart=bdf@0:18.2, it is for ttyS2 */
+
+	/* format: vuart=ttySx@irqN, like vuart=ttyS1@irq6; better to unify
+	 * uart & vuart & SOS console the same one, and irq same with the native.
+	 * ttySx range (0-3), irqN (0-255)
+	 */
+	"vuart=ttyS",
 };
 
 enum IDX_CMD {
 	IDX_DISABLE_UART,
 	IDX_PORT_UART,
 	IDX_PCI_UART,
+	IDX_SET_VUART,
 
 	IDX_MAX_CMD,
 };
@@ -55,6 +62,8 @@ static void handle_cmd(const char *cmd, int32_t len)
 
 		} else if (i == IDX_PCI_UART) {
 			uart16550_set_property(true, false, (uint64_t)(cmd+tmp));
+		} else if (i == IDX_SET_VUART) {
+			vuart_set_property(cmd+tmp);
 		}
 	}
 }

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+
+#define MAX_PORT			0x10000  /* port 0 - 64K */
+#define DEFAULT_UART_PORT	0x3F8
+
+#define MAX_CMD_LEN		64
+
+static const char * const cmd_list[] = {
+	"uart=disabled",	/* to disable uart */
+	"uart=port@",		/* like uart=port@0x3F8 */
+	"uart=bdf@",	/*like: uart=bdf@0:18.2, it is for ttyS2 */
+
+	/* format: vuart=ttySx@irqN, like vuart=ttyS1@irq6; better to unify
+	 * uart & vuart & SOS console the same one, and irq same with the native.
+	 * ttySx range (0-3), irqN (0-255)
+	 */
+	"vuart=ttyS",
+};
+
+enum IDX_CMD_DBG {
+	IDX_DISABLE_UART,
+	IDX_PORT_UART,
+	IDX_PCI_UART,
+	IDX_SET_VUART,
+
+	IDX_MAX_CMD,
+};
+
+bool handle_dbg_cmd(const char *cmd, int32_t len)
+{
+	int32_t i;
+	bool handled = false;
+
+	for (i = 0; i < IDX_MAX_CMD; i++) {
+		int32_t tmp = strnlen_s(cmd_list[i], MAX_CMD_LEN);
+
+		/*cmd prefix should be same with one in cmd_list */
+		if (len < tmp)
+			continue;
+
+		if (strncmp(cmd_list[i], cmd, tmp) != 0)
+			continue;
+
+		if (i == IDX_DISABLE_UART) {
+			/* set uart disabled*/
+			uart16550_set_property(false, false, 0UL);
+		} else if (i == IDX_PORT_UART) {
+			uint64_t addr = strtoul_hex(cmd + tmp);
+
+			if (addr > MAX_PORT) {
+				addr = DEFAULT_UART_PORT;
+			}
+
+			uart16550_set_property(true, true, addr);
+
+		} else if (i == IDX_PCI_UART) {
+			uart16550_set_property(true, false, (uint64_t)(cmd+tmp));
+		} else if (i == IDX_SET_VUART) {
+			vuart_set_property(cmd+tmp);
+		}
+	}
+
+	if (i < IDX_MAX_CMD) {
+		handled = true;
+	}
+
+	return handled;
+}

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -235,3 +235,8 @@ bool is_pci_dbg_uart(union pci_bdf bdf_value)
 
 	return ret;
 }
+
+bool is_dbg_uart_enabled(void)
+{
+	return uart_enabled;
+}

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -408,3 +408,8 @@ void vuart_init(struct acrn_vm *vm)
 	vuart_lock_init(vu);
 	vuart_register_io_handler(vm);
 }
+
+bool hv_used_dbg_intx(uint8_t intx_pin)
+{
+	return is_dbg_uart_enabled() && (intx_pin == CONFIG_COM_IRQ);
+}

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -33,6 +33,8 @@
 
 #include "uart16550.h"
 
+static uint8_t vuart_com_irq =  CONFIG_COM_IRQ;
+static uint16_t vuart_com_base = CONFIG_COM_BASE;
 
 #ifndef CONFIG_PARTITION_MODE
 static char vuart_rx_buf[RX_BUF_SIZE];
@@ -111,8 +113,7 @@ static uint8_t vuart_intr_reason(const struct acrn_vuart *vu)
 {
 	if (((vu->lsr & LSR_OE) != 0U) && ((vu->ier & IER_ELSI) != 0U)) {
 		return IIR_RLS;
-	} else if ((fifo_numchars(&vu->rxfifo) > 0U) &&
-					((vu->ier & IER_ERBFI) != 0U)) {
+	} else if ((fifo_numchars(&vu->rxfifo) > 0U) && ((vu->ier & IER_ERBFI) != 0U)) {
 		return IIR_RXTOUT;
 	} else if (vu->thre_int_pending && ((vu->ier & IER_ETBEI) != 0U)) {
 		return IIR_TXRDY;
@@ -132,7 +133,7 @@ static void vuart_toggle_intr(const struct acrn_vuart *vu)
 	uint32_t operation;
 
 	intr_reason = vuart_intr_reason(vu);
-	vioapic_get_rte(vu->vm, CONFIG_COM_IRQ, &rte);
+	vioapic_get_rte(vu->vm, vuart_com_irq, &rte);
 
 	/* TODO:
 	 * Here should assert vuart irq according to CONFIG_COM_IRQ polarity.
@@ -143,15 +144,13 @@ static void vuart_toggle_intr(const struct acrn_vuart *vu)
 	 * we want to make it as an known issue.
 	 */
 	if ((rte.full & IOAPIC_RTE_INTPOL) != 0UL) {
-		operation = (intr_reason != IIR_NOPEND) ?
-				GSI_SET_LOW : GSI_SET_HIGH;
+		operation = (intr_reason != IIR_NOPEND) ? GSI_SET_LOW : GSI_SET_HIGH;
 	} else {
-		operation = (intr_reason != IIR_NOPEND) ?
-				GSI_SET_HIGH : GSI_SET_LOW;
+		operation = (intr_reason != IIR_NOPEND) ? GSI_SET_HIGH : GSI_SET_LOW;
 	}
 
-	vpic_set_irq(vu->vm, CONFIG_COM_IRQ, operation);
-	vioapic_set_irq(vu->vm, CONFIG_COM_IRQ, operation);
+	vpic_set_irq(vu->vm, vuart_com_irq, operation);
+	vioapic_set_irq(vu->vm, vuart_com_irq, operation);
 }
 
 static void vuart_write(struct acrn_vm *vm, uint16_t offset_arg,
@@ -202,8 +201,7 @@ static void vuart_write(struct acrn_vm *vm, uint16_t offset_arg,
 				fifo_reset(&vu->rxfifo);
 			}
 
-			vu->fcr = value_u8 &
-				(FCR_FIFOE | FCR_DMA | FCR_RX_MASK);
+			vu->fcr = value_u8 & (FCR_FIFOE | FCR_DMA | FCR_RX_MASK);
 		}
 		break;
 	case UART16550_LCR:
@@ -323,7 +321,7 @@ static void vuart_register_io_handler(struct acrn_vm *vm)
 {
 	struct vm_io_range range = {
 		.flags = IO_ATTR_RW,
-		.base = CONFIG_COM_BASE,
+		.base = vuart_com_base,
 		.len = 8U
 	};
 
@@ -402,7 +400,7 @@ void vuart_init(struct acrn_vm *vm)
 	vm->vuart.dlh = (uint8_t)(divisor >> 8U);
 
 	vm->vuart.active = false;
-	vm->vuart.base = CONFIG_COM_BASE;
+	vm->vuart.base = vuart_com_base;
 	vm->vuart.vm = vm;
 	vuart_fifo_init(vu);
 	vuart_lock_init(vu);
@@ -411,5 +409,5 @@ void vuart_init(struct acrn_vm *vm)
 
 bool hv_used_dbg_intx(uint8_t intx_pin)
 {
-	return is_dbg_uart_enabled() && (intx_pin == CONFIG_COM_IRQ);
+	return is_dbg_uart_enabled() && (intx_pin == vuart_com_irq);
 }

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -411,3 +411,19 @@ bool hv_used_dbg_intx(uint8_t intx_pin)
 {
 	return is_dbg_uart_enabled() && (intx_pin == vuart_com_irq);
 }
+
+/* vuart=ttySx@irqN, like vuart=ttyS1@irq6 head "vuart=ttyS" is parsed */
+void vuart_set_property(const char *vuart_info)
+{
+	const uint16_t com_map[4] = {0x3f8, 0x2F8, 0x3E8, 0x2E8}; /* map to ttyS0-ttyS3 */
+	uint8_t com_idx;
+
+	com_idx = (uint8_t)(vuart_info[0] - '0');
+	if (com_idx < 4) {
+		vuart_com_base = com_map[com_idx];
+	}
+
+	if (strncmp(vuart_info + 1, "@irq", 4) == 0) {
+		vuart_com_irq = (uint8_t)strtol_deci(vuart_info + 5);
+	}
+}

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -38,6 +38,7 @@ char console_getc(void);
 void console_setup_timer(void);
 void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr);
 bool is_pci_dbg_uart(union pci_bdf bdf_value);
+bool is_dbg_uart_enabled(void);
 
 void shell_init(void);
 void shell_kick(void);

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -46,4 +46,5 @@ void shell_kick(void);
 void suspend_console(void);
 void resume_console(void);
 
+bool handle_dbg_cmd(const char *cmd, int32_t len);
 #endif /* CONSOLE_H */

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -75,4 +75,5 @@ struct acrn_vuart *vuart_console_active(void);
 void vuart_console_tx_chars(struct acrn_vuart *vu);
 void vuart_console_rx_chars(struct acrn_vuart *vu);
 
+bool hv_used_dbg_intx(uint8_t intx_pin);
 #endif /* VUART_H */

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -76,4 +76,5 @@ void vuart_console_tx_chars(struct acrn_vuart *vu);
 void vuart_console_rx_chars(struct acrn_vuart *vu);
 
 bool hv_used_dbg_intx(uint8_t intx_pin);
+void vuart_set_property(const char *vuart_info);
 #endif /* VUART_H */

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -24,7 +24,7 @@ void console_setup_timer(void) {}
 void suspend_console(void) {}
 void resume_console(void) {}
 
-void uart16550_set_property(__unused bool enabled, __unused bool port_mapped, __unused uint64_t base_addr) {}
+bool handle_dbg_cmd(__unused const char *cmd, __unused int32_t len) { return false; }
 bool is_pci_dbg_uart(__unused union pci_bdf bdf_value) { return false; }
 bool is_dbg_uart_enabled(void) { return false; }
 

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -26,6 +26,7 @@ void resume_console(void) {}
 
 void uart16550_set_property(__unused bool enabled, __unused bool port_mapped, __unused uint64_t base_addr) {}
 bool is_pci_dbg_uart(__unused union pci_bdf bdf_value) { return false; }
+bool is_dbg_uart_enabled(void) { return false; }
 
 void shell_init(void) {}
 void shell_kick(void) {}

--- a/hypervisor/release/vuart.c
+++ b/hypervisor/release/vuart.c
@@ -20,5 +20,3 @@ bool hv_used_dbg_intx(__unused uint8_t intx_pin)
 {
 	return false;
 }
-
-void vuart_set_property(__unused const char *vuart_info) {}

--- a/hypervisor/release/vuart.c
+++ b/hypervisor/release/vuart.c
@@ -20,3 +20,5 @@ bool hv_used_dbg_intx(__unused uint8_t intx_pin)
 {
 	return false;
 }
+
+void vuart_set_property(__unused const char *vuart_info) {}

--- a/hypervisor/release/vuart.c
+++ b/hypervisor/release/vuart.c
@@ -15,3 +15,8 @@ struct acrn_vuart *vuart_console_active(void)
 
 void vuart_console_tx_chars(__unused struct acrn_vuart *vu) {}
 void vuart_console_rx_chars(__unused struct acrn_vuart *vu) {}
+
+bool hv_used_dbg_intx(__unused uint8_t intx_pin)
+{
+	return false;
+}


### PR DESCRIPTION
1. to support set vuart params by HV command line, so it can be configured dyanmically
through UEFI shell.

2. refine cmdline.c code.

V2-->V3: modify func name to hv_used_dbg_intx as Eddie' comments; add is_dbg_uart_enabled before vuart_init   as Anthony's comments.

V1-->V2: add a new patch as Eddie & Fei's comments, to move debug related command into ./debug/dbg_cmd.c

Tracked-On: #2170
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
