### PR TITLE
Fix msi/msix interrupt after pci device un-assigned from uos

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -541,7 +541,7 @@ vm_set_ptdev_msix_info(struct vmctx *ctx, struct ic_ptdev_irq *ptirq)
 }
 
 int
-vm_reset_ptdev_msix_info(struct vmctx *ctx, uint16_t virt_bdf,
+vm_reset_ptdev_msix_info(struct vmctx *ctx, uint16_t virt_bdf, uint16_t phys_bdf,
 			 int vector_count)
 {
 	struct ic_ptdev_irq ptirq;
@@ -549,6 +549,7 @@ vm_reset_ptdev_msix_info(struct vmctx *ctx, uint16_t virt_bdf,
 	bzero(&ptirq, sizeof(ptirq));
 	ptirq.type = IRQ_MSIX;
 	ptirq.virt_bdf = virt_bdf;
+	ptirq.phys_bdf = phys_bdf;
 	ptirq.msix.vector_cnt = vector_count;
 
 	return ioctl(ctx->fd, IC_RESET_PTDEV_INTR_INFO, &ptirq);

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -508,7 +508,7 @@ deinit_msix_table(struct vmctx *ctx, struct passthru_dev *ptdev)
 	if (ptdev->msix.ptirq_allocated) {
 		printf("ptdev reset msix: 0x%x-%x, vector_cnt=%d.\n",
 				virt_bdf, ptdev->phys_bdf, vector_cnt);
-		vm_reset_ptdev_msix_info(ctx, virt_bdf, vector_cnt);
+		vm_reset_ptdev_msix_info(ctx, virt_bdf, ptdev->phys_bdf, vector_cnt);
 		ptdev->msix.ptirq_allocated = false;
 	}
 
@@ -909,8 +909,7 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		deinit_msix_table(ctx, ptdev);
 	else if(ptdev->msi.capoff != 0) {
 		/* Currently only support 1 vector */
-		printf("ptdev reset msi: 0x%x-%x\n", virt_bdf, ptdev->phys_bdf);
-		vm_reset_ptdev_msix_info(ctx, virt_bdf, 1);
+		vm_reset_ptdev_msix_info(ctx, virt_bdf, ptdev->phys_bdf, 1);
 	}
 
 	printf("vm_reset_ptdev_intx:0x%x-%x, ioapic virpin=%d.\n",

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -130,7 +130,7 @@ int	vm_unmap_ptdev_mmio(struct vmctx *ctx, int bus, int slot, int func,
 int	vm_setup_ptdev_msi(struct vmctx *ctx,
 			   struct acrn_vm_pci_msix_remap *msi_remap);
 int	vm_set_ptdev_msix_info(struct vmctx *ctx, struct ic_ptdev_irq *ptirq);
-int	vm_reset_ptdev_msix_info(struct vmctx *ctx, uint16_t virt_bdf,
+int	vm_reset_ptdev_msix_info(struct vmctx *ctx, uint16_t virt_bdf, uint16_t phys_bdf,
 	int vector_count);
 int	vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 	uint16_t phys_bdf, int virt_pin, int phys_pin, bool pic_pin);

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -251,6 +251,8 @@ void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, 
 
 			if (vm != NULL) {
 				vdev->vpci = &vm->vpci;
+				/* vbdf equals to pbdf in sos */
+				vdev->vbdf.value = vdev->pdev->bdf.value;
 			}
 		}
 	}


### PR DESCRIPTION
The msi/msix interrupt information is not properly configured after a pci device un-assigned from UOS.
The patch series pass physcial bdf, which is needed in hypervisor to find the right pci dev.
After the pci device un-assigned from UOS, the virtual bdf should be restored.

Tracked-On: #2788 