### PR TITLE
HV: Fix modularization vm config code lost CAT code

### DIFF
--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -9,6 +9,8 @@
 #include <errno.h>
 #include <acrn_common.h>
 #include <page.h>
+#include <logmsg.h>
+#include <cat.h>
 #ifndef CONFIG_PARTITION_MODE
 #include <sos_vm.h>
 
@@ -119,6 +121,16 @@ int32_t sanitize_vm_config(void)
 			/* Nothing to do for a UNDEFINED_VM, break directly. */
 			break;
 		}
+
+		if ((vm_config->guest_flags & CLOS_REQUIRED) != 0U) {
+			if (cat_cap_info.support && (vm_config->clos <= cat_cap_info.clos_max)) {
+					cat_cap_info.enabled = true;
+			} else {
+				pr_err("%s set wrong CLOS or CAT is not supported\n", __func__);
+				ret = -EINVAL;
+			}
+		}
+
 		if (ret != 0) {
 			break;
 		}


### PR DESCRIPTION
Previous change 'HV: modularization vm config code', commit id
1bb15c64a668a82c87b92aa5b5e3ceb88f264d2a, lost CAT code when move
sanitize_vm_config() from vm.c to vm_config.c

Tracked-On: #2291
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>