### PR TITLE
hv:cleanup header files for release folder

### DIFF
--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <pci.h>
 
 size_t console_write(__unused const char *str, __unused size_t len)
 {

--- a/hypervisor/release/dump.c
+++ b/hypervisor/release/dump.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <irq.h>
 
 void dump_intr_excp_frame(__unused const struct intr_excp_ctx *ctx) {}
 void dump_exception(__unused struct intr_excp_ctx *ctx, __unused uint16_t pcpu_id) {}

--- a/hypervisor/release/hypercall.c
+++ b/hypervisor/release/hypercall.c
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <errno.h>
+#include <vm.h>
 
 int32_t hcall_debug(__unused struct acrn_vm *vm, __unused uint64_t param1, __unused uint64_t param2,
 			__unused uint64_t hypcall_id)

--- a/hypervisor/release/logmsg.c
+++ b/hypervisor/release/logmsg.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
 
 void init_logmsg(__unused uint32_t flags) {}
 void do_logmsg(__unused uint32_t severity, __unused const char *fmt, ...) {}

--- a/hypervisor/release/npk_log.c
+++ b/hypervisor/release/npk_log.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <acrn_hv_defs.h>
 
 void npk_log_setup(__unused struct hv_npk_log_param *param) {}
 void npk_log_write(__unused const char *buf, __unused size_t len) {}

--- a/hypervisor/release/profiling.c
+++ b/hypervisor/release/profiling.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <vcpu.h>
 
 void profiling_vmenter_handler(__unused struct acrn_vcpu *vcpu) {}
 void profiling_pre_vmexit_handler(__unused struct acrn_vcpu *vcpu) {}

--- a/hypervisor/release/trace.c
+++ b/hypervisor/release/trace.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
 
 void TRACE_2L(__unused uint32_t evid, __unused uint64_t e, __unused uint64_t f) {}
 

--- a/hypervisor/release/vuart.c
+++ b/hypervisor/release/vuart.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <vm.h>
 
 void vuart_init(__unused struct acrn_vm *vm) {}
 


### PR DESCRIPTION
cleanup release folder, only include some necessary
header files,doesn't include hypervisor.h

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>

	modified:   release/console.c
	modified:   release/dump.c
	modified:   release/hypercall.c
	modified:   release/logmsg.c
	modified:   release/npk_log.c
	modified:   release/profiling.c
	modified:   release/trace.c
	modified:   release/vuart.c