### PR TITLE
Add fatal warning PCI MSIX table count > conf max

### DIFF
--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -351,6 +351,8 @@ static void pci_read_cap(struct pci_pdev *pdev)
 				pdev->msix.table_offset = table_info & ~PCIM_MSIX_BIR_MASK;
 				pdev->msix.table_count = (msgctrl & PCIM_MSIXCTRL_TABLE_SIZE) + 1U;
 
+				ASSERT(pdev->msix.table_count <= CONFIG_MAX_MSIX_TABLE_NUM);
+
 				/* Copy MSIX capability struct into buffer */
 				for (idx = 0U; idx < len; idx++) {
 					pdev->msix.cap[idx] = (uint8_t)pci_pdev_read_cfg(pdev->bdf, offset + idx, 1U);


### PR DESCRIPTION
Add a fatal warning when an PCI device is added with an MSI-X table_count
larger than CONFIG_MAX_MSIX_TABLE_NUM. This is fatal since the init function
in the handler for MSI-X (vmsix_init) only looks at table_count when
populating the table. Since CONFIG_MAX_MSIX_TABLE_NUM is the max size of the
table array entry in the pci_msix struct. This will cause the msix handler
to write outside of the table array.
Tracked-On: #2624