### PR TITLE
Makefile: undefine _FORTIFY_SOURCE prior using it

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -16,7 +16,7 @@ CFLAGS += -DNO_OPENSSL
 CFLAGS += -m64
 CFLAGS += -Wall -ffunction-sections
 CFLAGS += -Werror
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 CFLAGS += -fpie
 

--- a/tools/acrn-crashlog/Makefile
+++ b/tools/acrn-crashlog/Makefile
@@ -18,7 +18,7 @@ CFLAGS += -D_GNU_SOURCE
 CFLAGS += -m64
 CFLAGS += -Wall -ffunction-sections
 CFLAGS += -Werror
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 CFLAGS += -fpie
 CFLAGS += -Wall -Wextra -pedantic

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -9,7 +9,7 @@ MANAGER_CFLAGS += -DNO_OPENSSL
 MANAGER_CFLAGS += -m64
 MANAGER_CFLAGS += -Wall -ffunction-sections
 MANAGER_CFLAGS += -Werror
-MANAGER_CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+MANAGER_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 MANAGER_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 MANAGER_CFLAGS += -fpie -fpic
 #FIXME: remove me. work-around for system() calls, which will be removed

--- a/tools/acrnlog/Makefile
+++ b/tools/acrnlog/Makefile
@@ -8,7 +8,7 @@ LOG_CFLAGS += -DNO_OPENSSL
 LOG_CFLAGS += -m64
 LOG_CFLAGS += -Wall -ffunction-sections
 LOG_CFLAGS += -Werror
-LOG_CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+LOG_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 LOG_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 LOG_CFLAGS += -fpie -fpic
 LOG_CFLAGS += $(CFLAGS)

--- a/tools/acrntrace/Makefile
+++ b/tools/acrntrace/Makefile
@@ -8,7 +8,7 @@ TRACE_CFLAGS += -DNO_OPENSSL
 TRACE_CFLAGS += -m64
 TRACE_CFLAGS += -Wall -ffunction-sections
 TRACE_CFLAGS += -Werror
-TRACE_CFLAGS += -O2 -D_FORTIFY_SOURCE=2
+TRACE_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 TRACE_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 TRACE_CFLAGS += -fpie -fpic
 TRACE_CFLAGS += $(CFLAGS)


### PR DESCRIPTION
Currently, we are enforcing the _FORTIFY_SOURCE=2 without any
previous detection if the macro has been already defined, e.g.
by environment, or is just enabled by compiler by default on
some distributions (e.g. Gentoo).

This could result in the error like this:
<command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
<built-in>: note: this is the location of the previous definition

Tracked-On: #2344
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>