### PR TITLE
script: remove enable_initial_modeset for UP2 platform

### DIFF
--- a/devicemodel/samples/up2/sos_bootargs_debug.txt
+++ b/devicemodel/samples/up2/sos_bootargs_debug.txt
@@ -6,7 +6,6 @@ loglevel=7
 consoleblank=0
 root=/dev/mmcblk0p1 rw rootwait
 i915.nuclear_pageflip=1
-i915.enable_initial_modeset=1
 i915.avail_planes_per_pipe=0x01010F
 i915.domain_plane_owners=0x011111110000
 i915.enable_gvt=1

--- a/devicemodel/samples/up2/sos_bootargs_release.txt
+++ b/devicemodel/samples/up2/sos_bootargs_release.txt
@@ -6,7 +6,6 @@ loglevel=7
 consoleblank=0
 root=/dev/mmcblk0p1 rw rootwait
 i915.nuclear_pageflip=1
-i915.enable_initial_modeset=1
 i915.avail_planes_per_pipe=0x01010F
 i915.domain_plane_owners=0x011111110000
 i915.enable_gvt=1


### PR DESCRIPTION
For UP2 releases, we don't need enable_initial_modeset, just as the NUC
platforms, so remove this parameter from the boot args.

Tracked-On: #2516
Signed-off-by: Min He <min.he@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>