### PR TITLE
Makefile: specify BOARD&FIRMWARE in sb-hypervisor-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ ifeq ($(PLATFORM),uefi)
 endif
 
 sbl-hypervisor-install:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
+	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) install
 
 devicemodel-install:
 	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install


### PR DESCRIPTION
BOARD&FIRMWARE are wrong When 'make sbl-hypervisor-install' w/o parameters
due to default platform is uefi. So set them clearly.

Tracked-On: #1995
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>