### PR TITLE
profiling: resolve the mismatch in max VCPUs between hypervisor

### DIFF
--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -867,6 +867,10 @@ int32_t profiling_vm_list_info(struct acrn_vm *vm, uint64_t addr)
 	vm_info_list.vm_list[vm_idx].vm_id_num = -1;
 	(void)memcpy_s((void *)vm_info_list.vm_list[vm_idx].vm_name, 4U, "VMM\0", 4U);
 	for (i = 0U; i < pcpu_nums; i++) {
+		if (i >= MAX_VCPU_NUM) {
+			pr_err("%s: Unable to store cpu mapping\n", __func__);
+			return -EINVAL;
+		}
 		vm_info_list.vm_list[vm_idx].cpu_map[i].vcpu_id = i;
 		vm_info_list.vm_list[vm_idx].cpu_map[i].pcpu_id = i;
 		vm_info_list.vm_list[vm_idx].cpu_map[i].apic_id
@@ -891,6 +895,10 @@ int32_t profiling_vm_list_info(struct acrn_vm *vm, uint64_t addr)
 		vm_info_list.vm_list[vm_idx].num_vcpus = 0;
 		i = 0U;
 		foreach_vcpu(i, tmp_vm, vcpu) {
+			if (i >= MAX_VCPU_NUM) {
+				pr_err("%s: Unable to store cpu mapping\n", __func__);
+				return -EINVAL;
+			}
 			vm_info_list.vm_list[vm_idx].cpu_map[i].vcpu_id
 				= vcpu->vcpu_id;
 			vm_info_list.vm_list[vm_idx].cpu_map[i].pcpu_id

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -11,6 +11,7 @@
 
 #define MAX_MSR_LIST_NUM	15U
 #define MAX_GROUP_NUM		1U
+#define MAX_VCPU_NUM		4
 
 #define COLLECT_PROFILE_DATA	0
 #define COLLECT_POWER_DATA	1
@@ -109,7 +110,7 @@ struct profiling_vm_info {
 	uint8_t guid[16];
 	char vm_name[16];
 	uint16_t num_vcpus;
-	struct profiling_vcpu_pcpu_map cpu_map[CONFIG_MAX_VCPUS_PER_VM];
+	struct profiling_vcpu_pcpu_map cpu_map[MAX_VCPU_NUM];
 };
 
 struct profiling_vm_info_list {


### PR DESCRIPTION
and SOS profiling module.

The number of max VCPUs defined in MAX_VCPUS_PER_VM can be different,
compared to SOS profiling module. In the case, the profiling tool
can't obtain vcpu-pcpu mapping information properly.

To match, the profiling uses its own macro.

Tracked-On: #2476
Signed-off-by: Min Lim <min.yeol.lim@intel.com>