### PR TITLE
hv: enhance ACRN shell interactive help

### DIFF
--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -36,62 +36,65 @@ struct shell {
 /* Shell Command list with parameters and help description */
 #define SHELL_CMD_HELP			"help"
 #define SHELL_CMD_HELP_PARAM		NULL
-#define SHELL_CMD_HELP_HELP		"Display info about the supported shell commands."
+#define SHELL_CMD_HELP_HELP		"Display information about supported hypervisor shell commands"
 
 #define SHELL_CMD_VM_LIST		"vm_list"
 #define SHELL_CMD_VM_LIST_PARAM		NULL
-#define SHELL_CMD_VM_LIST_HELP		"Lists all VMs (VM Name, VM ID, VM State)"
+#define SHELL_CMD_VM_LIST_HELP		"List all VMs, displaying the VM name, ID, and state"
 
 #define SHELL_CMD_VCPU_LIST		"vcpu_list"
 #define SHELL_CMD_VCPU_LIST_PARAM	NULL
-#define SHELL_CMD_VCPU_LIST_HELP	"Lists all VCPU in all VMs"
+#define SHELL_CMD_VCPU_LIST_HELP	"List all vCPUs in all VMs"
 
 #define SHELL_CMD_VCPU_DUMPREG		"vcpu_dumpreg"
 #define SHELL_CMD_VCPU_DUMPREG_PARAM	"<vm id, vcpu id>"
-#define SHELL_CMD_VCPU_DUMPREG_HELP	"Dump registers for a specific vcpu"
+#define SHELL_CMD_VCPU_DUMPREG_HELP	"Dump registers for a specific vCPU"
 
 #define SHELL_CMD_DUMPMEM		"dumpmem"
 #define SHELL_CMD_DUMPMEM_PARAM		"<addr, length>"
-#define SHELL_CMD_DUMPMEM_HELP		"Dump physical memory"
+#define SHELL_CMD_DUMPMEM_HELP		"Dump host memory, starting at a given address, and for a given length (in "\
+					"bytes)"
 
 #define SHELL_CMD_SOS_CONSOLE		"sos_console"
 #define SHELL_CMD_SOS_CONSOLE_PARAM	NULL
-#define SHELL_CMD_SOS_CONSOLE_HELP	"Switch to SOS's console"
+#define SHELL_CMD_SOS_CONSOLE_HELP	"Switch to the SOS's console. Use [Ctrl+Spacebar] to return to the ACRN shell "\
+					"console"
 
 #define SHELL_CMD_INTERRUPT		"int"
 #define SHELL_CMD_INTERRUPT_PARAM	NULL
-#define SHELL_CMD_INTERRUPT_HELP	"show interrupt info per CPU"
+#define SHELL_CMD_INTERRUPT_HELP	"List interrupt information per CPU"
 
 #define SHELL_CMD_PTDEV			"pt"
 #define SHELL_CMD_PTDEV_PARAM		NULL
-#define SHELL_CMD_PTDEV_HELP		"show pass-through device info"
+#define SHELL_CMD_PTDEV_HELP		"Show pass-through device information"
 
 #define SHELL_CMD_REBOOT		"reboot"
 #define SHELL_CMD_REBOOT_PARAM		NULL
-#define SHELL_CMD_REBOOT_HELP		"trigger system reboot"
+#define SHELL_CMD_REBOOT_HELP		"Trigger a system reboot (immediately)"
 
 #define SHELL_CMD_IOAPIC		"dump_ioapic"
 #define SHELL_CMD_IOAPIC_PARAM		NULL
-#define SHELL_CMD_IOAPIC_HELP		"show native ioapic info"
+#define SHELL_CMD_IOAPIC_HELP		"Show native IOAPIC information"
 
 #define SHELL_CMD_VIOAPIC		"vioapic"
 #define SHELL_CMD_VIOAPIC_PARAM		"<vm id>"
-#define SHELL_CMD_VIOAPIC_HELP		"show vioapic info"
+#define SHELL_CMD_VIOAPIC_HELP		"Show virtual IOAPIC (vIOAPIC) information for a specific VM"
 
 #define SHELL_CMD_LOG_LVL		"loglevel"
-#define SHELL_CMD_LOG_LVL_PARAM		"[<console_loglevel> [<mem_loglevel> " \
-					"[npk_loglevel]]]"
-#define SHELL_CMD_LOG_LVL_HELP		"get(para is NULL), or set loglevel [0-6]"
+#define SHELL_CMD_LOG_LVL_PARAM		"[<console_loglevel> [<mem_loglevel> [npk_loglevel]]]"
+#define SHELL_CMD_LOG_LVL_HELP		"No argument: get the level of logging for the console, memory and npk. Set "\
+					"the level by giving (up to) 3 parameters between 0 and 6 (verbose)"
 
 #define SHELL_CMD_CPUID			"cpuid"
 #define SHELL_CMD_CPUID_PARAM		"<leaf> [subleaf]"
-#define SHELL_CMD_CPUID_HELP		"cpuid leaf [subleaf], in hexadecimal"
+#define SHELL_CMD_CPUID_HELP		"Display the CPUID leaf [subleaf], in hexadecimal"
 
 #define SHELL_CMD_RDMSR			"rdmsr"
 #define SHELL_CMD_RDMSR_PARAM		"[-p<pcpu_id>]	<msr_index>"
-#define SHELL_CMD_RDMSR_HELP		"rdmsr -p<pcpu_id> <msr_index>, msr_index in hexadecimal"
+#define SHELL_CMD_RDMSR_HELP		"Read the MSR at msr_index (in hexadecimal) for CPU ID pcpu_id"
 
 #define SHELL_CMD_WRMSR			"wrmsr"
 #define SHELL_CMD_WRMSR_PARAM		"[-p<pcpu_id>]	<msr_index> <value>"
-#define SHELL_CMD_WRMSR_HELP		"wrmsr -p<pcpu_id> <msr_index> <value>, msr_index and value in hexadecimal"
+#define SHELL_CMD_WRMSR_HELP		"Write value (in hexadecimal) to the MSR at msr_index (in hexadecimal) for CPU"\
+					" ID pcpu_id"
 #endif /* SHELL_PRIV_H */


### PR DESCRIPTION
Enhance the ACRN shell interactive help. It is close to a 1-1 mapping with
the online documentation but cut a little shorter in various places to make it
more user-friendly when using it from the ACRN console.

Tracked-On: #2829
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>