### PR TITLE
hv: replace MEM_2K with a new macro MAX_BOOTARGS_SIZE for bootargs size

### DIFF
--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -59,7 +59,7 @@ static uint32_t parse_seed_arg(void)
 	if (cmd_src != NULL) {
 		for (i = 0U; seed_arg[i].str != NULL; i++) {
 			len = strnlen_s(seed_arg[i].str, MEM_1K);
-			arg = strstr_s((const char *)cmd_src, MEM_2K, seed_arg[i].str, len);
+			arg = strstr_s((const char *)cmd_src, MAX_BOOTARGS_SIZE, seed_arg[i].str, len);
 			if (arg != NULL) {
 				arg += len;
 				seed_arg[i].addr = strtoul_hex(arg);
@@ -71,7 +71,8 @@ static uint32_t parse_seed_arg(void)
 				 */
 				arg_end = strchr(arg, ' ');
 				arg -= len;
-				len = (arg_end != NULL) ? (uint32_t)(arg_end - arg) : strnlen_s(arg, MEM_2K);
+				len = (arg_end != NULL) ? (uint32_t)(arg_end - arg) :
+					strnlen_s(arg, MAX_BOOTARGS_SIZE);
 				(void)memset((void *)arg, (char)' ', len);
 				break;
 			}
@@ -120,7 +121,7 @@ void append_seed_arg(char *cmd_dst, bool vm_is_sos)
 					boot_params->p_platform_info = sos_vm_hpa2gpa(boot_params->p_platform_info);
 				}
 
-				(void)strncpy_s(cmd_dst, MEM_2K, buf, strnlen_s(buf, MEM_1K));
+				(void)strncpy_s(cmd_dst, MAX_BOOTARGS_SIZE, buf, strnlen_s(buf, MEM_1K));
 
 				break;
 			}

--- a/hypervisor/boot/sbl/multiboot.c
+++ b/hypervisor/boot/sbl/multiboot.c
@@ -18,7 +18,7 @@
  * - cmdline from acrn stitching tool. mod[0].mm_string
  * We need to merge them together
  */
-static char kernel_cmdline[MEM_2K + 1U];
+static char kernel_cmdline[MAX_BOOTARGS_SIZE + 1U];
 
 /* now modules support: FIRMWARE & RAMDISK & SeedList */
 static void parse_other_modules(struct acrn_vm *vm, const struct multiboot_module *mods, uint32_t mods_count)
