### PR TITLE
Backport acrnd patches from apl_sdc_stable

### DIFF
--- a/tools/acrn-manager/acrn_mngr.h
+++ b/tools/acrn-manager/acrn_mngr.h
@@ -6,12 +6,6 @@
 #ifndef ACRN_MANAGER_H
 #define ACRN_MANAGER_H
 
-#ifdef MNGR_DEBUG
-#define pdebug()        fprintf(stderr, "%s %d\n", __FUNCTION__, __LINE__)
-#else
-#define pdebug()        while(0){}
-#endif
-
 #include <stdlib.h>
 
 #define MNGR_MSG_MAGIC   0x67736d206d6d76	/* that is char[8] "mngr msg", on X86 */

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -75,11 +75,14 @@ static int query_state(const char *name)
 	req.timestamp = time(NULL);
 
 	ret = send_msg(name, &req, &ack);
-	if (ret)
-		return ret;
-
-	if (ack.data.state < 0)
+	if (ret) {
 		pdebug();
+		return ret;
+	}
+
+	if (ack.data.state < 0) {
+		fprintf(stderr, "%s ack.data.state:%d\n", __FUNCTION__, ack.data.state);
+	}
 
 	return ack.data.state;
 }
@@ -178,6 +181,8 @@ static void _scan_alive_vm(void)
 				vm->state = VM_SUSPENDED;
 				break;
 			default:
+				fprintf(stderr, "Warnning: unknow vm state:0x%lx\n",
+										vm->state);
 				vm->state = VM_STATE_UNKNOWN;
 			}
 		vm->update = update_count;

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -76,7 +76,7 @@ static int query_state(const char *name)
 
 	ret = send_msg(name, &req, &ack);
 	if (ret) {
-		pdebug();
+		printf("%s: Error to quary %s state, err: %d\n", __func__, name, ret);
 		return ret;
 	}
 
@@ -133,13 +133,13 @@ static void _scan_alive_vm(void)
 
 	ret = check_dir(ACRN_DM_SOCK_PATH);
 	if (ret) {
-		pdebug();
+		printf("%s: Failed to check directory %s, err: %d\n", __func__, ACRN_DM_SOCK_PATH, ret);
 		return;
 	}
 
 	dir = opendir(ACRN_DM_SOCK_PATH);
 	if (!dir) {
-		pdebug();
+		printf("%s: Failed to open directory %s\n", __func__, ACRN_DM_SOCK_PATH);
 		return;
 	}
 
@@ -150,9 +150,9 @@ static void _scan_alive_vm(void)
 			continue;
 
 		if (name[sizeof(name) - 1]) {
-			pdebug();
 			/* truncate name and go a head */
 			name[sizeof(name) - 1] = 0;
+			printf("%s: Truncate name as %s\n", __func__, name);
 		}
 
 		vm = vmmngr_find(name);
@@ -160,7 +160,7 @@ static void _scan_alive_vm(void)
 		if (!vm) {
 			vm = calloc(1, sizeof(*vm));
 			if (!vm) {
-				pdebug();
+				printf("%s: Failed to alloc mem for %s\n", __func__, name);
 				continue;
 			}
 			memcpy(vm->name, name, sizeof(vm->name) - 1);
@@ -207,9 +207,9 @@ static inline int _get_vmname_suffix(const char *src,
 
 	strncpy(name, src, p - src);
 	if (p - src >= max_len_name) {
-		pdebug();
 		/* truncate name and go a head */
 		name[max_len_name - 1] = '\0';
+		printf("%s: Truncate name as %s\n", __func__, name);
 	}
 
 	strncpy(suffix, p + 1, max_len_suffix);
@@ -230,26 +230,25 @@ static void _scan_added_vm(void)
 
 	ret = check_dir(ACRN_CONF_PATH);
 	if (ret) {
-		pdebug();
+		printf("%s: Failed to check directory %s, err: %d\n", __func__, ACRN_CONF_PATH, ret);
 		return;
 	}
 
 	ret = check_dir(ACRN_CONF_PATH_ADD);
 	if (ret) {
-		pdebug();
+		printf("%s: Failed to check directory %s, err: %d\n", __func__, ACRN_CONF_PATH_ADD, ret);
 		return;
 	}
 
 	dir = opendir(ACRN_CONF_PATH_ADD);
 	if (!dir) {
-		pdebug();
+		printf("%s: Failed to open directory %s\n", __func__, ACRN_CONF_PATH_ADD);
 		return;
 	}
 
 	while ((entry = readdir(dir))) {
 		ret = strnlen(entry->d_name, sizeof(entry->d_name));
 		if (ret >= sizeof(name)) {
-			pdebug();
 			continue;
 		}
 
@@ -265,7 +264,7 @@ static void _scan_added_vm(void)
 		if (!vm) {
 			vm = calloc(1, sizeof(*vm));
 			if (!vm) {
-				pdebug();
+				printf("%s: Failed to alloc mem for %s\n", __func__, name);
 				continue;
 			}
 			memcpy(vm->name, name, sizeof(vm->name) - 1);
@@ -287,7 +286,7 @@ static void _remove_dead_vm(void)
 		if (vm->update == update_count)
 			continue;
 		LIST_REMOVE(vm, list);
-		pdebug();
+		printf("%s: Removed dead %s\n", __func__, vm->name);
 		free(vm);
 	}
 };

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -171,19 +171,19 @@ static void _scan_alive_vm(void)
 
 		if (ret < 0)
 			/* unsupport query */
-			vm->state = VM_STARTED;
+			vm->state_tmp = VM_STARTED;
 		else
 			switch (ret) {
 			case VM_SUSPEND_NONE:
-				vm->state = VM_STARTED;
+				vm->state_tmp = VM_STARTED;
 				break;
 			case VM_SUSPEND_SUSPEND:
-				vm->state = VM_SUSPENDED;
+				vm->state_tmp = VM_SUSPENDED;
 				break;
 			default:
 				fprintf(stderr, "Warnning: unknow vm state:0x%lx\n",
 										vm->state);
-				vm->state = VM_STATE_UNKNOWN;
+				vm->state_tmp = VM_STATE_UNKNOWN;
 			}
 		vm->update = update_count;
 	}
@@ -271,7 +271,7 @@ static void _scan_added_vm(void)
 			LIST_INSERT_HEAD(&vmmngr_head, vm, list);
 		}
 
