### PR TITLE
hv: init: minor fix related to header file

### DIFF
--- a/hypervisor/include/arch/x86/init.h
+++ b/hypervisor/include/arch/x86/init.h
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef	INIT_H
+#ifndef INIT_H
+#define INIT_H
 
 /* hypervisor stack bottom magic('intl') */
 #define SP_BOTTOM_MAGIC    0x696e746cUL


### PR DESCRIPTION
Header file shall not be included multiple times.
The following prototype shall be used.

        #ifndef INIT_H
        #define INIT_H

        /* body */

        #endif /* INIT_H*/

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>