### PR TITLE
doc: add v0.7 version to master branch (/latest)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,6 +189,7 @@ else:
 html_context = {
    'current_version': current_version,
    'versions': ( ("latest", "/latest/"),
+                 ("0.7", "/0.7/"),
                  ("0.6", "/0.6/"),
                  ("0.5", "/0.5/"),
                  ("0.4", "/0.4/"),


### PR DESCRIPTION
With the 0.7 release published, we can add the v0.7 doc menu choice.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>