### PR TITLE
hv: fix MISRA-C violations in dm/vpci

### DIFF
--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -49,10 +49,10 @@ static struct pci_vdev *partition_mode_find_vdev(struct acrn_vpci *vpci, union p
 	return NULL;
 }
 
-static int32_t partition_mode_vpci_init(struct acrn_vm *vm)
+static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
-	struct acrn_vpci *vpci = &vm->vpci;
+	const struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_vdev *vdev;
 	int32_t i;
 
@@ -73,7 +73,7 @@ static int32_t partition_mode_vpci_init(struct acrn_vm *vm)
 	return 0;
 }
 
-static void partition_mode_vpci_deinit(struct acrn_vm *vm)
+static void partition_mode_vpci_deinit(const struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
 	struct pci_vdev *vdev;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -102,7 +102,7 @@ static void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf
 	}
 }
 
-static struct pci_vdev *alloc_pci_vdev(struct acrn_vm *vm, union pci_bdf bdf)
+static struct pci_vdev *alloc_pci_vdev(const struct acrn_vm *vm, union pci_bdf bdf)
 {
 	struct pci_vdev *vdev;
 
@@ -121,9 +121,9 @@ static struct pci_vdev *alloc_pci_vdev(struct acrn_vm *vm, union pci_bdf bdf)
 	return vdev;
 }
 
-static void enumerate_pci_dev(uint16_t pbdf, void *cb_data)
+static void enumerate_pci_dev(uint16_t pbdf, const void *cb_data)
 {
-	struct acrn_vm *vm = (struct acrn_vm *)cb_data;
+	const struct acrn_vm *vm = (const struct acrn_vm *)cb_data;
 	struct pci_vdev *vdev;
 
 	vdev = alloc_pci_vdev(vm, (union pci_bdf)pbdf);
@@ -132,7 +132,7 @@ static void enumerate_pci_dev(uint16_t pbdf, void *cb_data)
 	}
 }
 
-static int32_t sharing_mode_vpci_init(struct acrn_vm *vm)
+static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i, j;
@@ -150,7 +150,7 @@ static int32_t sharing_mode_vpci_init(struct acrn_vm *vm)
 		(void)memset((void *)sharing_mode_vdev_array, 0U, sizeof(sharing_mode_vdev_array));
 
 		/* build up vdev array for vm0 */
-		pci_scan_bus(enumerate_pci_dev, (void *)vm);
+		pci_scan_bus(enumerate_pci_dev, vm);
 
 		for (i = 0U; i < num_pci_vdev; i++) {
 			vdev = &sharing_mode_vdev_array[i];
@@ -166,7 +166,7 @@ static int32_t sharing_mode_vpci_init(struct acrn_vm *vm)
 	return ret;
 }
 
-static void sharing_mode_vpci_deinit(__unused struct acrn_vm *vm)
+static void sharing_mode_vpci_deinit(__unused const struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i, j;
@@ -229,7 +229,10 @@ void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, 
 		/* Return this PCI device to SOS */
 		if (vdev->vpci->vm == target_vm) {
 			vm = get_vm_from_vmid(0U);
-			vdev->vpci = &vm->vpci;
+
+			if (vm != NULL) {
+				vdev->vpci = &vm->vpci;
+			}
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -137,9 +137,9 @@ void vpci_init(struct acrn_vm *vm)
 	}
 }
 
-void vpci_cleanup(struct acrn_vm *vm)
+void vpci_cleanup(const struct acrn_vm *vm)
 {
-	struct acrn_vpci *vpci = &vm->vpci;
+	const struct acrn_vpci *vpci = &vm->vpci;
 
 	if ((vpci->ops != NULL) && (vpci->ops->deinit != NULL)) {
 		vpci->ops->deinit(vm);

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -120,7 +120,7 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable)
 #define BUS_SCAN_SKIP		0U
 #define BUS_SCAN_PENDING	1U
 #define BUS_SCAN_COMPLETE	2U
-void pci_scan_bus(pci_enumeration_cb cb_func, void *cb_data)
+void pci_scan_bus(pci_enumeration_cb cb_func, const void *cb_data)
 {
 	union pci_bdf pbdf;
 	uint8_t hdr_type, secondary_bus, dev, func;

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -138,7 +138,7 @@ enum pci_bar_type {
 	PCIBAR_MEM64,
 };
 
-typedef void (*pci_enumeration_cb)(uint16_t pbdf, void *data);
+typedef void (*pci_enumeration_cb)(uint16_t pbdf, const void *data);
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {
@@ -178,6 +178,6 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
-void pci_scan_bus(pci_enumeration_cb cb, void *cb_data);
+void pci_scan_bus(pci_enumeration_cb cb, const void *cb_data);
 
 #endif /* PCI_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -101,7 +101,7 @@ struct pci_vdev {
 	const struct pci_vdev_ops *ops;
 #endif
 
-	struct acrn_vpci *vpci;
+	const struct acrn_vpci *vpci;
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf vbdf;
 
@@ -125,8 +125,8 @@ struct pci_addr_info {
 };
 
 struct vpci_ops {
-	int32_t (*init)(struct acrn_vm *vm);
-	void (*deinit)(struct acrn_vm *vm);
+	int32_t (*init)(const struct acrn_vm *vm);
+	void (*deinit)(const struct acrn_vm *vm);
 	void (*cfgread)(struct acrn_vpci *vpci, union pci_bdf vbdf, uint32_t offset,
 		uint32_t bytes, uint32_t *val);
 	void (*cfgwrite)(struct acrn_vpci *vpci, union pci_bdf vbdf, uint32_t offset,
@@ -146,7 +146,7 @@ extern const struct pci_vdev_ops pci_ops_vdev_pt;
 #endif
 
 void vpci_init(struct acrn_vm *vm);
-void vpci_cleanup(struct acrn_vm *vm);
+void vpci_cleanup(const struct acrn_vm *vm);
 void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 


### PR DESCRIPTION
120D: Pointer param should be declared pointer to const.
  Add 'const' qualifier to function parameters whenever it's possible:
    alloc_pci_vdev()
    enumerate_pci_dev()
    pci_scan_bus()
    pci_enumeration_cb()
    partition_mode_vpci_init()
    partition_mode_vpci_deinit()
    sharing_mode_vpci_init()
    sharing_mode_vpci_deinit()
    vpci_cleanup()

45D: Pointer not checked for null before use.
  Check pointer vm in vpci_reset_ptdev_intr_info() before using it.

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>