### PR TITLE
hv:fix violations

### DIFF
--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -133,7 +133,7 @@ static void timer_softirq(uint16_t pcpu_id)
 	struct per_cpu_timers *cpu_timer;
 	struct hv_timer *timer;
 	struct list_head *pos, *n;
-	int32_t tries = MAX_TIMER_ACTIONS;
+	uint32_t tries = MAX_TIMER_ACTIONS;
 	uint64_t current_tsc = rdtsc();
 
 	/* handle passed timer */
@@ -149,7 +149,7 @@ static void timer_softirq(uint16_t pcpu_id)
 		timer = list_entry(pos, struct hv_timer, node);
 		/* timer expried */
 		tries--;
-		if ((timer->fire_tsc <= current_tsc) && (tries > 0)) {
+		if ((timer->fire_tsc <= current_tsc) && (tries != 0U)) {
 			del_timer(timer);
 
 			run_timer(timer);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -299,7 +299,7 @@ vcpu_vlapic(struct acrn_vcpu *vcpu)
 	return &(vcpu->arch.vlapic);
 }
 
-void default_idle(struct sched_object *obj);
+void default_idle(__unused struct sched_object *obj);
 void vcpu_thread(struct sched_object *obj);
 
 /* External Interfaces */


### PR DESCRIPTION
fix
1."Value is not of appropriate type."
2."Function prototype/defn param type mismatch"

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>