### PR TITLE
coding style: use the defined data type and add `const` qualifier for some function

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -26,7 +26,8 @@ void destroy_ept(struct acrn_vm *vm)
 uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 {
 	uint64_t hpa = INVALID_HPA;
-	uint64_t *pgentry, pg_size = 0UL;
+	const uint64_t *pgentry;
+	uint64_t pg_size = 0UL;
 	void *eptp;
 	struct acrn_vcpu *vcpu = vcpu_from_pid(vm, get_cpu_id());
 

--- a/hypervisor/arch/x86/trusty.c
+++ b/hypervisor/arch/x86/trusty.c
@@ -8,8 +8,6 @@
 #include <crypto_api.h>
 #include <security.h>
 
-#define ACRN_DBG_TRUSTY 6U
-
 #define TRUSTY_VERSION   1U
 #define TRUSTY_VERSION_2 2U
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -235,7 +235,7 @@ extern uint64_t               secondary_cpu_stack[1];
 struct descriptor_table {
 	uint16_t limit;
 	uint64_t base;
-} __attribute__((packed));
+} __packed;
 
 /* CPU states defined */
 enum pcpu_boot_state {

--- a/hypervisor/include/arch/x86/guest/vm0_boot.h
+++ b/hypervisor/include/arch/x86/guest/vm0_boot.h
@@ -12,7 +12,7 @@ struct efi_context {
 	struct acrn_vcpu_regs vcpu_regs;
 	void *rsdp;
 	void *ap_trampoline_buf;
-}__attribute__((packed));
+} __packed;
 
 void *get_rsdp_from_uefi(void);
 void *get_ap_trampoline_buf(void);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -169,7 +169,7 @@ void invept(const struct acrn_vcpu *vcpu);
 /**
  *@pre (pml4_page != NULL) && (pg_size != NULL)
  */
-uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
+const uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, const struct memory_ops *mem_ops);
 
 /** Defines a single entry in an E820 memory map. */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -172,8 +172,6 @@ void invept(const struct acrn_vcpu *vcpu);
 uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, const struct memory_ops *mem_ops);
 
-#pragma pack(1)
-
 /** Defines a single entry in an E820 memory map. */
 struct e820_entry {
    /** The base address of the memory range. */
@@ -182,9 +180,7 @@ struct e820_entry {
 	uint64_t length;
    /** The type of memory region. */
 	uint32_t type;
-};
-
-#pragma pack()
+} __packed;
 
 /* E820 memory types */
 #define E820_TYPE_RAM		1U	/* EFI 1, 2, 3, 4, 5, 6, 7 */

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -55,7 +55,7 @@ struct per_cpu_region {
 #endif
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
-extern struct per_cpu_region per_cpu_data[];
+extern struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM];
 /*
  * get percpu data for pcpu_id.
  */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -394,7 +394,7 @@ struct acrn_descriptor_ptr {
 	uint16_t limit;
 	uint64_t base;
 	uint16_t reserved[3];   /* align struct size to 64bit */
-} __attribute__((packed));
+} __packed;
 
 /**
  * @brief registers info for vcpu.

--- a/hypervisor/partition/apl-mrb/mptable.c
+++ b/hypervisor/partition/apl-mrb/mptable.c
@@ -80,7 +80,7 @@ struct mpfps {
 	uint8_t	mpfb3;
 	uint8_t	mpfb4;
 	uint8_t	mpfb5;
-} __attribute__((packed));
+} __packed;
 
 /* MP Configuration Table Header */
 struct mpcth {
@@ -97,7 +97,7 @@ struct mpcth {
 	uint16_t extended_table_length;
 	uint8_t	extended_table_checksum;
 	uint8_t	reserved;
-} __attribute__((packed));
+} __packed;
 
 struct proc_entry {
 	uint8_t	type;
@@ -108,13 +108,13 @@ struct proc_entry {
 	uint32_t feature_flags;
 	uint32_t reserved1;
 	uint32_t reserved2;
-} __attribute__((packed));
+} __packed;
 
 struct bus_entry {
 	uint8_t	type;
 	uint8_t	bus_id;
 	uint8_t	bus_type[6];
-} __attribute__((packed));
+} __packed;
 
 struct int_entry {
 	uint8_t	type;
@@ -124,7 +124,7 @@ struct int_entry {
 	uint8_t	src_bus_irq;
 	uint8_t	dst_apic_id;
 	uint8_t	dst_apic_int;
-} __attribute__((packed));
+} __packed;
 
 struct mptable_info {
 	struct mpfps		mpfp;

--- a/hypervisor/partition/cb2_dnv/mptable.c
+++ b/hypervisor/partition/cb2_dnv/mptable.c
@@ -80,7 +80,7 @@ struct mpfps {
 	uint8_t	mpfb3;
 	uint8_t	mpfb4;
 	uint8_t	mpfb5;
-} __attribute__((packed));
+} __packed;
 
 /* MP Configuration Table Header */
 struct mpcth {
@@ -97,7 +97,7 @@ struct mpcth {
 	uint16_t extended_table_length;
 	uint8_t	extended_table_checksum;
 	uint8_t	reserved;
-} __attribute__((packed));
+} __packed;
 
 struct proc_entry {
 	uint8_t	type;
@@ -108,13 +108,13 @@ struct proc_entry {
 	uint32_t feature_flags;
 	uint32_t reserved1;
 	uint32_t reserved2;
-} __attribute__((packed));
+} __packed;
 
 struct bus_entry {
 	uint8_t	type;
 	uint8_t	bus_id;
 	uint8_t	bus_type[6];
-} __attribute__((packed));
+} __packed;
 
 struct int_entry {
 	uint8_t	type;
@@ -124,7 +124,7 @@ struct int_entry {
 	uint8_t	src_bus_irq;
 	uint8_t	dst_apic_id;
 	uint8_t	dst_apic_int;
-} __attribute__((packed));
+} __packed;
 
 struct mptable_info {
 	struct mpfps		mpfp;


### PR DESCRIPTION
    hv: coding style: use the defined data type __packed

    1) Use __attribute__((packed)) instead of #pragma pack(1)
    2) Use the defined data type __packed instead of __attribute__((packed))

    hv: coding style: add `const` qualifier for some function

    Add `const` qualifier for lookup_address and find_vcpuid_entry.

   Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>