### PR TITLE
Acrn 2358 tools acrnctl

### DIFF
--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -418,21 +418,15 @@ static int acrnctl_do_add(int argc, char *argv[])
 static int acrnctl_do_stop(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int i;
 
-	for (i = 1; i < argc; i++) {
-		s = vmmngr_find(argv[i]);
-		if (!s) {
-			printf("can't find %s\n", argv[i]);
-			continue;
-		}
-		if (s->state == VM_CREATED) {
-			printf("%s is already (%s)\n", argv[i],
-			       state_str[s->state]);
-			continue;
-		}
-		stop_vm(argv[i]);
+	s = vmmngr_find(argv[1]);
+	if (!s) {
+		printf("can't find %s\n", argv[1]);
 	}
+	if (s->state == VM_CREATED) {
+		printf("%s is already (%s)\n", argv[1],state_str[s->state]);
+	}
+	stop_vm(argv[1]);
 
 	return 0;
 }
@@ -487,36 +481,28 @@ static inline int del_runC(char *argv)
 static int acrnctl_do_del(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int i;
 	char cmd[PATH_LEN];
 
-	for (i = 1; i < argc; i++) {
-		s = vmmngr_find(argv[i]);
-		if (!s) {
-			printf("can't find %s\n", argv[i]);
-			continue;
-		}
-		if (s->state != VM_CREATED) {
-			printf("can't delete %s(%s)\n", argv[i],
-			       state_str[s->state]);
-			continue;
-		}
-		if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.sh",
-			 ACRN_CONF_PATH_ADD, argv[i]) >= sizeof(cmd)) {
-			printf("WARN: cmd is truncated\n");
-			return -1;
-		}
-		system(cmd);
-		if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.args",
-			 ACRN_CONF_PATH_ADD, argv[i]) >= sizeof(cmd)) {
-			printf("WARN: cmd is truncated\n");
-			return -1;
-		}
-		system(cmd);
-		if (del_runC(argv[i]) < 0) {
-			printf("ERROR: del runC failed!\n");
-			return -1;
-		}
+	s = vmmngr_find(argv[1]);
+	if (!s) {
+		printf("can't find %s\n", argv[1]);
+	}
+	if (s->state != VM_CREATED) {
+		printf("can't delete %s(%s)\n", argv[1],state_str[s->state]);
+	}
+	if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.sh",ACRN_CONF_PATH_ADD, argv[1]) >= sizeof(cmd)) {
+		printf("WARN: cmd is truncated\n");
+		return -1;
+	}
+	system(cmd);
+	if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.args",ACRN_CONF_PATH_ADD, argv[1]) >= sizeof(cmd)) {
+		printf("WARN: cmd is truncated\n");
+		return -1;
+	}
+	system(cmd);
+	if (del_runC(argv[1]) < 0) {
+		printf("ERROR: del runC failed!\n");
+		return -1;
 	}
 
 	return 0;
