### PR TITLE
dm: leave a gap for 32-bit PCI hole in E820 map

### DIFF
--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -55,8 +55,8 @@ static char bootargs[STR_LEN];
  * 1:        0xA0000 -  0x100000    (reserved)      0x60000
  * 2:       0x100000 -  lowmem      RAM             lowmem - 1MB
  * 3:         lowmem -  0x80000000  (reserved)      2GB - lowmem
- * 4:     0x80000000 -  0x100000000 PCI hole, MMIO  2GB
- * 5:    0x100000000 -  0x140000000 PCI hole        1GB
+ * 4:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
+ * 5:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
  * 6:    0x140000000 -  highmem     RAM             highmem - 5GB
  */
 const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
@@ -84,9 +84,9 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		.type     = E820_TYPE_RESERVED
 	},
 
-	{	/* lowmem_limit to 4GB */
-		.baseaddr = 0x80000000,
-		.length   = 0x80000000,
+	{	/* ECFG_BASE to 4GB */
+		.baseaddr = PCI_EMUL_ECFG_BASE,
+		.length   = (4 * GB) - PCI_EMUL_ECFG_BASE,
 		.type     = E820_TYPE_RESERVED
 	},
 

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -93,7 +93,6 @@ extern bool skip_pci_mem64bar_workaround;
 #define	PCI_EMUL_IOBASE		0x2000
 #define	PCI_EMUL_IOLIMIT	0x10000
 
-#define	PCI_EMUL_ECFG_BASE	0xE0000000		    /* 3.5GB */
 #define	PCI_EMUL_ECFG_SIZE	(MAXBUSES * 1024 * 1024)    /* 1MB per bus */
 SYSRES_MEM(PCI_EMUL_ECFG_BASE, PCI_EMUL_ECFG_SIZE);
 
@@ -1236,12 +1235,6 @@ pci_emul_ecfg_handler(struct vmctx *ctx, int vcpu, int dir, uint64_t addr,
 		*val = ~0UL;
 	pci_cfgrw(ctx, vcpu, in, bus, slot, func, coff, bytes, (uint32_t *)val);
 	return 0;
-}
-
-uint64_t
-pci_ecfg_base(void)
-{
-	return PCI_EMUL_ECFG_BASE;
 }
 
 #define	BUSIO_ROUNDUP		32

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -603,7 +603,7 @@ basl_fwrite_mcfg(FILE *fp, struct vmctx *ctx)
 	EFPRINTF(fp, "[0008]\t\tReserved : 0\n");
 	EFPRINTF(fp, "\n");
 
-	EFPRINTF(fp, "[0008]\t\tBase Address : %016lX\n", pci_ecfg_base());
+	EFPRINTF(fp, "[0008]\t\tBase Address : %016lX\n", PCI_EMUL_ECFG_BASE);
 	EFPRINTF(fp, "[0002]\t\tSegment Group: 0000\n");
 	EFPRINTF(fp, "[0001]\t\tStart Bus: 00\n");
 	EFPRINTF(fp, "[0001]\t\tEnd Bus: FF\n");

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -38,8 +38,10 @@
 #define	PCI_BARMAX	PCIR_MAX_BAR_0	/* BAR registers in a Type 0 header */
 #define	PCI_BDF(b, d, f) (((b & 0xFF) << 8) | ((d & 0x1F) << 3) | ((f & 0x7)))
 
-#define	PCI_EMUL_MEMBASE64	0x100000000UL
-#define	PCI_EMUL_MEMLIMIT64	0x140000000UL
+#define	PCI_EMUL_ECFG_BASE	0xE0000000UL	/* 3.5GB */
+
+#define	PCI_EMUL_MEMBASE64	0x100000000UL	/* 4GB */
+#define	PCI_EMUL_MEMLIMIT64	0x140000000UL	/* 5GB */
 
 struct vmctx;
 struct pci_vdev;
@@ -310,7 +312,6 @@ uint64_t pci_emul_msix_tread(struct pci_vdev *pi, uint64_t offset, int size);
 int	pci_count_lintr(int bus);
 void	pci_walk_lintr(int bus, pci_lintr_cb cb, void *arg);
 void	pci_write_dsdt(void);
-uint64_t pci_ecfg_base(void);
 int	pci_bus_configured(int bus);
 int	emulate_pci_cfgrw(struct vmctx *ctx, int vcpu, int in, int bus,
 			  int slot, int func, int reg, int bytes, int *value);


### PR DESCRIPTION
Guest OS (e.g. Linux) may rely on a gap in E820 map in the 32-bit memory
space to determine the MMIO space for its PCI devices. Leave this gap
when building E820 map to keep the guest's PCI subsystem working.

After commit 7752d5cfe3d11ca0bb9c673ec38bd78ba6578f8e, Linux kernel no
longer requires the MMCONFIG region to be reserved in the E820 map.
Nonetheless, keep it in the reserved region to be on the safe side.

Tracked-On: #2843
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>