### PR TITLE
hv:remove several redundancy variables related memory

### DIFF
--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -28,8 +28,6 @@ static void obtain_e820_mem_info(void)
 	e820_mem.mem_bottom = UINT64_MAX;
 	e820_mem.mem_top = 0x0UL;
 	e820_mem.total_mem_size = 0UL;
-	e820_mem.max_ram_blk_base = 0UL;
-	e820_mem.max_ram_blk_size = 0UL;
 
 	for (i = 0U; i < e820_entries_count; i++) {
 		entry = &e820[i];
@@ -43,10 +41,6 @@ static void obtain_e820_mem_info(void)
 
 		if (entry->type == E820_TYPE_RAM) {
 			e820_mem.total_mem_size += entry->length;
-			if (entry->baseaddr == UOS_DEFAULT_START_ADDR) {
-				e820_mem.max_ram_blk_base = entry->baseaddr;
-				e820_mem.max_ram_blk_size = entry->length;
-			}
 		}
 	}
 }

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -265,9 +265,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	vm->emul_mmio_regions = 0U;
 	vm->snoopy_mem = true;
 
-	/* gpa_lowtop are used for system start up */
-	vm->hw.gpa_lowtop = 0UL;
-
 	init_ept_mem_ops(vm);
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);
 	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp);

--- a/hypervisor/bsp/include/bsp_extern.h
+++ b/hypervisor/bsp/include/bsp_extern.h
@@ -21,8 +21,6 @@
 #include "default_acpi_info.h"
 #include "platform_acpi_info.h"
 
-#define UOS_DEFAULT_START_ADDR   (0x100000000UL)
-
 /* BSP Interfaces */
 void init_bsp(void);
 uint64_t bsp_get_ap_trampoline(void);

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -29,8 +29,6 @@ struct e820_mem_params {
 	uint64_t mem_bottom;
 	uint64_t mem_top;
 	uint64_t total_mem_size;
-	uint64_t max_ram_blk_base; /* used for the start address of UOS */
-	uint64_t max_ram_blk_size;
 };
 
 /* HV read multiboot header to get e820 entries info and calc total RAM info */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -24,7 +24,6 @@ struct vm_hw_info {
 	/* vcpu array of this VM */
 	struct acrn_vcpu vcpu_array[CONFIG_MAX_VCPUS_PER_VM];
 	uint16_t created_vcpus;	/* Number of created vcpus */
-	uint64_t gpa_lowtop;    /* top lowmem gpa of this VM */
 } __aligned(PAGE_SIZE);
 
 struct sw_linux {


### PR DESCRIPTION
Remove redundancy code since they are not used now.
-- remove 'max_ram_blk_base' & 'max_ram_blk_size' in
   struct e820_mem_params
-- remove 'gpa_lowtop' in struct vm_hw_info
-- remove MACRO 'UOS_DEFAULT_START_ADDR'

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>