### PR TITLE
IOC mediator: fix the issue of abnormally missing tx package

### DIFF
--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1166,6 +1166,7 @@ ioc_build_request(struct ioc_dev *ioc, int32_t link_len, int32_t srv_len)
 	}
 	req->srv_len = srv_len;
 	req->link_len = link_len;
+	req->rtype = CBC_REQ_T_PROT;
 	cbc_request_enqueue(ioc, req, CBC_QUEUE_T_RX, false);
 }
 


### PR DESCRIPTION
The issue will result in the loss of wakeup reason and signal
data, because the CBC header was not added when generating the
tx package.

Tracked-On: #2282
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>