### PR TITLE
doc: fix broken external links

### DIFF
--- a/doc/api/devicemodel_api.rst
+++ b/doc/api/devicemodel_api.rst
@@ -4,10 +4,11 @@ Device Model APIs
 #################
 
 This section contains APIs for the SOS Device Model services.  Sources
-for the Device Model are found in the `ACRN Device Model GitHub repo`_
+for the Device Model are found in the devicemodel folder of the `ACRN
+hypervisor GitHub repo`_
 
-.. _ACRN Device Model GitHub repo:
-   https://github.com/projectacrn/acrn-devicemodel/
+.. _ACRN hypervisor GitHub repo:
+   https://github.com/projectacrn/acrn-hypervisor
 
 .. doxygengroup:: acrn_virtio
    :project: Project ACRN

--- a/doc/developer-guides/doc_guidelines.rst
+++ b/doc/developer-guides/doc_guidelines.rst
@@ -16,10 +16,10 @@ web browser. This same ``.rst`` content is also fed into the
 You can read details about `reStructuredText`_
 and about `Sphinx extensions`_ from their respective websites.
 
-.. _Sphinx extensions: http://www.sphinx-doc.org/en/stable/contents.html
+.. _Sphinx extensions: https://www.sphinx-doc.org/en/stable/contents.html
 .. _reStructuredText: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
-.. _Sphinx Inline Markup:  http://sphinx-doc.org/markup/inline.html#inline-markup
-.. _Project ACRN documentation:  http://projectacrn.github.io
+.. _Sphinx Inline Markup: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html 
+.. _Project ACRN documentation:  https://projectacrn.github.io
 
 This document provides a quick reference for commonly used reST and
 Sphinx-defined directives and roles used to create the documentation

--- a/doc/developer-guides/hld/hld-security.rst
+++ b/doc/developer-guides/hld/hld-security.rst
@@ -210,7 +210,7 @@ following rules:
 Detailed configurations and policies are out of scope for this document.
 For good references for OS system security hardening and enhancement,
 see `AGL security
-<http://docs.automotivelinux.org/docs/architecture/en/dev/reference/security/01-overview.html>`_
+<http://docs.automotivelinux.org/master/docs/architecture/en/dev/reference/security/part-2/0_Abstract.html>`_
 and `Android security <https://source.android.com/security/>`_
 
 Hypervisor Security Enhancement

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -13,7 +13,8 @@ Hardware setup
 Two Apollo Lake Intel platforms, described in :ref:`hardware`, are currently
 supported for ACRN development:
 
-- The `UP Squared board <http://www.up-board.org/upsquared/>`_ (UP2) is also
+- The `UP Squared board
+  <https://www.up-board.org/upsquared/specifications/>`_ (UP2) is also
   known to work and its setup is described in :ref:`getting-started-up2`.
 
 Firmware update on the NUC

--- a/doc/getting-started/up2.rst
+++ b/doc/getting-started/up2.rst
@@ -6,7 +6,7 @@ Getting started guide for UP2 board
 Hardware setup
 **************
 
-The `UP Squared board <http://www.up-board.org/upsquared/>`_ (UP2) is
+The `UP Squared board <http://www.up-board.org/upsquared/specifications/>`_ (UP2) is
 an x86 maker board based on the Intel Apollo Lake platform. The UP boards
 are used in IoT applications, industrial automation, digital signage, and more.
 

--- a/doc/hardware.rst
+++ b/doc/hardware.rst
@@ -29,7 +29,7 @@ up ACRN on the NUC.
    https://www.anandtech.com/show/12295/intel-nuc6cayh-arches-canyon-apollo-lake-ucff-pc-review
 
 .. _Amazon:
-   https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords=NUC6CAYH
+   https://www.amazon.com/s?k=NUC6CAYH
 
 .. _SimplyNUC:
    https://www.simplynuc.com/?s=NUC6CAYH&post_type=product
@@ -61,7 +61,7 @@ also apply to KBL NUCs.
 UP Squared board
 ****************
 
-The `UP Squared board <http://www.up-board.org/upsquared/>`_ (UP2) is
+The `UP Squared board <http://www.up-board.org/upsquared/specifications/>`_ (UP2) is
 an x86 maker board based on the Intel Apollo Lake platform. The UP boards
 are used in IoT, industrial automation, digital signage, and more.
 

--- a/doc/tutorials/agl-vms.rst
+++ b/doc/tutorials/agl-vms.rst
@@ -56,7 +56,7 @@ Here is the hardware used for the demo development:
        * `Specifications
          <https://www.intel.com/content/dam/support/us/en/documents/mini-pcs/nuc-kits/NUC7i7DN_TechProdSpec.pdf>`_,
        * `Tested components and peripherals
-         <http://compatibleproducts.intel.com/ProductDetails?EPMID=130392>`_,
+         <http://compatibleproducts.intel.com/ProductDetails?prodSearch=True&searchTerm=NUC7i7DNHE#>`_,
        * 16GB RAM, and
        * 250GB SSD
    * - eDP display

--- a/doc/tutorials/trustyACRN.rst
+++ b/doc/tutorials/trustyACRN.rst
@@ -393,7 +393,7 @@ should obey these following rules (and more):
 Detailed configurations and policies are out of scope in this article.
 Good references for OS system security hardening and enhancement
 include: `AGL security
-<http://docs.automotivelinux.org/docs/architecture/en/dev/reference/security/01-overview.html>`_
+<http://docs.automotivelinux.org/master/docs/architecture/en/dev/reference/security/part-2/0_Abstract.html>`_
 and `Android security
 <https://source.android.com/security/>`_
 


### PR DESCRIPTION
Found some broken links to external sites in the documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>