### PR TITLE
hv: vlapic: code clean-up

### DIFF
--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -94,12 +94,6 @@ an interrupt, for example:
 
 These APIs will finish by making a request for *ACRN_REQUEST_EVENT.*
 
-.. doxygenfunction:: vlapic_intr_level
-  :project: Project ACRN
-
-.. doxygenfunction:: vlapic_intr_edge
-  :project: Project ACRN
-
 .. doxygenfunction:: vlapic_intr_accepted
   :project: Project ACRN
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -384,7 +384,7 @@ void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx)
 	vcpu = per_cpu(vcpu, get_cpu_id());
 	if (vr < VECTOR_FIXED_START) {
 		send_lapic_eoi();
-		vlapic_intr_edge(vcpu, vr);
+		vlapic_set_intr(vcpu, vr, LAPIC_TRIG_EDGE);
 	} else {
 		dispatch_interrupt(ctx);
 	}

--- a/hypervisor/boot/uefi/uefi_boot.c
+++ b/hypervisor/boot/uefi/uefi_boot.c
@@ -17,7 +17,7 @@ static void efi_spurious_handler(int32_t vector)
 		struct acrn_vcpu *vcpu = per_cpu(vcpu, BOOT_CPU_ID);
 
 		if (vcpu != NULL) {
-			vlapic_set_intr(vcpu, vector, 0);
+			vlapic_set_intr(vcpu, vector, LAPIC_TRIG_EDGE);
 		} else {
 			pr_err("%s vcpu or vlapic is not ready, interrupt lost\n", __func__);
 		}

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -22,7 +22,7 @@ static void fire_vhm_interrupt(void)
 
 	vcpu = vcpu_from_vid(vm0, 0U);
 
-	vlapic_intr_edge(vcpu, acrn_vhm_vector);
+	vlapic_set_intr(vcpu, acrn_vhm_vector, LAPIC_TRIG_EDGE);
 }
 
 #if defined(HV_DEBUG)

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -194,31 +194,6 @@ void vlapic_set_intr(struct acrn_vcpu *vcpu, uint32_t vector, bool level);
 
 #define	LAPIC_TRIG_LEVEL	true
 #define	LAPIC_TRIG_EDGE		false
-/**
- * @brief Pend level-trigger mode virtual interrupt to vCPU.
- *
- * @param[in] vcpu    Pointer to target vCPU data structure
- * @param[in] vector  Vector to be injected.
- *
- */
-static inline void
-vlapic_intr_level(struct acrn_vcpu *vcpu, uint32_t vector)
-{
-	vlapic_set_intr(vcpu, vector, LAPIC_TRIG_LEVEL);
-}
-
-/**
- * @brief Pend edge-trigger mode virtual interrupt to vCPU.
- *
- * @param[in] vcpu    Pointer to target vCPU data structure
- * @param[in] vector  Vector to be injected.
- *
- */
-static inline void
-vlapic_intr_edge(struct acrn_vcpu *vcpu, uint32_t vector)
-{
-	vlapic_set_intr(vcpu, vector, LAPIC_TRIG_EDGE);
-}
 
 /**
  * @brief Triggers LAPIC local interrupt(LVT).


### PR DESCRIPTION
 * rename `vlapic_set_intr_ready` to `vlapic_accept_intr`
 * replace calling of `vlapic_intr_edge` with `vlapic_set_intr`
 * remove `vlapic_intr_level` and `vlapic_intr_edge`

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>