### PR TITLE
hv: vlapic: add TPR below threshold implement

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2513,8 +2513,8 @@ int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu)
 	return handled;
 }
 
-int32_t tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu)
+int32_t tpr_below_threshold_vmexit_handler(struct acrn_vcpu *vcpu)
 {
-	pr_err("Unhandled %s.", __func__);
+	vcpu_make_request(vcpu, ACRN_REQUEST_EVENT);
 	return 0;
 }

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -345,13 +345,12 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	} else {
 		/*
 		 * This field exists only on processors that support
-		 * the 1-setting  of the "use TPR shadow"
-		 * VM-execution control.
+		 * the 1-setting of the "use TPR shadow" VM-execution control.
 		 *
-		 * Set up TPR threshold for virtual interrupt delivery
+		 * Set up TPR threshold for virtual interrupt delivery not support
 		 * - pg 2904 24.6.8
 		 */
-		exec_vmwrite32(VMX_TPR_THRESHOLD, 0U);
+		exec_vmwrite32(VMX_TPR_THRESHOLD, 0xFU);
 	}
 
 	if (cpu_has_cap(X86_FEATURE_OSXSAVE)) {

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -234,7 +234,7 @@ void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);
 int32_t apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);
-int32_t tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
+int32_t tpr_below_threshold_vmexit_handler(struct acrn_vcpu *vcpu);
 void vlapic_calc_dest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
 void vlapic_calc_dest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 


### PR DESCRIPTION
Set TPR threshold to highest value (0xF) to trap out almost the TPR set.
This will simplify the TPR below threshold implement as much as possible.

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>