### PR TITLE
hv: fix dest of IPI for CPU with lapic_pt

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -564,6 +564,7 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 {
 	uint32_t value32;
 	if (is_lapic_pt(vcpu->vm)) {
+		dev_dbg(ACRN_DBG_LAPICPT, "%s: switching to x2apic and passthru", __func__);
 		/*
 		 * Disable external interrupt exiting and irq ack
 		 * Disable posted interrupt processing


### PR DESCRIPTION
With lapic_pt based on vlapic, guest always see vitual apic_id.
We need to convert the virtual apic_id from guest to physical apic_id
before writing ICR.

SMP for VM with lapic_pt is supported with this fix.

Tracked-On: #2351
Signed-off-by: Yan, Like <like.yan@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>