### PR TITLE
hv:fix MISRA-C violation in multiboot.c

### DIFF
--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -139,10 +139,10 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
 	 */
 	zeropage = (struct zero_page *)kernel_src_addr;
 	if (zeropage->hdr.relocatable_kernel != 0U) {
-		zeropage = (void *)zeropage->hdr.pref_addr;
+		zeropage = (struct zero_page *)zeropage->hdr.pref_addr;
 	}
 
-	return zeropage;
+	return (void *)zeropage;
 }
 
 /**


### PR DESCRIPTION
fix this violation "Value is not of appropriate type"
in get_kernel_load_addr()

Tracked-On: #861
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>