### PR TITLE
tools: acrn-crashlog: Reboot system to cold after collecting reserve log

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/channels.c
+++ b/tools/acrn-crashlog/acrnprobe/channels.c
@@ -111,10 +111,6 @@ static void channel_oneshot(struct channel_t *cnl)
 	if (!is_boot_id_changed())
 		return;
 
-	e = create_event(REBOOT, cname, NULL, 0, NULL, 0);
-	if (e)
-		event_enqueue(e);
-
 	for_each_crash(id, crash, conf) {
 		if (!crash || !is_root_crash(crash))
 			continue;
@@ -146,6 +142,10 @@ static void channel_oneshot(struct channel_t *cnl)
 			}
 		}
 	}
+
+	e = create_event(REBOOT, cname, NULL, 0, NULL, 0);
+	if (e)
+		event_enqueue(e);
 
 	for_each_info(id, info, conf) {
 		if (!info)


### PR DESCRIPTION
After panic, kernel will do warm boot to reserve memory for log collecting.
Need to cold reboot system as the original behaviour.

Tracked-On:#1024
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Acked-by: Chen, Gang <gang.c.chen@intel.com>