### PR TITLE
Patches to passthru PMU to UOS

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -32,6 +32,8 @@ ARCH_ASFLAGS :=
 ARCH_ARFLAGS :=
 ARCH_LDFLAGS :=
 
+PROFILING ?= 1
+
 .PHONY: default
 default: all
 
@@ -239,7 +241,10 @@ endif
 
 C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(C_SRCS))
 ifneq ($(CONFIG_RELEASE),y)
-CFLAGS += -DHV_DEBUG -DPROFILING_ON -fno-omit-frame-pointer
+CFLAGS += -DHV_DEBUG -fno-omit-frame-pointer
+ifeq ($(PROFILING), 1)
+CFLAGS += -DPROFILING_ON
+endif
 endif
 S_OBJS := $(patsubst %.S,$(HV_OBJDIR)/%.o,$(S_SRCS))
 

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -230,8 +230,10 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 				break;
 
 			/* These features are disabled */
+#ifdef PROFILING_ON
 			/* PMU is not supported */
 			case 0x0aU:
+#endif /* PROFILING_ON */
 			/* Intel RDT */
 			case 0x0fU:
 			case 0x10U:

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -982,11 +982,7 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t vector)
 	default:
 		return -EINVAL;
 	}
-	if (vector < 16U) {
-		vlapic_set_error(vlapic, APIC_ESR_RECEIVE_ILLEGAL_VECTOR);
-	} else {
-		vlapic_fire_lvt(vlapic, lvt);
-	}
+	vlapic_fire_lvt(vlapic, lvt);
 	return 0;
 }
 

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -110,6 +110,7 @@ static const uint32_t unsupported_msrs[NUM_UNSUPPORTED_MSRS] = {
 	MSR_SGXOWNEREPOCH0,
 	MSR_SGXOWNEREPOCH1,
 
+#ifdef PROFILING_ON
 	/* Performance Counters and Events: CPUID.0AH.EAX[15:8] */
 	MSR_IA32_PMC0,
 	MSR_IA32_PMC1,
@@ -138,6 +139,7 @@ static const uint32_t unsupported_msrs[NUM_UNSUPPORTED_MSRS] = {
 	MSR_IA32_PERF_GLOBAL_OVF_CTRL,
 	MSR_IA32_PERF_GLOBAL_STATUS_SET,
 	MSR_IA32_PERF_GLOBAL_INUSE,
+#endif /* PROFILING_ON */
 
 	/* QOS Configuration disabled: CPUID.10H.ECX[2] */
 	MSR_IA32_L3_QOS_CFG,

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -61,6 +61,14 @@ static int32_t hcall_profiling_ops(struct acrn_vm *vm, uint64_t cmd, uint64_t pa
 	}
  	return ret;
 }
+
+#else
+
+static int32_t hcall_profiling_ops(__unused struct acrn_vm *vm, __unused uint64_t cmd, __unused uint64_t param)
+{
+	return -EPERM;
+}
+
 #endif /* PROFILING_ON */
 
 /**


### PR DESCRIPTION
make hypervisor PROFILING=0, it will disable profiling and pmu will be pass-thru and perf tools can be run directly inside UOS.

Tracked-On:#2598
Signed-off-by: Min He <min.he@intel.com>