### PR TITLE
HV: Modularize iommu

### DIFF
--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <vtd.h>
 
 #include "guest/instr_emul.h"
 
@@ -188,7 +189,7 @@ void ept_mr_add(struct acrn_vm *vm, uint64_t *pml4_page,
 	 * to force snooping of PCIe devices if the page
 	 * is cachable
 	 */
-	if (((prot & EPT_MT_MASK) != EPT_UNCACHED) && vm->snoopy_mem) {
+	if (((prot & EPT_MT_MASK) != EPT_UNCACHED) && iommu_snoop_supported(vm->iommu)) {
 		prot |= EPT_SNOOP_CTRL;
 	}
 
@@ -209,7 +210,7 @@ void ept_mr_modify(struct acrn_vm *vm, uint64_t *pml4_page,
 
 	dev_dbg(ACRN_DBG_EPT, "%s,vm[%d] gpa 0x%llx size 0x%llx\n", __func__, vm->vm_id, gpa, size);
 
-	if (((local_prot & EPT_MT_MASK) != EPT_UNCACHED) && vm->snoopy_mem) {
+	if (((local_prot & EPT_MT_MASK) != EPT_UNCACHED) && iommu_snoop_supported(vm->iommu)) {
 		local_prot |= EPT_SNOOP_CTRL;
 	}
 

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -7,6 +7,7 @@
 #include <init.h>
 #include <hypervisor.h>
 #include <schedule.h>
+#include <vtd.h>
 
 /* Push sp magic to top of stack for call trace */
 #define SWITCH_TO(rsp, to)                                              \

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -5,6 +5,7 @@
 #include <hypervisor.h>
 #include <trampoline.h>
 #include <ioapic.h>
+#include <vtd.h>
 
 struct cpu_context cpu_ctx;
 

--- a/hypervisor/arch/x86/vmcs.c
+++ b/hypervisor/arch/x86/vmcs.c
@@ -8,6 +8,7 @@
 
 #include <hypervisor.h>
 #include <cpu.h>
+#include <vtd.h>
 
 static uint64_t cr0_always_on_mask;
 static uint64_t cr0_always_off_mask;
@@ -240,7 +241,7 @@ void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0)
 					 * disabled behavior
 					 */
 					exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, PAT_ALL_UC_VALUE);
-					if (!iommu_snoop_supported(vcpu->vm)) {
+					if (!iommu_snoop_supported(vcpu->vm->iommu)) {
 						cache_flush_invalidate_all();
 					}
 				} else {

--- a/hypervisor/arch/x86/vmexit.c
+++ b/hypervisor/arch/x86/vmexit.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <vtd.h>
 
 /*
  * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
@@ -357,7 +358,7 @@ static int32_t xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 
 static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 {
-	if (!iommu_snoop_supported(vcpu->vm)) {
+	if (!iommu_snoop_supported(vcpu->vm->iommu)) {
 		cache_flush_invalidate_all();
 	}
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -7,6 +7,7 @@
 #define pr_prefix		"iommu: "
 
 #include <hypervisor.h>
+#include <vtd.h>
 
 #define DBG_IOMMU 0
 
@@ -116,15 +117,6 @@ struct dmar_context_entry {
 	uint64_t upper;
 };
 
-struct iommu_domain {
-	bool is_host;
-	bool is_tt_ept;     /* if reuse EPT of the domain */
-	uint16_t vm_id;
-	uint32_t addr_width;   /* address width of the domain */
-	uint64_t trans_table_ptr;
-	bool iommu_snoop;
-};
-
 struct context_table {
 	struct page buses[CONFIG_IOMMU_BUS_NUM];
 };
@@ -141,16 +133,15 @@ static inline uint8_t* get_ctx_table(uint32_t dmar_index, uint8_t bus_no)
 	return ctx_tables[dmar_index].buses[bus_no].contents;
 }
 
-bool iommu_snoop_supported(const struct acrn_vm *vm)
+bool iommu_snoop_supported(const struct iommu_domain *iommu)
 {
 	bool ret;
 
-	if ((vm->iommu == NULL) || (vm->iommu->iommu_snoop)) {
+	if ((iommu == NULL) || (iommu->iommu_snoop)) {
 		ret =  true;
 	} else {
 		ret = false;
 	}
-
 	return ret;
 }
 
@@ -823,7 +814,7 @@ static void dmar_resume(struct dmar_drhd_rt *dmar_unit)
 	dmar_enable(dmar_unit);
 }
 
-static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun)
+int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_root_entry *root_table;
@@ -833,7 +824,6 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 	struct dmar_context_entry *context_entry;
 	uint64_t upper;
 	uint64_t lower = 0UL;
-	struct acrn_vm *vm;
 	int32_t ret = 0;
 
 	dmar_unit = device_to_dmaru(segment, bus, devfun);
@@ -847,10 +837,6 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 		ret = -EINVAL;
 	} else {
 		if (iommu_ecap_sc(dmar_unit->ecap) == 0U) {
-			vm = get_vm_from_vmid(domain->vm_id);
-			if (vm != NULL) {
-				vm->snoopy_mem = false;
-			}
 			/* TODO: remove iommu_snoop from iommu_domain */
 			domain->iommu_snoop = false;
 			dev_dbg(ACRN_DBG_IOMMU, "vm=%d add %x:%x no snoop control!", domain->vm_id, bus, devfun);
@@ -938,7 +924,7 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 	return ret;
 }
 
-static int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun)
+int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_root_entry *root_table;
@@ -1033,6 +1019,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 		domain->trans_table_ptr = translation_table;
 		domain->addr_width = addr_width;
 		domain->is_tt_ept = true;
