### PR TITLE
HV: check to avoid interrupt delay timer add twice

### DIFF
--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -87,6 +87,18 @@ static inline bool timer_expired(const struct hv_timer *timer)
 }
 
 /**
+ * @brief Check a timer whether in timer list.
+ *
+ * @param[in] timer Pointer to timer.
+ *
+ * @retval true if the timer is in timer list, false otherwise.
+ */
+static inline bool timer_is_started(const struct hv_timer *timer)
+{
+	return (!list_empty(&timer->node));
+}
+
+/**
  * @brief Add a timer.
  *
  * @param[in] timer Pointer to timer.


### PR DESCRIPTION
to edge interrupt, like eth device, it can triger the interrupt again
when its IRQ in softirq entry queue or in timer list.

in current design, for sofrirq entry, it calls "list_del" before
"list_add_tail", to avoid the entry added twice.

so for interrupt delay timer, add to check if it is started
then just drop the next one; to avoid it enqueue twice.

Tracked-On: #2365
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>