### PR TITLE
hv: remove unused fields in 'struct acrn_vcpu'

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -380,7 +380,6 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 	*rtn_vcpu_handle = vcpu;
 
 	vcpu->launched = false;
-	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
 	vcpu->arch.nr_sipi = 0;
 	vcpu->state = VCPU_INIT;
@@ -531,7 +530,6 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 	vcpu->state = VCPU_INIT;
 
 	vcpu->launched = false;
-	vcpu->paused_cnt = 0U;
 	vcpu->running = 0;
 	vcpu->arch.nr_sipi = 0;
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -267,13 +267,9 @@ struct acrn_vcpu {
 	/* State of this VCPU before suspend */
 	volatile enum vcpu_state prev_state;
 	volatile enum vcpu_state state;	/* State of this VCPU */
-	/* State of debug request for this VCPU */
-	volatile enum vcpu_state dbg_req_state;
-	uint64_t sync;	/*hold the bit events*/
 
 	struct sched_object sched_obj;
 	bool launched; /* Whether the vcpu is launched on target pcpu */
-	uint32_t paused_cnt; /* how many times vcpu is paused */
 	uint32_t running; /* vcpu is picked up and run? */
 
 	struct io_request req; /* used by io/ept emulation */


### PR DESCRIPTION
below fields are defined but not used.
- sync, pause_cnt & dbg_req_state.

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>