### PR TITLE
hv: seed: refine header file

### DIFF
--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -3,8 +3,14 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
-#include <hypervisor.h>
+#include <types.h>
+#include <cpu.h>
+#include <pgtable.h>
+#include <rtl.h>
+#include <mmu.h>
+#include <sprintf.h>
+#include <ept.h>
+#include <logmsg.h>
 #include <multiboot.h>
 #include <crypto_api.h>
 #include <seed.h>

--- a/hypervisor/arch/x86/seed/seed_abl.c
+++ b/hypervisor/arch/x86/seed/seed_abl.c
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <cpu.h>
+#include <pgtable.h>
+#include <rtl.h>
 #include <seed.h>
 #include "seed_abl.h"
 

--- a/hypervisor/arch/x86/seed/seed_sbl.c
+++ b/hypervisor/arch/x86/seed/seed_sbl.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <hypervisor.h>
+#include <types.h>
+#include <cpu.h>
+#include <pgtable.h>
+#include <rtl.h>
+#include <logmsg.h>
 #include <seed.h>
 #include "seed_sbl.h"
 

--- a/hypervisor/include/arch/x86/guest/trusty.h
+++ b/hypervisor/include/arch/x86/guest/trusty.h
@@ -7,11 +7,10 @@
 #ifndef TRUSTY_H_
 #define TRUSTY_H_
 #include <acrn_hv_defs.h>
+#include <seed.h>
 
-#define BOOTLOADER_SEED_MAX_ENTRIES     10U
 #define RPMB_MAX_PARTITION_NUMBER       6U
 #define MMC_PROD_NAME_WITH_PSN_LEN      15U
-#define BUP_MKHI_BOOTLOADER_SEED_LEN    64U
 
 #define TRUSTY_RAM_SIZE	(16UL * 1024UL * 1024UL)	/* 16 MB for now */
 
@@ -22,14 +21,6 @@
 
 struct acrn_vcpu;
 struct acrn_vm;
-
-/* Structure of seed info */
-struct seed_info {
-	uint8_t cse_svn;
-	uint8_t bios_svn;
-	uint8_t padding[2];
-	uint8_t seed[BUP_MKHI_BOOTLOADER_SEED_LEN];
-};
 
 /* Structure of key info */
 struct trusty_key_info {

--- a/hypervisor/include/arch/x86/seed.h
+++ b/hypervisor/include/arch/x86/seed.h
@@ -7,6 +7,18 @@
 #ifndef SEED_H_
 #define SEED_H_
 
+#define BOOTLOADER_SEED_MAX_ENTRIES     10U
+#define BUP_MKHI_BOOTLOADER_SEED_LEN    64U
+
+/* Structure of seed info */
+struct seed_info {
+	uint8_t cse_svn;
+	uint8_t bios_svn;
+	uint8_t padding[2];
+	uint8_t seed[BUP_MKHI_BOOTLOADER_SEED_LEN];
+};
+
+/* Structure of physical seed */
 struct physical_seed {
 	struct seed_info seed_list[BOOTLOADER_SEED_MAX_ENTRIES];
 	uint32_t num_seeds;


### PR DESCRIPTION
1. move seed_info structure from trusty.h to seed.h
2. replace "#include <hypervisor.h>" with necessary including headers
   in seed.c/seed_abl.c/seed_sbl.c

Tracked-On: #2777
Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>