### PR TITLE
VPCI code cleanup

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -195,6 +195,7 @@ void init_cpu_post(uint16_t pcpu_id)
 		timer_init();
 		setup_notification();
 		setup_posted_intr_notification();
+		init_pci_pdev_list();
 
 		/* Start all secondary cores */
 		startup_paddr = prepare_trampoline();

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -46,7 +46,7 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 {
 	struct ptirq_msi_info info;
-	union pci_bdf pbdf = vdev->pdev.bdf;
+	union pci_bdf pbdf = vdev->pdev->bdf;
 	struct acrn_vm *vm = vdev->vpci->vm;
 	uint32_t capoff = vdev->msi.capoff;
 	uint32_t msgctrl, msgdata;
@@ -185,7 +185,7 @@ static void buf_write32(uint8_t buf[], uint32_t val)
 
 void populate_msi_struct(struct pci_vdev *vdev)
 {
-	struct pci_pdev *pdev = &vdev->pdev;
+	struct pci_pdev *pdev = vdev->pdev;
 	uint32_t val;
 
 	/* Copy MSI/MSI-X capability struct into virtual device */

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -92,7 +92,7 @@ static inline void enable_disable_msix(const struct pci_vdev *vdev, bool enable)
 	} else {
 		msgctrl &= ~PCIM_MSIXCTRL_MSIX_ENABLE;
 	}
-	pci_pdev_write_cfg(vdev->pdev.bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
+	pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
 }
 
 /* Do MSI-X remap for all MSI-X table entries in the target device */
@@ -114,7 +114,7 @@ static int32_t vmsix_remap(const struct pci_vdev *vdev, bool enable)
 	/* If MSI Enable is being set, make sure INTxDIS bit is set */
 	if (ret == 0) {
 		if (enable) {
-			enable_disable_pci_intx(vdev->pdev.bdf, false);
+			enable_disable_pci_intx(vdev->pdev->bdf, false);
 		}
 		enable_disable_msix(vdev, enable);
 	}
@@ -135,13 +135,13 @@ static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index
 	if (ret == 0) {
 		/* If MSI Enable is being set, make sure INTxDIS bit is set */
 		if (enable) {
-			enable_disable_pci_intx(vdev->pdev.bdf, false);
+			enable_disable_pci_intx(vdev->pdev->bdf, false);
 		}
 
 		/* Restore MSI-X Enable bit */
 		msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
 		if ((msgctrl & PCIM_MSIXCTRL_MSIX_ENABLE) == PCIM_MSIXCTRL_MSIX_ENABLE) {
-			pci_pdev_write_cfg(vdev->pdev.bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
+			pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
 		}
 	}
 
@@ -186,7 +186,7 @@ static int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t b
 			}
 
 			if (((msgctrl ^ val) & PCIM_MSIXCTRL_FUNCTION_MASK) != 0U) {
-				pci_pdev_write_cfg(vdev->pdev.bdf, offset, 2U, val);
+				pci_pdev_write_cfg(vdev->pdev->bdf, offset, 2U, val);
 			}
 		}
 		ret = 0;
@@ -316,7 +316,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 	uint32_t i;
 	uint64_t addr_hi, addr_lo;
 	struct pci_msix *msix = &vdev->msix;
-	struct pci_pdev *pdev = &vdev->pdev;
+	struct pci_pdev *pdev = vdev->pdev;
 	struct pci_bar *bar;
 	int32_t ret;
 
@@ -367,7 +367,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 		}
 		ret = 0;
 	} else {
-		pr_err("%s, MSI-X device (%x) invalid table BIR %d", __func__, vdev->pdev.bdf.value, msix->table_bar);
+		pr_err("%s, MSI-X device (%x) invalid table BIR %d", __func__, vdev->pdev->bdf.value, msix->table_bar);
 		vdev->msix.capoff = 0U;
 	    ret = -EIO;
 	}

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -155,7 +155,7 @@ static int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint3
 
 	if (msixcap_access(vdev, offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
-	        ret = 0;
+	    ret = 0;
 	} else {
 		ret = -ENODEV;
 	}
@@ -189,8 +189,7 @@ static int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t b
 				pci_pdev_write_cfg(vdev->pdev.bdf, offset, 2U, val);
 			}
 		}
