### PR TITLE
DM: Attestation Keybox support in SOS DM

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -87,6 +87,7 @@ SRCS += hw/platform/acpi/acpi.c
 SRCS += hw/platform/acpi/acpi_pm.c
 SRCS += hw/platform/rpmb/rpmb_sim.c
 SRCS += hw/platform/rpmb/rpmb_backend.c
+SRCS += hw/platform/rpmb/att_keybox.c
 SRCS += hw/platform/tpm/tpm_emulator.c
 SRCS += hw/platform/tpm/tpm_crb.c
 SRCS += hw/platform/tpm/tpm.c

--- a/devicemodel/hw/platform/rpmb/att_keybox.c
+++ b/devicemodel/hw/platform/rpmb/att_keybox.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+#include <linux/mei.h>
+#include "att_keybox.h"
+
+static const uuid_le HECI_CLIENT_GUID =
+	UUID_LE(0x8e6a6715, 0x9abc, 0x4043,
+			0x88, 0xef, 0x9e, 0x39, 0xc6, 0xf6, 0x3e, 0x0f);
+
+#define MEI_DEV                     "/dev/mei0"
+#define HECI_READ_ATTKB_GRP_ID      0x0a
+#define HECI_READ_ATTKB_EX_CMD_REQ  0x1a
+#define HECI_MTU 2048
+
+uint16_t get_attkb_size(void)
+{
+	struct mei_connect_client_data mdcd;
+	int fd = -1, ret = 0;
+	HECI_READ_ATTKB_EX_Request req;
+	HECI_READ_ATTKB_EX_Response resp;
+
+	fd = open(MEI_DEV, O_RDWR);
+	if (fd == -1) {
+		fprintf(stderr, "Failed to open %s, %s\n",
+				MEI_DEV, strerror(errno));
+		return 0;
+	}
+
+	memset(&mdcd, 0, sizeof(mdcd));
+	memcpy(&mdcd.in_client_uuid, &HECI_CLIENT_GUID, sizeof(HECI_CLIENT_GUID));
+
+	ret = ioctl(fd, IOCTL_MEI_CONNECT_CLIENT, &mdcd);
+	if (ret) {
+		fprintf(stderr, "HECI connection failed, %s\n",
+				strerror(errno));
+		goto err;
+	}
+
+	/* Get the size of encrypted attestation keybox */
+	memset(&req, 0, sizeof(req));
+	req.header.groupid = HECI_READ_ATTKB_GRP_ID;
+	req.header.command = HECI_READ_ATTKB_EX_CMD_REQ;
+	req.size = 0;
+	req.offset = 0;
+	req.flags.encryption = 1;
+
+	ret = write(fd, &req, sizeof(req));
+	if (ret != sizeof(req)) {
+		fprintf(stderr, "Failed to send HECI command, %s\n",
+				strerror(errno));
+		goto err;
+	}
+
+	ret = read(fd, &resp, sizeof(resp));
+	if (ret != sizeof(resp)) {
+		fprintf(stderr, "ret = %d,Failed to read HECI command result, %d:%s\n",
+				ret, errno, strerror(errno));
+		goto err;
+	}
+
+	if ((resp.header.is_response != 1) || (resp.header.result != 0)) {
+		fprintf(stderr,	"Failed to check resp header = 0x%x\n",
+				resp.header.result);
+		goto err;
+	}
+
+	if (resp.total_file_size == 0) {
+		fprintf(stderr,	"ret = %d, Unexpected filesize 0!\n", ret);
+	}
+
+	close(fd);
+
+	return resp.total_file_size;
+
+err:
+	close(fd);
+	return 0;
+}
+
+uint16_t read_attkb(void *data, uint16_t size)
+{
+	struct mei_connect_client_data mdcd;
+	HECI_READ_ATTKB_EX_Request req;
+	HECI_READ_ATTKB_EX_Response resp;
+	int fd = -1, ret = 0;
+	uint16_t left_size = 0;
+	uint16_t bytes_read = 0;
+	void *ptr = data;
+
+	if ((ptr == NULL) || (size == 0)) {
+		return 0;
+	}
+
+	fd = open(MEI_DEV, O_RDWR);
+	if (fd == -1) {
+		fprintf(stderr, "Failed to open %s, %s\n",
+				MEI_DEV, strerror(errno));
+		return 0;
+	}
+
+	memset(&mdcd, 0, sizeof(mdcd));
+	memcpy(&mdcd.in_client_uuid, &HECI_CLIENT_GUID, sizeof(HECI_CLIENT_GUID));
+
+	ret = ioctl(fd, IOCTL_MEI_CONNECT_CLIENT, &mdcd);
+	if (ret) {
+		fprintf(stderr, "HECI connection failed, %s\n",
+				strerror(errno));
+		goto err;
+	}
+
+	left_size = size;
+
+	memset(&req, 0, sizeof(req));
+	req.header.groupid = HECI_READ_ATTKB_GRP_ID;
+	req.header.command = HECI_READ_ATTKB_EX_CMD_REQ;
+	req.offset = 0;
+	req.size = HECI_MTU > left_size ? left_size : HECI_MTU;
+	req.flags.encryption = 1;
+
+	while (left_size) {
+		req.offset = bytes_read;
+		req.size = HECI_MTU > left_size ? left_size : HECI_MTU;
+
+		ret = write(fd, &req, sizeof(req));
+		if (ret != sizeof(req)) {
+			fprintf(stderr, "Failed to send HECI command, %s\n",
+					strerror(errno));
+			goto err;
+		}
+
+		ret = read(fd, &resp, sizeof(resp));
+		if (ret != sizeof(resp)) {
+			fprintf(stderr, "Failed to read HECI command result, %s\n",
+					strerror(errno));
+			goto err;
+		}
+
+		if ((resp.header.is_response != 1) || (resp.header.result != 0)) {
+			fprintf(stderr,	"Failed to check resp header = 0x%x\n",
+					resp.header.result);
+			goto err;
+		}
+
+		ret = read(fd, (uint8_t *)data + bytes_read, req.size);
+		if (ret != req.size) {
+			fprintf(stderr, "Failed to read attkb, %s\n",
+					strerror(errno));
+			goto err;
+		}
+
+		ptr += ret;
+		bytes_read += ret;
+		left_size -= ret;
+	}
+
+	close(fd);
+
+	return bytes_read;
+
+err:
+	close(fd);
+	return 0;
+}

