### PR TITLE
VPCI code cleanup

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -189,6 +189,7 @@ void init_cpu_post(uint16_t pcpu_id)
 		timer_init();
 		setup_notification();
 		setup_posted_intr_notification();
+		init_pci_pdev_list();
 
 		/* Start all secondary cores */
 		startup_paddr = prepare_trampoline();

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -45,7 +45,7 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 {
 	struct ptirq_msi_info info;
-	union pci_bdf pbdf = vdev->pdev.bdf;
+	union pci_bdf pbdf = vdev->pdev->bdf;
 	struct acrn_vm *vm = vdev->vpci->vm;
 	uint32_t capoff = vdev->msi.capoff;
 	uint32_t msgctrl, msgdata;
@@ -183,7 +183,7 @@ static void buf_write32(uint8_t *buf, uint32_t val)
 
 void populate_msi_struct(struct pci_vdev *vdev)
 {
-	struct pci_pdev *pdev = &vdev->pdev;
+	struct pci_pdev *pdev = vdev->pdev;
 	uint32_t val;
 
 	/* Copy MSI/MSI-X capability struct into virtual device */

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -166,68 +166,53 @@ static const struct pci_vdev_ops pci_ops_vdev_msi = {
 	.cfgread = vmsi_cfgread,
 };
 
+/* Read a uint32_t from buffer (little endian) */
+static uint32_t buf_read32(uint8_t *buf)
+{
+	return buf[0] | ((uint32_t)buf[1] << 8U) | ((uint32_t)buf[2] << 16U) | ((uint32_t)buf[3] << 24U);
+}
+
+/* Write a uint32_t to buffer (little endian) */
+static void buf_write32(uint8_t *buf, uint32_t val)
+{
+	buf[0] = (uint8_t)(val & 0xFFU);
+	buf[1] = (uint8_t)((val >> 8U)  & 0xFFU);
+	buf[2] = (uint8_t)((val >> 16U) & 0xFFU);
+	buf[3] = (uint8_t)((val >> 24U) & 0xFFU);
+}
+
 void populate_msi_struct(struct pci_vdev *vdev)
 {
-	uint8_t ptr, cap;
-	uint32_t msgctrl;
-	uint32_t len, bytes, offset, val;
-	union pci_bdf pbdf = vdev->pdev.bdf;
+	struct pci_pdev *pdev = &vdev->pdev;
+	uint32_t val;
 
-	/* Has new Capabilities list? */
-	if ((pci_pdev_read_cfg(pbdf, PCIR_STATUS, 2U) & PCIM_STATUS_CAPPRESENT) != 0U) {
-		ptr = (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_CAP_PTR, 1U);
-		while ((ptr != 0U) && (ptr != 0xFFU)) {
-			cap = (uint8_t)pci_pdev_read_cfg(pbdf, ptr + PCICAP_ID, 1U);
+	/* Copy MSI/MSI-X capability struct into virtual device */
+	if (pdev->msi.capoff != 0U) {
+		vdev->msi.capoff = pdev->msi.capoff;
+		vdev->msi.caplen = pdev->msi.caplen;
 
-			/* Ignore all other Capability IDs for now */
-			if ((cap == PCIY_MSI) || (cap == PCIY_MSIX)) {
-				offset = ptr;
-				if (cap == PCIY_MSI) {
-					vdev->msi.capoff = offset;
-					msgctrl = pci_pdev_read_cfg(pbdf, offset + PCIR_MSI_CTRL, 2U);
+		/* Assign MSI handler for configuration read and write */
+		add_vdev_handler(vdev, &pci_ops_vdev_msi);
 
-					/*
-					 * Ignore the 'mask' and 'pending' bits in the MSI capability
-					 * (msgctrl & PCIM_MSICTRL_VECTOR).
-					 * We'll let the guest manipulate them directly.
-					 */
-					len = ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) ? 14U : 10U;
-					vdev->msi.caplen = len;
+		(void)memcpy_s((void *)&vdev->cfgdata.data_8[pdev->msi.capoff], pdev->msi.caplen, (void *)&pdev->msi.cap[0U],
+			pdev->msi.caplen);
 
-					/* Assign MSI handler for configuration read and write */
-					add_vdev_handler(vdev, &pci_ops_vdev_msi);
-				} else {
-					vdev->msix.capoff = offset;
-					vdev->msix.caplen = MSIX_CAPLEN;
-					len = vdev->msix.caplen;
+		val = buf_read32(&pdev->msi.cap[0U]);
+		val &= ~((uint32_t)PCIM_MSICTRL_MMC_MASK << 16U);
+		val &= ~((uint32_t)PCIM_MSICTRL_MME_MASK << 16U);
 
-					/* Assign MSI-X handler for configuration read and write */
-					add_vdev_handler(vdev, &pci_ops_vdev_msix);
-				}
+		buf_write32(&vdev->cfgdata.data_8[pdev->msi.capoff], val);
+	}
 
-				/* Copy MSI/MSI-X capability struct into virtual device */
-				while (len > 0U) {
-					bytes = (len >= 4U) ? 4U : len;
-					val = pci_pdev_read_cfg(pbdf, offset, bytes);
+	if (pdev->msix.capoff != 0U) {
+		vdev->msix.capoff = pdev->msix.capoff;
+		vdev->msix.caplen = pdev->msix.caplen;
 
-					if ((cap == PCIY_MSI) && (offset == vdev->msi.capoff)) {
-						/*
-						 * Don't support multiple vector for now,
-						 * Force Multiple Message Enable and Multiple Message
-						 * Capable to 0
-						 */
-						val &= ~((uint32_t)PCIM_MSICTRL_MMC_MASK << 16U);
-						val &= ~((uint32_t)PCIM_MSICTRL_MME_MASK << 16U);
-					}
+		/* Assign MSI-X handler for configuration read and write */
+		add_vdev_handler(vdev, &pci_ops_vdev_msix);
 
-					pci_vdev_write_cfg(vdev, offset, bytes, val);
-					len -= bytes;
-					offset += bytes;
-				}
-			}
-
-			ptr = (uint8_t)pci_pdev_read_cfg(pbdf, ptr + PCICAP_NEXTPTR, 1U);
-		}
+		(void)memcpy_s((void *)&vdev->cfgdata.data_8[pdev->msix.capoff], pdev->msix.caplen, (void *)&pdev->msix.cap[0U],
+			pdev->msix.caplen);
 	}
 }
 

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -92,7 +92,7 @@ static inline void enable_disable_msix(const struct pci_vdev *vdev, bool enable)
 	} else {
 		msgctrl &= ~PCIM_MSIXCTRL_MSIX_ENABLE;
 	}
-	pci_pdev_write_cfg(vdev->pdev.bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
+	pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
 }
 
 /* Do MSI-X remap for all MSI-X table entries in the target device */
@@ -114,7 +114,7 @@ static int32_t vmsix_remap(const struct pci_vdev *vdev, bool enable)
 	/* If MSI Enable is being set, make sure INTxDIS bit is set */
 	if (ret == 0) {
 		if (enable) {
-			enable_disable_pci_intx(vdev->pdev.bdf, false);
+			enable_disable_pci_intx(vdev->pdev->bdf, false);
 		}
 		enable_disable_msix(vdev, enable);
 	}
@@ -135,13 +135,13 @@ static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index
 	if (ret == 0) {
 		/* If MSI Enable is being set, make sure INTxDIS bit is set */
 		if (enable) {
-			enable_disable_pci_intx(vdev->pdev.bdf, false);
+			enable_disable_pci_intx(vdev->pdev->bdf, false);
 		}
 
 		/* Restore MSI-X Enable bit */
 		msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
 		if ((msgctrl & PCIM_MSIXCTRL_MSIX_ENABLE) == PCIM_MSIXCTRL_MSIX_ENABLE) {
-			pci_pdev_write_cfg(vdev->pdev.bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
+			pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
 		}
 	}
 
@@ -186,7 +186,7 @@ static int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t b
 			}
 
 			if (((msgctrl ^ val) & PCIM_MSIXCTRL_FUNCTION_MASK) != 0U) {
-				pci_pdev_write_cfg(vdev->pdev.bdf, offset, 2U, val);
+				pci_pdev_write_cfg(vdev->pdev->bdf, offset, 2U, val);
 			}
 		}
 
