### PR TITLE
Vlapic: refine vlapic Error Handling

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2456,9 +2456,14 @@ static void vlapic_x2apic_self_ipi_handler(struct acrn_vlapic *vlapic)
 	struct acrn_vcpu *target_vcpu;
 
 	lapic = &(vlapic->apic_page);
-	vector = lapic->self_ipi.v & 0xFFU;
+	vector = lapic->self_ipi.v & APIC_VECTOR_MASK;
 	target_vcpu = vlapic->vcpu;
-	vlapic_set_intr(target_vcpu, vector, LAPIC_TRIG_EDGE);
+	if (vector < 16U) {
+		vlapic_set_error(vlapic, APIC_ESR_SEND_ILLEGAL_VECTOR);
+		dev_dbg(ACRN_DBG_LAPIC, "Ignoring invalid IPI %u", vector);
+	} else {
+		vlapic_set_intr(target_vcpu, vector, LAPIC_TRIG_EDGE);
+	}
 }
 
 int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu)

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -793,9 +793,7 @@ vlapic_fire_lvt(struct acrn_vlapic *vlapic, uint32_t lvt)
 
 		switch (mode) {
 		case APIC_LVT_DM_FIXED:
-			if (vlapic_accept_intr(vlapic, vec, LAPIC_TRIG_EDGE)) {
-				vcpu_make_request(vcpu, ACRN_REQUEST_EVENT);
-			}
+			vlapic_set_intr(vcpu, vec, LAPIC_TRIG_EDGE);
 			break;
 		case APIC_LVT_DM_NMI:
 			vcpu_inject_nmi(vcpu);
@@ -969,7 +967,7 @@ vlapic_set_error(struct acrn_vlapic *vlapic, uint32_t mask)
 static int32_t
 vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t lvt_index)
 {
-	uint32_t lvt, vec, mode;
+	uint32_t lvt;
 	int32_t ret = 0;
 	struct acrn_vcpu *vcpu = vlapic->vcpu;
 
@@ -1027,13 +1025,7 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t lvt_index)
 		}
 
 		if (ret == 0) {
-			vec = lvt & APIC_LVT_VECTOR;
-			mode = lvt & APIC_LVT_DM;
-			if ((mode == APIC_LVT_DM_FIXED) && (vec < 16U)) {
-				vlapic_set_error(vlapic, APIC_ESR_RECEIVE_ILLEGAL_VECTOR);
-			} else {
-				vlapic_fire_lvt(vlapic, lvt);
-			}
+			vlapic_fire_lvt(vlapic, lvt);
 		}
 	}
 	return ret;


### PR DESCRIPTION
1) call vlapic_accept_intr directly in vlapic_set_error  to fire it directly. Otherwise, if LVT ERR vector is invalid, an invalid interrupt will be accepted in IRR.
2) add vector check for x2apic SELF IPI
3) move LVT IRQ vector check to vlapic_fire_lvt to simple the vector check for LVT IRQ

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>