### PR TITLE
dm: replace unsafe string api for acrn-dm

### DIFF
--- a/devicemodel/include/dm_kmsg.h
+++ b/devicemodel/include/dm_kmsg.h
@@ -8,7 +8,6 @@
 #ifndef _DM_KMSG_H_
 #define _DM_KMSG_H_
 
-#define DM_BUF    4096
 #define KERN_NODE "/dev/kmsg"
 #define KMSG_FMT  "dm_run:"
 


### PR DESCRIPTION
    String function of strlen()/vsnprintf() shuould be replaced.
    This patch remove the strlen(). And vsnprintf() replaced by vasprintf().

Tracked-On: #2687
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>