### PR TITLE
hv: coding style: remove basic type declaration use

### DIFF
--- a/hypervisor/include/arch/x86/cpu_caps.h
+++ b/hypervisor/include/arch/x86/cpu_caps.h
@@ -47,7 +47,7 @@ void init_cpu_capabilities(void);
 void init_cpu_model_name(void);
 bool check_cpu_security_cap(void);
 void cpu_l1d_flush(void);
-int detect_hardware_support(void);
+int32_t detect_hardware_support(void);
 struct cpuinfo_x86 *get_cpu_info(void);
 
 #endif /* CPUINFO_H */

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -477,10 +477,10 @@ void do_print(const char *fmt_arg, struct print_param *param,
 				if ((param->vars.flags &
 					PRINT_FLAG_LONG_LONG) != 0U) {
 					print_decimal(param,
-						__builtin_va_arg(args, long));
+						__builtin_va_arg(args, int64_t));
 				} else {
 					print_decimal(param,
-						__builtin_va_arg(args, int));
+						__builtin_va_arg(args, int32_t));
 				}
 			}
 			/* unsigned decimal number */
@@ -526,7 +526,7 @@ void do_print(const char *fmt_arg, struct print_param *param,
 			else if (ch == 'c') {
 				char c[2];
 
-				c[0] = __builtin_va_arg(args, int);
+				c[0] = __builtin_va_arg(args, int32_t);
 				c[1] = 0;
 				print_string(param, c);
 			}


### PR DESCRIPTION
Typedefs that indicate size and signedness should be used in place of
the basic numerical types

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>