### PR TITLE
hv:validate ID and state of vCPU for related APIs

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -751,6 +751,12 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 	}
 
 	vcpu = vcpu_from_vid(vm, vcpu_id);
+	if (vcpu->state == VCPU_OFFLINE) {
+		shell_puts("vcpu is offline\r\n");
+		status = -EINVAL;
+		goto out;
+	}
+
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
 	dump.str_max = SHELL_LOG_BUF_SIZE;


### PR DESCRIPTION
 to validate the ID and state of vCPU in below functions:
  - hcall_set_vcpu_regs()
  - hcall_notify_ioreq_finish()
  - shell_vcpu_dumpreq()

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>