### PR TITLE
hv: add new hypercall to fetch platform configurations

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -40,6 +40,10 @@ static int32_t dispatch_hypercall(struct acrn_vcpu *vcpu)
 		ret = hcall_get_api_version(vm, param1);
 		break;
 
+	case HC_GET_PLATFORM_INFO:
+		ret = hcall_get_platform_info(vm, param1);
+		break;
+
 	case HC_SET_CALLBACK_VECTOR:
 		ret = hcall_set_callback_vector(vm, param1);
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -103,6 +103,33 @@ int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param)
 }
 
 /**
+ * @brief Get basic platform information.
+ *
+ * The function returns basic hardware or configuration information
+ * for the current platform.
+ *
+ * @param vm Pointer to VM data structure.
+ * @param param GPA pointer to struct hc_platform_info.
+ *
+ * @pre Pointer vm shall point to SOS_VM
+ * @return 0 on success, -1 in case of error.
+ */
+int32_t hcall_get_platform_info(struct acrn_vm *vm, uint64_t param)
+{
+	int32_t ret = 0;
+	struct hc_platform_info platform_info;
+
+	platform_info.cpu_num = get_pcpu_nums();
+	platform_info.max_vcpus_per_vm = CONFIG_MAX_VCPUS_PER_VM;
+	if (copy_to_gpa(vm, &platform_info, param, sizeof(platform_info)) != 0) {
+		pr_err("%s: Unable copy param to vm\n", __func__);
+		ret = -1;
+	}
+
+	return ret;
+}
+
+/**
  * @brief create virtual machine
  *
  * Create a virtual machine based on parameter, currently there is no

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -51,6 +51,21 @@ int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid);
  */
 int32_t hcall_get_api_version(struct acrn_vm *vm, uint64_t param);
 
+
+/**
+ * @brief Get basic platform information.
+ *
+ * The function returns basic hardware or configuration information
+ * for the current platform.
+ *
+ * @param vm Pointer to VM data structure.
+ * @param param GPA pointer to struct hc_platform_info.
+ *
+ * @pre Pointer vm shall point to SOS_VM
+ * @return 0 on success, -1 in case of error.
+ */
+int32_t hcall_get_platform_info(struct acrn_vm *vm, uint64_t param);
+
 /**
  * @brief create virtual machine
  *

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -28,6 +28,7 @@
 #define HC_GET_API_VERSION          BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x00UL)
 #define HC_SOS_OFFLINE_CPU          BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x01UL)
 #define HC_SET_CALLBACK_VECTOR      BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x02UL)
+#define HC_GET_PLATFORM_INFO        BASE_HC_ID(HC_ID, HC_ID_GEN_BASE + 0x03UL)
 
 /* VM management */
 #define HC_ID_VM_BASE               0x10UL
@@ -279,6 +280,25 @@ struct hc_api_version {
 
 	/** hypervisor api minor version */
 	uint32_t minor_version;
+} __aligned(8);
+
+/**
+ * Hypervisor API, return it for HC_GET_PLATFORM_INFO hypercall
+ */
+struct hc_platform_info {
+	/** Hardware Information */
+	/** Physical CPU number */
+	uint16_t cpu_num;
+
+	/** Align the size of version & hardware info to 128Bytes. */
+	uint8_t reserved0[126];
+
+	/** Configuration Information */
+	/** Maximum vCPU number for one VM. */
+	uint16_t max_vcpus_per_vm;
+
+	/** Align the size of Configuration info to 128Bytes. */
+	uint8_t reserved1[126];
 } __aligned(8);
 
 /**


### PR DESCRIPTION
 to wrap hypercalls that get platform information,
 such as API version, physical CPU number.

Tracked-On: #2538
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>