### PR TITLE
DM: Set thre_int_pending as true when write IER_ETXRDY

### DIFF
--- a/devicemodel/hw/uart_core.c
+++ b/devicemodel/hw/uart_core.c
@@ -466,7 +466,13 @@ uart_write(struct uart_vdev *uart, int offset, uint8_t value)
 		/*
 		 * Apply mask so that bits 4-7 are 0
 		 * Also enables bits 0-3 only if they're 1
+		 *
+		 * Set uart->thre_int_pending to true if (uart->ier & IER_ETXRDY) changes
+		 * from 0 to 1 in order trigger one tx interrupt as expect.
 		 */
+		if (((uart->ier & IER_ETXRDY) == 0) && ((value & IER_ETXRDY) != 0)) {
+			uart->thre_int_pending = true;
+		}
 		uart->ier = value & 0x0F;
 		break;
 	case REG_FCR:


### PR DESCRIPTION
There are uart drivers which send data to hardware in ISR, like zephyr.
Zephyr uart driver stores data in tx_ringbuf and then write the IER of
uart to trigger tx interrupt. Finally, it write the data stored in tx_ringbuf
to uart hardware in ISR.

In current design of vUART in acrn-dm, we cann't handle above situation as we
only mark thre_int_pending as true when writing to REG_DATA. But it will no
real data write to uart hardware before firing interrupt in implementation of
zephyr's uart driver. Consequently, zephyr uart driver will wait for tx
interrupt to be triggered and then wirte data to uart hardware. But acrn-dm
will wait for data arriving to trigger interrupt. Here, dead loop occurs.

This patch set uart->thre_int_pending to true if (uart->ier & IER_ETXRDY)
changes from 0 to 1 in order to tigger one tx interrupt as expect to make
zephyr uart driver happy.

Tracked-On: #2713
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Signed-off-by: Anthony Xu <anthony.xu@intel.com>