### PR TITLE
hv: Remove redundant get_dmar_info API calls

### DIFF
--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -306,6 +306,7 @@ static int32_t parse_dmar_table(void)
 
 /**
  * @post return != NULL
+ * @post return->drhd_count > 0U
  */
 struct dmar_info *get_dmar_info(void)
 {

--- a/hypervisor/bsp/sbl/const_dmar.c
+++ b/hypervisor/bsp/sbl/const_dmar.c
@@ -130,6 +130,10 @@ static struct dmar_info sbl_dmar_info = {
 	.drhd_units = drhd_info_array,
 };
 
+/**
+ * @post return != NULL
+ * @post return->drhd_count > 0U
+ */
 struct dmar_info *get_dmar_info(void)
 {
 	return &sbl_dmar_info;


### PR DESCRIPTION
get_dmar_info API is called from multiple functions in vtd.c. This patch
calls get_dmar_info once during init and uses the cached info during
runtime.

Tracked-On: #2657
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>