### PR TITLE
vmtrr: add hide_mtrr config for per-VM

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -311,10 +311,6 @@ config UEFI_OS_LOADER_NAME
 	depends on PLATFORM_UEFI
 	default "\\EFI\\org.clearlinux\\bootloaderx64.efi"
 
-config MTRR_ENABLED
-	bool "Memory Type Range Registers (MTRR) enabled"
-	default y
-
 config RELOC
 	bool "Enable hypervisor relocation"
 	default y

--- a/hypervisor/arch/x86/configs/apl-mrb/partition_config.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/partition_config.h
@@ -20,6 +20,7 @@
 #define VM0_CONFIG_OS_BOOTARGS			"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable xapic_phys"
+#define VM0_CONFIG_HIDE_MTRR			false
 
 #define	VM1_CONFIGURED
 
@@ -34,6 +35,7 @@
 #define VM1_CONFIG_OS_BOOTARGS			"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
 						consoleblank=0 tsc=reliable xapic_phys"
+#define VM1_CONFIG_HIDE_MTRR			false
 
 #define VM0_CONFIG_PCI_PTDEV_NUM		2U
 #define VM1_CONFIG_PCI_PTDEV_NUM		3U

--- a/hypervisor/arch/x86/configs/dnv-cb2/partition_config.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/partition_config.h
@@ -20,6 +20,7 @@
 #define VM0_CONFIG_OS_BOOTARGS			"root=/dev/sda rw rootwait noxsave maxcpus=4 nohpet console=hvc0 " \
 						"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 						"consoleblank=0 tsc=reliable xapic_phys  apic_debug"
+#define VM0_CONFIG_HIDE_MTRR			false
 
 #define	VM1_CONFIGURED
 
@@ -34,6 +35,7 @@
 #define VM1_CONFIG_OS_BOOTARGS			"root=/dev/sda2 rw rootwait noxsave maxcpus=4 nohpet console=hvc0 "\
 							"console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M "\
 							"consoleblank=0 tsc=reliable xapic_phys apic_debug"
+#define VM1_CONFIG_HIDE_MTRR			false
 
 #define VM0_CONFIG_PCI_PTDEV_NUM		3U
 #define VM1_CONFIG_PCI_PTDEV_NUM		3U

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -27,6 +27,21 @@ static struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] __aligned(PAGE_SIZE) 
 			.name = SOS_VM_CONFIG_OS_NAME,
 		},
 	},
+	{
+#ifdef VM1_CONFIG_HIDE_MTRR
+		.hide_mtrr = VM1_CONFIG_HIDE_MTRR,
+#endif
+	},
+	{
+#ifdef VM2_CONFIG_HIDE_MTRR
+		.hide_mtrr = VM2_CONFIG_HIDE_MTRR,
+#endif
+	},
+	{
+#ifdef VM3_CONFIG_HIDE_MTRR
+		.hide_mtrr = VM3_CONFIG_HIDE_MTRR,
+#endif
+	},
 };
 #else
 #include <partition_config.h>
@@ -48,6 +63,7 @@ static struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] __aligned(PAGE_SIZE) 
 		.vm_vuart = true,	\
 		.pci_ptdev_num = VM##idx##_CONFIG_PCI_PTDEV_NUM,	\
 		.pci_ptdevs = vm##idx##_pci_ptdevs,	\
