### PR TITLE
hv: add default handlers for PIO/MMIO access

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -339,6 +339,12 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);
 	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp);
 
+	/* Register default handlers for PIO & MMIO if it is SOS VM or Pre-launched VM */
+	if ((vm_config->type == SOS_VM) || (vm_config->type == PRE_LAUNCHED_VM)) {
+		register_pio_default_emulation_handler(vm);
+		register_mmio_default_emulation_handler(vm);
+	}
+
 	if (is_sos_vm(vm)) {
 		/* Only for SOS_VM */
 		create_sos_vm_e820(vm);

--- a/hypervisor/include/arch/x86/guest/io_emul.h
+++ b/hypervisor/include/arch/x86/guest/io_emul.h
@@ -84,4 +84,17 @@ int32_t register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
 	uint64_t end, void *handler_private_data);
 
+/**
+ * @brief Register port I/O default handler
+ *
+ * @param vm      The VM to which the port I/O handlers are registered
+ */
+void register_pio_default_emulation_handler(struct acrn_vm *vm);
+
+/**
+ * @brief Register MMIO default handler
+ *
+ * @param vm The VM to which the MMIO handler is registered
+ */
+void register_mmio_default_emulation_handler(struct acrn_vm *vm);
 #endif /* IO_EMUL_H */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -112,6 +112,8 @@ struct vm_arch {
 	struct acrn_vioapic vioapic;	/* Virtual IOAPIC base address */
 	struct acrn_vpic vpic;      /* Virtual PIC */
 	struct vm_io_handler_desc emul_pio[EMUL_PIO_IDX_MAX];
+	io_read_fn_t default_io_read;
+	io_write_fn_t default_io_write;
 
 	/* reference to virtual platform to come here (as needed) */
 } __aligned(PAGE_SIZE);
@@ -132,6 +134,7 @@ struct acrn_vm {
 
 	uint16_t emul_mmio_regions; /* Number of emulated mmio regions */
 	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
+	hv_mem_io_handler_t default_read_write;
 
 	uint8_t GUID[16];
 	struct secure_world_control sworld_control;


### PR DESCRIPTION
Add the default handlers for PIO and MMIO access which returns all
FFs on read and discards write. These default handlers are registered
when SOS VM or pre-launched VM is created.

v2 -> v3:
- use runtime vm type instead of CONFIG_PARTITION_MODE
- revise the pio/mmio emulation functions
- revise the pio/mmio default read functions according to MISRA C
- revise the commit message

v1 -> v2:
- add default handlers members in struct acrn_vm and add interfaces
  to register default handlers for PIO and MMIO.

Tracked-On: #2860
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>