### PR TITLE
hv: Make reserved regions in E820 table to Supervisor pages

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -306,7 +306,7 @@ void init_paging(void)
 #ifdef CONFIG_DMAR_PARSE_ENABLED
 	for (i = 0U; i < entries_count; i++) {
 		entry = p_e820 + i;
-		if (entry->type == E820_TYPE_ACPI_RECLAIM) {
+		if ((entry->type == E820_TYPE_ACPI_RECLAIM) || (entry->type == E820_TYPE_RESERVED)) {
 			hv_access_memory_region_update(entry->baseaddr, entry->length);
 		}
 	}


### PR DESCRIPTION
On platforms that put ACPI RSDT in E820 "Reserved" type memory, ACRN
fails to parse RSDP and therefore ACPI Tables. This patch adds
"Reserved" memory regions in E820 as Supervisor pages.

Tracked-On: #2320
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>