### PR TITLE
Use $(MAKE) when recursing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,35 +46,35 @@ export TOOLS_OUT
 all: hypervisor devicemodel tools
 
 hypervisor:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) clean
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) clean
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
 ifeq ($(FIRMWARE),uefi)
 	echo "building hypervisor as EFI executable..."
-	make -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT)
+	$(MAKE) -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT)
 endif
 
 sbl-hypervisor:
 	@mkdir -p $(HV_OUT)-sbl/apl-mrb $(HV_OUT)-sbl/up2
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) clean
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE)
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE) clean
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) clean
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE) clean
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE)
 
 devicemodel: tools
-	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
-	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG)
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG)
 
 tools:
 	mkdir -p $(TOOLS_OUT)
-	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/tools OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE)
 
 doc:
-	make -C $(T)/doc html BUILDDIR=$(DOC_OUT)
+	$(MAKE) -C $(T)/doc html BUILDDIR=$(DOC_OUT)
 
 .PHONY: clean
 clean:
-	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) clean
-	make -C $(T)/doc BUILDDIR=$(DOC_OUT) clean
+	$(MAKE) -C $(T)/tools OUT_DIR=$(TOOLS_OUT) clean
+	$(MAKE) -C $(T)/doc BUILDDIR=$(DOC_OUT) clean
 	rm -rf $(ROOT_OUT)
 
 .PHONY: install
@@ -82,31 +82,31 @@ install: hypervisor-install devicemodel-install tools-install
 
 hypervisor-install:
 ifeq ($(FIRMWARE),sbl)
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
 endif
 ifeq ($(FIRMWARE),uefi)
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
-	make -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT) all install
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT) all install
 endif
 
 hypervisor-install-debug:
 ifeq ($(FIRMWARE),sbl)
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install-debug
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install-debug
 endif
 ifeq ($(FIRMWARE),uefi)
-	make -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT) all install-debug
+	$(MAKE) -C $(T)/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT) all install-debug
 endif
 
 sbl-hypervisor-install:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) install
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE) install
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) install
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE) install
 
 sbl-hypervisor-install-debug:
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) install-debug
-	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE) install-debug
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-mrb BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE) install-debug
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/up2 BOARD=up2 FIRMWARE=sbl RELEASE=$(RELEASE) install-debug
 
 devicemodel-install:
-	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install
 
 tools-install:
-	make -C $(T)/tools OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) install
+	$(MAKE) -C $(T)/tools OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) install

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -165,7 +165,7 @@ all: $(DM_OBJDIR)/$(PROGRAM)
 	@echo -n ""
 
 $(VMCFG_CONFIG_H):
-	make -C $(BASEDIR)/vmcfg $@ BASEDIR=$(BASEDIR) DM_OBJDIR=$(DM_OBJDIR)
+	$(MAKE) -C $(BASEDIR)/vmcfg $@ BASEDIR=$(BASEDIR) DM_OBJDIR=$(DM_OBJDIR)
 
 $(DM_OBJDIR)/$(PROGRAM): $(OBJS)
 	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
@@ -228,4 +228,4 @@ install-bios: $(BIOS_BIN)
 	install -D --mode=0664 -t $(DESTDIR)/usr/share/acrn/bios $^
 
 install-vmcfg:
-	make -C $(BASEDIR)/vmcfg install DESTDIR=$(DESTDIR) BASEDIR=$(BASEDIR)
+	$(MAKE) -C $(BASEDIR)/vmcfg install DESTDIR=$(DESTDIR) BASEDIR=$(BASEDIR)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -9,26 +9,26 @@ all: acrnlog acrn-manager acrntrace acrnbridge
 endif
 
 acrn-crashlog:
-	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
 
 acrnlog:
-	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR)
+	$(MAKE) -C $(T)/acrnlog OUT_DIR=$(OUT_DIR)
 
 acrn-manager:
-	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) RELEASE=$(RELEASE)
 
 acrntrace:
-	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR)
+	$(MAKE) -C $(T)/acrntrace OUT_DIR=$(OUT_DIR)
 
 acrnbridge:
-	make -C $(T)/acrnbridge OUT_DIR=$(OUT_DIR)
+	$(MAKE) -C $(T)/acrnbridge OUT_DIR=$(OUT_DIR)
 
 .PHONY: clean
 clean:
-	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) clean
-	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) clean
-	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR) clean
-	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR) clean
+	$(MAKE) -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) clean
+	$(MAKE) -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) clean
+	$(MAKE) -C $(T)/acrntrace OUT_DIR=$(OUT_DIR) clean
+	$(MAKE) -C $(T)/acrnlog OUT_DIR=$(OUT_DIR) clean
 	rm -rf $(OUT_DIR)
 
 .PHONY: install
@@ -39,16 +39,16 @@ install: acrnlog-install acrn-manager-install acrntrace-install acrnbridge-insta
 endif
 
 acrn-crashlog-install:
-	make -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) install
+	$(MAKE) -C $(T)/acrn-crashlog OUT_DIR=$(OUT_DIR) install
 
 acrnlog-install:
-	make -C $(T)/acrnlog OUT_DIR=$(OUT_DIR) install
+	$(MAKE) -C $(T)/acrnlog OUT_DIR=$(OUT_DIR) install
 
 acrn-manager-install:
-	make -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) install
+	$(MAKE) -C $(T)/acrn-manager OUT_DIR=$(OUT_DIR) install
 
 acrntrace-install:
-	make -C $(T)/acrntrace OUT_DIR=$(OUT_DIR) install
+	$(MAKE) -C $(T)/acrntrace OUT_DIR=$(OUT_DIR) install
 
 acrnbridge-install:
-	make -C $(T)/acrnbridge OUT_DIR=$(OUT_DIR) install
+	$(MAKE) -C $(T)/acrnbridge OUT_DIR=$(OUT_DIR) install


### PR DESCRIPTION
Using 'make' directly means that the jobserver environment variables don't get
passed down, so sub-builds for example don't use -j.

This is documented as the wrong thing to do:
https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable

Use $(MAKE) instead, and compile times drastically improve:

  acrn-devicemodel    do_compile   -13.5s   -89.6%      15.0s -> 1.6s
Tracked-On: #2370
Signed-off-by: Ross Burton <ross.burton@intel.com>
