### PR TITLE
hv: fix MISRA-C violations in vmsr.c

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -264,16 +264,16 @@ uint32_t vmsr_get_guest_msr_index(uint32_t msr)
 
 static void enable_msr_interception(uint8_t *bitmap, uint32_t msr_arg, uint32_t mode)
 {
-	uint8_t *read_map = bitmap;
-	uint8_t *write_map = bitmap + 2048;
+	uint32_t read_offset = 0U;
+	uint32_t write_offset = 2048U;
 	uint32_t msr = msr_arg;
 	uint8_t msr_bit;
 	uint32_t msr_index;
 
 	if ((msr <= 0x1FFFU) || ((msr >= 0xc0000000U) && (msr <= 0xc0001fffU))) {
 		if ((msr & 0xc0000000U) != 0U) {
-			read_map = read_map + 1024;
-			write_map = write_map + 1024;
+			read_offset = read_offset + 1024U;
+			write_offset = write_offset + 1024U;
 		}
 
 		msr &= 0x1FFFU;
@@ -281,15 +281,15 @@ static void enable_msr_interception(uint8_t *bitmap, uint32_t msr_arg, uint32_t 
 		msr_index = msr >> 3U;
 
 		if ((mode & INTERCEPT_READ) == INTERCEPT_READ) {
-			read_map[msr_index] |= msr_bit;
+			bitmap[read_offset + msr_index] |= msr_bit;
 		} else {
-			read_map[msr_index] &= ~msr_bit;
+			bitmap[read_offset + msr_index] &= ~msr_bit;
 		}
 
 		if ((mode & INTERCEPT_WRITE) == INTERCEPT_WRITE) {
-			write_map[msr_index] |= msr_bit;
+			bitmap[write_offset + msr_index] |= msr_bit;
 		} else {
-			write_map[msr_index] &= ~msr_bit;
+			bitmap[write_offset + msr_index] &= ~msr_bit;
 		}
 	} else {
 		pr_err("%s, Invalid MSR: 0x%x", __func__, msr);


### PR DESCRIPTION
In enable_msr_interception(), by removing the local pointer declarations and
all pointer arithmetic operations, the following violations are fixed.

- Use of pointer arithmetic.
- Pointer arithmetic is not on array.
- Pointer not checked for null before use.

Change enable_msr_interception() signature, replacing "uint8_t *bitmap" with
"uint8_t bitmap[]" to fix violations:
- Pointer param should be declared pointer to const.
- Declaration does not specify an array.

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>