### PR TITLE
ABL seed parse new argument

### DIFF
--- a/hypervisor/boot/sbl/abl_seed_parse.c
+++ b/hypervisor/boot/sbl/abl_seed_parse.c
@@ -22,7 +22,11 @@ struct dev_sec_info {
 	struct abl_seed_info seed_list[ABL_SEED_LIST_MAX];
 };
 
-static const char *dev_sec_info_arg = "dev_sec_info.param_addr=";
+static const char *abl_seed_arg[] = {
+		"ABL.svnseed=",
+		"dev_sec_info.param_addr=",
+		NULL
+};
 
 static void parse_seed_list_abl(void *param_addr)
 {
@@ -103,13 +107,18 @@ bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 	char *arg, *arg_end;
 	char *param;
 	void *param_addr;
-	uint32_t len;
+	uint32_t len, i;
 	bool parse_success = false;
 
 	if (cmdline != NULL) {
 
-		len = strnlen_s(dev_sec_info_arg, MEM_1K);
-		arg = strstr_s((const char *)cmdline, MEM_2K, dev_sec_info_arg, len);
+		for(i = 0U; abl_seed_arg[i] != NULL; i++) {
+			len = strnlen_s(abl_seed_arg[i], MEM_1K);
+			arg = strstr_s((const char *)cmdline, MEM_2K, abl_seed_arg[i], len);
+			if (arg != NULL) {
+				break;
+			}
+		}
 
 		if (arg != NULL) {
 			param = arg + len;
@@ -129,7 +138,7 @@ bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 				/* Convert the param_addr to SOS GPA and copy to caller */
 				if (out_arg != NULL) {
 					snprintf(out_arg, out_len, "%s0x%X ",
-							dev_sec_info_arg, hva2gpa(vm, param_addr));
+							abl_seed_arg[i], hva2gpa(vm, param_addr));
 				}
 
 				parse_success = true;

--- a/hypervisor/boot/sbl/abl_seed_parse.c
+++ b/hypervisor/boot/sbl/abl_seed_parse.c
@@ -30,56 +30,49 @@ static void parse_seed_list_abl(void *param_addr)
 	uint32_t legacy_seed_index = 0U;
 	struct seed_info dseed_list[BOOTLOADER_SEED_MAX_ENTRIES];
 	struct dev_sec_info *sec_info = (struct dev_sec_info *)param_addr;
+	bool parse_success = false;
 
-	if (sec_info == NULL) {
-		goto fail;
-	}
-
-	if (sec_info->num_seeds < 2U ||
-			sec_info->num_seeds > ABL_SEED_LIST_MAX) {
-		goto fail;
-	}
-
-	/*
-	 * The seed_list from ABL contains several seeds which based on SVN
-	 * and one legacy seed which is not based on SVN. The legacy seed's
-	 * svn value is minimum in the seed list. And CSE ensures at least two
-	 * seeds will be generated which will contain the legacy seed.
-	 * Here find the legacy seed index first.
-	 */
-	for (i = 1U; i < sec_info->num_seeds; i++) {
-		if (sec_info->seed_list[i].svn <
-				sec_info->seed_list[legacy_seed_index].svn) {
-			legacy_seed_index = i;
-		}
-	}
-
-	/*
-	 * Copy out abl_seed for trusty and clear the original seed in memory.
-	 * The SOS requires the legacy seed to derive RPMB key. So skip the
-	 * legacy seed when clear original seed.
-	 */
-	(void)memset((void *)dseed_list, 0U, sizeof(dseed_list));
-	for (i = 0U; i < sec_info->num_seeds; i++) {
-		dseed_list[i].cse_svn = sec_info->seed_list[i].svn;
-		(void)memcpy_s((void *)dseed_list[i].seed,
-				sizeof(dseed_list[i].seed),
-				(void *)sec_info->seed_list[i].seed,
-				sizeof(sec_info->seed_list[i].seed));
-
-		if (i == legacy_seed_index) {
-			continue;
+	if ((sec_info != NULL) && (sec_info->num_seeds >= 2U) && (sec_info->num_seeds <= ABL_SEED_LIST_MAX)) {
+		/*
+		 * The seed_list from ABL contains several seeds which based on SVN
+		 * and one legacy seed which is not based on SVN. The legacy seed's
+		 * svn value is minimum in the seed list. And CSE ensures at least two
+		 * seeds will be generated which will contain the legacy seed.
+		 * Here find the legacy seed index first.
+		 */
+		for (i = 1U; i < sec_info->num_seeds; i++) {
+			if (sec_info->seed_list[i].svn < sec_info->seed_list[legacy_seed_index].svn) {
+				legacy_seed_index = i;
+			}
 		}
 
-		(void)memset((void *)sec_info->seed_list[i].seed, 0U,
-				sizeof(sec_info->seed_list[i].seed));
+		/*
+		 * Copy out abl_seed for trusty and clear the original seed in memory.
+		 * The SOS requires the legacy seed to derive RPMB key. So skip the
+		 * legacy seed when clear original seed.
+		 */
+		(void)memset((void *)dseed_list, 0U, (BOOTLOADER_SEED_MAX_ENTRIES * sizeof(struct seed_info)));
+		for (i = 0U; i < sec_info->num_seeds; i++) {
+			dseed_list[i].cse_svn = sec_info->seed_list[i].svn;
+			(void)memcpy_s((void *)dseed_list[i].seed, sizeof(dseed_list[i].seed),
+					(void *)sec_info->seed_list[i].seed, sizeof(sec_info->seed_list[i].seed));
+
+			if (i == legacy_seed_index) {
+				continue;
+			}
+
+			(void)memset((void *)sec_info->seed_list[i].seed, 0U, sizeof(sec_info->seed_list[i].seed));
+		}
+
+		parse_success = true;
 	}
 
-	trusty_set_dseed((void *)dseed_list, (uint8_t)(sec_info->num_seeds));
-	(void)memset((void *)dseed_list, 0U, sizeof(dseed_list));
-	return;
-fail:
-	trusty_set_dseed(NULL, 0U);
+	if (parse_success) {
+		trusty_set_dseed((void *)dseed_list, (uint8_t)(sec_info->num_seeds));
+	} else {
+		trusty_set_dseed(NULL, 0U);
+	}
+
 	(void)memset((void *)dseed_list, 0U, sizeof(dseed_list));
 }
 
@@ -111,45 +104,42 @@ bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 	char *param;
 	void *param_addr;
 	uint32_t len;
+	bool parse_success = false;
 
-	if (cmdline == NULL) {
-		goto fail;
+	if (cmdline != NULL) {
+
+		len = strnlen_s(dev_sec_info_arg, MEM_1K);
+		arg = strstr_s((const char *)cmdline, MEM_2K, dev_sec_info_arg, len);
+
+		if (arg != NULL) {
+			param = arg + len;
+			param_addr = (void *)hpa2hva(strtoul_hex(param));
+			if (param_addr != NULL) {
+				parse_seed_list_abl(param_addr);
+
+				/*
+				 * Replace original arguments with spaces since SOS's GPA is not
+				 * identity mapped to HPA. The argument will be appended later when
+				 * compose cmdline for SOS.
+				 */
+				arg_end = strchr(arg, ' ');
+				len = (arg_end != NULL) ? (uint32_t)(arg_end - arg) : strnlen_s(arg, MEM_2K);
+				(void)memset((void *)arg, ' ', len);
+
+				/* Convert the param_addr to SOS GPA and copy to caller */
+				if (out_arg != NULL) {
+					snprintf(out_arg, out_len, "%s0x%X ",
+							dev_sec_info_arg, hva2gpa(vm, param_addr));
+				}
+
+				parse_success = true;
+			}
+		}
 	}
 
-	len = strnlen_s(dev_sec_info_arg, MEM_1K);
-	arg = strstr_s(cmdline, MEM_2K, dev_sec_info_arg, len);
-
-	if (arg == NULL) {
-		goto fail;
+	if (!parse_success) {
+		parse_seed_list_abl(NULL);
 	}
 
-	param = arg + len;
-	param_addr = (void *)hpa2hva(strtoul_hex(param));
-	if (param_addr == NULL) {
-		goto fail;
-	}
-
-	parse_seed_list_abl(param_addr);
-
-	/*
-	 * Replace original arguments with spaces since SOS's GPA is not
-	 * identity mapped to HPA. The argument will be appended later when
-	 * compose cmdline for SOS.
-	 */
-	arg_end = strchr(arg, ' ');
-	len = (arg_end != NULL) ? (uint32_t)(arg_end - arg) :
-							strnlen_s(arg, MEM_2K);
-	(void)memset((void *)arg, ' ', len);
-
-	/* Convert the param_addr to SOS GPA and copy to caller */
-	if (out_arg != NULL) {
-		snprintf(out_arg, out_len, "%s0x%X ",
-			dev_sec_info_arg, hva2gpa(vm, param_addr));
-	}
-
-	return true;
-
-fail:
-	parse_seed_list_abl(NULL);
-	return false;
+	return parse_success;
 }


### PR DESCRIPTION
Due to ABL design change, it will reword the "dev_sec_info.param_addr="
to "ABL.svnseed" in command line.

Tracked-On: projectacrn#2605
Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Acked-by: Zhu Bing <bing.zhu@intel.com>