### PR TITLE
Script: Fix snd_soc_skl typo in launch script

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -11,9 +11,10 @@ ipu_passthrough=1
 fi
 
 # use the modprobe to force loading snd-soc-skl/sst_bxt_bdf8532
-modprobe -q snd-soc-skl
+modprobe -q snd_soc_skl
+modprobe -q snd_soc_tdf8532
 modprobe -q snd_soc_sst_bxt_sos_tdf8532
-
+modprobe -q snd_soc_skl_virtio_be
 audio_passthrough=0
 
 # Check the device file of /dev/vbs_k_audio to determine the audio mode


### PR DESCRIPTION
Script: Fix snd_soc_skl typo in launch script 

Tracked-On:https://github.com/projectacrn/acrn-hypervisor/issues/2666