### PR TITLE
hv: destroy IOMMU domain after vpci_cleanup()

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -449,18 +449,19 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 
 		ptdev_release_all_entries(vm);
 
-		/* Free EPT allocated resources assigned to VM */
-		destroy_ept(vm);
+		vpci_cleanup(vm);
 
 		/* Free iommu */
 		if (vm->iommu != NULL) {
 			destroy_iommu_domain(vm->iommu);
 		}
 
+		/* Free EPT allocated resources assigned to VM */
+		destroy_ept(vm);
+
 		/* Free vm id */
 		free_vm_id(vm);
 
-		vpci_cleanup(vm);
 		ret = 0;
 	} else {
 	        ret = -EINVAL;


### PR DESCRIPTION
In partition mode, unassign_iommu_device() is called from vpci_cleanup(),
so when shutdown_vm() is called, unassign_iommu_device() could fail because
of "domain id mismatch" and DMAR is not cleared.

Also move destroy_ept() after the call to destroy_iommu_domain().

Tracked-On: #2700
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>