### PR TITLE
doc: fix correct use of Clear Linux OS

### DIFF
--- a/doc/developer-guides/hld/hld-overview.rst
+++ b/doc/developer-guides/hld/hld-overview.rst
@@ -42,7 +42,7 @@ A typical In-Vehicle Infotainment (IVI) system would support:
   - connection to IVI front system and mobile devices (cloud
     connectivity)
 
-ACRN supports guest OSes of Clear Linux and Android. OEMs can use the ACRN
+ACRN supports guest OSes of Clear Linux OS and Android. OEMs can use the ACRN
 hypervisor and Linux or Android guest OS reference code to implement their own
 VMs for a customized IC/IVI/RSE.
 

--- a/doc/developer-guides/hld/hld-security.rst
+++ b/doc/developer-guides/hld/hld-security.rst
@@ -184,7 +184,7 @@ securely.
 SOS Hardening
 -------------
 
-In project ACRN, the reference SOS is based on Clear Linux. Customers
+In project ACRN, the reference SOS is based on Clear Linux OS. Customers
 may choose to use different open source OSes or their own proprietary OS
 systems. To minimize the attack surfaces and achieve the goal of
 "defense in depth", there are many common guidelines to ensure the

--- a/doc/developer-guides/primer.rst
+++ b/doc/developer-guides/primer.rst
@@ -90,7 +90,7 @@ ACRN Device Model source tree
   files are used to generate the :ref:`acrn_apis` documentation)
 
 **samples/**
-  scripts (included in the Clear Linux build) for setting up the network
+  scripts (included in the Clear Linux OS build) for setting up the network
   and launching the User OS on the platform.
 
 ACRN Tools source tree

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -17,8 +17,8 @@ What hardware does ACRN support?
 ACRN runs on Intel Apollo Lake and Kaby Lake boards, as documented in
 our :ref:`hardware` documentation.
 
-Clear Linux* fails to boot on my NUC
-************************************
+Clear Linux* OS fails to boot on my NUC
+***************************************
 
 If you're following the :ref:`getting_started` documentation and the NUC
 fails to boot, here are some options to try:

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -37,33 +37,33 @@ complete this setup.
 
 .. note::
 
-   Please refer to Release Note for the Clear Linux version number, and
-   you will need to adjust the instruction below to reference the version
-   number of Clear Linux you are using. Below document will use version
-   27230 as example.
+   Please refer to the ACRN :ref:`release_notes` for the Clear Linux OS
+   version number tested with a specific ACRN release.  Adjust the
+   instruction below to reference the appropriate version number of Clear
+   Linux OS (we use version 27230 as an example).
 
-#. Download the compressed Clear installer image from
+#. Download the compressed Clear Linux OS installer image from
    https://download.clearlinux.org/releases/27230/clear/clear-27230-installer.img.xz
-   and follow the `Clear Linux installation guide
+   and follow the `Clear Linux OS installation guide
    <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install>`__
-   as a starting point for installing Clear Linux onto your platform.  Follow the recommended
+   as a starting point for installing Clear Linux OS onto your platform.  Follow the recommended
    options for choosing an **Manual (Advanced)** installation type, and using the platform's
    storage as the target device for installation (overwriting the existing data
    and creating three partitions on the platform's storage drive).
 
    High-level steps should be:
 
-   #.  Install Clear on a NUC using the "Manual (Advanced)" option.
+   #.  Install Clear Linux OS on a NUC using the "Manual (Advanced)" option.
    #.  Use default partition scheme for storage
    #.  Name the host "clr-sos-guest"
    #.  Add an administrative user "clear" with "sudoers" privilege
    #.  Add these additional bundles "editors", "user-basic", "desktop-autostart", "network-basic"
    #.  For network, choose “DHCP”
 
-#. After installation is complete, boot into Clear Linux, login as
+#. After installation is complete, boot into Clear Linux OS, login as
    **clear**, and set a password.
 
-#. Clear Linux is set to automatically update itself. We recommend that you disable
+#. Clear Linux OS is set to automatically update itself. We recommend that you disable
    this feature to have more control over when the updates happen. Use this command
    to disable the autoupdate feature:
 
@@ -72,26 +72,26 @@ complete this setup.
       $ sudo swupd autoupdate --disable
 
    .. note::
-      The Clear Linux installer will automatically check for updates and install the
+      The Clear Linux OS installer will automatically check for updates and install the
       latest version available on your system. If you wish to use a specific version
       (such as 27230), you can achieve that after the installation has completed using
       ``sudo swupd verify --fix --picky -m 27230``
 
-#. If you have an older version of Clear Linux already installed
-   on your hardware, use this command to upgrade Clear Linux
+#. If you have an older version of Clear Linux OS already installed
+   on your hardware, use this command to upgrade Clear Linux OS
    to version 27230 (or newer):
 
    .. code-block:: none
 
       $ sudo swupd update -m 27230     # or newer version
 
-#. Use the ``sudo swupd bundle-add`` command and add these Clear Linux bundles:
+#. Use the ``sudo swupd bundle-add`` command and add these Clear Linux OS bundles:
 
    .. code-block:: none
 
       $ sudo swupd bundle-add service-os kernel-iot-lts2018
 
-   .. table:: Clear Linux bundles
+   .. table:: Clear Linux OS bundles
       :widths: auto
       :name: CL-bundles
 
@@ -125,7 +125,7 @@ partition. Follow these steps:
       loaderx64.efi
 
    .. note::
-      On Clear Linux, the EFI System Partion (e.g.: ``/dev/sda1``) is mounted under ``/boot`` by default
+      On Clear Linux OS, the EFI System Partion (e.g.: ``/dev/sda1``) is mounted under ``/boot`` by default
       The Clear Linux project releases updates often, sometimes
       twice a day, so make note of the specific kernel versions (*iot-lts2018 and *iot-lts2018-sos*) listed on your system,
       as you will need them later.
@@ -138,7 +138,7 @@ partition. Follow these steps:
       (NVMe).
 
 #. Put the ``acrn.efi`` hypervisor application (included in the Clear
-   Linux release) on the EFI partition with:
+   Linux OS release) on the EFI partition with:
 
    .. code-block:: none
 
@@ -158,8 +158,8 @@ partition. Follow these steps:
 
    .. note::
 
-      Be aware that a Clearlinux update that includes a kernel upgrade will
-      reset the boot option changes you just made. A Clearlinux update could
+      Be aware that a Clear Linux OS update that includes a kernel upgrade will
+      reset the boot option changes you just made. A Clear Linux OS update could
       happen automatically (if you have not disabled it as described above),
       if you later install a new bundle to your system, or simply if you
       decide to trigger an update manually. Whenever that happens,
@@ -171,7 +171,7 @@ partition. Follow these steps:
 
    1. ``bootloader=``: this sets the EFI executable to be loaded once the hypervisor
       is up and running. This is typically the bootloader of the Service OS and the
-      default value is to use the Clearlinux bootloader, i.e.:
+      default value is to use the Clear Linux OS bootloader, i.e.:
       ``\EFI\org.clearlinux\bootloaderx64.efi``.
    #. ``uart=``: this tells the hypervisor where the serial port (UART) is found or
       whether it should be disabled. There are three forms for this parameter:
@@ -209,7 +209,8 @@ partition. Follow these steps:
    | options   | Options to pass to the Service OS kernel (kernel parameters)   |
    +-----------+----------------------------------------------------------------+
 
-   A starter acrn.conf configuration file is included in the Clear Linux release and is
+   A starter acrn.conf configuration file is included in the Clear Linux
+   OS release and is
    also available in the acrn-hypervisor/hypervisor GitHub repo as `acrn.conf
    <https://github.com/projectacrn/acrn-hypervisor/blob/master/efi-stub/clearlinux/acrn.conf>`__
    as shown here:
@@ -234,7 +235,7 @@ partition. Follow these steps:
       It is also possible to use the device name directly, e.g. ``root=/dev/sda3``
 
 #. Add a timeout period for Systemd-Boot to wait, otherwise it will not
-   present the boot menu and will always boot the base Clear Linux
+   present the boot menu and will always boot the base Clear Linux OS
 
    .. code-block:: none
 
@@ -257,13 +258,13 @@ partition. Follow these steps:
       Reboot Into Firmware Interface
 
 #. After booting up the ACRN hypervisor, the Service OS will be launched
-   automatically by default, and the Clear Linux desktop will be showing with user "clear",
+   automatically by default, and the Clear Linux OS desktop will be showing with user "clear",
    (or you can login remotely with an "ssh" client).
    If there is any issue which makes the GNOME desktop doesn't show successfully, then the system will go to
    shell console.
 
 #. From ssh client, login as user "clear" using the password you set previously when
-   you installed Clear Linux.
+   you installed Clear Linux OS.
 
 #. After rebooting the system, check that the ACRN hypervisor is running properly with:
 
@@ -290,7 +291,7 @@ automatically enabled after a system restart.
 Set up Reference UOS
 ====================
 
-#. On your platform, download the pre-built reference Clear Linux UOS
+#. On your platform, download the pre-built reference Clear Linux OS UOS
    image version 27230 (or newer) into your (root) home directory:
 
    .. code-block:: none
@@ -301,7 +302,7 @@ Set up Reference UOS
       $ curl https://download.clearlinux.org/releases/27230/clear/clear-27230-kvm.img.xz -o uos.img.xz
 
    .. note::
-      In case you want to use or try out a newer version of Clear Linux as the UOS, you can
+      In case you want to use or try out a newer version of Clear Linux OS as the UOS, you can
       download the latest from http://download.clearlinux.org/image. Make sure to adjust the steps
       described below accordingly (image file name and kernel modules version).
 
@@ -326,7 +327,7 @@ Set up Reference UOS
 
    A sample `launch_uos.sh
    <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/devicemodel/samples/nuc/launch_uos.sh>`__
-   is included in the Clear Linux release, and
+   is included in the Clear Linux OS release, and
    is also available in the acrn-hypervisor/devicemodel GitHub repo (in the samples
    folder) as shown here:
 

--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -16,7 +16,7 @@ each with their own way to install development tools:
      ACRN uses ``menuconfig``, a python3 text-based user interface (TUI) for
      configuring hypervisor options and using python's ``kconfiglib`` library.
 
-* On a Clear Linux development system, install the necessary tools:
+* On a Clear Linux OS development system, install the necessary tools:
 
   .. code-block:: none
 

--- a/doc/release_notes_0.1.rst
+++ b/doc/release_notes_0.1.rst
@@ -71,7 +71,7 @@ Known Issues
 
 :acrn-issue:`663` - Black screen displayed after booting SOS/UOS
   The ``weston`` display server, window manager, and compositor used by ACRN
-  (from Clear Linux) may not have been properly installed and started.
+  (from Clear Linux OS) may not have been properly installed and started.
   **Workaround** is described in ACRN GitHub issue :acrn-issue:`663`.
 
 :acrn-issue:`677` - SSD Disk ID not consistent between SOS/UOS

--- a/doc/release_notes_0.2.rst
+++ b/doc/release_notes_0.2.rst
@@ -133,7 +133,7 @@ Fixed Issues
 * :acrn-issue:`721` - DM for IPU mediation
 * :acrn-issue:`707` - Issues found with instructions for using Ubuntu as SOS
 * :acrn-issue:`706` - Invisible mouse cursor in UOS
-* :acrn-issue:`424` - Clear Linux desktop GUI of SOS fails to launch
+* :acrn-issue:`424` - Clear Linux OS desktop GUI of SOS fails to launch
 
 
 Known Issues

--- a/doc/release_notes_0.3.rst
+++ b/doc/release_notes_0.3.rst
@@ -138,7 +138,8 @@ Known Issues
    After SOS boots up with both "desktop" and "soft-defined-cockpit" bundles installed
    or without any, there's no output on SOS screen.
    **Impact:** Cannot access SOS.
-   **Workaround:** Only install "desktop" bundle, then enable and start weston in Native Clear Linux,
+   **Workaround:** Only install "desktop" bundle, then enable and start
+   weston in Native Clear Linux OS,
    and then reboot to SOS. The issues will be fixed in the next release.
 
 :acrn-issue:`1795` - [KBL NUC] SOS fails to get IP address

--- a/doc/release_notes_0.5.rst
+++ b/doc/release_notes_0.5.rst
@@ -55,7 +55,7 @@ now supports APL UP2 board with slim Bootloader (SBL) firmware.
 Slim Bootloader is a modern, flexible, light-weither, open source 
 reference boot loader with key benefits such as being fast, small, 
 customizable, and secure. An end-to-end reference build with 
-ACRN hypervisor, Clear Linux as SOS, and Clear Linux as UOS has been 
+ACRN hypervisor, Clear Linux OS as SOS, and Clear Linux OS as UOS has been 
 verified on UP2/SBL board. See the :ref:`using-sbl-up2` documentation 
 for step-by-step instructions.
 
@@ -95,7 +95,7 @@ for step-by-step instructions.
 - :acrn-issue:`2079` - Replace banned API with permitted API function in a crn device-model                                  
 - :acrn-issue:`2120` - Optimize trusty logic to meet MISRA-C rules                             
 - :acrn-issue:`2145` - Reuse linux common virtio header file for virtio                                                   
-- :acrn-issue:`2170` -  For UEFI based hardware platforms, one ClearLinux E2E build binary can be used for all platform's installation 
+- :acrn-issue:`2170` -  For UEFI based hardware platforms, one Clear Linux OS E2E build binary can be used for all platform's installation 
 - :acrn-issue:`2187` - Complete the cleanup of unbounded APIs usage 
 
 Fixed Issues

--- a/doc/tutorials/agl-vms.rst
+++ b/doc/tutorials/agl-vms.rst
@@ -24,7 +24,7 @@ meter, the In-Vehicle Infotainment (IVI) system, and the rear seat
 entertainment (RSE).  For the software, there are three VMs running on
 top of ACRN:
 
-* Clear Linux runs as the service OS (SOS) to control the cluster meter,
+* Clear Linux OS runs as the service OS (SOS) to control the cluster meter,
 * an AGL instance runs as a user OS (UOS) controlling the IVI display, and
 * a second AGL UOS controls the RSE display.
 
@@ -111,9 +111,9 @@ The demo setup uses these software components and versions:
    * - ACRN hypervisor
      - 0.3
      - `ACRN project <https://github.com/projectacrn/acrn-hypervisor>`_
-   * - Clear Linux
+   * - Clear Linux OS
      - 26200
-     - `Clear Linux installer image
+     - `Clear Linux OS installer image
        <https://download.clearlinux.org/releases/26200/clear/clear-26200-installer.img.xz>`_
    * - AGL
      - Funky Flounder (6.02)
@@ -126,34 +126,34 @@ The demo setup uses these software components and versions:
 Service OS
 ==========
 
-#. Download the compressed Clear installer image from
+#. Download the compressed Clear Linux OS installer image from
    https://download.clearlinux.org/releases/26200/clear/clear-26200-installer.img.xz
-   and follow the `Clear Linux installation guide
+   and follow the `Clear Linux OS installation guide
    <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install>`_
-   as a starting point for installing Clear Linux onto your platform.
+   as a starting point for installing Clear Linux OS onto your platform.
    Follow the recommended options for choosing an Automatic installation
    type, and using the platform’s storage as the target device for
    installation (overwriting the existing data and creating three
    partitions on the platform’s storage drive).
 
-#. After installation is complete, boot into Clear Linux, login as
+#. After installation is complete, boot into Clear Linux OS, login as
    root, and set a password.
 
-#. Clear Linux is set to automatically update itself. We recommend that
+#. Clear Linux OS is set to automatically update itself. We recommend that
    you disable this feature to have more control over when the updates
    happen. Use this command (as root) to disable the autoupdate feature::
 
       # swupd autoupdate --disable
 
 #. This demo setup uses a specific release version (26200) of Clear
-   Linux which has been verified to work with ACRN. In case you
-   unintentionally update or change the Clear Linux version, you can
+   Linux OS which has been verified to work with ACRN. In case you
+   unintentionally update or change the Clear Linux OS version, you can
    fix it again using::
 
       # swupd verify --fix --picky -m 26200
 
 #. Use the ``swupd bundle-add`` command and add needed Clear Linux
-   bundles::
+   OS bundles::
 
       # swupd bundle-add openssh-server sudo network-basic \
           kernel-iot-lts2018 os-clr-on-clr os-core-dev \
@@ -186,7 +186,7 @@ Service OS
 
 
 #. Build ACRN. In this demo we use the ACRN v0.3 release.
-   Open a terminal window in Clear Linux desktop, create a workspace,
+   Open a terminal window in Clear Linux OS desktop, create a workspace,
    install needed tools, clone the ACRN Hypervisor repo source, and build ACRN::
 
       $ mkdir workspace
@@ -229,7 +229,7 @@ Service OS
       $ sudo clr-boot-manager update
 
 
-#. Reboot the system, choose "ACRN Hypervisor" and launch Clear Linux
+#. Reboot the system, choose "ACRN Hypervisor" and launch Clear Linux OS
    SOS. If the EFI boot order is not right, use :kbd:`F10`
    on boot up to enter the EFI menu and choose "ACRN Hypervisor".
 

--- a/doc/tutorials/building_uos_from_clearlinux.rst
+++ b/doc/tutorials/building_uos_from_clearlinux.rst
@@ -1,40 +1,39 @@
 .. _build UOS from Clearlinux:
 
-Building UOS from Clear Linux
-#############################
+Building UOS from Clear Linux OS
+################################
 
-This document builds on the :ref:`getting_started`, 
-and explains how to build UOS from Clear Linux.
-      
-Build UOS image in Clear Linux native
-*************************************
+This document builds on the :ref:`getting_started`,
+and explains how to build UOS from Clear Linux OS.
 
-In order to build out the image of UOS, 
-follow these steps to build a UOS image from Clear Linux:
+Build UOS image in Clear Linux OS
+*********************************
 
-#. In Clear Linux native, install ``ister`` (a template-based
-   installer for Linux) included in the Clear Linux bundle 
+Follow these steps to build a UOS image from Clear Linux OS:
+
+#. In Clear Linux OS, install ``ister`` (a template-based
+   installer for Linux) included in the Clear Linux OS bundle
    ``os-installer``.
-   For more information about ``ister``, 
+   For more information about ``ister``,
    please visit https://github.com/bryteise/ister.
 
    .. code-block:: none
 
       $ sudo swupd bundle-add os-installer
-   
-#. After installation is complete, use ``ister.py`` to 
-   generate the image for UOS with the configuration in 
+
+#. After installation is complete, use ``ister.py`` to
+   generate the image for UOS with the configuration in
    ``uos-image.json``:
 
    .. code-block:: none
-   
-      $ cd ~   
+
+      $ cd ~
       $ sudo ister.py -t uos-image.json
-      
+
    An example of the configuration file ``uos-image.json``:
 
    .. code-block:: none
-   
+
       {
           "DestinationType" : "virtual",
           "PartitionLayout" : [ { "disk" : "uos.img",
@@ -76,17 +75,17 @@ follow these steps to build a UOS image from Clear Linux:
        }
 
    .. note::
-      To generate the image with a specified version, 
-      please modify the ``"Version"`` argument, 
-      and we can set ``"Version": 26550`` instead of 
+      To generate the image with a specified version,
+      please modify the ``"Version"`` argument,
+      and we can set ``"Version": 26550`` instead of
       ``"Version": "latest"`` for example.
-      
-   Here we will use ``"Version": 26550`` for example, 
-   and the UOS image called ``uos.img`` will be generated 
+
+   Here we will use ``"Version": 26550`` for example,
+   and the UOS image called ``uos.img`` will be generated
    after successful installation. An example output log is:
-   
+
    .. code-block:: none
-   
+
       Reading configuration
       Validating configuration
       Creating virtual disk
@@ -98,19 +97,19 @@ follow these steps to build a UOS image from Clear Linux:
       Installing 9 bundles (and dependencies)...
       Verifying version 26550
       Downloading packs...
-        
+
       Extracting emacs pack for version 26550
-      
+
       Extracting vim pack for version 26550
       ...
       Cleaning up
       Successful installation
-      
+
 #. On your target device, boot the system and select "The ACRN Service OS", as shown below:
 
    .. code-block:: console
       :emphasize-lines: 1
-      
+
       => The ACRN Service OS
       Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-4.19.0-19)
       Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-sos-4.19.0-19)
@@ -136,24 +135,24 @@ Start the User OS (UOS)
       default-iot-lts2018 -> org.clearlinux.iot-lts2018.4.19.0-26
       install.d
       org.clearlinux.iot-lts2018.4.19.0-26
-   
-#. Adjust the ``/usr/share/acrn/samples/nuc/launch_uos.sh`` 
-   script to match your installation. 
+
+#. Adjust the ``/usr/share/acrn/samples/nuc/launch_uos.sh``
+   script to match your installation.
    These are the couple of lines you need to modify:
 
    .. code-block:: none
-   
+
       -s 3,virtio-blk,~/uos.img \
       -k /mnt/usr/lib/kernel/default-iot-lts2018  \
 
    .. note::
       UOS image ``uos.img`` is in the directory ``~/``
       and UOS kernel ``default-iot-lts2018`` is in ``/mnt/usr/lib/kernel/``.
-   
+
 #. You are now all set to start the User OS (UOS):
 
    .. code-block:: none
-   
+
       $ sudo /usr/share/acrn/samples/nuc/launch_uos.sh
-      
+
    You are now watching the User OS booting up!

--- a/doc/tutorials/docbuild.rst
+++ b/doc/tutorials/docbuild.rst
@@ -137,7 +137,7 @@ Our documentation processing has been tested to run with:
 
 Depending on your Linux version, install the needed tools:
 
-* For Clear Linux: follow the :ref:`getting-started-apl-nuc` to install
+* For Clear Linux OS: follow the :ref:`getting-started-apl-nuc` to install
   all the tools required
 
 * For Ubuntu use:

--- a/doc/tutorials/skl-nuc.rst
+++ b/doc/tutorials/skl-nuc.rst
@@ -21,7 +21,7 @@ Software Configuration
   <https://github.com/projectacrn/acrn-hypervisor/releases/tag/acrn-2018w39.6-140000p>`_
 * `acrn-kernel tag acrn-2018w39.6-140000p
   <https://github.com/projectacrn/acrn-kernel/releases/tag/acrn-2018w39.6-140000p>`_
-* Clear Linux:       version: 25130 (UOS and SOS use this version)
+* Clear Linux OS: version: 25130 (UOS and SOS use this version)
 
 Source code patches are provided in `skl-patches-for-acrn.tar file
 <../_static/downloads/skl-patches-for-acrn.tar>`_ to work around or add support for
@@ -40,7 +40,7 @@ Please follow the :ref:`getting-started-apl-nuc`, with the following changes:
 
 1. Set up a Clear Linux Operating System
 
-   Clear Linux will update to the latest version during installation.
+   Clear Linux OS will update to the latest version during installation.
    Run this command (as root) to roll back to version 25130, using the
    ``–x`` switch to ignore version mismatch::
 
@@ -72,7 +72,7 @@ Please follow the :ref:`getting-started-apl-nuc`, with the following changes:
       # cp build/devicemodel/acrn-dm  /usr/bin/acrn-dm
 
 #. Put the new ``acrn.efi`` hypervisor application (included in the
-   Clear Linux release) on the EFI partition (as root)::
+   Clear Linux OS release) on the EFI partition (as root)::
 
       # mount /dev/nvme0n1p1 /mnt
       # mkdir /mnt/EFI/acrn

--- a/doc/tutorials/static-ip.rst
+++ b/doc/tutorials/static-ip.rst
@@ -12,7 +12,7 @@ address. You need ``root`` privileges to make these changes to the system.
 ACRN Network Setup
 ******************
 
-The ACRN Service OS is based on `Clear Linux`_ and it uses `systemd-networkd`_
+The ACRN Service OS is based on `Clear Linux OS`_ and it uses `systemd-networkd`_
 to set up the Service OS networking. A few files are responsible for setting up the
 ACRN bridge (``acrn-br0``), the TAP device (``acrn_tap0``), and how these are all
 connected. Those files are installed in ``/usr/lib/systemd/network``
@@ -72,7 +72,7 @@ of the configuration you are trying to set up, the modifications you have made t
 the output of ``journalctl -b -u systemd-networkd`` so we can best assist you.
 
 .. _systemd-networkd: https://www.freedesktop.org/software/systemd/man/systemd-networkd.service.html
-.. _Clear Linux: https://clearlinux.org
+.. _Clear Linux OS: https://clearlinux.org
 .. _systemd-network: https://www.freedesktop.org/software/systemd/man/systemd.network.html
 .. _ACRN-users mailing list: https://lists.projectacrn.org/g/acrn-users
 .. _ACRN hypervisor issues: https://github.com/projectacrn/acrn-hypervisor/issues

--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -20,9 +20,9 @@ Prerequisites
 *************
 
 In this tutorial two Linux privileged VMs are started by the ACRN hypervisor.
-To set up the Linux root filesystems for each VM, follow the Clear Linux
+To set up the Linux root filesystems for each VM, follow the Clear Linux OS
 `bare metal installation guide <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install#bare-metal-install>`_
-to install Clear Linux on a **SATA disk** and a **USB flash disk** prior the setup,
+to install Clear Linux OS on a **SATA disk** and a **USB flash disk** prior the setup,
 as the two privileged VMs will mount the root filesystems via the SATA controller
 and the USB controller respectively.
 
@@ -73,12 +73,12 @@ Build kernel and modules for partition mode UOS
 
    .. code-block:: none
 
-     # Mount the Clear Linux root filesystem on the SATA disk
+     # Mount the Clear Linux OS root filesystem on the SATA disk
      $ sudo mount /dev/sda3 /mnt
      $ sudo cp -r <kernel-modules-folder-built-in-step1>/lib/modules/* /mnt/lib/modules
      $ sudo umount /mnt
      
-     # Mount the Clear Linux root filesystem on the USB flash disk
+     # Mount the Clear Linux OS root filesystem on the USB flash disk
      $ sudo mount /dev/sdb3 /mnt
      $ sudo cp -r <path-to-kernel-module-folder-built-in-step1>/lib/modules/* /mnt/lib/modules
      $ sudo umount /mnt
@@ -257,7 +257,7 @@ Enable partition mode in ACRN hypervisor
 #. Optionally, configure the ``.bootargs`` kernel command line arguments
 
    The kernel command line arguments used to boot the privileged VMs are
-   hardcoded as ``/dev/sda3`` to meet the Clear Linux automatic installation.
+   hardcoded as ``/dev/sda3`` to meet the Clear Linux OS automatic installation.
    In case you plan to use your customized root
    filesystem, you may optionally edit the ``root=`` parameter specified
    in the ``.bootargs`` field of the ``.vm_desc_array`` structure, to

--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -4,7 +4,7 @@ Using Ubuntu as the Service OS
 ##############################
 
 This document builds on the :ref:`getting_started`, and explains how to use
-Ubuntu instead of using `Clear Linux`_ as the Service OS with the ACRN
+Ubuntu instead of using `Clear Linux OS`_ as the Service OS with the ACRN
 hypervisor. (Note that different OSes can be used for the Service and User OS.)
 In the following instructions we'll build on material in the
 :ref:`getting-started-apl-nuc`.
@@ -133,13 +133,13 @@ Install the Service OS kernel
 You can download latest Service OS kernel from
 `<https://download.clearlinux.org/releases/current/clear/x86_64/os/Packages/>`_
 
-1. The latest Service OS kernel from the latest Clear Linux release
+1. The latest Service OS kernel from the latest Clear Linux OS release
    from this area:
    https://download.clearlinux.org/releases/current/clear/x86_64/os/Packages.  Look for an
    ``.rpm`` file named ``linux-iot-lts2018-sos-<kernel-version>-<build-version>.x86_64.rpm``.
 
-   While we recommend using the "current" (latest) release of Clear Linux, you can download
-   a specific Clear Linux release from an area with that release number, e.g.: 
+   While we recommend using the "current" (latest) release of Clear Linux OS, you can download
+   a specific Clear Linux release from an area with that release number, e.g.:
    https://download.clearlinux.org/releases/26440/clear/x86_64/os/Packages/linux-iot-lts2018-sos-4.19.0-22.x86_64.rpm
 
 #. Download and extract the latest Service OS kernel(this guide is based on 26440 as the current example)
@@ -230,9 +230,9 @@ You can download latest Service OS kernel from
 Prepare the User OS (UOS)
 *************************
 
-For the User OS, we are using the same `Clear Linux`_ release version as the Service OS.
+For the User OS, we are using the same `Clear Linux OS`_ release version as the Service OS.
 
-* Download the Clear Linux image from `<https://download.clearlinux.org>`_
+* Download the Clear Linux OS image from `<https://download.clearlinux.org>`_
 
   .. code-block:: none
 
@@ -347,4 +347,4 @@ Please refer to :ref:`getting-started-apl-nuc` for enabling the
 USB keyboard and mouse for the UOS.
 
  
-.. _Clear Linux: https://clearlinux.org
+.. _Clear Linux OS: https://clearlinux.org


### PR DESCRIPTION
Proper use of the Clear Linux name is with a noun, specifically "OS".
Also fixed some grammar edits along the way.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>