### PR TITLE
doc: use the new board name for UP2 in create-up2-images.sh script

### DIFF
--- a/doc/tutorials/create-up2-images.sh
+++ b/doc/tutorials/create-up2-images.sh
@@ -50,7 +50,7 @@ create_sos_images() {
 
     if [[ ! ${ACRN_SBL} || ! -f ${ACRN_SBL} ]]
     then
-        ACRN_SBL=sos_rootfs/usr/lib/acrn/acrn.up2.sbl
+        ACRN_SBL=sos_rootfs/usr/lib/acrn/acrn.apl-up2.sbl
     fi
 
     if [ ${ACRN_HV_CODE_PATH} ]
@@ -58,7 +58,7 @@ create_sos_images() {
         SOS_BOOTARGS_DEBUG=${ACRN_HV_CODE_PATH}/devicemodel/samples/up2/sos_bootargs_debug.txt
 
         make -C ${ACRN_HV_CODE_PATH} clean || return 1
-        make -C ${ACRN_HV_CODE_PATH} hypervisor BOARD=up2 FIRMWARE=sbl || return 1
+        make -C ${ACRN_HV_CODE_PATH} hypervisor BOARD=apl-up2 FIRMWARE=sbl || return 1
         ACRN_SBL=${ACRN_HV_CODE_PATH}/build/hypervisor/acrn.32.out
     fi
 


### PR DESCRIPTION
The board name for building images for UP2 has been changed from 'up2' to 'apl-up2' by the commit https://github.com/projectacrn/acrn-hypervisor/commit/f9b5e21bdc325a57a253001685d26174984d212c

Tracked-On: #2661
Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>