### PR TITLE
doc: add 0.6 to doc version menu

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,6 +189,7 @@ else:
 html_context = {
    'current_version': current_version,
    'versions': ( ("latest", "/latest/"),
+                 ("0.6", "/0.6/"),
                  ("0.5", "/0.5/"),
                  ("0.4", "/0.4/"),
                  ("0.3", "/0.3/"),


### PR DESCRIPTION
Add the 0.6 version of documentation to the menu list (again)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>