### PR TITLE
HV: add vrtc for sharing mode

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -215,6 +215,7 @@ endif
 C_SRCS += hw/pci.c
 
 C_SRCS += dm/vpic.c
+C_SRCS += dm/vrtc.c
 C_SRCS += dm/vioapic.c
 C_SRCS += dm/vpci/vdev.c
 C_SRCS += dm/vpci/vpci.c
@@ -223,7 +224,6 @@ C_SRCS += dm/vmptable.c
 C_SRCS += dm/vpci/partition_mode.c
 C_SRCS += dm/vpci/hostbridge.c
 C_SRCS += dm/vpci/pci_pt.c
-C_SRCS += dm/vrtc.c
 else
 C_SRCS += dm/vpci/sharing_mode.c
 C_SRCS += dm/vpci/msi.c

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -407,8 +407,8 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		if (vm_config->vm_vuart && is_dbg_uart_enabled()) {
 			vuart_init(vm);
 		}
-		vrtc_init(vm);
 #endif
+		vrtc_init(vm);
 
 		vpci_init(vm);
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -148,8 +148,8 @@ struct acrn_vm {
 
 #ifdef CONFIG_PARTITION_MODE
 	struct mptable_info mptable;
-	uint8_t vrtc_offset;
 #endif
+	uint8_t vrtc_offset;
 
 	spinlock_t softirq_dev_lock;
 	struct list_head softirq_dev_entry_list;
@@ -217,8 +217,8 @@ extern vm_sw_loader_t vm_sw_loader;
 
 #ifdef CONFIG_PARTITION_MODE
 uint16_t get_vm_pcpu_nums(const struct acrn_vm_config *vm_config);
-void vrtc_init(struct acrn_vm *vm);
 #endif
+void vrtc_init(struct acrn_vm *vm);
 
 bool is_lapic_pt(const struct acrn_vm *vm);
 bool vm_hide_mtrr(const struct acrn_vm *vm);


### PR DESCRIPTION
Previously vrtc is for partition mode only, now enable it for sharing mode;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>