### PR TITLE
Makefile: build for apl-nuc by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # global helper variables
 T := $(CURDIR)
 
-BOARD ?= apl-mrb
+BOARD ?= apl-nuc
 
 ifeq ($(BOARD),apl-nuc)
 FIRMWARE ?= uefi


### PR DESCRIPTION
apl-nuc will be the default board building for.

Tracked-On: #2780
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>