@@ -316,7 +316,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 	uint32_t i;
 	uint64_t addr_hi, addr_lo;
 	struct pci_msix *msix = &vdev->msix;
-	struct pci_pdev *pdev = &vdev->pdev;
+	struct pci_pdev *pdev = vdev->pdev;
 	struct pci_bar *table_bar;
 	int32_t ret;
 
@@ -365,7 +365,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 		}
 		ret = 0;
 	} else {
-		pr_err("%s, MSI-X device (%x) invalid table BIR %d", __func__, vdev->pdev.bdf.value, msix->table_bar);
+		pr_err("%s, MSI-X device (%x) invalid table BIR %d", __func__, vdev->pdev->bdf.value, msix->table_bar);
 		vdev->msix.capoff = 0U;
 	        ret = -EIO;
 	}

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -66,24 +66,24 @@ static inline bool is_valid_bar(struct pci_bar *bar)
 	return is_valid_bar_type(bar) && is_valid_bar_size(bar);
 }
 
-void partition_mode_pdev_init(struct pci_vdev *vdev)
+static void partition_mode_pdev_init(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev_ref;
 	uint32_t idx;
 	struct pci_bar *pbar, *vbar;
 
-	pdev_ref = find_pci_pdev(vdev->pdev.bdf);
+	pdev_ref = find_pci_pdev(vdev->pbdf);
 	if (pdev_ref == NULL) {
 		pr_err("No pdev found for pbdf %x:%x.%x\n",
-			vdev->pdev.bdf.bits.b, vdev->pdev.bdf.bits.d, vdev->pdev.bdf.bits.f);
+			vdev->pbdf.bits.b, vdev->pbdf.bits.d, vdev->pbdf.bits.f);
 		return;
 	}
 
