### PR TITLE
HV: PAE: Add stac()/clac() in local_gva2gpa_pae

### DIFF
--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -215,7 +215,9 @@ static int32_t local_gva2gpa_pae(struct acrn_vcpu *vcpu, struct page_walk_info *
 	base = (uint64_t *)gpa2hva(vcpu->vm, addr);
 	if (base != NULL) {
 		index = (gva >> 30U) & 0x3UL;
+		stac();
 		entry = base[index];
+		clac();
 
 		if ((entry & PAGE_PRESENT) != 0U) {
 			pw_info->level = 2U;


### PR DESCRIPTION
Accessing memory of guest will cause page fault when SMAP is enabled.
This patch stac()/clac() correspondingly to get rid of this situation.

Tracked-On: #2713
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>