+		.hide_mtrr = VM##idx##_CONFIG_HIDE_MTRR,	\
 	}
 
 static struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] __aligned(PAGE_SIZE) = {

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -391,9 +391,9 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 	/* Create per vcpu vlapic */
 	vlapic_create(vcpu);
 
-#ifdef CONFIG_MTRR_ENABLED
-	init_vmtrr(vcpu);
-#endif
+	if (!vm_hide_mtrr(vm)) {
+		init_vmtrr(vcpu);
+	}
 
 	spinlock_init(&(vcpu->arch.lock));
 

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -322,10 +322,10 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 			*ebx &= ~APIC_ID_MASK;
 			*ebx |= (apicid <<  APIC_ID_SHIFT);
 
-#ifndef CONFIG_MTRR_ENABLED
-			/* mask mtrr */
-			*edx &= ~CPUID_EDX_MTRR;
-#endif
+			if (vm_hide_mtrr(vcpu->vm)) {
+				/* mask mtrr */
+				*edx &= ~CPUID_EDX_MTRR;
+			}
 
 			/* mask Debug Store feature */
 			*ecx &= ~(CPUID_ECX_DTES64 | CPUID_ECX_DS_CPL);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -363,6 +363,8 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	}
 
 	if (status == 0) {
+		vm->arch_vm.hide_mtrr = vm_config->hide_mtrr;
+
 		enable_iommu();
 
 		INIT_LIST_HEAD(&vm->softirq_dev_entry_list);

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -407,11 +407,11 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	case MSR_IA32_MTRR_FIX4K_F0000:
 	case MSR_IA32_MTRR_FIX4K_F8000:
 	{
-#ifdef CONFIG_MTRR_ENABLED
-		v = read_vmtrr(vcpu, msr);
-#else
-		err = -EACCES;
-#endif
+		if (!vm_hide_mtrr(vcpu->vm)) {
+			v = read_vmtrr(vcpu, msr);
+		} else {
+			err = -EACCES;
+		}
 		break;
 	}
 	case MSR_IA32_BIOS_SIGN_ID:
@@ -549,11 +549,11 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	case MSR_IA32_MTRR_FIX4K_F0000:
 	case MSR_IA32_MTRR_FIX4K_F8000:
 	{
-#ifdef CONFIG_MTRR_ENABLED
-		write_vmtrr(vcpu, msr, v);
-#else
-		err = -EACCES;
-#endif
+		if (!vm_hide_mtrr(vcpu->vm)) {
+			write_vmtrr(vcpu, msr, v);
+		} else {
+			err = -EACCES;
+		}
 		break;
 	}
 	case MSR_IA32_BIOS_SIGN_ID:

--- a/hypervisor/arch/x86/guest/vmtrr.c
+++ b/hypervisor/arch/x86/guest/vmtrr.c
@@ -12,8 +12,6 @@
 #include <vm.h>
 #include <logmsg.h>
 
-#ifdef CONFIG_MTRR_ENABLED
-
 #define MTRR_FIXED_RANGE_ALL_WB (MTRR_MEM_TYPE_WB \
 					| (MTRR_MEM_TYPE_WB << 8U) \
 					| (MTRR_MEM_TYPE_WB << 16U) \
@@ -266,5 +264,3 @@ uint64_t read_vmtrr(const struct acrn_vcpu *vcpu, uint32_t msr)
 
 	return ret;
 }
-
-#endif /* CONFIG_MTRR_ENABLED */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -260,9 +260,7 @@ struct acrn_vcpu_arch {
 	/* per vcpu lapic */
 	struct acrn_vlapic vlapic;
 
-#ifdef CONFIG_MTRR_ENABLED
 	struct acrn_vmtrr vmtrr;
-#endif
 
 	int32_t cur_context;
 	struct cpu_context contexts[NR_WORLD];

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -159,6 +159,11 @@ struct acrn_vm {
 	uint64_t intr_inject_delay_delta; /* delay of intr injection */
 } __aligned(PAGE_SIZE);
 
+static inline bool vm_hide_mtrr(const struct acrn_vm *vm)
+{
+	return vm->arch_vm.hide_mtrr;
+}
+
 /*
  * @pre vlapic != NULL
  */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -113,6 +113,8 @@ struct vm_arch {
 	struct acrn_vpic vpic;      /* Virtual PIC */
 	struct vm_io_handler_desc emul_pio[EMUL_PIO_IDX_MAX];
 
+	bool hide_mtrr;
+
 	/* reference to virtual platform to come here (as needed) */
 } __aligned(PAGE_SIZE);
 

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -58,6 +58,7 @@ struct acrn_vm_config {
 	struct acrn_vm_pci_ptdev_config *pci_ptdevs;	/* point to PCI PT devices BDF list */
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
 	uint16_t clos;					/* if guest_flags has CAT_ENABLED, then VM use this CLOS */
+	bool hide_mtrr;					/* if the guest doesn't need MTRR, just hide it */
 
 #ifdef CONFIG_PARTITION_MODE
 	bool			vm_vuart;


### PR DESCRIPTION
v2:
remove the globle CONFIG_MTRR_ENABLED

v1:
Add config for per-VM to hide mtrr from VM.
For partition mode VM, disable hide_mtrr by default;
For sharing mode VM, SOS always enable mtrr, normal VM doesn't configure this
to enable mtrr too.

Tracked-On: #1842
    Signed-off-by: Li, Fei1 <fei1.li@intel.com>
