### PR TITLE
tools: acrn-crashlog: Limit the log size of kmsg

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -57,6 +57,8 @@ struct log_t {
 	size_t		path_len;
 	const char	*lines;
 	size_t		lines_len;
+	const char	*sizelimit;
+	size_t		sizelimit_len;
 
 	void (*get)(struct log_t *, void *);
 };

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -73,6 +73,7 @@ static void print(void)
 		print_id_item(type, log, id);
 		print_id_item(lines, log, id);
 		print_id_item(path, log, id);
+		print_id_item(sizelimit, log, id);
 	}
 
 	for_each_info(id, info, conf) {
@@ -466,6 +467,8 @@ static int parse_log(xmlNodePtr cur, struct log_t *log)
 			res = load_cur_content(cur, log, path);
 		else if (name_is(cur, "lines"))
 			res = load_cur_content(cur, log, lines);
+		else if (name_is(cur, "sizelimit"))
+			res = load_cur_content(cur, log, sizelimit);
 
 		if (res)
 			return -1;

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -123,9 +123,10 @@ static void get_log_file(const char *despath, const char *srcpath,
 		get_log_file_complete(despath, srcpath);
 }
 
-static void get_log_node(const char *despath, const char *nodepath)
+static void get_log_node(const char *despath, const char *nodepath,
+			size_t sizelimit)
 {
-	const int res = do_copy_eof(nodepath, despath);
+	const int res = do_copy_limit(nodepath, despath, sizelimit);
 
 	if (res < 0) {
 		LOGE("copy (%s) failed, error (%s)\n", nodepath,
@@ -156,8 +157,17 @@ static void get_log_by_type(const char *despath, const struct log_t *log,
 			if (cfg_atoi(log->lines, log->lines_len, &lines) == -1)
 				return;
 		get_log_file(despath, srcpath, lines);
-	} else if (!strcmp("node", log->type))
-		get_log_node(despath, log->path);
+	} else if (!strcmp("node", log->type)) {
+		int size;
+
+		if (!log->sizelimit)
+			size = 0;
+		else
+			if (cfg_atoi(log->sizelimit, log->sizelimit_len,
+				     &size) == -1)
+				return;
+		get_log_node(despath, log->path, (size_t)(size * 1024 * 1024));
+	}
 	else if (!strcmp("cmd", log->type))
 		get_log_cmd(despath, log->path);
 }

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -92,7 +92,7 @@ void file_reset_init(const char *filename);
 int file_read_int(const char *filename, unsigned int *pcurrent);
 int file_update_int(const char *filename, unsigned int current,
 			unsigned int max);
-int do_copy_eof(const char *src, const char *des);
+int do_copy_limit(const char *src, const char *des, size_t limitsize);
 int space_available(const char *path, int quota);
 int count_lines_in_file(const char *filename);
 int read_full_binary_file(const char *path, unsigned long *size,

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -72,8 +72,9 @@
 		</log>
 		<log id='2' enable='true'>
 			<name>kmsg</name>
-			<type>cmd</type>
-			<path>dmesg</path>
+			<type>node</type>
+			<path>/dev/kmsg</path>
+			<sizelimit>2</sizelimit>
 		</log>
 		<log id='3' enable='true'>
 			<name>cmdline</name>


### PR DESCRIPTION
Dmesg collects too much log when kernel meets log storm.
This patch reads kernel log from "/dev/kmsg" intead of dmesg and limits
the generated log size.

Tracked-On: #1024
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Acked-by: Chen, Gang <gang.c.chen@intel.com>