### PR TITLE
Fix RTC issues in ACPI

### DIFF
--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -200,7 +200,7 @@ pm1_enable_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 		 * the global lock, but ACPI-CA whines profusely if it
 		 * can't set GBL_EN.
 		 */
-		pm1_enable = *eax & (PM1_PWRBTN_EN | PM1_GBL_EN);
+		pm1_enable = *eax & (PM1_RTC_EN | PM1_PWRBTN_EN | PM1_GBL_EN);
 		sci_update(ctx);
 	}
 	pthread_mutex_unlock(&pm_lock);

--- a/devicemodel/hw/platform/rtc.c
+++ b/devicemodel/hw/platform/rtc.c
@@ -39,6 +39,8 @@
 #include "rtc.h"
 #include "mevent.h"
 #include "timer.h"
+#include "acpi.h"
+#include "lpc.h"
 
 /* #define DEBUG_RTC */
 #ifdef DEBUG_RTC
@@ -1178,3 +1180,27 @@ vrtc_deinit(struct vmctx *ctx)
 	free(vrtc);
 	ctx->vrtc = NULL;
 }
+
+static void
+rtc_dsdt(void)
+{
+	dsdt_line("");
+	dsdt_line("Device (RTC)");
+	dsdt_line("{");
+	dsdt_line("  Name (_HID, EisaId (\"PNP0B00\"))");
+	dsdt_line("  Name (_CRS, ResourceTemplate ()");
+	dsdt_line("  {");
+	dsdt_indent(2);
+	dsdt_fixed_ioport(IO_RTC, 2);
+	dsdt_fixed_irq(8);
+	dsdt_unindent(2);
+	dsdt_line("  })");
+	dsdt_line("}");
+}
+LPC_DSDT(rtc_dsdt);
+
+/*
+ * Reserve the extended RTC I/O ports although they are not emulated at this
+ * time.
+ */
+SYSRES_IO(0x72, 6);


### PR DESCRIPTION
Clear Linux complains about RTC in ACPI:

platform rtc_cmos: registered platform RTC device (no PNP device found)
ACPI Error: Could not enable RealTimeClock event (20180531/evxfevnt-184)
ACPI Warning: Could not enable fixed event - RealTimeClock (4) (20180531/evxface-620)
Tracked-On: #2176
Signed-off-by: Peter Fang <peter.fang@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>