### PR TITLE
Cleanup header files for debug folder

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -9,6 +9,7 @@
 #include <sprintf.h>
 #include <vm.h>
 #include <bits.h>
+#include <uart16550.h>
 #include <e820.h>
 #include <multiboot.h>
 #include <vtd.h>

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -10,6 +10,7 @@
 #include <per_cpu.h>
 #include <profiling.h>
 #include <vtd.h>
+#include <shell.h>
 #include <vmx.h>
 #include <vm.h>
 #include <logmsg.h>

--- a/hypervisor/bsp/uefi/cmdline.c
+++ b/hypervisor/bsp/uefi/cmdline.c
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <errno.h>
 #include <multiboot.h>
+#include <pgtable.h>
+#include <dbg_cmd.h>
+#include <logmsg.h>
 
 #define ACRN_DBG_PARSE		6
 

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
-#include <shell.h>
+#include <types.h>
+#include <pci.h>
 #include <uart16550.h>
+#include <shell.h>
+#include <timer.h>
+#include <vuart.h>
+#include <logmsg.h>
 
 struct hv_timer console_timer;
 

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -5,7 +5,8 @@
  */
 
 #include <hypervisor.h>
-#include "uart16550.h"
+#include <shell.h>
+#include <uart16550.h>
 
 struct hv_timer console_timer;
 

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <rtl.h>
+#include <pci.h>
 #include <uart16550.h>
+#include <vuart.h>
 
 #define MAX_PORT			0x10000  /* port 0 - 64K */
 #define DEFAULT_UART_PORT	0x3F8

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -5,6 +5,7 @@
  */
 
 #include <hypervisor.h>
+#include <uart16550.h>
 
 #define MAX_PORT			0x10000  /* port 0 - 64K */
 #define DEFAULT_UART_PORT	0x3F8

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <per_cpu.h>
+#include <mmu.h>
+#include <vcpu.h>
+#include <vmx.h>
+#include <vm.h>
 #include <init.h>
+#include <logmsg.h>
 
 #define CALL_TRACE_HIERARCHY_MAX    20U
 #define DUMP_STACK_SIZE 0x200U

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
-#include <schedule.h>
-#include <hypercall.h>
-#include <version.h>
-#include <reloc.h>
+#include <types.h>
+#include <errno.h>
+#include <profiling.h>
+#include <sbuf.h>
+#include <npk_log.h>
+#include <vm.h>
+#include <logmsg.h>
 
 #ifdef PROFILING_ON
 /**

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <atomic.h>
+#include <sprintf.h>
+#include <spinlock.h>
 #include <per_cpu.h>
+#include <npk_log.h>
+#include <logmsg.h>
+
 /* buf size should be identical to the size in hvlog option, which is
  * transfered to SOS:
  * bsp/uefi/clearlinux/acrn.conf: hvlog=2M@0x1FE00000

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <atomic.h>
+#include <acrn_hv_defs.h>
+#include <io.h>
+#include <per_cpu.h>
+#include <mmu.h>
+#include <logmsg.h>
 
 static int32_t npk_log_setup_ref;
 static bool npk_log_enabled;

--- a/hypervisor/debug/printf.c
+++ b/hypervisor/debug/printf.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <rtl.h>
+#include <util.h>
+#include <sprintf.h>
+#include <console.h>
 
 static void
 charout(size_t cmd, const char *s_arg, uint32_t sz_arg, struct snprint_param *param)

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -5,7 +5,16 @@
  */
 #ifdef PROFILING_ON
 