--- a/devicemodel/include/att_keybox.h
+++ b/devicemodel/include/att_keybox.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ATT_KEYBOX_H
+#define _ATT_KEYBOX_H
+
+typedef struct _HECI_MESSAGE_HEADER {
+	uint32_t  groupid : 8;
+	uint32_t  command : 7;
+	uint32_t  is_response : 1;
+	uint32_t  reserved : 8;
+	uint32_t  result : 8;
+} HECI_MESSAGE_HEADER;
+
+typedef struct
+{
+	HECI_MESSAGE_HEADER    header;
+	/* Size of the whole attkb file, including the added encryption header. */
+	uint16_t               total_file_size;
+	uint16_t               read_offset;
+	/* Size in bytes actually read */
+	uint16_t               read_size;
+	uint16_t               reserved;
+	uint8_t                file_data[];
+} HECI_READ_ATTKB_EX_Response;
+
+typedef struct
+{
+	HECI_MESSAGE_HEADER    header;
+	uint16_t               offset; // Offset in file in bytes.
+	uint16_t               size;   // Size in bytes to read
+	struct
+	{
+		uint32_t encryption : 1;
+		uint32_t reserved   : 31;
+	} flags;
+} HECI_READ_ATTKB_EX_Request;
+
+#pragma pack (1)
+typedef struct rpmb_block {
+	uint8_t  signature[4];
+	uint32_t length;
+	uint32_t revision;
+	uint32_t flag;
+	uint16_t attkb_addr;
+	uint32_t attkb_size;
+	uint16_t attkb_svn;
+	uint16_t uos_rpmb_size;
+	uint8_t  reserved[230];
+} rpmb_block_t;
+#pragma pack ()
+
+uint16_t read_attkb(void *data, uint16_t size);
+uint16_t get_attkb_size(void);
+
+#endif    // _ATT_KEYBOX_H


### PR DESCRIPTION
Retrieve the encrypted attestation Keybox from CSE
and provision it to RPMB storage.

Tracked-On: #2604
Signed-off-by: Huang Yang <yang.huang@intel.com>
Signed-off-by: Wei Xinghai <xinghaix.wei@intel.com>
Signed-off-by: Chen Gang <gang.g.chen@intel.com>
Acked-by: Zhu Bing <bing.zhu@intel.com>