### PR TITLE
DM: virtio-gpio: use virtio_base as the first member of virtio_gpio

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -186,8 +186,8 @@ struct native_gpio_chip {
 };
 
 struct virtio_gpio {
-	pthread_mutex_t	mtx;
 	struct virtio_base	base;
+	pthread_mutex_t	mtx;
 	struct virtio_vq_info	queues[VIRTIO_GPIO_MAXQ];
 	struct native_gpio_chip	chips[VIRTIO_GPIO_MAX_CHIPS];
 	uint32_t		nchip;


### PR DESCRIPTION
For virtio-based device, it needs to use virtio_base as the first member
otherwise, virtio_linkup will fail.

Tracked-On: #2512
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>