+		domain->iommu_snoop = true;
 
 		dev_dbg(ACRN_DBG_IOMMU, "create domain [%d]: vm_id = %hu, ept@0x%x",
 			vmid_to_domainid(domain->vm_id), domain->vm_id, domain->trans_table_ptr);
@@ -1119,26 +1106,4 @@ int32_t init_iommu(void)
 	}
 
 	return ret;
-}
-
-void init_iommu_vm0_domain(struct acrn_vm *vm0)
-{
-	uint16_t bus;
-	uint16_t devfun;
-
-	vm0->iommu = create_iommu_domain(vm0->vm_id, hva2hpa(vm0->arch_vm.nworld_eptp), 48U);
-
-	vm0_domain = (struct iommu_domain *) vm0->iommu;
-	if (vm0_domain == NULL) {
-		pr_err("vm0 domain is NULL\n");
-	} else {
-		for (bus = 0U; bus < CONFIG_IOMMU_BUS_NUM; bus++) {
-			for (devfun = 0U; devfun <= 255U; devfun++) {
-				if (add_iommu_device(vm0_domain, 0U, (uint8_t)bus, (uint8_t)devfun) != 0) {
-					/* the panic only occurs before VM0 starts running in sharing mode */
-					panic("Failed to add %x:%x.%x to VM0 domain", bus, pci_slot(devfun), pci_func(devfun));
-				}
-			}
-		}
-	}
 }

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -7,7 +7,7 @@
 #ifdef CONFIG_DMAR_PARSE_ENABLED
 #include <hypervisor.h>
 #include "pci.h"
-#include "vtd.h"
+#include <vtd.h>
 #include "acpi_priv.h"
 
 enum acpi_dmar_type {

--- a/hypervisor/bsp/sbl/const_dmar.c
+++ b/hypervisor/bsp/sbl/const_dmar.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <vtd.h>
 
 #ifndef CONFIG_DMAR_PARSE_ENABLED
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -9,6 +9,7 @@
 #include <hypercall.h>
 #include <version.h>
 #include <reloc.h>
+#include <vtd.h>
 
 #define ACRN_DBG_HYCALL	6U
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -31,6 +31,7 @@
 
 #include <hypervisor.h>
 #include "pci_priv.h"
+#include <vtd.h>
 
 static inline uint32_t pci_bar_base(uint32_t bar)
 {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -162,7 +162,6 @@ struct acrn_vm {
 	spinlock_t softirq_dev_lock;
 	struct list_head softirq_dev_entry_list;
 	uint64_t intr_inject_delay_delta; /* delay of intr injection */
-	bool snoopy_mem;
 } __aligned(PAGE_SIZE);
 
 #ifdef CONFIG_PARTITION_MODE

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -36,7 +36,6 @@
 #include <vmx.h>
 #include <vmcs.h>
 #include <assign.h>
-#include <vtd.h>
 
 #include <guest.h>
 #include <vmexit.h>

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -35,6 +35,18 @@
 #define DMAR_ICS_REG    0x9cU    /* Invalidation complete status register */
 #define DMAR_IRTA_REG   0xb8U    /* Interrupt remapping table addr register */
 
+struct iommu_domain {
+	bool is_host;
+	bool is_tt_ept;     /* if reuse EPT of the domain */
+	uint16_t vm_id;
+	uint32_t addr_width;   /* address width of the domain */
+	uint64_t trans_table_ptr;
+	bool iommu_snoop;
+};
+
+int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun);
+int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun);
+
 static inline uint8_t dmar_ver_major(uint64_t version)
 {
 	return (((uint8_t)version & 0xf0U) >> 4U);
@@ -594,21 +606,6 @@ void resume_iommu(void);
 int32_t init_iommu(void);
 
 /**
- * @brief Init VM0 domain of iommu.
- *
- * Create VM0 domain using the Normal World's EPT table of VM0 as address translation table.
- * All PCI devices are added to the VM0 domain when creating it.
- *
- * @param[in] vm0 pointer to VM0
- *
- * @pre vm0 shall point to VM0
- *
- * @remark to reduce boot time & memory cost, a config IOMMU_INIT_BUS_LIMIT, which limit the bus number.
- *
- */
-void init_iommu_vm0_domain(struct acrn_vm *vm0);
-
-/**
  * @brief check the iommu if support cache snoop.
  *
  * @param[in] vm pointer to VM to check
@@ -617,7 +614,7 @@ void init_iommu_vm0_domain(struct acrn_vm *vm0);
  * @retval false not support
  *
  */
-bool iommu_snoop_supported(const struct acrn_vm *vm);
+bool iommu_snoop_supported(const struct iommu_domain *iommu);
 
 /**
   * @}


### PR DESCRIPTION
Modified some of the code in order to isolate
iommu code to vtd.c.
Treating acrn_vm as higher level module, removed
any dependency of acrn_vm structure from vtd.c.
Removed any reference to snoopy_mem from iommu_structure,
and added code to set and read iommu_snoop, which is
limited inside the iommu structure.

Tracked-On: #1842
Signed-off-by: Arindam Roy <arindam.roy@intel.com>