### PR TITLE
Rework TMR and EOI_EXIT_BITMAP updating logic

### DIFF
--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -405,10 +405,6 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 			flush_vpid_single(arch->vpid);
 		}
 
-		if (bitmap_test_and_clear_lock(ACRN_REQUEST_TMR_UPDATE,	pending_req_bits)) {
-			vioapic_update_tmr(vcpu);
-		}
-
 		if (bitmap_test_and_clear_lock(ACRN_REQUEST_EOI_EXIT_UPDATE, pending_req_bits)) {
 			vcpu_set_vmcs_eoi_exit(vcpu);
 		}

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -409,6 +409,10 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 			vioapic_update_tmr(vcpu);
 		}
 
+		if (bitmap_test_and_clear_lock(ACRN_REQUEST_EOI_EXIT_UPDATE, pending_req_bits)) {
+			vcpu_set_vmcs_eoi_exit(vcpu);
+		}
+
 		/* handling cancelled event injection when vcpu is switched out */
 		if (arch->inject_event_pending) {
 			if ((arch->inject_info.intr_info & (EXCEPTION_ERROR_CODE_VALID << 8U)) != 0U) {

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -31,17 +31,16 @@
 /*
  * VCPU related APIs
  */
-#define ACRN_REQUEST_EXCP      0U
-#define ACRN_REQUEST_EVENT    1U
-#define ACRN_REQUEST_EXTINT   2U
-#define ACRN_REQUEST_NMI        3U
-#define ACRN_REQUEST_TMR_UPDATE  4U
-#define ACRN_REQUEST_EPT_FLUSH      5U
-#define ACRN_REQUEST_TRP_FAULT      6U
-#define ACRN_REQUEST_VPID_FLUSH    7U /* flush vpid tlb */
-#define ACRN_REQUEST_EOI_EXIT_UPDATE  8U
+#define ACRN_REQUEST_EXCP		0U
+#define ACRN_REQUEST_EVENT		1U
+#define ACRN_REQUEST_EXTINT		2U
+#define ACRN_REQUEST_NMI		3U
+#define ACRN_REQUEST_EOI_EXIT_UPDATE	4U
+#define ACRN_REQUEST_EPT_FLUSH		5U
+#define ACRN_REQUEST_TRP_FAULT		6U
+#define ACRN_REQUEST_VPID_FLUSH		7U /* flush vpid tlb */
 
-#define E820_MAX_ENTRIES    32U
+#define E820_MAX_ENTRIES		32U
 
 #define save_segment(seg, SEG_NAME)				\
 {								\

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -39,6 +39,7 @@
 #define ACRN_REQUEST_EPT_FLUSH      5U
 #define ACRN_REQUEST_TRP_FAULT      6U
 #define ACRN_REQUEST_VPID_FLUSH    7U /* flush vpid tlb */
+#define ACRN_REQUEST_EOI_EXIT_UPDATE  8U
 
 #define E820_MAX_ENTRIES    32U
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -169,6 +169,8 @@ struct ext_context {
 #define NUM_COMMON_MSRS		7U
 #define NUM_GUEST_MSRS		(NUM_WORLD_MSRS + NUM_COMMON_MSRS)
 
+#define EOI_EXIT_BITMAP_SIZE	256U
+
 struct event_injection_info {
 	uint32_t intr_info;
 	uint32_t error_code;
@@ -247,6 +249,10 @@ struct acrn_vcpu_arch {
 
 	/* List of MSRS to be stored and loaded on VM exits or VM entries */
 	struct msr_store_area msr_area;
+
+	/* EOI_EXIT_BITMAP buffer, for the bitmap update */
+	uint64_t eoi_exit_bitmap[EOI_EXIT_BITMAP_SIZE >> 6U];
+	spinlock_t lock;
 } __aligned(PAGE_SIZE);
 
 struct acrn_vm;
@@ -498,6 +504,36 @@ uint64_t vcpu_get_guest_msr(const struct acrn_vcpu *vcpu, uint32_t msr);
  */
 void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val);
 
+/**
+ * @brief write eoi_exit_bitmap to VMCS fields
+ *
+ * @param[in] vcpu pointer to vcpu data structure
+ *
+ * @return void
+ */
+void vcpu_set_vmcs_eoi_exit(struct acrn_vcpu *vcpu);
+
+/**
+ * @brief reset eoi_exit_bitmap
+ *
+ * @param[in] vcpu pointer to vcpu data structure
+ *
+ * @return void
+ */
+
+void vcpu_reset_eoi_exit_all(struct acrn_vcpu *vcpu);
+
+/**
+ * @brief set eoi_exit_bitmap bit
+ *
+ * Set corresponding bit of vector in eoi_exit_bitmap
+ *
+ * @param[in] vcpu pointer to vcpu data structure
+ * @param[in] vector
+ *
+ * @return void 
+ */
+void vcpu_set_eoi_exit(struct acrn_vcpu *vcpu, uint32_t vector);
 /**
  * @brief set all the vcpu registers
  *

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -99,7 +99,6 @@ void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t irqline, uint32
  * @return None
  */
 void	vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
-void	vioapic_update_tmr(struct acrn_vcpu *vcpu);
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);
 void	vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -227,9 +227,6 @@ int32_t vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg);
 void vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest,
 		bool phys, uint32_t delmode, uint32_t vec, bool rh);
 
-/* Reset the trigger-mode bits for all vectors to be edge-triggered */
-void vlapic_reset_tmr(struct acrn_vlapic *vlapic);
-
 /*
  * Set the trigger-mode bit associated with 'vector' to level-triggered if
  * the (dest,phys,delmode) tuple resolves to an interrupt being delivered to

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -227,15 +227,6 @@ int32_t vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg);
 void vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest,
 		bool phys, uint32_t delmode, uint32_t vec, bool rh);
 
-/*
- * Set the trigger-mode bit associated with 'vector' to level-triggered if
- * the (dest,phys,delmode) tuple resolves to an interrupt being delivered to
- * this 'vlapic'.
- */
-void vlapic_set_tmr_one_vec(struct acrn_vlapic *vlapic, uint32_t delmode,
-		uint32_t vector, bool level);
-
-void vlapic_apicv_batch_set_tmr(struct acrn_vlapic *vlapic);
 uint32_t vlapic_get_apicid(const struct acrn_vlapic *vlapic);
 int32_t vlapic_create(struct acrn_vcpu *vcpu);
 /*


### PR DESCRIPTION
These patches make TMR set/clear behavior like real hardware, and update EOI_EXIT
bitmap upon changes to related fields of RTEs.

With these changes, we may get rid of current issue to support per_cpu vector in guest
OS. Because only target vlapic TMR bit will be set/cleared.

For EOI_EXIT_BITMAP, we removed the logic dependency from TMR, and update the bitmaps
according to contents of RTEs. And we also optimized the process to go through all
RTEs one-time on a singel cpu for each update.

Tracked-On: #2343