### PR TITLE
S3 implemetation to speed up resuming time

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1820,9 +1820,6 @@ pci_xhci_cmd_disable_slot(struct pci_xhci_vdev *xdev, uint32_t slot)
 			break;
 
 	if (i <= XHCI_MAX_DEVS && XHCI_PORTREG_PTR(xdev, i)) {
-		XHCI_PORTREG_PTR(xdev, i)->portsc &= ~(XHCI_PS_CSC |
-				XHCI_PS_CCS | XHCI_PS_PED | XHCI_PS_PP);
-
 		udev = dev->dev_instance;
 		assert(udev);
 

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1336,9 +1336,6 @@ pci_xhci_portregs_write(struct pci_xhci_vdev *xdev,
 		portsc &= XHCI_PS_PED | XHCI_PS_PLS_MASK |
 			     XHCI_PS_SPEED_MASK | XHCI_PS_PIC_MASK;
 
-		if (XHCI_DEVINST_PTR(xdev, port))
-			p->portsc |= XHCI_PS_CCS;
-
 		portsc |= (value &
 			      ~(XHCI_PS_OCA |
 				XHCI_PS_PR  |

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -592,9 +592,10 @@ usb_dev_native_toggle_if_drivers(struct usb_dev *udev, int attach)
 
 	c = config->bConfigurationValue;
 	for (i = 0; i < config->bNumInterfaces; i++) {
-		if (attach == 1)
+		if (attach == 1) {
+			usb_dev_native_toggle_if(udev, 0);
 			r = libusb_attach_kernel_driver(udev->handle, i);
-		else {
+		} else {
 			if (libusb_kernel_driver_active(udev->handle, i) == 1)
 				r = libusb_detach_kernel_driver(udev->handle,
 						i);

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1054,22 +1054,27 @@ errout:
 }
 
 void
-usb_dev_deinit(void *pdata)
+usb_dev_deinit(void *pdata, bool full)
 {
 	int rc = 0;
 	struct usb_dev *udev;
 
 	udev = pdata;
-	if (udev) {
-		if (udev->handle) {
-			rc = usb_dev_native_toggle_if_drivers(udev, 1);
-			if (rc)
-				UPRINTF(LWRN, "fail to attach if drv rc:%d\r\n",
-						rc);
-			libusb_close(udev->handle);
-		}
+	if (!udev)
+		return;
+
+	if (!udev->handle)
+		goto out;
+
+	rc = usb_dev_native_toggle_if_drivers(udev, 1);
+	if (rc)
+		UPRINTF(LWRN, "fail to attach if drv rc:%d\r\n", rc);
+
+	libusb_close(udev->handle);
+	udev->handle = NULL;
+out:
+	if (full)
 		free(udev);
-	}
 }
 
 int

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -116,7 +116,7 @@ struct usb_devemu {
 	int	(*ue_reset)(void *sc);
 	int	(*ue_remove)(void *sc);
 	int	(*ue_stop)(void *sc);
-	void	(*ue_deinit)(void *pdata);
+	void	(*ue_deinit)(void *pdata, bool full);
 };
 #define	USB_EMUL_SET(x)	DATA_SET(usb_emu_set, x)
 

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -114,7 +114,7 @@ int usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
 		void *hci_data, int log_level);
 void usb_dev_sys_deinit(void);
 void *usb_dev_init(void *pdata, char *opt);
-void usb_dev_deinit(void *pdata);
+void usb_dev_deinit(void *pdata, bool full);
 int usb_dev_info(void *pdata, int type, void *value, int size);
 int usb_dev_request(void *pdata, struct usb_data_xfer *xfer);
 int usb_dev_reset(void *pdata);


### PR DESCRIPTION
This patch set is used to speed up resuming time. The test result shows
it could decrease this time by 500ms ~ 1000ms.
Tracked-On: #2576 
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>