### PR TITLE
HV: return an error code when REQ state mismatch in acrn_insert_request

### DIFF
--- a/hypervisor/common/io_req.c
+++ b/hypervisor/common/io_req.c
@@ -95,9 +95,8 @@ int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_
 	int32_t ret = 0;
 	uint16_t cur;
 
-	if (vcpu->vm->sw.io_shared_page != NULL) {
-		ASSERT(get_vhm_req_state(vcpu->vm, vcpu->vcpu_id) == REQ_STATE_FREE,
-			"VHM request buffer is busy");
+	if ((vcpu->vm->sw.io_shared_page != NULL)
+		 && (get_vhm_req_state(vcpu->vm, vcpu->vcpu_id) == REQ_STATE_FREE)) {
 
 		req_buf = (union vhm_request_buffer *)(vcpu->vm->sw.io_shared_page);
 		cur = vcpu->vcpu_id;


### PR DESCRIPTION
This issue is triggered when launch fuzzing test.
Fuzzing test thread will call destroy_vm(IC_DESTROY_VM)
to set the guest vCPU state to VCPU_ZOMBIE then VCPU_INIT
and then VCPU_OFFLINE, it will cause post-work can't resume
the guest vCPU and can't changes the state of the
corresponding I/O request slot to REQ_STATE_FREE.

So replace improper use of ASSERT with return error code.

Tracked-On: #2606
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>