-	(void)memcpy_s((void *)&vdev->pdev, sizeof(struct pci_pdev), (void *)pdev_ref, sizeof(struct pci_pdev));
+	vdev->pdev = pdev_ref;
 
 	/* Sanity checking for vbar */
 	for (idx = 0U; idx < (uint32_t)PCI_BAR_COUNT; idx++) {
-		pbar = &vdev->pdev.bar[idx];
+		pbar = &vdev->pdev->bar[idx];
 		vbar = &vdev->bar[idx];
 
 		if (is_valid_bar(pbar)) {
@@ -120,7 +120,7 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 
 		if (vdev->ops->init != NULL) {
 			if (vdev->ops->init(vdev) != 0) {
-				pr_err("%s() failed at PCI device (bdf %x)!", __func__,
+				pr_err("%s() failed at PCI device (vbdf %x)!", __func__,
 					vdev->vbdf);
 			}
 		}

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -50,6 +50,53 @@ static struct pci_vdev *partition_mode_find_vdev(struct acrn_vpci *vpci, union p
 	return NULL;
 }
 
+static inline bool is_valid_bar_type(struct pci_bar *bar)
+{
+	return (bar->type == PCIBAR_MEM32) || (bar->type == PCIBAR_MEM64);
+}
+
+static inline bool is_valid_bar_size(struct pci_bar *bar)
+{
+	return (bar->size > 0UL) && (bar->size <= 0xffffffffU);
+}
+
+/* Only MMIO is supported and bar size cannot be greater than 4GB */
+static inline bool is_valid_bar(struct pci_bar *bar)
+{
+	return is_valid_bar_type(bar) && is_valid_bar_size(bar);
+}
+
+void partition_mode_pdev_init(struct pci_vdev *vdev)
+{
+	struct pci_pdev *pdev_ref;
+	uint32_t idx;
+	struct pci_bar *pbar, *vbar;
+
+	pdev_ref = find_pci_pdev(vdev->pdev.bdf);
+	if (pdev_ref == NULL) {
+		pr_err("No pdev found for pbdf %x:%x.%x\n",
+			vdev->pdev.bdf.bits.b, vdev->pdev.bdf.bits.d, vdev->pdev.bdf.bits.f);
+		return;
+	}
+
+	(void)memcpy_s((void *)&vdev->pdev, sizeof(struct pci_pdev), (void *)pdev_ref, sizeof(struct pci_pdev));
+
+	/* Sanity checking for vbar */
+	for (idx = 0U; idx < (uint32_t)PCI_BAR_COUNT; idx++) {
+		pbar = &vdev->pdev.bar[idx];
+		vbar = &vdev->bar[idx];
+
+		if (is_valid_bar(pbar)) {
+			vbar->size = (pbar->size < 0x1000U) ? 0x1000U : pbar->size;
+			vbar->type = PCIBAR_MEM32;
+		} else {
+			/* Mark this vbar as invalid */
+			vbar->size = 0UL;
+			vbar->type = PCIBAR_NONE;
+		}
+	}
+}
+
 static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 {
 	struct vpci_vdev_array *vdev_array;
@@ -63,6 +110,11 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 	for (i = 0; i < vdev_array->num_pci_vdev; i++) {
 		vdev = &vdev_array->vpci_vdev_list[i];
 		vdev->vpci = vpci;
+
+		/* Exclude hostbridge */
+		if (vdev->vbdf.value != 0U) {
+			partition_mode_pdev_init(vdev);
+		}
 
 		if ((vdev->ops != NULL) && (vdev->ops->init != NULL)) {
 			if (vdev->ops->init(vdev) != 0) {

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -111,12 +111,14 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 		vdev = &vdev_array->vpci_vdev_list[i];
 		vdev->vpci = vpci;
 
-		/* Exclude hostbridge */
 		if (vdev->vbdf.value != 0U) {
 			partition_mode_pdev_init(vdev);
-		}
+			vdev->ops = &pci_ops_vdev_pt;
+		} else {
+			vdev->ops = &pci_ops_vdev_hostbridge;
+ 		}
 
-		if ((vdev->ops != NULL) && (vdev->ops->init != NULL)) {
+		if (vdev->ops->init != NULL) {
 			if (vdev->ops->init(vdev) != 0) {
 				pr_err("%s() failed at PCI device (bdf %x)!", __func__,
 					vdev->vbdf);

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -75,13 +75,13 @@ static int32_t vdev_pt_init(struct pci_vdev *vdev)
 			hva2hpa(vm->arch_vm.nworld_eptp), 48U);
 	}
 
-	ret = assign_iommu_device(vm->iommu, (uint8_t)vdev->pdev.bdf.bits.b,
-		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
+	ret = assign_iommu_device(vm->iommu, (uint8_t)vdev->pdev->bdf.bits.b,
+		(uint8_t)(vdev->pdev->bdf.value & 0xFFU));
 
-	pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U);
+	pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U);
 	/* Disable INTX */
 	pci_command |= 0x400U;
-	pci_pdev_write_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U, pci_command);
+	pci_pdev_write_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U, pci_command);
 
 	return ret;
 }
@@ -91,8 +91,8 @@ static int32_t vdev_pt_deinit(struct pci_vdev *vdev)
 	int32_t ret;
 	struct acrn_vm *vm = vdev->vpci->vm;
 
-	ret = unassign_iommu_device(vm->iommu, (uint8_t)vdev->pdev.bdf.bits.b,
-		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
+	ret = unassign_iommu_device(vm->iommu, (uint8_t)vdev->pdev->bdf.bits.b,
+		(uint8_t)(vdev->pdev->bdf.value & 0xFFU));
 
 	return ret;
 }
@@ -110,7 +110,7 @@ static int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	if (pci_bar_access(offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
 	} else {
-		*val = pci_pdev_read_cfg(vdev->pdev.bdf, offset, bytes);
+		*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
 	}
 
 	return 0;
@@ -130,7 +130,7 @@ static void vdev_pt_remap_bar(struct pci_vdev *vdev, uint32_t idx,
 	if (new_base != 0U) {
 		/* Map the physical BAR in the guest MMIO space */
 		ept_mr_add(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
-			vdev->pdev.bar[idx].base, /* HPA */
+			vdev->pdev->bar[idx].base, /* HPA */
 			new_base, /*GPA*/
 			vdev->bar[idx].size,
 			EPT_WR | EPT_RD | EPT_UNCACHED);
@@ -189,7 +189,7 @@ static int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 		vdev_pt_cfgwrite_bar(vdev, offset, bytes, val);
 	} else {
 		/* Write directly to physical device's config space */
-		pci_pdev_write_cfg(vdev->pdev.bdf, offset, bytes, val);
+		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 	}
 
 	return 0;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -40,7 +40,7 @@ struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf)
 
 	/* in SOS_VM, it uses phys BDF */
 	for (i = 0U; i < num_pci_vdev; i++) {
-		if (sharing_mode_vdev_array[i].pdev.bdf.value == pbdf.value) {
+		if (sharing_mode_vdev_array[i].pdev->bdf.value == pbdf.value) {
 			vdev = &sharing_mode_vdev_array[i];
 		}
 	}
@@ -71,7 +71,7 @@ static void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf 
 
 		/* Not handled by any handlers. Passthru to physical device */
 		if (!handled) {
-			*val = pci_pdev_read_cfg(vdev->pdev.bdf, offset, bytes);
+			*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
 		}
 	}
 }
@@ -96,7 +96,7 @@ static void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf
 
 			/* Not handled by any handlers. Passthru to physical device */
 			if (!handled) {
-				pci_pdev_write_cfg(vdev->pdev.bdf, offset, bytes, val);
+				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 			}
 		}
 	}
@@ -114,7 +114,7 @@ static struct pci_vdev *alloc_pci_vdev(const struct acrn_vm *vm, struct pci_pdev
 		vdev->vbdf = pdev_ref->bdf;
 		vdev->vpci = &vm->vpci;
 
-		(void)memcpy_s((void *)&vdev->pdev, sizeof(struct pci_pdev), (void *)pdev_ref, sizeof(struct pci_pdev));
+		vdev->pdev = pdev_ref;
 	} else {
 		vdev = NULL;
 	}
@@ -209,7 +209,7 @@ void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, ui
 		/* UOS may do BDF mapping */
 		vdev->vpci = (struct acrn_vpci *)&(target_vm->vpci);
 		vdev->vbdf.value = vbdf;
-		vdev->pdev.bdf.value = pbdf;
+		vdev->pdev->bdf.value = pbdf;
 	}
 }
 

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -123,7 +123,7 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable)
 #define BUS_SCAN_SKIP		0U
 #define BUS_SCAN_PENDING	1U
 #define BUS_SCAN_COMPLETE	2U
