### PR TITLE
hv: Remove multiple definitions for dmar translation structures

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -101,8 +101,8 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	dest_mask = calculate_logical_dest_mask(pdmask);
 
 	/* Using phys_irq as index in the corresponding IOMMU */
-	irte.entry.lower = 0UL;
-	irte.entry.upper = 0UL;
+	irte.entry.lo_64 = 0UL;
+	irte.entry.hi_64 = 0UL;
 	irte.bits.vector = vector;
 	irte.bits.delivery_mode = delmode;
 	irte.bits.dest_mode = MSI_ADDR_DESTMODE_LOGICAL;
@@ -197,8 +197,8 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		vector = irq_to_vector(phys_irq);
 		dest_mask = calculate_logical_dest_mask(pdmask);
 
-		irte.entry.lower = 0UL;
-		irte.entry.upper = 0UL;
+		irte.entry.lo_64 = 0UL;
+		irte.entry.hi_64 = 0UL;
 		irte.bits.vector = vector;
 		irte.bits.delivery_mode = delmode;
 		irte.bits.dest_mode = IOAPIC_RTE_DESTMODE_LOGICAL;

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -489,11 +489,13 @@ struct dmar_info {
 	struct dmar_drhd *drhd_units;
 };
 
+struct dmar_entry {
+	uint64_t lo_64;
+	uint64_t hi_64;
+};
+
 union dmar_ir_entry {
-	struct {
-		uint64_t lower;
-		uint64_t upper;
-	} entry;
+	struct dmar_entry entry;
 	struct {
 		uint64_t present:1;
 		uint64_t fpd:1;


### PR DESCRIPTION
Except for few translation structures in x86 IOMMU, all translation
structures are 128-bit. All the translation structures used by ACRN
are 128 bit. So removed multiple definitions and defined a struct
that accomodates 128 bit entries.

Tracked-On: #2668
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>