### PR TITLE
hv: passthru TSC_ADJUST to VM with lapic pt

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -658,4 +658,5 @@ void update_msr_bitmap_x2apic_passthru(const struct acrn_vcpu *vcpu)
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_LDR, INTERCEPT_READ);
 	enable_msr_interception(msr_bitmap, MSR_IA32_EXT_APIC_ICR, INTERCEPT_WRITE);
 	enable_msr_interception(msr_bitmap, MSR_IA32_TSC_DEADLINE, INTERCEPT_DISABLE);
+	enable_msr_interception(msr_bitmap, MSR_IA32_TSC_ADJUST, INTERCEPT_DISABLE);
 }


### PR DESCRIPTION
Linux access TSC_ADJUST to verify it has not tampered every time when enter idle.
So for RTVM running rt-linux, the access will cause vm exit which affect real-time performance.

This commit pass through TSC_ADJUST to VM with lapic_pt, to avoid TSC_ADJUST caused vm_exit.
For other VMs, TSC_ADJUST msr access is still trapped and emulated.

Tracked-On: #2813
Signed-off-by: Yan, Like <like.yan@intel.com>