### PR TITLE
HV: Remove snoopy_mem from iommu

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -7,6 +7,7 @@
 #include <hypervisor.h>
 
 #include <instr_emul.h>
+#include <vtd.h>
 
 #define ACRN_DBG_EPT	6U
 
@@ -106,7 +107,7 @@ void ept_mr_add(struct acrn_vm *vm, uint64_t *pml4_page,
 	 * to force snooping of PCIe devices if the page
 	 * is cachable
 	 */
-	if (((prot & EPT_MT_MASK) != EPT_UNCACHED) && vm->snoopy_mem) {
+	if (((prot & EPT_MT_MASK) != EPT_UNCACHED) && iommu_snoop_supported(vm->iommu)) {
 		prot |= EPT_SNOOP_CTRL;
 	}
 
@@ -127,7 +128,7 @@ void ept_mr_modify(struct acrn_vm *vm, uint64_t *pml4_page,
 
 	dev_dbg(ACRN_DBG_EPT, "%s,vm[%d] gpa 0x%llx size 0x%llx\n", __func__, vm->vm_id, gpa, size);
 
-	if (((local_prot & EPT_MT_MASK) != EPT_UNCACHED) && vm->snoopy_mem) {
+	if (((local_prot & EPT_MT_MASK) != EPT_UNCACHED) && iommu_snoop_supported(vm->iommu)) {
 		local_prot |= EPT_SNOOP_CTRL;
 	}
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -272,7 +272,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	vm->vm_id = vm_id;
 	vm->hw.created_vcpus = 0U;
 	vm->emul_mmio_regions = 0U;
-	vm->snoopy_mem = true;
 
 	init_ept_mem_ops(vm);
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);
@@ -280,7 +279,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 
 	if (is_sos_vm(vm)) {
 		/* Only for SOS_VM */
-		vm->snoopy_mem = false;
 		create_sos_vm_e820(vm);
 		prepare_sos_vm_memmap(vm);
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1066,7 +1066,6 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 	struct dmar_context_entry *context_entry;
 	uint64_t upper;
 	uint64_t lower = 0UL;
-	struct acrn_vm *vm;
 	int32_t ret = 0;
 
 	dmar_unit = device_to_dmaru(segment, bus, devfun);
@@ -1080,10 +1079,6 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 		ret = -EINVAL;
 	} else {
 		if (iommu_ecap_sc(dmar_unit->ecap) == 0U) {
-			vm = get_vm_from_vmid(domain->vm_id);
-			if (vm != NULL) {
-				vm->snoopy_mem = false;
-			}
 			/* TODO: remove iommu_snoop from iommu_domain */
 			domain->iommu_snoop = false;
 			dev_dbg(ACRN_DBG_IOMMU, "vm=%d add %x:%x no snoop control!", domain->vm_id, bus, devfun);
@@ -1266,6 +1261,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 		domain->trans_table_ptr = translation_table;
 		domain->addr_width = addr_width;
 		domain->is_tt_ept = true;
+		domain->iommu_snoop = true;
 
 		dev_dbg(ACRN_DBG_IOMMU, "create domain [%d]: vm_id = %hu, ept@0x%x",
 			vmid_to_domainid(domain->vm_id), domain->vm_id, domain->trans_table_ptr);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -156,7 +156,6 @@ struct acrn_vm {
 	spinlock_t softirq_dev_lock;
 	struct list_head softirq_dev_entry_list;
 	uint64_t intr_inject_delay_delta; /* delay of intr injection */
-	bool snoopy_mem;
 } __aligned(PAGE_SIZE);
 
 #define MAX_BOOTARGS_SIZE	1024U


### PR DESCRIPTION
Removed the remaining reference of acrn vm from
inside of vtd.c.
Removed usage of snoopy_mem, and added code to achieve
the same using iommu_snoop.
Initialize iommu_snoop to true in create default iommu.

Tracked-On: #2496
Signed-off-by: Arindam Roy <arindam.roy@intel.com>