### PR TITLE
hv: trusty: refine control registers switching method

### DIFF
--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -158,18 +158,16 @@ static void save_world_ctx(struct acrn_vcpu *vcpu, struct ext_context *ext_ctx)
 {
 	uint32_t i;
 
-	/* cache on-demand run_context for efer/rflags/rsp/rip */
+	/* cache on-demand run_context for efer/rflags/rsp/rip/cr0/cr4 */
 	(void)vcpu_get_efer(vcpu);
 	(void)vcpu_get_rflags(vcpu);
 	(void)vcpu_get_rsp(vcpu);
 	(void)vcpu_get_rip(vcpu);
+	(void)vcpu_get_cr0(vcpu);
+	(void)vcpu_get_cr4(vcpu);
 
 	/* VMCS GUEST field */
 	ext_ctx->tsc_offset = exec_vmread(VMX_TSC_OFFSET_FULL);
-	ext_ctx->vmx_cr0 = exec_vmread(VMX_GUEST_CR0);
-	ext_ctx->vmx_cr4 = exec_vmread(VMX_GUEST_CR4);
-	ext_ctx->vmx_cr0_read_shadow = exec_vmread(VMX_CR0_READ_SHADOW);
-	ext_ctx->vmx_cr4_read_shadow = exec_vmread(VMX_CR4_READ_SHADOW);
 	ext_ctx->cr3 = exec_vmread(VMX_GUEST_CR3);
 	ext_ctx->dr7 = exec_vmread(VMX_GUEST_DR7);
 	ext_ctx->ia32_debugctl = exec_vmread64(VMX_GUEST_IA32_DEBUGCTL_FULL);
@@ -219,20 +217,18 @@ static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext
 {
 	uint32_t i;
 
-	/* mark to update on-demand run_context for efer/rflags/rsp */
+	/* mark to update on-demand run_context for efer/rflags/rsp/rip/cr0/cr4 */
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RFLAGS, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RSP, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RIP, &vcpu->reg_updated);
+	bitmap_set_lock(CPU_REG_CR0, &vcpu->reg_updated);
+	bitmap_set_lock(CPU_REG_CR4, &vcpu->reg_updated);
 
 	/* VMCS Execution field */
 	exec_vmwrite64(VMX_TSC_OFFSET_FULL, ext_ctx->tsc_offset);
 
 	/* VMCS GUEST field */
-	exec_vmwrite(VMX_GUEST_CR0, ext_ctx->vmx_cr0);
-	exec_vmwrite(VMX_GUEST_CR4, ext_ctx->vmx_cr4);
-	exec_vmwrite(VMX_CR0_READ_SHADOW, ext_ctx->vmx_cr0_read_shadow);
-	exec_vmwrite(VMX_CR4_READ_SHADOW, ext_ctx->vmx_cr4_read_shadow);
 	exec_vmwrite(VMX_GUEST_CR3, ext_ctx->cr3);
 	exec_vmwrite(VMX_GUEST_DR7, ext_ctx->dr7);
 	exec_vmwrite64(VMX_GUEST_IA32_DEBUGCTL_FULL, ext_ctx->ia32_debugctl);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -171,7 +171,7 @@ struct run_context {
 };
 
 /*
- * extended context does not save/restore during vm exity/entry, it's mainly
+ * extended context does not save/restore during vm exit/entry, it's mainly
  * used in trusty world switch
  */
 struct ext_context {
@@ -202,11 +202,6 @@ struct ext_context {
 
 	uint64_t dr7;
 	uint64_t tsc_offset;
-
-	uint64_t vmx_cr0;
-	uint64_t vmx_cr4;
-	uint64_t vmx_cr0_read_shadow;
-	uint64_t vmx_cr4_read_shadow;
 
 	/* The 512 bytes area to save the FPU/MMX/SSE states for the guest */
 	uint64_t


### PR DESCRIPTION
Remove vmx_cr0/vmx_cr4 from ext_context structure, they are duplicated
with cr0/cr4 fields in run_context.
Switch cr0/cr4 of run_context structure on demand when do world switch.

Remove vmx_cr0_read_shadow/vmx_cr4_read_shadow from ext_context structure.
These fields should be same for both normal world and secure world.

Tracked-On: #2773
Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>