### PR TITLE
Enabling DM-launched VM with lapic_pt

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -171,7 +171,8 @@ usage(int code)
 		"       --intr_monitor: enable interrupt storm monitor\n"
 		"            its params: threshold/s,probe-period(s),delay_time(ms),delay_duration(ms)\n"
 		"       --virtio_poll: enable virtio poll mode with poll interval with ns\n"
-		"       --vtpm2: Virtual TPM2 args: sock_path=$PATH_OF_SWTPM_SOCKET\n",
+		"       --vtpm2: Virtual TPM2 args: sock_path=$PATH_OF_SWTPM_SOCKET\n"
+		"       --lapic_pt: enable local apic passthrough\n",
 		progname, (int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "");
@@ -706,6 +707,7 @@ enum {
 	CMD_OPT_DUMP,
 	CMD_OPT_INTR_MONITOR,
 	CMD_OPT_VTPM2,
+	CMD_OPT_LAPIC_PT,
 };
 
 static struct option long_options[] = {
@@ -744,6 +746,7 @@ static struct option long_options[] = {
 	{"debugexit",		no_argument,		0, CMD_OPT_DEBUGEXIT},
 	{"intr_monitor",	required_argument,	0, CMD_OPT_INTR_MONITOR},
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
+	{"lapic_pt",		no_argument,		0, CMD_OPT_LAPIC_PT},
 	{0,			0,			0,  0  },
 };
 
@@ -886,6 +889,9 @@ dm_run(int argc, char *argv[])
 			break;
 		case CMD_OPT_DEBUGEXIT:
 			debugexit_enabled = true;
+			break;
+		case CMD_OPT_LAPIC_PT:
+			lapic_pt = true;
 			break;
 		case CMD_OPT_VTPM2:
 			if (acrn_parse_vtpm2(optarg) != 0) {

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -88,6 +88,7 @@ char *elf_file_name;
 uint8_t trusty_enabled;
 char *mac_seed;
 bool stdio_in_use;
+bool lapic_pt;
 
 static int virtio_msix = 1;
 static bool debugexit_enabled;

--- a/devicemodel/core/mptbl.c
+++ b/devicemodel/core/mptbl.c
@@ -335,16 +335,19 @@ mptable_build(struct vmctx *ctx, int ncpu)
 	curraddr += sizeof(*mpeb) * MPE_NUM_BUSES;
 	mpch->entry_count += MPE_NUM_BUSES;
 
-	mpei = (io_apic_entry_ptr)curraddr;
-	mpt_build_ioapic_entries(mpei, 0);
-	curraddr += sizeof(*mpei);
-	mpch->entry_count++;
+	/* Don't generate io_apic entry for VM with lapic pt */
+	if (!lapic_pt) {
+		mpei = (io_apic_entry_ptr)curraddr;
+		mpt_build_ioapic_entries(mpei, 0);
+		curraddr += sizeof(*mpei);
+		mpch->entry_count++;
 
-	mpie = (int_entry_ptr) curraddr;
-	ioints = mpt_count_ioint_entries();
-	mpt_build_ioint_entries(mpie, 0);
-	curraddr += sizeof(*mpie) * ioints;
-	mpch->entry_count += ioints;
+		mpie = (int_entry_ptr) curraddr;
+		ioints = mpt_count_ioint_entries();
+		mpt_build_ioint_entries(mpie, 0);
+		curraddr += sizeof(*mpie) * ioints;
+		mpch->entry_count += ioints;
+	}
 
 	mpie = (int_entry_ptr)curraddr;
 	mpt_build_localint_entries(mpie);

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -138,6 +138,14 @@ vm_create(const char *name, uint64_t req_buf)
 	else
 		create_vm.vm_flag &= (~SECURE_WORLD_ENABLED);
 
+	if (lapic_pt) {
+		create_vm.vm_flag |= LAPIC_PASSTHROUGH;
+		create_vm.vm_flag |= IOREQ_COMPLETION_POLLING;
+	} else {
+		create_vm.vm_flag &= (~LAPIC_PASSTHROUGH);
+		create_vm.vm_flag &= (~IOREQ_COMPLETION_POLLING);
+	}
+
 	create_vm.req_buf = req_buf;
 	while (retry > 0) {
 		error = ioctl(ctx->fd, IC_CREATE_VM, &create_vm);

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -45,6 +45,7 @@ extern char *elf_file_name;
 extern char *vmname;
 extern bool stdio_in_use;
 extern char *mac_seed;
+extern bool lapic_pt;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,
 		       int *vcpu);

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -66,7 +66,9 @@
 #endif
 
 /* Generic VM flags from guest OS */
-#define SECURE_WORLD_ENABLED    (1UL<<0)  /* Whether secure world is enabled */
+#define SECURE_WORLD_ENABLED		(1UL << 0U)	/* Whether secure world is enabled */
+#define LAPIC_PASSTHROUGH		(1UL << 1U)	/* Whether LAPIC is passed through */
+#define IOREQ_COMPLETION_POLLING	(1UL << 2U)	/* Whether need hypervisor poll IO completion */
 
 /**
  * @brief Hypercall

--- a/devicemodel/samples/nuc/launch_hard_rt_vm.sh
+++ b/devicemodel/samples/nuc/launch_hard_rt_vm.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# This is an example of launch script for KBL NUC7i7DNH, may need to revise for other platform.
+
+function launch_hard_rt_vm()
+{
+#for memsize setting
+mem_size=1024M
+
+modprobe pci_stub
+# Ethernet pass-through
+#echo "8086 156f" > /sys/bus/pci/drivers/pci-stub/new_id
+#echo "0000:00:1f.6" > /sys/bus/pci/devices/0000:00:1f.6/driver/unbind
+#echo "0000:00:1f.6" > /sys/bus/pci/drivers/pci-stub/bind
+
+# SATA pass-through
+echo "8086 9d03" > /sys/bus/pci/drivers/pci-stub/new_id
+echo "0000:00:17.0" > /sys/bus/pci/devices/0000:00:17.0/driver/unbind
+echo "0000:00:17.0" > /sys/bus/pci/drivers/pci-stub/bind
+
+/usr/bin/acrn-dm -m $mem_size -c $1 \
+  -k /root/rt_uos_kernel \
+   --lapic_pt \
+   --virtio_poll 1000000 \
+   -s 2,passthru,0/17/0 \
+   -s 3,virtio-console,@stdio:stdio_port \
+  -B "root=/dev/sda3 rw rootwait maxcpus=$1 nohpet console=hvc0 \
+  no_timer_check ignore_loglevel log_buf_len=16M \
+  consoleblank=0 tsc=reliable x2apic_phys" hard_rtvm
+}
+
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+        fi
+done
+
+launch_hard_rt_vm 1

--- a/hypervisor/arch/x86/assign.c
+++ b/hypervisor/arch/x86/assign.c
@@ -541,7 +541,13 @@ int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,
 			info->pmsi_data.full = 0U;
 		} else {
 			/* build physical config MSI, update to info->pmsi_xxx */
-			ptirq_build_physical_msi(vm, info, irq_to_vector(entry->allocated_pirq));
+			if (is_lapic_pt(vm)) {
+				/* for vm with lapic-pt, keep vector from guest */
+				ptirq_build_physical_msi(vm, info, info->vmsi_data.bits.vector);
+			} else {
+				ptirq_build_physical_msi(vm, info, irq_to_vector(entry->allocated_pirq));
+			}
+
 			entry->msi = *info;
 			dev_dbg(ACRN_DBG_IRQ, "PCI %x:%x.%x MSI VR[%d] 0x%x->0x%x assigned to vm%d",
 				pci_bus(virt_bdf), pci_slot(virt_bdf), pci_func(virt_bdf), entry_nr,

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -362,10 +362,10 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 		}
 		case 0x0bU:
 			/* Patching X2APIC */
-#ifdef CONFIG_PARTITION_MODE
-			cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
-#else
-			if (is_sos_vm(vcpu->vm)) {
+			if (is_lapic_pt(vcpu->vm)) {
+				/* for VM with LAPIC_PT, eg. PRE_LAUNCHED_VM or NORMAL_VM with LAPIC_PT*/
+				cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
+			} else if (is_sos_vm(vcpu->vm)) {
 				cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
 			} else {
 				*ecx = subleaf & 0xFFU;
@@ -393,7 +393,6 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 				break;
 				}
 			}
-#endif
 			break;
 
 		case 0x0dU:

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2020,7 +2020,6 @@ static inline  uint32_t x2apic_msr_to_regoff(uint32_t msr)
 	return (((msr - 0x800U) & 0x3FFU) << 4U);
 }
 
-#ifdef CONFIG_PARTITION_MODE
 /*
  * If x2apic is pass-thru to guests, we have to special case the following
  * 1. INIT Delivery mode
@@ -2068,7 +2067,6 @@ vlapic_x2apic_pt_icr_access(struct acrn_vm *vm, uint64_t val)
 	}
 	return 0;
 }
-#endif
 
 static int32_t vlapic_x2apic_access(struct acrn_vcpu *vcpu, uint32_t msr, bool write,
 								uint64_t *val)
@@ -2083,24 +2081,32 @@ static int32_t vlapic_x2apic_access(struct acrn_vcpu *vcpu, uint32_t msr, bool w
 	 */
 	vlapic = vcpu_vlapic(vcpu);
 	if (is_x2apic_enabled(vlapic)) {
-#ifdef CONFIG_PARTITION_MODE
-		struct acrn_vm_config *vm_config = get_vm_config(vcpu->vm->vm_id);
-
-		if((vm_config->guest_flags & LAPIC_PASSTHROUGH) != 0U ) {
-			if (msr == MSR_IA32_EXT_APIC_ICR) {
-				error = vlapic_x2apic_pt_icr_access(vcpu->vm, *val);
-			}
-			return error;
-		}
-#endif
-		offset = x2apic_msr_to_regoff(msr);
-		if (write) {
-			if (!is_x2apic_read_only_msr(msr)) {
-				error = vlapic_write(vlapic, offset, *val);
+		if (is_lapic_pt(vcpu->vm)) {
+			switch (msr) {
+				case MSR_IA32_EXT_APIC_ICR:
+					error = vlapic_x2apic_pt_icr_access(vcpu->vm, *val);
+					break;
+				case MSR_IA32_EXT_APIC_LDR:
+				case MSR_IA32_EXT_XAPICID:
+					if (!write) {
+						offset = x2apic_msr_to_regoff(msr);
+						error = vlapic_read(vlapic, offset, val);
+					}
+					break;
+				default:
+					pr_err("%s: unexpected MSR[0x%x] access with lapic_pt", __func__, msr);
+					break;
 			}
 		} else {
-			if (!is_x2apic_write_only_msr(msr)) {
-				error = vlapic_read(vlapic, offset, val);
+			offset = x2apic_msr_to_regoff(msr);
+			if (write) {
+				if (!is_x2apic_read_only_msr(msr)) {
+					error = vlapic_write(vlapic, offset, *val);
+				}
+			} else {
+				if (!is_x2apic_write_only_msr(msr)) {
+					error = vlapic_read(vlapic, offset, val);
+				}
 			}
 		}
 	}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -104,7 +104,7 @@ vm_lapic_from_vcpu_id(struct acrn_vm *vm, uint16_t vcpu_id)
 	return vcpu_vlapic(vcpu);
 }
 
-static uint16_t vm_apicid2vcpu_id(struct acrn_vm *vm, uint8_t lapicid)
+static uint16_t vm_apicid2vcpu_id(struct acrn_vm *vm, uint32_t lapicid)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu;
@@ -120,7 +120,7 @@ static uint16_t vm_apicid2vcpu_id(struct acrn_vm *vm, uint8_t lapicid)
 
 	if (cpu_id == INVALID_CPU_ID) {
 		cpu_id = get_pcpu_nums();
-		pr_err("%s: bad lapicid %hhu", __func__, lapicid);
+		pr_err("%s: bad lapicid %lu", __func__, lapicid);
 	}
 
 	return cpu_id;
@@ -1048,7 +1048,7 @@ vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, b
 		 * Physical mode: destination is LAPIC ID.
 		 */
 		*dmask = 0UL;
-		vcpu_id = vm_apicid2vcpu_id(vm, (uint8_t)dest);
+		vcpu_id = vm_apicid2vcpu_id(vm, dest);
 		if (vcpu_id < vm->hw.created_vcpus) {
 			bitmap_set_lock(vcpu_id, dmask);
 		}
@@ -1135,6 +1135,57 @@ vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, b
 		if (lowprio && (target != NULL)) {
 			bitmap_set_lock(target->vcpu->vcpu_id, dmask);
 		}
+	}
+}
+
+/*
+ * This function populates 'dmask' with the set of vcpus that is the possible destination
+ * when lapic is passthru.
+ */
+void
+vlapic_calcdest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys)
+{
+	struct acrn_vlapic *vlapic;
+	struct acrn_vcpu *vcpu;
+	uint32_t ldr, logical_id, dest_logical_id, dest_cluster_id;
+	uint16_t vcpu_id;
+
+	if (dest == 0xffU) {
+		/*
+		 * Broadcast in both logical and physical modes.
+		 */
+		*dmask = vm_active_cpus(vm);
+	} else if (phys) {
+		/*
+		 * Physical mode: destination is LAPIC ID.
+		 */
+		*dmask = 0UL;
+		vcpu_id = vm_apicid2vcpu_id(vm, dest);
+		if (vcpu_id < vm->hw.created_vcpus) {
+			bitmap_set_lock(vcpu_id, dmask);
+		}
+		dev_dbg(ACRN_DBG_LAPICPT, "%s: phys destmod, dmask: 0x%016llx", __func__, *dmask);
+	} else {
+		/*
+		 * Logical mode: match each APIC that has a bit set
+		 * in its LDR that matches a bit in the ldest.
+		 */
+		foreach_vcpu(vcpu_id, vm, vcpu) {
+			vlapic = vm_lapic_from_vcpu_id(vm, vcpu_id);
+
+			ldr = vlapic->apic_page.ldr.v;
+			logical_id = ldr & 0xFFFFU;
+
+			dest_cluster_id = (dest >> 16U) & 0xFFFFU;
+			dest_logical_id = dest & 0xFFFFU;
+			if (dest_cluster_id != ((ldr >> 16U) & 0xFFFFU)) {
+				continue;
+			}
+			if ((dest_logical_id & logical_id) != 0U) {
+				bitmap_set_lock(vcpu_id, dmask);
+			}
+		}
+		dev_dbg(ACRN_DBG_LAPICPT, "%s: logical destmod, dmask: 0x%016llx", __func__, *dmask);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -628,6 +628,12 @@ void update_msr_bitmap_x2apic_apicv(const struct acrn_vcpu *vcpu)
 	}
 }
 