-
-	        ret = 0;
+		ret = 0;
 	} else {
 		ret = -ENODEV;
 	}
@@ -230,6 +229,7 @@ static void vmsix_table_rw(struct pci_vdev *vdev, struct mmio_request *mmio, uin
 				 */
 				if (entry_offset < offsetof(struct msix_table_entry, data)) {
 					uint64_t qword_mask = ~0UL;
+
 					if (mmio->size == 4U) {
 						qword_mask = (entry_offset == 0U) ?
 								0x00000000FFFFFFFFUL : 0xFFFFFFFF00000000UL;
@@ -311,67 +311,18 @@ static int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *
 	return ret;
 }
 
-static void decode_msix_table_bar(struct pci_vdev *vdev)
-{
-	uint32_t bir = vdev->msix.table_bar;
-	union pci_bdf pbdf = vdev->pdev.bdf;
-	uint64_t base, size;
-	uint32_t bar_lo, bar_hi, val32;
-
-	bar_lo = pci_pdev_read_cfg(pbdf, pci_bar_offset(bir), 4U);
-	if ((bar_lo & PCIM_BAR_SPACE) != PCIM_BAR_IO_SPACE) {
-		/* Get the base address */
-		base = (uint64_t)bar_lo & PCIM_BAR_MEM_BASE;
-		if ((bar_lo & PCIM_BAR_MEM_TYPE) == PCIM_BAR_MEM_64) {
-			bar_hi = pci_pdev_read_cfg(pbdf, pci_bar_offset(bir + 1U), 4U);
-			base |= ((uint64_t)bar_hi << 32U);
-		}
-
-		vdev->msix.mmio_hva = (uint64_t)hpa2hva(base);
-		vdev->msix.mmio_gpa = sos_vm_hpa2gpa(base);
-
-		/* Sizing the BAR */
-		size = 0U;
-		if (((bar_lo & PCIM_BAR_MEM_TYPE) == PCIM_BAR_MEM_64) && (bir < (PCI_BAR_COUNT - 1U))) {
-			pci_pdev_write_cfg(pbdf, pci_bar_offset(bir + 1U), 4U, ~0U);
-			size = (uint64_t)pci_pdev_read_cfg(pbdf, pci_bar_offset(bir + 1U), 4U);
-			size <<= 32U;
-		}
-
-		pci_pdev_write_cfg(pbdf, pci_bar_offset(bir), 4U, ~0U);
-		val32 = pci_pdev_read_cfg(pbdf, pci_bar_offset(bir), 4U);
-		size |= ((uint64_t)val32 & PCIM_BAR_MEM_BASE);
-
-		vdev->msix.mmio_size = size & ~(size - 1U);
-
-		/* Restore the BAR */
-		pci_pdev_write_cfg(pbdf, pci_bar_offset(bir), 4U, bar_lo);
-
-		if ((bar_lo & PCIM_BAR_MEM_TYPE) == PCIM_BAR_MEM_64) {
-			pci_pdev_write_cfg(pbdf, pci_bar_offset(bir + 1U), 4U, bar_hi);
-		}
-	} else {
-		/* I/O bar, should never happen */
-		pr_err("PCI device (%x) has MSI-X Table at IO BAR", vdev->vbdf.value);
-	}
-}
-
 static int32_t vmsix_init(struct pci_vdev *vdev)
 {
-	uint32_t msgctrl;
-	uint32_t table_info, i;
+	uint32_t i;
 	uint64_t addr_hi, addr_lo;
 	struct pci_msix *msix = &vdev->msix;
+	struct pci_pdev *pdev = &vdev->pdev;
+	struct pci_bar *bar;
 	int32_t ret;
 
-	msgctrl = pci_pdev_read_cfg(vdev->pdev.bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
-
-	/* Read Table Offset and Table BIR */
-	table_info = pci_pdev_read_cfg(vdev->pdev.bdf, msix->capoff + PCIR_MSIX_TABLE, 4U);
-
-	msix->table_bar = table_info & PCIM_MSIX_BIR_MASK;
-	msix->table_offset = table_info & ~PCIM_MSIX_BIR_MASK;
-	msix->table_count = (msgctrl & PCIM_MSIXCTRL_TABLE_SIZE) + 1U;
+	msix->table_bar = pdev->msix.table_bar;
+	msix->table_offset = pdev->msix.table_offset;
+	msix->table_count = pdev->msix.table_count;
 
 	if (msix->table_bar < (PCI_BAR_COUNT - 1U)) {
 		/* Mask all table entries */
@@ -381,7 +332,12 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 			msix->tables[i].data = 0U;
 		}
 
-		decode_msix_table_bar(vdev);
+		bar = &pdev->bar[msix->table_bar];
+		if (bar != NULL) {
+			vdev->msix.mmio_hva = (uint64_t)hpa2hva(bar->base);
+			vdev->msix.mmio_gpa = sos_vm_hpa2gpa(bar->base);
+			vdev->msix.mmio_size = bar->size;
+		}
 
 		if (msix->mmio_gpa != 0U) {
 			/*
@@ -413,7 +369,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 	} else {
 		pr_err("%s, MSI-X device (%x) invalid table BIR %d", __func__, vdev->pdev.bdf.value, msix->table_bar);
 		vdev->msix.capoff = 0U;
-	        ret = -EIO;
+	    ret = -EIO;
 	}
 
 	return ret;

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -107,12 +107,14 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 		vdev = &vdev_array->vpci_vdev_list[i];
 		vdev->vpci = vpci;
 
-		/* Exclude hostbridge */
 		if (vdev->vbdf.value != 0U) {
 			partition_mode_pdev_init(vdev);
+			vdev->ops = &pci_ops_vdev_pt;
+		} else {
+			vdev->ops = &pci_ops_vdev_hostbridge;
 		}
 
-		if ((vdev->ops != NULL) && (vdev->ops->init != NULL)) {
+		if (vdev->ops->init != NULL) {
 			if (vdev->ops->init(vdev) != 0) {
 				pr_err("%s() failed at PCI device (bdf %x)!", __func__,
 					vdev->vbdf);

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -72,13 +72,13 @@ static void partition_mode_pdev_init(struct pci_vdev *vdev)
 	uint32_t idx;
 	struct pci_bar *pbar, *vbar;
 
-	pdev_ref = find_pci_pdev(vdev->pdev.bdf);
+	pdev_ref = find_pci_pdev(vdev->pbdf);
 	if (pdev_ref != NULL) {
-		(void)memcpy_s((void *)&vdev->pdev, sizeof(struct pci_pdev), (void *)pdev_ref, sizeof(struct pci_pdev));
+		vdev->pdev = pdev_ref;
 
 		/* Sanity checking for vbar */
 		for (idx = 0U; idx < (uint32_t)PCI_BAR_COUNT; idx++) {
-			pbar = &vdev->pdev.bar[idx];
+			pbar = &vdev->pdev->bar[idx];
 			vbar = &vdev->bar[idx];
 
 			if (is_valid_bar(pbar)) {
@@ -116,7 +116,7 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 
 		if (vdev->ops->init != NULL) {
 			if (vdev->ops->init(vdev) != 0) {
-				pr_err("%s() failed at PCI device (bdf %x)!", __func__,
+				pr_err("%s() failed at PCI device (vbdf %x)!", __func__,
 					vdev->vbdf);
 			}
 		}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -75,13 +75,13 @@ static int32_t vdev_pt_init(struct pci_vdev *vdev)
 			hva2hpa(vm->arch_vm.nworld_eptp), 48U);
 	}
 
-	ret = assign_iommu_device(vm->iommu, (uint8_t)vdev->pdev.bdf.bits.b,
-		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
+	ret = assign_iommu_device(vm->iommu, (uint8_t)vdev->pdev->bdf.bits.b,
+		(uint8_t)(vdev->pdev->bdf.value & 0xFFU));
 
-	pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U);
+	pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U);
 	/* Disable INTX */
 	pci_command |= 0x400U;
-	pci_pdev_write_cfg(vdev->pdev.bdf, PCIR_COMMAND, 2U, pci_command);
+	pci_pdev_write_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U, pci_command);
 
 	return ret;
 }
@@ -91,8 +91,8 @@ static int32_t vdev_pt_deinit(struct pci_vdev *vdev)
 	int32_t ret;
 	struct acrn_vm *vm = vdev->vpci->vm;
 
-	ret = unassign_iommu_device(vm->iommu, (uint8_t)vdev->pdev.bdf.bits.b,
-		(uint8_t)(vdev->pdev.bdf.value & 0xFFU));
+	ret = unassign_iommu_device(vm->iommu, (uint8_t)vdev->pdev->bdf.bits.b,
+		(uint8_t)(vdev->pdev->bdf.value & 0xFFU));
 
 	return ret;
 }
@@ -110,7 +110,7 @@ static int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	if (pci_bar_access(offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
 	} else {
-		*val = pci_pdev_read_cfg(vdev->pdev.bdf, offset, bytes);
+		*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
 	}
 
 	return 0;
@@ -130,7 +130,7 @@ static void vdev_pt_remap_bar(struct pci_vdev *vdev, uint32_t idx,
 	if (new_base != 0U) {
 		/* Map the physical BAR in the guest MMIO space */
 		ept_mr_add(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
-			vdev->pdev.bar[idx].base, /* HPA */
+			vdev->pdev->bar[idx].base, /* HPA */
 			new_base, /*GPA*/
 			vdev->bar[idx].size,
 			EPT_WR | EPT_RD | EPT_UNCACHED);
@@ -189,7 +189,7 @@ static int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 		vdev_pt_cfgwrite_bar(vdev, offset, bytes, val);
 	} else {
 		/* Write directly to physical device's config space */
-		pci_pdev_write_cfg(vdev->pdev.bdf, offset, bytes, val);
+		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 	}
 
 	return 0;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -102,31 +102,32 @@ static void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf
 	}
 }
 
-static struct pci_vdev *alloc_pci_vdev(const struct acrn_vm *vm, union pci_bdf bdf)
+static struct pci_vdev *alloc_pci_vdev(const struct acrn_vm *vm, const struct pci_pdev *pdev_ref)
 {
-	struct pci_vdev *vdev;
+	struct pci_vdev *vdev = NULL;
 
 	if (num_pci_vdev < CONFIG_MAX_PCI_DEV_NUM) {
 		vdev = &sharing_mode_vdev_array[num_pci_vdev];
 		num_pci_vdev++;
 
-		/* vbdf equals to pbdf otherwise remapped */
-		vdev->vbdf = bdf;
-		vdev->vpci = &vm->vpci;
-		vdev->pdev.bdf = bdf;
-	} else {
-		vdev = NULL;
+		if ((vm != NULL) && (vdev != NULL) && (pdev_ref != NULL)) {
+			vdev->vpci = &vm->vpci;
+			/* vbdf equals to pbdf otherwise remapped */
+			vdev->vbdf = pdev_ref->bdf;
+			(void)memcpy_s((void *)&vdev->pdev, sizeof(struct pci_pdev),
+				(const void *)pdev_ref, sizeof(struct pci_pdev));
+		}
 	}
 
 	return vdev;
 }
 
-static void enumerate_pci_dev(uint16_t pbdf, const void *cb_data)
+static void init_vdev_for_pdev(const struct pci_pdev *pdev, const void *cb_data)
 {
 	const struct acrn_vm *vm = (const struct acrn_vm *)cb_data;
 	struct pci_vdev *vdev;
 
-	vdev = alloc_pci_vdev(vm, (union pci_bdf)pbdf);
+	vdev = alloc_pci_vdev(vm, pdev);
 	if (vdev != NULL) {
 		populate_msi_struct(vdev);
 	}
@@ -143,14 +144,10 @@ static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
 	 * IO/MMIO requests from non-sos_vm guests will be injected to device model.
 	 */
 	if (!is_sos_vm(vm)) {
-	        ret = -ENODEV;
+		ret = -ENODEV;
 	} else {
-		/* Initialize PCI vdev array */
-		num_pci_vdev = 0U;
-		(void)memset((void *)sharing_mode_vdev_array, 0U, sizeof(sharing_mode_vdev_array));
-
-		/* build up vdev array for sos_vm */
-		pci_scan_bus(enumerate_pci_dev, vm);
+		/* Build up vdev array for sos_vm */
+		pci_pdev_foreach(init_vdev_for_pdev, vm);
 
 		for (i = 0U; i < num_pci_vdev; i++) {
 			vdev = &sharing_mode_vdev_array[i];

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -401,3 +401,17 @@ void pci_pdev_foreach(pci_pdev_enumeration_cb cb_func, const void *ctx)
 	}
 }
 
+struct pci_pdev *find_pci_pdev(union pci_bdf pbdf)
+{
+	struct pci_pdev *pdev = NULL;
+	uint32_t i;
+
+	for (i = 0U; i < num_pci_pdev; i++) {
+		if (pci_pdev_array[i].bdf.value == pbdf.value) {
+			pdev = &pci_pdev_array[i];
+			break;
+		}
+	}
+
+	return pdev;
+}

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -138,6 +138,21 @@ enum pci_bar_type {
 	PCIBAR_MEM64,
 };
 
+struct pci_bar {
+	uint64_t base;
+	uint64_t size;
+	enum pci_bar_type type;
+};
+
+struct pci_pdev {
+	/* The bar info of the physical PCI device. */
+	struct pci_bar bar[PCI_BAR_COUNT];
+
+	/* The bus/device/function triple of the physical PCI device. */
+	union pci_bdf bdf;
+};
+
+
 typedef void (*pci_enumeration_cb)(uint16_t pbdf, const void *data);
 
 static inline uint32_t pci_bar_offset(uint32_t idx)

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -179,8 +179,7 @@ struct pci_pdev {
 	struct pci_msix_cap msix;
 };
 
-
-typedef void (*pci_enumeration_cb)(uint16_t pbdf, const void *data);
+typedef void (*pci_pdev_enumeration_cb)(const struct pci_pdev *pdev, const void *data);
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {
@@ -195,7 +194,7 @@ static inline bool pci_bar_access(uint32_t offset)
 		&& (offset < pci_bar_offset(PCI_BAR_COUNT))) {
 		ret = true;
 	} else {
-	        ret = false;
+	    ret = false;
 	}
 
 	return ret;
@@ -225,7 +224,7 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
-void pci_scan_bus(pci_enumeration_cb cb, const void *cb_data);
+void pci_pdev_foreach(pci_pdev_enumeration_cb cb, const void *ctx);
 void init_pci_pdev_list(void);
 
 

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -179,7 +179,7 @@ struct pci_pdev {
 	struct pci_msix_cap msix;
 };
 
-typedef void (*pci_pdev_enumeration_cb)(const struct pci_pdev *pdev, const void *data);
+typedef void (*pci_pdev_enumeration_cb)(struct pci_pdev *pdev, const void *data);
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -225,6 +225,7 @@ void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
 void pci_pdev_foreach(pci_pdev_enumeration_cb cb, const void *ctx);
+struct pci_pdev *find_pci_pdev(union pci_bdf pbdf);
 void init_pci_pdev_list(void);
 
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -91,7 +91,10 @@ struct pci_vdev {
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf vbdf;
 
-	struct pci_pdev pdev;
+	/* The bus/device/function triple of the physical PCI device. */
+	union pci_bdf pbdf;
+
+	struct pci_pdev *pdev;
 
 	union pci_cfgdata cfgdata;
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -45,24 +45,10 @@ struct pci_vdev_ops {
 		uint32_t bytes, uint32_t *val);
 };
 
-struct pci_bar {
-	uint64_t base;
-	uint64_t size;
-	enum pci_bar_type type;
-};
-
 struct msix_table_entry {
 	uint64_t	addr;
 	uint32_t	data;
 	uint32_t	vector_control;
-};
-
-struct pci_pdev {
-	/* The bar info of the physical PCI device. */
-	struct pci_bar bar[PCI_BAR_COUNT];
-
-	/* The bus/device/function triple of the physical PCI device. */
-	union pci_bdf bdf;
 };
 
 /* MSI capability structure */

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -13,7 +13,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_hostbridge,
 	  .pdev = {
 		 .bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -21,7 +20,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 	 {/*vdev 1: SATA controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_pt,
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
 		}
@@ -35,7 +33,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_hostbridge,
 	  .pdev = {
 			.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -43,7 +40,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 	 {/*vdev 1: USB controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_pt,
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
 		}
@@ -51,7 +47,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 	 {/*vdev 2: Ethernet*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-	  .ops = &pci_ops_vdev_pt,
 	 .pdev = {
 		.bdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
 		}

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -13,16 +13,12 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .pdev = {
-		 .bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	 },
 
 	 {/*vdev 1: SATA controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	 .pdev = {
-		.bdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
 	 },
 	}
 };
@@ -33,23 +29,17 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .pdev = {
-			.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	 },
 
 	 {/*vdev 1: USB controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	 .pdev = {
-		.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
 	 },
 
 	 {/*vdev 2: Ethernet*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-	 .pdev = {
-		.bdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
-		}
+	  .pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
 	 },
 	}
 };

--- a/hypervisor/partition/apl-mrb/vm_description.c
+++ b/hypervisor/partition/apl-mrb/vm_description.c
@@ -14,7 +14,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	 {/*vdev 0: hostbridge */
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_hostbridge,
-	  .bar = {},
 	  .pdev = {
 		 .bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -23,42 +22,8 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	 {/*vdev 1: SATA controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_pt,
-	  .bar = {
-			[0] = {
-			.base = 0UL,
-			.size = 0x2000UL,
-			.type = PCIBAR_MEM32
-			},
-			[1] = {
-			.base = 0UL,
-			.size = 0x1000UL,
-			.type = PCIBAR_MEM32
-			},
-			[5] = {
-			.base = 0UL,
-			.size = 0x1000UL,
-			.type = PCIBAR_MEM32
-			},
-	  },
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
-		.bar = {
-			[0] = {
-			.base = 0xb3f10000UL,
-			.size = 0x2000UL,
-			.type = PCIBAR_MEM32
-			},
-			[1] = {
-			.base = 0xb3f53000UL,
-			.size = 0x100UL,
-			.type = PCIBAR_MEM32
-			},
-			[5] = {
-			.base = 0xb3f52000UL,
-			.size = 0x800UL,
-			.type = PCIBAR_MEM32
-			},
-		 }
 		}
 	 },
 	}
@@ -71,7 +36,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	 {/*vdev 0: hostbridge*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_hostbridge,
-	  .bar = {},
 	  .pdev = {
 			.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		}
@@ -80,54 +44,16 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	 {/*vdev 1: USB controller*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_pt,
-	  .bar = {
-			[0] = {
-			.base = 0UL,
-			.size = 0x10000UL,
-			.type = PCIBAR_MEM32
-		 },
-	  },
 	 .pdev = {
 		.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-		.bar = {
-			[0] = {
-			.base = 0xb3f00000UL,
-			.size = 0x10000UL,
-			.type = PCIBAR_MEM64
-			},
-		 }
 		}
 	 },
 
 	 {/*vdev 2: Ethernet*/
 	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
 	  .ops = &pci_ops_vdev_pt,
-	  .bar = {
-			[0] = {
-			.base = 0UL,
-			.size = 0x80000UL,
-			.type = PCIBAR_MEM32
-			},
-			[3] = {
-			.base = 0UL,
-			.size = 0x4000UL,
-			.type = PCIBAR_MEM32
-			},
-	  },
 	 .pdev = {
 		.bdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
-		.bar = {
-			[0] = {
-			.base = 0xb3c00000UL,
-			.size = 0x80000UL,
-			.type = PCIBAR_MEM32
-			},
-			[3] = {
-			.base = 0xb3c80000UL,
-			.size = 0x4000UL,
-			.type = PCIBAR_MEM32
-			 },
-		 }
 		}
 	 },
 	}

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -13,7 +13,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 		{/*vdev 0: hostbridge */
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			.ops = &pci_ops_vdev_hostbridge,
-			.bar = {},
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -22,54 +21,17 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 		{/*vdev 1: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x200000UL,
-					.type = PCIBAR_MEM32,
-				},
-				[4] = {
-					.base = 0UL,
-					.size = 0x4000UL,
-					.type = PCIBAR_MEM32,
-				},
-			},
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
-				.bar = {
-					[0] = {
-						.base = 0x80C00000,
-						.size = 0x200000UL,
-						.type = PCIBAR_MEM32,
-					},
-					[4] = {
-						.base = 0x81000000,
-						.size = 0x4000UL,
-						.type = PCIBAR_MEM32,
-					},
-				}
 			}
 		},
 
 		{/*vdev 2: USB*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x10000UL,
-					.type = PCIBAR_MEM32,
-				}
-			},
+
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-				.bar = {
-					[0] = {
-						.base = 0x81340000,
-						.size = 0x10000UL,
-						.type = PCIBAR_MEM32,
-					}
-				}
 			}
 		},
 	}
@@ -82,7 +44,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 		{/*vdev 0: hostbridge*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			.ops = &pci_ops_vdev_hostbridge,
-			.bar = {},
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -91,75 +52,17 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 		{/*vdev 1: SATA controller*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x2000UL,
-					.type = PCIBAR_MEM32
-				},
-				[1] = {
-					.base = 0UL,
-					.size = 0x1000UL,
-					.type = PCIBAR_MEM32
-				},
-				[5] = {
-					.base = 0UL,
-					.size = 0x1000UL,
-					.type = PCIBAR_MEM32
-				},
-			},
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
-				.bar = {
-					[0] = {
-						.base = 0x81354000,
-						.size = 0x2000UL,
-						.type = PCIBAR_MEM32
-					},
-					[1] = {
-						.base = 0x8135f000,
-						.size = 0x1000UL,
-						.type = PCIBAR_MEM32
-					},
-					[5] = {
-						.base = 0x8135e000,
-						.size = 0x1000UL,
-						.type = PCIBAR_MEM32
-					},
-				}
 			}
 		},
 
 		{/*vdev 2: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
 			.ops = &pci_ops_vdev_pt,
-			.bar = {
-				[0] = {
-					.base = 0UL,
-					.size = 0x200000UL,
-					.type = PCIBAR_MEM32,
-				},
-				[4] = {
-					.base = 0UL,
-					.size = 0x4000UL,
-					.type = PCIBAR_MEM32,
-				},
-			},
 
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
-				.bar = {
-					[0] = {
-						.base = 0x80e00000,
-						.size = 0x200000UL,
-						.type = PCIBAR_MEM32,
-					},
-					[4] = {
-						.base = 0x81004000,
-						.size = 0x4000UL,
-						.type = PCIBAR_MEM32,
-					}
-				}
 			}
 
 		},

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -12,7 +12,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge */
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.ops = &pci_ops_vdev_hostbridge,
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -20,7 +19,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 		{/*vdev 1: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
 			}
@@ -28,7 +26,6 @@ static struct vpci_vdev_array vpci_vdev_array1 = {
 
 		{/*vdev 2: USB*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
@@ -43,7 +40,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.ops = &pci_ops_vdev_hostbridge,
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 			}
@@ -51,7 +47,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 		{/*vdev 1: SATA controller*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 			.pdev = {
 				.bdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
 			}
@@ -59,7 +54,6 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 
 		{/*vdev 2: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
-			.ops = &pci_ops_vdev_pt,
 
 			.pdev = {
 				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},

--- a/hypervisor/partition/dnv-cb2/vm_description.c
+++ b/hypervisor/partition/dnv-cb2/vm_description.c
@@ -9,27 +9,21 @@
 
 static struct vpci_vdev_array vpci_vdev_array1 = {
 	.num_pci_vdev = 3,
+
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge */
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		},
 
 		{/*vdev 1: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
-			}
+			.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
 		},
 
 		{/*vdev 2: USB*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
 		},
 	}
 };
@@ -40,27 +34,18 @@ static struct vpci_vdev_array vpci_vdev_array2 = {
 	.vpci_vdev_list = {
 		{/*vdev 0: hostbridge*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
 		},
 
 		{/*vdev 1: SATA controller*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
-			.pdev = {
-				.bdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
-			}
+			.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
 		},
 
 		{/*vdev 2: Ethernet*/
 			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
-
-			.pdev = {
-				.bdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
-			}
-
+			.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
 		},
-
 	}
 };
 


### PR DESCRIPTION
Scan all physical PCI devices and store all needed info in global pdev array
Use the cached pci device (pdev) info for sharing mode and partition mode
Simply vm_description for pci passthru, only vbdf and pbdf need to be specified by user
vdev stores a pointer to pdev

Tracked-On: #2431
Signed-off-by: dongshen dongsheng.x.zhang@intel.com
Reviewed-by: Anthony Xu anthony.xu@intel.com