### PR TITLE
Documentation: tweak GSG (and acrn.conf)

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -121,11 +121,11 @@ partition. Follow these steps:
 
       $ sudo ls -1 /boot/EFI/org.clearlinux
       bootloaderx64.efi
-      kernel-org.clearlinux.native.4.20.2-683
-      kernel-org.clearlinux.iot-lts2018-sos.4.19.13-1901141830
-      kernel-org.clearlinux.iot-lts2018.4.19.13-1901141830
-      kernel-org.clearlinux.pk414-sos.4.14.74-115
+      kernel-org.clearlinux.iot-lts2018.4.19.19-8
+      kernel-org.clearlinux.iot-lts2018-sos.4.19.19-8
+      kernel-org.clearlinux.native.4.20.7-694
       loaderx64.efi
+
 
    .. note::
       On Clear Linux OS, the EFI System Partion (e.g.: ``/dev/sda1``) is mounted under ``/boot`` by default
@@ -232,7 +232,13 @@ partition. Follow these steps:
    (``root=PARTUUID=<UUID of rootfs partition>``) in the ``options`` section, and
    add the ``hugepagesz=1G hugepages=2`` at end of the ``options`` section.
 
-   Use ``blkid`` to find out what your ``/dev/sda3`` ``PARTUUID`` value is.
+   Use ``blkid`` to find out what your ``/dev/sda3`` ``PARTUUID`` value is. Here
+   is a handy one-line command to do that:
+
+   .. code-block:: none
+
+      # sed -i "s/<UUID of rootfs partition>/`blkid -s PARTUUID -o value \
+                     /dev/sda3`/g" /boot/loader/entries/acrn.conf
 
    .. note::
       It is also possible to use the device name directly, e.g. ``root=/dev/sda3``
@@ -254,9 +260,9 @@ partition. Follow these steps:
       :caption: ACRN Service OS Boot Menu
 
       => The ACRN Service OS
-      Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-4.19.13-1901141830)
-      Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-sos-4.19.13-1901141830)
-      Clear Linux OS for Intel Architecture (Clear-linux-native.4.20.2-683)
+      Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-4.19.19-8)
+      Clear Linux OS for Intel Architecture (Clear-linux-iot-lts2018-sos-4.19.19-8)
+      Clear Linux OS for Intel Architecture (Clear-linux-native.4.20.7-694)
       EFI Default Loader
       Reboot Into Firmware Interface
 

--- a/efi-stub/clearlinux/acrn.conf
+++ b/efi-stub/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title The ACRN Service OS
-linux   /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.13-1901141830
+linux   /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.19-8
 options console=tty0 console=ttyS0 i915.nuclear_pageflip=1 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.tsd_init=7 i915.tsd_delay=2000 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_guc_loading=0 i915.enable_guc_submission=0 i915.enable_preemption=1 i915.context_priority_mode=2 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000


### PR DESCRIPTION
* Update kernel versions to the latest (to reflect the new 'release'
  number used in the 'iot-lts2018' kernel
* Add a one-line command to insert the PARTUUID into the acrn.conf
  file (without copying it all manually)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>