### PR TITLE
hv:move several inline APIs from vm.h to *.c

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -321,7 +321,7 @@ int32_t reset_vm(struct acrn_vm *vm)
 		}
 
 		reset_vm_ioreqs(vm);
-		vioapic_reset(vm_ioapic(vm));
+		vioapic_reset(vm);
 		destroy_secure_world(vm, false);
 		vm->sworld_control.flag.active = 0UL;
 		ret = 0;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -122,6 +122,11 @@ static uint8_t vuart_intr_reason(const struct acrn_vuart *vu)
 	}
 }
 
+struct acrn_vuart *vm_vuart(struct acrn_vm *vm)
+{
+	return &(vm->vuart);
+}
+
 /*
  * Toggle the COM port's intr pin depending on whether or not we have an
  * interrupt condition to report to the processor.

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -33,6 +33,11 @@
 
 static void vpic_set_pinstate(struct acrn_vpic *vpic, uint32_t pin, uint8_t level);
 
+static inline struct acrn_vpic *vm_pic(const struct acrn_vm *vm)
+{
+	return (struct acrn_vpic *)&(vm->arch_vm.vpic);
+}
+
 static inline bool master_pic(const struct acrn_vpic *vpic, const struct i8259_reg_state *i8259)
 {
 	bool ret;

--- a/hypervisor/include/arch/x86/guest/vioapic.h
+++ b/hypervisor/include/arch/x86/guest/vioapic.h
@@ -60,7 +60,7 @@ struct acrn_vioapic {
 };
 
 void    vioapic_init(struct acrn_vm *vm);
-void	vioapic_reset(struct acrn_vioapic *vioapic);
+void	vioapic_reset(struct acrn_vm *vm);
 
 
 /**

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -272,24 +272,6 @@ static inline struct acrn_vcpu *get_primary_vcpu(struct acrn_vm *vm)
 	return target_vcpu;
 }
 
-static inline struct acrn_vuart*
-vm_vuart(struct acrn_vm *vm)
-{
-	return &(vm->vuart);
-}
-
-static inline struct acrn_vpic *
-vm_pic(const struct acrn_vm *vm)
-{
-	return (struct acrn_vpic *)&(vm->arch_vm.vpic);
-}
-
-static inline struct acrn_vioapic *
-vm_ioapic(const struct acrn_vm *vm)
-{
-	return (struct acrn_vioapic *)&(vm->arch_vm.vioapic);
-}
-
 int32_t shutdown_vm(struct acrn_vm *vm);
 void pause_vm(struct acrn_vm *vm);
 void resume_vm(struct acrn_vm *vm);

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -70,6 +70,7 @@ struct acrn_vuart {
 extern int8_t vuart_vmid;
 #endif /* CONFIG_PARTITION_MODE */
 
+struct acrn_vuart *vm_vuart(struct acrn_vm *vm);
 void vuart_init(struct acrn_vm *vm);
 struct acrn_vuart *vuart_console_active(void);
 void vuart_console_tx_chars(struct acrn_vuart *vu);


### PR DESCRIPTION
-- move vm_pic() from vm.h to vpic.c since it is
   only used in vpic.c
-- move vm_ioapic() from vm.h to vioapic.c
   change vioapic_reset(struct acrn_vioapic *vioapic) -->
          vioapic_reset(struct acrn_vm *vm)
   then vm_vioapic() is only used in vioapic.c
-- move vm_vuart() from vm.h to vuart.c,
   now this api is used in vuart.c and shell.c

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>