### PR TITLE
Unifying the VPCI partition mode and sharing mode code (patch series #5)

### DIFF
--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -91,12 +91,6 @@ void vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev)
 int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
-	/* Assumption: access needed to be aligned on 1/2/4 bytes */
-	if ((offset & (bytes - 1U)) != 0U) {
-		*val = 0xFFFFFFFFU;
-		return -EINVAL;
-	}
-
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
 
 	return 0;
@@ -105,11 +99,6 @@ int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
-	/* Assumption: access needed to be aligned on 1/2/4 bytes */
-	if ((offset & (bytes - 1U)) != 0U) {
-		return -EINVAL;
-	}
-
 	if (!pci_bar_access(offset)) {
 		pci_vdev_write_cfg(vdev, offset, bytes, val);
 	}

--- a/hypervisor/dm/vpci/hostbridge.c
+++ b/hypervisor/dm/vpci/hostbridge.c
@@ -39,7 +39,7 @@
 #include <pci.h>
 #include "pci_priv.h"
 
-int32_t vdev_hostbridge_init(struct pci_vdev *vdev)
+void vdev_hostbridge_init(struct pci_vdev *vdev)
 {
 	/* PCI config space */
 	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
@@ -82,13 +82,10 @@ int32_t vdev_hostbridge_init(struct pci_vdev *vdev)
 	pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
 	pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
 	pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
-
-	return 0;
 }
 
-int32_t vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev)
+void vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev)
 {
-	return 0;
 }
 
 int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
@@ -119,11 +116,3 @@ int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 
 	return 0;
 }
-
-const struct pci_vdev_ops pci_ops_vdev_hostbridge = {
-	.init = vdev_hostbridge_init,
-	.deinit = vdev_hostbridge_deinit,
-	.cfgwrite = vdev_hostbridge_cfgwrite,
-	.cfgread = vdev_hostbridge_cfgread,
-};
-

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -118,6 +118,7 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret;
+
 	/* For PIO access, we emulate Capability Structures only */
 	if (msicap_access(vdev, offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);

--- a/hypervisor/dm/vpci/msi.c
+++ b/hypervisor/dm/vpci/msi.c
@@ -117,14 +117,12 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
-	int32_t ret;
+	int32_t ret = -ENODEV;
 
 	/* For PIO access, we emulate Capability Structures only */
 	if (msicap_access(vdev, offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
 	    ret = 0;
-	} else {
-		ret = -ENODEV;
 	}
 
 	return ret;

--- a/hypervisor/dm/vpci/msix.c
+++ b/hypervisor/dm/vpci/msix.c
@@ -167,14 +167,12 @@ static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index
 
 int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
-	int32_t ret;
+	int32_t ret = -ENODEV;
 	/* For PIO access, we emulate Capability Structures only */
 
 	if (msixcap_access(vdev, offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
 	    ret = 0;
-	} else {
-		ret = -ENODEV;
 	}
 
 	return ret;
@@ -183,7 +181,7 @@ int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t byt
 int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	uint32_t msgctrl;
-	int32_t ret;
+	int32_t ret = -ENODEV;
 
 	/* Writing MSI-X Capability Structure */
 	if (msixcap_access(vdev, offset)) {
@@ -207,8 +205,6 @@ int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, u
 			}
 		}
 		ret = 0;
-	} else {
-		ret = -ENODEV;
 	}
 
 	return ret;

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -91,7 +91,7 @@ static void partition_mode_pdev_init(struct pci_vdev *vdev, union pci_bdf pbdf)
  * @pre vm != NULL
  * @pre vm->vpci.pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
  */
-static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
+int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
 {
 	struct acrn_vpci *vpci = (struct acrn_vpci *)&(vm->vpci);
 	struct pci_vdev *vdev;
@@ -121,7 +121,7 @@ static int32_t partition_mode_vpci_init(const struct acrn_vm *vm)
  * @pre vm != NULL
  * @pre vm->vpci.pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
  */
-static void partition_mode_vpci_deinit(const struct acrn_vm *vm)
+void partition_mode_vpci_deinit(const struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i;
@@ -137,7 +137,7 @@ static void partition_mode_vpci_deinit(const struct acrn_vm *vm)
 	}
 }
 
-static void partition_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf vbdf,
+void partition_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	struct pci_vdev *vdev = pci_find_vdev_by_vbdf(vpci, vbdf);
@@ -155,7 +155,7 @@ static void partition_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf vbdf,
 	}
 }
 
