### PR TITLE
Change the default notification vector and start guest OS on the renamed vhm module

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+offline_path="/sys/class/vhm/acrn_vhm"
+
+# Check the device file of /dev/acrn_hsm to determine the offline_path
+if [ -e "/dev/acrn_hsm" ]; then
+offline_path="/sys/class/acrn/acrn_hsm"
+fi
 
 kernel_version=$(uname -r | awk -F. '{ printf("%d.%d", $1,$2) }')
 
@@ -442,7 +448,7 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
 			echo 0 > $i/online
 			online=`cat $i/online`
 		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+                echo $idx > ${offline_path}/offline_cpu
         fi
 done
 

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+offline_path="/sys/class/vhm/acrn_vhm"
+
+# Check the device file of /dev/acrn_hsm to determine the offline_path
+if [ -e "/dev/acrn_hsm" ]; then
+offline_path="/sys/class/acrn/acrn_hsm"
+fi
+
 function launch_clear()
 {
 mac=$(cat /sys/class/net/e*/address)
@@ -45,7 +52,7 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
 			echo 0 > $i/online
 			online=`cat $i/online`
 		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+                echo $idx > ${offline_path}/offline_cpu
         fi
 done
 

--- a/devicemodel/samples/up2/launch_uos.sh
+++ b/devicemodel/samples/up2/launch_uos.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+offline_path="/sys/class/vhm/acrn_vhm"
+
+# Check the device file of /dev/acrn_hsm to determine the offline_path
+if [ -e "/dev/acrn_hsm" ]; then
+offline_path="/sys/class/acrn/acrn_hsm"
+fi
 
 kernel_version=$(uname -r | awk -F. '{ printf("%d.%d", $1,$2) }')
 
@@ -419,7 +425,7 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
 			echo 0 > $i/online
 			online=`cat $i/online`
 		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+                echo $idx > ${offline_path}/offline_cpu
         fi
 done
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1118,7 +1118,7 @@ int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
  * @brief set upcall notifier vector
  *
  * This is the API that helps to switch the notifer vecotr. If this API is
- * not called, the hypervisor will use the default notifier vector(0xF7)
+ * not called, the hypervisor will use the default notifier vector(0xF3)
  * to notify the SOS kernel.
  *
  * @param vm Pointer to VM data structure

--- a/hypervisor/common/io_request.c
+++ b/hypervisor/common/io_request.c
@@ -7,7 +7,7 @@
 
 #define ACRN_DBG_IOREQUEST	6U
 
-static uint32_t acrn_vhm_vector = VECTOR_VIRT_IRQ_VHM;
+static uint32_t acrn_vhm_vector = VECTOR_HYPERVISOR_CALLBACK_VHM;
 
 static void fire_vhm_interrupt(void)
 {


### PR DESCRIPTION
This is the patch set that fixes the issue in
Tracked-On: #2355  #2356
Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>

1. It allows devicemodel to start guest OS on the renamed VHM module.
2. the default up-notification vector is changed from 0xF7 to 0xF3.