### PR TITLE
dm: fix possible memory leak in 'load_elf32()'

### DIFF
--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -136,6 +136,7 @@ static int load_elf32(struct vmctx *ctx, FILE *fp, void *buf)
 					ctx->lowmem) {
 				fprintf(stderr,
 					"No enough memory to load elf file\n");
+				free(elf32_phdr_bk);
 				return -1;
 			}
 


### PR DESCRIPTION
Dynamic memory stored in 'elf32_phdr' allocated
through 'calloc' be lost.

Tracked-On: #2705
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>