### PR TITLE
hv:Change acrn_vhm_vector to static

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1138,7 +1138,7 @@ int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param)
 		pr_err("%s: Invalid passed vector\n");
 		ret = -EINVAL;
 	} else {
-		acrn_vhm_vector = (uint32_t)param;
+		set_vhm_vector((uint32_t)param);
 		ret = 0;
 	}
 

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -7,7 +7,7 @@
 
 #define ACRN_DBG_IOREQUEST	6U
 
-uint32_t acrn_vhm_vector = VECTOR_VIRT_IRQ_VHM;
+static uint32_t acrn_vhm_vector = VECTOR_VIRT_IRQ_VHM;
 
 static void fire_vhm_interrupt(void)
 {
@@ -194,4 +194,9 @@ void set_vhm_req_state(struct acrn_vm *vm, uint16_t vhm_req_id, uint32_t state)
 		atomic_store32(&vhm_req->processed, state);
 		clac();
 	}
+}
+
+void set_vhm_vector(uint32_t vector)
+{
+	acrn_vhm_vector = vector;
 }

--- a/hypervisor/include/arch/x86/ioreq.h
+++ b/hypervisor/include/arch/x86/ioreq.h
@@ -317,6 +317,14 @@ uint32_t get_vhm_req_state(struct acrn_vm *vm, uint16_t vhm_req_id);
 void set_vhm_req_state(struct acrn_vm *vm, uint16_t vhm_req_id, uint32_t state);
 
 /**
+ * @brief Set the vector for HV callback VHM
+ *
+ * @param vector vector for HV callback VHM
+ * @return None
+ */
+void set_vhm_vector(uint32_t vector);
+
+/**
  * @}
  */
 

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -244,7 +244,6 @@ void interrupt_init(uint16_t pcpu_id);
 
 void cancel_event_injection(struct acrn_vcpu *vcpu);
 
-extern uint32_t acrn_vhm_vector;
 extern uint64_t irq_alloc_bitmap[IRQ_ALLOC_BITMAP_SIZE];
 
 /**


### PR DESCRIPTION
-- Change acrn_vhm_vector to static, only used in io_request.c
-- Add set_vhm_vector() api, it will call this api instead of
   acrn_vhm_vector except io_request.c

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>