### PR TITLE
dm: virtio: fix compile issue on ubuntu

### DIFF
--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -230,6 +230,14 @@ enum {
 #define	VIRTIO_DEV_COREU	0x8608
 
 /*
+ * VIRTIO_CONFIG_S_NEEDS_RESET is not defined
+ * in some environments's virtio_config.h
+ */
+#ifndef VIRTIO_CONFIG_S_NEEDS_RESET
+#define VIRTIO_CONFIG_S_NEEDS_RESET	0x40
+#endif
+
+/*
  * Bits in VIRTIO_PCI_ISR.  These apply only if not using MSI-X.
  *
  * (We don't [yet?] ever use CONF_CHANGED.)


### PR DESCRIPTION
As VIRTIO_CONFIG_S_NEEDS_RESET is not defined in standard virtio header
file on ubuntu, there will be compile issue. so add
VIRTIO_CONFIG_S_NEEDS_RESET to fix it.

Tracked-On: #2219 
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>