### PR TITLE
doc: minor changes according to one binary for SBL and UEFI

### DIFF
--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -306,7 +306,7 @@ Enable partition mode in ACRN hypervisor
 
    .. code-block:: none
 
-     $ make PLATFORM=sbl
+     $ make BOARD=apl-up2
      ...
      $ sudo cp build/acrn.32.out /boot
 

--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -67,7 +67,7 @@ the source code, build it, and install it on your device.
    .. code-block:: none
 
       cd ~/acrn-hypervisor
-      make PLATFORM=uefi
+      make
       sudo make install
 
    For more details, please refer to the :ref:`getting-started-building`.


### PR DESCRIPTION
PLATFORM=xxx is no longer supported, use BOARD instead.

Tracked-On: #2708
Signed-off-by: Tw <wei.tan@intel.com>