### PR TITLE
hv: isrvec_stk_top could be zero once we enable APICv

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -887,15 +887,14 @@ vlapic_process_eoi(struct acrn_vlapic *vlapic)
 		i--;
 		bitpos = (uint32_t)fls32(isrptr[i].v);
 		if (bitpos != INVALID_BIT_INDEX) {
-			if (vlapic->isrvec_stk_top == 0U) {
-				panic("invalid vlapic isrvec_stk_top %u",
-					vlapic->isrvec_stk_top);
-			}
 			isrptr[i].v &= ~(1U << bitpos);
 			vector = (i * 32U) + bitpos;
 			dev_dbg(ACRN_DBG_LAPIC, "EOI vector %u", vector);
 			vlapic_dump_isr(vlapic, "vlapic_process_eoi");
-			vlapic->isrvec_stk_top--;
+			if (vlapic->isrvec_stk_top != 0U) {
+				vlapic->isrvec_stk_top--;
+			}
+
 			vlapic_update_ppr(vlapic);
 			if ((tmrptr[i].v & (1U << bitpos)) != 0U) {
 				/* hook to vIOAPIC */


### PR DESCRIPTION
With APICv enabled, it's possible that the interrupt is not
injected through VMX_ENTRY_INT_INFO_FIELD. In that case, the
isrvec_stk_top will not be increased.

Tracked-On: #2558
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>