-#include <hypervisor.h>
+#include <types.h>
+#include <errno.h>
+#include <irq.h>
+#include <per_cpu.h>
+#include <pgtable.h>
+#include <vmx.h>
+#include <cpuid.h>
+#include <vm.h>
+#include <sprintf.h>
+#include <logmsg.h>
 
 #define ACRN_DBG_PROFILING		5U
 #define ACRN_ERR_PROFILING		3U

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -9,7 +9,12 @@
  *
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <rtl.h>
+#include <errno.h>
+#include <sbuf.h>
+#include <cpu.h>
+#include <per_cpu.h>
 
 static inline bool sbuf_is_empty(const struct shared_buf *sbuf)
 {

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -4,9 +4,21 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
-#include <ioapic.h>
+#include <types.h>
+#include <errno.h>
+#include <bits.h>
+#include <page.h>
 #include "shell_priv.h"
+#include <irq.h>
+#include <console.h>
+#include <per_cpu.h>
+#include <vmx.h>
+#include <cpuid.h>
+#include <ioapic.h>
+#include <ptdev.h>
+#include <vm.h>
+#include <sprintf.h>
+#include <logmsg.h>
 
 #define TEMP_STR_SIZE		60U
 #define MAX_STR_SIZE		256U

--- a/hypervisor/debug/string.c
+++ b/hypervisor/debug/string.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <rtl.h>
 
 /*
  * Convert a string to a long integer - decimal support only.

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <per_cpu.h>
 
 #define TRACE_CUSTOM			0xFCU
 #define TRACE_FUNC_ENTER		0xFDU

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -5,7 +5,7 @@
  */
 
 #include <hypervisor.h>
-#include "uart16550.h"
+#include <uart16550.h>
 
 #define MAX_BDF_LEN 8
 

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include  <types.h>
+#include <spinlock.h>
+#include <pci.h>
+#include <pgtable.h>
 #include <uart16550.h>
+#include <io.h>
+#include <mmu.h>
 
 #define MAX_BDF_LEN 8
 

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -28,10 +28,13 @@
  * $FreeBSD$
  */
 
-#include <hypervisor.h>
-#include <ioapic.h>
-
+#include <types.h>
+#include <pci.h>
 #include <uart16550.h>
+#include <console.h>
+#include <vuart.h>
+#include <vm.h>
+#include <logmsg.h>
 
 static uint32_t vuart_com_irq =  CONFIG_COM_IRQ;
 static uint16_t vuart_com_base = CONFIG_COM_BASE;

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -31,7 +31,7 @@
 #include <hypervisor.h>
 #include <ioapic.h>
 
-#include "uart16550.h"
+#include <uart16550.h>
 
 static uint32_t vuart_com_irq =  CONFIG_COM_IRQ;
 static uint16_t vuart_com_base = CONFIG_COM_BASE;

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -30,6 +30,7 @@
  */
 
 #include <hypervisor.h>
+#include <uart16550.h>
 #include <pci.h>
 
 static spinlock_t pci_device_lock;

--- a/hypervisor/include/arch/x86/multiboot.h
+++ b/hypervisor/include/arch/x86/multiboot.h
@@ -13,6 +13,7 @@
 #define	MULTIBOOT_INFO_HAS_MMAP		0x00000040U
 #define	MULTIBOOT_INFO_HAS_DRIVES	0x00000080U
 
+struct acrn_vm;
 struct multiboot_info {
 	uint32_t               mi_flags;
 

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -7,8 +7,6 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
-#include <pci.h>
-
 /* Switching key combinations for shell and uart console */
 #define GUEST_CONSOLE_TO_HV_SWITCH_KEY      0       /* CTRL + SPACE */
 

--- a/hypervisor/include/debug/console.h
+++ b/hypervisor/include/debug/console.h
@@ -38,15 +38,8 @@ void console_putc(const char *ch);
 char console_getc(void);
 
 void console_setup_timer(void);
-void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr);
-bool is_pci_dbg_uart(union pci_bdf bdf_value);
-bool is_dbg_uart_enabled(void);
-
-void shell_init(void);
-void shell_kick(void);
 
 void suspend_console(void);
 void resume_console(void);
 
-bool handle_dbg_cmd(const char *cmd, int32_t len);
 #endif /* CONSOLE_H */

--- a/hypervisor/include/debug/dbg_cmd.h
+++ b/hypervisor/include/debug/dbg_cmd.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DBG_CMD_H
+#define DBG_CMD_H
+
+bool handle_dbg_cmd(const char *cmd, int32_t len);
+
+#endif /* DBG_CMD_H */

--- a/hypervisor/include/debug/shell.h
+++ b/hypervisor/include/debug/shell.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SHELL_H
+#define SHELL_H
+
+void shell_init(void);
+void shell_kick(void);
+
+#endif /* SHELL_H */

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -109,5 +109,8 @@
 void uart16550_init(void);
 char uart16550_getc(void);
 size_t uart16550_puts(const char *buf, uint32_t len);
+void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr);
+bool is_pci_dbg_uart(union pci_bdf bdf_value);
+bool is_dbg_uart_enabled(void);
 
 #endif /* !UART16550_H */

--- a/hypervisor/include/debug/vuart.h
+++ b/hypervisor/include/debug/vuart.h
@@ -29,6 +29,8 @@
 
 #ifndef VUART_H
 #define VUART_H
+#include <types.h>
+#include <spinlock.h>
 
 #define RX_BUF_SIZE		256U
 #define TX_BUF_SIZE		8192U


### PR DESCRIPTION
only include some necessary header files, doesn't include hypervisor.h

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>