### PR TITLE
DOC: add vuart setting guide to avoid conflict

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -166,7 +166,7 @@ partition. Follow these steps:
       double-check the platform boot order using ``efibootmgr -v`` and
       modify it if needed.
 
-   The ACRN hypervisor (``acrn.efi``) accepts two command-line parameters that
+   The ACRN hypervisor (``acrn.efi``) accepts three command-line parameters that
    tweak its behaviour:
 
    1. ``bootloader=``: this sets the EFI executable to be loaded once the hypervisor
@@ -178,8 +178,13 @@ partition. Follow these steps:
 
       #. ``uart=disabled``: this disables the serial port completely
       #. ``uart=bdf@<BDF value>``:  this sets the PCI serial port based on its BDF.
-         For example, use ``bdf@0:18.2`` for a BDF of 0:18.2 ttyS2.
+         For example, use ``bdf@0:18.1`` for a BDF of 0:18.1 ttyS1.
       #. ``uart=port@<port address>``: this sets the serial port address
+   #. ``vuart=ttySn@irqN``: this tells the hypervisor which virtual serial device SOS
+      will use and its IRQ number. This is used to avoid conflict with SOS passthrough  
+      devices' interrupt. If UART is set to ttyS1, and its native IRQ is 5, you'd better
+      set ``vuart=ttyS1@irq5`` (Use 'dmesg | grep tty' to get IRQ information).
+      Also set ``console=ttyS1`` in ``acrn.conf`` to match the SOS boot args.
 
    Here is a more complete example of how to configure the EFI firmware to load the ACRN
    hypervisor and set these parameters.

--- a/doc/getting-started/up2.rst
+++ b/doc/getting-started/up2.rst
@@ -75,13 +75,15 @@ You will need to keep these in mind in a few places:
   .. code-block:: none
 
      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/mmcblk0 -p 1 -L "ACRN Hypervisor" \
-         -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=bdf@0:18.1"
+         -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=bdf@0:18.1 vuart=ttyS1@irq5"
 
 UP2 serial port setting
 =======================
 
-The serial port in the 40-pin HAT connector is located at ``serial PCI BDF 0:18.1``.
+The serial port (ttyS1) in the 40-pin HAT connector is located at ``serial PCI BDF 0:18.1``.
 You can check this from the ``lspci`` output from the initial Clearlinux installation.
+Also you can use ``dmesg | grep tty`` to get its IRQ infomation for vuart setting; and update
+SOS bootargs ``console=ttyS1`` in acrn.conf to match with vuart setting.
 
 .. code-block:: none
 
@@ -89,7 +91,11 @@ You can check this from the ``lspci`` output from the initial Clearlinux install
    00:18.0 . Series HSUART Controller #1 (rev 0b)
    00:18.1 . Series HSUART Controller #2 (rev 0b)
 
-The second entry associated with ``00:18.1`` is the one on the 40-pin HAT connector.
+   # dmesg | grep tty
+   dw-apb-uart.8: ttyS0 at MMIO 0x91524000 (irq = 4, base_baud = 115200) is a 16550A
+   dw-apb-uart.9: ttyS1 at MMIO 0x91522000 (irq = 5, base_baud = 115200) is a 16550A
+
+The second entry associated with ``00:18.1 @irq5`` is the one on the 40-pin HAT connector.
 
 UP2 block device
 ================


### PR DESCRIPTION
different serial devices could be used on different boards.
"vuart=ttySn@irqN" is used to avoid vuart's irq conflict
with SOS passthrough devices.

on UEFI platform, if ttyS1 used for debug uart, and its IRQ
on native OS is 5, you'd better set "vuart=ttyS1@irq5"; also
for its SOS bootargs in acrn.conf, you need set "console=ttyS1"
to match its vuart setting.

Tracked-On: #2170
Signed-off-by: Minggui Cao <minggui.cao@intel.com>