### PR TITLE
hv: vlapic: remove `calcvdest`

### DIFF
--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -80,7 +80,7 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	dest = (uint32_t)(info->vmsi_addr & MSI_ADDR_DEST) >> MSI_ADDR_DEST_SHIFT;
 	phys = ((info->vmsi_addr & MSI_ADDR_LOG) != MSI_ADDR_LOG);
 
-	calcvdest(vm, &vdmask, dest, phys);
+	vlapic_calcdest(vm, &vdmask, dest, phys, false);
 	pdmask = vcpumask2pcpumask(vm, vdmask);
 
 	/* get physical delivery mode */
@@ -137,7 +137,7 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* physical destination cpu mask */
 		phys = ((virt_rte.full & IOAPIC_RTE_DESTMOD) == IOAPIC_RTE_DESTPHY);
 		dest = (uint32_t)(virt_rte.full >> IOAPIC_RTE_DEST_SHIFT);
-		calcvdest(vm, &vdmask, dest, phys);
+		vlapic_calcdest(vm, &vdmask, dest, phys, false);
 		pdmask = vcpumask2pcpumask(vm, vdmask);
 
 		/* physical delivery mode */

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1028,9 +1028,8 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t vector)
  * This function populates 'dmask' with the set of vcpus that match the
  * addressing specified by the (dest, phys, lowprio) tuple.
  */
-static void
-vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest,
-		bool phys, bool lowprio)
+void
+vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio)
 {
 	struct acrn_vlapic *vlapic;
 	struct acrn_vlapic *target = NULL;
@@ -1137,12 +1136,6 @@ vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest,
 			bitmap_set_lock(target->vcpu->vcpu_id, dmask);
 		}
 	}
-}
-
-	void
-calcvdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys)
-{
-	vlapic_calcdest(vm, dmask, dest, phys, false);
 }
 
 static void

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -213,7 +213,7 @@ vioapic_update_eoi_exit(const struct acrn_vioapic *vioapic)
 			} else {
 				dest = (uint32_t)((rte.full) >> IOAPIC_RTE_DEST_SHIFT);
 				phys = ((rte.full & IOAPIC_RTE_DESTLOG) == 0UL);
-				calcvdest(vioapic->vm, &mask, dest, phys);
+				vlapic_calcdest(vioapic->vm, &mask, dest, phys, false);
 				
 				for (vcpu_id = ffs64(mask); vcpu_id != INVALID_BIT_INDEX; vcpu_id = ffs64(mask)) {
 					vcpu = vcpu_from_vid(vioapic->vm, vcpu_id);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -248,7 +248,7 @@ int32_t apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
-void calcvdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
+void vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
 
 /**
  * @}


### PR DESCRIPTION
- remove `calcvdest` and use `vlapic_calcdest` directly

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>