### PR TITLE
Vlapic: refine some functions to internal

### DIFF
--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -106,9 +106,6 @@ These APIs will finish by making a request for *ACRN_REQUEST_EVENT.*
 .. doxygenfunction:: vlapic_intr_msi
   :project: Project ACRN
 
-.. doxygenfunction:: vlapic_post_intr
-  :project: Project ACRN
-
 .. doxygenfunction:: apicv_get_pir_desc_paddr
   :project: Project ACRN
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -101,6 +101,14 @@ static void vlapic_timer_expired(void *data);
 
 static inline bool is_x2apic_enabled(const struct acrn_vlapic *vlapic);
 
+static inline bool vlapic_enabled(const struct acrn_vlapic *vlapic)
+{
+	const struct lapic_regs *lapic = &(vlapic->apic_page);
+
+	return (((vlapic->msr_apicbase & APICBASE_ENABLED) != 0UL) &&
+			((lapic->svr.v & APIC_SVR_ENABLE) != 0U));
+}
+
 static struct acrn_vlapic *
 vm_lapic_from_vcpu_id(struct acrn_vm *vm, uint16_t vcpu_id)
 {
@@ -1877,22 +1885,6 @@ vlapic_receive_intr(struct acrn_vm *vm, bool level, uint32_t dest, bool phys,
 			}
 		}
 	}
-}
-
-bool
-vlapic_enabled(const struct acrn_vlapic *vlapic)
-{
-	bool ret;
-	const struct lapic_regs *lapic = &(vlapic->apic_page);
-
-	if (((vlapic->msr_apicbase & APICBASE_ENABLED) != 0UL) &&
-			((lapic->svr.v & APIC_SVR_ENABLE) != 0U)) {
-		ret = true;
-	} else {
-	        ret = false;
-	}
-
-	return ret;
 }
 
 /*

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -90,6 +90,8 @@ static inline void vlapic_dump_isr(__unused const struct acrn_vlapic *vlapic, __
 static int32_t
 apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector);
 
+static void apicv_post_intr(uint16_t dest_pcpu_id);
+
 /*
  * Post an interrupt to the vcpu running on 'hostcpu'. This will use a
  * hardware assist if available (e.g. Posted Interrupt) or fall back to
@@ -522,7 +524,7 @@ vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 			 *    it to vCPU in next vmentry.
 			 */
 			bitmap_set_lock(ACRN_REQUEST_EVENT, &vlapic->vcpu->arch.pending_req);
-			vlapic_post_intr(vlapic->vcpu->pcpu_id);
+			apicv_post_intr(vlapic->vcpu->pcpu_id);
 			ret = false;
 		} else {
 			ret = (pending_intr != 0);
@@ -555,7 +557,7 @@ vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
  *
  * @return None
  */
-void vlapic_post_intr(uint16_t dest_pcpu_id)
+static void apicv_post_intr(uint16_t dest_pcpu_id)
 {
 	send_single_ipi(dest_pcpu_id, VECTOR_POSTED_INTR);
 }

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -137,23 +137,6 @@ static uint16_t vm_apicid2vcpu_id(struct acrn_vm *vm, uint32_t lapicid)
 /*
  * @pre vlapic != NULL
  */
-static uint64_t
-vm_active_cpus(const struct acrn_vm *vm)
-{
-	uint64_t dmask = 0UL;
-	uint16_t i;
-	const struct acrn_vcpu *vcpu;
-
-	foreach_vcpu(i, vm, vcpu) {
-		bitmap_set_nolock(vcpu->vcpu_id, &dmask);
-	}
-
-	return dmask;
-}
-
-/*
- * @pre vlapic != NULL
- */
 uint32_t
 vlapic_get_apicid(const struct acrn_vlapic *vlapic)
 {

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -156,20 +156,6 @@ bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint32_t *ve
 void vlapic_get_deliverable_intr(struct acrn_vlapic *vlapic, uint32_t vector);
 
 /**
- * @brief Send notification vector to target pCPU.
- *
- * If APICv Posted-Interrupt is enabled and target pCPU is in non-root mode,
- * pCPU will sync pending virtual interrupts from PIR to vIRR automatically,
- * without VM exit.
- * If pCPU in root-mode, virtual interrupt will be injected in next VM entry.
- *
- * @param[in] dest_pcpu_id Target CPU ID.
- *
- * @return None
- */
-void vlapic_post_intr(uint16_t dest_pcpu_id);
-
-/**
  * @brief Get physical address to PIR description.
  *
  * If APICv Posted-interrupt is supported, this address will be configured

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -242,7 +242,6 @@ void vlapic_free(struct acrn_vcpu *vcpu);
 void vlapic_init(struct acrn_vlapic *vlapic);
 void vlapic_reset(struct acrn_vlapic *vlapic);
 void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs);
-bool vlapic_enabled(const struct acrn_vlapic *vlapic);
 uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);
 void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -14,6 +14,7 @@
 #ifndef ASSEMBLER
 
 #include <types.h>
+#include <bits.h>
 #include <spinlock.h>
 #include <acrn_common.h>
 #include <bsp_extern.h>
@@ -210,6 +211,22 @@ struct acrn_vm_config {
 #endif
 
 } __aligned(8);
+
+/*
+ * @pre vlapic != NULL
+ */
+static inline uint64_t vm_active_cpus(const struct acrn_vm *vm)
+{
+	uint64_t dmask = 0UL;
+	uint16_t i;
+	const struct acrn_vcpu *vcpu;
+
+	foreach_vcpu(i, vm, vcpu) {
+		bitmap_set_nolock(vcpu->vcpu_id, &dmask);
+	}
+
+	return dmask;
+}
 
 /*
  * @pre vcpu_id < CONFIG_MAX_VCPUS_PER_VM


### PR DESCRIPTION
These functions are only used by vlapic, it'd better to refine them as internal function. and remove vlapic un-related function out of vlapic.c

Tracked-On: #1842 
Signed-off-by: Li, Fei1 <fei1.li@intel.com>


