### PR TITLE
hv: do EPT mapping only for physical memory backed GPA on pre-launche…

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/ve820.c
@@ -7,33 +7,33 @@
 #include <e820.h>
 
 const struct e820_entry ve820_entry[E820_MAX_ENTRIES] = {
-	{	/* 0 to mptable */
+	{	/* usable RAM under 1MB */
 		.baseaddr = 0x0UL,
-		.length   = 0xEFFFFUL,
+		.length   = 0xF0000UL,		/* 960KB */
 		.type     = E820_TYPE_RAM
 	},
 
-	{	/* mptable 65536U */
-		.baseaddr = 0xF0000UL,
-		.length   = 0x10000UL,
+	{	/* mptable */
+		.baseaddr = 0xF0000UL,		/* 960KB */
+		.length   = 0x10000UL,		/* 16KB */
 		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* mptable to lowmem */
-		.baseaddr = 0x100000UL,
-		.length   = 0x1FF00000UL,
+	{	/* lowmem */
+		.baseaddr = 0x200000UL,		/* 2MB */
+		.length   = 0x1FE00000UL,	/* 510MB */
 		.type     = E820_TYPE_RAM
 	},
 
-	{	/* lowmem to PCI hole */
-		.baseaddr = 0x20000000UL,
-		.length   = 0xa0000000UL,
+	{	/* between lowmem and PCI hole */
+		.baseaddr = 0x20000000UL,	/* 512MB */
+		.length   = 0xA0000000UL,	/* 2560MB */
 		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* PCI hole to 4G */
-		.baseaddr = 0xe0000000UL,
-		.length   = 0x20000000UL,
+	{	/* between PCI hole and 4GB */
+		.baseaddr = 0xe0000000UL,	/* 3.5GB */
+		.length   = 0x20000000UL,	/* 512MB */
 		.type     = E820_TYPE_RESERVED
 	},
 };

--- a/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
@@ -7,33 +7,33 @@
 #include <e820.h>
 
 const struct e820_entry ve820_entry[E820_MAX_ENTRIES] = {
-	{	/* 0 to mptable */
+	{	/* usable RAM under 1MB */
 		.baseaddr = 0x0UL,
-		.length   = 0xEFFFFUL,
+		.length   = 0xF0000UL,		/* 960KB */
 		.type     = E820_TYPE_RAM
 	},
 
-	{	/* mptable 65536U */
-		.baseaddr = 0xF0000UL,
-		.length   = 0x10000UL,
+	{	/* mptable */
+		.baseaddr = 0xF0000UL,		/* 960KB */
+		.length   = 0x10000UL,		/* 16KB */
 		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* mptable to lowmem */
-		.baseaddr = 0x100000UL,
-		.length   = 0x7FF00000UL,
+	{	/* lowmem */
+		.baseaddr = 0x200000UL,		/* 2MB */
+		.length   = 0x7FE00000UL,	/* 2046MB */
 		.type     = E820_TYPE_RAM
 	},
 
-	{	/* lowmem to PCI hole */
-		.baseaddr = 0x80000000UL,
-		.length   = 0x40000000UL,
+	{	/* between lowmem and PCI hole */
+		.baseaddr = 0x80000000UL,	/* 2GB */
+		.length   = 0x40000000UL,	/* 1GB */
 		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* PCI hole to 4G */
-		.baseaddr = 0xe0000000UL,
-		.length   = 0x20000000UL,
+	{	/* between PCI hole and 4GB */
+		.baseaddr = 0xe0000000UL,	/* 3.5GB */
+		.length   = 0x20000000UL,	/* 512MB */
 		.type     = E820_TYPE_RESERVED
 	},
 };


### PR DESCRIPTION
…d VMs

Currently for pre-launched VMs, HV intends to do EPT mapping for all GPA space,
which implies that it wastes HPA to back PCI hole and other vE820 entries that
are not of E820_TYPE_RAM type.

This patch only maps GPAs that are actually backed by physical memory to solve
this issue. Also, it fixes ve820 entries whose length is not aligned to 4K.

Tracked-On: #2587
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>