-static void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
+void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	struct pci_vdev *vdev = pci_find_vdev_by_vbdf(vpci, vbdf);

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -172,10 +172,3 @@ void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
 		}
 	}
 }
-
-const struct vpci_ops partition_mode_vpci_ops = {
-	.init = partition_mode_vpci_init,
-	.deinit = partition_mode_vpci_deinit,
-	.cfgread = partition_mode_cfgread,
-	.cfgwrite = partition_mode_cfgwrite,
-};

--- a/hypervisor/dm/vpci/partition_mode.c
+++ b/hypervisor/dm/vpci/partition_mode.c
@@ -149,7 +149,8 @@ void partition_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf vbdf,
 			}
 		} else {
 			if (vdev_pt_cfgread(vdev, offset, bytes, val) != 0) {
-				pr_err("vdev_pt_cfgread failed!");
+				/* Not handled by any handlers, passthru to physical device */
+				*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
 			}
 		}
 	}
@@ -167,7 +168,8 @@ void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
 			}
 		} else {
 			if (vdev_pt_cfgwrite(vdev, offset, bytes, val) != 0){
-				pr_err("vdev_pt_cfgwrite failed!");
+				/* Not handled by any handlers, passthru to physical device */
+				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 			}
 		}
 	}

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -69,15 +69,15 @@ static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset
 
 #ifdef CONFIG_PARTITION_MODE
 extern const struct vpci_ops partition_mode_vpci_ops;
-int32_t vdev_hostbridge_init(struct pci_vdev *vdev);
+void vdev_hostbridge_init(struct pci_vdev *vdev);
 int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev);
+void vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev);
 
-int32_t vdev_pt_init(struct pci_vdev *vdev);
+void vdev_pt_init(struct pci_vdev *vdev);
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-int32_t vdev_pt_deinit(const struct pci_vdev *vdev);
+void vdev_pt_deinit(const struct pci_vdev *vdev);
 
 #else
 extern const struct vpci_ops sharing_mode_vpci_ops;

--- a/hypervisor/dm/vpci/pci_priv.h
+++ b/hypervisor/dm/vpci/pci_priv.h
@@ -68,7 +68,6 @@ static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset
 }
 
 #ifdef CONFIG_PARTITION_MODE
-extern const struct vpci_ops partition_mode_vpci_ops;
 void vdev_hostbridge_init(struct pci_vdev *vdev);
 int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
@@ -80,8 +79,6 @@ int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
 void vdev_pt_deinit(const struct pci_vdev *vdev);
 
 #else
