### PR TITLE
VPCI  code bug fix and cleanup

### DIFF
--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -34,17 +34,18 @@
 
 static struct pci_vdev *partition_mode_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf)
 {
-	struct pci_vdev *vdev = NULL;
+	struct pci_vdev *vdev, *tmp;
 	struct acrn_vm_config *vm_config = get_vm_config(vpci->vm->vm_id);
 	int32_t i;
 
+	vdev = NULL;
 	for (i = 0; i < vm_config->pci_ptdev_num; i++) {
-		vdev = &vpci->vm->pci_vdevs[i];
+		tmp = &vpci->vm->pci_vdevs[i];
 
-		if (vdev->vbdf.value == vbdf.value) {
+		if (bdf_is_equal(&(tmp->vbdf), &vbdf)) {
+			vdev = tmp;
 			break;
 		}
-		vdev = NULL;
 	}
 
 	return vdev;

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -67,13 +67,13 @@ static inline bool is_valid_bar(const struct pci_bar *bar)
 	return (is_valid_bar_type(bar) && is_valid_bar_size(bar));
 }
 
-static void partition_mode_pdev_init(struct pci_vdev *vdev)
+static void partition_mode_pdev_init(struct pci_vdev *vdev, union pci_bdf pbdf)
 {
 	struct pci_pdev *pdev_ref;
 	uint32_t idx;
 	struct pci_bar *pbar, *vbar;
 
-	pdev_ref = find_pci_pdev(vdev->pbdf);
+	pdev_ref = find_pci_pdev(pbdf);
 	if (pdev_ref != NULL) {
 		vdev->pdev = pdev_ref;
 
@@ -107,10 +107,9 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 		ptdev_config = vm_config->pci_ptdevs + i;
 		vdev->vpci = vpci;
 		vdev->vbdf.value = ptdev_config->vbdf.value;
-		vdev->pbdf.value = ptdev_config->pbdf.value;
 
 		if (vdev->vbdf.value != 0U) {
-			partition_mode_pdev_init(vdev);
+			partition_mode_pdev_init(vdev, ptdev_config->pbdf);
 			vdev->ops = &pci_ops_vdev_pt;
 		} else {
 			vdev->ops = &pci_ops_vdev_hostbridge;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -35,13 +35,16 @@ static struct pci_vdev sharing_mode_vdev_array[CONFIG_MAX_PCI_DEV_NUM];
 
 struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf)
 {
-	struct pci_vdev *vdev = NULL;
+	struct pci_vdev *vdev, *tmp;
 	uint32_t i;
 
+	vdev = NULL;
 	/* SOS_VM uses phys BDF */
 	for (i = 0U; i < num_pci_vdev; i++) {
-		if (sharing_mode_vdev_array[i].pdev->bdf.value == pbdf.value) {
-			vdev = &sharing_mode_vdev_array[i];
+		tmp = &sharing_mode_vdev_array[i];
+		if ((tmp->pdev != NULL) && bdf_is_equal((union pci_bdf*)&(tmp->pdev->bdf), &pbdf)) {
+			vdev = tmp;
+			break;
 		}
 	}
 

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -38,7 +38,7 @@ struct pci_vdev *sharing_mode_find_vdev(union pci_bdf pbdf)
 	struct pci_vdev *vdev = NULL;
 	uint32_t i;
 
-	/* in SOS_VM, it uses phys BDF */
+	/* SOS_VM uses phys BDF */
 	for (i = 0U; i < num_pci_vdev; i++) {
 		if (sharing_mode_vdev_array[i].pdev->bdf.value == pbdf.value) {
 			vdev = &sharing_mode_vdev_array[i];
@@ -69,7 +69,7 @@ static void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf 
 			}
 		}
 
-		/* Not handled by any handlers. Passthru to physical device */
+		/* Not handled by any handlers, passthru to physical device */
 		if (!handled) {
 			*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
 		}
@@ -94,7 +94,7 @@ static void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf
 				}
 			}
 
-			/* Not handled by any handlers. Passthru to physical device */
+			/* Not handled by any handlers, passthru to physical device */
 			if (!handled) {
 				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 			}
@@ -139,7 +139,7 @@ static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
 	int32_t ret;
 
 	/*
-	 * Only setup IO bitmap for SOS.
+	 * Only set up IO bitmap for SOS.
 	 * IO/MMIO requests from non-sos_vm guests will be injected to device model.
 	 */
 	if (!is_sos_vm(vm)) {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -124,7 +124,7 @@ void vpci_init(struct acrn_vm *vm)
 
 	if ((vpci->ops->init != NULL) && (vpci->ops->init(vm) == 0)) {
 		/*
-		 * SOS: intercep port CF8 only.
+		 * SOS: intercept port CF8 only.
 		 * UOS or partition mode: register handler for CF8 only and I/O requests to CF9/CFA/CFB are
 		 *      not handled by vpci.
 		 */

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -407,7 +407,7 @@ struct pci_pdev *find_pci_pdev(union pci_bdf pbdf)
 	uint32_t i;
 
 	for (i = 0U; i < num_pci_pdev; i++) {
-		if (pci_pdev_array[i].bdf.value == pbdf.value) {
+		if (bdf_is_equal(&pci_pdev_array[i].bdf, &pbdf)) {
 			pdev = &pci_pdev_array[i];
 			break;
 		}

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -247,6 +247,7 @@ static uint8_t pci_pdev_read_bar(union pci_bdf bdf, uint8_t idx, struct pci_bar 
 	base = 0UL;
 	size = 0UL;
 	type = pci_pdev_read_bar_type(bdf, idx);
+	bar_hi = 0U;
 
 	if (type != PCIBAR_NONE) {
 		if (type == PCIBAR_IO_SPACE) {
@@ -260,14 +261,13 @@ static uint8_t pci_pdev_read_bar(union pci_bdf bdf, uint8_t idx, struct pci_bar 
 		/* Get the base address */
 		base = (uint64_t)bar_lo & bar_base_mask;
 
-		if (base != 0UL) {
-			if (type == PCIBAR_MEM64) {
-				bar_hi = pci_pdev_read_cfg(bdf, pci_bar_offset(idx + 1U), 4U);
-				base |= ((uint64_t)bar_hi << 32U);
-			}
+		if (type == PCIBAR_MEM64) {
+			bar_hi = pci_pdev_read_cfg(bdf, pci_bar_offset(idx + 1U), 4U);
+			base |= ((uint64_t)bar_hi << 32U);
+		}
 
+		if (base != 0UL) {
 			/* Sizing the BAR */
-			size = 0UL;
 			if ((type == PCIBAR_MEM64) && (idx < (PCI_BAR_COUNT - 1U))) {
 				pci_pdev_write_cfg(bdf, pci_bar_offset(idx + 1U), 4U, ~0U);
 				size = (uint64_t)pci_pdev_read_cfg(bdf, pci_bar_offset(idx + 1U), 4U);

--- a/hypervisor/include/dm/pci.h
+++ b/hypervisor/include/dm/pci.h
@@ -220,6 +220,14 @@ static inline uint8_t pci_devfn(uint16_t bdf)
 	return (uint8_t)(bdf & 0xFFU);
 }
 
+/*
+ * @pre a != NULL && b != NULL
+ */
+static inline bool bdf_is_equal(const union pci_bdf *a, const union pci_bdf *b)
+{
+	return (a->value == b->value);
+}
+
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -91,9 +91,6 @@ struct pci_vdev {
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf vbdf;
 
-	/* The bus/device/function triple of the physical PCI device. */
-	union pci_bdf pbdf;
-
 	struct pci_pdev *pdev;
 
 	union pci_cfgdata cfgdata;


### PR DESCRIPTION
Some vpci code bug fix and cleanup:

pci.c: fixes bar address non-zero checking for 64-bit bars
Fix comments issue
Define function bdf_is_equal() to compare bdf
Remove pbdf from struct pci_vdev

Tracked-On: #2534
Signed-off-by: dongshen <dongsheng.x.zhang@intel.com>