### PR TITLE
dm: add log for debuging pci while vm reset

### DIFF
--- a/devicemodel/arch/x86/pm.c
+++ b/devicemodel/arch/x86/pm.c
@@ -41,6 +41,7 @@
 #include "mevent.h"
 #include "irq.h"
 #include "lpc.h"
+#include "dm.h"
 
 static pthread_mutex_t pm_lock = PTHREAD_MUTEX_INITIALIZER;
 static struct mevent *power_button;
@@ -68,12 +69,14 @@ reset_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 
 		if (*eax & 0x8) {
 			fprintf(stderr, "full reset\r\n");
+			write_kmsg("full reset\n");
 			error = vm_suspend(ctx, VM_SUSPEND_FULL_RESET);
 			assert(error ==0 || errno == EALREADY);
 			mevent_notify();
 			reset_control = 0;
 		} else if (*eax & 0x4) {
 			fprintf(stderr, "system reset\r\n");
+			write_kmsg("system reset\n");
 			error = vm_suspend(ctx, VM_SUSPEND_SYSTEM_RESET);
 			assert(error ==0 || errno == EALREADY);
 			mevent_notify();

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -409,6 +409,7 @@ vm_get_suspend_mode(void)
 int
 vm_suspend(struct vmctx *ctx, enum vm_suspend_how how)
 {
+	write_kmsg("vm_suspend mode to: %d\n", how);
 	vm_set_suspend_mode(how);
 	mevent_notify();
 

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1273,10 +1273,15 @@ init_pci(struct vmctx *ctx)
 					continue;
 				ops = pci_emul_finddev(fi->fi_name);
 				assert(ops != NULL);
+				write_kmsg("%s before init ---\n", fi->fi_name);
 				error = pci_emul_init(ctx, ops, bus, slot,
 				    func, fi);
-				if (error)
+				if (error) {
+					write_kmsg("%s after init failure ---\n", fi->fi_name);
 					goto pci_emul_init_fail;
+				}
+
+				write_kmsg("%s after init ---\n", fi->fi_name);
 				success_cnt++;
 			}
 		}
@@ -1430,8 +1435,9 @@ deinit_pci(struct vmctx *ctx)
 					continue;
 				ops = pci_emul_finddev(fi->fi_name);
 				assert(ops != NULL);
-				pci_emul_deinit(ctx, ops, bus, slot,
-				    func, fi);
+				write_kmsg("%s before deinit ---\n", fi->fi_name);
+				pci_emul_deinit(ctx, ops, bus, slot, func, fi);
+				write_kmsg("%s after deinit ---\n", fi->fi_name);
 			}
 		}
 	}


### PR DESCRIPTION
dm: add log for debuging pci while vm reset

Print some log to dmesg when init/deinit vdev.

Tracked-On: #2419
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
