### PR TITLE
hv: exception: fault type exception should set resume flag in rflags

### DIFF
--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -107,6 +107,7 @@ uint32_t irq_to_vector(uint32_t irq);
 
 /* RFLAGS */
 #define HV_ARCH_VCPU_RFLAGS_IF              (1UL<<9U)
+#define HV_ARCH_VCPU_RFLAGS_RF              (1UL<<16U)
 
 /* Interruptability State info */
 #define HV_ARCH_VCPU_BLOCKED_BY_MOVSS       (1UL<<1U)


### PR DESCRIPTION
According to SDM 17.3.1.1, for any fault-class exception except a
debug exception generated in response to an instruction breakpoint,
the value pushed for RF is 1.

This patch set Resume Flag for fault class exceptions.

Tracked-On: #2405
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>