### PR TITLE
hv: fix misra-c violations in reused partition mode functions

### DIFF
--- a/hypervisor/arch/x86/vmcs.c
+++ b/hypervisor/arch/x86/vmcs.c
@@ -563,7 +563,7 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
-	if(is_lapic_pt(vcpu->vm)) {
+	if (is_lapic_pt(vcpu->vm)) {
 		/*
 		 * Disable external interrupt exiting and irq ack
 		 * Disable posted interrupt processing


### PR DESCRIPTION
Fixed violations in vlapic_x2apic_pt_icr_access()
- Procedure has more than one exit point;
- Value is not of appropriate type;
- Narrower init conversion without cast;
- Implicit conversion: actual to formal param (MR)
Fixed violation in switch_apicv_mode_x2apic()
- No space between if, while, for and expresn.

Tracked-On: #861
Signed-off-by: Yan, Like <like.yan@intel.com>