### PR TITLE
HV: Modularize boot folder

### DIFF
--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -437,8 +437,3 @@ void *gpa2hva(struct acrn_vm *vm, uint64_t x)
 {
 	return hpa2hva(gpa2hpa(vm, x));
 }
-
-uint64_t hva2gpa(struct acrn_vm *vm, void *x)
-{
-	return (is_sos_vm(vm)) ? sos_vm_hpa2gpa(hva2hpa(x)) : INVALID_GPA;
-}

--- a/hypervisor/boot/dmar_parse.c
+++ b/hypervisor/boot/dmar_parse.c
@@ -5,7 +5,12 @@
  */
 
 #ifdef CONFIG_DMAR_PARSE_ENABLED
-#include <hypervisor.h>
+#include <types.h>
+#include <logmsg.h>
+#include <host_pm.h>
+#include <io.h>
+#include <spinlock.h>
+#include <mem_mgt.h>
 #include "pci.h"
 #include "vtd.h"
 #include "acpi_priv.h"

--- a/hypervisor/boot/sbl/abl_seed_parse.c
+++ b/hypervisor/boot/sbl/abl_seed_parse.c
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <errno.h>
+#include <sprintf.h>
+#include <vm.h>
+#include <mmu.h>
+#include <logmsg.h>
 #include <abl_seed_parse.h>
+#include <ept.h>
 
 #define ABL_SEED_LEN 32U
 struct abl_seed_info {
@@ -92,7 +98,6 @@ static void parse_seed_list_abl(void *param_addr)
  *       original address is HPA.
  *
  * input:
- *    vm            pointer to vm structure
  *    cmdline       pointer to cmdline string
  *    out_len       the max len of out_arg
  *
@@ -102,7 +107,7 @@ static void parse_seed_list_abl(void *param_addr)
  * return value:
  *    true if parse successfully, otherwise false.
  */
-bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len)
+bool abl_seed_parse(char *cmdline, char *out_arg, uint32_t out_len)
 {
 	char *arg = NULL, *arg_end;
 	char *param;
@@ -138,7 +143,7 @@ bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t o
 				/* Convert the param_addr to SOS GPA and copy to caller */
 				if (out_arg != NULL) {
 					snprintf(out_arg, out_len, "%s0x%X ",
-							abl_seed_arg[i], hva2gpa(vm, param_addr));
+							abl_seed_arg[i], sos_vm_hpa2gpa(hva2hpa(param_addr)));
 				}
 
 				parse_success = true;

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -152,8 +152,8 @@ int32_t sbl_init_vm_boot_info(struct acrn_vm *vm)
 					vm->sw.linux_info.bootargs_size =
 						strnlen_s(vm_config->os_config.bootargs, MEM_2K);
 				} else {
-					vm->sw.kernel_info.kernel_load_addr = (void *)hva2gpa(vm,
-						get_kernel_load_addr(vm->sw.kernel_info.kernel_src_addr));
+					vm->sw.kernel_info.kernel_load_addr =
+						get_kernel_load_addr(vm->sw.kernel_info.kernel_src_addr);
 
 					/*
 					 * If there is cmdline from mbi->mi_cmdline, merge it with
@@ -174,9 +174,9 @@ int32_t sbl_init_vm_boot_info(struct acrn_vm *vm)
 						 * so here first try to get seed from SBL, if fail then try
 						 * ABL.
 						 */
-						status = sbl_seed_parse(vm, cmd_src, buf, sizeof(buf));
+						status = sbl_seed_parse(is_sos_vm(vm), cmd_src, buf, sizeof(buf));
 						if (!status) {
-							status = abl_seed_parse(vm, cmd_src, buf, sizeof(buf));
+							status = abl_seed_parse(cmd_src, buf, sizeof(buf));
 						}
 
 						if (status) {

--- a/hypervisor/boot/uefi/uefi_boot.c
+++ b/hypervisor/boot/uefi/uefi_boot.c
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
-#include <multiboot.h>
+#include <types.h>
+#include <cpu.h>
+#include <per_cpu.h>
+#include <guest/vm.h>
 #include <boot_context.h>
 #include <firmware_uefi.h>
 

--- a/hypervisor/include/arch/x86/abl_seed_parse.h
+++ b/hypervisor/include/arch/x86/abl_seed_parse.h
@@ -7,6 +7,6 @@
 #ifndef ABL_SEED_PARSE_H_
 #define ABL_SEED_PARSE_H_
 
-bool abl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len);
+bool abl_seed_parse(char *cmdline, char *out_arg, uint32_t out_len);
 
 #endif /* ABL_SEED_PARSE_H_ */

--- a/hypervisor/include/arch/x86/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/guest/guest_memory.h
@@ -36,8 +36,6 @@ enum vm_paging_mode get_vcpu_paging_mode(struct acrn_vcpu *vcpu);
 /* gpa --> hpa -->hva */
 void *gpa2hva(struct acrn_vm *vm, uint64_t x);
 
-uint64_t hva2gpa(struct acrn_vm *vm, void *x);
-
 /**
  * @brief Data transfering between hypervisor and VM
  *

--- a/hypervisor/include/arch/x86/sbl_seed_parse.h
+++ b/hypervisor/include/arch/x86/sbl_seed_parse.h
@@ -7,6 +7,6 @@
 #ifndef SBL_SEED_PARSE_H_
 #define SBL_SEED_PARSE_H_
 
-bool sbl_seed_parse(struct acrn_vm *vm, char *cmdline, char *out_arg, uint32_t out_len);
+bool sbl_seed_parse(bool vm_is_sos, char *cmdline, char *out_arg, uint32_t out_len);
 
 #endif /* SBL_SEED_PARSE_H_ */


### PR DESCRIPTION
In order to remove the usage of hypervisor.h,
modularize the boot folder.
Current changes include modifications to remove
usage of acrn_vm structure pointer, from some of
the call, and remove calls to hypervisor.h,
as and when deemed fit.

Removed hva2gpa, as this was not used anywhere else
after the changes.

Tracked-On: #2694 
Signed-off-by: Arindam Roy <arindam.roy@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>