### PR TITLE
security: bounds checking to avoid buffer overflow error

### DIFF
--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -114,7 +114,7 @@ struct profiling_vm_info {
 
 struct profiling_vm_info_list {
 	uint16_t num_vms;
-	struct profiling_vm_info vm_list[CONFIG_MAX_VM_NUM];
+	struct profiling_vm_info vm_list[CONFIG_MAX_VM_NUM+1];
 };
 
 struct sw_msr_op_info {


### PR DESCRIPTION
The array index of 'vm_list' may be out of bound
vm_idx should be less than CONFIG_MAX_VM_NUM, so updated for loop

Bug : ACRN-2544
Tracked-On: #2385
Signed-off-by: Manisha Chinthapally <manisha.chinthapally@intel.com>
