### PR TITLE
refine x2apic MSR bitmap setting part 1

### DIFF
--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -417,24 +417,6 @@ int32_t cr_access_vmexit_handler(struct acrn_vcpu *vcpu)
 		/* mov to cr4 */
 		vcpu_set_cr4(vcpu, reg);
 		break;
-	case 0x08UL:
-		/* mov to cr8 */
-		/* According to SDM 6.15 "Exception and interrupt Reference":
-		 *
-		 * set reserved bit in CR8 causes GP to guest
-		 */
-		if ((reg & ~0xFUL) != 0UL) {
-			pr_dbg("Invalid cr8 write operation from guest");
-			vcpu_inject_gp(vcpu, 0U);
-			break;
-		}
-		vlapic_set_cr8(vcpu_vlapic(vcpu), reg);
-		break;
-	case 0x18UL:
-		/* mov from cr8 */
-		reg = vlapic_get_cr8(vcpu_vlapic(vcpu));
-		vcpu_set_gpreg(vcpu, idx, reg);
-		break;
 	default:
 		ASSERT(false, "Unhandled CR access");
 		ret = -EINVAL;

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -632,10 +632,11 @@ void update_msr_bitmap_x2apic_apicv(const struct acrn_vcpu *vcpu)
 		 * writes to them are virtualized with Register Virtualization
 		 * Refer to Section 29.1 in Intel SDM Vol. 3
 		 */
-		enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_TPR, INTERCEPT_DISABLE);
 		enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_EOI, INTERCEPT_READ);
 		enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_SELF_IPI, INTERCEPT_READ);
 	}
+
+	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_TPR, INTERCEPT_DISABLE);
 }
 
 /*

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -111,10 +111,6 @@ struct acrn_vlapic {
 } __aligned(PAGE_SIZE);
 
 
-/* APIC write handlers */
-void vlapic_set_cr8(struct acrn_vlapic *vlapic, uint64_t val);
-uint64_t vlapic_get_cr8(const struct acrn_vlapic *vlapic);
-
 /**
  * @brief virtual LAPIC
  *


### PR DESCRIPTION
1) Shouldn't trap TPR since we always enable "Use TPR shadow"
2) remove TPR set/get API

Since we always enable "Use TPR shadow", so operate on TPR will not
    trigger VM exit. So remove these APIs.

   Tracked-On: #1842
   Signed-off-by: Li, Fei1 <fei1.li@intel.com>
    Acked-by: Anthony Xu <anthony.xu@intel.com>
