### PR TITLE
hv: fix wrong comment message about CLOS usage in vm config

### DIFF
--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -57,7 +57,7 @@ struct acrn_vm_config {
 	uint16_t pci_ptdev_num;				/* indicate how many PCI PT devices in VM */
 	struct acrn_vm_pci_ptdev_config *pci_ptdevs;	/* point to PCI PT devices BDF list */
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
-	uint16_t clos;					/* if guest_flags has CAT_ENABLED, then VM use this CLOS */
+	uint16_t clos;					/* if guest_flags has CLOS_REQUIRED, then VM use this CLOS */
 
 #ifdef CONFIG_PARTITION_MODE
 	bool			vm_vuart;


### PR DESCRIPTION
VM use CLOS when set CLOS_REQUIRED in guest flags of vm_config. The
wrong comment is 'if guest_flags has CAT_ENABLED', and should be fixed
as 'if guest_flags has CLOS_REQUIRED'

Tracked-On: #2462
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>