### PR TITLE
tools: respect CFLAGS and LDFLAGS from environment

### DIFF
--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -2,21 +2,22 @@ T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
 
-CFLAGS := -g -O0 -std=gnu11
-CFLAGS += -D_GNU_SOURCE
-CFLAGS += -DNO_OPENSSL
-CFLAGS += -m64
-CFLAGS += -Wall -ffunction-sections
-CFLAGS += -Werror
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
-CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
-CFLAGS += -fpie -fpic
+MANAGER_CFLAGS := -g -O0 -std=gnu11
+MANAGER_CFLAGS += -D_GNU_SOURCE
+MANAGER_CFLAGS += -DNO_OPENSSL
+MANAGER_CFLAGS += -m64
+MANAGER_CFLAGS += -Wall -ffunction-sections
+MANAGER_CFLAGS += -Werror
+MANAGER_CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+MANAGER_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+MANAGER_CFLAGS += -fpie -fpic
 #FIXME: remove me. work-around for system() calls, which will be removed
-CFLAGS += -Wno-format-truncation -Wno-unused-result
+MANAGER_CFLAGS += -Wno-format-truncation -Wno-unused-result
+MANAGER_CFLAGS += $(CFLAGS)
 
-CFLAGS += -I../../devicemodel/include
-CFLAGS += -I../../devicemodel/include/public
-CFLAGS += -I../../hypervisor/include
+MANAGER_CFLAGS += -I../../devicemodel/include
+MANAGER_CFLAGS += -I../../devicemodel/include/public
+MANAGER_CFLAGS += -I../../hypervisor/include
 
 GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
 GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
@@ -26,32 +27,33 @@ STACK_PROTECTOR := 1
 
 ifdef STACK_PROTECTOR
 ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
-CFLAGS += -fstack-protector-strong
+MANAGER_CFLAGS += -fstack-protector-strong
 else
 ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
-CFLAGS += -fstack-protector-strong
+MANAGER_CFLAGS += -fstack-protector-strong
 else
-CFLAGS += -fstack-protector
+MANAGER_CFLAGS += -fstack-protector
 endif
 endif
 endif
 
 ifeq ($(RELEASE),0)
-CFLAGS += -g -DMNGR_DEBUG
+MANAGER_CFLAGS += -g -DMNGR_DEBUG
 endif
 
