### PR TITLE
ACRN: dm: Fix luanch UOS script "-d" parameter fail issue

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -465,7 +465,7 @@ echo "'#runc exec <vmname> bash' to login the container bash"
 exit
 }
 
-while getopts "V:M:hd:C" opt
+while getopts "V:M:hdC" opt
 do
 	case $opt in
 		V) launch_type=$[$OPTARG]


### PR DESCRIPTION
Fix run launch_uos script with "-d" parameter fail issue.

Tracked-On: #2659
Signed-off-by: Long Liu <long.liu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>