### PR TITLE
move instr_emul_ctxt instance to struct vcpu

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -486,7 +486,6 @@ static void get_guest_paging_info(struct acrn_vcpu *vcpu, struct instr_emul_ctxt
 	cpl = (uint8_t)((csar >> 5U) & 3U);
 	emul_ctxt->paging.cr3 = exec_vmread(VMX_GUEST_CR3);
 	emul_ctxt->paging.cpl = cpl;
-	emul_ctxt->paging.cpu_mode = get_vcpu_mode(vcpu);
 	emul_ctxt->paging.paging_mode = get_vcpu_paging_mode(vcpu);
 }
 

--- a/hypervisor/arch/x86/guest/io_emul.c
+++ b/hypervisor/arch/x86/guest/io_emul.c
@@ -53,7 +53,7 @@ emulate_pio_complete(struct acrn_vcpu *vcpu, const struct io_request *io_req)
  * either a previous call to emulate_io() returning 0 or the corresponding VHM
  * request transferring to the COMPLETE state.
  */
-static void emulate_mmio_complete(const struct acrn_vcpu *vcpu, const struct io_request *io_req)
+static void emulate_mmio_complete(struct acrn_vcpu *vcpu, const struct io_request *io_req)
 {
 	const struct mmio_request *mmio_req = &io_req->reqs.mmio;
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -12,11 +12,13 @@
  #include <pgtable.h>
  #include <host_pm.h>
  #include <trampoline.h>
+ #include <msr.h>
  #include <vmx.h>
  #include <console.h>
  #include <ioapic.h>
  #include <vtd.h>
  #include <lapic.h>
+ #include <vcpu.h>
 
 struct cpu_context cpu_ctx;
 

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -7,6 +7,8 @@
 #include <types.h>
 #include <errno.h>
 #include <io.h>
+#include <msr.h>
+#include <apicreg.h>
 #include <cpuid.h>
 #include <cpu_caps.h>
 #include <softirq.h>

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -7,6 +7,7 @@
  */
 
 #include <types.h>
+#include <msr.h>
 #include <per_cpu.h>
 #include <pgtable.h>
 

--- a/hypervisor/include/arch/x86/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/guest/instr_emul.h
@@ -32,8 +32,9 @@
 
 #include <types.h>
 #include <cpu.h>
-#include <vcpu.h>
+#include <guest_memory.h>
 
+struct acrn_vcpu;
 struct instr_emul_vie_op {
 	uint8_t		op_type;	/* type of operation (e.g. MOV) */
 	uint16_t	op_flags;
@@ -94,10 +95,9 @@ struct vm_guest_paging {
 struct instr_emul_ctxt {
 	struct instr_emul_vie vie;
 	struct vm_guest_paging paging;
-	struct acrn_vcpu *vcpu;
 };
 
-int32_t emulate_instruction(const struct acrn_vcpu *vcpu);
+int32_t emulate_instruction(struct acrn_vcpu *vcpu);
 int32_t decode_instruction(struct acrn_vcpu *vcpu);
 
 #endif

--- a/hypervisor/include/arch/x86/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/guest/instr_emul.h
@@ -88,7 +88,6 @@ struct instr_emul_vie {
 struct vm_guest_paging {
 	uint64_t	cr3;
 	uint8_t		cpl;
-	enum vm_cpu_mode cpu_mode;
 	enum vm_paging_mode paging_mode;
 };
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -60,6 +60,7 @@
 #include <io_req.h>
 #include <msr.h>
 #include <cpu.h>
+#include <instr_emul.h>
 
 /**
  * @brief vcpu
@@ -326,6 +327,7 @@ struct acrn_vcpu {
 	bool launched; /* Whether the vcpu is launched on target pcpu */
 	uint32_t running; /* vcpu is picked up and run? */
 
+	struct instr_emul_ctxt inst_ctxt;
 	struct io_request req; /* used by io/ept emulation */
 
 	uint64_t reg_cached;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -10,10 +10,13 @@
 #include <types.h>
 #include <sbuf.h>
 #include <irq.h>
+#include <page.h>
+#include <timer.h>
 #include <instr_emul.h>
 #include <profiling.h>
 #include <logmsg.h>
 #include <gdt.h>
+#include <schedule.h>
 #include <security.h>
 
 struct per_cpu_region {
@@ -36,7 +39,6 @@ struct per_cpu_region {
 	struct per_cpu_timers cpu_timers;
 	struct sched_context sched_ctx;
 	struct sched_object idle;
-	struct instr_emul_ctxt g_inst_ctxt;
 	struct host_gdt gdt;
 	struct tss_64 tss;
 	enum pcpu_boot_state boot_state;


### PR DESCRIPTION
--now the 'cpu_mode' is unused in struct vm_guest_paging,
    and there is the  same variable in struct acrn_vcpu_arch
--  move instr_emul_ctxt instance from struct per_cpu_region
     to struct vcpu, and rename it from g_inst_ctxt to inst_ctxt

Tracked-On: #1842