-LDFLAGS := -Wl,-z,noexecstack
-LDFLAGS += -Wl,-z,relro,-z,now
-LDFLAGS += -pie
-LDFLAGS += -L$(OUT_DIR)
-LDFLAGS +=  -lpthread
-LDFLAGS += -lacrn-mngr
+MANAGER_LDFLAGS := -Wl,-z,noexecstack
+MANAGER_LDFLAGS += -Wl,-z,relro,-z,now
+MANAGER_LDFLAGS += -pie
+MANAGER_LDFLAGS += -L$(OUT_DIR)
+MANAGER_LDFLAGS +=  -lpthread
+MANAGER_LDFLAGS += -lacrn-mngr
+MANAGER_LDFLAGS += $(LDFLAGS)
 
 .PHONY: all
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnctl $(OUT_DIR)/acrnd
 
 $(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h
-	$(CC) $(CFLAGS) -c acrn_mngr.c -o $(OUT_DIR)/acrn_mngr.o
+	$(CC) $(MANAGER_CFLAGS) -c acrn_mngr.c -o $(OUT_DIR)/acrn_mngr.o
 	ar -cr $@ $(OUT_DIR)/acrn_mngr.o
 
 ifneq ($(OUT_DIR),.)
@@ -60,10 +62,10 @@ $(OUT_DIR)/acrn_mngr.h: ./acrn_mngr.h
 endif
 
 $(OUT_DIR)/acrnctl: acrnctl.c acrn_mngr.h $(OUT_DIR)/libacrn-mngr.a
-	$(CC) -o $(OUT_DIR)/acrnctl acrnctl.c acrn_vm_ops.c $(CFLAGS) $(LDFLAGS)
+	$(CC) -o $(OUT_DIR)/acrnctl acrnctl.c acrn_vm_ops.c $(MANAGER_CFLAGS) $(MANAGER_LDFLAGS)
 
 $(OUT_DIR)/acrnd: acrnd.c $(OUT_DIR)/libacrn-mngr.a
-	$(CC) -o $(OUT_DIR)/acrnd acrnd.c acrn_vm_ops.c $(CFLAGS) $(LDFLAGS)
+	$(CC) -o $(OUT_DIR)/acrnd acrnd.c acrn_vm_ops.c $(MANAGER_CFLAGS) $(MANAGER_LDFLAGS)
 ifneq ($(OUT_DIR),.)
 	cp ./acrnd.service $(OUT_DIR)/acrnd.service
 endif

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -2,15 +2,16 @@ T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
 
-CFLAGS := -g -O0 -std=gnu11
-CFLAGS += -D_GNU_SOURCE
-CFLAGS += -DNO_OPENSSL
-CFLAGS += -m64
-CFLAGS += -Wall -ffunction-sections
-CFLAGS += -Werror
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
-CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
-CFLAGS += -fpie -fpic
+LOG_CFLAGS := -g -O0 -std=gnu11
+LOG_CFLAGS += -D_GNU_SOURCE
+LOG_CFLAGS += -DNO_OPENSSL
+LOG_CFLAGS += -m64
+LOG_CFLAGS += -Wall -ffunction-sections
+LOG_CFLAGS += -Werror
+LOG_CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+LOG_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+LOG_CFLAGS += -fpie -fpic
+LOG_CFLAGS += $(CFLAGS)
 
 GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
 GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
@@ -20,22 +21,23 @@ STACK_PROTECTOR := 1
 
 ifdef STACK_PROTECTOR
 ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
-CFLAGS += -fstack-protector-strong
+LOG_CFLAGS += -fstack-protector-strong
 else
 ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
-CFLAGS += -fstack-protector-strong
+LOG_CFLAGS += -fstack-protector-strong
 else
-CFLAGS += -fstack-protector
+LOG_CFLAGS += -fstack-protector
 endif
 endif
 endif
 
-LDFLAGS := -Wl,-z,noexecstack
-LDFLAGS += -Wl,-z,relro,-z,now
-LDFLAGS += -pie
+LOG_LDFLAGS := -Wl,-z,noexecstack
+LOG_LDFLAGS += -Wl,-z,relro,-z,now
+LOG_LDFLAGS += -pie
+LOG_LDFLAGS += $(LDFLAGS)
 
 all:
-	$(CC) -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread $(CFLAGS) $(LDFLAGS)
+	$(CC) -g acrnlog.c -o $(OUT_DIR)/acrnlog -lpthread $(LOG_CFLAGS) $(LOG_LDFLAGS)
 	cp acrnlog.service $(OUT_DIR)/acrnlog.service
 
 clean:

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -2,15 +2,16 @@ T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
 
-CFLAGS := -g -O0 -std=gnu11
-CFLAGS += -D_GNU_SOURCE
-CFLAGS += -DNO_OPENSSL
-CFLAGS += -m64
-CFLAGS += -Wall -ffunction-sections
-CFLAGS += -Werror
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
-CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
-CFLAGS += -fpie -fpic
+TRACE_CFLAGS := -g -O0 -std=gnu11
+TRACE_CFLAGS += -D_GNU_SOURCE
+TRACE_CFLAGS += -DNO_OPENSSL
+TRACE_CFLAGS += -m64
+TRACE_CFLAGS += -Wall -ffunction-sections
+TRACE_CFLAGS += -Werror
+TRACE_CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+TRACE_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+TRACE_CFLAGS += -fpie -fpic
+TRACE_CFLAGS += $(CFLAGS)
 
 GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
 GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
@@ -20,22 +21,23 @@ STACK_PROTECTOR := 1
 
 ifdef STACK_PROTECTOR
 ifeq (true, $(shell [ $(GCC_MAJOR) -gt 4 ] && echo true))
-CFLAGS += -fstack-protector-strong
+TRACE_CFLAGS += -fstack-protector-strong
 else
 ifeq (true, $(shell [ $(GCC_MAJOR) -eq 4 ] && [ $(GCC_MINOR) -ge 9 ] && echo true))
-CFLAGS += -fstack-protector-strong
+TRACE_CFLAGS += -fstack-protector-strong
 else
-CFLAGS += -fstack-protector
+TRACE_CFLAGS += -fstack-protector
 endif
 endif
 endif
 
-LDFLAGS := -Wl,-z,noexecstack
-LDFLAGS += -Wl,-z,relro,-z,now
-LDFLAGS += -pie
+TRACE_LDFLAGS := -Wl,-z,noexecstack
+TRACE_LDFLAGS += -Wl,-z,relro,-z,now
+TRACE_LDFLAGS += -pie
+TRACE_LDFLAGS += $(LDFLAGS)
 
 all:
-	$(CC) -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread -lrt $(CFLAGS) $(LDFLAGS)
+	$(CC) -o $(OUT_DIR)/acrntrace acrntrace.c sbuf.c -I. -lpthread -lrt $(TRACE_CFLAGS) $(TRACE_LDFLAGS)
 
 clean:
 	rm -f $(OUT_DIR)/acrntrace


### PR DESCRIPTION
The build environment might want to pass extra CFLAGS or LDFLAGS to the build of
the acrn tools. With conventional build systems like automake, Meson, etc this
is possible by just setting CFLAGS and LDFLAGS in the environment.

However as the tools are built using bare Makefiles, these environment variables
are overwritten.  Respect them by renaming the variables in the Makefiles to
e.g. LOG_CFLAGS and adding CFLAGS to that.

Tracked-On: #2316
Signed-off-by: Ross Burton <ross.burton@intel.com>