### PR TITLE
hv: Use domain/device specific invalidation for DMAR translation caches

### DIFF
--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -300,11 +300,6 @@ static inline uint8_t iommu_ecap_pds(uint64_t ecap)
 #define DMA_GSTS_CFIS (1U << 23U)
 
 /* CCMD_REG */
-#define DMA_CCMD_ICC (1UL << 63U)
-#define DMA_CCMD_ICC_32 (1U << 31U)
-#define DMA_CCMD_GLOBAL_INVL (1UL << 61U)
-#define DMA_CCMD_DOMAIN_INVL (2UL << 61U)
-#define DMA_CCMD_DEVICE_INVL (3UL << 61U)
 #define DMA_CONTEXT_GLOBAL_INVL (1UL << 4U)
 #define DMA_CONTEXT_DOMAIN_INVL (2UL << 4U)
 #define DMA_CONTEXT_DEVICE_INVL (3UL << 4U)
@@ -357,6 +352,9 @@ static inline uint8_t dma_iotlb_invl_addr_am(uint8_t am)
 	return (am & 0x3fU);
 }
 
+/* IEC_REG */
+#define DMAR_IECI_INDEXED		(((uint64_t)1UL) << 4U)
+#define DMAR_IEC_GLOBAL_INVL		(((uint64_t)0UL) << 4U)
 static inline uint64_t dma_iec_index(uint16_t index, uint8_t index_mask)
 {
 	return ((((uint64_t)index & 0xFFFFU) << 32U) | (((uint64_t)index_mask & 0x1FU) << 27U));


### PR DESCRIPTION
ACRN uses global invalidation for all DMAR translation caches. Whenever
a UOS is shutdown or rebooted, it ends up clearing entries in translation
caches belonging to other VMs/domains. This patch adds support for
domain/device level invalidation for DMA translation caches and index
based invalidation for Interrupt Remapping Cache

Tracked-On: #2738
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>