### PR TITLE
hv: refined the pmu passthru irq handling

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -714,6 +714,13 @@ vlapic_lvt_write_handler(struct acrn_vlapic *vlapic, uint32_t offset)
 	*lvtptr = val;
 	idx = lvt_off_to_idx(offset);
 	atomic_store32(&vlapic->lvt_last[idx], val);
+
+#if defined(HV_DEBUG) && !defined(PROFILING_ON)
+	if ((offset == APIC_OFFSET_PERF_LVT) &&
+			(val == APIC_LVT_DM_NMI)) {
+		msr_write(MSR_IA32_EXT_APIC_LVT_PMI, VECTOR_PMI);
+	}
+#endif
 }
 
 static void

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1460,7 +1460,6 @@ static void pmu_passthru_pmi_handler(__unused uint32_t irq, __unused void *data)
 
 	msr_write(MSR_IA32_EXT_APIC_LVT_PMI, VECTOR_PMI|LAPIC_LVT_MASK);
 	vlapic_set_local_intr(vcpu->vm, vcpu->vcpu_id, APIC_LVT_PMC);
-	msr_write(MSR_IA32_EXT_APIC_LVT_PMI, VECTOR_PMI);
 }
 
 void profiling_setup(void)


### PR DESCRIPTION
This patch refined the pmu passthru irq handling, which will re-enable
the PMC interrupt in the vlapic handler. So that can avoid some
interrupt storm situation happens.

This patch can fix the remaining Android perf CTS failure.

Tracked-On: #2598
Signed-off-by: Min He <min.he@intel.com>