### PR TITLE
HV: correct COM_IRQ default config type

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -175,7 +175,7 @@ config COM_BASE
 	  Base address of the vuart port.
 
 config COM_IRQ
-	hex "IRQ of the vuart port"
+	int "IRQ of the vuart port"
 	depends on !RELEASE
 	default 4
 	help


### PR DESCRIPTION
change the config type of COM_IRQ from "hex" to "int"; make
it consistent with its default value.

Tracked-On: #2689
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>