### PR TITLE
Unifying the VPCI partition mode and sharing mode code (patch series #3)

### DIFF
--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -34,7 +34,6 @@
 #include <vpci.h>
 #include "pci_priv.h"
 
-static int32_t vmsi_init(struct pci_vdev *vdev);
 
 static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 {
@@ -107,7 +106,7 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 	return ret;
 }
 
-static int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret;
 	/* For PIO access, we emulate Capability Structures only */
@@ -121,7 +120,7 @@ static int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32
 	return ret;
 }
 
-static int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	bool message_changed = false;
 	bool enable;
@@ -159,7 +158,7 @@ static int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t by
 	return ret;
 }
 
-static int32_t vmsi_deinit(struct pci_vdev *vdev)
+int32_t vmsi_deinit(struct pci_vdev *vdev)
 {
 	if (vdev->msi.capoff != 0U) {
 		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);
@@ -190,7 +189,7 @@ static void buf_write32(uint8_t buf[], uint32_t val)
 	buf[3] = (uint8_t)((val >> 24U) & 0xFFU);
 }
 
-static int32_t vmsi_init(struct pci_vdev *vdev)
+int32_t vmsi_init(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev = vdev->pdev;
 	uint32_t val;

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -156,7 +156,7 @@ static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index
 	return ret;
 }
 
-static int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret;
 	/* For PIO access, we emulate Capability Structures only */
@@ -171,7 +171,7 @@ static int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint3
 	return ret;
 }
 
-static int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	uint32_t msgctrl;
 	int32_t ret;
@@ -383,7 +383,7 @@ static int32_t vmsix_init_helper(struct pci_vdev *vdev)
 	return ret;
 }
 
-static int32_t vmsix_init(struct pci_vdev *vdev)
+int32_t vmsix_init(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev = vdev->pdev;
 	int32_t ret = 0;
@@ -401,7 +401,7 @@ static int32_t vmsix_init(struct pci_vdev *vdev)
 	return ret;
 }
 
-static int32_t vmsix_deinit(struct pci_vdev *vdev)
+int32_t vmsix_deinit(struct pci_vdev *vdev)
 {
 	vdev->msix.intercepted_size = 0U;
 

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -71,13 +71,12 @@ static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset
 extern const struct vpci_ops partition_mode_vpci_ops;
 #else
 extern const struct vpci_ops sharing_mode_vpci_ops;
+extern const struct pci_vdev_ops pci_ops_vdev_msi;
 extern const struct pci_vdev_ops pci_ops_vdev_msix;
 #endif
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-
-void populate_msi_struct(struct pci_vdev *vdev);
 
 void add_vdev_handler(struct pci_vdev *vdev, const struct pci_vdev_ops *ops);
 

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -73,6 +73,16 @@ extern const struct vpci_ops partition_mode_vpci_ops;
 extern const struct vpci_ops sharing_mode_vpci_ops;
 extern const struct pci_vdev_ops pci_ops_vdev_msi;
 extern const struct pci_vdev_ops pci_ops_vdev_msix;
+
+int32_t vmsi_init(struct pci_vdev *vdev);
+int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+int32_t vmsi_deinit(struct pci_vdev *vdev);
+
+int32_t vmsix_init(struct pci_vdev *vdev);
+int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+int32_t vmsix_deinit(struct pci_vdev *vdev);
 #endif
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -137,7 +137,11 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const void *cb_data)
 
 	vdev = alloc_pci_vdev(vm, pdev);
 	if (vdev != NULL) {
-		populate_msi_struct(vdev);
+		/* Assign MSI handler for configuration read and write */
+		add_vdev_handler(vdev, &pci_ops_vdev_msi);
+
+		/* Assign MSI-X handler for configuration read and write */
+		add_vdev_handler(vdev, &pci_ops_vdev_msix);
 	}
 }
 


### PR DESCRIPTION
Changes include:

Remove the populate_msi_struct() function, put msi initialization specific
functionality into msi.x, and put msix initialization specific functionality
into msix.c

Declare and export sharing mode's vdev functions as global instead of static local

Tracked-On: #2534
Signed-off-by: dongshen dongsheng.x.zhang@intel.com

Will need to post more patches to eventually unify the VPCI partition/sharing mode code