### PR TITLE
HV: repace vpci_vdev_array with pci_ptdev config

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/partition_config.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/partition_config.h
@@ -37,6 +37,10 @@
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable xapic_phys"
 
-extern struct vpci_vdev_array vpci_vdev_array0, vpci_vdev_array1;
+#define VM0_CONFIG_PCI_PTDEV_NUM		2U
+#define VM1_CONFIG_PCI_PTDEV_NUM		3U
+
+extern struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM];
+extern struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM];
 
 #endif /* PARTITION_CONFIG_H */

--- a/hypervisor/arch/x86/configs/apl-mrb/pt_dev.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/pt_dev.c
@@ -6,39 +6,28 @@
 
 #include <hypervisor.h>
 
-struct vpci_vdev_array vpci_vdev_array0 = {
-	.num_pci_vdev = 2,
-
-	.vpci_vdev_list = {
-	 {/*vdev 0: hostbridge */
-	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	 },
-
-	 {/*vdev 1: SATA controller*/
-	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	  .pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x0U},
-	 },
-	}
+struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[2] = {
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x00U},
+	},
 };
 
-struct vpci_vdev_array vpci_vdev_array1 = {
-	.num_pci_vdev = 3,
-
-	.vpci_vdev_list = {
-	 {/*vdev 0: hostbridge*/
-	  .vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	  .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-	 },
-
-	 {/*vdev 1: USB controller*/
-	  .vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-	  .pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-	 },
-
-	 {/*vdev 2: Ethernet*/
-	  .vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-	  .pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x0U},
-	 },
-	}
+struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[3] = {
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x00U},
+	},
 };

--- a/hypervisor/arch/x86/configs/dnv-cb2/partition_config.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/partition_config.h
@@ -37,6 +37,10 @@
 							"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 							"consoleblank=0 tsc=reliable xapic_phys apic_debug"
 
-extern struct vpci_vdev_array vpci_vdev_array0, vpci_vdev_array1;
+#define VM0_CONFIG_PCI_PTDEV_NUM		3U
+#define VM1_CONFIG_PCI_PTDEV_NUM		3U
+
+extern struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM];
+extern struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM];
 
 #endif /* PARTITION_CONFIG_H */

--- a/hypervisor/arch/x86/configs/dnv-cb2/pt_dev.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/pt_dev.c
@@ -6,44 +6,32 @@
 
 #include <hypervisor.h>
 
-struct vpci_vdev_array vpci_vdev_array0 = {
-	.num_pci_vdev = 3,
-
-	.vpci_vdev_list = {
-		{/*vdev 0: hostbridge */
-			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-		},
-
-		{/*vdev 1: Ethernet*/
-			.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x0U},
-			.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x1U},
-		},
-
-		{/*vdev 2: USB*/
-			.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x0U},
-			.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x0U},
-		},
-	}
+struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[3] = {
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x01U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U},
+	},
 };
 
-struct vpci_vdev_array vpci_vdev_array1 = {
-	.num_pci_vdev = 3,
-
-	.vpci_vdev_list = {
-		{/*vdev 0: hostbridge*/
-			.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-			.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x0U},
-		},
-
-		{/*vdev 1: SATA controller*/
-			.vbdf.bits = {.b = 0x00U, .d = 0x05U, .f = 0x0U},
-			.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x0U},
-		},
-
-		{/*vdev 2: Ethernet*/
-			.vbdf.bits = {.b = 0x00U, .d = 0x06U, .f = 0x0U},
-			.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x0U},
-		},
-	}
+struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[3] = {
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U},
+	},
+	{
+		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x00U},
+	},
 };

--- a/hypervisor/arch/x86/configs/partition_config.c
+++ b/hypervisor/arch/x86/configs/partition_config.c
@@ -22,7 +22,8 @@
 			.bootargs = VM##idx##_CONFIG_OS_BOOTARGS,	\
 		},	\
 		.vm_vuart = true,	\
-		.vpci_vdev_array = &vpci_vdev_array##idx,	\
+		.pci_ptdev_num = VM##idx##_CONFIG_PCI_PTDEV_NUM,	\
+		.pci_ptdevs = vm##idx##_pci_ptdevs,	\
 	},
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] __aligned(PAGE_SIZE) = {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -155,6 +155,8 @@ struct acrn_vm {
 	struct acrn_vpci vpci;
 #ifdef CONFIG_PARTITION_MODE
 	struct mptable_info mptable;
+	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
+	/* the valid number of pci_vdevs[] is vm_config->pci_ptdev_num */
 	uint8_t vrtc_offset;
 #endif
 
@@ -163,13 +165,6 @@ struct acrn_vm {
 	uint64_t intr_inject_delay_delta; /* delay of intr injection */
 	bool snoopy_mem;
 } __aligned(PAGE_SIZE);
-
-#ifdef CONFIG_PARTITION_MODE
-struct vpci_vdev_array {
-	int32_t num_pci_vdev;
-	struct pci_vdev vpci_vdev_list[];
-};
-#endif
 
 #define MAX_BOOTARGS_SIZE	1024U
 #define MAX_CONFIG_NAME_SIZE	32U


### PR DESCRIPTION
Use acrn_vm_pci_ptdev_config struct for PCI PT devices configuration
in acrn_vm_config, the only needed configure item is PT devices's
vBDF and pBDF info. When init PT devices, the BDF info will be stored
in pci_vdevs[] of acrn_vm.

With this patch, the previous vpci_vdev_array struct is not needed.

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>