-extern const struct vpci_ops sharing_mode_vpci_ops;
-
 void vmsi_init(struct pci_vdev *vdev);
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -105,12 +105,6 @@ void vdev_pt_deinit(const struct pci_vdev *vdev)
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
-	/* Assumption: access needed to be aligned on 1/2/4 bytes */
-	if ((offset & (bytes - 1U)) != 0U) {
-		*val = 0xFFFFFFFFU;
-		return -EINVAL;
-	}
-
 	/* PCI BARs is emulated */
 	if (pci_bar_access(offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
@@ -184,11 +178,6 @@ static void vdev_pt_cfgwrite_bar(struct pci_vdev *vdev, uint32_t offset,
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
-	/* Assumption: access needed to be aligned on 1/2/4 bytes */
-	if ((offset & (bytes - 1U)) != 0U) {
-		return -EINVAL;
-	}
-
 	/* PCI BARs are emulated */
 	if (pci_bar_access(offset)) {
 		vdev_pt_cfgwrite_bar(vdev, offset, bytes, val);

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -105,14 +105,15 @@ void vdev_pt_deinit(const struct pci_vdev *vdev)
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
+	int32_t ret = -ENODEV;
+
 	/* PCI BARs is emulated */
 	if (pci_bar_access(offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
-	} else {
-		*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 
 static void vdev_pt_remap_bar(struct pci_vdev *vdev, uint32_t idx,
@@ -178,14 +179,14 @@ static void vdev_pt_cfgwrite_bar(struct pci_vdev *vdev, uint32_t offset,
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
+	int32_t ret = -ENODEV;
+
 	/* PCI BARs are emulated */
 	if (pci_bar_access(offset)) {
 		vdev_pt_cfgwrite_bar(vdev, offset, bytes, val);
-	} else {
-		/* Write directly to physical device's config space */
-		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -45,14 +45,12 @@ static struct pci_vdev *sharing_mode_find_vdev_sos(union pci_bdf pbdf)
 void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val)
 {
-	struct pci_vdev *vdev;
+	struct pci_vdev *vdev = sharing_mode_find_vdev_sos(bdf);
 
-	vdev = sharing_mode_find_vdev_sos(bdf);
+	*val = ~0U;
 
 	/* vdev == NULL: Could be hit for PCI enumeration from guests */
-	if (vdev == NULL) {
-		*val = ~0U;
-	} else {
+	if (vdev != NULL) {
 		if ((vmsi_cfgread(vdev, offset, bytes, val) != 0)
 			&& (vmsix_cfgread(vdev, offset, bytes, val) != 0)
 			) {
@@ -65,9 +63,8 @@ void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	struct pci_vdev *vdev;
+	struct pci_vdev *vdev = sharing_mode_find_vdev_sos(bdf);
 
-	vdev = sharing_mode_find_vdev_sos(bdf);
 	if (vdev != NULL) {
 		if ((vmsi_cfgwrite(vdev, offset, bytes, val) != 0)
 			&& (vmsix_cfgwrite(vdev, offset, bytes, val) != 0)

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -50,7 +50,7 @@ void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	vdev = sharing_mode_find_vdev_sos(bdf);
 
 	/* vdev == NULL: Could be hit for PCI enumeration from guests */
-	if ((vdev == NULL) || ((bytes != 1U) && (bytes != 2U) && (bytes != 4U))) {
+	if (vdev == NULL) {
 		*val = ~0U;
 	} else {
 		if ((vmsi_cfgread(vdev, offset, bytes, val) != 0)
@@ -67,15 +67,13 @@ void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 {
 	struct pci_vdev *vdev;
 
-	if ((bytes == 1U) || (bytes == 2U) || (bytes == 4U)) {
-		vdev = sharing_mode_find_vdev_sos(bdf);
-		if (vdev != NULL) {
-			if ((vmsi_cfgwrite(vdev, offset, bytes, val) != 0)
-				&& (vmsix_cfgwrite(vdev, offset, bytes, val) != 0)
-				) {
-				/* Not handled by any handlers, passthru to physical device */
-				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
-			}
+	vdev = sharing_mode_find_vdev_sos(bdf);
+	if (vdev != NULL) {
+		if ((vmsi_cfgwrite(vdev, offset, bytes, val) != 0)
+			&& (vmsix_cfgwrite(vdev, offset, bytes, val) != 0)
+			) {
+			/* Not handled by any handlers, passthru to physical device */
+			pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 		}
 	}
 }

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -42,7 +42,7 @@ static struct pci_vdev *sharing_mode_find_vdev_sos(union pci_bdf pbdf)
 	return pci_find_vdev_by_pbdf(&vm->vpci, pbdf);
 }
 
-static void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
+void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	struct pci_vdev *vdev;
@@ -62,7 +62,7 @@ static void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf 
 	}
 }
 
-static void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
+void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	struct pci_vdev *vdev;
@@ -105,7 +105,7 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const void *vm)
 	}
 }
 
-static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
+int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
 {
 	int32_t ret = -ENODEV;
 
@@ -126,7 +126,7 @@ static int32_t sharing_mode_vpci_init(const struct acrn_vm *vm)
  * @pre vm != NULL
  * @pre vm->vpci.pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
  */
-static void sharing_mode_vpci_deinit(const struct acrn_vm *vm)
+void sharing_mode_vpci_deinit(const struct acrn_vm *vm)
 {
 	struct pci_vdev *vdev;
 	uint32_t i;

--- a/hypervisor/dm/vpci/sharing_mode.c
+++ b/hypervisor/dm/vpci/sharing_mode.c
@@ -142,13 +142,6 @@ void sharing_mode_vpci_deinit(const struct acrn_vm *vm)
 	}
 }
 
-const struct vpci_ops sharing_mode_vpci_ops = {
-	.init = sharing_mode_vpci_init,
-	.deinit = sharing_mode_vpci_deinit,
-	.cfgread = sharing_mode_cfgread,
-	.cfgwrite = sharing_mode_cfgwrite,
-};
-
 void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf)
 {
 	struct pci_vdev *vdev;

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -65,7 +65,8 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 }
 
 /**
- * @pre tmp != NULL
+ * @pre vpci != NULL
+ * @pre vpci->pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
  */
 struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_bdf vbdf)
 {
@@ -86,7 +87,8 @@ struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_b
 }
 
 /**
- * @pre tmp != NULL
+ * @pre vpci != NULL
+ * @pre vpci->pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
  */
 struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf)
 {

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -105,6 +105,20 @@ struct acrn_vpci {
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };
 
+int32_t partition_mode_vpci_init(const struct acrn_vm *vm);
+void partition_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf vbdf,
+	uint32_t offset, uint32_t bytes, uint32_t *val);
+void partition_mode_cfgwrite(struct acrn_vpci *vpci, union pci_bdf vbdf,
+	uint32_t offset, uint32_t bytes, uint32_t val);
+void partition_mode_vpci_deinit(const struct acrn_vm *vm);
+
+int32_t sharing_mode_vpci_init(const struct acrn_vm *vm);
+void sharing_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf bdf,
+	uint32_t offset, uint32_t bytes, uint32_t *val);
+void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
+	uint32_t offset, uint32_t bytes, uint32_t val);
+void sharing_mode_vpci_deinit(const struct acrn_vm *vm);
+
 void vpci_init(struct acrn_vm *vm);
 void vpci_cleanup(const struct acrn_vm *vm);
 void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -32,18 +32,6 @@
 
 #include <pci.h>
 
-struct pci_vdev;
-struct pci_vdev_ops {
-	int32_t (*init)(struct pci_vdev *vdev);
-
-	int32_t (*deinit)(const struct pci_vdev *vdev);
-
-	int32_t (*cfgwrite)(struct pci_vdev *vdev, uint32_t offset,
-		uint32_t bytes, uint32_t val);
-
-	int32_t (*cfgread)(const struct pci_vdev *vdev, uint32_t offset,
-		uint32_t bytes, uint32_t *val);
-};
 
 struct msix_table_entry {
 	uint64_t	addr;
@@ -77,10 +65,6 @@ union pci_cfgdata {
 };
 
 struct pci_vdev {
-#ifdef CONFIG_PARTITION_MODE
-	const struct pci_vdev_ops *ops;
-#endif
-
 	const struct acrn_vpci *vpci;
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf vbdf;
@@ -120,11 +104,6 @@ struct acrn_vpci {
 	uint32_t pci_vdev_cnt;
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };
-
-#ifdef CONFIG_PARTITION_MODE
-extern const struct pci_vdev_ops pci_ops_vdev_hostbridge;
-extern const struct pci_vdev_ops pci_ops_vdev_pt;
-#endif
 
 void vpci_init(struct acrn_vm *vm);
 void vpci_cleanup(const struct acrn_vm *vm);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -88,19 +88,9 @@ struct pci_addr_info {
 	bool cached_enable;
 };
 
-struct vpci_ops {
-	int32_t (*init)(const struct acrn_vm *vm);
-	void (*deinit)(const struct acrn_vm *vm);
-	void (*cfgread)(struct acrn_vpci *vpci, union pci_bdf vbdf, uint32_t offset,
-		uint32_t bytes, uint32_t *val);
-	void (*cfgwrite)(struct acrn_vpci *vpci, union pci_bdf vbdf, uint32_t offset,
-		uint32_t bytes, uint32_t val);
-};
-
 struct acrn_vpci {
 	struct acrn_vm *vm;
 	struct pci_addr_info addr_info;
-	const struct vpci_ops *ops;
 	uint32_t pci_vdev_cnt;
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };


### PR DESCRIPTION
Changes include:
Remove vdev ops for partition mode, change related code to directly call the corresponding
functions instead.

Do not call vpci ops, call the corresponding sharing mode/partition functions
directly instead

Various misra C violations fix

Unify the sharing mode and partition mode coding style for similar functions

Centralize the pci cfg read/write sanity checking code

Tracked-On: #2534
Signed-off-by: dongshen dongsheng.x.zhang@intel.com

Will need to post more patches to eventually unify the VPCI partition/sharing mode code