### PR TITLE
hv: debug: mark the mmio address for npk log as hv owned

### DIFF
--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -95,6 +95,9 @@ void npk_log_setup(struct hv_npk_log_param *param)
 				for (i = 0U; i < pcpu_nums; i++) {
 					per_cpu(npk_log_ref, i) = 0U;
 				}
+				hv_access_memory_region_update(base,
+					pcpu_nums * (HV_NPK_LOG_REF_MASK + 1U)
+					* sizeof(struct npk_chan));
 			}
 			param->res = HV_NPK_LOG_RES_OK;
 			npk_log_enabled = 1;


### PR DESCRIPTION
Otherwise, page fault will be triggered when writing npk log
to these mmio addresses.

Tracked-On: #2589
Signed-off-by: Zhi Jin <zhi.jin@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>