### PR TITLE
dm: acpi: add PSDS table in ACPI table

### DIFF
--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -42,6 +42,7 @@
 
 /* All dynamic table entry no. */
 #define NHLT_ENTRY_NO		8
+#define PSDS_ENTRY_NO		10
 
 void acpi_table_enable(int num);
 uint32_t get_acpi_base(void);


### PR DESCRIPTION
Expose a new ACPI table PSDS to UOS.
This PSDS table show the security capability of the VM.
Only enable this table in UOS when PSDS presented in SOS.

Tracked-On: #2241
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>