@@ -60,14 +60,14 @@ static void parse_other_modules(struct acrn_vm *vm, const struct multiboot_modul
 			/*copy boot args to load addr, set src=load addr*/
 			if (copy_once != 0) {
 				copy_once = 0;
-				(void)strncpy_s(load_addr, MEM_2K + 1U,
+				(void)strncpy_s(load_addr, MAX_BOOTARGS_SIZE + 1U,
 					(const char *)vm->sw.linux_info.bootargs_src_addr,
 					vm->sw.linux_info.bootargs_size);
 				vm->sw.linux_info.bootargs_src_addr = load_addr;
 			}
 
 			(void)strncpy_s(load_addr + args_size, 100U, dyn_bootargs, 100U);
-			vm->sw.linux_info.bootargs_size = strnlen_s(load_addr, MEM_2K);
+			vm->sw.linux_info.bootargs_size = strnlen_s(load_addr, MAX_BOOTARGS_SIZE);
 
 		} else if (strncmp("RAMDISK", start, type_len) == 0) {
 			vm->sw.linux_info.ramdisk_src_addr = mod_addr;
@@ -97,12 +97,12 @@ static void merge_cmdline(const struct acrn_vm *vm, const char *cmdline, const c
 	 * seed_arg string ends with a white space and '\0', so no aditional delimiter is needed
 	 */
 	append_seed_arg(cmd_dst, is_sos_vm(vm));
-	dst_len = strnlen_s(cmd_dst, MEM_2K);
-	dst_avail = MEM_2K + 1U - dst_len;
+	dst_len = strnlen_s(cmd_dst, MAX_BOOTARGS_SIZE);
+	dst_avail = MAX_BOOTARGS_SIZE + 1U - dst_len;
 	cmd_dst += dst_len;
 
-	cmdline_len = strnlen_s(cmdline, MEM_2K);
-	cmdstr_len = strnlen_s(cmdstr, MEM_2K);
+	cmdline_len = strnlen_s(cmdline, MAX_BOOTARGS_SIZE);
+	cmdstr_len = strnlen_s(cmdstr, MAX_BOOTARGS_SIZE);
 
 	/* reserve one character for the delimiter between 2 strings (one white space) */
 	if ((cmdline_len + cmdstr_len + 1U) >= dst_avail) {
@@ -192,7 +192,7 @@ int32_t sbl_init_vm_boot_info(struct acrn_vm *vm)
 					vm->sw.kernel_info.kernel_load_addr = (void *)(MEM_1M * 16U);
 					vm->sw.linux_info.bootargs_src_addr = (void *)vm_config->os_config.bootargs;
 					vm->sw.linux_info.bootargs_size =
-						strnlen_s(vm_config->os_config.bootargs, MEM_2K);
+						strnlen_s(vm_config->os_config.bootargs, MAX_BOOTARGS_SIZE);
 				} else {
 					vm->sw.kernel_info.kernel_load_addr =
 						get_kernel_load_addr(vm->sw.kernel_info.kernel_src_addr);
@@ -206,12 +206,14 @@ int32_t sbl_init_vm_boot_info(struct acrn_vm *vm)
 								hpa2hva((uint64_t)mods[0].mm_string));
 
 						vm->sw.linux_info.bootargs_src_addr = kernel_cmdline;
-						vm->sw.linux_info.bootargs_size = strnlen_s(kernel_cmdline, MEM_2K);
+						vm->sw.linux_info.bootargs_size =
+							strnlen_s(kernel_cmdline, MAX_BOOTARGS_SIZE);
 					} else {
 						vm->sw.linux_info.bootargs_src_addr =
 							hpa2hva((uint64_t)mods[0].mm_string);
 						vm->sw.linux_info.bootargs_size =
-							strnlen_s(hpa2hva((uint64_t)mods[0].mm_string), MEM_2K);
+							strnlen_s(hpa2hva((uint64_t)mods[0].mm_string),
+							MAX_BOOTARGS_SIZE);
 					}
 				}
 

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -10,6 +10,7 @@
 #include <boot_context.h>
 #include <ept.h>
 #include <mmu.h>
+#include <multiboot.h>
 #include <errno.h>
 #include <sprintf.h>
 #include <logmsg.h>
@@ -146,7 +147,7 @@ int32_t general_sw_loader(struct acrn_vm *vm)
 		/* Copy Guest OS bootargs to its load location */
 		(void)copy_to_gpa(vm, linux_info->bootargs_src_addr,
 			(uint64_t)linux_info->bootargs_load_addr,
-			(strnlen_s((char *)linux_info->bootargs_src_addr, MEM_2K - 1U) + 1U));
+			(strnlen_s((char *)linux_info->bootargs_src_addr, MAX_BOOTARGS_SIZE) + 1U));
 
 		/* add "hugepagesz=1G hugepages=x" to cmdline for 1G hugepage
 		 * reserving. Current strategy is "total_mem_size in Giga -

--- a/hypervisor/include/arch/x86/multiboot.h
+++ b/hypervisor/include/arch/x86/multiboot.h
@@ -14,6 +14,9 @@
 #define	MULTIBOOT_INFO_HAS_DRIVES	0x00000080U
 #define	MULTIBOOT_INFO_HAS_LOADER_NAME	0x00000200U
 
+/* maximum lengt of the guest OS' command line parameter string */
+#define MAX_BOOTARGS_SIZE		2048U
+
 struct acrn_vm;
 struct multiboot_info {
 	uint32_t               mi_flags;

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -9,8 +9,8 @@
 
 #include <types.h>
 #include <pci.h>
+#include <multiboot.h>
 
-#define MAX_BOOTARGS_SIZE	1024U
 #define MAX_CONFIG_NAME_SIZE	32U
 
 #define PLUG_CPU(n)		(1U << (n))


### PR DESCRIPTION
- for all cases of referring guest bootargs size, replace MEM_2K with
  CONFIG_MAX_BOOTARGS_SIZE for better readability.
- remove duplicated MAX_BOOTARGS_SIZE definition from vm_config.h.

Also fix one minor issue in general_sw_loader() which uses copy_to_gpa()
to copy a string. Since copy_to_gpa() makes use of memncpy_s() to do the
job, the size parameter should include the string null ternimator.

Tracked-On: #2806
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>