### PR TITLE
DM: sos_bootargs: Add panic_print parameter to help debugging

### DIFF
--- a/devicemodel/samples/apl-mrb/sos_bootargs_debug.txt
+++ b/devicemodel/samples/apl-mrb/sos_bootargs_debug.txt
@@ -20,3 +20,4 @@ ramoops.mem_address=0x6da00000
 ramoops.mem_size=0x400000
 ramoops.console_size=0x200000
 reboot_panic=p,w
+panic_print=0x1f

--- a/devicemodel/samples/apl-mrb/sos_bootargs_release.txt
+++ b/devicemodel/samples/apl-mrb/sos_bootargs_release.txt
@@ -14,3 +14,4 @@ i915.enable_guc=0x02
 video=DP-1:d
 video=DP-2:d
 cma=64M@0-
+panic_print=0x1f


### PR DESCRIPTION
Adding this parameter so that it could provide more info when
kernel panic happens. And this has almost no overhead as it only
uses several existing kernel APIs.

The 0x1f is a bitmask for type of info to be dumped, and it means
it will print task/memory/timer/lock/ftrace info when panic happens.

Tracked-On: https://github.com/projectacrn/acrn-hypervisor/issues/2330
Signed-off-by: Feng Tang <feng.tang@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>