+/*
+ * After switch to x2apic mode, most MSRs are passthrough to guest, but vlapic is still valid
+ * for virtualization of some MSRs for security consideration:
+ * - XAPICID/LDR: Read to XAPICID/LDR need to be trapped to guarantee guest always see right vlapic_id.
+ * - ICR: Write to ICR need to be trapped to avoid milicious IPI.
+ */
 void update_msr_bitmap_x2apic_passthru(const struct acrn_vcpu *vcpu)
 {
 	uint32_t msr;
@@ -638,6 +644,8 @@ void update_msr_bitmap_x2apic_passthru(const struct acrn_vcpu *vcpu)
 			msr <= MSR_IA32_EXT_APIC_SELF_IPI; msr++) {
 		enable_msr_interception(msr_bitmap, msr, INTERCEPT_DISABLE);
 	}
+	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_XAPICID, INTERCEPT_READ);
+	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_LDR, INTERCEPT_READ);
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_ICR, INTERCEPT_WRITE);
 	enable_msr_interception(msr_bitmap, MSR_IA32_TSC_DEADLINE, INTERCEPT_DISABLE);
 }

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -6,27 +6,6 @@
 
 #include <hypervisor.h>
 
-/* x2APIC Interrupt Command Register (ICR) structure */
-union apic_icr {
-	uint64_t value;
-	struct {
-		uint32_t lo_32;
-		uint32_t hi_32;
-	} value_32;
-	struct {
-		uint32_t vector:8;
-		uint32_t delivery_mode:3;
-		uint32_t destination_mode:1;
-		uint32_t rsvd_1:2;
-		uint32_t level:1;
-		uint32_t trigger_mode:1;
-		uint32_t rsvd_2:2;
-		uint32_t shorthand:2;
-		uint32_t rsvd_3:12;
-		uint32_t dest_field:32;
-	} bits;
-};
-
 union lapic_base_msr {
 	uint64_t value;
 	struct {

--- a/hypervisor/arch/x86/virq.c
+++ b/hypervisor/arch/x86/virq.c
@@ -375,7 +375,6 @@ int32_t external_interrupt_vmexit_handler(struct acrn_vcpu *vcpu)
 #else
 		dispatch_interrupt(&ctx);
 #endif
-
 		vcpu_retain_rip(vcpu);
 
 		TRACE_2L(TRACE_VMEXIT_EXTERNAL_INTERRUPT, ctx.vector, 0UL);

--- a/hypervisor/arch/x86/vmcs.c
+++ b/hypervisor/arch/x86/vmcs.c
@@ -560,23 +560,10 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 	init_exit_ctrl(vcpu);
 }
 
-#ifndef CONFIG_PARTITION_MODE
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
-	value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS2);
-	value32 &= ~VMX_PROCBASED_CTLS2_VAPIC;
-	value32 |= VMX_PROCBASED_CTLS2_VX2APIC;
-	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS2, value32);
-	update_msr_bitmap_x2apic_apicv(vcpu);
-}
-#else
-void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
-{
-	uint32_t value32;
-	struct acrn_vm_config *vm_config = get_vm_config(vcpu->vm->vm_id);
-
-	if((vm_config->guest_flags & LAPIC_PASSTHROUGH) != 0U ) {
+	if(is_lapic_pt(vcpu->vm)) {
 		/*
 		 * Disable external interrupt exiting and irq ack
 		 * Disable posted interrupt processing
@@ -620,4 +607,3 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 		update_msr_bitmap_x2apic_apicv(vcpu);
 	}
 }
-#endif

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -249,6 +249,7 @@ int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
 void vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
+void vlapic_calcdest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -176,6 +176,11 @@ struct vpci_vdev_array {
 #define MAX_BOOTARGS_SIZE	1024U
 #define MAX_CONFIG_NAME_SIZE	32U
 
+/*
+ * PRE_LAUNCHED_VM is launched by ACRN hypervisor, with LAPIC_PT;
+ * SOS_VM is launched by ACRN hypervisor, without LAPIC_PT;
+ * NORMAL_VM is launched by ACRN devicemodel, with/without LAPIC_PT depends on usecases.
+ */
 enum acrn_vm_type {
 	UNDEFINED_VM = 0,
 	PRE_LAUNCHED_VM,
@@ -330,6 +335,11 @@ static inline struct acrn_vm_config *get_vm_config(uint16_t vm_id)
 #else
 	return &vm_configs[vm_id];
 #endif
+}
+
+static inline bool is_lapic_pt(const struct acrn_vm *vm)
+{
+	return ((vm_configs[vm->vm_id].guest_flags & LAPIC_PASSTHROUGH) != 0U);
 }
 
 #endif /* VM_H_ */

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -51,6 +51,26 @@ enum intr_cpu_startup_shorthand {
 	INTR_CPU_STARTUP_UNKNOWN,
 };
 
+/* x2APIC Interrupt Command Register (ICR) structure */
+union apic_icr {
+	uint64_t value;
+	struct {
+		uint32_t lo_32;
+		uint32_t hi_32;
+	} value_32;
+	struct {
+		uint32_t vector:8;
+		uint32_t delivery_mode:3;
+		uint32_t destination_mode:1;
+		uint32_t rsvd_1:2;
+		uint32_t level:1;
+		uint32_t trigger_mode:1;
+		uint32_t rsvd_2:2;
+		uint32_t shorthand:2;
+		uint32_t rsvd_3:12;
+		uint32_t dest_field:32;
+	} bits;
+};
 
 /**
  * @brief Save context of lapic

--- a/hypervisor/include/debug/logmsg.h
+++ b/hypervisor/include/debug/logmsg.h
@@ -27,6 +27,7 @@
  */
 #define LOG_MESSAGE_MAX_SIZE	(4U * LOG_ENTRY_SIZE)
 
+#define ACRN_DBG_LAPICPT	5U
 #if defined(HV_DEBUG)
 
 extern uint16_t console_loglevel;


### PR DESCRIPTION
This is a patch series to extend lapic passthrough support for DM-launched VMs. 
The DM launched VM with lapic_pt is generally for hard RT scenarios, should be trapped to hypervisor at boot time only, must never trapped at runtime.

The main changes of this patch series include:
- extend lapic passed through for DM-launched vm;
- change the msi remap/msi inject logic slightly to make it work
  with lapic pass-through;
- add option to devicemodel for LAPIC_PT.

Known issues:
- SMP is not supported for VM with lapic_pt;
- S5 is not supported for VM with lapic_pt.

Tracked-On:   #2351
