### PR TITLE
hv: fix MISRA-C violations in vpic.c and vioapic.c

### DIFF
--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -119,7 +119,7 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
  * @return None
  */
 void
-vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
+vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic;
 	uint32_t pin = irqline;
@@ -162,7 +162,7 @@ vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irqline, uint32_t operat
  * @return None
  */
 void
-vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
+vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic = vm_ioapic(vm);
 

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -33,7 +33,7 @@
 
 static void vpic_set_pinstate(struct acrn_vpic *vpic, uint32_t pin, uint8_t level);
 
-static inline bool master_pic(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259)
+static inline bool master_pic(const struct acrn_vpic *vpic, const struct i8259_reg_state *i8259)
 {
 	bool ret;
 
@@ -232,7 +232,7 @@ static int32_t vpic_icw1(const struct acrn_vpic *vpic, struct i8259_reg_state *i
 	i8259->poll = false;
 	i8259->smm = 0U;
 
-	if ((val & ICW1_SNGL) != 0) {
+	if ((val & ICW1_SNGL) != 0U) {
 		dev_dbg(ACRN_DBG_PIC, "vpic cascade mode required\n");
 		ret = -1;
 	} else if ((val & ICW1_IC4) == 0U) {
@@ -341,7 +341,7 @@ static int32_t vpic_ocw1(const struct acrn_vpic *vpic, struct i8259_reg_state *i
 	return 0;
 }
 
-static int32_t vpic_ocw2(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int32_t vpic_ocw2(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: i8259 ocw2 0x%x\n",
 		vpic->vm, val);
@@ -382,7 +382,7 @@ static int32_t vpic_ocw2(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, 
 	return 0;
 }
 
-static int32_t vpic_ocw3(struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
+static int32_t vpic_ocw3(const struct acrn_vpic *vpic, struct i8259_reg_state *i8259, uint8_t val)
 {
 	dev_dbg(ACRN_DBG_PIC, "vm 0x%x: i8259 ocw3 0x%x\n",
 		vpic->vm, val);
@@ -453,7 +453,7 @@ static void vpic_set_pinstate(struct acrn_vpic *vpic, uint32_t pin, uint8_t leve
  *
  * @return None
  */
-void vpic_set_irqline(struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
+void vpic_set_irqline(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
 {
 	struct acrn_vpic *vpic;
 	struct i8259_reg_state *i8259;
@@ -503,7 +503,7 @@ vpic_pincount(void)
  * @pre vm->vpic != NULL
  * @pre irqline < NR_VPIC_PINS_TOTAL
  */
-void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irqline,
+void vpic_get_irqline_trigger_mode(const struct acrn_vm *vm, uint32_t irqline,
 		enum vpic_trigger *trigger)
 {
 	struct acrn_vpic *vpic;

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -82,7 +82,7 @@ void	vioapic_reset(struct acrn_vioapic *vioapic);
  *
  * @return None
  */
-void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
+void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Set vIOAPIC IRQ line status.
@@ -98,7 +98,7 @@ void	vioapic_set_irqline_lock(struct acrn_vm *vm, uint32_t irqline, uint32_t ope
  * @pre irqline < vioapic_pincount(vm)
  * @return None
  */
-void	vioapic_set_irqline_nolock(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
+void	vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -250,13 +250,13 @@ vm_vuart(struct acrn_vm *vm)
 }
 
 static inline struct acrn_vpic *
-vm_pic(struct acrn_vm *vm)
+vm_pic(const struct acrn_vm *vm)
 {
 	return (struct acrn_vpic *)&(vm->arch_vm.vpic);
 }
 
 static inline struct acrn_vioapic *
-vm_ioapic(struct acrn_vm *vm)
+vm_ioapic(const struct acrn_vm *vm)
 {
 	return (struct acrn_vioapic *)&(vm->arch_vm.vioapic);
 }

--- a/hypervisor/include/arch/x86/guest/vpic.h
+++ b/hypervisor/include/arch/x86/guest/vpic.h
@@ -149,7 +149,7 @@ void vpic_init(struct acrn_vm *vm);
  *
  * @return None
  */
-void vpic_set_irqline(struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
+void vpic_set_irqline(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
@@ -173,7 +173,7 @@ void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
  * @pre vm != NULL
  */
 void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector);
-void vpic_get_irqline_trigger_mode(struct acrn_vm *vm, uint32_t irqline, enum vpic_trigger *trigger);
+void vpic_get_irqline_trigger_mode(const struct acrn_vm *vm, uint32_t irqline, enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
 
 /**


### PR DESCRIPTION
120D: Pointer param should be declared pointer to const.
  add 'const' qualifier to function signatures when it's possible.
  - vioapic_set_irqline_nolock()
  - vioapic_set_irqline_lock()
  - master_pic()
  - vpic_ocw2()
  - vpic_ocw3()
  - vpic_set_irqline()
  - vpic_get_irqline_trigger_mode()
  - vm_pic()
  - vm_ioapic

93S: Value is not of appropriate type.
  change '0' to '0U' in function vpic_icw1().

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>