### PR TITLE
hv: virq: fix wrong coding style

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -402,7 +402,8 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 			flush_vpid_single(arch->vpid);
 		}
 
-		if (bitmap_test_and_clear_lock(ACRN_REQUEST_TMR_UPDATE,	pending_req_bits)) {				vioapic_update_tmr(vcpu);
+		if (bitmap_test_and_clear_lock(ACRN_REQUEST_TMR_UPDATE,	pending_req_bits)) {
+			vioapic_update_tmr(vcpu);
 		}
 
 		/* handling cancelled event injection when vcpu is switched out */


### PR DESCRIPTION
hypervisor/arch/x86/virq.c missed a new line at:

if (bitmap_test_and_clear_lock(...)) { vioapic_update_tmr(vcpu);

Tracked-On: #861
Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>