### PR TITLE
vmcall handling fix

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -192,14 +192,14 @@ int32_t vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 	/* hypercall ID from guest*/
 	uint64_t hypcall_id = vcpu_get_gpreg(vcpu, CPU_REG_R8);
 
-	if (!is_hypercall_from_ring0()) {
-		pr_err("hypercall is only allowed from RING-0!\n");
-	        ret = -EACCES;
-	} else if (!is_sos_vm(vm) && (hypcall_id != HC_WORLD_SWITCH) &&
+	if (!is_sos_vm(vm) && (hypcall_id != HC_WORLD_SWITCH) &&
 		(hypcall_id != HC_INITIALIZE_TRUSTY) &&
 		(hypcall_id != HC_SAVE_RESTORE_SWORLD_CTX)) {
 		vcpu_inject_ud(vcpu);
 		pr_err("hypercall %d is only allowed from SOS_VM!\n", hypcall_id);
+	        ret = -EACCES;
+	} else if (!is_hypercall_from_ring0()) {
+		pr_err("hypercall is only allowed from RING-0!\n");
 	        ret = -EACCES;
 	} else {
 		/* Dispatch the hypercall handler */

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -197,16 +197,15 @@ int32_t vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 		(hypcall_id != HC_SAVE_RESTORE_SWORLD_CTX)) {
 		vcpu_inject_ud(vcpu);
 		pr_err("hypercall %d is only allowed from SOS_VM!\n", hypcall_id);
-	        ret = -EACCES;
 	} else if (!is_hypercall_from_ring0()) {
 		pr_err("hypercall is only allowed from RING-0!\n");
 	        ret = -EACCES;
+		vcpu_set_gpreg(vcpu, CPU_REG_RAX, (uint64_t)ret);
 	} else {
 		/* Dispatch the hypercall handler */
 		ret = dispatch_hypercall(vcpu);
+		vcpu_set_gpreg(vcpu, CPU_REG_RAX, (uint64_t)ret);
 	}
-
-	vcpu_set_gpreg(vcpu, CPU_REG_RAX, (uint64_t)ret);
 
 	TRACE_2L(TRACE_VMEXIT_VMCALL, vm->vm_id, hypcall_id);
 


### PR DESCRIPTION
ACRN HV hide VMX capability from guest. Only vmcall from SOS or some
specific vmcall from UOS are allowed.
Unsupported vmcall from UOS should be considered a "not in VMX
operation" case, and should be handled first according to SDM Vol. 3C 30-9.

HV passes the return value of vmcall by register RAX unconditionally.
However, if the vmcall is undefined for a guest, RAX value of guest vcpu
should not be changed.

According to SDM Vol. 3C 30-9, VMCALL is allowed from any CPL in guest.
VMCALL is NOT allowed from  CPL > 0 in vmx root mode.
ACRN hypervisor doesn't call VMCALL in vmx root mode, though.
In current code, ACRN also deny VMCALL from CPL > 0 in guest.
So for this case, #GP will not be injected, instead, modify the RAX to notify
the return value.

Tracked-On: #2405
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>