### PR TITLE
hv: vlapic: make vlapic deliver interrupt related functions more read…

### DIFF
--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -94,10 +94,10 @@ an interrupt, for example:
 
 These APIs will finish by making a request for *ACRN_REQUEST_EVENT.*
 
-.. doxygenfunction:: vlapic_intr_accepted
+.. doxygenfunction:: vlapic_get_deliverable_intr
   :project: Project ACRN
 
-.. doxygenfunction:: vlapic_pending_intr
+.. doxygenfunction:: vlapic_find_deliverable_intr
   :project: Project ACRN
 
 .. doxygenfunction:: vlapic_set_local_intr

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -84,7 +84,7 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	dest = info->vmsi_addr.bits.dest_field;
 	phys = (info->vmsi_addr.bits.dest_mode == MSI_ADDR_DESTMODE_PHYS);
 
-	vlapic_calcdest(vm, &vdmask, dest, phys, false);
+	vlapic_calc_dest(vm, &vdmask, dest, phys, false);
 	pdmask = vcpumask2pcpumask(vm, vdmask);
 
 	/* get physical delivery mode */
@@ -178,7 +178,7 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* physical destination cpu mask */
 		phys = (virt_rte.bits.dest_mode == IOAPIC_RTE_DESTMODE_PHY);
 		dest = (uint32_t)virt_rte.bits.dest_field;
-		vlapic_calcdest(vm, &vdmask, dest, phys, false);
+		vlapic_calc_dest(vm, &vdmask, dest, phys, false);
 		pdmask = vcpumask2pcpumask(vm, vdmask);
 
 		/* physical delivery mode */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -400,7 +400,7 @@ static void inject_msi_lapic_pt(struct acrn_vm *vm, const struct acrn_msi_entry 
 		 * the delivery mode of vmsi will be forwarded to ICR delievry field
 		 * and handled by hardware.
 		 */
-		vlapic_calcdest_lapic_pt(vm, &vdmask, vdest, phys);
+		vlapic_calc_dest_lapic_pt(vm, &vdmask, vdest, phys);
 		dev_dbg(ACRN_DBG_LAPICPT, "%s: vcpu destination mask 0x%016llx", __func__, vdmask);
 
 		vcpu_id = ffs64(vdmask);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -73,7 +73,7 @@ vioapic_generate_intr(struct acrn_vioapic *vioapic, uint32_t pin)
 			}
 			vector = rte.bits.vector;
 			dest = rte.bits.dest_field;
-			vlapic_deliver_intr(vioapic->vm, level, dest, phys, delmode, vector, false);
+			vlapic_receive_intr(vioapic->vm, level, dest, phys, delmode, vector, false);
 		}
 	}
 }
@@ -217,7 +217,7 @@ vioapic_update_eoi_exit(const struct acrn_vioapic *vioapic)
 			} else {
 				dest = (uint32_t)rte.bits.dest_field;
 				phys = (rte.bits.dest_mode == IOAPIC_RTE_DESTMODE_PHY);
-				vlapic_calcdest(vioapic->vm, &mask, dest, phys, false);
+				vlapic_calc_dest(vioapic->vm, &mask, dest, phys, false);
 				
 				for (vcpu_id = ffs64(mask); vcpu_id != INVALID_BIT_INDEX; vcpu_id = ffs64(mask)) {
 					vcpu = vcpu_from_vid(vioapic->vm, vcpu_id);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -122,25 +122,25 @@ uint64_t vlapic_get_cr8(const struct acrn_vlapic *vlapic);
 
 
 /**
- * @brief Get pending virtual interrupts for vLAPIC.
+ * @brief Find a deliverable virtual interrupts for vLAPIC in irr.
  *
  * @param[in]    vlapic Pointer to target vLAPIC data structure
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *               with eligible vector if any.
  *
- * @retval 0 There is no eligible pending vector.
- * @retval 1 There is pending vector.
+ * @retval false There is no deliverable pending vector.
+ * @retval true There is deliverable vector.
  *
  * @remark The vector does not automatically transition to the ISR as a
  *	   result of calling this function.
  */
-int32_t vlapic_pending_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
+bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
 
 /**
- * @brief Accept virtual interrupt.
+ * @brief Get a deliverable virtual interrupt from irr to isr.
  *
  * Transition 'vector' from IRR to ISR. This function is called with the
- * vector returned by 'vlapic_pending_intr()' when the guest is able to
+ * vector returned by 'vlapic_find_deliverable_intr()' when the guest is able to
  * accept this interrupt (i.e. RFLAGS.IF = 1 and no conditions exist that
  * block interrupt delivery).
  *
@@ -151,7 +151,7 @@ int32_t vlapic_pending_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
  *
  * @pre vlapic != NULL
  */
-void vlapic_intr_accepted(struct acrn_vlapic *vlapic, uint32_t vector);
+void vlapic_get_deliverable_intr(struct acrn_vlapic *vlapic, uint32_t vector);
 
 /**
  * @brief Send notification vector to target pCPU.
@@ -224,7 +224,7 @@ int32_t vlapic_set_local_intr(struct acrn_vm *vm, uint16_t vcpu_id_arg, uint32_t
  */
 int32_t vlapic_intr_msi(struct acrn_vm *vm, uint64_t addr, uint64_t msg);
 
-void vlapic_deliver_intr(struct acrn_vm *vm, bool level, uint32_t dest,
+void vlapic_receive_intr(struct acrn_vm *vm, bool level, uint32_t dest,
 		bool phys, uint32_t delmode, uint32_t vec, bool rh);
 
 uint32_t vlapic_get_apicid(const struct acrn_vlapic *vlapic);
@@ -248,8 +248,8 @@ int32_t apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
-void vlapic_calcdest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
-void vlapic_calcdest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
+void vlapic_calc_dest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
+void vlapic_calc_dest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 
 /**
  * @}


### PR DESCRIPTION
…able

Rename vlapic_deliver_intr to vlapic_receive_intr: ioapic/msi device
deliver an interrupt to lapic.
Rename vlapic_pending_intr to vlapic_find_deliverable_intr: find a
deliverable interrupt which pending in irr and its priority large than ppr.
Rename vlapic_intr_accepted to vlapic_get_deliverable_intr: get the deliverable
interrupt from irr and set it in isr (which also raise ppr update)

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>