### PR TITLE
profiling: fix the system freeze issue when running profiling tool

### DIFF
--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -9,7 +9,11 @@
 
 #ifdef PROFILING_ON
 
-#define MAX_MSR_LIST_NUM	15U
+#include <vcpu.h>
+
+#define MAX_MSR_LIST_NUM		15U
+#define MAX_PROFILING_MSR_STORE_NUM	1
+#define MAX_HV_MSR_LIST_NUM		(MSR_AREA_COUNT)
 #define MAX_GROUP_NUM		1U
 
 #define COLLECT_PROFILE_DATA	0
@@ -158,12 +162,6 @@ struct profiling_vmsw_config {
 	struct profiling_msr_op exit_list[MAX_MSR_LIST_NUM];
 };
 
-struct vmexit_msr {
-	uint32_t msr_idx;
-	uint32_t reserved;
-	uint64_t msr_data;
-};
-
 struct guest_vm_info {
 	uint64_t vmenter_tsc;
 	uint64_t vmexit_tsc;
@@ -210,8 +208,8 @@ struct sep_state {
 	uint32_t frozen_delayed;
 	uint32_t nofrozen_pmi;
 
-	struct vmexit_msr vmexit_msr_list[MAX_MSR_LIST_NUM];
-	int32_t vmexit_msr_cnt;
+	struct msr_store_entry vmexit_msr_list[MAX_PROFILING_MSR_STORE_NUM + MAX_HV_MSR_LIST_NUM];
+	uint32_t vmexit_msr_cnt;
 	uint64_t guest_debugctl_value;
 	uint64_t saved_debugctl_value;
 } __aligned(8);


### PR DESCRIPTION
The msr load/restore during vmexit/vmentry is enabled in HV by
default. The profiling has assumption that it's only user for this
feature, which could overwrite of HV default setting.

This fix combine the msr load list for vmexit when profiling.

Tracked-On: #2422
Signed-off-by: Min Lim <min.yeol.lim@intel.com>