### PR TITLE
kconfig: update .config on missed or conflicting symbol values

### DIFF
--- a/scripts/kconfig/silentoldconfig.py
+++ b/scripts/kconfig/silentoldconfig.py
@@ -75,6 +75,19 @@ def main():
             kconfig = kdefconfig
             sys.stdout.write("Overwrite with default configuration based on %s.\n" % defconfig_path)
             need_update = True
+        else:
+            # Use the existing .config as the base.
+            #
+            # Mark need_update if any visible symbol picks a different value
+            # from what is specified in .config.
+            for sym in [x for x in kconfig.unique_defined_syms if x.visibility]:
+                if sym.type in [kconfiglib.BOOL, kconfiglib.TRISTATE]:
+                    picked_value = sym.tri_value
+                else:
+                    picked_value = sym.str_value
+                need_update = (picked_value != sym.user_value)
+                if need_update:
+                    break
     else:
         # base on a default configuration
         if kdefconfig:


### PR DESCRIPTION
The existing .config may have missed or conflicting values if the file is
manually edited or Kconfig is changed. Kconfiglib will assign default values to
missed symbols and resolve conflicts when loading .config, but the current
silentoldconfig.py fails to write the updated symbol values back to .config.

This patch checks if any missed or conflicting symbol value is fixed by
Kconfiglib and write the updated values back to .config if necessary.

Tracked-On: #2371
Signed-off-by: Junjie Mao <junjie.mao@intel.com>