### PR TITLE
dm: split out offline cpu from launch script for dm booting

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -153,7 +153,9 @@ DISTCLEAN_OBJS := $(shell find $(BASEDIR) -name '*.o')
 PROGRAM := acrn-dm
 
 SAMPLES_NUC := $(wildcard samples/nuc/*)
+SAMPLES_UP2 := $(wildcard samples/up2/*)
 SAMPLES_MRB := $(wildcard samples/apl-mrb/*)
+COMMON_SH := $(wildcard samples/apl-mrb/offline_cpu.sh)
 
 BIOS_BIN := $(wildcard bios/*)
 
@@ -205,11 +207,17 @@ $(DM_OBJDIR)/%.o: %.c $(HEADERS)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \
 	$(CC) $(CFLAGS) -c $< -o $@
 
-install: $(DM_OBJDIR)/$(PROGRAM) install-samples-nuc install-samples-mrb install-bios install-vmcfg
+install: $(DM_OBJDIR)/$(PROGRAM) install-common install-samples-nuc install-samples-up2 install-samples-mrb install-bios install-vmcfg
 	install -D --mode=0755 $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)/usr/bin/$(PROGRAM)
+
+install-common: $(COMMON_SH)
+	install -D -t $(DESTDIR)/usr/share/acrn/samples/common $^
 
 install-samples-nuc: $(SAMPLES_NUC)
 	install -D -t $(DESTDIR)/usr/share/acrn/samples/nuc $^
+
+install-samples-up2: $(SAMPLES_UP2)
+	install -D -t $(DESTDIR)/usr/share/acrn/samples/up2 $^
 
 install-samples-mrb: $(SAMPLES_MRB)
 	install -D -t $(DESTDIR)/usr/share/acrn/samples/apl-mrb $^

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -955,6 +955,8 @@ dm_run(int argc, char *argv[])
 
 		write_kmsg("%s smbios_build end---\n", KMSG_FMT);
 
+		error = system("/usr/share/acrn/samples/common/offline_cpu.sh");
+
 		if (acpi) {
 			error = acpi_build(ctx, guest_ncpus);
 			if (error)

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -438,26 +438,6 @@ if [ $launch_type == 6 ]; then
 	fi
 fi
 
-echo "dm_run: before offline cpu" > /dev/kmsg
-# offline SOS CPUs except BSP before launch UOS
-for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
-        online=`cat $i/online`
-        idx=`echo $i | tr -cd "[1-99]"`
-        echo cpu$idx online=$online
-        if [ "$online" = "1" ]; then
-                echo 0 > $i/online
-		online=`cat $i/online`
-		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
-		while [ "$online" = "1" ]; do
-			sleep 0.1
-			echo 0 > $i/online
-			online=`cat $i/online`
-		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
-        fi
-done
-echo "dm_run: after offline cpu" > /dev/kmsg
-
 case $launch_type in
 	1) echo "Launch clearlinux UOS"
 		launch_clearlinux 1 3 "64 448 8" 0x070F00 clearlinux "LaaG" $debug

--- a/devicemodel/samples/apl-mrb/offline_cpu.sh
+++ b/devicemodel/samples/apl-mrb/offline_cpu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "dm_run: before offline cpu" > /dev/kmsg
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+                echo 0 > $i/online
+		online=`cat $i/online`
+		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+		while [ "$online" = "1" ]; do
+			sleep 0.1
+			echo 0 > $i/online
+			online=`cat $i/online`
+		done
+                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
+        fi
+done
+echo "dm_run: after offline cpu" > /dev/kmsg

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -32,21 +32,4 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   i915.enable_guc_submission=0 i915.enable_guc=0" $vm_name
 }
 
-# offline SOS CPUs except BSP before launch UOS
-for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
-        online=`cat $i/online`
-        idx=`echo $i | tr -cd "[1-99]"`
-        echo cpu$idx online=$online
-        if [ "$online" = "1" ]; then
-                echo 0 > $i/online
-		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
-		while [ "$online" = "1" ]; do
-			sleep 1
-			echo 0 > $i/online
-			online=`cat $i/online`
-		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
-        fi
-done
-
 launch_clear 1 1 "64 448 8" 0x070F00

--- a/devicemodel/samples/up2/launch_uos.sh
+++ b/devicemodel/samples/up2/launch_uos.sh
@@ -409,24 +409,6 @@ if [ $launch_type == 6 ]; then
 	fi
 fi
 
-# offline SOS CPUs except BSP before launch UOS
-for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
-        online=`cat $i/online`
-        idx=`echo $i | tr -cd "[1-99]"`
-        echo cpu$idx online=$online
-        if [ "$online" = "1" ]; then
-                echo 0 > $i/online
-		online=`cat $i/online`
-		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
-		while [ "$online" = "1" ]; do
-			sleep 1
-			echo 0 > $i/online
-			online=`cat $i/online`
-		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
-        fi
-done
-
 case $launch_type in
 	1) echo "Launch clearlinux UOS"
 		launch_clearlinux 1 1 "64 448 8" 0x070F00 clearlinux "LaaG" $debug


### PR DESCRIPTION
    dm: split out offline cpu from launch script for dm

    V3-V4:
      1. Use one acrn-dm for different hw platforms.
      2. Install offline_cpu.sh to samples/common/ .

    V2-V3:
      1. Move offline.sh -> offline_cpu.sh
      2. And refine other hw platform script.

    V1-V2:
      1. Aaag sometimes lost adb when stability test, move back tap device.

    V1:
      As the workload much higher when booting, offline cpu operation should
      be delay to speed up booting.
      This patch will split tap device and offline cpu operation from launch_uos and
      trigger them at the proper time to reduce time when booting.

    Tracked-On: #2579
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Reviewed-by: Alek Du <alek.du@intel.com>
    Reviewed-by: Minggui Cao <minggui.cao@intel.com>
    Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>