### PR TITLE
DM: virtio-gpio: implement GPIO IRQ

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -1372,12 +1372,30 @@ virtio_gpio_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	VIRTIO_GPIO_LOG_DEINIT;
 }
 
+static void
+virtio_gpio_write_dsdt(struct pci_vdev *dev)
+{
+	dsdt_line("");
+	dsdt_line("Device (AGPI)");
+	dsdt_line("{");
+	dsdt_line("    Name (_ADR, 0x%04X%04X)", dev->slot, dev->func);
+	dsdt_line("    Name (_DDN, \"Virtio GPIO Controller \")");
+	dsdt_line("    Name (_UID, One)");
+	dsdt_line("    Name (LINK, \"\\\\_SB_.PCI0.AGPI\")");
+	dsdt_line("    Method (_CRS, 0, NotSerialized)");
+	dsdt_line("    {");
+	dsdt_line("    }");
+	dsdt_line("}");
+	dsdt_line("");
+}
+
 struct pci_vdev_ops pci_ops_virtio_gpio = {
 	.class_name	= "virtio-gpio",
 	.vdev_init	= virtio_gpio_init,
 	.vdev_deinit	= virtio_gpio_deinit,
 	.vdev_barwrite	= virtio_pci_write,
 	.vdev_barread	= virtio_pci_read,
+	.vdev_write_dsdt	= virtio_gpio_write_dsdt,
 };
 
 static void


### PR DESCRIPTION
virtio GPIO IRQ emulates a GPIO IRQ controller to support
level trigger and edge trigger interrupts, it uses two virtqueues
one is for IRQ chip operations and the other is to notify IRQ sources.

v2: 1) refine code style.
    2) refine IRQ controller that removing the IRQ generating thread.
    3) add ACPI GPIO dsdt.

v3: 1) fix IRQ missing case.
    2) if an IRQ is disabled, reconfig it to GPIO mode.
    3) refine code style.

v4: 1) remove ndesc check since the FE driver will not kick the queue.
    2) add comments.
    3) add UOS and SOS flags for GPIO IRQ diagram.

Tracked-On: #2512
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>