### PR TITLE
cleanup the data type for interrupt pin

### DIFF
--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -8,7 +8,6 @@
 #include <ioapic.h>
 
 #define	IOAPIC_MAX_PIN		240U
-#define IOAPIC_INVALID_PIN      0xffU
 
 /*
  * IOAPIC_MAX_LINES is architecturally defined.
@@ -86,7 +85,7 @@ static const uint32_t pic_ioapic_pin_map[NR_LEGACY_PIN] = {
 
 uint32_t get_pic_pin_from_ioapic_pin(uint32_t pin_index)
 {
-	uint32_t pin_id = IOAPIC_INVALID_PIN;
+	uint32_t pin_id = INVALID_INTERRUPT_PIN;
 	if (pin_index < NR_LEGACY_PIN) {
 		pin_id = pic_ioapic_pin_map[pin_index];
 	}
@@ -284,7 +283,7 @@ uint32_t ioapic_irq_to_pin(uint32_t irq)
 	if (ioapic_irq_is_gsi(irq)) {
 		ret = gsi_table_data[irq].pin;
 	} else {
-	        ret = IOAPIC_INVALID_PIN;
+		ret = INVALID_INTERRUPT_PIN;
 	}
 
 	return ret;
@@ -292,7 +291,7 @@ uint32_t ioapic_irq_to_pin(uint32_t irq)
 
 bool ioapic_is_pin_valid(uint32_t pin)
 {
-	return (pin != IOAPIC_INVALID_PIN);
+	return (pin != INVALID_INTERRUPT_PIN);
 }
 
 uint32_t ioapic_pin_to_irq(uint32_t pin)

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -906,7 +906,7 @@ static int32_t shell_show_cpu_int(__unused int32_t argc, __unused char **argv)
 #define PTDEV_INVALID_PIN 0xffU
 static void get_entry_info(const struct ptirq_remapping_info *entry, char *type,
 		uint32_t *irq, uint32_t *vector, uint64_t *dest, bool *lvl_tm,
-		uint8_t *pin, uint8_t *vpin, uint32_t *bdf, uint32_t *vbdf)
+		uint32_t *pin, uint32_t *vpin, uint32_t *bdf, uint32_t *vbdf)
 {
 	if (is_entry_active(entry)) {
 		if (entry->intr_type == PTDEV_INTR_MSI) {
@@ -967,7 +967,7 @@ static void get_ptdev_info(char *str_arg, size_t str_max)
 	char type[16];
 	uint64_t dest;
 	bool lvl_tm;
-	uint8_t pin, vpin;
+	uint32_t pin, vpin;
 	uint32_t bdf, vbdf;
 
 	len = snprintf(str, size, "\r\nVM\tTYPE\tIRQ\tVEC\tDEST\tTM\tPIN\tVPIN\tBDF\tVBDF");
@@ -1133,8 +1133,8 @@ static int32_t get_ioapic_info(char *str_arg, size_t str_max_len)
 
 	ioapic_nr_gsi = ioapic_get_nr_gsi ();
 	for (irq = 0U; irq < ioapic_nr_gsi; irq++) {
-		void *addr = ioapic_get_gsi_irq_addr (irq);
-		uint8_t pin = ioapic_irq_to_pin (irq);
+		void *addr = ioapic_get_gsi_irq_addr(irq);
+		uint32_t pin = ioapic_irq_to_pin(irq);
 		union ioapic_rte rte;
 
 		bool irr, phys, level, mask;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -903,7 +903,6 @@ static int32_t shell_show_cpu_int(__unused int32_t argc, __unused char **argv)
 	return 0;
 }
 
-#define PTDEV_INVALID_PIN 0xffU
 static void get_entry_info(const struct ptirq_remapping_info *entry, char *type,
 		uint32_t *irq, uint32_t *vector, uint64_t *dest, bool *lvl_tm,
 		uint32_t *pin, uint32_t *vpin, uint32_t *bdf, uint32_t *vbdf)
@@ -917,8 +916,8 @@ static void get_entry_info(const struct ptirq_remapping_info *entry, char *type,
 			} else {
 				*lvl_tm = false;
 			}
-			*pin = PTDEV_INVALID_PIN;
-			*vpin = PTDEV_INVALID_PIN;
+			*pin = INVALID_INTERRUPT_PIN;
+			*vpin = INVALID_INTERRUPT_PIN;
 			*bdf = entry->phys_sid.msi_id.bdf;
 			*vbdf = entry->virt_sid.msi_id.bdf;
 		} else {

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -33,7 +33,7 @@
 
 #include "uart16550.h"
 
-static uint8_t vuart_com_irq =  CONFIG_COM_IRQ;
+static uint32_t vuart_com_irq =  CONFIG_COM_IRQ;
 static uint16_t vuart_com_base = CONFIG_COM_BASE;
 
 #ifndef CONFIG_PARTITION_MODE
@@ -407,7 +407,7 @@ void vuart_init(struct acrn_vm *vm)
 	vuart_register_io_handler(vm);
 }
 
-bool hv_used_dbg_intx(uint8_t intx_pin)
+bool hv_used_dbg_intx(uint32_t intx_pin)
 {
 	return is_dbg_uart_enabled() && (intx_pin == vuart_com_irq);
 }

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -49,7 +49,7 @@ static inline bool master_pic(const struct acrn_vpic *vpic, struct i8259_reg_sta
 static inline uint32_t vpic_get_highest_isrpin(const struct i8259_reg_state *i8259)
 {
 	uint32_t bit, pin, i;
-	uint32_t found_pin = VPIC_INVALID_PIN;
+	uint32_t found_pin = INVALID_INTERRUPT_PIN;
 
 	pin = (i8259->lowprio + 1U) & 0x7U;
 
@@ -79,7 +79,7 @@ static inline uint32_t vpic_get_highest_irrpin(const struct i8259_reg_state *i82
 {
 	uint8_t serviced;
 	uint32_t bit, pin, tmp;
-	uint32_t found_pin = VPIC_INVALID_PIN;
+	uint32_t found_pin = INVALID_INTERRUPT_PIN;
 
 	/*
 	 * In 'Special Fully-Nested Mode' when an interrupt request from

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -36,7 +36,7 @@
  * @pre vm != NULL
  *
  */
