### PR TITLE
array bound checking before it is used

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -721,6 +721,9 @@ xhci_vbdp_thread(void *data)
 				break;
 			}
 
+		if (i >= XHCI_MAX_VIRT_PORTS)
+			continue;
+
 		j = pci_xhci_get_native_port_index_by_path(xdev,
 				&xdev->vbdp_devs[i].path);
 		if (j < 0)

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -337,7 +337,7 @@ config MTRR_ENABLED
 
 config RELOC
 	bool "Enable hypervisor relocation"
-	default n
+	default y
 	help
 	  When selected, the hypervisor will relocate itself to where it is
 	  loaded. This allows the bootloader to put the hypervisor image to


### PR DESCRIPTION
DM: xHCI: array bound checking before it is used 
Tracked-On: #1252
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>

Revert "EFI: Disable RELOC by default temporary" 
Tracked-On: #1122
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>