### PR TITLE
IOC mediator: dynamically enable dummy channels

### DIFF
--- a/devicemodel/include/ioc.h
+++ b/devicemodel/include/ioc.h
@@ -79,6 +79,8 @@
 #define CBC_WK_RSN_DOR	(1 << 11)	/* CBC wakeup reason field cardoor */
 #define CBC_WK_RSN_FS5	(1 << 22)	/* CBC wakeup reason field force S5 */
 #define CBC_WK_RSN_SOC	(1 << 23)	/* CBC wakeup reason field soc */
+/* CBC wakeup reason field debug channel */
+#define CBC_WK_RSN_DGB  (1 << 24)
 
 /* CBC wakeup reason filed suspend or shutdown */
 #define CBC_WK_RSN_SHUTDOWN	(0)


### PR DESCRIPTION
The dummy channels can emulate cbc lifecycle, cbc signal and cbc raw
channel instead canbox, and the feature can be enabled by ioc command
line within wakeup reason bit 24.

Tracked-On: #2481
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>