### PR TITLE
HV: modularization improve UEFI macro control code

### DIFF
--- a/efi-stub/Makefile
+++ b/efi-stub/Makefile
@@ -60,7 +60,7 @@ LDSCRIPT := $(GNUEFI_DIR)/elf_$(ARCH)_efi.lds
 INCDIR := $(SYSROOT)/usr/include
 
 CFLAGS=-I. -I.. -I../hypervisor/include/arch/x86/guest -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
-		-I../hypervisor/include/public -I../hypervisor/include/lib \
+		-I../hypervisor/include/public -I../hypervisor/include/lib -I../hypervisor/bsp/include/uefi \
 		-DEFI_FUNCTION_WRAPPER -fPIC -fshort-wchar -ffreestanding \
 		-Wall -I../fs/ -D$(ARCH) -O2 \
 		-include config.h

--- a/efi-stub/boot.c
+++ b/efi-stub/boot.c
@@ -37,7 +37,7 @@
 #include "stdlib.h"
 #include "boot.h"
 #include "acrn_common.h"
-#include "vm0_boot.h"
+#include "uefi.h"
 
 EFI_SYSTEM_TABLE *sys_table;
 EFI_BOOT_SERVICES *boot;

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -234,6 +234,7 @@ C_SRCS += dm/vpci/msix.c
 endif
 
 ifeq ($(CONFIG_PLATFORM_UEFI),y)
+INCLUDE_PATH += bsp/include/uefi
 C_SRCS += bsp/uefi/uefi.c
 C_SRCS += bsp/uefi/cmdline.c
 C_SRCS += boot/uefi/uefi_boot.c

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -5,7 +5,6 @@
  */
 
 #include <hypervisor.h>
-#include <bsp_extern.h>
 #include <multiboot.h>
 #include <reloc.h>
 #include <e820.h>

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -6,7 +6,6 @@
 
 #include <hypervisor.h>
 #include <schedule.h>
-#include <vm0_boot.h>
 #include <security.h>
 #include <virtual_cr.h>
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -9,7 +9,6 @@
 #include <multiboot.h>
 #include <e820.h>
 #include <vtd.h>
-#include <vm0_boot.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -142,11 +141,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		rebuild_sos_vm_e820();
 		prepare_sos_vm_memmap(vm);
 
-#ifndef CONFIG_EFI_STUB
 		status = init_vm_boot_info(vm);
-#else
-		status = efi_boot_init();
-#endif
 		if (status == 0) {
 			init_iommu_sos_vm_domain(vm);
 		} else {

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -468,7 +468,6 @@ void interrupt_init(uint16_t pcpu_id)
 	set_idt(idtd);
 	init_lapic(pcpu_id);
 	init_default_irqs(pcpu_id);
-#ifndef CONFIG_EFI_STUB
-	CPU_IRQ_ENABLE();
-#endif
+
+	bsp_init_irq();
 }

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -6,7 +6,6 @@
 #include <hypervisor.h>
 #include <reloc.h>
 #include <trampoline.h>
-#include <vm0_boot.h>
 #include <e820.h>
 #include <ld_sym.h>
 
@@ -108,11 +107,7 @@ uint64_t prepare_trampoline(void)
 	uint64_t size, dest_pa, i;
 
 	size = (uint64_t)(&ld_trampoline_end - &ld_trampoline_start);
-#ifndef CONFIG_EFI_STUB
-	dest_pa = e820_alloc_low_memory(CONFIG_LOW_RAM_SIZE);
-#else
-	dest_pa = (uint64_t)get_ap_trampoline_buf();
-#endif
+	dest_pa = bsp_get_ap_trampoline();
 
 	pr_dbg("trampoline code: %llx size %x", dest_pa, size);
 

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -7,7 +7,6 @@
  */
 
 #include <hypervisor.h>
-#include <vm0_boot.h>
 #include <cpu.h>
 
 /**

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -30,7 +30,6 @@
 #include <hypervisor.h>
 #include "acpi_priv.h"
 #include "acpi.h"
-#include <vm0_boot.h>
 
 #define ACPI_SIG_RSDP             "RSD PTR " /* Root System Description Ptr */
 #define ACPI_OEM_ID_SIZE           6
@@ -138,9 +137,7 @@ static struct acpi_table_rsdp *get_rsdp(void)
 	struct acpi_table_rsdp *rsdp = NULL;
 	uint16_t *addr;
 
