### PR TITLE
[RFC PATCH v2 0/3] correct improper use of panic and ASSERT

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -39,7 +39,7 @@ static void init_percpu_lapic_id(void)
 	pcpu_num = parse_madt(lapic_id_array);
 	if (pcpu_num == 0U) {
 		/* failed to get the physcial cpu number */
-		ASSERT(false);
+		panic("failed to get the physcial cpu number");
 	}
 
 	phys_cpu_num = pcpu_num;

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -426,7 +426,7 @@ int32_t cr_access_vmexit_handler(struct acrn_vcpu *vcpu)
 		vcpu_set_gpreg(vcpu, idx, reg);
 		break;
 	default:
-		panic("Unhandled CR access");
+		ASSERT(false, "Unhandled CR access");
 		ret = -EINVAL;
 		break;
 	}

--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -248,15 +248,17 @@ local_parse_madt(struct acpi_table_madt *madt, uint32_t lapic_id_array[CONFIG_MA
 /* The lapic_id info gotten from madt will be returned in lapic_id_array */
 uint16_t parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM])
 {
-	struct acpi_table_madt *madt;
+	uint16_t ret = 0U;
 
 	acpi_rsdp = get_rsdp();
-	ASSERT(acpi_rsdp != NULL, "fail to get rsdp");
+	if (acpi_rsdp != NULL) {
+		struct acpi_table_madt *madt = (struct acpi_table_madt *)get_acpi_tbl(ACPI_SIG_MADT);
+		if (madt != NULL) {
+			ret = local_parse_madt(madt, lapic_id_array);
+		}
+	}
 
-	madt = (struct acpi_table_madt *)get_acpi_tbl(ACPI_SIG_MADT);
-	ASSERT(madt != NULL, "fail to get madt");
-
-	return local_parse_madt(madt, lapic_id_array);
+	return ret;
 }
 
 void *get_dmar_table(void)

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -26,7 +26,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 	int32_t ret = -EINVAL;
 
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
-		ASSERT(false, "no multiboot info found");
+		panic("no multiboot info found");
 	} else {
 		mbi = hpa2hva((uint64_t)boot_regs[1]);
 		if (mbi != NULL) {
@@ -34,7 +34,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 			dev_dbg(ACRN_DBG_BOOT, "Multiboot detected, flag=0x%x", mbi->mi_flags);
 			if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_MODS) == 0U) {
 				clac();
-				ASSERT(false, "no kernel info found");
+				panic("no kernel info found");
 			} else {
 				dev_dbg(ACRN_DBG_BOOT, "mod counts=%d\n", mbi->mi_mods_count);
 
@@ -163,7 +163,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 	int32_t ret = -EINVAL;
 
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
-		ASSERT(false, "no multiboot info found");
+		panic("no multiboot info found");
 	} else {
 		mbi = (struct multiboot_info *)hpa2hva((uint64_t)boot_regs[1]);
 
@@ -171,7 +171,7 @@ int32_t init_vm_boot_info(struct acrn_vm *vm)
 			stac();
 			dev_dbg(ACRN_DBG_BOOT, "Multiboot detected, flag=0x%x", mbi->mi_flags);
 			if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_MODS) == 0U) {
-				ASSERT(false, "no sos kernel info found");
+				panic("no sos kernel info found");
 				clac();
 			} else {
 

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -174,7 +174,7 @@ void run_sched_thread(struct sched_object *obj)
 		obj->thread(obj);
 	}
 
-	panic("Shouldn't go here, invalid thread!");
+	ASSERT(false, "Shouldn't go here, invalid thread!");
 }
 
 void switch_to_idle(run_thread_t idle_thread)


### PR DESCRIPTION
v1-v2:
Retrun 0 in parse_madt and let the caller call panic if something wrong with parse_madt.

v1:
Now panic and ASSER are misused: Panic should only be used when system booting.
Once the system boot done, it could never be used. While ASSERT could be used
in some situations, such as, there are some pre-assumption for some code,
using ASSERT here for debug.

TODO: there still have panic misused in vlapic.c and ASSERT misused in some files.

Li, Fei1 (3):
  hv: replace improper use of panic with ASSERT
  hv: multiboot: replace improper use of ASSERT with panic
  hv: replace improper use of ASSERT with panic for parse_madt

Tracked-On: #861
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@inte.com>