### PR TITLE
HV: refine acrn vm configs series 2

### DIFF
--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -123,7 +123,7 @@
 struct vm_memmap {
 	/** memory mapping type */
 	uint32_t type;
-	/** using vma_base to get vm0_gpa,
+	/** using vma_base to get sos_vm_gpa,
 	 * only for type == VM_MEMMAP_SYSMEM
 	 */
 	uint32_t using_vma;

--- a/doc/developer-guides/hld/hv-memmgt.rst
+++ b/doc/developer-guides/hld/hv-memmgt.rst
@@ -439,7 +439,7 @@ Address Space Translation
 .. doxygenfunction:: gpa2hpa
    :project: Project ACRN
 
-.. doxygenfunction:: vm0_hpa2gpa
+.. doxygenfunction:: sos_vm_hpa2gpa
    :project: Project ACRN
 
 EPT

--- a/doc/developer-guides/hld/hv-vt-d.rst
+++ b/doc/developer-guides/hld/hv-vt-d.rst
@@ -306,7 +306,7 @@ deinitialization:
 .. doxygenfunction:: init_iommu
    :project: Project ACRN
 
-.. doxygenfunction:: init_iommu_vm0_domain
+.. doxygenfunction:: init_iommu_sos_vm_domain
    :project: Project ACRN
 
 runtime

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -279,11 +279,11 @@ config PLATFORM_RAM_SIZE
 	  (MMIO not included).
 
 config SOS_RAM_SIZE
-	hex "Size of the vm0 (SOS) RAM"
+	hex "Size of the Service OS (SOS) RAM"
 	default 0x200000000 if PLATFORM_SBL
 	default 0x400000000 if PLATFORM_UEFI
 	help
-	  A 64-bit integer indicating the size of the vm0 (SOS) RAM (MMIO not
+	  A 64-bit integer indicating the size of the Service OS RAM (MMIO not
 	  included).
 
  config UOS_RAM_SIZE

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -11,7 +11,7 @@
 
 /*
  * e820.c contains the related e820 operations; like HV to get memory info for its MMU setup;
- * and hide HV memory from VM0...
+ * and hide HV memory from SOS_VM...
  */
 
 static uint32_t e820_entries_count;
@@ -51,8 +51,8 @@ static void obtain_e820_mem_info(void)
 	}
 }
 
-/* before boot vm0(service OS), call it to hide the HV RAM entry in e820 table from vm0 */
-void rebuild_vm0_e820(void)
+/* before boot sos_vm(service OS), call it to hide the HV RAM entry in e820 table from sos_vm */
+void rebuild_sos_vm_e820(void)
 {
 	uint32_t i;
 	uint64_t entry_start;
@@ -116,7 +116,7 @@ void rebuild_vm0_e820(void)
 	e820_mem.total_mem_size -= CONFIG_HV_RAM_SIZE;
 }
 
-/* get some RAM below 1MB in e820 entries, hide it from vm0, return its start address */
+/* get some RAM below 1MB in e820 entries, hide it from sos_vm, return its start address */
 uint64_t e820_alloc_low_memory(uint32_t size_arg)
 {
 	uint32_t i;

--- a/hypervisor/arch/x86/ept.c
+++ b/hypervisor/arch/x86/ept.c
@@ -67,7 +67,7 @@ uint64_t gpa2hpa(struct acrn_vm *vm, uint64_t gpa)
 /**
  * @pre: the gpa and hpa are identical mapping in SOS.
  */
-uint64_t vm0_hpa2gpa(uint64_t hpa)
+uint64_t sos_vm_hpa2gpa(uint64_t hpa)
 {
 	return hpa;
 }

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -448,9 +448,9 @@ int32_t copy_to_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
  * @retval 0 on success
  *
  * @pre vm != NULL
- * @pre is_vm0(vm) == true
+ * @pre is_sos_vm(vm) == true
  */
-void prepare_vm0_memmap(struct acrn_vm *vm)
+void prepare_sos_vm_memmap(struct acrn_vm *vm)
 {
 	uint32_t i;
 	uint64_t attr_uc = (EPT_RWX | EPT_UNCACHED);
@@ -462,11 +462,11 @@ void prepare_vm0_memmap(struct acrn_vm *vm)
 	const struct e820_entry *p_e820 = get_e820_entry();
 	const struct e820_mem_params *p_e820_mem_info = get_e820_mem_info();
 
-	dev_dbg(ACRN_DBG_GUEST, "vm0: bottom memory - 0x%llx, top memory - 0x%llx\n",
+	dev_dbg(ACRN_DBG_GUEST, "sos_vm: bottom memory - 0x%llx, top memory - 0x%llx\n",
 		p_e820_mem_info->mem_bottom, p_e820_mem_info->mem_top);
 
 	if (p_e820_mem_info->mem_top > EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE)) {
-		panic("Please configure VM0_ADDRESS_SPACE correctly!\n");
+		panic("Please configure SOS_VM_ADDRESS_SPACE correctly!\n");
 	}
 
 	/* create real ept map for all ranges with UC */
@@ -481,7 +481,7 @@ void prepare_vm0_memmap(struct acrn_vm *vm)
 		}
 	}
 
