### PR TITLE
fix hypervisor relocation issue and enable it as default in kconfig

### DIFF
--- a/efi-stub/boot.c
+++ b/efi-stub/boot.c
@@ -363,7 +363,7 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 	 * instead.
 	 */
 #ifdef CONFIG_RELOC
-	err = emalloc_reserved_mem(&hv_hpa, HV_RUNTIME_MEM_SIZE, MEM_ADDR_4GB);
+	err = emalloc_reserved_aligned(&hv_hpa, HV_RUNTIME_MEM_SIZE, 1 << 21, MEM_ADDR_4GB);
 #else
 	err = emalloc_fixed_addr(&hv_hpa, HV_RUNTIME_MEM_SIZE, CONFIG_HV_RAM_START);
 #endif

--- a/efi-stub/boot.h
+++ b/efi-stub/boot.h
@@ -77,14 +77,14 @@ typedef void(*hv_func)(int32_t, struct multiboot_info*);
 #define MBOOT_MMAP_SIZE (sizeof(struct multiboot_mmap) * MBOOT_MMAP_NUMS)
 #define MBOOT_INFO_SIZE (sizeof(struct multiboot_info))
 #define BOOT_CTX_SIZE  (sizeof(struct efi_context))
-#define HV_RUNTIME_MEM_SIZE \
-	(CONFIG_HV_RAM_SIZE + MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE)
+#define EFI_BOOT_MEM_SIZE \
+	(MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE)
 #define MBOOT_MMAP_PTR(addr) \