@@ -545,24 +531,19 @@ static int acrnctl_do_start(int argc, char *argv[])
 static int acrnctl_do_pause(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int i;
 
-	for (i = 1; i < argc; i++) {
-		s = vmmngr_find(argv[i]);
-		if (!s) {
-			printf("Can't find vm %s\n", argv[i]);
-			continue;
-		}
+	s = vmmngr_find(argv[1]);
+	if (!s) {
+		printf("Can't find vm %s\n", argv[1]);
+	}
 
-		/* Send pause cmd to arcn-dm only when vm is in VM_STARTED */
-		switch (s->state) {
-			case VM_STARTED:
-				pause_vm(argv[i]);
-				break;
-			default:
-				printf("%s current state %s, can't pause\n",
-					argv[i], state_str[s->state]);
-		}
+	/* Send pause cmd to arcn-dm only when vm is in VM_STARTED */
+	switch (s->state) {
+		case VM_STARTED:
+			pause_vm(argv[1]);
+			break;
+		default:
+			printf("%s current state %s, can't pause\n",argv[1], state_str[s->state]);
 	}
 
 	return 0;
@@ -571,27 +552,22 @@ static int acrnctl_do_pause(int argc, char *argv[])
 static int acrnctl_do_continue(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int i;
 
-	for (i = 1; i < argc; i++) {
-		s = vmmngr_find(argv[i]);
-		if (!s) {
-			printf("Can't find vm %s\n", argv[i]);
-			continue;
-		}
+	s = vmmngr_find(argv[1]);
+	if (!s) {
+		printf("Can't find vm %s\n", argv[1]);
+	}
 
-		/* Per current implemention, we can't know if vm is in paused
-		   state. Send continue cmd to acrn-dm when VM_STARTED and will
-		   correct it later when we have a way to check if vm has been
-		   paused */
-		switch (s->state) {
-			case VM_STARTED:
-				continue_vm(argv[i]);
-				break;
-			default:
-				printf("%s current state %s, can't continue\n",
-					argv[i], state_str[s->state]);
-		}
+	/* Per current implemention, we can't know if vm is in paused
+	   state. Send continue cmd to acrn-dm when VM_STARTED and will
+           correct it later when we have a way to check if vm has been
+	   paused */
+	switch (s->state) {
+		case VM_STARTED:
+			continue_vm(argv[1]);
+			break;
+		default:
+			printf("%s current state %s, can't continue\n",argv[1], state_str[s->state]);
 	}
 
 	return 0;
@@ -600,24 +576,19 @@ static int acrnctl_do_continue(int argc, char *argv[])
 static int acrnctl_do_suspend(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int i;
 
-	for (i = 1; i < argc; i++) {
-		s = vmmngr_find(argv[1]);
-		if (!s) {
-			printf("Can't find vm %s\n", argv[i]);
-			continue;
-		}
+	s = vmmngr_find(argv[1]);
+	if (!s) {
+		printf("Can't find vm %s\n", argv[1]);
+	}
 
-		/* Only send suspend cmd to acrn-dm now when VM_STARTED */
-		switch (s->state) {
-			case VM_STARTED:
-				suspend_vm(argv[i]);
-				break;
-			default:
-				printf("%s current state %s, can't suspend\n",
-					argv[i], state_str[s->state]);
-		}
+	/* Only send suspend cmd to acrn-dm now when VM_STARTED */
+	switch (s->state) {
+		case VM_STARTED:
+			suspend_vm(argv[1]);
+			break;
+		default:
+			printf("%s current state %s, can't suspend\n",argv[1], state_str[s->state]);
 	}
 
 	return 0;
@@ -646,8 +617,7 @@ static int acrnctl_do_resume(int argc, char *argv[])
 			printf("resume %s reason(0x%x\n", argv[1], reason);
 			break;
 		default:
-			printf("%s current state %s, can't resume\n",
-				argv[1], state_str[s->state]);
+			printf("%s current state %s, can't resume\n",argv[1], state_str[s->state]);
 	}
 
 	return 0;
@@ -682,30 +652,24 @@ static int wait_vm_stop(const char * vmname, unsigned int timeout)
 static int acrnctl_do_reset(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int i;
 
-	for (i = 1; i < argc; i++) {
-		s = vmmngr_find(argv[i]);
-		if (!s) {
-			printf("Can't find vm %s\n", argv[i]);
-			continue;
-		}
+	s = vmmngr_find(argv[1]);
+	if (!s) {
+		printf("Can't find vm %s\n", argv[1]);
+	}
 
-		switch(s->state) {
-			case VM_STARTED:
-			case VM_SUSPENDED:
-				stop_vm(argv[i]);
-				if (wait_vm_stop(argv[i], STOP_TIMEOUT)) {
-					printf("Failed to stop %s in %u sec, reset failed\n",
-						argv[i], STOP_TIMEOUT);
-					return -1;
-				}
-				start_vm(argv[i]);
-				break;
-			default:
-				printf("%s current state: %s, can't reset\n",
-					argv[i], state_str[s->state]);
-		}
+	switch(s->state) {
+		case VM_STARTED:
+		case VM_SUSPENDED:
+			stop_vm(argv[1]);
+			if (wait_vm_stop(argv[1], STOP_TIMEOUT)) {
+				printf("Failed to stop %s in %u sec, reset failed\n",argv[1], STOP_TIMEOUT);
+				return -1;
+			}
+			start_vm(argv[1]);
+			break;
+		default:
+			printf("%s current state: %s, can't reset\n",argv[1], state_str[s->state]);
 	}
 	return 0;
 }


### PR DESCRIPTION
Tools: acrnctl fix return value when it fails to execute the commands
acrnctl commands can manage multiple vms with a single
 command launched, which is not useful actually.
 To make the logic simple, this patch makes it to manage
 only a single vm by each command.

 Tracked-On: #1262
 Signed-off-by:liuyonggang <yonggangx.liu@intel.com>
 Acked-by: Yan, Like <like.yan@intel.com>