### PR TITLE
Pass ACRN E820 map to OVMF

### DIFF
--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -50,57 +50,56 @@ static char bootargs[STR_LEN];
  *   map[0]:0~ctx->lowmem_limit & map[2]:4G~ctx->highmem for RAM
  *   ctx->highmem = request_memory_size - ctx->lowmem_limit
  *
- *             Begin      End         Type         Length
- * 0:             0 -     0xef000     RAM          0xEF000
- * 1	    0xef000 -	  0x100000    (reserved)   0x11000
- * 2       0x100000 -	  lowmem      RAM          lowmem - 0x100000
- * 3:        lowmem -     bff_fffff   (reserved)   0xc00_00000-lowmem
- * 4:   0xc00_00000 -     dff_fffff   PCI hole     512MB
- * 5:   0xe00_00000 -     fff_fffff   (reserved)   512MB
- * 6:   1_000_00000 -     1_400_00000 PCI hole     1G
- * 7:   1_400_00000 -     highmem     RAM          highmem-5G
+ *             Begin    Limit       Type            Length
+ * 0:              0 -  0xA0000     RAM             0xA0000
+ * 1:        0xA0000 -  0x100000    (reserved)      0x60000
+ * 2:       0x100000 -  lowmem      RAM             lowmem - 1MB
+ * 3:         lowmem -  0x80000000  (reserved)      2GB - lowmem
+ * 4:     0x80000000 -  0x100000000 PCI hole, MMIO  2GB
+ * 5:    0x100000000 -  0x140000000 PCI hole        1GB
+ * 6:    0x140000000 -  highmem     RAM             highmem - 5GB
  */
 const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
