### PR TITLE
hv: emulate IA32_FEATURE_CONTROL MSR

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -32,7 +32,8 @@ static const uint32_t emulated_guest_msrs[NUM_GUEST_MSRS] = {
 	MSR_IA32_BIOS_SIGN_ID,
 	MSR_IA32_TIME_STAMP_COUNTER,
 	MSR_IA32_APIC_BASE,
-	MSR_IA32_PERF_CTL
+	MSR_IA32_PERF_CTL,
+	MSR_IA32_FEATURE_CONTROL,
 };
 
 #define NUM_MTRR_MSRS	13U
@@ -424,6 +425,11 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 		err = vlapic_rdmsr(vcpu, msr, &v);
 		break;
 	}
+	case MSR_IA32_FEATURE_CONTROL:
+	{
+		v = MSR_IA32_FEATURE_CONTROL_LOCK;
+		break;
+	}
 	default:
 	{
 		if (is_x2apic_msr(msr)) {
@@ -568,6 +574,11 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	case MSR_IA32_APIC_BASE:
 	{
 		err = vlapic_wrmsr(vcpu, msr, v);
+		break;
+	}
+	case MSR_IA32_FEATURE_CONTROL:
+	{
+		err = -EACCES;
 		break;
 	}
 	default:

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -166,7 +166,7 @@ struct ext_context {
 #define SECURE_WORLD	1
 
 #define NUM_WORLD_MSRS		2U
-#define NUM_COMMON_MSRS		6U
+#define NUM_COMMON_MSRS		7U
 #define NUM_GUEST_MSRS		(NUM_WORLD_MSRS + NUM_COMMON_MSRS)
 
 struct event_injection_info {


### PR DESCRIPTION
All features controlled by IA32_FEATURE_CONTROL are disabled from guests,
so set the Lock bit to prevent it from writing by guests.

Also hide the MSR_IA32_FEATURE_CONTROL_VMX_NO_SMX bit from guest.

Tracked-On: #1867
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>