### PR TITLE
dm: storage: change DISCARD to synchronous mode

### DIFF
--- a/devicemodel/hw/block_if.c
+++ b/devicemodel/hw/block_if.c
@@ -313,6 +313,8 @@ blockif_process_discard(struct blockif_ctxt *bc, struct blockif_req *br)
 			 */
 			err = fallocate(bc->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
 				arg[i][0], arg[i][1]);
+			if (!err)
+				err = fdatasync(bc->fd);
 		}
 		if (err) {
 			WPRINTF(("Failed to discard offset=%ld nbytes=%ld err code: %d\n",


### PR DESCRIPTION
For virtio-blk, when the back-end is a regular file, the discard and is implemented by fallocate(), but this function will not wait for the discard command handled by disk.
So, add fdatasync to make sure the DISCARD is executed synchronously.

Tracked-On: #2395
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Wang Yu <yu1.wang@intel.com>