### PR TITLE
hv: vmsr: add IA32_MISC_ENABLE to msr store area

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -328,9 +328,9 @@ static void intercept_x2apic_msrs(uint8_t *msr_bitmap_arg, uint32_t mode)
 
 static void init_msr_area(struct acrn_vcpu *vcpu)
 {
-	vcpu->arch.msr_area.guest[MSR_AREA_TSC_AUX].msr_num = MSR_IA32_TSC_AUX;
+	vcpu->arch.msr_area.guest[MSR_AREA_TSC_AUX].msr_index = MSR_IA32_TSC_AUX;
 	vcpu->arch.msr_area.guest[MSR_AREA_TSC_AUX].value = vcpu->vcpu_id;
-	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].msr_num = MSR_IA32_TSC_AUX;
+	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].msr_index = MSR_IA32_TSC_AUX;
 	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].value = vcpu->pcpu_id;
 }
 

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -332,6 +332,11 @@ static void init_msr_area(struct acrn_vcpu *vcpu)
 	vcpu->arch.msr_area.guest[MSR_AREA_TSC_AUX].value = vcpu->vcpu_id;
 	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].msr_index = MSR_IA32_TSC_AUX;
 	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].value = vcpu->pcpu_id;
+
+	vcpu->arch.msr_area.guest[MSR_AREA_IA32_MISC_ENABLE].msr_index = MSR_IA32_MISC_ENABLE;
+	vcpu->arch.msr_area.guest[MSR_AREA_IA32_MISC_ENABLE].value = msr_read(MSR_IA32_MISC_ENABLE);
+	vcpu->arch.msr_area.host[MSR_AREA_IA32_MISC_ENABLE].msr_index = MSR_IA32_MISC_ENABLE;
+	vcpu->arch.msr_area.host[MSR_AREA_IA32_MISC_ENABLE].value = msr_read(MSR_IA32_MISC_ENABLE);
 }
 
 void init_msr_emulation(struct acrn_vcpu *vcpu)

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -130,7 +130,7 @@ static void profiling_enable_pmu(void)
 			(void)memcpy_s(ss->vmexit_msr_list, size, vcpu->arch.msr_area.host, size);
 			ss->vmexit_msr_cnt = MAX_HV_MSR_LIST_NUM;
 
-			ss->vmexit_msr_list[MAX_HV_MSR_LIST_NUM].msr_num = MSR_IA32_DEBUGCTL;
+			ss->vmexit_msr_list[MAX_HV_MSR_LIST_NUM].msr_index = MSR_IA32_DEBUGCTL;
 			ss->vmexit_msr_list[MAX_HV_MSR_LIST_NUM].value = ss->guest_debugctl_value & VALID_DEBUGCTL_BIT_MASK;
 			ss->vmexit_msr_cnt++;
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -242,6 +242,7 @@ struct msr_store_entry {
 
 enum {
 	MSR_AREA_TSC_AUX = 0,
+	MSR_AREA_IA32_MISC_ENABLE,
 	MSR_AREA_COUNT,
 };
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -235,7 +235,7 @@ struct cpu_context {
 
 /* Intel SDM 24.8.2, the address must be 16-byte aligned */
 struct msr_store_entry {
-	uint32_t msr_num;
+	uint32_t msr_index;
 	uint32_t reserved;
 	uint64_t value;
 } __aligned(16);


### PR DESCRIPTION
Currently MSR IA32_MISC_ENABLE is passthrough to guest.
However, guest may change the value of this MSR, which will cause issue in hypervisor.
This patch uses VMX MSR store area to isolate the MSR IA32_MISC_ENABLE between guest and host.

TODO:
Some bits of the MSR IA32_MISC_ENABLE is not just per core, but per package.
So need to check if need to prevent guest from setting or clearing these bits that may affect other cores.

Tracked-On: #2834
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>