### PR TITLE
DM: xHCI: array bound checking before it is used

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -721,6 +721,9 @@ xhci_vbdp_thread(void *data)
 				break;
 			}
 
+		if (i >= XHCI_MAX_VIRT_PORTS)
+			continue;
+
 		j = pci_xhci_get_native_port_index_by_path(xdev,
 				&xdev->vbdp_devs[i].path);
 		if (j < 0)


### PR DESCRIPTION
Array index of "vbdp_devs" may be out of bounds if
"i >= XHCI_MAX_VIRT_PORTS", so index checking is necessary.

Tracked-On: #1252
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>