### PR TITLE
hv: rename register_io_emulation_handler

### DIFF
--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -187,7 +187,7 @@ static void register_gas_io_handler(struct acrn_vm *vm, uint32_t pio_idx, const 
 		gas_io.base = (uint16_t)gas->address;
 		gas_io.len = io_len[gas->access_size];
 
-		register_io_emulation_handler(vm, pio_idx, &gas_io, &pm1ab_io_read, &pm1ab_io_write);
+		register_pio_emulation_handler(vm, pio_idx, &gas_io, &pm1ab_io_read, &pm1ab_io_write);
 
 		pr_dbg("Enable PM1A trap for VM %d, port 0x%x, size %d\n", vm->vm_id, gas_io.base, gas_io.len);
 	}

--- a/hypervisor/arch/x86/io.c
+++ b/hypervisor/arch/x86/io.c
@@ -467,7 +467,7 @@ void setup_io_bitmap(struct acrn_vm *vm)
  * @param io_write_fn_ptr The handler for emulating writes to the given range
  * @pre pio_idx < EMUL_PIO_IDX_MAX
  */
-void register_io_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
+void register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
 		const struct vm_io_range *range, io_read_fn_t io_read_fn_ptr, io_write_fn_t io_write_fn_ptr)
 {
 	if (is_vm0(vm)) {

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -325,7 +325,7 @@ static void vuart_register_io_handler(struct acrn_vm *vm)
 		.len = 8U
 	};
 
-	register_io_emulation_handler(vm, UART_PIO_IDX, &range, vuart_read, vuart_write);
+	register_pio_emulation_handler(vm, UART_PIO_IDX, &range, vuart_read, vuart_write);
 }
 
 /**

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -128,11 +128,11 @@ void vpci_init(struct acrn_vm *vm)
 		 * UOS or partition mode: register handler for CF8 only and I/O requests to CF9/CFA/CFB are
 		 *      not handled by vpci.
 		 */
-		register_io_emulation_handler(vm, PCI_CFGADDR_PIO_IDX, &pci_cfgaddr_range,
+		register_pio_emulation_handler(vm, PCI_CFGADDR_PIO_IDX, &pci_cfgaddr_range,
 			pci_cfgaddr_io_read, pci_cfgaddr_io_write);
 
 		/* Intercept and handle I/O ports CFC -- CFF */
-		register_io_emulation_handler(vm, PCI_CFGDATA_PIO_IDX, &pci_cfgdata_range,
+		register_pio_emulation_handler(vm, PCI_CFGDATA_PIO_IDX, &pci_cfgdata_range,
 			pci_cfgdata_io_read, pci_cfgdata_io_write);
 	}
 }

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -872,11 +872,11 @@ static void vpic_register_io_handler(struct acrn_vm *vm)
 		.len = 2U
 	};
 
-	register_io_emulation_handler(vm, PIC_MASTER_PIO_IDX, &master_range,
+	register_pio_emulation_handler(vm, PIC_MASTER_PIO_IDX, &master_range,
 			vpic_master_io_read, vpic_master_io_write);
-	register_io_emulation_handler(vm, PIC_SLAVE_PIO_IDX, &slave_range,
+	register_pio_emulation_handler(vm, PIC_SLAVE_PIO_IDX, &slave_range,
 			vpic_slave_io_read, vpic_slave_io_write);
-	register_io_emulation_handler(vm, PIC_ELC_PIO_IDX, &elcr_range,
+	register_pio_emulation_handler(vm, PIC_ELC_PIO_IDX, &elcr_range,
 			vpic_elc_io_read, vpic_elc_io_write);
 }
 

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -77,5 +77,5 @@ void vrtc_init(struct acrn_vm *vm)
 	/* Initializing the CMOS RAM offset to 0U */
 	vm->vrtc_offset = 0U;
 
-	register_io_emulation_handler(vm, RTC_PIO_IDX, &range, vrtc_read, vrtc_write);
+	register_pio_emulation_handler(vm, RTC_PIO_IDX, &range, vrtc_read, vrtc_write);
 }

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -206,7 +206,7 @@ void   allow_guest_pio_access(struct acrn_vm *vm, uint16_t port_address,
  * @param io_write_fn_ptr The handler for emulating writes to the given range
  * @pre pio_idx < EMUL_PIO_IDX_MAX
  */
-void   register_io_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
+void   register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
 		const struct vm_io_range *range, io_read_fn_t io_read_fn_ptr, io_write_fn_t io_write_fn_ptr);
 
 /**


### PR DESCRIPTION
This patch renames `register_io_emulation_handler` to
`register_pio_emulation_handler`.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>