### PR TITLE
hv:move forward the initialization for  iommu & ptdev

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -10,6 +10,7 @@
 #include <page.h>
 #include <e820.h>
 #include <mmu.h>
+#include <vtd.h>
 #include <lapic.h>
 #include <per_cpu.h>
 #include <cpufeatures.h>
@@ -213,6 +214,12 @@ void init_cpu_post(uint16_t pcpu_id)
 		setup_notification();
 		setup_posted_intr_notification();
 		init_pci_pdev_list();
+
+		if (init_iommu() != 0) {
+			panic("failed to initialize iommu!");
+		}
+
+		ptdev_init();
 
 		/* Start all secondary cores */
 		startup_paddr = prepare_trampoline();

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -47,16 +47,6 @@ static void init_debug_post(uint16_t pcpu_id)
 	profiling_setup();
 }
 
-/*TODO: move into pass-thru module */
-static void init_passthru(void)
-{
-	if (init_iommu() != 0) {
-		panic("failed to initialize iommu!");
-	}
-
-	ptdev_init();
-}
-
 /*TODO: move into guest-vcpu module */
 static void enter_guest_mode(uint16_t pcpu_id)
 {
@@ -80,8 +70,6 @@ static void init_primary_cpu_post(void)
 	init_cpu_post(BOOT_CPU_ID);
 
 	init_debug_post(BOOT_CPU_ID);
-
-	init_passthru();
 
 	enter_guest_mode(BOOT_CPU_ID);
 }


### PR DESCRIPTION
move 'init_iommu()' & 'ptdev_init()' before starting
all secondary cores to avoid access uninitialized resource
in partition mode.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>