### PR TITLE
hv: remove CONFIG_PARTITION_MODE for pre-launched VM vE820 creation

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -137,8 +137,8 @@ C_SRCS += arch/x86/seed/seed_sbl.c
 
 # configuration component
 C_SRCS += arch/x86/configs/vm_config.c
-ifeq ($(CONFIG_PARTITION_MODE),y)
 C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/ve820.c
+ifeq ($(CONFIG_PARTITION_MODE),y)
 C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/pt_dev.c
 endif
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -133,6 +133,7 @@ uint16_t get_vm_pcpu_nums(const struct acrn_vm_config *vm_config)
 	}
 	return pcpu_num;
 }
+#endif
 
 /**
  * @pre vm != NULL
@@ -175,7 +176,6 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 		}
 	}
 }
-#endif
 
 /**
  * before boot sos_vm(service OS), call it to hide the HV RAM entry in e820 table from sos_vm
@@ -356,11 +356,12 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 
 		(void)memcpy_s(&vm->GUID[0], sizeof(vm->GUID),
 			&vm_config->GUID[0], sizeof(vm_config->GUID));
-#ifdef CONFIG_PARTITION_MODE
-		create_prelaunched_vm_e820(vm);
-		prepare_prelaunched_vm_memmap(vm, vm_config);
-		(void)firmware_init_vm_boot_info(vm);
-#endif
+
+		 if (vm_config->type == PRE_LAUNCHED_VM) {
+			create_prelaunched_vm_e820(vm);
+			prepare_prelaunched_vm_memmap(vm, vm_config);
+			(void)firmware_init_vm_boot_info(vm);
+		 }
 	}
 
 	if (status == 0) {


### PR DESCRIPTION
Preparing for hybrid mode:
- Compile ve820.c even when CONFIG_PARTITION_MODE is not defined.
- Check VM type for creating vE820 and other init code.

Tracked-On: #2291
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>