### PR TITLE
Revert "hv: trusty: refine control registers switching method"

### DIFF
--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -219,7 +219,7 @@ static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext
 {
 	uint32_t i;
 
-	/* mark to update on-demand run_context for efer/rflags/rsp */
+	/* mark to update on-demand run_context for efer/rflags/rsp/rip */
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RFLAGS, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RSP, &vcpu->reg_updated);

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -158,16 +158,18 @@ static void save_world_ctx(struct acrn_vcpu *vcpu, struct ext_context *ext_ctx)
 {
 	uint32_t i;
 
-	/* cache on-demand run_context for efer/rflags/rsp/rip/cr0/cr4 */
+	/* cache on-demand run_context for efer/rflags/rsp/rip */
 	(void)vcpu_get_efer(vcpu);
 	(void)vcpu_get_rflags(vcpu);
 	(void)vcpu_get_rsp(vcpu);
 	(void)vcpu_get_rip(vcpu);
-	(void)vcpu_get_cr0(vcpu);
-	(void)vcpu_get_cr4(vcpu);
 
 	/* VMCS GUEST field */
 	ext_ctx->tsc_offset = exec_vmread(VMX_TSC_OFFSET_FULL);
+	ext_ctx->vmx_cr0 = exec_vmread(VMX_GUEST_CR0);
+	ext_ctx->vmx_cr4 = exec_vmread(VMX_GUEST_CR4);
+	ext_ctx->vmx_cr0_read_shadow = exec_vmread(VMX_CR0_READ_SHADOW);
+	ext_ctx->vmx_cr4_read_shadow = exec_vmread(VMX_CR4_READ_SHADOW);
 	ext_ctx->cr3 = exec_vmread(VMX_GUEST_CR3);
 	ext_ctx->dr7 = exec_vmread(VMX_GUEST_DR7);
 	ext_ctx->ia32_debugctl = exec_vmread64(VMX_GUEST_IA32_DEBUGCTL_FULL);
@@ -217,18 +219,20 @@ static void load_world_ctx(struct acrn_vcpu *vcpu, const struct ext_context *ext
 {
 	uint32_t i;
 
-	/* mark to update on-demand run_context for efer/rflags/rsp/rip/cr0/cr4 */
+	/* mark to update on-demand run_context for efer/rflags/rsp */
 	bitmap_set_lock(CPU_REG_EFER, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RFLAGS, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RSP, &vcpu->reg_updated);
 	bitmap_set_lock(CPU_REG_RIP, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_CR0, &vcpu->reg_updated);
-	bitmap_set_lock(CPU_REG_CR4, &vcpu->reg_updated);
 
 	/* VMCS Execution field */
 	exec_vmwrite64(VMX_TSC_OFFSET_FULL, ext_ctx->tsc_offset);
 
 	/* VMCS GUEST field */
+	exec_vmwrite(VMX_GUEST_CR0, ext_ctx->vmx_cr0);
+	exec_vmwrite(VMX_GUEST_CR4, ext_ctx->vmx_cr4);
+	exec_vmwrite(VMX_CR0_READ_SHADOW, ext_ctx->vmx_cr0_read_shadow);
+	exec_vmwrite(VMX_CR4_READ_SHADOW, ext_ctx->vmx_cr4_read_shadow);
 	exec_vmwrite(VMX_GUEST_CR3, ext_ctx->cr3);
 	exec_vmwrite(VMX_GUEST_DR7, ext_ctx->dr7);
 	exec_vmwrite64(VMX_GUEST_IA32_DEBUGCTL_FULL, ext_ctx->ia32_debugctl);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -171,7 +171,7 @@ struct run_context {
 };
 
 /*
- * extended context does not save/restore during vm exity/entry, it's mainly
+ * extended context does not save/restore during vm exit/entry, it's mainly
  * used in trusty world switch
  */
 struct ext_context {

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -171,7 +171,7 @@ struct run_context {
 };
 
 /*
- * extended context does not save/restore during vm exit/entry, it's mainly
+ * extended context does not save/restore during vm exity/entry, it's mainly
  * used in trusty world switch
  */
 struct ext_context {
@@ -202,6 +202,11 @@ struct ext_context {
 
 	uint64_t dr7;
 	uint64_t tsc_offset;
+
+	uint64_t vmx_cr0;
+	uint64_t vmx_cr4;
+	uint64_t vmx_cr0_read_shadow;
+	uint64_t vmx_cr4_read_shadow;
 
 	/* The 512 bytes area to save the FPU/MMX/SSE states for the guest */
 	uint64_t


### PR DESCRIPTION
This reverts commit ff41c00.

run_context.cr0 is updated on each vmexit. It is composition
of VMX_CR0_READ_SHADOW and VMX_GUEST_CR0.
So vmx_cr0 and vmx_cr0_read_shadow cannot be removed from ext_context.
There might be potential issue in future.

Tracked-On: projectacrn#2773
Signed-off-by: Qi Yadong <yadong.qi@intel.com>