-#ifdef CONFIG_EFI_STUB
-	rsdp = (struct acpi_table_rsdp *) get_rsdp_from_uefi();
-#endif
+	rsdp = (struct acpi_table_rsdp *)bsp_get_rsdp();
 	if (rsdp == NULL) {
 		/* EBDA is addressed by the 16 bit pointer at 0x40E */
 		addr = (uint16_t *)hpa2hva(0x40eUL);

--- a/hypervisor/boot/uefi/uefi_boot.c
+++ b/hypervisor/boot/uefi/uefi_boot.c
@@ -7,9 +7,7 @@
 #include <hypervisor.h>
 #include <multiboot.h>
 #include <boot_context.h>
-#include <vm0_boot.h>
-
-#ifdef CONFIG_EFI_STUB
+#include <uefi.h>
 
 static void efi_spurious_handler(int32_t vector)
 {
@@ -54,11 +52,10 @@ static int32_t uefi_sw_loader(struct acrn_vm *vm)
 	return ret;
 }
 
-int32_t efi_boot_init(void)
+int32_t init_vm_boot_info(__unused struct acrn_vm *vm)
 {
 	vm_sw_loader = uefi_sw_loader;
 	spurious_handler = (spurious_handler_t)efi_spurious_handler;
 
 	return 0;
 }
-#endif

--- a/hypervisor/bsp/include/bsp_extern.h
+++ b/hypervisor/bsp/include/bsp_extern.h
@@ -23,29 +23,14 @@
 
 #define UOS_DEFAULT_START_ADDR   (0x100000000UL)
 
-struct acpi_info {
-	uint8_t			x86_family;
-	uint8_t			x86_model;
-	struct pm_s_state_data	pm_s_state;
-	/* TODO: we can add more acpi info field here if needed. */
-};
-
-/**********************************/
-/* EXTERNAL VARIABLES             */
-/**********************************/
 /* BSP Interfaces */
 void init_bsp(void);
+uint64_t bsp_get_ap_trampoline(void);
+void *bsp_get_rsdp(void);
+void bsp_init_irq(void);
 
 #ifndef CONFIG_CONSTANT_ACPI
 void acpi_fixup(void);
-#endif
-
-#ifdef CONFIG_EFI_STUB
-
-void *get_rsdp_from_uefi(void);
-void *get_ap_trampoline_buf(void);
-const struct efi_context *get_efi_ctx(void);
-const struct lapic_regs *get_efi_lapic_regs(void);
 #endif
 
 #endif /* BSP_EXTERN_H */

--- a/hypervisor/bsp/include/uefi/uefi.h
+++ b/hypervisor/bsp/include/uefi/uefi.h
@@ -4,17 +4,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef VM0_BOOT_H
-#define VM0_BOOT_H
+#ifndef _UEFI_H_
+#define _UEFI_H_
 
-#ifdef CONFIG_EFI_STUB
 struct efi_context {
 	struct acrn_vcpu_regs vcpu_regs;
 	void *rsdp;
 	void *ap_trampoline_buf;
 } __packed;
 
-int32_t efi_boot_init(void);
-#endif
+const struct efi_context *get_efi_ctx(void);
+const struct lapic_regs *get_efi_lapic_regs(void);
 
-#endif /* VM0_BOOT_H */
+#endif

--- a/hypervisor/bsp/sbl/sbl.c
+++ b/hypervisor/bsp/sbl/sbl.c
@@ -5,10 +5,26 @@
  */
 
 #include <hypervisor.h>
+#include <e820.h>
 
 void    init_bsp(void)
 {
 #ifndef CONFIG_CONSTANT_ACPI
 	acpi_fixup();
 #endif
+}
+
+uint64_t bsp_get_ap_trampoline(void)
+{
+	return e820_alloc_low_memory(CONFIG_LOW_RAM_SIZE);
+}
+
+void *bsp_get_rsdp(void)
+{
+	return NULL;
+}
+
+void bsp_init_irq(void)
+{
+	CPU_IRQ_ENABLE();
 }

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -7,8 +7,6 @@
 #ifndef IOAPIC_H
 #define IOAPIC_H
 
-#include <bsp_extern.h>
-
 #define NR_LEGACY_IRQ		16U
 #define NR_LEGACY_PIN		NR_LEGACY_IRQ
 void ioapic_setup_irqs(void);

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -8,7 +8,6 @@
 #define PER_CPU_H
 
 #include <hypervisor.h>
-#include <bsp_extern.h>
 #include <schedule.h>
 #include <common/irq.h>
 #include <arch/x86/irq.h>


### PR DESCRIPTION
1. in UEFI bsp code, not need UEFI macro; it is controlled in makefile.
2. in vm/acpi/interrupt code, unify the API name for SBL & UEFI.
3. remove unnecessary header including and unused code.

Tracked-On: #1842
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>