### PR TITLE
Acrn stable memory leak

### DIFF
--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -262,9 +262,18 @@ pci_gvt_deinit(struct vmctx *ctx, struct pci_vdev *pi, char *opts)
 	int ret;
 	struct pci_gvt *gvt = pi->arg;
 
+	if (gvt && gvt->host_config) {
+		/* Free the allocated host_config */
+		free(gvt->host_config);
+		gvt->host_config = NULL;
+	}
+
 	ret = gvt_destroy_instance(gvt);
 	if (ret)
 		WPRINTF(("GVT: %s: failed: errno=%d\n", __func__, ret));
+
+	free(gvt);
+	pi->arg = NULL;
 }
 
 struct pci_vdev_ops pci_ops_gvt = {

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -857,6 +857,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			break;
 		}
 	}
+	pci_iterator_destroy(iter);
 
 	if (error < 0) {
 		warnx("No physical PCI device %x:%x.%x!", bus, slot, func);


### PR DESCRIPTION
Fix the memory leak in pci_gvt_init and passthru_init of DeviceModel.
Tracked-On: #2752
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: He, Min <min.he@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>