### PR TITLE
hv: minor fixes to a few calls to strncpy_s()

### DIFF
--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -18,7 +18,7 @@
  * - cmdline from acrn stitching tool. mod[0].mm_string
  * We need to merge them together
  */
-static char kernel_cmdline[MEM_2K];
+static char kernel_cmdline[MEM_2K + 1U];
 
 /* now modules support: FIRMWARE & RAMDISK & SeedList */
 static void parse_other_modules(struct acrn_vm *vm, const struct multiboot_module *mods, uint32_t mods_count)
@@ -60,7 +60,8 @@ static void parse_other_modules(struct acrn_vm *vm, const struct multiboot_modul
 			/*copy boot args to load addr, set src=load addr*/
 			if (copy_once != 0) {
 				copy_once = 0;
-				(void)strncpy_s(load_addr, MEM_2K, (const char *)vm->sw.linux_info.bootargs_src_addr,
+				(void)strncpy_s(load_addr, MEM_2K + 1U,
+					(const char *)vm->sw.linux_info.bootargs_src_addr,
 					vm->sw.linux_info.bootargs_size);
 				vm->sw.linux_info.bootargs_src_addr = load_addr;
 			}
@@ -169,11 +170,10 @@ int32_t sbl_init_vm_boot_info(struct acrn_vm *vm)
 						 * Append seed argument for SOS
 						 */
 						append_seed_arg(cmd_dst, is_sos_vm(vm));
-
 						off = strnlen_s(cmd_dst, MEM_2K);
 
 						cmd_dst += off;
-						(void)strncpy_s(cmd_dst, MEM_2K - off, (const char *)cmd_src,
+						(void)strncpy_s(cmd_dst, MEM_2K + 1U - off, (const char *)cmd_src,
 							strnlen_s(cmd_src, MEM_2K - off));
 						off = strnlen_s(cmd_dst, MEM_2K - off);
 						cmd_dst[off] = ' ';	/* insert space */
@@ -181,7 +181,7 @@ int32_t sbl_init_vm_boot_info(struct acrn_vm *vm)
 
 						cmd_dst += off;
 						cmd_src = (char *)hpa2hva((uint64_t)mods[0].mm_string);
-						(void)strncpy_s(cmd_dst, MEM_2K - off, cmd_src,
+						(void)strncpy_s(cmd_dst, MEM_2K + 1U - off, cmd_src,
 							strnlen_s(cmd_src, MEM_2K - off));
 
 						vm->sw.linux_info.bootargs_src_addr = kernel_cmdline;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -355,7 +355,7 @@ static int32_t shell_process_cmd(const char *p_input_line)
 	/* Copy the input line INTo an argument string to become part of the
 	 * argument vector.
 	 */
-	(void)strncpy_s(&cmd_argv_str[0], SHELL_CMD_MAX_LEN, p_input_line, SHELL_CMD_MAX_LEN);
+	(void)strncpy_s(&cmd_argv_str[0], SHELL_CMD_MAX_LEN + 1U, p_input_line, SHELL_CMD_MAX_LEN);
 	cmd_argv_str[SHELL_CMD_MAX_LEN] = 0;
 
 	/* Build the argv vector from the string. The first argument in the

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -18,17 +18,17 @@
 static bool serial_port_mapped = true;
 static bool uart_enabled = true;
 static uint64_t uart_base_address = CONFIG_SERIAL_PIO_BASE;
-static char pci_bdf_info[MAX_BDF_LEN];
+static char pci_bdf_info[MAX_BDF_LEN + 1U];
 #elif defined(CONFIG_SERIAL_PCI_BDF)
 static bool serial_port_mapped;
 static bool uart_enabled = true;
 static uint64_t uart_base_address;
-static char pci_bdf_info[MAX_BDF_LEN] = CONFIG_SERIAL_PCI_BDF;
+static char pci_bdf_info[MAX_BDF_LEN + 1U] = CONFIG_SERIAL_PCI_BDF;
 #else
 static bool serial_port_mapped;
 static bool uart_enabled;
 static uint64_t uart_base_address;
-static char pci_bdf_info[MAX_BDF_LEN];
+static char pci_bdf_info[MAX_BDF_LEN + 1U];
 #endif
 
 typedef uint32_t uart_reg_t;
@@ -224,7 +224,7 @@ void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr)
 		uart_base_address = base_addr;
 	} else {
 		const char *bdf = (const char *)base_addr;
-		strncpy_s(pci_bdf_info, MAX_BDF_LEN, bdf, MAX_BDF_LEN);
+		strncpy_s(pci_bdf_info, MAX_BDF_LEN + 1U, bdf, MAX_BDF_LEN);
 	}
 }
 


### PR DESCRIPTION
strncpy_s(d, dmax, s, slen): the 'dmax' includes the null terminator, while
slen doesn't. Thus if (dmax == slen == strlen(s)), strncpy_s() chooses to
discard the last character from s and instead write '\0' to d[dmax - 1].

strnlen_s(s, maxsize): if there is no terminating null character in the
first maxsize characters pointed to by s, strnlen_s() returns maxsize.

So in the following example or similar cases, we need to increase the size
of d[] by 1 to accommodate the null terminator, and add '1' to the dmax
argument to strncpy_s().

uint8_t d[MAX_LEN];
size = strnlen_s(s, MAX_LEN);
strncpy_s(d, MAX_LEN, s, size);

Tracked-On: #861
Signed-off-by: Zide Chen <zide.chen@intel.com>