-void pci_scan_bus(pci_enumeration_cb cb_func, const void *cb_data)
+void pci_scan_bus(pci_enumeration_cb cb_func)
 {
 	union pci_bdf pbdf;
 	uint8_t hdr_type, secondary_bus, dev, func;
@@ -165,7 +165,7 @@ void pci_scan_bus(pci_enumeration_cb cb_func, const void *cb_data)
 				}
 
 				if (cb_func != NULL) {
-					cb_func(pbdf.value, cb_data);
+					cb_func(pbdf.value);
 				}
 
 				hdr_type = (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_HDRTYPE, 1U);
@@ -379,7 +379,7 @@ static void fill_pdev(uint16_t pbdf, struct pci_pdev *pdev)
 	}
 }
 
-static void init_pdev(uint16_t pbdf, __unused const void *cb_data)
+static void init_pdev(uint16_t pbdf)
 {
 	static struct pci_pdev *pdev = NULL;
 
@@ -393,8 +393,21 @@ static void init_pdev(uint16_t pbdf, __unused const void *cb_data)
 	}
 }
 
+void pci_pdev_foreach(pci_pdev_enumeration_cb cb_func, const void *ctx)
+{
+	static struct pci_pdev *pdev = NULL;
+	uint32_t idx;
+
+	for (idx = 0U; idx < num_pci_pdev; idx++) {
+		pdev = &pci_pdev_array[idx];
+		if (cb_func != NULL) {
+			cb_func(pdev, ctx);
+		}
+	}
+}
+
 void init_pci_pdev_list(void)
 {
 	/* Build up pdev array */
-	pci_scan_bus(init_pdev, NULL);
+	pci_scan_bus(init_pdev);
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -1,4 +1,7 @@
 /*
+ * Copyright (c) 1997, Stefan Esser <se@freebsd.org>
+ * Copyright (c) 2000, Michael Smith <msmith@freebsd.org>
+ * Copyright (c) 2000, BSDi
  * Copyright (c) 2011 NetApp, Inc.
  * Copyright (c) 2018 Intel Corporation
  * All rights reserved.
@@ -30,10 +33,10 @@
 #include <hypervisor.h>
 #include <pci.h>
 
-static spinlock_t pci_device_lock = {
-	.head = 0U,
-	.tail = 0U
-};
+static spinlock_t pci_device_lock;
+static uint32_t num_pci_pdev;
+static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
+
 
 static uint32_t pci_pdev_calc_address(union pci_bdf bdf, uint32_t offset)
 {
@@ -180,4 +183,218 @@ void pci_scan_bus(pci_enumeration_cb cb_func, const void *cb_data)
 			}
 		}
 	}
+}
+
+static uint8_t pci_pdev_get_num_bars(uint8_t hdrtype)
+{
+	uint8_t num_bars = (uint8_t)0U;
+
+	switch (hdrtype & PCIM_HDRTYPE) {
+	case PCIM_HDRTYPE_NORMAL:
+		num_bars = (uint8_t)6U;
+		break;
+
+	case PCIM_HDRTYPE_BRIDGE:
+		num_bars = (uint8_t)2U;
+		break;
+
+	case PCIM_HDRTYPE_CARDBUS:
+		num_bars = (uint8_t)1U;
+		break;
+
+	default:
+		break;
+	}
+
+	return num_bars;
+}
+
+static enum pci_bar_type pci_pdev_read_bar_type(union pci_bdf bdf, uint8_t idx)
+{
+	uint32_t bar;
+	enum pci_bar_type type = PCIBAR_NONE;
+
+	bar = pci_pdev_read_cfg(bdf, pci_bar_offset(idx), 4U);
+	if ((bar & PCIM_BAR_SPACE) == PCIM_BAR_IO_SPACE) {
+		type = PCIBAR_IO_SPACE;
+	} else {
+		switch (bar & PCIM_BAR_MEM_TYPE) {
+		case PCIM_BAR_MEM_32:
+		case PCIM_BAR_MEM_1MB:
+			type = PCIBAR_MEM32;
+			break;
+
+		case PCIM_BAR_MEM_64:
+			type = PCIBAR_MEM64;
+			break;
+		}
+	}
+
+	return type;
+}
+
+static void pci_pdev_read_bar(union pci_bdf bdf, uint8_t idx, struct pci_bar *bar)
+{
+	uint64_t base, size;
+	enum pci_bar_type type;
+	uint32_t bar_lo, bar_hi, val32;
+	uint32_t orig_cmd;
+	uint32_t bar_base_mask;
+
+	base = 0UL;
+	size = 0UL;
+	type = pci_pdev_read_bar_type(bdf, idx);
+
+	if (type == PCIBAR_IO_SPACE) {
+		bar_base_mask = ~0x03U;
+	} else {
+		bar_base_mask = ~0x0fU;
+	}
+
+	if (type != PCIBAR_NONE) {
+		bar_lo = pci_pdev_read_cfg(bdf, pci_bar_offset(idx), 4U);
+
+		/* Get the base address */
+		base = (uint64_t)bar_lo & bar_base_mask;
+		if (type == PCIBAR_MEM64) {
+			bar_hi = pci_pdev_read_cfg(bdf, pci_bar_offset(idx + 1U), 4U);
+			base |= ((uint64_t)bar_hi << 32U);
+		}
+
+		orig_cmd = pci_pdev_read_cfg(bdf, PCIR_COMMAND, 2U);
+		pci_pdev_write_cfg(bdf, PCIR_COMMAND, 2U, orig_cmd & ~(PCIM_CMD_MEMEN | PCIM_CMD_PORTEN));
+
+		/* Sizing the BAR */
+		size = 0UL;
+		if ((type == PCIBAR_MEM64) && (idx < (PCI_BAR_COUNT - 1U))) {
+			pci_pdev_write_cfg(bdf, pci_bar_offset(idx + 1U), 4U, ~0U);
+			size = (uint64_t)pci_pdev_read_cfg(bdf, pci_bar_offset(idx + 1U), 4U);
+			size <<= 32U;
+		}
+
+		pci_pdev_write_cfg(bdf, pci_bar_offset(idx), 4U, ~0U);
+		val32 = pci_pdev_read_cfg(bdf, pci_bar_offset(idx), 4U);
+		size |= ((uint64_t)val32 & bar_base_mask);
+
+		if (size != 0UL) {
+			size = size & ~(size - 1U);
+		}
+
+		/* Restore the BAR */
+		pci_pdev_write_cfg(bdf, pci_bar_offset(idx), 4U, bar_lo);
+
+		if (type == PCIBAR_MEM64) {
+			pci_pdev_write_cfg(bdf, pci_bar_offset(idx + 1U), 4U, bar_hi);
+		}
+
+		/* Restore cmd reg */
+		pci_pdev_write_cfg(bdf, PCIR_COMMAND, 2U, orig_cmd);
+	}
+
+	bar->base = base;
+	bar->size = size;
+	bar->type = type;
+}
+
+static void pci_pdev_read_bars(union pci_bdf bdf, uint8_t nr_bars, struct pci_bar bar[PCI_BAR_COUNT])
+{
+	uint8_t	idx;
+
+	for (idx = 0U; idx < nr_bars; idx++) {
+		pci_pdev_read_bar(bdf, idx, &bar[idx]);
+
+		if (bar[idx].type == PCIBAR_MEM64) {
+			idx++;
+			bar[idx].type = PCIBAR_NONE;
+		}
+	}
+}
+
+static void pci_read_cap(struct pci_pdev *pdev)
+{
+	uint8_t ptr, cap;
+	uint32_t msgctrl;
+	uint32_t len, offset, idx;
+	uint32_t table_info;
+	uint8_t *dst;
+
+	ptr = (uint8_t)pci_pdev_read_cfg(pdev->bdf, PCIR_CAP_PTR, 1U);
+
+	while ((ptr != 0U) && (ptr != 0xFFU)) {
+		cap = (uint8_t)pci_pdev_read_cfg(pdev->bdf, ptr + PCICAP_ID, 1U);
+
+		/* Ignore all other Capability IDs for now */
+		if ((cap == PCIY_MSI) || (cap == PCIY_MSIX)) {
+			offset = ptr;
+			if (cap == PCIY_MSI) {
+				pdev->msi.capoff = offset;
+				msgctrl = pci_pdev_read_cfg(pdev->bdf, offset + PCIR_MSI_CTRL, 2U);
+				len = ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) ? 14U : 10U;
+				pdev->msi.caplen = len;
+				dst = &pdev->msi.cap[0];
+			} else {
+				pdev->msix.capoff = offset;
+				pdev->msix.caplen = MSIX_CAPLEN;
+				len = pdev->msix.caplen;
+				dst = &pdev->msix.cap[0];
+
+				msgctrl = pci_pdev_read_cfg(pdev->bdf, pdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
+
+				/* Read Table Offset and Table BIR */
+				table_info = pci_pdev_read_cfg(pdev->bdf, pdev->msix.capoff + PCIR_MSIX_TABLE, 4U);
+
+				pdev->msix.table_bar = (uint8_t)(table_info & PCIM_MSIX_BIR_MASK);
+
+				pdev->msix.table_offset = table_info & ~PCIM_MSIX_BIR_MASK;
+				pdev->msix.table_count = (msgctrl & PCIM_MSIXCTRL_TABLE_SIZE) + 1U;
+			}
+
+			/* Copy MSI/MSI-X capability struct into buffer */
+			for (idx = 0U; idx < len; idx++) {
+				dst[idx] = (uint8_t)pci_pdev_read_cfg(pdev->bdf, offset + idx, 1U);
+			}
+		}
+
+		ptr = (uint8_t)pci_pdev_read_cfg(pdev->bdf, ptr + PCICAP_NEXTPTR, 1U);
+	}
+}
+
+static void fill_pdev(uint16_t pbdf, struct pci_pdev *pdev)
+{
+	uint8_t  nr_bars;
+
+	pdev->bdf.value = pbdf;
+
+	pdev->cfg.vendor = (uint16_t)pci_pdev_read_cfg(pdev->bdf, PCIR_VENDOR, 2U);
+	pdev->cfg.device = (uint16_t)pci_pdev_read_cfg(pdev->bdf, PCIR_DEVICE, 2U);
+	pdev->cfg.revid = (uint8_t)pci_pdev_read_cfg(pdev->bdf, PCIR_REVID, 1U);
+	pdev->cfg.hdrtype = (uint8_t)pci_pdev_read_cfg(pdev->bdf, PCIR_HDRTYPE, 1U);
+
+	nr_bars = pci_pdev_get_num_bars(pdev->cfg.hdrtype);
+
+	pci_pdev_read_bars(pdev->bdf, nr_bars, &pdev->bar[0]);
+
+	if ((pci_pdev_read_cfg(pdev->bdf, PCIR_STATUS, 2U) & PCIM_STATUS_CAPPRESENT) != 0U) {
+		pci_read_cap(pdev);
+	}
+}
+
+static void init_pdev(uint16_t pbdf, __unused const void *cb_data)
+{
+	static struct pci_pdev *pdev = NULL;
+
+	if (num_pci_pdev < CONFIG_MAX_PCI_DEV_NUM) {
+		pdev = &pci_pdev_array[num_pci_pdev];
+		num_pci_pdev++;
+
+		fill_pdev(pbdf, pdev);
+	} else {
+		pr_err("%s, failed to alloc pci_pdev!\n", __func__);
+	}
+}
+
+void init_pci_pdev_list(void)
+{
+	/* Build up pdev array */
+	pci_scan_bus(init_pdev, NULL);
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -406,6 +406,21 @@ void pci_pdev_foreach(pci_pdev_enumeration_cb cb_func, const void *ctx)
 	}
 }
 
