### PR TITLE
Documentation build tools: update min version for kconfiglib

### DIFF
--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -2,4 +2,4 @@ breathe==4.9.1
 sphinx==1.7.7
 docutils==0.14
 sphinx_rtd_theme==0.4.0
-kconfiglib==10.*
+kconfiglib>=10.2


### PR DESCRIPTION
Versions of kconfiglib lower than 10.2 cannot build the documentation
correctly. The minimum version required is >=10.2. This patch updates
the 'requirements.txt' accordingly.

Tracked-On: #2429
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>