### PR TITLE
DM: ACPI: Avoiding hard code the ASL_COMPILER macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ sbl-hypervisor:
 
 devicemodel: tools
 	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
-	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG)
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER)
 
 tools:
 	mkdir -p $(TOOLS_OUT)

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -25,6 +25,10 @@ CFLAGS += -I$(BASEDIR)/include/public
 CFLAGS += -I$(DM_OBJDIR)/include
 CFLAGS += -I$(TOOLS_OUT)
 
+ifneq (, $(DM_ASL_COMPILER))
+CFLAGS += -DASL_COMPILER=\"$(DM_ASL_COMPILER)\"
+endif
+
 GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
 GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
 

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -89,7 +89,9 @@
 
 #define	ASL_TEMPLATE	"dm.XXXXXXX"
 #define ASL_SUFFIX	".aml"
+#ifndef ASL_COMPILER
 #define ASL_COMPILER	"/usr/sbin/iasl"
+#endif
 
 uint64_t audio_nhlt_len = 0;
 uint32_t csme_sec_cap = 0;


### PR DESCRIPTION
The ASL_COMPILER macro is hard coded as /usr/sbin/iasl, it is
complained by some developers. This patch changes it to a
flexible way, by which the following make command lines are
supported:

make
make devicemodel
make ASL_COMPILER=/path/to/iasl
make ASL_COMPILER=/path/to/iasl devicemodel

Tracked-On: #2298
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>