### PR TITLE
Pci bar64 highmem

### DIFF
--- a/devicemodel/core/smbiostbl.c
+++ b/devicemodel/core/smbiostbl.c
@@ -522,7 +522,7 @@ static struct smbios_template_entry smbios_template[] = {
 	{ NULL, NULL, NULL }
 };
 
-static uint64_t guest_lomem, guest_himem;
+static uint64_t guest_lomem, guest_himem, guest_highmem_base;
 static uint16_t type16_handle;
 
 static int
@@ -709,7 +709,7 @@ smbios_type19_initializer(struct smbios_structure *template_entry,
 		    curaddr, endaddr, n, size);
 		type19 = (struct smbios_table_type19 *)curaddr;
 		type19->arrayhand = type16_handle;
-		type19->xsaddr = 4*GB;
+		type19->xsaddr = guest_highmem_base;
 		type19->xeaddr = guest_himem;
 	}
 
@@ -767,6 +767,7 @@ smbios_build(struct vmctx *ctx)
 
 	guest_lomem = vm_get_lowmem_size(ctx);
 	guest_himem = vm_get_highmem_size(ctx);
+	guest_highmem_base = ctx->highmem_gpa_base;
 
 	startaddr = paddr_guest2host(ctx, SMBIOS_BASE, SMBIOS_MAX_LENGTH);
 	if (startaddr == NULL) {

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -33,6 +33,7 @@
 #include "vmmapi.h"
 #include "sw_load.h"
 #include "dm.h"
+#include "pci_core.h"
 
 int with_bootargs;
 static char bootargs[STR_LEN];
@@ -56,7 +57,8 @@ static char bootargs[STR_LEN];
  * 3:        lowmem -     bff_fffff   (reserved)   0xc00_00000-lowmem
  * 4:   0xc00_00000 -     dff_fffff   PCI hole     512MB
  * 5:   0xe00_00000 -     fff_fffff   (reserved)   512MB
- * 6:   1_000_00000 -     highmem     RAM          highmem-4G
+ * 6:   1_000_00000 -     1_400_00000 PCI hole     1G
+ * 7:   1_400_00000 -     highmem     RAM          highmem-5G
  */
 const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 	{	/* 0 to mptable/smbios/acpi */
@@ -89,8 +91,14 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		.type     =  E820_TYPE_RESERVED
 	},
 
+	{	/* 4G to 5G */
+		.baseaddr =  PCI_EMUL_MEMBASE64,
+		.length   =  PCI_EMUL_MEMLIMIT64 - PCI_EMUL_MEMBASE64,
+		.type     =  E820_TYPE_RESERVED
+	},
+
 	{
-		.baseaddr =  0x100000000,
+		.baseaddr =  PCI_EMUL_MEMLIMIT64,
 		.length   =  0x000100000,
 		.type     =  E820_TYPE_RESERVED
 	},

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -97,8 +97,8 @@ SYSRES_MEM(PCI_EMUL_ECFG_BASE, PCI_EMUL_ECFG_SIZE);
 
 #define	PCI_EMUL_MEMLIMIT32	PCI_EMUL_ECFG_BASE
 
-#define	PCI_EMUL_MEMBASE64	0x7000000000UL
-#define	PCI_EMUL_MEMLIMIT64	0x8D00000000UL
+#define	PCI_EMUL_MEMBASE64	0x100000000UL
+#define	PCI_EMUL_MEMLIMIT64	0x140000000UL
 
 static struct pci_vdev_ops *pci_emul_finddev(char *name);
 static void pci_lintr_route(struct pci_vdev *dev);

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -698,30 +698,16 @@ pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx, uint64_t hostbase,
 		break;
 	case PCIBAR_MEM64:
 		/*
-		 * XXX
-		 * Some drivers do not work well if the 64-bit BAR is allocated
-		 * above 4GB. Allow for this by allocating small requests under
-		 * 4GB unless then allocation size is larger than some arbitrary
-		 * number (32MB currently).
+		 * XXX special case for device requiring peer-peer DMA
 		 */
-		if (size > 32 * 1024 * 1024) {
-			/*
-			 * XXX special case for device requiring peer-peer DMA
-			 */
-			if (size == 0x100000000UL)
-				baseptr = &hostbase;
-			else
-				baseptr = &pci_emul_membase64;
-			limit = PCI_EMUL_MEMLIMIT64;
-			mask = PCIM_BAR_MEM_BASE;
-			lobits = PCIM_BAR_MEM_SPACE | PCIM_BAR_MEM_64 |
-				 PCIM_BAR_MEM_PREFETCH;
-			break;
-		}
-		baseptr = &pci_emul_membase32;
-		limit = PCI_EMUL_MEMLIMIT32;
+		if (size == 0x100000000UL)
+			baseptr = &hostbase;
+		else
+			baseptr = &pci_emul_membase64;
+		limit = PCI_EMUL_MEMLIMIT64;
 		mask = PCIM_BAR_MEM_BASE;
-		lobits = PCIM_BAR_MEM_SPACE | PCIM_BAR_MEM_64;
+		lobits = PCIM_BAR_MEM_SPACE | PCIM_BAR_MEM_64 |
+			PCIM_BAR_MEM_PREFETCH;
 		break;
 	case PCIBAR_MEM32:
 		baseptr = &pci_emul_membase32;

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -97,9 +97,6 @@ SYSRES_MEM(PCI_EMUL_ECFG_BASE, PCI_EMUL_ECFG_SIZE);
 
 #define	PCI_EMUL_MEMLIMIT32	PCI_EMUL_ECFG_BASE
 
-#define	PCI_EMUL_MEMBASE64	0x100000000UL
-#define	PCI_EMUL_MEMLIMIT64	0x140000000UL
-
 static struct pci_vdev_ops *pci_emul_finddev(char *name);
 static void pci_lintr_route(struct pci_vdev *dev);
 static void pci_lintr_update(struct pci_vdev *dev);

--- a/devicemodel/hw/pci/virtio/vhost.c
+++ b/devicemodel/hw/pci/virtio/vhost.c
@@ -523,10 +523,10 @@ vhost_set_mem_table(struct vhost_dev *vdev)
 	}
 
 	if (ctx->highmem > 0) {
-		mem->regions[nregions].guest_phys_addr = 4*GB;
+		mem->regions[nregions].guest_phys_addr = ctx->highmem_gpa_base;
 		mem->regions[nregions].memory_size = ctx->highmem;
 		mem->regions[nregions].userspace_addr =
-			(uintptr_t)(ctx->baseaddr + 4*GB);
+			(uintptr_t)(ctx->baseaddr + ctx->highmem_gpa_base);
 		DPRINTF("[%d][0x%llx -> 0x%llx, 0x%llx]\n",
 			nregions,
 			mem->regions[nregions].guest_phys_addr,

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -38,6 +38,9 @@
 #define	PCI_BARMAX	PCIR_MAX_BAR_0	/* BAR registers in a Type 0 header */
 #define	PCI_BDF(b, d, f) (((b & 0xFF) << 8) | ((d & 0x1F) << 3) | ((f & 0x7)))
 
+#define	PCI_EMUL_MEMBASE64	0x100000000UL
+#define	PCI_EMUL_MEMLIMIT64	0x140000000UL
+
 struct vmctx;
 struct pci_vdev;
 struct memory_region;

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -38,9 +38,9 @@
 #define E820_TYPE_ACPI_NVS      4   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        6
+#define NUM_E820_ENTRIES        7
 #define LOWRAM_E820_ENTRIES     2
-#define HIGHRAM_E820_ENTRIES    5
+#define HIGHRAM_E820_ENTRIES    6
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -52,6 +52,7 @@ struct vmctx {
 	int     vmid;
 	int     ioreq_client;
 	uint32_t lowmem_limit;
+	uint64_t highmem_gpa_base;
 	size_t  lowmem;
 	size_t  biosmem;
 	size_t  highmem;

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -243,8 +243,8 @@ config HV_RAM_START
 
 config HV_RAM_SIZE
 	hex "Size of the RAM region used by the hypervisor"
-	default 0x07800000 if PLATFORM_SBL
-	default 0x0b000000 if PLATFORM_UEFI
+	default 0x08000000 if PLATFORM_SBL
+	default 0x0b800000 if PLATFORM_UEFI
 	help
 	  A 64-bit integer indicating the size of RAM used by the hypervisor.
 	  It is ensured at link time that the footprint of the hypervisor

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -14,13 +14,22 @@
 /* size of the low MMIO address space: 2GB */
 #define PLATFORM_LO_MMIO_SIZE	0x80000000UL
 
+/* size of the high MMIO address space: 1GB */
+#define PLATFORM_HI_MMIO_SIZE	0x40000000UL
+
 #define PML4_PAGE_NUM(size)	1UL
 #define PDPT_PAGE_NUM(size)	(((size) + PML4E_SIZE - 1UL) >> PML4E_SHIFT)
 #define PD_PAGE_NUM(size)	(((size) + PDPTE_SIZE - 1UL) >> PDPTE_SHIFT)
 #define PT_PAGE_NUM(size)	(((size) + PDE_SIZE - 1UL) >> PDE_SHIFT)
 
-/* The size of the guest physical address space, covered by the EPT page table of a VM */
-#define EPT_ADDRESS_SPACE(size)	(((size) != 0UL) ? ((size) + PLATFORM_LO_MMIO_SIZE) : 0UL)
+/*
+ * The size of the guest physical address space, covered by the EPT page table of a VM.
+ * With the assumptions:
+ * - The GPA of DRAM & MMIO are contiguous.
+ * - Guest OS won't re-program device MMIO bars to the address not covered by
+ *   this EPT_ADDRESS_SPACE.
+ */
+#define EPT_ADDRESS_SPACE(size)	(((size) != 0UL) ? ((size) + PLATFORM_LO_MMIO_SIZE + PLATFORM_HI_MMIO_SIZE) : 0UL)
 
 #define TRUSTY_PML4_PAGE_NUM(size)	(1UL)
 #define TRUSTY_PDPT_PAGE_NUM(size)	(1UL)


### PR DESCRIPTION
Add 1G PCI high MMIO address space

OVMF will check the bar address 64 bits bar and it asserts 64 bits
bar address should be above 4G. This patch adds 1G address space
from 4G to 5G which servers this requirement. The changes include:
1) Add additional 8MB RAM size for UOS in hypervisor because currently
   pages used for EPT mapping is statically defined. Additional 2MB is
   required for 1G per VM. The default VM number is 4.
2) Allocate 64bit MMIO above 4G strictly to pass OVMF check
3) Change the EPT mapping, device model user space address mapping and
   e820 table accordingly.
Tracked-On: #2577
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>