### PR TITLE
add full context switch scheduling support

### DIFF
--- a/doc/developer-guides/hld/hv-io-emulation.rst
+++ b/doc/developer-guides/hld/hv-io-emulation.rst
@@ -324,19 +324,7 @@ I/O Emulation
 
 The following APIs are provided for I/O emulation at runtime:
 
-.. doxygenfunction:: emulate_io
-   :project: Project ACRN
-
-.. doxygenfunction:: acrn_insert_request_wait
-   :project: Project ACRN
-
-.. doxygenfunction:: emulate_io_post
-   :project: Project ACRN
-
-.. doxygenfunction:: emulate_mmio_post
-   :project: Project ACRN
-
-.. doxygenfunction:: dm_emulate_mmio_post
+.. doxygenfunction:: acrn_insert_request
    :project: Project ACRN
 
 .. doxygenfunction:: pio_instr_vmexit_handler

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -170,6 +170,7 @@ C_SRCS += arch/x86/pm.c
 S_SRCS += arch/x86/wakeup.S
 C_SRCS += arch/x86/static_checks.c
 C_SRCS += arch/x86/trampoline.c
+C_SRCS += arch/x86/sched.c
 C_SRCS += arch/x86/guest/vcpuid.c
 C_SRCS += arch/x86/guest/vcpu.c
 C_SRCS += arch/x86/guest/vm.c

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -383,7 +383,6 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
 	vcpu->arch.nr_sipi = 0;
-	vcpu->pending_pre_work = 0U;
 	vcpu->state = VCPU_INIT;
 
 	reset_vcpu_regs(vcpu);
@@ -535,7 +534,6 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
 	vcpu->arch.nr_sipi = 0;
-	vcpu->pending_pre_work = 0U;
 
 	vcpu->arch.exception_info.exception = VECTOR_INVALID;
 	vcpu->arch.cur_context = NORMAL_WORLD;
@@ -678,9 +676,4 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 	vcpu->sched_obj.prepare_switch_in = context_switch_in;
 
 	return ret;
-}
-
-void request_vcpu_pre_work(struct acrn_vcpu *vcpu, uint16_t pre_work_id)
-{
-	bitmap_set_lock(pre_work_id, &vcpu->pending_pre_work);
 }

--- a/hypervisor/arch/x86/io_emul.c
+++ b/hypervisor/arch/x86/io_emul.c
@@ -146,18 +146,7 @@ void emulate_io_post(struct acrn_vcpu *vcpu)
 		} else {
 			switch (vcpu->req.type) {
 			case REQ_MMIO:
-				/*
-				 * In IO completion polling mode, the post work of IO emulation will
-				 * be running on its own pcpu, then we can do MMIO post work directly;
-				 * While in notification mode, the post work of IO emulation will be
-				 * running on SOS pcpu, then we need request_vcpu_pre_work and let
-				 * its own pcpu get scheduled and finish the MMIO post work.
-				 */
-				if (!vcpu->vm->sw.is_completion_polling) {
-					request_vcpu_pre_work(vcpu, ACRN_VCPU_MMIO_COMPLETE);
-				} else {
-					dm_emulate_mmio_post(vcpu);
-				}
+				dm_emulate_mmio_post(vcpu);
 				break;
 
 			case REQ_PORTIO:

--- a/hypervisor/arch/x86/sched.c
+++ b/hypervisor/arch/x86/sched.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <spinlock.h>
+#include <list.h>
+#include <schedule.h>
+
+void arch_switch_to(struct sched_object *prev, struct sched_object *next)
+{
+	asm volatile ("pushf\n"
+			"pushq %%rbx\n"
+			"pushq %%rbp\n"
+			"pushq %%r12\n"
+			"pushq %%r13\n"
+			"pushq %%r14\n"
+			"pushq %%r15\n"
+			"pushq %%rdi\n"
+			"movq %%rsp, %0\n"
+			"movq %1, %%rsp\n"
+			"popq %%rdi\n"
+			"popq %%r15\n"
+			"popq %%r14\n"
+			"popq %%r13\n"
+			"popq %%r12\n"
+			"popq %%rbp\n"
+			"popq %%rbx\n"
+			"popf\n"
+			"retq\n"
+			: "=m"(prev->host_sp)
+			: "r"(next->host_sp)
+			: "memory");
+}

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -23,14 +23,14 @@ void vcpu_thread(struct sched_object *obj)
 	uint32_t basic_exit_reason = 0U;
 	int32_t ret = 0;
 
-	/* If vcpu is not launched, we need to do init_vmcs first */
-	if (!vcpu->launched) {
-		init_vmcs(vcpu);
-	}
-
 	run_vcpu_pre_work(vcpu);
 
 	do {
+		/* If vcpu is not launched, we need to do init_vmcs first */
+		if (!vcpu->launched) {
+			init_vmcs(vcpu);
+		}
+
 		/* handle pending softirq when irq enable*/
 		do_softirq();
 		CPU_IRQ_DISABLE();

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -489,7 +489,9 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 			ret = -EINVAL;
 		} else {
 			vcpu = vcpu_from_vid(target_vm, vcpu_id);
-			emulate_io_post(vcpu);
+			if (!vcpu->vm->sw.is_completion_polling) {
+				resume_vcpu(vcpu);
+			}
 			ret = 0;
 		}
 	}

--- a/hypervisor/common/io_req.c
+++ b/hypervisor/common/io_req.c
@@ -87,12 +87,12 @@ static inline bool has_complete_ioreq(const struct acrn_vcpu *vcpu)
  *
  * @pre vcpu != NULL && io_req != NULL
  */
-int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request *io_req)
+int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_req)
 {
 	union vhm_request_buffer *req_buf = NULL;
 	struct vhm_request *vhm_req;
 	bool is_polling = false;
-	int32_t ret;
+	int32_t ret = 0;
 	uint16_t cur;
 
 	if (vcpu->vm->sw.io_shared_page != NULL) {
@@ -149,19 +149,18 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 			while (!need_reschedule(vcpu->pcpu_id)) {
 				if (has_complete_ioreq(vcpu)) {
 					/* we have completed ioreq pending */
-					emulate_io_post(vcpu);
 					break;
 				}
 				asm_pause();
 			}
 		} else if (need_reschedule(vcpu->pcpu_id)) {
 			schedule();
+		} else {
+			ret = -EINVAL;
 		}
-		ret = 0;
 	} else {
 		ret = -EINVAL;
 	}
