### PR TITLE
tools: Acrnd timer expire when enter s3

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -75,11 +75,14 @@ static int query_state(const char *name)
 	req.timestamp = time(NULL);
 
 	ret = send_msg(name, &req, &ack);
-	if (ret)
-		return ret;
-
-	if (ack.data.state < 0)
+	if (ret) {
 		pdebug();
+		return ret;
+	}
+
+	if (ack.data.state < 0) {
+		fprintf(stderr, "%s ack.data.state:%d\n", __FUNCTION__, ack.data.state);
+	}
 
 	return ack.data.state;
 }
@@ -178,6 +181,8 @@ static void _scan_alive_vm(void)
 				vm->state = VM_SUSPENDED;
 				break;
 			default:
+				fprintf(stderr, "Warnning: unknow vm state:0x%lx\n",
+										vm->state);
 				vm->state = VM_STATE_UNKNOWN;
 			}
 		vm->update = update_count;

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -171,19 +171,19 @@ static void _scan_alive_vm(void)
 
 		if (ret < 0)
 			/* unsupport query */
-			vm->state = VM_STARTED;
+			vm->state_tmp = VM_STARTED;
 		else
 			switch (ret) {
 			case VM_SUSPEND_NONE:
-				vm->state = VM_STARTED;
+				vm->state_tmp = VM_STARTED;
 				break;
 			case VM_SUSPEND_SUSPEND:
-				vm->state = VM_SUSPENDED;
+				vm->state_tmp = VM_SUSPENDED;
 				break;
 			default:
 				fprintf(stderr, "Warnning: unknow vm state:0x%lx\n",
 										vm->state);
-				vm->state = VM_STATE_UNKNOWN;
+				vm->state_tmp = VM_STATE_UNKNOWN;
 			}
 		vm->update = update_count;
 	}
@@ -272,7 +272,7 @@ static void _scan_added_vm(void)
 			LIST_INSERT_HEAD(&vmmngr_head, vm, list);
 		}
 
-		vm->state = VM_CREATED;
+		vm->state_tmp = VM_CREATED;
 		vm->update = update_count;
 	}
 
@@ -284,8 +284,10 @@ static void _remove_dead_vm(void)
 	struct vmmngr_struct *vm, *tvm;
 
 	list_foreach_safe(vm, &vmmngr_head, list, tvm) {
-		if (vm->update == update_count)
+		if (vm->update == update_count) {
+			vm->state = vm->state_tmp;
 			continue;
+		}
 		LIST_REMOVE(vm, list);
 		pdebug();
 		free(vm);

--- a/tools/acrn-manager/acrnctl.h
+++ b/tools/acrn-manager/acrnctl.h
@@ -38,6 +38,7 @@ struct vmmngr_struct *vmmngr_find(const char *vmname);
 struct vmmngr_struct {
 	char name[MAX_NAME_LEN];
 	unsigned long state;
+	unsigned long state_tmp;
 	unsigned long update;   /* update count, remove a vm if no update for it */
 	LIST_ENTRY(vmmngr_struct) list;
 };

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -122,6 +122,7 @@ unsigned get_sos_wakeup_reason(void);
 void acrnd_vm_timer_func(struct work_arg *arg)
 {
 	struct vmmngr_struct *vm;
+	pid_t pid;
 
 	if (!arg) {
 		pdebug();
@@ -137,7 +138,9 @@ void acrnd_vm_timer_func(struct work_arg *arg)
 
 	switch (vm->state) {
 	case VM_CREATED:
-		acrnd_run_vm(arg->name);
+		pid = fork();
+		if (!pid)
+			acrnd_run_vm(vm->name);
 		break;
 	case VM_SUSPENDED:
 		resume_vm(arg->name, CBC_WK_RSN_RTC);


### PR DESCRIPTION
Print more information at acrnd_add_work(), query_state(), try_do_works() and handle_acrnd_resume()
fix a race condition on updating VM state
Fix launch UOS by timer list without fork()

Tracked-On: #2306
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>

