### PR TITLE
Rename several APIs for vpic and vioapic

### DIFF
--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -144,10 +144,10 @@ vLAPIC APIs.
 
 **Supported APIs:**
 
-.. doxygenfunction:: vioapic_set_irq
+.. doxygenfunction:: vioapic_set_irqline_lock
   :project: Project ACRN
 
-.. doxygenfunction:: vioapic_set_irq_nolock
+.. doxygenfunction:: vioapic_set_irqline_nolock
   :project: Project ACRN
 
 Virtual PIC
@@ -165,7 +165,7 @@ If an interrupt source from vPIC need to inject an interrupt, the
 following APIs need be called, which will finally make a request for
 *ACRN_REQUEST_EXTINT or ACRN_REQUEST_EVENT*:
 
-.. doxygenfunction:: vpic_set_irq
+.. doxygenfunction:: vpic_set_irqline
   :project: Project ACRN
 
 The following APIs are used to query the vector needed to be injected and ACK

--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -124,16 +124,12 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* init polarity & pin state */
 		if ((rte.full & IOAPIC_RTE_INTPOL) != 0UL) {
 			if (entry->polarity == 0U) {
-				vioapic_set_irqline_nolock(vm,
-					(uint32_t)virt_sid->intx_id.pin,
-					GSI_SET_HIGH);
+				vioapic_set_irqline_nolock(vm, virt_sid->intx_id.pin, GSI_SET_HIGH);
 			}
 			entry->polarity = 1U;
 		} else {
 			if (entry->polarity == 1U) {
-				vioapic_set_irqline_nolock(vm,
-					(uint32_t)virt_sid->intx_id.pin,
-					GSI_SET_LOW);
+				vioapic_set_irqline_nolock(vm, virt_sid->intx_id.pin, GSI_SET_LOW);
 			}
 			entry->polarity = 0U;
 		}
@@ -171,7 +167,7 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* just update trigger mode */
 		ioapic_get_rte(phys_irq, &phys_rte);
 		rte.full = phys_rte.full & (~IOAPIC_RTE_TRGRMOD);
-		vpic_get_irqline_trigger_mode(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
+		vpic_get_irqline_trigger_mode(vm, virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
 			rte.full |= IOAPIC_RTE_TRGRLVL;
 		}
@@ -377,15 +373,15 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 
 		if (trigger_lvl) {
 			if (entry->polarity != 0U) {
-				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_LOW);
+				vioapic_set_irqline_lock(vm, virt_sid->intx_id.pin, GSI_SET_LOW);
 			} else {
-				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_HIGH);
+				vioapic_set_irqline_lock(vm, virt_sid->intx_id.pin, GSI_SET_HIGH);
 			}
 		} else {
 			if (entry->polarity != 0U) {
-				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_FALLING_PULSE);
+				vioapic_set_irqline_lock(vm, virt_sid->intx_id.pin, GSI_FALLING_PULSE);
 			} else {
-				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_RAISING_PULSE);
+				vioapic_set_irqline_lock(vm, virt_sid->intx_id.pin, GSI_RAISING_PULSE);
 			}
 		}
 
@@ -401,11 +397,11 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 		enum vpic_trigger trigger;
 
 		/* VPIN_PIC src means we have vpic enabled */
-		vpic_get_irqline_trigger_mode(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
+		vpic_get_irqline_trigger_mode(vm, virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
-			vpic_set_irqline(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_HIGH);
+			vpic_set_irqline(vm, virt_sid->intx_id.pin, GSI_SET_HIGH);
 		} else {
-			vpic_set_irqline(vm, (uint32_t)virt_sid->intx_id.pin, GSI_RAISING_PULSE);
+			vpic_set_irqline(vm, virt_sid->intx_id.pin, GSI_RAISING_PULSE);
 		}
 		break;
 	}
@@ -459,7 +455,7 @@ void ptirq_softirq(uint16_t pcpu_id)
 	}
 }
 