-void ptirq_intx_ack(struct acrn_vm *vm, uint8_t virt_pin, uint8_t vpin_src);
+void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
 
 /**
  * @brief MSI/MSI-x remapping for passthrough device.
@@ -81,7 +81,7 @@ int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t entry_n
  * @pre vm != NULL
  *
  */
-int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint8_t virt_pin, uint8_t vpin_src);
+int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
 
 /**
  * @brief Add an interrupt remapping entry for INTx as pre-hold mapping.
@@ -103,7 +103,7 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint8_t virt_pin, uint8_t vpin_
  * @pre vm != NULL
  *
  */
-int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint8_t virt_pin, uint8_t phys_pin, bool pic_pin);
+int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, uint32_t phys_pin, bool pic_pin);
 
 /**
  * @brief Remove an interrupt remapping entry for INTx.
@@ -119,7 +119,7 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint8_t virt_pin, uint8_t p
  * @pre vm != NULL
  *
  */
-void ptirq_remove_intx_remapping(struct acrn_vm *vm, uint8_t virt_pin, bool pic_pin);
+void ptirq_remove_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, bool pic_pin);
 
 /**
  * @brief Add interrupt remapping entry/entries for MSI/MSI-x as pre-hold mapping.

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -74,15 +74,15 @@ void	vioapic_reset(struct acrn_vioapic *vioapic);
  * @brief Set vIOAPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irq < vioapic_pincount(vm)
+ * @pre irqline < vioapic_pincount(vm)
  *
  * @return None
  */
-void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Set vIOAPIC IRQ line status.
@@ -91,14 +91,14 @@ void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irq, uint32_t operati
  * operation be done with ioapic lock.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irq < vioapic_pincount(vm)
+ * @pre irqline < vioapic_pincount(vm)
  * @return None
  */
-void	vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void	vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -118,7 +118,7 @@ struct i8259_reg_state {
 	uint8_t		smm;		/* special mask mode */
 
 	uint8_t		pin_state[8];	/* pin state for level */
-	uint8_t		lowprio;	/* lowest priority irq */
+	uint32_t	lowprio;	/* lowest priority irq */
 
 	bool		intr_raised;
 	uint8_t		elc;
@@ -144,13 +144,13 @@ void vpic_init(struct acrn_vm *vm);
  * @brief Set vPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irq       Target IRQ number
+ * @param[in] irqline   Target IRQ number
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @return None
  */
-void vpic_set_irqline(struct acrn_vm *vm, uint32_t irq, uint32_t operation);
+void vpic_set_irqline(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
@@ -174,7 +174,7 @@ void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
  * @pre vm != NULL
  */
 void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector);
-void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irq, enum vpic_trigger *trigger);
+void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irqline, enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
 
 /**

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -94,7 +94,6 @@
 
 #define NR_VPIC_PINS_PER_CHIP	8U
 #define NR_VPIC_PINS_TOTAL	16U
-#define VPIC_INVALID_PIN	0xffU
 
 enum vpic_trigger {
 	EDGE_TRIGGER,

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -14,14 +14,14 @@
 void ioapic_setup_irqs(void);
 
 bool ioapic_irq_is_gsi(uint32_t irq);
-uint8_t ioapic_irq_to_pin(uint32_t irq);
+uint32_t ioapic_irq_to_pin(uint32_t irq);
 
 /**
  * @brief Get irq num from pin num
  *
  * @param[in]	pin The pin number
  */
