### PR TITLE
HV: Modularize vtd.c to remove acrn_vm usage

### DIFF
--- a/doc/developer-guides/hld/hv-vt-d.rst
+++ b/doc/developer-guides/hld/hv-vt-d.rst
@@ -306,7 +306,7 @@ deinitialization:
 .. doxygenfunction:: init_iommu
    :project: Project ACRN
 
-.. doxygenfunction:: init_iommu_sos_vm_domain
+.. doxygenfunction:: init_fallback_iommu_domain
    :project: Project ACRN
 
 runtime

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -6,6 +6,7 @@
 
 #include <hypervisor.h>
 #include <ioapic.h>
+#include <vtd.h>
 
 /*
  * lookup a ptdev entry by sid

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -9,6 +9,7 @@
 #include <hypervisor.h>
 #include <cpu.h>
 #include <virtual_cr.h>
+#include <vtd.h>
 
 /* CR0 bits hv want to trap to track status change */
 #define CR0_TRAP_MASK (CR0_PE | CR0_PG | CR0_WP | CR0_CD | CR0_NW)
@@ -160,7 +161,7 @@ static void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0)
 					 * disabled behavior
 					 */
 					exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, PAT_ALL_UC_VALUE);
-					if (!iommu_snoop_supported(vcpu->vm)) {
+					if (!iommu_snoop_supported(vcpu->vm->iommu)) {
 						cache_flush_invalidate_all();
 					}
 				} else {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -143,7 +143,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 
 		status = init_vm_boot_info(vm);
 		if (status == 0) {
-			init_iommu_sos_vm_domain(vm);
+			init_fallback_iommu_domain(vm->iommu, vm->vm_id, vm->arch_vm.nworld_eptp);
 		} else {
 			need_cleanup = true;
 		}

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -6,6 +6,7 @@
 
 #include <hypervisor.h>
 #include <virtual_cr.h>
+#include <vtd.h>
 
 /*
  * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
@@ -306,7 +307,7 @@ static int32_t xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 
 static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 {
-	if (!iommu_snoop_supported(vcpu->vm)) {
+	if (!iommu_snoop_supported(vcpu->vm->iommu)) {
 		cache_flush_invalidate_all();
 	}
 

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -7,6 +7,7 @@
 #include <init.h>
 #include <hypervisor.h>
 #include <schedule.h>
+#include <vtd.h>
 
 /* Push sp magic to top of stack for call trace */
 #define SWITCH_TO(rsp, to)                                              \

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -5,6 +5,7 @@
 #include <hypervisor.h>
 #include <trampoline.h>
 #include <ioapic.h>
+#include <vtd.h>
 
 struct cpu_context cpu_ctx;
 

--- a/hypervisor/bsp/sbl/const_dmar.c
+++ b/hypervisor/bsp/sbl/const_dmar.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <vtd.h>
 
 #ifndef CONFIG_DMAR_PARSE_ENABLED
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -9,6 +9,7 @@
 #include <hypercall.h>
 #include <version.h>
 #include <reloc.h>
+#include <vtd.h>
 
 #define ACRN_DBG_HYCALL	6U
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -30,6 +30,7 @@
 /* Passthrough PCI device related operations */
 
 #include <hypervisor.h>
+#include <vtd.h>
 #include "pci_priv.h"
 
 static inline uint32_t pci_bar_base(uint32_t bar)

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -39,7 +39,6 @@
 #include <vmx.h>
 #include <vmcs.h>
 #include <assign.h>
-#include <vtd.h>
 
 #include <guest.h>
 #include <vmexit.h>

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -46,6 +46,15 @@ enum acpi_dmar_scope_type {
 	ACPI_DMAR_SCOPE_TYPE_RESERVED       = 6 /* 6 and greater are reserved */
 };
 
+struct iommu_domain {
+	bool is_host;
+	bool is_tt_ept;     /* if reuse EPT of the domain */
+	uint16_t vm_id;
+	uint32_t addr_width;   /* address width of the domain */
+	uint64_t trans_table_ptr;
+	bool iommu_snoop;
+};
+
 static inline uint8_t dmar_ver_major(uint64_t version)
 {
 	return (((uint8_t)version & 0xf0U) >> 4U);
@@ -531,7 +540,7 @@ struct iommu_domain;
 /**
  * @brief Assign a device specified by bus & devfun to a iommu domain.
  *
- * Remove the device from the SOS_VM domain (if present), and add it to the specific domain.
+ * Remove the device from the fallback iommu domain (if present), and add it to the specific domain.
  *
  * @param[in]    domain iommu domain the device is assigned to
  * @param[in]    bus the 8-bit bus number of the device
@@ -548,7 +557,7 @@ int32_t assign_iommu_device(struct iommu_domain *domain, uint8_t bus, uint8_t de
 /**
  * @brief Unassign a device specified by bus & devfun from a iommu domain .
  *
- * Remove the device from the specific domain, and then add it to the SOS_VM domain (if present).
+ * Remove the device from the specific domain, and then add it to the fallback iommu domain (if present).
  *
  * @param[in]    domain iommu domain the device is assigned to
  * @param[in]    bus the 8-bit bus number of the device
@@ -640,30 +649,32 @@ void resume_iommu(void);
 int32_t init_iommu(void);
 
 /**
- * @brief Init SOS_VM domain of iommu.
+ * @brief Init fallback iommu domain of iommu.
  *
- * Create SOS_VM domain using the Normal World's EPT table of SOS_VM as address translation table.
- * All PCI devices are added to the SOS_VM domain when creating it.
+ * Create fallback iommu domain using the Normal World's EPT table of fallback iommu as address translation table.
+ * All PCI devices are added to the fallback iommu domain when creating it.
  *
- * @param[in] sos_vm pointer to SOS_VM
+ * @param[in] fallback_iommu pointer to fallback iommu domain
+ * @param[in] vm_id ID of the VM for which iommu_domain needs to be created
+ * @param[in] translation_table EPT hieararchy table
  *
- * @pre sos_vm shall point to SOS_VM
+ * @pre iommu shall point to fallback iommu domain
  *
  * @remark to reduce boot time & memory cost, a config IOMMU_INIT_BUS_LIMIT, which limit the bus number.
  *
  */
-void init_iommu_sos_vm_domain(struct acrn_vm *sos_vm);
+void init_fallback_iommu_domain(struct iommu_domain *fallback_iommu, uint16_t vm_id, void *translation_table);
 
 /**
  * @brief check the iommu if support cache snoop.
  *
- * @param[in] vm pointer to VM to check
+ * @param[in] iommu pointer to iommu domain to check
  *
  * @retval true support
  * @retval false not support
  *
  */
-bool iommu_snoop_supported(const struct acrn_vm *vm);
+bool iommu_snoop_supported(const struct iommu_domain *iommu);
 
 /**
  * @brief Assign RTE for Interrupt Remapping Table.


### PR DESCRIPTION
This patch is a modified one. It removes the usage
of acrn_vm struct from inside vtd.c.
It also puts struct iommu_domain inside vtd.h,
from vtd.c.
It modifies the signature of init_iommu_domain
in order to remove dependency on acrn_vm from
inside vtd.c.
Incorporated comments from Jason and Eddie.
Changed the name of sos_vm_domain to
fallback_iommu_domain
Removed any reference of sos_vm from vtd.[c|h]
files, including comments.

Tracked-On:https://github.com/projectacrn/acrn-hypervisor/issues/2496
Signed-off-by: Arindam Roy <arindam.roy@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>