### PR TITLE
dm: script: use -d to check existence of gpio460

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -412,7 +412,7 @@ do
 	esac
 done
 
-if [ ! -f "/sys/class/gpio/gpio460" ]; then
+if [ ! -d "/sys/class/gpio/gpio460" ]; then
   echo "export gpio460"
   echo 460 > /sys/class/gpio/export
   echo 'high' > /sys/class/gpio/gpio460/direction


### PR DESCRIPTION
/sys/class/gpio/gpio460 is a directory,
should use -d instead of -f to check its existence.

Tracked-On: #2328
Signed-off-by: Binbin Wu <binbin.wu@intel.com>