-uint32_t ioapic_pin_to_irq(uint8_t pin);
+uint32_t ioapic_pin_to_irq(uint32_t pin);
 
 /**
  * @brief Set the redirection table entry
@@ -51,17 +51,17 @@ void resume_ioapic(void);
 void ioapic_gsi_mask_irq(uint32_t irq);
 void ioapic_gsi_unmask_irq(uint32_t irq);
 
-void ioapic_get_rte_entry(void *ioapic_addr, uint8_t pin, union ioapic_rte *rte);
+void ioapic_get_rte_entry(void *ioapic_addr, uint32_t pin, union ioapic_rte *rte);
 
 struct gsi_table {
 	uint8_t ioapic_id;
-	uint8_t pin;
+	uint32_t pin;
 	void  *addr;
 };
 
 void *ioapic_get_gsi_irq_addr(uint32_t irq_num);
 uint32_t ioapic_get_nr_gsi(void);
-uint8_t get_pic_pin_from_ioapic_pin(uint8_t pin_index);
-bool ioapic_is_pin_valid(uint8_t pin);
+uint32_t get_pic_pin_from_ioapic_pin(uint32_t pin_index);
+bool ioapic_is_pin_valid(uint32_t pin);
 
 #endif /* IOAPIC_H */

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -54,6 +54,8 @@
 
 #define IRQ_ALLOC_BITMAP_SIZE	INT_DIV_ROUNDUP(NR_IRQS, 64U)
 
+#define INVALID_INTERRUPT_PIN	0xffffffffU
+
 /*
  * Definition of the stack frame layout
  */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -24,15 +24,15 @@ union source_id (name) = {.msi_id = {.bdf = (a), .entry_nr = (b)} }
 union source_id (name) = {.intx_id = {.pin = (a), .src = (b)} }
 
 union source_id {
-	uint32_t value;
+	uint64_t value;
 	struct {
 		uint16_t bdf;
 		uint16_t entry_nr;
+		uint32_t reserved;
 	} msi_id;
 	struct {
-		uint8_t pin;
-		uint8_t src;
-		uint16_t reserved;
+		uint32_t pin;
+		uint32_t src;
 	} intx_id;
 };
 

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -75,6 +75,6 @@ struct acrn_vuart *vuart_console_active(void);
 void vuart_console_tx_chars(struct acrn_vuart *vu);
 void vuart_console_rx_chars(struct acrn_vuart *vu);
 
-bool hv_used_dbg_intx(uint8_t intx_pin);
+bool hv_used_dbg_intx(uint32_t intx_pin);
 void vuart_set_property(const char *vuart_info);
 #endif /* VUART_H */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -246,30 +246,24 @@ struct hc_ptdev_irq {
 	/** physical BDF of the ptdev */
 	uint16_t phys_bdf;
 
-	union {
+	union irq_source {
 		/** INTX remapping info */
-		struct {
+		struct intx_info {
 			/** virtual IOAPIC/PIC pin */
-			uint8_t virt_pin;
-
-			/** Reserved */
-			uint32_t reserved0:24;
+			uint32_t virt_pin;
 
 			/** physical IOAPIC pin */
-			uint8_t phys_pin;
-
-			/** Reserved */
-			uint32_t reserved1:24;
+			uint32_t phys_pin;
 
 			/** is virtual pin from PIC */
 			bool pic_pin;
 
 			/** Reserved */
-			uint32_t reserved2:24;
+			uint8_t reserved[3];
 		} intx;
 
 		/** MSIx remapping info */
-		struct {
+		struct msix_info {
 			/** vector count of MSI/MSIX */
 			uint32_t vector_cnt;
 		} msix;

--- a/hypervisor/release/vuart.c
+++ b/hypervisor/release/vuart.c
@@ -16,7 +16,7 @@ struct acrn_vuart *vuart_console_active(void)
 void vuart_console_tx_chars(__unused struct acrn_vuart *vu) {}
 void vuart_console_rx_chars(__unused struct acrn_vuart *vu) {}
 
-bool hv_used_dbg_intx(__unused uint8_t intx_pin)
+bool hv_used_dbg_intx(__unused uint32_t intx_pin)
 {
 	return false;
 }


### PR DESCRIPTION
-- change the type from uint8_t to uint32_t
-- unify the MACRO for invalid interrupt pin

Tracked-On: #861