-	{	/* 0 to mptable/smbios/acpi */
-		.baseaddr =  0x00000000,
-		.length   =  0xEF000,
-		.type     =  E820_TYPE_RAM
+	{	/* 0 to video memory */
+		.baseaddr = 0x00000000,
+		.length   = 0xA0000,
+		.type     = E820_TYPE_RAM
 	},
 
-	{	/* guest_cfg_addr/mptable/smbios/acpi to lowmem */
-		.baseaddr = 0xEF000,
-		.length	  = 0x11000,
-		.type	  = E820_TYPE_RESERVED
+	{	/* video memory, ROM (used for e820/mptable/smbios/acpi) */
+		.baseaddr = 0xA0000,
+		.length   = 0x60000,
+		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* lowmem to lowmem_limit*/
-		.baseaddr =  0x100000,
-		.length   =  0x48f00000,
-		.type     =  E820_TYPE_RAM
+	{	/* 1MB to lowmem */
+		.baseaddr = 0x100000,
+		.length   = 0x48f00000,
+		.type     = E820_TYPE_RAM
 	},
 
-	{	/* lowmem to lowmem_limit*/
-		.baseaddr =  0x49000000,
-		.length   =  0x77000000,
-		.type     =  E820_TYPE_RESERVED
+	{	/* lowmem to lowmem_limit */
+		.baseaddr = 0x49000000,
+		.length   = 0x37000000,
+		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* lowmem_limit to 4G */
-		.baseaddr =  0xe0000000,
-		.length   =  0x20000000,
-		.type     =  E820_TYPE_RESERVED
+	{	/* lowmem_limit to 4GB */
+		.baseaddr = 0x80000000,
+		.length   = 0x80000000,
+		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* 4G to 5G */
-		.baseaddr =  PCI_EMUL_MEMBASE64,
-		.length   =  PCI_EMUL_MEMLIMIT64 - PCI_EMUL_MEMBASE64,
-		.type     =  E820_TYPE_RESERVED
+	{	/* 4GB to 5GB */
+		.baseaddr = PCI_EMUL_MEMBASE64,
+		.length   = PCI_EMUL_MEMLIMIT64 - PCI_EMUL_MEMBASE64,
+		.type     = E820_TYPE_RESERVED
 	},
 
-	{
-		.baseaddr =  PCI_EMUL_MEMLIMIT64,
-		.length   =  0x000100000,
-		.type     =  E820_TYPE_RESERVED
+	{	/* 5GB to highmem */
+		.baseaddr = PCI_EMUL_MEMLIMIT64,
+		.length   = 0x000100000,
+		.type     = E820_TYPE_RESERVED
 	},
 };
 

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1334,12 +1334,13 @@ init_pci(struct vmctx *ctx)
 
 	/*
 	 * The guest physical memory map looks like the following:
-	 * [0,		    lowmem)		guest system memory
-	 * [lowmem,	    lowmem_limit)	memory hole (may be absent)
-	 * [lowmem_limit,   0xE0000000)		PCI hole (32-bit BAR allocation)
-	 * [0xE0000000,	    0xF0000000)		PCI extended config window
-	 * [0xF0000000,	    4GB)		LAPIC, IOAPIC, HPET, firmware
-	 * [4GB,	    4GB + highmem)
+	 * [0,              lowmem)         guest system memory
+	 * [lowmem,         lowmem_limit)   memory hole (may be absent)
+	 * [lowmem_limit,   0xE0000000)     PCI hole (32-bit BAR allocation)
+	 * [0xE0000000,     0xF0000000)     PCI extended config window
+	 * [0xF0000000,     4GB)            LAPIC, IOAPIC, HPET, firmware
+	 * [4GB,            5GB)            PCI hole (64-bit BAR allocation)
+	 * [5GB,            5GB + highmem)  guest system memory
 	 */
 
 	/*
@@ -1348,10 +1349,20 @@ init_pci(struct vmctx *ctx)
 	 */
 	lowmem = vm_get_lowmem_size(ctx);
 	bzero(&mr, sizeof(struct mem_range));
-	mr.name = "PCI hole";
+	mr.name = "PCI hole (32-bit)";
 	mr.flags = MEM_F_RW;
 	mr.base = lowmem;
 	mr.size = (4ULL * 1024 * 1024 * 1024) - lowmem;
+	mr.handler = pci_emul_fallback_handler;
+	error = register_mem_fallback(&mr);
+	assert(error == 0);
+
+	/* ditto for the 64-bit PCI host aperture */
+	bzero(&mr, sizeof(struct mem_range));
+	mr.name = "PCI hole (64-bit)";
+	mr.flags = MEM_F_RW;
+	mr.base = PCI_EMUL_MEMBASE64;
+	mr.size = PCI_EMUL_MEMLIMIT64 - PCI_EMUL_MEMBASE64;
 	mr.handler = pci_emul_fallback_handler;
 	error = register_mem_fallback(&mr);
 	assert(error == 0);
@@ -1413,9 +1424,16 @@ deinit_pci(struct vmctx *ctx)
 	/* Release PCI hole space */
 	lowmem = vm_get_lowmem_size(ctx);
 	bzero(&mr, sizeof(struct mem_range));
-	mr.name = "PCI hole";
+	mr.name = "PCI hole (32-bit)";
 	mr.base = lowmem;
 	mr.size = (4ULL * 1024 * 1024 * 1024) - lowmem;
+	unregister_mem_fallback(&mr);
+
+	/* ditto for the 64-bit PCI host aperture */
+	bzero(&mr, sizeof(struct mem_range));
+	mr.name = "PCI hole (64-bit)";
+	mr.base = PCI_EMUL_MEMBASE64;
+	mr.size = PCI_EMUL_MEMLIMIT64 - PCI_EMUL_MEMBASE64;
 	unregister_mem_fallback(&mr);
 
 	for (bus = 0; bus < MAXBUSES; bus++) {

--- a/devicemodel/include/mem.h
+++ b/devicemodel/include/mem.h
@@ -49,13 +49,13 @@ struct mem_range {
 #define	MEM_F_RW		0x3
 #define	MEM_F_IMMUTABLE		0x4	/* mem_range cannot be unregistered */
 
-void	init_mem(void);
 int	emulate_mem(struct vmctx *ctx, struct mmio_request *mmio_req);
+int	disable_mem(struct mem_range *memp);
+int	enable_mem(struct mem_range *memp);
 int	register_mem(struct mem_range *memp);
 int	register_mem_fallback(struct mem_range *memp);
 int	unregister_mem(struct mem_range *memp);
 int	unregister_mem_fallback(struct mem_range *memp);
-int	disable_mem(struct mem_range *memp);
-int	enable_mem(struct mem_range *memp);
+void	init_mem(void);
 
 #endif	/* _MEM_H_ */

--- a/devicemodel/include/public/acrn_common.h
+++ b/devicemodel/include/public/acrn_common.h
@@ -449,18 +449,6 @@ struct acrn_vm_pci_msix_remap {
 } __aligned(8);
 
 /**
- * @brief The guest config pointer offset.
- *
- * It's designed to support passing DM config data pointer, based on it,
- * hypervisor would parse then pass DM defined configuration to GUEST VCPU
- * when booting guest VM.
- * the address 0xef000 here is designed by DM, as it arranged all memory
- * layout below 1M, DM add this address to E280 reserved range to make sure
- * there is no overlap for the address 0xef000 usage.
- */
-#define GUEST_CFG_OFFSET	0xef000UL
-
-/**
  * @brief Info The power state data of a VCPU.
  *
  */

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,8 +39,8 @@
 #define E820_TYPE_UNUSABLE      5   /* EFI 8 */
 
 #define NUM_E820_ENTRIES        7
-#define LOWRAM_E820_ENTRIES     2
-#define HIGHRAM_E820_ENTRIES    6
+#define LOWRAM_E820_ENTRY       2
+#define HIGHRAM_E820_ENTRY      6
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {

--- a/devicemodel/include/tree.h
+++ b/devicemodel/include/tree.h
@@ -385,7 +385,7 @@ struct {								\
 #define	RB_PROTOTYPE(name, type, field, cmp)				\
 	RB_PROTOTYPE_INTERNAL(name, type, field, cmp,)
 #define	RB_PROTOTYPE_STATIC(name, type, field, cmp)			\
-	RB_PROTOTYPE_INTERNAL(name, type, field, cmp, __unused static)
+	RB_PROTOTYPE_INTERNAL(name, type, field, cmp, static)
 #define RB_PROTOTYPE_INTERNAL(name, type, field, cmp, attr)		\
 	RB_PROTOTYPE_INSERT_COLOR(name, type, attr);			\
 	RB_PROTOTYPE_REMOVE_COLOR(name, type, attr);			\
@@ -422,7 +422,7 @@ struct {								\
 #define	RB_GENERATE(name, type, field, cmp)				\
 	RB_GENERATE_INTERNAL(name, type, field, cmp,)
 #define	RB_GENERATE_STATIC(name, type, field, cmp)			\
-	RB_GENERATE_INTERNAL(name, type, field, cmp, __unused static)
+	RB_GENERATE_INTERNAL(name, type, field, cmp, __attribute__((unused)) static)
 #define RB_GENERATE_INTERNAL(name, type, field, cmp, attr)		\
 	RB_GENERATE_INSERT_COLOR(name, type, field, attr)		\
 	RB_GENERATE_REMOVE_COLOR(name, type, field, attr)		\


### PR DESCRIPTION
OVMF requires a more descriptive mechanism than RTC CMOS to retrieve ACRN's memory layout, so we now pass the E820 map to it, starting at 0xEF000 (ROM area).

ACRN currently uses [4GB, 5GB) as its 64-bit PCI host aperture. This is inconsistent with OVMF's assumption of its platform's memory layout, because it derives the size of high memory from RTC CMOS, which is incapable of describing the 64-bit PCI hole.

By default, OVMF uses RTC CMOS 0x5b/0x5c/0x5d to determine the size of high memory. This value only tells OVMF how much memory is above 4GB, but not the platform's memory layout above 4GB.

Using RTC CMOS works for QEMU, because QEMU places its 64-bit PCI host aperture above its highmem. Therefore, OVMF can always assume highmem is located at [4GB, 4GB + highmem), which is not where ACRN's highmem is located. For example, if we have 1GB of usable memory above 4GB, ACRN will place it at [5GB, 6GB).

This patchset allows OVMF to correctly identify the guest's memory layout. It will consider any reserved region above 4GB as 64-bit PCI host aperture. It also adds the MMIO fallback handler to the 64-bit PCI host aperture to prevent the guest from inadvertently crashing acrn-dm.

v1 -> v2:
- provide more explanation to this patchset
- add signature before E820 map for OVMF backward compatibility
- add the MMIO fallback handler to the 64-bit PCI host aperture

Tracked-On: #2792
Signed-off-by: Peter Fang <peter.fang@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>