### PR TITLE
tools: do not include unnecessary files in release build

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,11 +1,12 @@
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
+RELEASE ?= 0
 
 .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
 ifeq ($(RELEASE),0)
 all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
 else
-all: acrnlog acrn-manager acrntrace acrnbridge
+all: acrn-manager acrnbridge
 endif
 
 acrn-crashlog:
@@ -35,7 +36,7 @@ clean:
 ifeq ($(RELEASE),0)
 install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
 else
-install: acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
+install: acrn-manager-install acrnbridge-install
 endif
 
 acrn-crashlog-install:

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -1,6 +1,7 @@
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
+RELEASE ?= 0
 
 MANAGER_CFLAGS := -g -O0 -std=gnu11
 MANAGER_CFLAGS += -D_GNU_SOURCE
@@ -50,7 +51,11 @@ MANAGER_LDFLAGS += -lacrn-mngr
 MANAGER_LDFLAGS += $(LDFLAGS)
 
 .PHONY: all
+ifeq ($(RELEASE),0)
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnctl $(OUT_DIR)/acrnd
+else
+all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnd
+endif
 
 $(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h
 	$(CC) $(MANAGER_CFLAGS) -c acrn_mngr.c -o $(OUT_DIR)/acrn_mngr.o
@@ -83,12 +88,14 @@ ifneq ($(OUT_DIR),.)
 endif
 
 .PHONY: install
-install: $(OUT_DIR)/acrnctl $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/libacrn-mngr.a
+install:
 	install -d $(DESTDIR)/usr/bin
 	install -d $(DESTDIR)/usr/lib/systemd/system
 	install -d $(DESTDIR)/usr/lib64/
 	install -d $(DESTDIR)/usr/include/acrn
+ifeq ($(RELEASE),0)
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnctl
+endif
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnd
 	install -t $(DESTDIR)/usr/lib64/ $(OUT_DIR)/libacrn-mngr.a
 	install -t $(DESTDIR)/usr/include/acrn $(OUT_DIR)/acrn_mngr.h


### PR DESCRIPTION
This commit removes the unnecessary tool files in release build, including:
- entire acrnlog module
- entire acrntrace module
- acrnctl binary in acrn-manager

Tracked-On: #2575
Signed-off-by: Yan, Like <like.yan@intel.com>
Reviewed-by: Huang, Yonghua <yonghua.huang@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>