### PR TITLE
hv: fix host call stack dump issue

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -8,6 +8,7 @@
 #include <schedule.h>
 #include <security.h>
 #include <virtual_cr.h>
+#include <init.h>
 
 inline uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg)
 {
@@ -637,6 +638,7 @@ static uint64_t build_stack_frame(struct acrn_vcpu *vcpu)
 	rsp &= ~(CPU_STACK_ALIGN - 1UL);
 	sp = (uint64_t *)rsp;
 
+	*sp-- = SP_BOTTOM_MAGIC;
 	*sp-- = (uint64_t)run_sched_thread; /*return address*/
 	*sp-- = 0UL; /* flag */
 	*sp-- = 0UL; /* rbx */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -13,7 +13,7 @@
 {                                                                       \
 	asm volatile ("movq %0, %%rsp\n"                                \
 			"pushq %1\n"                                    \
-			"call *%2\n"                                    \
+			"jmpq *%2\n"                                    \
 			 :                                              \
 			 : "r"(rsp), "rm"(SP_BOTTOM_MAGIC), "a"(to));   \
 }


### PR DESCRIPTION
As scheduler use its own stack now and let's take this into account when unwinding host call stack.