-	((struct multiboot_mmap *)((VOID *)addr + CONFIG_HV_RAM_SIZE))
-#define MBOOT_INFO_PTR(addr) ((struct multiboot_info *) \
-	((VOID *)addr + CONFIG_HV_RAM_SIZE + MBOOT_MMAP_SIZE))
-#define BOOT_CTX_PTR(addr) ((struct efi_context *) \
-	((VOID *)addr + CONFIG_HV_RAM_SIZE +  MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE))
+	((struct multiboot_mmap *)((VOID *)(addr)))
+#define MBOOT_INFO_PTR(addr)  \
+	((struct multiboot_info *)((VOID *)(addr) + MBOOT_MMAP_SIZE))
+#define BOOT_CTX_PTR(addr)	\
+	((struct efi_context *)((VOID *)(addr) + MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE))
 
 
 struct efi_info {

--- a/efi-stub/efilinux.h
+++ b/efi-stub/efilinux.h
@@ -52,6 +52,9 @@
 extern EFI_SYSTEM_TABLE *sys_table;
 extern EFI_BOOT_SERVICES *boot;
 
+extern EFI_STATUS
+emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align, EFI_PHYSICAL_ADDRESS maxaddr);
+
 /**
  * allocate_pages - Allocate memory pages from the system
  * @atype: type of allocation to perform

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -249,9 +249,9 @@ config LOW_RAM_SIZE
 	  0x10000, starting from address 0x0.
 
 config HV_RAM_START
-	hex "Start physical address of the RAM region used by the hypervisor"
+	hex "2M-aligned Start physical address of the RAM region used by the hypervisor"
 	default 0x6e000000 if PLATFORM_SBL
-	default 0x00100000 if PLATFORM_UEFI
+	default 0x00400000 if PLATFORM_UEFI
 	help
 	  A 64-bit integer indicating the base physical address where the
 	  hypervisor should be loaded. If RELOC is disabled, the bootloader
@@ -260,6 +260,8 @@ config HV_RAM_START
 	  hypervisor may relocate its symbols to where it is placed,
 	  and thus the bootloader might not place the hypervisor at this
 	  specific address.
+	  Note that the addr demands 2M aligned, otherwise memory corruption
+          may occur.
 
 config HV_RAM_SIZE
 	hex "Size of the RAM region used by the hypervisor"

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -339,7 +339,7 @@ config MTRR_ENABLED
 
 config RELOC
 	bool "Enable hypervisor relocation"
-	default n
+	default y
 	help
 	  When selected, the hypervisor will relocate itself to where it is
 	  loaded. This allows the bootloader to put the hypervisor image to

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -290,7 +290,7 @@ void init_paging(void)
 			CONFIG_HV_RAM_SIZE + (((hv_hpa & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER, &ppt_mem_ops, MR_MODIFY);
 
-	size = ((uint64_t)&ld_text_end - CONFIG_HV_RAM_START);
+	size = ((uint64_t)&ld_text_end - hv_hpa);
 	text_end = hv_hpa + size;
 	/*
 	 * remove 'NX' bit for pages that contain hv code section, as by default XD bit is set for

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -45,7 +45,7 @@ void write_trampoline_stack_sym(uint16_t pcpu_id)
 	hva = (uint64_t *)(hpa2hva(trampoline_start16_paddr) + trampoline_relo_addr(secondary_cpu_stack));
 
 	stack_sym_addr = (uint64_t)&per_cpu(stack, pcpu_id)[CONFIG_STACK_SIZE - 1];
-	*hva = stack_sym_addr + get_hv_image_delta();
+	*hva = stack_sym_addr;
 
 	clflush(hva);
 }

--- a/hypervisor/bsp/uefi/uefi.c
+++ b/hypervisor/bsp/uefi/uefi.c
@@ -11,7 +11,7 @@
 
 #ifdef CONFIG_EFI_STUB
 
-static struct efi_context *efi_ctx = NULL;
+static struct efi_context efi_ctx;
 static struct lapic_regs uefi_lapic_regs;
 static int32_t efi_initialized;
 
@@ -28,14 +28,9 @@ static void efi_init(void)
 			pr_err("no multiboot drivers for uefi found");
 		} else {
 
-			efi_ctx = (struct efi_context *)hpa2hva((uint64_t)mbi->mi_drives_addr);
-			if (efi_ctx == NULL) {
-				pr_err("no uefi context found");
-			} else {
-
-				save_lapic(&uefi_lapic_regs);
-				efi_initialized = 1;
-			}
+			memcpy_s(&efi_ctx, sizeof(struct efi_context), hpa2hva((uint64_t)mbi->mi_drives_addr), sizeof(struct efi_context));
+			save_lapic(&uefi_lapic_regs);
+			efi_initialized = 1;
 		}
 	}
 }
@@ -46,17 +41,17 @@ void *get_rsdp_from_uefi(void)
 		efi_init();
 	}
 
-	return hpa2hva((uint64_t)efi_ctx->rsdp);
+	return hpa2hva((uint64_t)efi_ctx.rsdp);
 }
 
 void *get_ap_trampoline_buf(void)
 {
-	return efi_ctx->ap_trampoline_buf;
+	return efi_ctx.ap_trampoline_buf;
 }
 
 const struct efi_context *get_efi_ctx(void)
 {
-	return efi_ctx;
+	return (const struct efi_context *)&efi_ctx;
 }
 
 const struct lapic_regs *get_efi_lapic_regs(void)


### PR DESCRIPTION
The patch set is to fix some issues when RELOC is enabled in Kconfig,  the last patch of the set is to enable RELOC to default to "Yes".

8fd1f68f (HEAD -> reloc, mygit/reloc) HV: modify RELOC kconfig option default to "enable"
743b4d85 HV: fix per-cpu stack relocation in trampoline.c
048bb06a HV: init_paging() wrongly calcuate the size of hypervisor
52aab666 HV: adjust the starting addr of HV to be 2M-aligned
2a8a473d HV: save efi_ctx into HV to use after init_paging()
d7ef43bb EFI: Allocate EFI boot related struct from EFI allocation pool
51ff395d EFI: Allocate 2M aligned memory for hypervisor image


   Tracked-On: https://github.com/projectacrn/acrn-hypervisor/issues/2349
    Signed-off-by: Chaohong guo <chaohong.guo@intel.com>
    Reviewed-By: Yin Fengwei <fengwei.yin@intel.com>
    Reviewed-by: Zide Chen <zide.chen@intel.com>
