### PR TITLE
HV: cleanup header files under hypervisor dm&common

### DIFF
--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <vmcs.h>
+#include <vmexit.h>
+#include <irq.h>
 #include <schedule.h>
 #include <softirq.h>
+#include <profiling.h>
+#include <trace.h>
+#include <logmsg.h>
 
 void vcpu_thread(struct sched_object *obj)
 {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -4,12 +4,20 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <vmcs.h>
 #include <schedule.h>
 #include <hypercall.h>
 #include <version.h>
 #include <reloc.h>
 #include <vtd.h>
+#include <per_cpu.h>
+#include <lapic.h>
+#include <assign.h>
+#include <ept.h>
+#include <mmu.h>
+#include <errno.h>
+#include <logmsg.h>
 
 #define ACRN_DBG_HYCALL	6U
 

--- a/hypervisor/common/io_req.c
+++ b/hypervisor/common/io_req.c
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <irq.h>
+#include <errno.h>
+#include <atomic.h>
+#include <logmsg.h>
 
 #define ACRN_DBG_IOREQUEST	6U
 

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
 #include <softirq.h>
 #include <ptdev.h>
+#include <irq.h>
+#include <atomic.h>
+#include <logmsg.h>
 
 #define PTIRQ_BITMAP_ARRAY_SIZE	INT_DIV_ROUNDUP(CONFIG_MAX_PT_IRQ_ENTRIES, 64U)
 struct ptirq_remapping_info ptirq_entries[CONFIG_MAX_PT_IRQ_ENTRIES];

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <rtl.h>
+#include <list.h>
+#include <bits.h>
+#include <cpu.h>
+#include <per_cpu.h>
+#include <lapic.h>
 #include <schedule.h>
+#include <sprintf.h>
 
 static uint64_t pcpu_used_bitmap;
 

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <bits.h>
+#include <cpu.h>
+#include <per_cpu.h>
 #include <softirq.h>
-
 
 static softirq_handler softirq_handlers[NR_SOFTIRQS];
 

--- a/hypervisor/common/stack_protector.c
+++ b/hypervisor/common/stack_protector.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
-#include <hypervisor.h>
+#include <types.h>
+#include <logmsg.h>
 
 void __stack_chk_fail(void)
 {

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
 #include <hypercall.h>
+#include <logmsg.h>
 
 #define ACRN_DBG_TRUSTY_HYCALL 6U
 

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
 #include <e820.h>
 #include <zeropage.h>
 #include <boot_context.h>
+#include <ept.h>
+#include <mmu.h>
+#include <errno.h>
+#include <sprintf.h>
+#include <logmsg.h>
 
 static void prepare_bsp_gdt(struct acrn_vm *vm)
 {

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -30,7 +30,13 @@
 
 #define pr_prefix	"vioapic: "
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
+#include <irq.h>
+#include <assign.h>
+#include <mem_mgt.h>
+#include <pci.h>
+#include <logmsg.h>
 
 #define	RTBL_RO_BITS	((uint32_t)0x00004000U | (uint32_t)0x00001000U) /*Remote IRR and Delivery Status bits*/
 

--- a/hypervisor/dm/vmptable.c
+++ b/hypervisor/dm/vmptable.c
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <per_cpu.h>
+#include <mptable.h>
+#include <default_acpi_info.h>
 
 static struct mptable_info mptable_template = {
 			.mpfp = {

--- a/hypervisor/dm/vpci/core.c
+++ b/hypervisor/dm/vpci/core.c
@@ -27,7 +27,7 @@
  * $FreeBSD$
  */
 
-#include <hypervisor.h>
+#include <vm.h>
 #include "pci_priv.h"
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -34,7 +34,9 @@
 * Series Host Bridge (rev 0b)
 */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
+#include <pci.h>
 #include "pci_priv.h"
 
 static int32_t vdev_hostbridge_init(struct pci_vdev *vdev)

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -27,7 +27,11 @@
  * $FreeBSD$
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
+#include <ptdev.h>
+#include <assign.h>
+#include <vpci.h>
 #include "pci_priv.h"
 
 static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -27,7 +27,15 @@
  * $FreeBSD$
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
+#include <ptdev.h>
+#include <assign.h>
+#include <vpci.h>
+#include <io.h>
+#include <ept.h>
+#include <mmu.h>
+#include <logmsg.h>
 #include "pci_priv.h"
 
 static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -29,7 +29,8 @@
 
 /* Virtual PCI device related operations (read/write, etc) */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <logmsg.h>
 #include "pci_priv.h"
 
 static struct pci_vdev *partition_mode_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf)

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -29,8 +29,12 @@
 
 /* Passthrough PCI device related operations */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
 #include <vtd.h>
+#include <ept.h>
+#include <mmu.h>
+#include <logmsg.h>
 #include "pci_priv.h"
 
 static inline uint32_t pci_bar_base(uint32_t bar)

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -27,7 +27,9 @@
  * $FreeBSD$
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <errno.h>
+#include <logmsg.h>
 #include "pci_priv.h"
 
 static uint32_t num_pci_vdev;

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -27,7 +27,7 @@
 * $FreeBSD$
 */
 
-#include <hypervisor.h>
+#include <vm.h>
 #include "pci_priv.h"
 
 static void pci_cfg_clear_cache(struct pci_addr_info *pi)

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -27,7 +27,10 @@
 
 #define pr_prefix	"vpic: "
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <irq.h>
+#include <assign.h>
+#include <logmsg.h>
 
 #define ACRN_DBG_PIC	6U
 

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <vm.h>
+#include <io.h>
 
 #define CMOS_ADDR_PORT		0x70U
 #define CMOS_DATA_PORT		0x71U


### PR DESCRIPTION
it removes hypervisor.h and just includes needed header files.

Tracked-On: #1842
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>