### PR TITLE
rdmsr/wrmsr HV debug cmd

### DIFF
--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -86,4 +86,12 @@ struct shell {
 #define SHELL_CMD_CPUID			"cpuid"
 #define SHELL_CMD_CPUID_PARAM		"<leaf> [subleaf]"
 #define SHELL_CMD_CPUID_HELP		"cpuid leaf [subleaf], in hexadecimal"
+
+#define SHELL_CMD_RDMSR			"rdmsr"
+#define SHELL_CMD_RDMSR_PARAM		"[-p<pcpu_id>]	<msr_index>"
+#define SHELL_CMD_RDMSR_HELP		"rdmsr -p<pcpu_id> <msr_index>, msr_index in hexadecimal"
+
+#define SHELL_CMD_WRMSR			"wrmsr"
+#define SHELL_CMD_WRMSR_PARAM		"[-p<pcpu_id>]	<msr_index> <value>"
+#define SHELL_CMD_WRMSR_HELP		"wrmsr -p<pcpu_id> <msr_index> <value>, msr_index and value in hexadecimal"
 #endif /* SHELL_PRIV_H */

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -445,6 +445,17 @@ static inline void msr_write(uint32_t reg_num, uint64_t value64)
 	cpu_msr_write(reg_num, value64);
 }
 
+
+/* wrmsr/rdmsr smp call data */
+struct msr_data_struct {
+	uint32_t msr_index;
+	uint64_t read_val;
+	uint64_t write_val;
+};
+
+void msr_write_pcpu(uint32_t msr_index, uint64_t value64, uint16_t pcpu_id);
+uint64_t msr_read_pcpu(uint32_t msr_index, uint16_t pcpu_id);
+
 static inline void write_xcr(int32_t reg, uint64_t val)
 {
 	asm volatile("xsetbv" : : "c" (reg), "a" ((uint32_t)val), "d" ((uint32_t)(val >> 32U)));


### PR DESCRIPTION
    Add these commands to  HV console:
    1.rdmsr [-p<pcpu_id>] [reg_num]
      read MSR register, eg., 'rdmsr 0xc8f' read MSR with address 0xc8f;
      'rdmsr -p1 0xc8f' read MSR address 0xc8f, on PCPU1.

    1.wrmsr [-p<pcpu_id>] [reg_num] [value]
      write to MSR register, eg., 'wrmsr 0xc8f 0x100000000' write
      0x100000000 to MSR, which address is 0xc8f;
      'wrmsr -p1 0xc8f 0x100000000' write 0x100000000 to MSR address
      0xc8f, on PCPU1.

Tracked-On: #2462
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>