### PR TITLE
HV: Fix a compiler warning in firmware.h

### DIFF
--- a/hypervisor/bsp/include/firmware.h
+++ b/hypervisor/bsp/include/firmware.h
@@ -8,6 +8,7 @@
 
 #define FIRMWARE_H
 
+struct acrn_vm;
 struct firmware_operations {
 	void (*init)(void);
 	uint64_t (*get_ap_trampoline)(void);


### PR DESCRIPTION
Added a struct acrn_vm in firmware.h to remove
a compiler warning.
No change in logic.

Tracked-On: #2830
Signed-off-by: Arindam Roy <arindam.roy@intel.com>