### PR TITLE
acrn.conf: clean-up SOS kernel options (EFI platforms)

### DIFF
--- a/doc/tutorials/agl-vms.rst
+++ b/doc/tutorials/agl-vms.rst
@@ -217,11 +217,10 @@ Service OS
       linux
       /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.0-19
 
-      options pci_devices_ignore=(0:18:1) console=tty0 console=ttyS0 i915.nuclear_pageflip=1
-      root=/dev/sda3
-      rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000
-      i915.avail_planes_per_pipe=0x00000F i915.domain_plane_owners=0x022211110000
-      i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_initial_modeset=1 i915.enable_guc=0 hvlog=2M@0x1FE00000
+      options pci_devices_ignore=(0:18:1) console=tty0 console=ttyS0
+      root=/dev/sda3 rw rootwait ignore_loglevel no_timer_check consoleblank=0
+      i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x00000F i915.domain_plane_owners=0x022211110000
+      i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000
 
 #. Set a longer timeout::
 

--- a/doc/tutorials/skl-nuc.rst
+++ b/doc/tutorials/skl-nuc.rst
@@ -90,7 +90,7 @@ Please follow the :ref:`getting-started-apl-nuc`, with the following changes:
       # vim /mnt/loader/entries/acrn.conf
       title The ACRN Service OS
       linux   /EFI/org.clearlinux/kernel-org.clearlinux.pk414-sos.4.14.68-99
-      options pci_devices_ignore=(0:18:1) console=tty0 console=ttyS2 i915.nuclear_pageflip=1 root=/dev/nvme0n1p3 rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_initial_modeset=0 i915.enable_guc=0 hvlog=2M@0x1FE00000
+      options pci_devices_ignore=(0:18:1) console=tty0 console=ttyS2 root=/dev/nvme0n1p3 rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000
 
 #. Don't Enable weston service (skip this step found in the NUC's getting
    started guide).

--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -173,7 +173,7 @@ You can download latest Service OS kernel from
                 insmod gzio
                 insmod part_gpt
                 insmod ext2
-                linux  /boot/acrn/org.clearlinux.iot-lts2018-sos.4.19.0-22  pci_devices_ignore=(0:18:1)  console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_initial_modeset=1 hvlog=2M@0x1FE00000
+                linux  /boot/acrn/org.clearlinux.iot-lts2018-sos.4.19.0-22  pci_devices_ignore=(0:18:1) console=tty0 console=ttyS0 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000
         }
 
    .. note::

--- a/efi-stub/clearlinux/acrn.conf
+++ b/efi-stub/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title The ACRN Service OS
 linux   /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.13-1901141830
-options console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000
+options console=tty0 console=ttyS0 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000


### PR DESCRIPTION
- Remove some i915 options that are obsolete and irrelevant for the
Service OS kernel
- Adjust the plane assignment to make them consistent
- Update to the latest iot-lts2018 kernel version

Tracked-On: #2518
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>