### PR TITLE
doc: add rdmsr/wrmsr to the "ACRN Shell Commands" documentation

### DIFF
--- a/doc/user-guides/acrn-shell.rst
+++ b/doc/user-guides/acrn-shell.rst
@@ -44,3 +44,9 @@ The ACRN hypervisor shell supports the following commands:
      - Display the CPUID leaf [subleaf], in hexadecimal
    * - reboot
      - Trigger a system reboot (immediately)
+   * - rdmsr [-p<pcpu_id>] <msr_index>
+     - Read the Model-Specific Register (MSR) at index ``msr_index`` (in
+       hexadecimal) for CPU ID ``pcpu_id``
+   * - wrmsr [-p<pcpu_id>] <msr_index> <value>
+     - Write ``value`` (in hexadecimal) to the Model-Specific Register (MSR) at
+       index ``msr_index`` (in hexadecimal) for CPU ID ``pcpu_id``


### PR DESCRIPTION
Add 'rdmsr' and 'wrmsr' to the "ACRN Shell Commands" documentation. Both are
already described via the interactive help command but not (yet) included in our
on-line documentation.

Tracked-On: #2684
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>