### PR TITLE
Unifying the VPCI partition mode and sharing mode code (patch series #4)

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -100,6 +100,8 @@ struct acrn_vm *get_vm_from_vmid(uint16_t vm_id)
 /* return a pointer to the virtual machine structure of SOS VM */
 struct acrn_vm *get_sos_vm(void)
 {
+	ASSERT(sos_vm_ptr != NULL, "sos_vm_ptr is NULL");
+
 	return sos_vm_ptr;
 }
 

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -86,7 +86,7 @@ int32_t vdev_hostbridge_init(struct pci_vdev *vdev)
 	return 0;
 }
 
-int32_t vdev_hostbridge_deinit(__unused struct pci_vdev *vdev)
+int32_t vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev)
 {
 	return 0;
 }

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -167,7 +167,7 @@ int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, ui
 	return ret;
 }
 
-int32_t vmsi_deinit(struct pci_vdev *vdev)
+int32_t vmsi_deinit(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
 		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -167,21 +167,12 @@ int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, ui
 	return ret;
 }
 
-int32_t vmsi_deinit(const struct pci_vdev *vdev)
+void vmsi_deinit(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
 		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);
 	}
-
-	return 0;
 }
-
-const struct pci_vdev_ops pci_ops_vdev_msi = {
-	.init = vmsi_init,
-	.deinit = vmsi_deinit,
-	.cfgwrite = vmsi_cfgwrite,
-	.cfgread = vmsi_cfgread,
-};
 
 /* Read a uint32_t from buffer (little endian) */
 static uint32_t buf_read32(const uint8_t buf[])
@@ -198,7 +189,7 @@ static void buf_write32(uint8_t buf[], uint32_t val)
 	buf[3] = (uint8_t)((val >> 24U) & 0xFFU);
 }
 
-int32_t vmsi_init(struct pci_vdev *vdev)
+void vmsi_init(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev = vdev->pdev;
 	uint32_t val;
@@ -216,7 +207,5 @@ int32_t vmsi_init(struct pci_vdev *vdev)
 
 		buf_write32(&vdev->cfgdata.data_8[pdev->msi.capoff], val);
 	}
-
-	return 0;
 }
 

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -415,7 +415,7 @@ int32_t vmsix_init(struct pci_vdev *vdev)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-int32_t vmsix_deinit(struct pci_vdev *vdev)
+int32_t vmsix_deinit(const struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -376,11 +376,8 @@ static int32_t vmsix_init_helper(struct pci_vdev *vdev)
 			/* The lower boundary of the 4KB aligned address range for MSI-X table */
 			addr_lo = round_page_down(msix->mmio_gpa + msix->table_offset);
 
-			msix->intercepted_gpa = addr_lo;
-			msix->intercepted_size = addr_hi - addr_lo;
-
 			(void)register_mmio_emulation_handler(vdev->vpci->vm, vmsix_table_mmio_access_handler,
-				msix->intercepted_gpa, msix->intercepted_gpa + msix->intercepted_size, vdev);
+				addr_lo, addr_hi, vdev);
 		}
 		ret = 0;
 	} else {
@@ -421,8 +418,6 @@ int32_t vmsix_init(struct pci_vdev *vdev)
 int32_t vmsix_deinit(struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
-		vdev->msix.intercepted_size = 0U;
-
 		if (vdev->msix.table_count != 0U) {
 			ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, vdev->msix.table_count);
 		}

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -72,12 +72,12 @@ extern const struct vpci_ops partition_mode_vpci_ops;
 int32_t vdev_hostbridge_init(struct pci_vdev *vdev);
 int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vdev_hostbridge_deinit(__unused struct pci_vdev *vdev);
+int32_t vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev);
 
 int32_t vdev_pt_init(struct pci_vdev *vdev);
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vdev_pt_deinit(struct pci_vdev *vdev);
+int32_t vdev_pt_deinit(const struct pci_vdev *vdev);
 
 #else
 extern const struct vpci_ops sharing_mode_vpci_ops;
