### PR TITLE
hv: pae: fix bug when calculate PDPT address

### DIFF
--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -206,7 +206,7 @@ static int32_t local_gva2gpa_pae(struct acrn_vcpu *vcpu, struct page_walk_info *
 	uint64_t addr;
 	int32_t ret = -EFAULT;
 
-	addr = pw_info->top_entry & 0xFFFFFFF0U;
+	addr = get_pae_pdpt_addr(pw_info->top_entry);
 	base = (uint64_t *)gpa2hva(vcpu->vm, addr);
 	if (base != NULL) {
 		index = (gva >> 30U) & 0x3UL;

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -267,7 +267,7 @@ static void vmx_write_cr4(struct acrn_vcpu *vcpu, uint64_t cr4)
 		uint64_t old_cr4 = vcpu_get_cr4(vcpu);
 
 		if (((cr4 ^ old_cr4) & (CR4_PGE | CR4_PSE | CR4_PAE | CR4_SMEP | CR4_SMAP | CR4_PKE)) != 0UL) {
-			if (((cr4 & CR4_PAE) != 0UL) && (is_paging_enabled(vcpu)) && (is_long_mode(vcpu))) {
+			if (((cr4 & CR4_PAE) != 0UL) && (is_paging_enabled(vcpu)) && (!is_long_mode(vcpu))) {
 				load_pdptrs(vcpu);
 			}
 

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -34,7 +34,7 @@ static void load_pdptrs(const struct acrn_vcpu *vcpu)
 {
 	uint64_t guest_cr3 = exec_vmread(VMX_GUEST_CR3);
 	/* TODO: check whether guest cr3 is valid */
-	uint64_t *guest_cr3_hva = (uint64_t *)gpa2hva(vcpu->vm, guest_cr3);
+	uint64_t *guest_cr3_hva = (uint64_t *)gpa2hva(vcpu->vm, get_pae_pdpt_addr(guest_cr3));
 
 	stac();
 	exec_vmwrite64(VMX_GUEST_PDPTE0_FULL, get_pgentry(guest_cr3_hva + 0UL));

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -175,6 +175,11 @@ static inline void clflush(volatile void *p)
 	asm volatile ("clflush (%0)" :: "r"(p));
 }
 
+/* get PDPT address from CR3 vaule in PAE mode */
+static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)
+{
+	return (cr3 & 0xFFFFFFE0UL);
+}
 
 /**
  * @}


### PR DESCRIPTION
There are two bugs related to PDPT address calculation for PAE mode.

1. Current code doesn't ignore the "Ignored" fileds when load pdpt registers.
Mask the "Ignored" fileds according to SDM Figure 4-7 Vol3.

2. Current code only ignores 4bits instead of 5bits in low "Ignored" filed when
calculate PDPT address in PAE mode for guest memory address translation.

Another issue, PDPTE registers should be loaded for PAE paging mode when handling guest CR4.

Tracked-On: #2561
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>