### PR TITLE
Cleanup head file

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
-#include <schedule.h>
-#include <security.h>
-#include <virtual_cr.h>
+#include <types.h>
+#include <vcpu.h>
+#include <bits.h>
+#include <vmx.h>
+#include <logmsg.h>
+#include <cpu_caps.h>
+#include <per_cpu.h>
 #include <init.h>
 
 inline uint64_t vcpu_get_gpreg(const struct acrn_vcpu *vcpu, uint32_t reg)

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -4,12 +4,21 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
-#include <bsp_extern.h>
-#include <multiboot.h>
+#include <types.h>
+#include <errno.h>
+#include <sprintf.h>
+#include <vm.h>
+#include <bits.h>
 #include <e820.h>
+#include <multiboot.h>
 #include <vtd.h>
 #include <reloc.h>
+#include <ept.h>
+#include <guest_pm.h>
+#include <console.h>
+#include <ptdev.h>
+#include <vmcs.h>
+#include <logmsg.h>
 
 vm_sw_loader_t vm_sw_loader;
 

--- a/hypervisor/include/arch/x86/guest/trusty.h
+++ b/hypervisor/include/arch/x86/guest/trusty.h
@@ -6,6 +6,7 @@
 
 #ifndef TRUSTY_H_
 #define TRUSTY_H_
+#include <acrn_hv_defs.h>
 
 #define BOOTLOADER_SEED_MAX_ENTRIES     10U
 #define RPMB_MAX_PARTITION_NUMBER       6U

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -52,6 +52,11 @@
 
 #include <guest_memory.h>
 #include <virtual_cr.h>
+#include <vlapic.h>
+#include <vmtrr.h>
+#include <schedule.h>
+#include <io_req.h>
+#include <msr.h>
 
 /**
  * @brief vcpu

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -50,6 +50,8 @@
 
 #ifndef ASSEMBLER
 
+#include <types.h>
+#include <acrn_common.h>
 #include <guest_memory.h>
 #include <virtual_cr.h>
 #include <vlapic.h>

--- a/hypervisor/include/arch/x86/guest/vcpuid.h
+++ b/hypervisor/include/arch/x86/guest/vcpuid.h
@@ -7,6 +7,19 @@
 #ifndef VCPUID_H_
 #define VCPUID_H_
 
+#define CPUID_CHECK_SUBLEAF	(1U << 0U)
+#define MAX_VM_VCPUID_ENTRIES	64U
+struct vcpuid_entry {
+	uint32_t eax;
+	uint32_t ebx;
+	uint32_t ecx;
+	uint32_t edx;
+	uint32_t leaf;
+	uint32_t subleaf;
+	uint32_t flags;
+	uint32_t padding;
+};
+
 int32_t set_vcpuid_entries(struct acrn_vm *vm);
 void guest_cpuid(struct acrn_vcpu *vcpu,
 			uint32_t *eax, uint32_t *ebx,

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -31,6 +31,8 @@
 #define VLAPIC_H
 
 #include <page.h>
+#include <timer.h>
+#include <apicreg.h>
 
 
 /**

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -13,9 +13,18 @@
 
 #ifndef ASSEMBLER
 
+#include <types.h>
+#include <spinlock.h>
+#include <acrn_common.h>
 #include <bsp_extern.h>
+#include <vcpu.h>
+#include <vioapic.h>
+#include <vpic.h>
+#include <io_emul.h>
+#include <vuart.h>
+#include <trusty.h>
+#include <vcpuid.h>
 #include <vpci.h>
-#include <page.h>
 #include <cpu_caps.h>
 #include <e820.h>
 
@@ -75,14 +84,6 @@ struct vm_pm_info {
 /* VM guest types */
 #define VM_LINUX_GUEST      0x02
 #define VM_MONO_GUEST       0x01
-
-enum vpic_wire_mode {
-	VPIC_WIRE_INTR = 0,
-	VPIC_WIRE_LAPIC,
-	VPIC_WIRE_IOAPIC,
-	VPIC_WIRE_NULL
-};
-
 /* Enumerated type for VM states */
 enum vm_state {
 	VM_STATE_UNKNOWN = 0,
@@ -114,20 +115,6 @@ struct vm_arch {
 
 	/* reference to virtual platform to come here (as needed) */
 } __aligned(PAGE_SIZE);
-
-
-#define CPUID_CHECK_SUBLEAF	(1U << 0U)
-#define MAX_VM_VCPUID_ENTRIES	64U
-struct vcpuid_entry {
-	uint32_t eax;
-	uint32_t ebx;
-	uint32_t ecx;
-	uint32_t edx;
-	uint32_t leaf;
-	uint32_t subleaf;
-	uint32_t flags;
-	uint32_t padding;
-};
 
 struct acrn_vm {
 	struct vm_arch arch_vm; /* Reference to this VM's arch information */

--- a/hypervisor/include/arch/x86/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/guest/vmcs.h
@@ -11,6 +11,7 @@
 #define VM_FAIL		-1
 
 #ifndef ASSEMBLER
+#include <vmx.h>
 
 #define VMX_VMENTRY_FAIL	0x80000000U
 

--- a/hypervisor/include/arch/x86/hv_arch.h
+++ b/hypervisor/include/arch/x86/hv_arch.h
@@ -30,7 +30,6 @@
 #include <vioapic.h>
 #include <vm.h>
 #include <cpuid.h>
-#include <vcpuid.h>
 #include <page.h>
 #include <ept.h>
 #include <mmu.h>

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -53,6 +53,7 @@
 /* IA32E Paging constants */
 #define IA32E_REF_MASK	((get_cpu_info())->physical_address_mask)
 
+struct acrn_vcpu;
 static inline uint64_t round_page_up(uint64_t addr)
 {
 	return (((addr + (uint64_t)PAGE_SIZE) - 1UL) & PAGE_MASK);

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -7,6 +7,8 @@
 #ifndef TIMER_H
 #define TIMER_H
 
+#include <list.h>
+
 /**
  * @brief Timer
  *

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -8,6 +8,7 @@
 #define TIMER_H
 
 #include <list.h>
+#include <rtl.h>
 
 /**
  * @brief Timer

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -6,6 +6,7 @@
 
 #ifndef VTD_H
 #define VTD_H
+#include <ptdev.h>
 /*
  * Intel IOMMU register specification per version 1.0 public spec.
  */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -6,6 +6,7 @@
 
 #ifndef SCHEDULE_H
 #define SCHEDULE_H
+#include <spinlock.h>
 
 #define	NEED_RESCHEDULE		(1U)
 #define	NEED_OFFLINE		(2U)

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -38,6 +38,7 @@
  */
 
 #include <apicreg.h>
+#include <util.h>
 
 #define	VIOAPIC_BASE	0xFEC00000UL
 #define	VIOAPIC_SIZE	4096UL

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -95,6 +95,13 @@
 #define NR_VPIC_PINS_PER_CHIP	8U
 #define NR_VPIC_PINS_TOTAL	16U
 
+enum vpic_wire_mode {
+	VPIC_WIRE_INTR = 0,
+	VPIC_WIRE_LAPIC,
+	VPIC_WIRE_IOAPIC,
+	VPIC_WIRE_NULL
+};
+
 enum vpic_trigger {
 	EDGE_TRIGGER,
 	LEVEL_TRIGGER


### PR DESCRIPTION
hypervisor.h is an universal set of header file for HV,
most modules include this header file, actually some header files
are not necessary,we will remove hypervisor.h in future, these two patches
are only for vm and vpu modules cleanup.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>