@@ -87,12 +87,12 @@ extern const struct pci_vdev_ops pci_ops_vdev_msix;
 int32_t vmsi_init(struct pci_vdev *vdev);
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vmsi_deinit(struct pci_vdev *vdev);
+int32_t vmsi_deinit(const struct pci_vdev *vdev);
 
 int32_t vmsix_init(struct pci_vdev *vdev);
 int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vmsix_deinit(struct pci_vdev *vdev);
+int32_t vmsix_deinit(const struct pci_vdev *vdev);
 #endif
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -81,24 +81,19 @@ int32_t vdev_pt_deinit(const struct pci_vdev *vdev);
 
 #else
 extern const struct vpci_ops sharing_mode_vpci_ops;
-extern const struct pci_vdev_ops pci_ops_vdev_msi;
-extern const struct pci_vdev_ops pci_ops_vdev_msix;
 
-int32_t vmsi_init(struct pci_vdev *vdev);
+void vmsi_init(struct pci_vdev *vdev);
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vmsi_deinit(const struct pci_vdev *vdev);
-
-int32_t vmsix_init(struct pci_vdev *vdev);
+void vmsi_deinit(const struct pci_vdev *vdev);
+void vmsix_init(struct pci_vdev *vdev);
 int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vmsix_deinit(const struct pci_vdev *vdev);
+void vmsix_deinit(const struct pci_vdev *vdev);
 #endif
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-
-void add_vdev_handler(struct pci_vdev *vdev, const struct pci_vdev_ops *ops);
 
 struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_bdf vbdf);
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -91,7 +91,7 @@ int32_t vdev_pt_init(struct pci_vdev *vdev)
 	return ret;
 }
 
-int32_t vdev_pt_deinit(struct pci_vdev *vdev)
+int32_t vdev_pt_deinit(const struct pci_vdev *vdev)
 {
 	int32_t ret;
 	struct acrn_vm *vm = vdev->vpci->vm;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -152,15 +152,13 @@ static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i, j;
-	int32_t ret;
+	int32_t ret = -ENODEV;
 
 	/*
 	 * Only set up IO bitmap for SOS.
 	 * IO/MMIO requests from non-sos_vm guests will be injected to device model.
 	 */
-	if (!is_sos_vm(vm)) {
-		ret = -ENODEV;
-	} else {
+	if (is_sos_vm(vm)) {
 		/* Build up vdev array for sos_vm */
 		pci_pdev_foreach(init_vdev_for_pdev, vm);
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -36,7 +36,7 @@ struct pci_vdev;
 struct pci_vdev_ops {
 	int32_t (*init)(struct pci_vdev *vdev);
 
-	int32_t (*deinit)(struct pci_vdev *vdev);
+	int32_t (*deinit)(const struct pci_vdev *vdev);
 
 	int32_t (*cfgwrite)(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t val);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -77,11 +77,7 @@ union pci_cfgdata {
 };
 
 struct pci_vdev {
-#ifndef CONFIG_PARTITION_MODE
-#define MAX_VPCI_DEV_OPS   4U
-	struct pci_vdev_ops ops[MAX_VPCI_DEV_OPS];
-	uint32_t nr_ops;
-#else
+#ifdef CONFIG_PARTITION_MODE
 	const struct pci_vdev_ops *ops;
 #endif
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -63,8 +63,6 @@ struct pci_msix {
 	uint64_t  mmio_gpa;
 	uint64_t  mmio_hpa;
 	uint64_t  mmio_size;
-	uint64_t  intercepted_gpa;
-	uint64_t  intercepted_size;
 	uint32_t  capoff;
 	uint32_t  caplen;
 	uint32_t  table_bar;


### PR DESCRIPTION
Changes include:
Extract common code blocks to has_msi_cap and has_msix_cap functions
Remove intercepted_gpa and intercepted_size from struct pci_msix
Add const qualifier for the deinit vdev op functions
Remove vdev ops for sharing mode
Misra c violation fix

Tracked-On: #2534
Signed-off-by: dongshen dongsheng.x.zhang@intel.com

Will need to post more patches to eventually unify the VPCI partition/sharing mode code