### PR TITLE
hv:Move severl variable declaration for boot code

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -12,6 +12,7 @@
 #include <e820.h>
 #include <cpu_caps.h>
 #include <security.h>
+#include <ld_sym.h>
 
 struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM] __aligned(PAGE_SIZE);
 static uint16_t phys_cpu_num = 0U;
@@ -91,8 +92,7 @@ void init_cpu_pre(uint16_t pcpu_id_args)
 		start_tsc = rdtsc();
 
 		/* Clear BSS */
-		(void)memset(&ld_bss_start, 0U,
-				(size_t)(&ld_bss_end - &ld_bss_start));
+		(void)memset(&ld_bss_start, 0U, (size_t)(&ld_bss_end - &ld_bss_start));
 
 		/* Get CPU capabilities thru CPUID, including the physical address bit
 		 * limit which is required for initializing paging.

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -30,6 +30,7 @@
 #include <hypervisor.h>
 #include <reloc.h>
 #include <e820.h>
+#include <ld_sym.h>
 
 static void *ppt_mmu_pml4_addr;
 static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -8,6 +8,7 @@
 #include <trampoline.h>
 #include <vm0_boot.h>
 #include <e820.h>
+#include <ld_sym.h>
 
 static uint64_t trampoline_start16_paddr;
 

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -12,7 +12,6 @@ extern uint64_t get_hv_image_base(void);
 
 /* external symbols that are helpful for relocation */
 extern uint8_t		_DYNAMIC[1];
-extern uint8_t		ld_trampoline_end;
 
 extern uint8_t		cpu_primary_start_32;
 extern uint8_t		cpu_primary_start_64;

--- a/hypervisor/boot/reloc.c
+++ b/hypervisor/boot/reloc.c
@@ -6,6 +6,7 @@
 
 #include <types.h>
 #include <reloc.h>
+#include <ld_sym.h>
 
 #ifdef CONFIG_RELOC
 #define DT_NULL		0	/* end of .dynamic section */

--- a/hypervisor/include/arch/x86/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/boot/ld_sym.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef LD_SYM_H
+#define LD_SYM_H
+
+extern uint8_t		ld_text_end;
+extern uint8_t		ld_bss_start;
+extern uint8_t		ld_bss_end;
+extern const uint8_t	ld_trampoline_load;
+extern uint8_t		ld_trampoline_start;
+extern uint8_t		ld_trampoline_end;
+
+#endif /* LD_SYM_H */

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -193,8 +193,6 @@ enum cpu_reg_name {
 /**********************************/
 /* EXTERNAL VARIABLES             */
 /**********************************/
-extern uint8_t		ld_bss_start;
-extern uint8_t		ld_bss_end;
 
 /* In trampoline range, hold the jump target which trampline will jump to */
 extern uint64_t               main_entry[1];

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -53,8 +53,6 @@
 /* IA32E Paging constants */
 #define IA32E_REF_MASK	((get_cpu_info())->physical_address_mask)
 
-extern uint8_t ld_text_end;
-
 static inline uint64_t round_page_up(uint64_t addr)
 {
 	return (((addr + (uint64_t)PAGE_SIZE) - 1UL) & PAGE_MASK);

--- a/hypervisor/include/arch/x86/trampoline.h
+++ b/hypervisor/include/arch/x86/trampoline.h
@@ -13,9 +13,6 @@ extern uint64_t prepare_trampoline(void);
 extern uint64_t get_trampoline_start16_paddr(void);
 
 /* external symbols that are helpful for relocation */
-extern const uint8_t	ld_trampoline_load;
-extern uint8_t		ld_trampoline_start;
-
 extern uint8_t		trampoline_fixup_cs;
 extern uint8_t		trampoline_fixup_ip;
 extern uint8_t		trampoline_fixup_target;


### PR DESCRIPTION
-- add header file ld_sym.h in include/arch/x86/boot/
-- move 'ld_bss_start/end' from cpu.h to ld_sym.h,
   avoid reverse dependency
-- move 'ld_text_end' from mmu.h to ld_sym.h
-- move 'ld_trampoline_load/start/end' to ld_sym.h

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>