### PR TITLE
HV: E820 refinement

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -145,6 +145,7 @@ ifeq ($(CONFIG_SHARING_MODE),y)
 C_SRCS += arch/x86/configs/sharing_config.c
 else ifeq ($(CONFIG_PARTITION_MODE),y)
 C_SRCS += arch/x86/configs/partition_config.c
+C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/ve820.c
 endif
 
 C_SRCS += boot/acpi.c

--- a/hypervisor/arch/x86/configs/apl-mrb/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/ve820.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+#include <e820.h>
+
+const struct e820_entry ve820_entry[NUM_E820_ENTRIES] = {
+	{	/* 0 to mptable */
+		.baseaddr =  0x0U,
+		.length   =  0xEFFFFU,
+		.type     =  E820_TYPE_RAM
+	},
+
+	{	/* mptable 65536U */
+		.baseaddr =  0xF0000U,
+		.length   =  0x10000U,
+		.type     =  E820_TYPE_RESERVED
+	},
+
+	{	/* mptable to lowmem */
+		.baseaddr =  0x100000U,
+		.length   =  0x1FF00000U,
+		.type     =  E820_TYPE_RAM
+	},
+
+	{	/* lowmem to PCI hole */
+		.baseaddr =  0x20000000U,
+		.length   =  0xa0000000U,
+		.type     =  E820_TYPE_RESERVED
+	},
+
+	{	/* PCI hole to 4G */
+		.baseaddr =  0xe0000000U,
+		.length   =  0x20000000U,
+		.type     =  E820_TYPE_RESERVED
+	},
+};

--- a/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <hypervisor.h>
+#include <e820.h>
+
+const struct e820_entry ve820_entry[NUM_E820_ENTRIES] = {
+	{	/* 0 to mptable */
+		.baseaddr =  0x0U,
+		.length   =  0xEFFFFU,
+		.type     =  E820_TYPE_RAM
+	},
+
+	{	/* mptable 65536U */
+		.baseaddr =  0xF0000U,
+		.length   =  0x10000U,
+		.type     =  E820_TYPE_RESERVED
+	},
+
+	{	/* mptable to lowmem */
+		.baseaddr =  0x100000U,
+		.length   =  0x7FF00000U,
+		.type     =  E820_TYPE_RAM
+	},
+
+	{	/* lowmem to PCI hole */
+		.baseaddr =  0x80000000U,
+		.length   =  0x40000000U,
+		.type     =  E820_TYPE_RESERVED
+	},
+
+	{	/* PCI hole to 4G */
+		.baseaddr =  0xe0000000U,
+		.length   =  0x20000000U,
+		.type     =  E820_TYPE_RESERVED
+	},
+};

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -232,9 +232,9 @@ uint32_t create_e820_table(struct e820_entry *param_e820)
 	uint32_t i;
 
 	for (i = 0U; i < NUM_E820_ENTRIES; i++) {
-		param_e820[i].baseaddr = e820_default_entries[i].baseaddr;
-		param_e820[i].length = e820_default_entries[i].length;
-		param_e820[i].type = e820_default_entries[i].type;
+		param_e820[i].baseaddr = ve820_entry[i].baseaddr;
+		param_e820[i].length = ve820_entry[i].length;
+		param_e820[i].type = ve820_entry[i].type;
 	}
 
 	return NUM_E820_ENTRIES;

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -62,7 +62,7 @@ const struct e820_mem_params *get_e820_mem_info(void);
  * there is reserved memory of 64K for MPtable and PCI hole of 512MB
  */
 #define NUM_E820_ENTRIES        5U