-		vm->state = VM_CREATED;
+		vm->state_tmp = VM_CREATED;
 		vm->update = update_count;
 	}
 
@@ -283,8 +283,10 @@ static void _remove_dead_vm(void)
 	struct vmmngr_struct *vm, *tvm;
 
 	list_foreach_safe(vm, &vmmngr_head, list, tvm) {
-		if (vm->update == update_count)
+		if (vm->update == update_count) {
+			vm->state = vm->state_tmp;
 			continue;
+		}
 		LIST_REMOVE(vm, list);
 		printf("%s: Removed dead %s\n", __func__, vm->name);
 		free(vm);

--- a/tools/acrn-manager/acrnctl.h
+++ b/tools/acrn-manager/acrnctl.h
@@ -38,6 +38,7 @@ struct vmmngr_struct *vmmngr_find(const char *vmname);
 struct vmmngr_struct {
 	char name[MAX_NAME_LEN];
 	unsigned long state;
+	unsigned long state_tmp;
 	unsigned long update;   /* update count, remove a vm if no update for it */
 	LIST_ENTRY(vmmngr_struct) list;
 };

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -56,7 +56,7 @@ int acrnd_add_work(void (*func) (struct work_arg *arg),
 	time_t current;
 
 	if (!func) {
-		pdebug();
+		printf("%s: No worker function configured\n", __func__);
 		return -1;
 	}
 
@@ -124,14 +124,14 @@ void acrnd_vm_timer_func(struct work_arg *arg)
 	struct vmmngr_struct *vm;
 
 	if (!arg) {
-		pdebug();
+		printf("%s: No work argument configured\n", __func__);
 		return;
 	}
 
 	vmmngr_update();
 	vm = vmmngr_find(arg->name);
 	if (!vm) {
-		pdebug();
+		printf("%s: Can't find %s\n", __func__, arg->name);
 		return;
 	}
 
@@ -143,7 +143,7 @@ void acrnd_vm_timer_func(struct work_arg *arg)
 		resume_vm(arg->name, CBC_WK_RSN_RTC);
 		break;
 	default:
-		pdebug();
+		printf("%s: Unknown vm state %ld\n", __func__, vm->state);
 	}
 }
 
@@ -259,7 +259,7 @@ static int active_all_vms(void)
 			ret += resume_vm(vm->name, reason);
 			break;
 		default:
-			pdebug();
+			printf("%s: Unkown vm state %ld\n", __func__, vm->state);
 		}
 	}
 
@@ -343,7 +343,7 @@ static void handle_timer_req(struct mngr_msg *msg, int client_fd, void *param)
 	vmmngr_update();
 	vm = vmmngr_find(msg->data.acrnd_timer.name);
 	if (!vm) {
-		pdebug();
+		printf("%s: Can't find %s\n", __func__, msg->data.acrnd_timer.name);
 		goto reply_ack;
 	}
 
@@ -354,7 +354,7 @@ static void handle_timer_req(struct mngr_msg *msg, int client_fd, void *param)
 	}
 
 	if (acrnd_add_work(acrnd_vm_timer_func, &arg, msg->data.acrnd_timer.t)) {
-		pdebug();
+		printf("%s: Failed to add acrnd_vm_timer_func\n", __func__);
 		goto reply_ack;
 	}
 
@@ -673,12 +673,12 @@ int main(int argc, char *argv[])
 	/* create listening thread */
 	acrnd_fd = mngr_open_un(ACRND_NAME, MNGR_SERVER);
 	if (acrnd_fd < 0) {
-		pdebug();
+		printf("%s: Failed to open %s, err: %s\n", __func__, ACRND_NAME, strerror(errno));
 		return -1;
 	}
 
 	if (init_vm()) {
-		pdebug();
+		printf("%s: Failed to init_vm\n", __func__);
 		return -1;
 	}
 

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -122,6 +122,7 @@ unsigned get_sos_wakeup_reason(void);
 void acrnd_vm_timer_func(struct work_arg *arg)
 {
 	struct vmmngr_struct *vm;
+	pid_t pid;
 
 	if (!arg) {
 		printf("%s: No work argument configured\n", __func__);
@@ -137,7 +138,9 @@ void acrnd_vm_timer_func(struct work_arg *arg)
 
 	switch (vm->state) {
 	case VM_CREATED:
-		acrnd_run_vm(arg->name);
+		pid = fork();
+		if (!pid)
+			acrnd_run_vm(vm->name);
 		break;
 	case VM_SUSPENDED:
 		resume_vm(arg->name, CBC_WK_RSN_RTC);


### PR DESCRIPTION
Backport acrnd patches from apl_sdc_stable
Print more information at acrnd_add_work(), query_state()
try_do_works() and handle_acrnd_resume()

Tracked-On: #2716
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>