### PR TITLE
DM USB: xHCI: fix an error logic in DRD logic

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1245,9 +1245,6 @@ pci_xhci_usbcmd_write(struct pci_xhci_vdev *xdev, uint32_t cmd)
 		}
 	}
 
-	if (cmd & XHCI_CMD_CRS)
-		if (xdev->pid == XHCI_PCI_DEVICE_ID_INTEL_APL &&
-				xdev->vid == XHCI_PCI_VENDOR_ID_INTEL)
 	cmd &= ~(XHCI_CMD_CSS | XHCI_CMD_CRS);
 	return cmd;
 }


### PR DESCRIPTION
The patch (commit id: b39524e) didn't achieve its purpose completely.
This patch is used to fix it.

Tracked-On: #2557
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>