+struct pci_pdev *find_pci_pdev(union pci_bdf pbdf)
+{
+	struct pci_pdev *pdev = NULL;
+	uint32_t i;
+
+	for (i = 0U; i < num_pci_pdev; i++) {
+		if (pci_pdev_array[i].bdf.value == pbdf.value) {
+			pdev = &pci_pdev_array[i];
+			break;
+		}
+	}
+
+	return pdev;
+}
+
 void init_pci_pdev_list(void)
 {
 	/* Build up pdev array */

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -138,6 +138,21 @@ enum pci_bar_type {
 	PCIBAR_MEM64,
 };
 
+struct pci_bar {
+	uint64_t base;
+	uint64_t size;
+	enum pci_bar_type type;
+};
+
+struct pci_pdev {
+	/* The bar info of the physical PCI device. */
+	struct pci_bar bar[PCI_BAR_COUNT];
+
+	/* The bus/device/function triple of the physical PCI device. */
+	union pci_bdf bdf;
+};
+
+
 typedef void (*pci_enumeration_cb)(uint16_t pbdf, const void *data);
 
 static inline uint32_t pci_bar_offset(uint32_t idx)

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -232,6 +232,7 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
 void pci_scan_bus(pci_enumeration_cb cb);
 void pci_pdev_foreach(pci_pdev_enumeration_cb cb, const void *ctx);
+struct pci_pdev *find_pci_pdev(union pci_bdf pbdf);
 void init_pci_pdev_list(void);
 
 

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -189,7 +189,8 @@ struct pci_pdev {
 };
 
 
-typedef void (*pci_enumeration_cb)(uint16_t pbdf, const void *data);
+typedef void (*pci_enumeration_cb)(uint16_t pbdf);
+typedef void (*pci_pdev_enumeration_cb)(struct pci_pdev *pdev, const void *data);
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {
@@ -229,7 +230,8 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
-void pci_scan_bus(pci_enumeration_cb cb, const void *cb_data);
+void pci_scan_bus(pci_enumeration_cb cb);
+void pci_pdev_foreach(pci_pdev_enumeration_cb cb, const void *ctx);
 void init_pci_pdev_list(void);
 
 

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -1,4 +1,5 @@
 /*-
+* Copyright (c) 1997, Stefan Esser <se@freebsd.org>
 * Copyright (c) 2011 NetApp, Inc.
 * Copyright (c) 2018 Intel Corporation
 * All rights reserved.
@@ -59,6 +60,8 @@
 #define PCIR_VENDOR           0x00U
 #define PCIR_DEVICE           0x02U
 #define PCIR_COMMAND          0x04U
+#define	PCIM_CMD_PORTEN       0x01U
+#define	PCIM_CMD_MEMEN        0x02U
 #define PCIM_CMD_INTxDIS      0x400U
 #define PCIR_STATUS           0x06U
 #define PCIM_STATUS_CAPPRESENT    0x0010U
@@ -69,6 +72,7 @@
 #define PCIM_HDRTYPE          0x7FU
 #define PCIM_HDRTYPE_NORMAL   0x00U
 #define PCIM_HDRTYPE_BRIDGE   0x01U
+#define	PCIM_HDRTYPE_CARDBUS  0x02U
 #define PCIM_MFDEV            0x80U
 #define PCIR_BARS             0x10U
 #define PCIM_BAR_SPACE        0x01U
@@ -120,6 +124,7 @@
 #define PCIM_MSIX_BIR_MASK    0x7U
 #define PCIM_MSIX_VCTRL_MASK  0x1U
 
+#define MSI_MAX_CAPLEN        14U
 #define MSIX_CAPLEN           12U
 #define MSIX_TABLE_ENTRY_SIZE 16U
 
@@ -134,6 +139,7 @@ union pci_bdf {
 
 enum pci_bar_type {
 	PCIBAR_NONE = 0,
+	PCIBAR_IO_SPACE,
 	PCIBAR_MEM32,
 	PCIBAR_MEM64,
 };
@@ -144,12 +150,42 @@ struct pci_bar {
 	enum pci_bar_type type;
 };
 
+struct pci_cfg_regs {
+	uint16_t vendor;
+	uint16_t device;
+	uint8_t  revid;
+	uint8_t  hdrtype;
+};
+
+/* Basic MSI capability info */
+struct pci_msi_cap {
+	uint32_t  capoff;
+	uint32_t  caplen;
+	uint8_t   cap[MSI_MAX_CAPLEN];
+};
+
+/* Basic MSIX capability info */
+struct pci_msix_cap {
+	uint32_t  capoff;
+	uint32_t  caplen;
+	uint8_t   table_bar;
+	uint32_t  table_offset;
+	uint32_t  table_count;
+	uint8_t   cap[MSIX_CAPLEN];
+};
+
 struct pci_pdev {
 	/* The bar info of the physical PCI device. */
 	struct pci_bar bar[PCI_BAR_COUNT];
 
 	/* The bus/device/function triple of the physical PCI device. */
 	union pci_bdf bdf;
+
+	struct pci_cfg_regs cfg;
+
+	struct pci_msi_cap msi;
+
+	struct pci_msix_cap msix;
 };
 
 
@@ -194,5 +230,7 @@ void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
 void pci_scan_bus(pci_enumeration_cb cb, const void *cb_data);
+void init_pci_pdev_list(void);
+
 
 #endif /* PCI_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -91,7 +91,10 @@ struct pci_vdev {
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf vbdf;
 
-	struct pci_pdev pdev;
+	/* The bus/device/function triple of the physical PCI device. */
+	union pci_bdf pbdf;
+
+	struct pci_pdev *pdev;
 
 	union pci_cfgdata cfgdata;
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -45,24 +45,10 @@ struct pci_vdev_ops {
 		uint32_t bytes, uint32_t *val);
 };
 
-struct pci_bar {
-	uint64_t base;
-	uint64_t size;
-	enum pci_bar_type type;
-};
-
 struct msix_table_entry {
 	uint64_t	addr;
 	uint32_t	data;
 	uint32_t	vector_control;
-};
-
-struct pci_pdev {
-	/* The bar info of the physical PCI device. */
-	struct pci_bar bar[PCI_BAR_COUNT];
-
-	/* The bus/device/function triple of the physical PCI device. */
-	union pci_bdf bdf;
 };
 
 /* MSI capability structure */

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -13,7 +13,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_hostbridge,
 	  .pdev = {
 		 .bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -21,7 +20,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 	 {/*vdev 1: SATA controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_pt,
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
 		}
@@ -35,7 +33,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_hostbridge,
 	  .pdev = {
 			.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -43,7 +40,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 	 {/*vdev 1: USB controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_pt,
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
 		}
@@ -51,7 +47,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 	 {/*vdev 2: Ethernet*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_pt,
 	 .pdev = {
 		.bdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
 		}

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -13,16 +13,12 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .pdev = {
-		 .bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	 },
 
 	 {/*vdev 1: SATA controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	 .pdev = {
-		.bdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
 	 },
 	}
 };
@@ -33,23 +29,17 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .pdev = {
-			.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	 },
 
 	 {/*vdev 1: USB controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	 .pdev = {
-		.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
 	 },
 
 	 {/*vdev 2: Ethernet*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-	 .pdev = {
-		.bdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
 	 },
 	}
 };

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -14,7 +14,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_hostbridge,
-	  .bar = {},
 	  .pdev = {
 		 .bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -23,42 +22,8 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	 {/*vdev 1: SATA controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_pt,
-	  .bar = {
-			[0] = {
-			.base = 0UL,
-			.size = 0x2000UL,
-			.type = PCIBAR_MEM32
-			},
-			[1] = {
-			.base = 0UL,
-			.size = 0x1000UL,
-			.type = PCIBAR_MEM32
-			},
-			[5] = {
-			.base = 0UL,
-			.size = 0x1000UL,
-			.type = PCIBAR_MEM32
-			},
-	  },
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
-		.bar = {
-			[0] = {
-			.base = 0xb3f10000UL,
-			.size = 0x2000UL,
-			.type = PCIBAR_MEM32
-			},
-			[1] = {
-			.base = 0xb3f53000UL,
-			.size = 0x100UL,
-			.type = PCIBAR_MEM32
-			},
-			[5] = {
-			.base = 0xb3f52000UL,
-			.size = 0x800UL,
-			.type = PCIBAR_MEM32
-			},
-		 }
 		}
 	 },
 	}
@@ -71,7 +36,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_hostbridge,
-	  .bar = {},
 	  .pdev = {
 			.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -80,54 +44,16 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	 {/*vdev 1: USB controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_pt,
-	  .bar = {
-			[0] = {
-			.base = 0UL,
-			.size = 0x10000UL,
-			.type = PCIBAR_MEM32
-		 },
-	  },
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-		.bar = {
-			[0] = {
-			.base = 0xb3f00000UL,
-			.size = 0x10000UL,
-			.type = PCIBAR_MEM64
-			},
-		 }
 		}
 	 },
 
 	 {/*vdev 2: Ethernet*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_pt,
-	  .bar = {
-			[0] = {
-			.base = 0UL,
-			.size = 0x80000UL,
-			.type = PCIBAR_MEM32
-			},
-			[3] = {
-			.base = 0UL,
-			.size = 0x4000UL,
-			.type = PCIBAR_MEM32
-			},
-	  },
 	 .pdev = {
 		.bdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
-		.bar = {
-			[0] = {
-			.base = 0xb3c00000UL,
-			.size = 0x80000UL,
-			.type = PCIBAR_MEM32
-			},
-			[3] = {
-			.base = 0xb3c80000UL,
-			.size = 0x4000UL,
-			.type = PCIBAR_MEM32
-			 },
-		 }
 		}
 	 },
 	}

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -13,7 +13,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 		{/*vdev 0: hostbridge */
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			.ops = &pci_ops_vdev_hostbridge,
-			.bar = {},
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -22,54 +21,17 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 		{/*vdev 1: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x200000UL,
-					.type = PCIBAR_MEM32,
-				},
-				[4] = {
-					.base = 0UL,
-					.size = 0x4000UL,
-					.type = PCIBAR_MEM32,
-				},
-			},
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
-				.bar = {
-					[0] = {
-						.base = 0x80C00000,
-						.size = 0x200000UL,
-						.type = PCIBAR_MEM32,
-					},
-					[4] = {
-						.base = 0x81000000,
-						.size = 0x4000UL,
-						.type = PCIBAR_MEM32,
-					},
-				}
 			}
 		},
 
 		{/*vdev 2: USB*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x10000UL,
-					.type = PCIBAR_MEM32,
-				}
-			},
+
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-				.bar = {
-					[0] = {
-						.base = 0x81340000,
-						.size = 0x10000UL,
-						.type = PCIBAR_MEM32,
-					}
-				}
 			}
 		},
 	}
@@ -82,7 +44,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 		{/*vdev 0: hostbridge*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			.ops = &pci_ops_vdev_hostbridge,
-			.bar = {},
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -91,75 +52,17 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 		{/*vdev 1: SATA controller*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x2000UL,
-					.type = PCIBAR_MEM32
-				},
-				[1] = {
-					.base = 0UL,
-					.size = 0x1000UL,
-					.type = PCIBAR_MEM32
-				},
-				[5] = {
-					.base = 0UL,
-					.size = 0x1000UL,
-					.type = PCIBAR_MEM32
-				},
-			},
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
-				.bar = {
-					[0] = {
-						.base = 0x81354000,
-						.size = 0x2000UL,
-						.type = PCIBAR_MEM32
-					},
-					[1] = {
-						.base = 0x8135f000,
-						.size = 0x1000UL,
-						.type = PCIBAR_MEM32
-					},
-					[5] = {
-						.base = 0x8135e000,
-						.size = 0x1000UL,
-						.type = PCIBAR_MEM32
-					},
-				}
 			}
 		},
 
 		{/*vdev 2: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x200000UL,
-					.type = PCIBAR_MEM32,
-				},
-				[4] = {
-					.base = 0UL,
-					.size = 0x4000UL,
-					.type = PCIBAR_MEM32,
-				},
-			},
 
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
-				.bar = {
-					[0] = {
-						.base = 0x80e00000,
-						.size = 0x200000UL,
-						.type = PCIBAR_MEM32,
-					},
-					[4] = {
-						.base = 0x81004000,
-						.size = 0x4000UL,
-						.type = PCIBAR_MEM32,
-					}
-				}
 			}
 
 		},

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -12,7 +12,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge */
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.ops = &pci_ops_vdev_hostbridge,
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -20,7 +19,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 		{/*vdev 1: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
 			}
@@ -28,7 +26,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 		{/*vdev 2: USB*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
@@ -43,7 +40,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.ops = &pci_ops_vdev_hostbridge,
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -51,7 +47,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 		{/*vdev 1: SATA controller*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
 			}
@@ -59,7 +54,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 		{/*vdev 2: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -9,27 +9,21 @@
 
 static struct vpci_vdev_array vpci_vdev_array1 = {
 	.num_pci_vdev = 3,
+
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge */
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		},
 
 		{/*vdev 1: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
-			}
+			.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
 		},
 
 		{/*vdev 2: USB*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
 		},
 	}
 };
@@ -40,27 +34,18 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		},
 
 		{/*vdev 1: SATA controller*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
 		},
 
 		{/*vdev 2: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
-
-			.pdev = {
-				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
-			}
-
+			.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
 		},
-
 	}
 };
 


### PR DESCRIPTION
-  Scan all physical PCI devices and store all needed info in global pdev array
 - Use the cached pci device (pdev) info for sharing mode and partition mode
 - Simply vm_description for pci passthru, only vbdf and pbdf need to be specified by user
 - vdev stores a pointer to pdev


Tracked-On: #2431
Signed-off-by: dongshen <dongsheng.x.zhang@intel.com>
Reviewed-by: Anthony Xu <anthony.xu@intel.com>