### PR TITLE
hv: remove CONFIG_PARTITION_MODE for pre-launched VM vE820 creation

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -137,8 +137,8 @@ C_SRCS += arch/x86/seed/seed_sbl.c
 
 # configuration component
 C_SRCS += arch/x86/configs/vm_config.c
-ifeq ($(CONFIG_PARTITION_MODE),y)
 C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/ve820.c
+ifeq ($(CONFIG_PARTITION_MODE),y)
 C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/pt_dev.c
 endif
 

--- a/hypervisor/arch/x86/configs/apl-mrb/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/ve820.c
@@ -5,8 +5,10 @@
  */
 
 #include <e820.h>
+#include <vm.h>
 
-const struct e820_entry ve820_entry[E820_MAX_ENTRIES] = {
+#define VE820_ENTRIES_APL_MRB  5U
+static const struct e820_entry ve820_entry[VE820_ENTRIES_APL_MRB] = {
 	{	/* usable RAM under 1MB */
 		.baseaddr = 0x0UL,
 		.length   = 0xF0000UL,		/* 960KB */
@@ -37,3 +39,12 @@ const struct e820_entry ve820_entry[E820_MAX_ENTRIES] = {
 		.type     = E820_TYPE_RESERVED
 	},
 };
+
+/**
+ * @pre vm != NULL
+ */
+void create_prelaunched_vm_e820(struct acrn_vm *vm)
+{
+	vm->e820_entry_num = VE820_ENTRIES_APL_MRB;
+	vm->e820_entries = (struct e820_entry *)ve820_entry;
+}

--- a/hypervisor/arch/x86/configs/apl-up2/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-up2/ve820.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm.h>
+
+/**
+ * @pre vm != NULL
+ */
+void create_prelaunched_vm_e820(struct acrn_vm *vm)
+{
+	vm->e820_entry_num = 0U;
+	vm->e820_entries = NULL;
+}

--- a/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
@@ -5,8 +5,10 @@
  */
 
 #include <e820.h>
+#include <vm.h>
 
-const struct e820_entry ve820_entry[E820_MAX_ENTRIES] = {
+#define VE820_ENTRIES_DNV_CB2	5U
+static const struct e820_entry ve820_entry[VE820_ENTRIES_DNV_CB2] = {
 	{	/* usable RAM under 1MB */
 		.baseaddr = 0x0UL,
 		.length   = 0xF0000UL,		/* 960KB */
@@ -37,3 +39,12 @@ const struct e820_entry ve820_entry[E820_MAX_ENTRIES] = {
 		.type     = E820_TYPE_RESERVED
 	},
 };
+
+/**
+ * @pre vm != NULL
+ */
+void create_prelaunched_vm_e820(struct acrn_vm *vm)
+{
+	vm->e820_entry_num = VE820_ENTRIES_DNV_CB2;
+	vm->e820_entries = (struct e820_entry *)ve820_entry;
+}

--- a/hypervisor/arch/x86/configs/nuc6cayh/ve820.c
+++ b/hypervisor/arch/x86/configs/nuc6cayh/ve820.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm.h>
+
+/**
+ * @pre vm != NULL
+ */
+void create_prelaunched_vm_e820(struct acrn_vm *vm)
+{
+	vm->e820_entry_num = 0U;
+	vm->e820_entries = NULL;
+}

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm.h>
+
+/**
+ * @pre vm != NULL
+ */
+void create_prelaunched_vm_e820(struct acrn_vm *vm)
+{
+	vm->e820_entry_num = 0U;
+	vm->e820_entries = NULL;
+}

--- a/hypervisor/include/arch/x86/board.h
+++ b/hypervisor/include/arch/x86/board.h
@@ -8,6 +8,9 @@
 
 #include <types.h>
 
+/* forward declarations */
+struct acrn_vm;
+
 struct platform_clos_info {
 	uint32_t clos_mask;
 	uint32_t msr_index;
@@ -15,5 +18,8 @@ struct platform_clos_info {
 
 extern struct platform_clos_info platform_clos_array[];
 extern uint16_t platform_clos_num;
+
+/* board specific functions */
+void create_prelaunched_vm_e820(struct acrn_vm *vm);
 
 #endif /* BOARD_H */

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -34,8 +34,6 @@ struct e820_mem_params {
 	uint64_t total_mem_size;
 };
 
-extern const struct e820_entry ve820_entry[E820_MAX_ENTRIES];
-
 /* HV read multiboot header to get e820 entries info and calc total RAM info */
 void init_e820(void);
 


### PR DESCRIPTION
Preparing for hybrid mode:

- create vE820 for pre-launched VMs and do other init code when the
  vm_config->type is PRE_LAUNCHED_VM.
- create ve820.c for each board because without wrapping by
  CONFIG_PARTITION_MODE, ve820_entry[] needs to be visible even when
  compiling target boards that haven't enabled pre-launched VMs.
- remove create_prelaunched_vm_e820() from vm.c and implement board
  specific function for each $(CONFIG_BOARD)/ve820.c. The reasons being:
  - don't need to define ve820_entry[32] for those boards that don't
    support pre-launched VMs.
  - more importantly, this makes it much easier to create different per-VM
    vE820 when it's needed.

Tracked-On: #2291
Signed-off-by: Zide Chen <zide.chen@intel.com>