### PR TITLE
HV: move Kconfig IOREQ_POLLING to acrn vm config

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -40,28 +40,6 @@ config PARTITION_MODE
 
 endchoice
 
-choice
-	prompt "I/O emulation completion mode"
-	default IOREQ_NOTIFICATION
-	help
-	  Select the mode of I/O emulation completion
-
-config IOREQ_NOTIFICATION
-	bool "Notification mode"
-	help
-	  When I/O request is completed, SOS will mark the completion status and
-	  notify hypervisor via hypercall. Hypervisor will finish the post work
-	  when notification is received.
-
-config IOREQ_POLLING
-	bool "Polling mode"
-	help
-	  When I/O request is completed, SOS will only mark completion status
-	  without notifying hypervisor. Hypervisor will poll the completion
-	  status and finish the post work.
-
-endchoice
-
 config BOARD
 	string "Target board"
 	help

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -226,10 +226,10 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		/* Populate return VM handle */
 		*rtn_vm = vm;
 		vm->sw.io_shared_page = NULL;
-#ifdef CONFIG_IOREQ_POLLING
-		/* Now, enable IO completion polling mode for all VMs with CONFIG_IOREQ_POLLING. */
-		vm->sw.is_completion_polling = true;
-#endif
+		if ((vm_config->guest_flags & IO_COMPLETION_POLLING) != 0U) {
+			/* enable IO completion polling mode per its guest flags in vm_config. */
+			vm->sw.is_completion_polling = true;
+		}
 		status = set_vcpuid_entries(vm);
 		if (status == 0) {
 			vm->state = VM_CREATED;

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -143,6 +143,7 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2)),
+				.guest_flags = IO_COMPLETION_POLLING,
 				.memory.start_hpa = 0x100000000UL,
 				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -155,7 +156,7 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3)),
-				.guest_flags = LAPIC_PASSTHROUGH,
+				.guest_flags = LAPIC_PASSTHROUGH | IO_COMPLETION_POLLING,
 				.memory.start_hpa = 0x120000000UL,
 				.memory.size = 0x20000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -177,7 +177,7 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(0) | PLUG_CPU(2) | PLUG_CPU(4) | PLUG_CPU(6)),
-				.guest_flags = LAPIC_PASSTHROUGH,
+				.guest_flags = LAPIC_PASSTHROUGH | IO_COMPLETION_POLLING,
 				.memory.start_hpa = 0x100000000UL,
 				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,
@@ -190,7 +190,7 @@ struct vm_config_arraies vm_config_partition = {
 			{
 				.type = PRE_LAUNCHED_VM,
 				.pcpu_bitmap = (PLUG_CPU(1) | PLUG_CPU(3) | PLUG_CPU(5) | PLUG_CPU(7)),
-				.guest_flags = LAPIC_PASSTHROUGH,
+				.guest_flags = LAPIC_PASSTHROUGH | IO_COMPLETION_POLLING,
 				.memory.start_hpa = 0x180000000UL,
 				.memory.size = 0x80000000UL, /* uses contiguous memory from host */
 				.vm_vuart = true,


### PR DESCRIPTION
Previously I/O emulation completion mode mode was configured in Kconfig:

	config IOREQ_NOTIFICATION
	       bool "Notification mode"
	       help
	         When I/O request is completed, SOS will mark the completion status and
	         notify hypervisor via hypercall. Hypervisor will finish the post work
	         when notification is received.

	config IOREQ_POLLING
	       bool "Polling mode"
	       help
	         When I/O request is completed, SOS will only mark completion status
	         without notifying hypervisor. Hypervisor will poll the completion
	         status and finish the post work.

Now move this configuration to guest_flags of acrn_vm_config struct.

	if ((vm_config->guest_flags & IO_COMPLETION_POLLING) != 0U) {
		I/O with polling;
	} else {
		I/O with notification;
	}

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>