### PR TITLE
hv: simplify `get_primary_vcpu` and `vcpu_from_vid`

### DIFF
--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -192,7 +192,7 @@ static int32_t vcpu_do_pending_extint(const struct acrn_vcpu *vcpu)
 
 	/* check if there is valid interrupt from vPIC, if yes just inject it */
 	/* PIC only connect with primary CPU */
-	primary = get_primary_vcpu(vm);
+	primary = vcpu_from_vid(vm, BOOT_CPU_ID);
 	if (vcpu == primary) {
 
 		vpic_pending_intr(vcpu->vm, &vector);

--- a/hypervisor/boot/uefi/uefi_boot.c
+++ b/hypervisor/boot/uefi/uefi_boot.c
@@ -25,7 +25,8 @@ static void efi_spurious_handler(int32_t vector)
 static int32_t uefi_sw_loader(struct acrn_vm *vm)
 {
 	int32_t ret = 0;
-	struct acrn_vcpu *vcpu = get_primary_vcpu(vm);
+	/* get primary vcpu */
+	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
 	struct acrn_vcpu_regs *vcpu_regs = &boot_context;
 	const struct efi_context *efi_ctx = get_efi_ctx();
 	const struct lapic_regs *uefi_lapic_regs = get_efi_lapic_regs();

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -102,7 +102,8 @@ int32_t general_sw_loader(struct acrn_vm *vm)
 	struct zero_page *zeropage;
 	struct sw_linux *linux_info = &(vm->sw.linux_info);
 	struct sw_kernel_info *sw_kernel = &(vm->sw.kernel_info);
-	struct acrn_vcpu *vcpu = get_primary_vcpu(vm);
+	/* get primary vcpu */
+	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
 	const struct e820_mem_params *p_e820_mem_info = get_e820_mem_info();
 
 	pr_dbg("Loading guest to run-time location");

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -175,18 +175,11 @@ static inline uint64_t vm_active_cpus(const struct acrn_vm *vm)
 
 /*
  * @pre vcpu_id < CONFIG_MAX_VCPUS_PER_VM
+ * @pre &(vm->hw.vcpu_array[vcpu_id])->state != VCPU_OFFLINE
  */
 static inline struct acrn_vcpu *vcpu_from_vid(struct acrn_vm *vm, uint16_t vcpu_id)
 {
-	uint16_t i;
-	struct acrn_vcpu *vcpu;
-
-	foreach_vcpu(i, vm, vcpu) {
-		if (vcpu->vcpu_id == vcpu_id) {
-			break;
-		}
-	}
-	return vcpu;
+	return &(vm->hw.vcpu_array[vcpu_id]);
 }
 
 static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_id)
@@ -196,21 +189,6 @@ static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_
 
 	foreach_vcpu(i, vm, vcpu) {
 		if (vcpu->pcpu_id == pcpu_id) {
-			target_vcpu = vcpu;
-			break;
-		}
-	}
-
-	return target_vcpu;
-}
-
-static inline struct acrn_vcpu *get_primary_vcpu(struct acrn_vm *vm)
-{
-	uint16_t i;
-	struct acrn_vcpu *vcpu, *target_vcpu = NULL;
-
-	foreach_vcpu(i, vm, vcpu) {
-		if (is_vcpu_bsp(vcpu)) {
 			target_vcpu = vcpu;
 			break;
 		}


### PR DESCRIPTION
This patch simplifies `get_primary_vcpu` and `vcpu_from_vid`.
The target_vcpu could be get from the index directly.

Tracked-On: #1842
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>