### PR TITLE
Documentation: add caption to the "PREEMPT_RT VM on ACRN" figure

### DIFF
--- a/doc/tutorials/rt_linux.rst
+++ b/doc/tutorials/rt_linux.rst
@@ -26,6 +26,8 @@ event such as an interrupt within a defined time frame.
    :width: 400px
    :name: rt-linux-arch
 
+   Real-Time Linux (PREEMPT_RT) VM on ACRN
+
 The privileged VM exclusively owns its passthrough devices, so in
 addition to the controller and file system used by the SOS, a dedicated
 storage controller and device are needed to host the privileged VM's


### PR DESCRIPTION
Add a caption to the figure describing the Real-Time Linux VM running
on ACRN. Without this text, the HTML output does not add the Figure
number below it. That figure number is still used in the paragraph
making it hard for the reader to understand which figure is really
referenced (except by clicking on the hyperlink)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>