### PR TITLE
DM: Try to load audio mediator BE driver before starting UOS

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -10,6 +10,10 @@ if [ ! -e "/dev/vbs_ipu" ]; then
 ipu_passthrough=1
 fi
 
+# use the modprobe to force loading snd-soc-skl/sst_bxt_bdf8532
+modprobe -q snd-soc-skl
+modprobe -q snd-soc-sst_bxt_tdf8532
+
 audio_passthrough=0
 
 # Check the device file of /dev/vbs_k_audio to determine the audio mode


### PR DESCRIPTION
Currently whether audio works in virtio mediator or pass-through mode can be determined
by checking the device file of vbs_k_audio

But before the completion of loading audio virtio-BE module, the device file of /dev/vbs_k_audio
doesn't exist. In such case in course of loading UOS, the incorrect work mode is selected
for audio device (passthru instead of mediator). This is incorrect

Tracked-On: projectacrn/acrn-hypervisor#2247
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Signed-off-by: Alek Du <alek.du@intel.com>