### PR TITLE
[RevertMe] dm: pci: restore workaround when alloc pci mem64 bar

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -89,6 +89,7 @@ uint8_t trusty_enabled;
 char *mac_seed;
 bool stdio_in_use;
 bool lapic_pt;
+bool skip_pci_mem64bar_workaround = false;
 
 static int virtio_msix = 1;
 static bool debugexit_enabled;
@@ -859,6 +860,7 @@ dm_run(int argc, char *argv[])
 				errx(EX_USAGE, "invalid ovmf param %s", optarg);
 				exit(1);
 			}
+			skip_pci_mem64bar_workaround = true;
 			break;
 		case CMD_OPT_PART_INFO:
 			if (acrn_parse_guest_part_info(optarg) != 0) {


### PR DESCRIPTION
There was a workaround in DM that allocates PCI 64bit mem bar in 32bit mem space
if the bar size is within 32MB.
After the workaround being removed, there is an issue to enter fastboot
mode for inappropriate handling of 64bit mem bar in guest driver.
The patch bring the workaround back, and skip the workaround when the guest
is booted by OVMF.

Revert the patch after the guest fixs the issue of handling 64bit mem bar in
fastboot mode.

Tracked-On: #2677
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>