-
 
 	return ret;
 }

--- a/hypervisor/common/io_req.c
+++ b/hypervisor/common/io_req.c
@@ -154,6 +154,8 @@ int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request
 				}
 				asm_pause();
 			}
+		} else if (need_reschedule(vcpu->pcpu_id)) {
+			schedule();
 		}
 		ret = 0;
 	} else {

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -8,7 +8,6 @@
 #include <schedule.h>
 
 static uint64_t pcpu_used_bitmap;
-static struct sched_object idle;
 
 void init_scheduler(void)
 {
@@ -191,7 +190,7 @@ void schedule(void)
 		release_schedule_lock(pcpu_id);
 
 		if (next == NULL) {
-			next = &idle;
+			next = &get_cpu_var(idle);
 		}
 
 		switch_to(next);
@@ -202,15 +201,13 @@ void schedule(void)
 
 void switch_to_idle(run_thread_t idle_thread)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	struct sched_object *idle = &get_cpu_var(idle);
 
-	if (pcpu_id == BOOT_CPU_ID) {
-		idle.thread = idle_thread;
-		idle.prepare_switch_out = NULL;
-		idle.prepare_switch_in = NULL;
-	}
+	idle->thread = idle_thread;
+	idle->prepare_switch_out = NULL;
+	idle->prepare_switch_in = NULL;
 
 	if (idle_thread != NULL) {
-		idle_thread(&idle);
+		idle_thread(idle);
 	}
 }

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -13,8 +13,6 @@
 #ifndef VCPU_H
 #define VCPU_H
 
-#define	ACRN_VCPU_MMIO_COMPLETE		(0U)
-
 /* Number of GPRs saved / restored for guest in VCPU structure */
 #define NUM_GPRS                            16U
 #define GUEST_STATE_AREA_SIZE               512
@@ -274,7 +272,6 @@ struct acrn_vcpu {
 	uint64_t sync;	/*hold the bit events*/
 
 	struct sched_object sched_obj;
-	uint64_t pending_pre_work; /* any pre work pending? */
 	bool launched; /* Whether the vcpu is launched on target pcpu */
 	uint32_t paused_cnt; /* how many times vcpu is paused */
 	uint32_t running; /* vcpu is picked up and run? */
@@ -605,8 +602,6 @@ void schedule_vcpu(struct acrn_vcpu *vcpu);
  * @param[in] pcpu_id which the vcpu will be mapped
  */
 int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id);
-
-void request_vcpu_pre_work(struct acrn_vcpu *vcpu, uint16_t pre_work_id);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -258,6 +258,8 @@ struct acrn_vcpu_arch {
 
 struct acrn_vm;
 struct acrn_vcpu {
+	uint8_t stack[CONFIG_STACK_SIZE] __aligned(16);
+
 	/* Architecture specific definitions for this VCPU */
 	struct acrn_vcpu_arch arch;
 	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */

--- a/hypervisor/include/arch/x86/io_emul.h
+++ b/hypervisor/include/arch/x86/io_emul.h
@@ -23,56 +23,6 @@
 #define EMUL_PIO_IDX_MAX	(RTC_PIO_IDX + 1U)
 
 /**
- * @brief General post-work for MMIO emulation
- *
- * @param vcpu The virtual CPU that triggers the MMIO access
- * @param io_req The I/O request holding the details of the MMIO access
- *
- * @pre io_req->type == REQ_MMIO
- *
- * @remark This function must be called when \p io_req is completed, after
- * either a previous call to emulate_io() returning 0 or the corresponding VHM
- * request transferring to the COMPLETE state.
- */
-void emulate_mmio_post(const struct acrn_vcpu *vcpu, const struct io_request *io_req);
-
-/**
- * @brief Post-work of VHM requests for MMIO emulation
- *
- * @param vcpu The virtual CPU that triggers the MMIO access
- *
- * @pre vcpu->req.type == REQ_MMIO
- *
- * @remark This function must be called after the VHM request corresponding to
- * \p vcpu being transferred to the COMPLETE state.
- */
-void dm_emulate_mmio_post(struct acrn_vcpu *vcpu);
-
-/**
- * @brief General post-work for all kinds of VHM requests for I/O emulation
- *
- * @param vcpu The virtual CPU that triggers the MMIO access
- */
-void emulate_io_post(struct acrn_vcpu *vcpu);
-
-/**
- * @brief Emulate \p io_req for \p vcpu
- *
- * Handle an I/O request by either invoking a hypervisor-internal handler or
- * deliver to VHM.
- *
- * @param vcpu The virtual CPU that triggers the MMIO access
- * @param io_req The I/O request holding the details of the MMIO access
- *
- * @retval 0       Successfully emulated by registered handlers.
- * @retval IOREQ_PENDING The I/O request is delivered to VHM.
- * @retval -EIO    The request spans multiple devices and cannot be emulated.
- * @retval -EINVAL \p io_req has an invalid type.
- * @retval <0 on other errors during emulation.
- */
-int32_t emulate_io(struct acrn_vcpu *vcpu, struct io_request *io_req);
-
-/**
  * @brief The handler of VM exits on I/O instructions
  *
  * @param vcpu The virtual CPU which triggers the VM exit on I/O instruction

--- a/hypervisor/include/arch/x86/io_req.h
+++ b/hypervisor/include/arch/x86/io_req.h
@@ -17,10 +17,6 @@
  * @{
  */
 
-/* The return value of emulate_io() indicating the I/O request is delivered to
- * VHM but not finished yet. */
-#define IOREQ_PENDING	1
-
 /**
  * @brief Internal representation of a I/O request.
  */
@@ -177,7 +173,7 @@ struct mem_io_node {
  *
  * @pre vcpu != NULL && io_req != NULL
  */
-int32_t acrn_insert_request_wait(struct acrn_vcpu *vcpu, const struct io_request *io_req);
+int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_req);
 
 /**
  * @brief Reset all IO requests status of the VM

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -39,6 +39,7 @@ struct per_cpu_region {
 #endif
 	struct per_cpu_timers cpu_timers;
 	struct sched_context sched_ctx;
+	struct sched_object idle;
 	struct instr_emul_ctxt g_inst_ctxt;
 	struct host_gdt gdt;
 	struct tss_64 tss;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -14,7 +14,9 @@ struct sched_object;
 typedef void (*run_thread_t)(struct sched_object *obj);
 typedef void (*prepare_switch_t)(struct sched_object *obj);
 struct sched_object {
+	char name[16];
 	struct list_head run_list;
+	uint64_t host_sp;
 	run_thread_t thread;
 	prepare_switch_t prepare_switch_out;
 	prepare_switch_t prepare_switch_in;
@@ -46,5 +48,8 @@ void make_pcpu_offline(uint16_t pcpu_id);
 int32_t need_offline(uint16_t pcpu_id);
 
 void schedule(void);
+void run_sched_thread(struct sched_object *obj);
+
+void arch_switch_to(struct sched_object *prev, struct sched_object *next);
 #endif /* SCHEDULE_H */
 


### PR DESCRIPTION
Now each time when scheduling happen, it will reset its thread stack and resume
thread from the beggining, it adds the complexes for mmio post handling, and
is not suitable for future cpu sharing.

This patch series enabled full context switch scheduling, there will be per-cpu
idle schedule object plus per-vcpu thread schedule object, each of one has its
own stack. The scheduing will do full context switch based on these per-cpu and
per-vcpu stack.

After this patch series, only three fixed points will trigger schedule:
- vcpu_thread loop, before vm entry
- default_idle loop
- io request, for DM handling IO REQ

Tracked-On: #2394
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Xu, Anthony <anthony.xu@intel.com>

