### PR TITLE
hv: vlapic: properly initialize DCR

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1758,6 +1758,7 @@ vlapic_reset(struct acrn_vlapic *vlapic)
 
 	lapic->icr_timer.v = 0U;
 	lapic->dcr_timer.v = 0U;
+	vlapic_dcr_write_handler(vlapic);
 	vlapic_reset_timer(vlapic);
 
 	vlapic->svr_last = lapic->svr.v;
@@ -1809,6 +1810,7 @@ void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs)
 	lapic->icr_timer = regs->icr_timer;
 	lapic->ccr_timer = regs->ccr_timer;
 	lapic->dcr_timer = regs->dcr_timer;
+	vlapic_dcr_write_handler(vlapic);
 }
 
 static uint64_t


### PR DESCRIPTION
DCR is initialized to 0 which means divisor shift is 1. Currently, both are initialized to 0 which result in incorrect APIC timer counts if the vLAPIC's DCR is never programmed.

This bug was exposed by OVMF because OVMF does not program DCR during LAPIC initialization.

Tracked-On: #2543
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>