-void ptirq_intx_ack(struct acrn_vm *vm, uint8_t virt_pin,
+void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin,
 		uint8_t vpin_src)
 {
 	uint32_t phys_irq;

--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -124,14 +124,14 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* init polarity & pin state */
 		if ((rte.full & IOAPIC_RTE_INTPOL) != 0UL) {
 			if (entry->polarity == 0U) {
-				vioapic_set_irq_nolock(vm,
+				vioapic_set_irqline_nolock(vm,
 					(uint32_t)virt_sid->intx_id.pin,
 					GSI_SET_HIGH);
 			}
 			entry->polarity = 1U;
 		} else {
 			if (entry->polarity == 1U) {
-				vioapic_set_irq_nolock(vm,
+				vioapic_set_irqline_nolock(vm,
 					(uint32_t)virt_sid->intx_id.pin,
 					GSI_SET_LOW);
 			}
@@ -171,7 +171,7 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* just update trigger mode */
 		ioapic_get_rte(phys_irq, &phys_rte);
 		rte.full = phys_rte.full & (~IOAPIC_RTE_TRGRMOD);
-		vpic_get_irq_trigger(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
+		vpic_get_irqline_trigger_mode(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
 			rte.full |= IOAPIC_RTE_TRGRLVL;
 		}
@@ -377,15 +377,15 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 
 		if (trigger_lvl) {
 			if (entry->polarity != 0U) {
-				vioapic_set_irq(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_LOW);
+				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_LOW);
 			} else {
-				vioapic_set_irq(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_HIGH);
+				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_HIGH);
 			}
 		} else {
 			if (entry->polarity != 0U) {
-				vioapic_set_irq(vm, (uint32_t)virt_sid->intx_id.pin, GSI_FALLING_PULSE);
+				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_FALLING_PULSE);
 			} else {
-				vioapic_set_irq(vm, (uint32_t)virt_sid->intx_id.pin, GSI_RAISING_PULSE);
+				vioapic_set_irqline_lock(vm, (uint32_t)virt_sid->intx_id.pin, GSI_RAISING_PULSE);
 			}
 		}
 
@@ -401,11 +401,11 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 		enum vpic_trigger trigger;
 
 		/* VPIN_PIC src means we have vpic enabled */
-		vpic_get_irq_trigger(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
+		vpic_get_irqline_trigger_mode(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
-			vpic_set_irq(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_HIGH);
+			vpic_set_irqline(vm, (uint32_t)virt_sid->intx_id.pin, GSI_SET_HIGH);
 		} else {
-			vpic_set_irq(vm, (uint32_t)virt_sid->intx_id.pin, GSI_RAISING_PULSE);
+			vpic_set_irqline(vm, (uint32_t)virt_sid->intx_id.pin, GSI_RAISING_PULSE);
 		}
 		break;
 	}
@@ -476,13 +476,13 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint8_t virt_pin,
 		switch (vpin_src) {
 		case PTDEV_VPIN_IOAPIC:
 			if (entry->polarity != 0U) {
-				vioapic_set_irq(vm, virt_pin, GSI_SET_HIGH);
+				vioapic_set_irqline_lock(vm, virt_pin, GSI_SET_HIGH);
 			} else {
-				vioapic_set_irq(vm, virt_pin, GSI_SET_LOW);
+				vioapic_set_irqline_lock(vm, virt_pin, GSI_SET_LOW);
 			}
 			break;
 		case PTDEV_VPIN_PIC:
-			vpic_set_irq(vm, virt_pin, GSI_SET_LOW);
+			vpic_set_irqline(vm, virt_pin, GSI_SET_LOW);
 			break;
 		default:
 			/*

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -356,11 +356,11 @@ int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 			 * number #2 to PIC IRQ #0.
 			 */
 			irq_pic = (ops->gsi == 2U) ? 0U : ops->gsi;
-			vpic_set_irq(target_vm, irq_pic, ops->op);
+			vpic_set_irqline(target_vm, irq_pic, ops->op);
 	        }
 
 		/* handle IOAPIC irqline */
-		vioapic_set_irq(target_vm, ops->gsi, ops->op);
+		vioapic_set_irqline_lock(target_vm, ops->gsi, ops->op);
 		ret = 0;
 	}
 

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -149,8 +149,8 @@ static void vuart_toggle_intr(const struct acrn_vuart *vu)
 		operation = (intr_reason != IIR_NOPEND) ? GSI_SET_HIGH : GSI_SET_LOW;
 	}
 
-	vpic_set_irq(vu->vm, vuart_com_irq, operation);
-	vioapic_set_irq(vu->vm, vuart_com_irq, operation);
+	vpic_set_irqline(vu->vm, vuart_com_irq, operation);
+	vioapic_set_irqline_lock(vu->vm, vuart_com_irq, operation);
 }
 
 static void vuart_write(struct acrn_vm *vm, uint16_t offset_arg,

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -78,7 +78,7 @@ vioapic_generate_intr(struct acrn_vioapic *vioapic, uint32_t pin)
  * @pre pin < vioapic_pincount(vm)
  */
 static void
-vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint16_t pin, uint32_t level)
+vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
 {
 	uint32_t old_lvl;
 	union ioapic_rte rte;
@@ -112,18 +112,18 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint16_t pin, uint32_t level)
  * operation be done with ioapic lock.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irq < vioapic_pincount(vm)
+ * @pre irqline < vioapic_pincount(vm)
  * @return None
  */
 void
-vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
+vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic;
-	uint16_t pin = (uint16_t)irq;
+	uint32_t pin = irqline;
 
 	vioapic = vm_ioapic(vm);
 
@@ -154,21 +154,21 @@ vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
  * @brief Set vIOAPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irq < vioapic_pincount(vm)
+ * @pre irqline < vioapic_pincount(vm)
  *
  * @return None
  */
 void
-vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
+vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic = vm_ioapic(vm);
 
 	spinlock_obtain(&(vioapic->mtx));
-	vioapic_set_irqline_nolock(vm, irq, operation);
+	vioapic_set_irqline_nolock(vm, irqline, operation);
 	spinlock_release(&(vioapic->mtx));
 }
 
@@ -467,7 +467,7 @@ vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
 			continue;
 		}
 
-		ptirq_intx_ack(vm, (uint8_t)pin, PTDEV_VPIN_IOAPIC);
+		ptirq_intx_ack(vm, pin, PTDEV_VPIN_IOAPIC);
 	}
 
 	/*

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -205,7 +205,7 @@ static void vpic_notify_intr(struct acrn_vpic *vpic)
 			 * to vioapic pin0 (irq2)
 			 * From MPSpec session 5.1
 			 */
-			vioapic_set_irq(vpic->vm, 0U, GSI_RAISING_PULSE);
+			vioapic_set_irqline_lock(vpic->vm, 0U, GSI_RAISING_PULSE);
 		}
 	} else {
 		dev_dbg(ACRN_DBG_PIC,
@@ -455,7 +455,7 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint8_t pin,
  *
  * @return None
  */
-void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
+void vpic_set_irqline(struct acrn_vm *vm, uint32_t irq, uint32_t operation)
 {
 	struct acrn_vpic *vpic;
 	struct i8259_reg_state *i8259;
@@ -505,7 +505,7 @@ vpic_pincount(void)
  * @pre vm->vpic != NULL
  * @pre irq < NR_VPIC_PINS_TOTAL
  */
-void vpic_get_irq_trigger(struct acrn_vm *vm, uint32_t irq,
+void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irq,
 		enum vpic_trigger *trigger)
 {
 	struct acrn_vpic *vpic;

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -36,7 +36,7 @@
  * @pre vm != NULL
  *
  */
-void ptirq_intx_ack(struct acrn_vm *vm, uint8_t virt_pin, uint8_t vpin_src);
+void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint8_t vpin_src);
 
 /**
  * @brief MSI/MSI-x remapping for passthrough device.

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -74,15 +74,15 @@ void	vioapic_reset(struct acrn_vioapic *vioapic);
  * @brief Set vIOAPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irq < vioapic_pincount(vm)
+ * @pre irqline < vioapic_pincount(vm)
  *
  * @return None
  */
-void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Set vIOAPIC IRQ line status.
@@ -91,14 +91,14 @@ void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irq, uint32_t operati
  * operation be done with ioapic lock.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irq < vioapic_pincount(vm)
+ * @pre irqline < vioapic_pincount(vm)
  * @return None
  */
-void	vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -82,12 +82,12 @@ void	vioapic_reset(struct acrn_vioapic *vioapic);
  *
  * @return None
  */
-void	vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 
 /**
  * @brief Set vIOAPIC IRQ line status.
  *
- * Similar with vioapic_set_irq(),but would not make sure
+ * Similar with vioapic_set_irqline_lock(),but would not make sure
  * operation be done with ioapic lock.
  *
  * @param[in] vm        Pointer to target VM
@@ -98,7 +98,7 @@ void	vioapic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
  * @pre irq < vioapic_pincount(vm)
  * @return None
  */
-void	vioapic_set_irq_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -144,13 +144,13 @@ void vpic_init(struct acrn_vm *vm);
  * @brief Set vPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @return None
  */
-void vpic_set_irqline(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void vpic_set_irqline(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
@@ -174,7 +174,7 @@ void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
  * @pre vm != NULL
  */
 void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector);
-void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irq, enum vpic_trigger *trigger);
+void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irqline, enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
 
 /**

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -150,7 +150,7 @@ void vpic_init(struct acrn_vm *vm);
  *
  * @return None
  */
-void vpic_set_irq(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void vpic_set_irqline(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
@@ -174,8 +174,7 @@ void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
  * @pre vm != NULL
  */
 void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector);
-void vpic_get_irq_trigger(struct acrn_vm *vm, uint32_t irq,
-	enum vpic_trigger *trigger);
+void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irq, enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
 
 /**

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -24,15 +24,16 @@ union source_id (name) = {.msi_id = {.bdf = (a), .entry_nr = (b)} }
 union source_id (name) = {.intx_id = {.pin = (a), .src = (b)} }
 
 union source_id {
-	uint32_t value;
+	uint64_t value;
 	struct {
 		uint16_t bdf;
 		uint16_t entry_nr;
+		uint32_t reserved;
 	} msi_id;
 	struct {
-		uint8_t pin;
+		uint32_t pin;
 		uint8_t src;
-		uint16_t reserved;
+		uint8_t reserved[3];
 	} intx_id;
 };
 


### PR DESCRIPTION
-- Rename some APIs for vpic and vioapic
-- Unify the type to uint32_t for interrupt pin

Tracked-On: #1842