-extern const struct e820_entry e820_default_entries[NUM_E820_ENTRIES];
+extern const struct e820_entry ve820_entry[NUM_E820_ENTRIES];
 #endif
 
 #endif

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -36,14 +36,8 @@ struct e820_mem_params {
 /* HV read multiboot header to get e820 entries info and calc total RAM info */
 void init_e820(void);
 
-/* before boot sos_vm(service OS), call it to hide the HV RAM entry in e820 table from sos_vm */
-void rebuild_sos_vm_e820(void);
-
 /* get some RAM below 1MB in e820 entries, hide it from sos_vm, return its start address */
 uint64_t e820_alloc_low_memory(uint32_t size_arg);
-
-/* copy the original e820 entries info to param_e820 */
-uint32_t create_e820_table(struct e820_entry *param_e820);
 
 /* get total number of the e820 entries */
 uint32_t get_e820_entries_count(void);
@@ -53,16 +47,5 @@ const struct e820_entry *get_e820_entry(void);
 
 /* get the e820 total memory info */
 const struct e820_mem_params *get_e820_mem_info(void);
-
-#ifdef CONFIG_PARTITION_MODE
-/*
- * Default e820 mem map:
- *
- * Assumption is every VM launched by ACRN in partition mode uses 2G of RAM.
- * there is reserved memory of 64K for MPtable and PCI hole of 512MB
- */
-#define NUM_E820_ENTRIES        5U
-extern const struct e820_entry ve820_entry[NUM_E820_ENTRIES];
-#endif
 
 #endif

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -10,6 +10,7 @@
 #include <vpci.h>
 #include <page.h>
 #include <cpu_caps.h>
+#include <e820.h>
 
 #ifdef CONFIG_PARTITION_MODE
 #include <mptable.h>
@@ -132,6 +133,8 @@ struct acrn_vm {
 	struct vm_hw_info hw;	/* Reference to this VM's HW information */
 	struct vm_sw_info sw;	/* Reference to SW associated with this VM */
 	struct vm_pm_info pm;	/* Reference to this VM's arch information */
+	uint32_t e820_entry_num;
+	struct e820_entry *e820_entries;
 	uint16_t vm_id;		    /* Virtual machine identifier */
 	enum vm_state state;	/* VM state */
 	struct acrn_vuart vuart;		/* Virtual UART */
@@ -291,6 +294,15 @@ struct acrn_vm *get_vm_from_vmid(uint16_t vm_id);
 struct acrn_vm *get_sos_vm(void);
 
 #ifdef CONFIG_PARTITION_MODE
+/*
+ * Default e820 mem map:
+ *
+ * Assumption is every VM launched by ACRN in partition mode uses 2G of RAM.
+ * there is reserved memory of 64K for MPtable and PCI hole of 512MB
+ */
+#define NUM_E820_ENTRIES        5U
+extern const struct e820_entry ve820_entry[NUM_E820_ENTRIES];
+
 struct vm_config_arraies {
 	int32_t                     num_vm_config;
 	struct acrn_vm_config   vm_config_array[CONFIG_MAX_VM_NUM];

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -186,35 +186,3 @@ const struct pcpu_vm_config_mapping pcpu_vm_config_map[] = {
 		.is_bsp = true,
 	},
 };
-
-const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
-	{	/* 0 to mptable */
-		.baseaddr =  0x0U,
-		.length   =  0xEFFFFU,
-		.type     =  E820_TYPE_RAM
-	},
-
-	{	/* mptable 65536U */
-		.baseaddr =  0xF0000U,
-		.length   =  0x10000U,
-		.type     =  E820_TYPE_RESERVED
-	},
-
-	{	/* mptable to lowmem */
-		.baseaddr =  0x100000U,
-		.length   =  0x1FF00000U,
-		.type     =  E820_TYPE_RAM
-	},
-
-	{	/* lowmem to PCI hole */
-		.baseaddr =  0x20000000U,
-		.length   =  0xa0000000U,
-		.type     =  E820_TYPE_RESERVED
-	},
-
-	{	/* PCI hole to 4G */
-		.baseaddr =  0xe0000000U,
-		.length   =  0x20000000U,
-		.type     =  E820_TYPE_RESERVED
-	},
-};

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -236,35 +236,3 @@ const struct pcpu_vm_config_mapping pcpu_vm_config_map[] = {
 		.is_bsp = true,
 	},
 };
-
-const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
-	{	/* 0 to mptable */
-		.baseaddr =  0x0U,
-		.length   =  0xEFFFFU,
-		.type     =  E820_TYPE_RAM
-	},
-
-	{	/* mptable 65536U */
-		.baseaddr =  0xF0000U,
-		.length   =  0x10000U,
-		.type     =  E820_TYPE_RESERVED
-	},
-
-	{	/* mptable to lowmem */
-		.baseaddr =  0x100000U,
-		.length   =  0x7FF00000U,
-		.type     =  E820_TYPE_RAM
-	},
-
-	{	/* lowmem to PCI hole */
-		.baseaddr =  0x80000000U,
-		.length   =  0x40000000U,
-		.type     =  E820_TYPE_RESERVED
-	},
-
-	{	/* PCI hole to 4G */
-		.baseaddr =  0xe0000000U,
-		.length   =  0x20000000U,
-		.type     =  E820_TYPE_RESERVED
-	},
-};


### PR DESCRIPTION
- move e820 entry out of vm description;    
- add e820 info in struct acrn_vm;
- rename rebuild_sos_vm_e820() to create_sos_vm_e820();
- add create_prelaunched_vm_e820() for partition mode;
- rename create_e820_table() to create_zeropage_e820() and merge for
  both sharing mode and partition mode;
- move create_xxx_vm_e820() to vm.c;
- move create_zeropage_e820() to vm_load.c;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>