-	dev_dbg(ACRN_DBG_GUEST, "VM0 e820 layout:\n");
+	dev_dbg(ACRN_DBG_GUEST, "SOS_VM e820 layout:\n");
 	for (i = 0U; i < entries_count; i++) {
 		entry = p_e820 + i;
 		dev_dbg(ACRN_DBG_GUEST, "e820 table: %d type: 0x%x", i, entry->type);

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -10,7 +10,7 @@ int32_t validate_pstate(const struct acrn_vm *vm, uint64_t perf_ctl)
 {
 	int32_t ret = -1;
 
-	if (is_vm0(vm)) {
+	if (is_sos_vm(vm)) {
 		ret = 0;
 	} else {
 		uint8_t i;
@@ -132,7 +132,7 @@ static inline void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t 
 	guest_wakeup_vec32 = *(vm->pm.sx_state_data->wake_vector_32);
 	clac();
 
-	pause_vm(vm);	/* pause vm0 before suspend system */
+	pause_vm(vm);	/* pause sos_vm before suspend system */
 	host_enter_s3(vm->pm.sx_state_data, pm1a_cnt_val, pm1b_cnt_val);
 	resume_vm_from_s3(vm, guest_wakeup_vec32);	/* jump back to vm */
 }

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -308,7 +308,7 @@ void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry)
  * vcpu_id/pcpu_id mapping table:
  *
  * if
- *     VM0_CPUS[2] = {0, 2} , VM1_CPUS[2] = {3, 1};
+ *     SOS_VM_CPUS[2] = {0, 2} , VM1_CPUS[2] = {3, 1};
  * then
  *     for physical CPU 0 : vcpu->pcpu_id = 0, vcpu->vcpu_id = 0, vmid = 0;
  *     for physical CPU 2 : vcpu->pcpu_id = 2, vcpu->vcpu_id = 1, vmid = 0;

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -365,7 +365,7 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 #ifdef CONFIG_PARTITION_MODE
 			cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
 #else
-			if (is_vm0(vcpu->vm)) {
+			if (is_sos_vm(vcpu->vm)) {
 				cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
 			} else {
 				*ecx = subleaf & 0xFFU;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2087,7 +2087,9 @@ static int32_t vlapic_x2apic_access(struct acrn_vcpu *vcpu, uint32_t msr, bool w
 	vlapic = vcpu_vlapic(vcpu);
 	if (is_x2apic_enabled(vlapic)) {
 #ifdef CONFIG_PARTITION_MODE
-		if (vcpu->vm->vm_config->lapic_pt) {
+		struct acrn_vm_config *vm_config = get_vm_config(vcpu->vm->vm_id);
+
+		if (vm_config->lapic_pt) {
 			if (msr == MSR_IA32_EXT_APIC_ICR) {
 				error = vlapic_x2apic_pt_icr_access(vcpu->vm, *val);
 			}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -174,7 +174,7 @@ vlapic_build_id(const struct acrn_vlapic *vlapic)
 	 */
 	vlapic_id = per_cpu(lapic_id, vcpu->pcpu_id);
 #else
-	if (is_vm0(vcpu->vm)) {
+	if (is_sos_vm(vcpu->vm)) {
 		/* Get APIC ID sequence format from cpu_storage */
 		vlapic_id = per_cpu(lapic_id, vcpu->vcpu_id);
 	} else {
@@ -2183,7 +2183,7 @@ int32_t vlapic_create(struct acrn_vcpu *vcpu)
 		uint64_t *pml4_page =
 			(uint64_t *)vcpu->vm->arch_vm.nworld_eptp;
 		/* only need unmap it from SOS as UOS never mapped it */
-		if (is_vm0(vcpu->vm)) {
+		if (is_sos_vm(vcpu->vm)) {
 			ept_mr_del(vcpu->vm, pml4_page,
 				DEFAULT_APIC_BASE, PAGE_SIZE);
 		}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2089,7 +2089,7 @@ static int32_t vlapic_x2apic_access(struct acrn_vcpu *vcpu, uint32_t msr, bool w
 #ifdef CONFIG_PARTITION_MODE
 		struct acrn_vm_config *vm_config = get_vm_config(vcpu->vm->vm_id);
 
-		if (vm_config->lapic_pt) {
+		if((vm_config->guest_flags & LAPIC_PASSTHROUGH) != 0U ) {
 			if (msr == MSR_IA32_EXT_APIC_ICR) {
 				error = vlapic_x2apic_pt_icr_access(vcpu->vm, *val);
 			}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -141,6 +141,10 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 				hva2hpa(ept_mem_ops->get_sworld_memory_base(ept_mem_ops->info)),
 				TRUSTY_EPT_REBASE_GPA, TRUSTY_RAM_SIZE, EPT_WB | EPT_RWX);
 		}
+		if (vm_config->name[0] == '\0') {
+			/* if VM name is not configured, specify with VM ID */
+			snprintf(vm_config->name, 16, "ACRN VM_%d", vm_id);
+		}
 
 		(void)memcpy_s(&vm->GUID[0], sizeof(vm->GUID),
 			&vm_config->GUID[0], sizeof(vm_config->GUID));
@@ -411,7 +415,7 @@ void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config)
 		/* start vm BSP automatically */
 		start_vm(vm);
 
-		pr_acrnlog("Start VM%x", vm->vm_id);
+		pr_acrnlog("Start VM id: %x name: %s", vm_id, vm_config->name);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -174,7 +174,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 			&vm_config->GUID[0], sizeof(vm_config->GUID));
 #ifdef CONFIG_PARTITION_MODE
 		ept_mr_add(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
-			vm_config->start_hpa, 0UL, vm_config->mem_size,
+			vm_config->memory.start_hpa, 0UL, vm_config->memory.size,
 			EPT_RWX|EPT_WB);
 		init_vm_boot_info(vm);
 #endif

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -73,6 +73,12 @@ struct acrn_vm *get_vm_from_vmid(uint16_t vm_id)
 	return &vm_array[vm_id];
 }
 
+/* return a pointer to the virtual machine structure of SOS VM */
+struct acrn_vm *get_sos_vm(void)
+{
+	return sos_vm_ptr;
+}
+
 /**
  * @pre vm_config != NULL
  */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -124,10 +124,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	vm = &vm_array[vm_id];
 	(void)memset((void *)vm, 0U, sizeof(struct acrn_vm));
 	vm->vm_id = vm_id;
-#ifdef CONFIG_PARTITION_MODE
-	/* Map Virtual Machine to its VM Description */
-	vm->vm_config = vm_config;
-#endif
 	vm->hw.created_vcpus = 0U;
 	vm->emul_mmio_regions = 0U;
 	vm->snoopy_mem = true;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -139,7 +139,9 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 
 	} else {
 		/* populate UOS vm fields according to vm_config */
-		vm->sworld_control.flag.supported = vm_config->sworld_supported;
+		if ((vm_config->guest_flags & SECURE_WORLD_ENABLED) != 0U) {
+			vm->sworld_control.flag.supported = 1U;
+		}
 		if (vm->sworld_control.flag.supported != 0UL) {
 			struct memory_ops *ept_mem_ops = &vm->arch_vm.ept_mem_ops;
 

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -195,10 +195,10 @@ int32_t vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 	if (!is_hypercall_from_ring0()) {
 		pr_err("hypercall is only allowed from RING-0!\n");
 	        ret = -EACCES;
-	} else if (!is_vm0(vm) && (hypcall_id != HC_WORLD_SWITCH) &&
+	} else if (!is_sos_vm(vm) && (hypcall_id != HC_WORLD_SWITCH) &&
 		(hypcall_id != HC_INITIALIZE_TRUSTY) &&
 		(hypcall_id != HC_SAVE_RESTORE_SWORLD_CTX)) {
-		pr_err("hypercall %d is only allowed from VM0!\n", hypcall_id);
+		pr_err("hypercall %d is only allowed from SOS_VM!\n", hypcall_id);
 	        ret = -EACCES;
 	} else {
 		/* Dispatch the hypercall handler */

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -553,7 +553,7 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	case MSR_IA32_BIOS_UPDT_TRIG:
 	{
 		/* We only allow SOS to do uCode update */
-		if (is_vm0(vcpu->vm)) {
+		if (is_sos_vm(vcpu->vm)) {
 			acrn_update_ucode(vcpu, v);
 		}
 		break;

--- a/hypervisor/arch/x86/guest/vmtrr.c
+++ b/hypervisor/arch/x86/guest/vmtrr.c
@@ -100,14 +100,14 @@ void init_vmtrr(struct acrn_vcpu *vcpu)
 	vmtrr->def_type.bits.fixed_enable = 1U;
 	vmtrr->def_type.bits.type = MTRR_MEM_TYPE_UC;
 
-	if (is_vm0(vcpu->vm)) {
+	if (is_sos_vm(vcpu->vm)) {
 		cap.value = msr_read(MSR_IA32_MTRR_CAP);
 	}
 
 	for (i = 0U; i < FIXED_RANGE_MTRR_NUM; i++) {
 		if (cap.bits.fix != 0U) {
 			/*
-			 * The system firmware runs in VMX non-root mode on VM0.
+			 * The system firmware runs in VMX non-root mode on SOS_VM.
 			 * In some cases, the firmware needs particular mem type
 			 * at certain mmeory locations (e.g. UC for some
 			 * hardware registers), so we need to configure EPT
@@ -116,7 +116,7 @@ void init_vmtrr(struct acrn_vcpu *vcpu)
 			vmtrr->fixed_range[i].value = msr_read(fixed_mtrr_map[i].msr);
 		} else {
 			/*
-			 * For non-vm0 EPT, all memory is setup with WB type in
+			 * For non-sos_vm EPT, all memory is setup with WB type in
 			 * EPT, so we setup fixed range MTRRs accordingly.
 			 */
 			vmtrr->fixed_range[i].value = MTRR_FIXED_RANGE_ALL_WB;

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -55,13 +55,7 @@ static void enter_guest_mode(uint16_t pcpu_id)
 {
 	vmx_on();
 
-#ifdef CONFIG_PARTITION_MODE
-	(void)prepare_vm(pcpu_id);
-#else
-	if (pcpu_id == BOOT_CPU_ID) {
-		(void)prepare_vm(pcpu_id);
-	}
-#endif
+	(void)launch_vms(pcpu_id);
 
 	switch_to_idle(default_idle);
 

--- a/hypervisor/arch/x86/io_emul.c
+++ b/hypervisor/arch/x86/io_emul.c
@@ -536,7 +536,7 @@ static void deny_guest_pio_access(struct acrn_vm *vm, uint16_t port_address,
 void register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
 		const struct vm_io_range *range, io_read_fn_t io_read_fn_ptr, io_write_fn_t io_write_fn_ptr)
 {
-	if (is_vm0(vm)) {
+	if (is_sos_vm(vm)) {
 		deny_guest_pio_access(vm, range->base, range->len);
 	}
 	vm->arch_vm.emul_pio[pio_idx].port_start = range->base;
@@ -588,7 +588,7 @@ int32_t register_mmio_emulation_handler(struct acrn_vm *vm,
 				 * should unmap it. But UOS will not, so we shouldn't
 				 * need to unmap it.
 				 */
-				if (is_vm0(vm)) {
+				if (is_sos_vm(vm)) {
 					ept_mr_del(vm, (uint64_t *)vm->arch_vm.nworld_eptp, start, end - start);
 				}
 

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -81,7 +81,7 @@ static int32_t request_notification_irq(irq_action_t func, void *data)
  */
 void setup_notification(void)
 {
-	/* support IPI notification, VM0 will register all CPU */
+	/* support IPI notification, SOS_VM will register all CPU */
 	if (request_notification_irq(kick_notification, NULL) < 0) {
 		pr_err("Failed to setup notification");
 	}

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -58,10 +58,10 @@ const struct memory_ops ppt_mem_ops = {
 	.get_pd_page = ppt_get_pd_page,
 };
 
-static struct page vm0_pml4_pages[PML4_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
-static struct page vm0_pdpt_pages[PDPT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
-static struct page vm0_pd_pages[PD_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
-static struct page vm0_pt_pages[PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page sos_vm_pml4_pages[PML4_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page sos_vm_pdpt_pages[PDPT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page sos_vm_pd_pages[PD_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
+static struct page sos_vm_pt_pages[PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))];
 
 /* uos_nworld_pml4_pages[i] is ...... of UOS i (whose vm_id = i +1) */
 static struct page uos_nworld_pml4_pages[CONFIG_MAX_VM_NUM - 1U][PML4_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))];
@@ -78,10 +78,10 @@ static union pgtable_pages_info ept_pages_info[CONFIG_MAX_VM_NUM] = {
 	{
 		.ept = {
 			.top_address_space = EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE),
-			.nworld_pml4_base = vm0_pml4_pages,
-			.nworld_pdpt_base = vm0_pdpt_pages,
-			.nworld_pd_base = vm0_pd_pages,
-			.nworld_pt_base = vm0_pt_pages,
+			.nworld_pml4_base = sos_vm_pml4_pages,
+			.nworld_pdpt_base = sos_vm_pdpt_pages,
+			.nworld_pd_base = sos_vm_pd_pages,
+			.nworld_pt_base = sos_vm_pt_pages,
 		},
 	},
 };

--- a/hypervisor/arch/x86/vmcs.c
+++ b/hypervisor/arch/x86/vmcs.c
@@ -574,7 +574,9 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
-	if(vcpu->vm->vm_config->lapic_pt) {
+	struct acrn_vm_config *vm_config = get_vm_config(vcpu->vm->vm_id);
+
+	if(vm_config->lapic_pt) {
 		/*
 		 * Disable external interrupt exiting and irq ack
 		 * Disable posted interrupt processing

--- a/hypervisor/arch/x86/vmcs.c
+++ b/hypervisor/arch/x86/vmcs.c
@@ -576,7 +576,7 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 	uint32_t value32;
 	struct acrn_vm_config *vm_config = get_vm_config(vcpu->vm->vm_id);
 
-	if(vm_config->lapic_pt) {
+	if((vm_config->guest_flags & LAPIC_PASSTHROUGH) != 0U ) {
 		/*
 		 * Disable external interrupt exiting and irq ack
 		 * Disable posted interrupt processing

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -49,8 +49,8 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 				vm->sw.kernel_info.kernel_src_addr = hpa2hva((uint64_t)mods[0].mm_mod_start);
 				vm->sw.kernel_info.kernel_size = mods[0].mm_mod_end - mods[0].mm_mod_start;
 				vm->sw.kernel_info.kernel_load_addr = (void *)(16 * 1024 * 1024UL);
-				vm->sw.linux_info.bootargs_src_addr = (void *)vm_config->bootargs;
-				vm->sw.linux_info.bootargs_size = strnlen_s(vm_config->bootargs, MEM_2K);
+				vm->sw.linux_info.bootargs_src_addr = (void *)vm_config->os_config.bootargs;
+				vm->sw.linux_info.bootargs_size = strnlen_s(vm_config->os_config.bootargs, MEM_2K);
 				vm->sw.linux_info.bootargs_load_addr = (void *)(vm_config->memory.size - 8*1024UL);
 				clac();
 				ret = 0;

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -51,7 +51,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 				vm->sw.kernel_info.kernel_load_addr = (void *)(16 * 1024 * 1024UL);
 				vm->sw.linux_info.bootargs_src_addr = (void *)vm_config->bootargs;
 				vm->sw.linux_info.bootargs_size = strnlen_s(vm_config->bootargs, MEM_2K);
-				vm->sw.linux_info.bootargs_load_addr = (void *)(vm_config->mem_size -  8*1024UL);
+				vm->sw.linux_info.bootargs_load_addr = (void *)(vm_config->memory.size - 8*1024UL);
 				clac();
 				ret = 0;
 			}

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -21,6 +21,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 {
 	struct multiboot_module *mods = NULL;
 	struct multiboot_info *mbi = NULL;
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	int32_t ret = -EINVAL;
 
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
@@ -48,9 +49,9 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 				vm->sw.kernel_info.kernel_src_addr = hpa2hva((uint64_t)mods[0].mm_mod_start);
 				vm->sw.kernel_info.kernel_size = mods[0].mm_mod_end - mods[0].mm_mod_start;
 				vm->sw.kernel_info.kernel_load_addr = (void *)(16 * 1024 * 1024UL);
-				vm->sw.linux_info.bootargs_src_addr = (void *)vm->vm_config->bootargs;
-				vm->sw.linux_info.bootargs_size = strnlen_s(vm->vm_config->bootargs, MEM_2K);
-				vm->sw.linux_info.bootargs_load_addr = (void *)(vm->vm_config->mem_size -  8*1024UL);
+				vm->sw.linux_info.bootargs_src_addr = (void *)vm_config->bootargs;
+				vm->sw.linux_info.bootargs_size = strnlen_s(vm_config->bootargs, MEM_2K);
+				vm->sw.linux_info.bootargs_load_addr = (void *)(vm_config->mem_size -  8*1024UL);
 				clac();
 				ret = 0;
 			}

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -60,7 +60,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 }
 
 #else
-/* There are two sources for vm0 kernel cmdline:
+/* There are two sources for sos_vm kernel cmdline:
  * - cmdline from sbl. mbi->cmdline
  * - cmdline from acrn stitching tool. mod[0].mm_string
  * We need to merge them together
@@ -152,7 +152,7 @@ static void *get_kernel_load_addr(void *kernel_src_addr)
  * @retval -EINVAL on invalid parameters
  *
  * @pre vm != NULL
- * @pre is_vm0(vm) == true
+ * @pre is_sos_vm(vm) == true
  */
 int32_t init_vm_boot_info(struct acrn_vm *vm)
 {

--- a/hypervisor/boot/sbl/sbl_seed_parse.c
+++ b/hypervisor/boot/sbl/sbl_seed_parse.c
@@ -138,7 +138,7 @@ bool sbl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 	uint32_t len;
 	bool parse_success = false;
 
-	if (is_vm0(vm) && (cmdline != NULL)) {
+	if (is_sos_vm(vm) && (cmdline != NULL)) {
 		len = strnlen_s(boot_params_arg, MEM_1K);
 		arg = strstr_s((const char *)cmdline, MEM_2K, boot_params_arg, len);
 
@@ -153,8 +153,8 @@ bool sbl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 				 * Convert the addresses to SOS GPA since this structure will
 				 * be used in SOS.
 				 */
-				boot_params->p_seed_list = vm0_hpa2gpa(boot_params->p_seed_list);
-				boot_params->p_platform_info = vm0_hpa2gpa(boot_params->p_platform_info);
+				boot_params->p_seed_list = sos_vm_hpa2gpa(boot_params->p_seed_list);
+				boot_params->p_platform_info = sos_vm_hpa2gpa(boot_params->p_platform_info);
 
 				/*
 				 * Replace original arguments with spaces since SOS's GPA is not

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -125,7 +125,6 @@ int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param)
 			/* TODO: set by DM */
 			vm_config->type = NORMAL_VM;
 			vm_config->guest_flags |= cv.vm_flag;
-			vm_config->sworld_supported = ((cv.vm_flag & (SECURE_WORLD_ENABLED)) != 0U);
 			(void)memcpy_s(&vm_config->GUID[0], 16U, &cv.GUID[0], 16U);
 
 			ret = create_vm(vm_id, vm_config, &target_vm);

--- a/hypervisor/common/io_req.c
+++ b/hypervisor/common/io_req.c
@@ -15,14 +15,15 @@ static void fire_vhm_interrupt(void)
 	 * use vLAPIC to inject vector to SOS vcpu 0 if vlapic is enabled
 	 * otherwise, send IPI hardcoded to BOOT_CPU_ID
 	 */
-	struct acrn_vm *vm0;
+	struct acrn_vm *sos_vm;
 	struct acrn_vcpu *vcpu;
 
-	vm0 = get_vm_from_vmid(0U);
+	sos_vm = get_sos_vm();
+	if (sos_vm != NULL) {
+		vcpu = vcpu_from_vid(sos_vm, BOOT_CPU_ID);
 
-	vcpu = vcpu_from_vid(vm0, 0U);
-
-	vlapic_set_intr(vcpu, acrn_vhm_vector, LAPIC_TRIG_EDGE);
+		vlapic_set_intr(vcpu, acrn_vhm_vector, LAPIC_TRIG_EDGE);
+	}
 }
 
 #if defined(HV_DEBUG)

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -66,8 +66,8 @@ struct ptirq_remapping_info *ptirq_dequeue_softirq(struct acrn_vm *vm)
 
 		list_del_init(&entry->softirq_node);
 
-		/* if vm0, just dequeue, if uos, check delay timer */
-		if (is_vm0(entry->vm) || timer_expired(&entry->intr_delay_timer)) {
+		/* if sos vm, just dequeue, if uos, check delay timer */
+		if (is_sos_vm(entry->vm) || timer_expired(&entry->intr_delay_timer)) {
 			break;
 		} else {
 			/* add it into timer list; dequeue next one */
@@ -131,7 +131,7 @@ static void ptirq_interrupt_handler(__unused uint32_t irq, void *data)
 	 * "interrupt storm" detection & delay intr injection just for UOS
 	 * pass-thru devices, collect its data and delay injection if needed
 	 */
-	if (!is_vm0(entry->vm)) {
+	if (!is_sos_vm(entry->vm)) {
 		entry->intr_count++;
 
 		/* if delta > 0, set the delay TSC, dequeue to handle */

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -128,7 +128,7 @@ int32_t general_sw_loader(struct acrn_vm *vm)
 		 * reserving. Current strategy is "total_mem_size in Giga -
 		 * remained 1G pages" for reserving.
 		 */
-		if (is_vm0(vm)) {
+		if (is_sos_vm(vm)) {
 			int32_t reserving_1g_pages;
 
 #ifdef CONFIG_REMAIN_1G_PAGES

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -20,7 +20,7 @@
  * @param param guest physical address. This gpa points to
  *             data structure required by each command
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 static int32_t hcall_profiling_ops(struct acrn_vm *vm, uint64_t cmd, uint64_t param)
@@ -67,7 +67,7 @@ static int32_t hcall_profiling_ops(struct acrn_vm *vm, uint64_t cmd, uint64_t pa
  * @param param guest physical address. This gpa points to
  *              struct sbuf_setup_param
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 static int32_t hcall_setup_sbuf(struct acrn_vm *vm, uint64_t param)
@@ -98,7 +98,7 @@ static int32_t hcall_setup_sbuf(struct acrn_vm *vm, uint64_t param)
   * @param param guest physical address. This gpa points to
   *              struct hv_npk_log_param
   *
-  * @pre Pointer vm shall point to VM0
+  * @pre Pointer vm shall point to SOS_VM
   * @return 0 on success, non-zero on error.
   */
 static int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, uint64_t param)
@@ -128,7 +128,7 @@ static int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, uint64_t param)
  * @param vm Pointer to vm data structure
  * @param param Guest physical address pointing to struct acrn_hw_info
  *
- * @pre vm shall point to VM0
+ * @pre vm shall point to SOS_VM
  * @pre param shall be a valid physical address
  *
  * @retval 0 on success
@@ -158,7 +158,7 @@ static int32_t hcall_get_hw_info(struct acrn_vm *vm, uint64_t param)
   * @param param2 hypercall param2 from guest
   * @param hypcall_id hypercall ID from guest
   *
-  * @pre Pointer vm shall point to VM0
+  * @pre Pointer vm shall point to SOS_VM
   * @return 0 on success, non-zero on error.
   */
 int32_t hcall_debug(struct acrn_vm *vm, uint64_t param1, uint64_t param2, uint64_t hypcall_id)

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1394,7 +1394,7 @@ void profiling_setup(void)
 	int32_t retval;
 	dev_dbg(ACRN_DBG_PROFILING, "%s: entering", __func__);
 	cpu = get_cpu_id();
-	/* support PMI notification, VM0 will register all CPU */
+	/* support PMI notification, SOS_VM will register all CPU */
 	if ((cpu == BOOT_CPU_ID) && (profiling_pmi_irq == IRQ_INVALID)) {
 		pr_info("%s: calling request_irq", __func__);
 		retval = request_irq(PMI_IRQ,

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -809,7 +809,7 @@ static int32_t shell_to_sos_console(__unused int32_t argc, __unused char **argv)
 	}
 
 #ifdef CONFIG_PARTITION_MODE
-	vm_config = vm->vm_config;
+	vm_config = get_vm_config(guest_no);
 	if (vm_config != NULL && vm_config->vm_vuart == false) {
 		snprintf(temp_str, TEMP_STR_SIZE, "No vUART configured for vm%d\n", guest_no);
 		shell_puts(temp_str);

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -513,17 +513,15 @@ static int32_t shell_list_vm(__unused int32_t argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
 	struct acrn_vm *vm;
-	uint16_t idx;
+	struct acrn_vm_config *vm_config;
+	uint16_t vm_id;
 	char state[32];
 
-	shell_puts("\r\nVM NAME                  VM ID            VM STATE"
-		"\r\n=======                  =====            ========\r\n");
+	shell_puts("\r\nVM NAME\t\t\t\tVM ID\t\tVM STATE"
+		"\r\n=======\t\t\t\t=====\t\t========\r\n");
 
-	for (idx = 0U; idx < CONFIG_MAX_VM_NUM; idx++) {
-		vm = get_vm_from_vmid(idx);
-		if (vm == NULL) {
-			continue;
-		}
+	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
+		vm = get_vm_from_vmid(vm_id);
 		switch (vm->state) {
 		case VM_CREATED:
 			(void)strncpy_s(state, 32U, "Created", 32U);
@@ -538,14 +536,13 @@ static int32_t shell_list_vm(__unused int32_t argc, __unused char **argv)
 			(void)strncpy_s(state, 32U, "Unknown", 32U);
 			break;
 		}
-		/* Create output string consisting of VM name and VM id
-		 */
-		snprintf(temp_str, MAX_STR_SIZE,
-				"vm_%-24d %-16d %-8s\r\n", vm->vm_id,
-				vm->vm_id, state);
+		vm_config = get_vm_config(vm_id);
+		if (vm_config->type != UNDEFINED_VM) {
+			snprintf(temp_str, MAX_STR_SIZE, "%-34s%-14d%-8s\r\n", vm_config->name, vm_id, state);
 
-		/* Output information for this task */
-		shell_puts(temp_str);
+			/* Output information for this task */
+			shell_puts(temp_str);
+		}
 	}
 
 	return 0;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -376,7 +376,7 @@ struct acrn_vuart *vuart_console_active(void)
 
 	vm = get_vm_from_vmid(vuart_vmid);
 #else
-	struct acrn_vm *vm = get_vm_from_vmid(0U);
+	struct acrn_vm *vm = get_sos_vm();
 #endif
 
 	if (vm != NULL) {

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -529,7 +529,7 @@ vioapic_pincount(const struct acrn_vm *vm)
 {
 	uint32_t ret;
 
-	if (is_vm0(vm)) {
+	if (is_sos_vm(vm)) {
 	        ret = REDIR_ENTRIES_HW;
 	} else {
 		ret = VIOAPIC_RTE_NUM;

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -328,7 +328,7 @@ static void decode_msix_table_bar(struct pci_vdev *vdev)
 		}
 
 		vdev->msix.mmio_hva = (uint64_t)hpa2hva(base);
-		vdev->msix.mmio_gpa = vm0_hpa2gpa(base);
+		vdev->msix.mmio_gpa = sos_vm_hpa2gpa(base);
 
 		/* Sizing the BAR */
 		size = 0U;

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -36,9 +36,10 @@ static struct pci_vdev *partition_mode_find_vdev(struct acrn_vpci *vpci, union p
 {
 	struct vpci_vdev_array *vdev_array;
 	struct pci_vdev *vdev;
+	struct acrn_vm_config *vm_config = get_vm_config(vpci->vm->vm_id);
 	int32_t i;
 
-	vdev_array = vpci->vm->vm_config->vpci_vdev_array;
+	vdev_array = vm_config->vpci_vdev_array;
 	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
 		vdev = &vdev_array->vpci_vdev_list[i];
 		if (vdev->vbdf.value == vbdf.value) {
@@ -54,9 +55,10 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 	struct vpci_vdev_array *vdev_array;
 	const struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_vdev *vdev;
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	int32_t i;
 
-	vdev_array = vm->vm_config->vpci_vdev_array;
+	vdev_array = vm_config->vpci_vdev_array;
 
 	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
 		vdev = &vdev_array->vpci_vdev_list[i];
@@ -77,9 +79,10 @@ static void partition_mode_vpci_deinit(const struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
 	struct pci_vdev *vdev;
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	int32_t i;
 
-	vdev_array = vm->vm_config->vpci_vdev_array;
+	vdev_array = vm_config->vpci_vdev_array;
 
 	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
 		vdev = &vdev_array->vpci_vdev_list[i];

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -228,7 +228,7 @@ void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, 
 	} else {
 		/* Return this PCI device to SOS */
 		if (vdev->vpci->vm == target_vm) {
-			vm = get_vm_from_vmid(0U);
+			vm = get_sos_vm();
 
 			if (vm != NULL) {
 				vdev->vpci = &vm->vpci;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -38,7 +38,7 @@ struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf)
 	struct pci_vdev *vdev = NULL;
 	uint32_t i;
 
-	/* in VM0, it uses phys BDF */
+	/* in SOS_VM, it uses phys BDF */
 	for (i = 0U; i < num_pci_vdev; i++) {
 		if (sharing_mode_vdev_array[i].pdev.bdf.value == pbdf.value) {
 			vdev = &sharing_mode_vdev_array[i];
@@ -140,16 +140,16 @@ static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
 
 	/*
 	 * Only setup IO bitmap for SOS.
-	 * IO/MMIO requests from non-vm0 guests will be injected to device model.
+	 * IO/MMIO requests from non-sos_vm guests will be injected to device model.
 	 */
-	if (!is_vm0(vm)) {
+	if (!is_sos_vm(vm)) {
 	        ret = -ENODEV;
 	} else {
 		/* Initialize PCI vdev array */
 		num_pci_vdev = 0U;
 		(void)memset((void *)sharing_mode_vdev_array, 0U, sizeof(sharing_mode_vdev_array));
 
-		/* build up vdev array for vm0 */
+		/* build up vdev array for sos_vm */
 		pci_scan_bus(enumerate_pci_dev, vm);
 
 		for (i = 0U; i < num_pci_vdev; i++) {
@@ -171,7 +171,7 @@ static void sharing_mode_vpci_deinit(__unused const struct acrn_vm *vm)
 	struct pci_vdev *vdev;
 	uint32_t i, j;
 
-	if (is_vm0(vm)) {
+	if (is_sos_vm(vm)) {
 		for (i = 0U; i < num_pci_vdev; i++) {
 			vdev = &sharing_mode_vdev_array[i];
 			for (j = 0U; j < vdev->nr_ops; j++) {

--- a/hypervisor/include/arch/x86/assign.h
+++ b/hypervisor/include/arch/x86/assign.h
@@ -86,7 +86,7 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpi
 /**
  * @brief Add an interrupt remapping entry for INTx as pre-hold mapping.
  *
- * Except vm0, Device Model should call this function to pre-hold ptdev intx
+ * Except sos_vm, Device Model should call this function to pre-hold ptdev intx
  * The entry is identified by phys_pin, one entry vs. one phys_pin.
  * Currently, one phys_pin can only be held by one pin source (vPIC or vIOAPIC).
  *
@@ -125,7 +125,7 @@ void ptirq_remove_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, bool pic
  * @brief Add interrupt remapping entry/entries for MSI/MSI-x as pre-hold mapping.
  *
  * Add pre-hold mapping of the given number of vectors between the given physical and virtual BDF for the given vm.
- * Except vm0, Device Model should call this function to pre-hold ptdev MSI/MSI-x.
+ * Except sos_vm, Device Model should call this function to pre-hold ptdev MSI/MSI-x.
  * The entry is identified by phys_bdf:msi_idx, one entry vs. one phys_bdf:msi_idx.
  *
  * @param[in] vm pointer to acrn_vm

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -18,10 +18,10 @@ struct e820_mem_params {
 /* HV read multiboot header to get e820 entries info and calc total RAM info */
 void init_e820(void);
 
-/* before boot vm0(service OS), call it to hide the HV RAM entry in e820 table from vm0 */
-void rebuild_vm0_e820(void);
+/* before boot sos_vm(service OS), call it to hide the HV RAM entry in e820 table from sos_vm */
+void rebuild_sos_vm_e820(void);
 
-/* get some RAM below 1MB in e820 entries, hide it from vm0, return its start address */
+/* get some RAM below 1MB in e820 entries, hide it from sos_vm, return its start address */
 uint64_t e820_alloc_low_memory(uint32_t size_arg);
 
 /* copy the original e820 entries info to param_e820 */

--- a/hypervisor/include/arch/x86/guest/guest.h
+++ b/hypervisor/include/arch/x86/guest/guest.h
@@ -70,7 +70,7 @@
 #define LDTR_AR                         (0x0082U) /* LDT, type must be 2, refer to SDM Vol3 26.3.1.2 */
 #define TR_AR                           (0x008bU) /* TSS (busy), refer to SDM Vol3 26.3.1.2 */
 
-void prepare_vm0_memmap(struct acrn_vm *vm);
+void prepare_sos_vm_memmap(struct acrn_vm *vm);
 
 /* Use # of paging level to identify paging mode */
 enum vm_paging_mode {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -217,7 +217,6 @@ struct acrn_vm_config {
 
 #ifdef CONFIG_PARTITION_MODE
 	bool			vm_vuart;
-	const char		*bootargs;
 	struct vpci_vdev_array  *vpci_vdev_array;
 	bool	lapic_pt;
 #endif

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -314,6 +314,7 @@ extern struct acrn_vm_config vm_configs[];
 bool is_sos_vm(const struct acrn_vm *vm);
 uint16_t find_free_vm_id(void);
 struct acrn_vm *get_vm_from_vmid(uint16_t vm_id);
+struct acrn_vm *get_sos_vm(void);
 
 #ifdef CONFIG_PARTITION_MODE
 struct vm_config_arraies {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -157,7 +157,6 @@ struct acrn_vm {
 	struct acrn_vpci vpci;
 #ifdef CONFIG_PARTITION_MODE
 	struct mptable_info mptable;
-	struct acrn_vm_config	*vm_config;
 	uint8_t vrtc_offset;
 #endif
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -216,13 +216,7 @@ struct acrn_vm_config {
 	struct acrn_vm_pci_ptdev_config *pci_ptdevs;	/* point to PCI PT devices BDF list */
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
 
-	/* The physical CPU IDs associated with this VM - The first CPU listed
-	 * will be the VM's BSP
-	 */
-	uint16_t               *vm_pcpu_ids;
-	uint16_t               vm_hw_num_cores;   /* Number of virtual cores */
 #ifdef CONFIG_PARTITION_MODE
-	uint8_t			vm_id;
 	uint64_t		start_hpa;
 	uint64_t		mem_size; /* UOS memory size in hex */
 	bool			vm_vuart;
@@ -327,6 +321,7 @@ struct pcpu_vm_config_mapping {
 extern const struct pcpu_vm_config_mapping pcpu_vm_config_map[];
 extern struct vm_config_arraies vm_config_partition;
 
+uint16_t get_vm_pcpu_nums(struct acrn_vm_config *vm_config);
 void vrtc_init(struct acrn_vm *vm);
 #endif
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -235,7 +235,7 @@ struct acrn_vm_config {
 
 } __aligned(8);
 
-static inline bool is_vm0(const struct acrn_vm *vm)
+static inline bool is_sos_vm(const struct acrn_vm *vm)
 {
 	return (vm->vm_id) == 0U;
 }

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -221,8 +221,6 @@ struct acrn_vm_config {
 	 */
 	uint16_t               *vm_pcpu_ids;
 	uint16_t               vm_hw_num_cores;   /* Number of virtual cores */
-	/* Whether secure world is supported for current VM. */
-	bool                   sworld_supported;
 #ifdef CONFIG_PARTITION_MODE
 	uint8_t			vm_id;
 	uint64_t		start_hpa;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -216,8 +216,6 @@ struct acrn_vm_config {
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
 
 #ifdef CONFIG_PARTITION_MODE
-	uint64_t		start_hpa;
-	uint64_t		mem_size; /* UOS memory size in hex */
 	bool			vm_vuart;
 	const char		*bootargs;
 	struct vpci_vdev_array  *vpci_vdev_array;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -218,7 +218,6 @@ struct acrn_vm_config {
 #ifdef CONFIG_PARTITION_MODE
 	bool			vm_vuart;
 	struct vpci_vdev_array  *vpci_vdev_array;
-	bool	lapic_pt;
 #endif
 
 } __aligned(8);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -238,13 +238,13 @@ uint64_t gpa2hpa(struct acrn_vm *vm, uint64_t gpa);
  */
 uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size);
 /**
- * @brief Translating from host-physical address to guest-physical address for VM0
+ * @brief Translating from host-physical address to guest-physical address for SOS_VM
  *
  * @param[in] hpa the specified host-physical address
  *
  * @pre: the gpa and hpa are identical mapping in SOS.
  */
-uint64_t vm0_hpa2gpa(uint64_t hpa);
+uint64_t sos_vm_hpa2gpa(uint64_t hpa);
 /**
  * @brief Guest-physical memory region mapping
  *

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -485,7 +485,7 @@ struct iommu_domain;
 /**
  * @brief Assign a device specified by bus & devfun to a iommu domain.
  *
- * Remove the device from the VM0 domain (if present), and add it to the specific domain.
+ * Remove the device from the SOS_VM domain (if present), and add it to the specific domain.
  *
  * @param[in]    domain iommu domain the device is assigned to
  * @param[in]    bus the 8-bit bus number of the device
@@ -502,7 +502,7 @@ int32_t assign_iommu_device(struct iommu_domain *domain, uint8_t bus, uint8_t de
 /**
  * @brief Unassign a device specified by bus & devfun from a iommu domain .
  *
- * Remove the device from the specific domain, and then add it to the VM0 domain (if present).
+ * Remove the device from the specific domain, and then add it to the SOS_VM domain (if present).
  *
  * @param[in]    domain iommu domain the device is assigned to
  * @param[in]    bus the 8-bit bus number of the device
@@ -594,19 +594,19 @@ void resume_iommu(void);
 int32_t init_iommu(void);
 
 /**
- * @brief Init VM0 domain of iommu.
+ * @brief Init SOS_VM domain of iommu.
  *
- * Create VM0 domain using the Normal World's EPT table of VM0 as address translation table.
- * All PCI devices are added to the VM0 domain when creating it.
+ * Create SOS_VM domain using the Normal World's EPT table of SOS_VM as address translation table.
+ * All PCI devices are added to the SOS_VM domain when creating it.
  *
- * @param[in] vm0 pointer to VM0
+ * @param[in] sos_vm pointer to SOS_VM
  *
- * @pre vm0 shall point to VM0
+ * @pre sos_vm shall point to SOS_VM
  *
  * @remark to reduce boot time & memory cost, a config IOMMU_INIT_BUS_LIMIT, which limit the bus number.
  *
  */
-void init_iommu_vm0_domain(struct acrn_vm *vm0);
+void init_iommu_sos_vm_domain(struct acrn_vm *sos_vm);
 
 /**
  * @brief check the iommu if support cache snoop.

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -32,7 +32,7 @@ bool is_hypercall_from_ring0(void);
  * @param vm Pointer to VM data structure
  * @param lapicid lapic id of the vcpu which wants to offline
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid);
@@ -40,13 +40,13 @@ int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid);
 /**
  * @brief Get hypervisor api version
  *
- * The function only return api version information when VM is VM0.
+ * The function only return api version information when VM is SOS_VM.
  *
  * @param vm Pointer to VM data structure
  * @param param guest physical memory address. The api version returned
  *              will be copied to this gpa
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param);
@@ -62,7 +62,7 @@ int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param);
  * @param param guest physical memory address. This gpa points to
  *              struct acrn_create_vm
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param);
@@ -131,7 +131,7 @@ int32_t hcall_pause_vm(uint16_t vmid);
  * @param param guest physical address. This gpa points to
  *              struct acrn_create_vcpu
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_create_vcpu(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -163,7 +163,7 @@ int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  * @param vmid ID of the VM
  * @param ops request command for IRQ set or clear
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
@@ -178,7 +178,7 @@ int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
  * @param vmid ID of the VM
  * @param param guest physical address. This gpa points to struct acrn_msi_entry
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_inject_msi(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -194,7 +194,7 @@ int32_t hcall_inject_msi(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  * @param param guest physical address. This gpa points to
  *              struct acrn_set_ioreq_buffer
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -219,7 +219,7 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id);
  * @param param guest physical address. This gpa points to
  *              struct set_memmaps
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_vm_memory_regions(struct acrn_vm *vm, uint64_t param);
@@ -232,7 +232,7 @@ int32_t hcall_set_vm_memory_regions(struct acrn_vm *vm, uint64_t param);
  * @param wp_gpa guest physical address. This gpa points to
  *              struct wp_data
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_write_protect_page(struct acrn_vm *vm, uint16_t vmid, uint64_t wp_gpa);
@@ -247,7 +247,7 @@ int32_t hcall_write_protect_page(struct acrn_vm *vm, uint16_t vmid, uint64_t wp_
  * @param vmid ID of the VM
  * @param param guest physical address. This gpa points to struct vm_gpa2hpa
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -261,7 +261,7 @@ int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  *              To keep the compatibility it still can be the guest physical address that
  *              points to the physical BDF of the assigning ptdev.(Depreciated)
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -275,7 +275,7 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  *              To keep the compatibility it still can be the guest physical address that
  *              points to the physical BDF of the deassigning ptdev.(Depreciated)
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -288,7 +288,7 @@ int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
  * @param param guest physical address. This gpa points to data structure of
  *              hc_ptdev_irq including intr remapping info
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -301,7 +301,7 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t pa
  * @param param guest physical address. This gpa points to data structure of
  *              hc_ptdev_irq including intr remapping info
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid,
@@ -315,7 +315,7 @@ int32_t hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid,
   * @param param2 hypercall param2 from guest
   * @param hypcall_id hypercall ID from guest
   *
-  * @pre Pointer vm shall point to VM0
+  * @pre Pointer vm shall point to SOS_VM
   * @return 0 on success, non-zero on error.
   */
 int32_t hcall_debug(struct acrn_vm *vm, uint64_t param1, uint64_t param2, uint64_t hypcall_id);
@@ -327,7 +327,7 @@ int32_t hcall_debug(struct acrn_vm *vm, uint64_t param1, uint64_t param2, uint64
  * @param cmd cmd to show get which VCPU power state data
  * @param param VCPU power state data
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 
@@ -341,7 +341,7 @@ int32_t hcall_get_cpu_pm_state(struct acrn_vm *vm, uint64_t cmd, uint64_t param)
  * @param param guest physical address. This gpa points to data structure of
  *              acrn_intr_monitor
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
@@ -412,7 +412,7 @@ int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu);
  * @param vm Pointer to VM data structure
  * @param param the expected notifier vector from guest
  *
- * @pre Pointer vm shall point to VM0
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param);

--- a/hypervisor/include/hypervisor.h
+++ b/hypervisor/include/hypervisor.h
@@ -45,7 +45,7 @@ static inline void *gpa2hva(struct acrn_vm *vm, uint64_t x)
 
 static inline uint64_t hva2gpa(struct acrn_vm *vm, void *x)
 {
-	return (is_vm0(vm)) ? vm0_hpa2gpa(hva2hpa(x)) : INVALID_GPA;
+	return (is_sos_vm(vm)) ? sos_vm_hpa2gpa(hva2hpa(x)) : INVALID_GPA;
 }
 
 #endif	/* !ASSEMBLER */

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -123,8 +123,8 @@ struct vm_memory_region {
 	/** the beginning guest physical address of the memory reion*/
 	uint64_t gpa;
 
-	/** VM0's guest physcial address which gpa will be mapped to */
-	uint64_t vm0_gpa;
+	/** SOS_VM's guest physcial address which gpa will be mapped to */
+	uint64_t sos_vm_gpa;
 
 	/** size of the memory region */
 	uint64_t size;

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -155,6 +155,7 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3)),
+				.guest_flags = LAPIC_PASSTHROUGH,
 				.memory.start_hpa = 0x120000000UL,
 				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -162,7 +163,6 @@ struct vm_config_arraies vm_config_partition = {
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable xapic_phys",
 				.vpci_vdev_array = &vpci_vdev_array2,
-				.lapic_pt = true,
 			},
 		}
 };

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -157,10 +157,10 @@ struct vm_config_arraies vm_config_partition = {
 		/* Virtual Machine descriptions */
 		.vm_config_array = {
 			{
+				.type = PRE_LAUNCHED_VM,
 				/* Internal variable, MUSTBE init to -1 */
 				.vm_hw_num_cores = VM1_NUM_CPUS,
 				.vm_pcpu_ids = &VM1_CPUS[0],
-				.vm_id = 1U,
 				.start_hpa = 0x100000000UL,
 				.mem_size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -171,10 +171,10 @@ struct vm_config_arraies vm_config_partition = {
 			},
 
 			{
+				.type = PRE_LAUNCHED_VM,
 				/* Internal variable, MUSTBE init to -1 */
 				.vm_hw_num_cores = VM2_NUM_CPUS,
 				.vm_pcpu_ids = &VM2_CPUS[0],
-				.vm_id = 2U,
 				.start_hpa = 0x120000000UL,
 				.mem_size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -7,18 +7,6 @@
 #include <hypervisor.h>
 #include <e820.h>
 
-/* Number of CPUs in VM1 */
-#define VM1_NUM_CPUS    2U
-
-/* Logical CPU IDs assigned to this VM */
-uint16_t VM1_CPUS[VM1_NUM_CPUS] = {0U, 2U};
-
-/* Number of CPUs in VM2 */
-#define VM2_NUM_CPUS    2U
-
-/* Logical CPU IDs assigned with this VM */
-uint16_t VM2_CPUS[VM2_NUM_CPUS] = {3U, 1U};
-
 static struct vpci_vdev_array vpci_vdev_array1 = {
 	.num_pci_vdev = 2,
 
@@ -154,9 +142,7 @@ struct vm_config_arraies vm_config_partition = {
 		.vm_config_array = {
 			{
 				.type = PRE_LAUNCHED_VM,
-				/* Internal variable, MUSTBE init to -1 */
-				.vm_hw_num_cores = VM1_NUM_CPUS,
-				.vm_pcpu_ids = &VM1_CPUS[0],
+				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2)),
 				.start_hpa = 0x100000000UL,
 				.mem_size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -168,9 +154,7 @@ struct vm_config_arraies vm_config_partition = {
 
 			{
 				.type = PRE_LAUNCHED_VM,
-				/* Internal variable, MUSTBE init to -1 */
-				.vm_hw_num_cores = VM2_NUM_CPUS,
-				.vm_pcpu_ids = &VM2_CPUS[0],
+				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3)),
 				.start_hpa = 0x120000000UL,
 				.mem_size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -7,8 +7,6 @@
 #include <hypervisor.h>
 #include <e820.h>
 
-#define NUM_USER_VMS    2U
-
 /* Number of CPUs in VM1 */
 #define VM1_NUM_CPUS    2U
 
@@ -151,8 +149,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 /* User Defined VM definitions */
 /*******************************/
 struct vm_config_arraies vm_config_partition = {
-		/* Number of user virtual machines */
-		.num_vm_config = NUM_USER_VMS,
 
 		/* Virtual Machine descriptions */
 		.vm_config_array = {

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -143,8 +143,8 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2)),
-				.start_hpa = 0x100000000UL,
-				.mem_size = 0x20000000UL, /* uses contiguous memory from host */
+				.memory.start_hpa = 0x100000000UL,
+				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
 				.bootargs = "root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
@@ -155,8 +155,8 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3)),
-				.start_hpa = 0x120000000UL,
-				.mem_size = 0x20000000UL, /* uses contiguous memory from host */
+				.memory.start_hpa = 0x120000000UL,
+				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
 				.bootargs = "root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -146,7 +146,7 @@ struct vm_config_arraies vm_config_partition = {
 				.memory.start_hpa = 0x100000000UL,
 				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
-				.bootargs = "root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
+				.os_config.bootargs = "root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable xapic_phys",
 				.vpci_vdev_array = &vpci_vdev_array1,
@@ -158,7 +158,7 @@ struct vm_config_arraies vm_config_partition = {
 				.memory.start_hpa = 0x120000000UL,
 				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
-				.bootargs = "root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
+				.os_config.bootargs = "root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable xapic_phys",
 				.vpci_vdev_array = &vpci_vdev_array2,

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -7,18 +7,6 @@
 #include <hypervisor.h>
 #include <e820.h>
 
-/* Number of CPUs in VM1*/
-#define VM1_NUM_CPUS    4U
-
-/* Logical CPU IDs assigned to this VM */
-uint16_t VM1_CPUS[VM1_NUM_CPUS] = {0U, 2U, 4U, 6U};
-
-/* Number of CPUs in VM2*/
-#define VM2_NUM_CPUS    4U
-
-/* Logical CPU IDs assigned with this VM */
-uint16_t VM2_CPUS[VM2_NUM_CPUS] = {7U, 5U, 3U, 1U};
-
 static struct vpci_vdev_array vpci_vdev_array1 = {
 	.num_pci_vdev = 3,
 	.vpci_vdev_list = {
@@ -188,9 +176,7 @@ struct vm_config_arraies vm_config_partition = {
 		.vm_config_array = {
 			{
 				.type = PRE_LAUNCHED_VM,
-				/* Internal variable, MUSTBE init to -1 */
-				.vm_hw_num_cores = VM1_NUM_CPUS,
-				.vm_pcpu_ids = &VM1_CPUS[0],
+				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2) | PLUG_CPU(4) | PLUG_CPU(6)),
 				.start_hpa = 0x100000000UL,
 				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -203,9 +189,7 @@ struct vm_config_arraies vm_config_partition = {
 
 			{
 				.type = PRE_LAUNCHED_VM,
-				/* Internal variable, MUSTBE init to -1 */
-				.vm_hw_num_cores = VM2_NUM_CPUS,
-				.vm_pcpu_ids = &VM2_CPUS[0],
+				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3) | PLUG_CPU(5) | PLUG_CPU(7)),
 				.start_hpa = 0x180000000UL,
 				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -7,8 +7,6 @@
 #include <hypervisor.h>
 #include <e820.h>
 
-#define NUM_USER_VMS    2U
-
 /* Number of CPUs in VM1*/
 #define VM1_NUM_CPUS    4U
 
@@ -185,8 +183,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 /* User Defined VM definitions */
 /*******************************/
 struct vm_config_arraies vm_config_partition = {
-		/* Number of user virtual machines */
-		.num_vm_config = NUM_USER_VMS,
 
 		/* Virtual Machine descriptions */
 		.vm_config_array = {

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -191,10 +191,10 @@ struct vm_config_arraies vm_config_partition = {
 		/* Virtual Machine descriptions */
 		.vm_config_array = {
 			{
+				.type = PRE_LAUNCHED_VM,
 				/* Internal variable, MUSTBE init to -1 */
 				.vm_hw_num_cores = VM1_NUM_CPUS,
 				.vm_pcpu_ids = &VM1_CPUS[0],
-				.vm_id = 1U,
 				.start_hpa = 0x100000000UL,
 				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -206,10 +206,10 @@ struct vm_config_arraies vm_config_partition = {
 			},
 
 			{
+				.type = PRE_LAUNCHED_VM,
 				/* Internal variable, MUSTBE init to -1 */
 				.vm_hw_num_cores = VM2_NUM_CPUS,
 				.vm_pcpu_ids = &VM2_CPUS[0],
-				.vm_id = 2U,
 				.start_hpa = 0x180000000UL,
 				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -180,7 +180,7 @@ struct vm_config_arraies vm_config_partition = {
 				.memory.start_hpa = 0x100000000UL,
 				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
-				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=4 nohpet console=hvc0 " \
+				.os_config.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=4 nohpet console=hvc0 " \
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 						"consoleblank=0 tsc=reliable xapic_phys  apic_debug",
 				.vpci_vdev_array = &vpci_vdev_array1,
@@ -193,7 +193,7 @@ struct vm_config_arraies vm_config_partition = {
 				.memory.start_hpa = 0x180000000UL,
 				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
-				.bootargs = "root=/dev/sda2 rw rootwait noxsave maxcpus=4 nohpet console=hvc0 "\
+				.os_config.bootargs = "root=/dev/sda2 rw rootwait noxsave maxcpus=4 nohpet console=hvc0 "\
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 						"consoleblank=0 tsc=reliable xapic_phys apic_debug",
 				.vpci_vdev_array = &vpci_vdev_array2,

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -177,6 +177,7 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2) | PLUG_CPU(4) | PLUG_CPU(6)),
+				.guest_flags = LAPIC_PASSTHROUGH,
 				.memory.start_hpa = 0x100000000UL,
 				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -184,12 +185,12 @@ struct vm_config_arraies vm_config_partition = {
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 						"consoleblank=0 tsc=reliable xapic_phys  apic_debug",
 				.vpci_vdev_array = &vpci_vdev_array1,
-				.lapic_pt = true,
 			},
 
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3) | PLUG_CPU(5) | PLUG_CPU(7)),
+				.guest_flags = LAPIC_PASSTHROUGH,
 				.memory.start_hpa = 0x180000000UL,
 				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -197,7 +198,6 @@ struct vm_config_arraies vm_config_partition = {
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 						"consoleblank=0 tsc=reliable xapic_phys apic_debug",
 				.vpci_vdev_array = &vpci_vdev_array2,
-				.lapic_pt = true,
 			},
 		}
 };

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -177,8 +177,8 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2) | PLUG_CPU(4) | PLUG_CPU(6)),
-				.start_hpa = 0x100000000UL,
-				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
+				.memory.start_hpa = 0x100000000UL,
+				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
 				.bootargs = "root=/dev/sda rw rootwait noxsave maxcpus=4 nohpet console=hvc0 " \
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
@@ -190,8 +190,8 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3) | PLUG_CPU(5) | PLUG_CPU(7)),
-				.start_hpa = 0x180000000UL,
-				.mem_size = 0x80000000UL, /* uses contiguous memory from host */
+				.memory.start_hpa = 0x180000000UL,
+				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
 				.bootargs = "root=/dev/sda2 rw rootwait noxsave maxcpus=4 nohpet console=hvc0 "\
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\


### PR DESCRIPTION
This is acrn_vm_config refine patch set series 2, includes 11 patches:

  HV: rename the term of vm0 to sos vm
  HV: refine launch vm interface
  HV: show correct vm name per config
  HV: add get_sos_vm api
  HV: remove sworld_supported in acrn_vm_config
  HV: remove unused vm num config
  HV: enable pcpu bitmap config for partition mode
  HV: remove vm_config pointer in acrn_vm struct
  HV: replace memory config with acrn_vm_mem_config
  HV: replace bootargs config with acrn_vm_os_config
  HV: replace lapic_pt with guest flag in vm_config

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
