### PR TITLE
[hv] set ECX.bit31 to indicate the presence of a hypervisor

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -345,6 +345,9 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 			/*mask vmx to guest os */
 			*ecx &= ~CPUID_ECX_VMX;
 
+			/* set Hypervisor Present Bit */
+			*ecx |= CPUID_ECX_HV;
+
 			/*no xsave support for guest if it is not enabled on host*/
 			if ((*ecx & CPUID_ECX_OSXSAVE) == 0U) {
 				*ecx &= ~CPUID_ECX_XSAVE;

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -41,6 +41,7 @@
 #define CPUID_ECX_XSAVE         (1U<<26U)
 #define CPUID_ECX_OSXSAVE       (1U<<27U)
 #define CPUID_ECX_AVX           (1U<<28U)
+#define CPUID_ECX_HV            (1U<<31U)
 #define CPUID_EDX_FPU           (1U<<0U)
 #define CPUID_EDX_VME           (1U<<1U)
 #define CPUID_EDX_DE            (1U<<2U)


### PR DESCRIPTION
ECS.bit31 is not used and always return 0 in SDM Vol.2A 3-195. It's a
standard way to indicate whether there is a hypervisor.

Track-On: #2490
Ref: https://lwn.net/Articles/301888/
Signed-off-by: Xinyun Liu <xinyun.liu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>