### PR TITLE
hv: Makefile: add the dependency of $(LIB_FLAGS)

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -333,7 +333,7 @@ $(HV_OBJDIR)/$(HV_FILE).32.out: $(HV_OBJDIR)/$(HV_FILE).out
 $(HV_OBJDIR)/$(HV_FILE).bin: $(HV_OBJDIR)/$(HV_FILE).out
 	$(OBJCOPY) -O binary $< $(HV_OBJDIR)/$(HV_FILE).bin
 
-$(HV_OBJDIR)/$(HV_FILE).out: $(C_OBJS) $(S_OBJS)
+$(HV_OBJDIR)/$(HV_FILE).out: $(C_OBJS) $(S_OBJS) $(LIB_FLAGS)
 	${BASH} ${LD_IN_TOOL} $(ARCH_LDSCRIPT_IN) $(ARCH_LDSCRIPT) ${HV_OBJDIR}/.config
 	$(CC) -Wl,-Map=$(HV_OBJDIR)/$(HV_FILE).map -o $@ $(LDFLAGS) $(ARCH_LDFLAGS) -T$(ARCH_LDSCRIPT) $^ $(LIB_FLAGS)
 


### PR DESCRIPTION
This patch adds the dependency of $(LIB_FLAGS) when building .out file.
So that the target is updated whenever there is a update in
debug/release library.

Tracked-On: #2389
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>