### PR TITLE
Fix two issues found on a new platform

### DIFF
--- a/efi-stub/boot.h
+++ b/efi-stub/boot.h
@@ -73,7 +73,7 @@ typedef void(*hv_func)(int32_t, struct multiboot_info*);
  * We allocate memory for the following struct together with hyperivosr itself
  * memory allocation during boot.
  */
-#define MBOOT_MMAP_NUMS        128
+#define MBOOT_MMAP_NUMS        256
 #define MBOOT_MMAP_SIZE (sizeof(struct multiboot_mmap) * MBOOT_MMAP_NUMS)
 #define MBOOT_INFO_SIZE (sizeof(struct multiboot_info))
 #define BOOT_CTX_SIZE  (sizeof(struct efi_context))

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -93,7 +93,7 @@ config MAX_PT_IRQ_ENTRIES
 
 config MAX_IOMMU_NUM
 	int "Maximum number of IOMMU devices"
-	range 1 2
+	range 1 6
 	default 2
 	help
 	  The maximum number of physical IOMMUs the hypervisor can support.


### PR DESCRIPTION
EFI: fix potential memory overwrite due to mmap table
Some bios may have more mmap table entry than our current limitation
which is 128. This will lead to a memory overwrite, so add a check to
prevent this and enlarge the limitation to 256. This should fix most
bioses.


Kconfig: enlarge range of maximum number of IOMMU  …
Some arches have more than two IOMMUs, so change this limitation.
Tracked-On: #2435
Signed-off-by: Tw <wei.tan@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>