### PR TITLE
tools: acrnd: fix wait_for_stop() return wrong vm state

### DIFF
--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -448,10 +448,8 @@ static int check_vms_status(unsigned int status)
 {
 	struct vmmngr_struct *s;
 
-	vmmngr_update();
-
 	LIST_FOREACH(s, &vmmngr_head, list)
-	    if (s->state != status && s->state != VM_CREATED)
+	    if (s->state != status)
 		return -1;
 
 	return 0;
@@ -465,6 +463,8 @@ static int wait_for_stop(unsigned int timeout)
 
 	/* list and update the vm status */
 	do {
+		vmmngr_update();
+
 		printf("Waiting %lu seconds for all vms enter S3/S5 state\n", t);
 
 		if (check_vms_status(VM_CREATED) == 0) {


### PR DESCRIPTION
The wait_for_stop() first check if all VM are stopped or suspended.
It first check if VMs are stopped, then check if they are suspend.

If the VMs change state from running to stoped, after check VMs
stopped fail, before start check suspend state. wait_for_stop() will
mistake resopnse 'All vms have entered S3 state successfully'

To fix that, wait_for_stop() must only update VMs's state once, and
see if they are stopped, or suspended.

Tracked-On: #2398
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>