### PR TITLE
Documentation: fix highlights in launch_uos.sh script

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -333,7 +333,7 @@ Set up Reference UOS
    .. literalinclude:: ../../devicemodel/samples/nuc/launch_uos.sh
       :caption: devicemodel/samples/nuc/launch_uos.sh
       :language: bash
-      :emphasize-lines: 23,25
+      :emphasize-lines: 24,27
 
    .. note::
       In case you have downloaded a different Clear Linux image than the one above


### PR DESCRIPTION
The couple of lines highlighted in the launch_uos.sh script are off
since the latest modifications made to that script. Fix them both
to highlight the correct script lines that require attention.

Tracked-On: #2270
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>