### PR TITLE
hv: disable mpx capability for guest

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -122,6 +122,9 @@ static void init_vcpuid_entry(uint32_t leaf, uint32_t subleaf,
 			entry->ebx &= ~CPUID_EBX_SGX;
 			entry->ecx &= ~CPUID_ECX_SGX_LC;
 
+			/* mask MPX */
+			entry->ebx &= ~CPUID_EBX_MPX;
+
 			/* mask Intel Processor Trace, since 14h is disabled */
 			entry->ebx &= ~CPUID_EBX_PROC_TRC;
 		} else {
@@ -414,6 +417,13 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 				*edx = 0U;
 			} else {
 				cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
+				if (subleaf == 0U) {
+					/* SDM Vol.1 17-2, On processors that do not support Intel MPX,
+					 * CPUID.(EAX=0DH,ECX=0):EAX[3] and
+					 * CPUID.(EAX=0DH,ECX=0):EAX[4] will both be 0 */
+					*eax &= ~ CPUID_EAX_XCR0_BNDREGS;
+					*eax &= ~ CPUID_EAX_XCR0_BNDCSR;
+				}
 			}
 			break;
 

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -64,7 +64,7 @@ static const uint32_t mtrr_msrs[NUM_MTRR_MSRS] = {
 };
 
 /* Following MSRs are intercepted, but it throws GPs for any guest accesses */
-#define NUM_UNSUPPORTED_MSRS	103U
+#define NUM_UNSUPPORTED_MSRS	104U
 static const uint32_t unsupported_msrs[NUM_UNSUPPORTED_MSRS] = {
 	/* Variable MTRRs are not supported */
 	MSR_IA32_MTRR_PHYSBASE_0,
@@ -119,6 +119,9 @@ static const uint32_t unsupported_msrs[NUM_UNSUPPORTED_MSRS] = {
 
 	/* SGX disabled : CPUID.07H.EBX[2] */
 	MSR_IA32_SGX_SVN_STATUS,
+
+	/* MPX disabled: CPUID.07H.EBX[14] */
+	MSR_IA32_BNDCFGS,
 
 	/* SGX disabled : CPUID.12H.EAX[0] */
 	MSR_SGXOWNEREPOCH0,

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -83,6 +83,14 @@
 #define CR4_SMAP                (1UL<<21U)
 #define CR4_PKE                 (1UL<<22U)	/* Protect-key-enable */
 
+/* XCR0_SSE */
+#define XCR0_SSE		(1U<<1U)
+/* XCR0_AVX */
+#define XCR0_AVX		(1U<<2U)
+/* XCR0_BNDREGS */
+#define XCR0_BNDREGS		(1U<<3U)
+/* XCR0_BNDCSR */
+#define XCR0_BNDCSR		(1U<<4U)
 
 /*
  * Entries in the Interrupt Descriptor Table (IDT)

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -76,6 +76,8 @@
 #define CPUID_EBX_TSC_ADJ       (1U<<1U)
 /* CPUID.07H:EBX.SGX */
 #define CPUID_EBX_SGX           (1U<<2U)
+/* CPUID.07H:EBX.MPX */
+#define CPUID_EBX_MPX           (1U<<14U)
 /* CPUID.07H:ECX.SGX_LC*/
 #define CPUID_ECX_SGX_LC        (1U<<30U)
 /* CPUID.07H:EDX.IBRS_IBPB*/
@@ -94,6 +96,10 @@
 #define CPUID_EBX_PROC_TRC      (1U<<25U)
 /* CPUID.01H:ECX.PCID*/
 #define CPUID_ECX_PCID          (1U<<17U)
+/* CPUID.0DH.EAX.XCR0_BNDREGS */
+#define CPUID_EAX_XCR0_BNDREGS	(1U<<3U)
+/* CPUID.0DH.EAX.XCR0_BNDCSR */
+#define CPUID_EAX_XCR0_BNDCSR	(1U<<4U)
 
 /* CPUID source operands */
 #define CPUID_VENDORSTRING      0U


### PR DESCRIPTION
This patch hide Memory Protection Extention (MPX) capability from guest.

- vCPUID change:
  Clear cpuid.07H.0.ebx[14]
  Clear cpuid.0DH.0.eax[4:3]
- vMSR change:
  Add MSR_IA32_BNDCFGS to un-supported MSR array.
- XCR0[4:3] is not allowed to set by guest.

Tracked-On: #2821
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>