### PR TITLE
Support HV Interrupt Remapping for pre-launched VMs

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -579,8 +579,8 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src)
  * entry_nr = 0 means first vector
  * user must provide bdf and entry_nr
  */
-int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,
-		uint16_t entry_nr, struct ptirq_msi_info *info)
+int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t phys_bdf,
+				uint16_t entry_nr, struct ptirq_msi_info *info)
 {
 	struct ptirq_remapping_info *entry;
 	DEFINE_MSI_SID(virt_sid, virt_bdf, entry_nr);
@@ -597,8 +597,8 @@ int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,
 	entry = ptirq_lookup_entry_by_sid(PTDEV_INTR_MSI, &virt_sid, vm);
 	if (entry == NULL) {
 		/* SOS_VM we add mapping dynamically */
-		if (is_sos_vm(vm)) {
-			entry = add_msix_remapping(vm, virt_bdf, virt_bdf, entry_nr);
+		if (is_sos_vm(vm) || is_prelaunched_vm(vm)) {
+			entry = add_msix_remapping(vm, virt_bdf, phys_bdf, entry_nr);
 			if (entry == NULL) {
 				pr_err("dev-assign: msi entry exist in others");
 			}

--- a/hypervisor/arch/x86/guest/io_emul.c
+++ b/hypervisor/arch/x86/guest/io_emul.c
@@ -592,7 +592,8 @@ void register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
 /**
  * @brief Register a MMIO handler
  *
- * This API registers a MMIO handler to \p vm before it is launched.
+ * This API registers a MMIO handler to \p vm before it is Started
+ * For Pre-launched VMs, this API can be called after it is Started
  *
  * @param vm The VM to which the MMIO handler is registered
  * @param read_write The handler for emulating accesses to the given range
@@ -610,9 +611,7 @@ int32_t register_mmio_emulation_handler(struct acrn_vm *vm,
 	int32_t status = -EINVAL;
 	struct mem_io_node *mmio_node;
 
-	if ((vm->hw.created_vcpus > 0U) && (vm->hw.vcpu_array[0].launched)) {
-		pr_err("register mmio handler after vm launched");
-	} else {
+	if (is_prelaunched_vm(vm) || (vm->state != VM_STARTED)) {
 		/* Ensure both a read/write handler and range check function exist */
 		if ((read_write != NULL) && (end > start)) {
 			if (vm->emul_mmio_regions >= CONFIG_MAX_EMULATED_MMIO_REGIONS) {
@@ -640,6 +639,8 @@ int32_t register_mmio_emulation_handler(struct acrn_vm *vm,
 				status = 0;
 			}
 		}
+	} else {
+		pr_err("register mmio handler after VM is Started");
 	}
 
 	/* Return status to caller */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -414,11 +414,7 @@ int32_t external_interrupt_vmexit_handler(struct acrn_vcpu *vcpu)
 		ctx.rflags = vcpu_get_rflags(vcpu);
 		ctx.cs     = exec_vmread32(VMX_GUEST_CS_SEL);
 
-#ifdef CONFIG_PARTITION_MODE
-		partition_mode_dispatch_interrupt(&ctx);
-#else
 		dispatch_interrupt(&ctx);
-#endif
 		vcpu_retain_rip(vcpu);
 
 		TRACE_2L(TRACE_VMEXIT_EXTERNAL_INTERRUPT, ctx.vector, 0UL);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -69,6 +69,18 @@ bool is_sos_vm(const struct acrn_vm *vm)
 }
 
 /**
+ * @pre vm != NULL
+ * @pre vm->vmid < CONFIG_MAX_VM_NUM
+ */
+bool is_prelaunched_vm(const struct acrn_vm *vm)
+{
+	struct acrn_vm_config *vm_config;
+
+	vm_config = get_vm_config(vm->vm_id);
+	return (vm_config->type == PRE_LAUNCHED_VM);
+}
+
+/**
  * @pre vm != NULL && vm_config != NULL && vm->vmid < CONFIG_MAX_VM_NUM
  */
 bool is_lapic_pt(const struct acrn_vm *vm)

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -380,28 +380,6 @@ void dispatch_exception(struct intr_excp_ctx *ctx)
 	cpu_dead();
 }
 
-#ifdef CONFIG_PARTITION_MODE
-void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx)
-{
-	uint8_t vr = ctx->vector;
-	struct acrn_vcpu *vcpu;
-
-	/*
-	 * There is no vector and APIC ID remapping for VMs in
-	 * ACRN partition mode. Device interrupts are injected with the same
-	 * vector into vLAPIC of vCPU running on the pCPU. Vectors used for
-	 * HV services are handled by HV using dispatch_interrupt.
-	 */
-	vcpu = per_cpu(vcpu, get_cpu_id());
-	if (vr < VECTOR_FIXED_START) {
-		send_lapic_eoi();
-		vlapic_set_intr(vcpu, vr, LAPIC_TRIG_EDGE);
-	} else {
-		dispatch_interrupt(ctx);
-	}
-}
-#endif
-
 static void init_irq_descs(void)
 {
 	uint32_t i;

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -93,7 +93,7 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 		info.vmsi_data.full = 0U;
 	}
 
-	ret = ptirq_msix_remap(vm, vdev->vbdf.value, 0U, &info);
+	ret = ptirq_msix_remap(vm, vdev->vbdf.value, pbdf.value, 0U, &info);
 	if (ret == 0) {
 		/* Update MSI Capability structure to physical device */
 		pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR, 0x4U, (uint32_t)info.pmsi_addr.full);

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -38,13 +38,6 @@
 #include <logmsg.h>
 #include "vpci_priv.h"
 
-/**
- * @pre vdev != NULL
- */
-static inline bool has_msix_cap(const struct pci_vdev *vdev)
-{
-	return (vdev->msix.capoff != 0U);
-}
 
 /**
  * @pre vdev != NULL
@@ -287,7 +280,7 @@ static void vmsix_table_rw(const struct pci_vdev *vdev, struct mmio_request *mmi
  * @pre io_req != NULL
  * @pre handler_private_data != NULL
  */
-static int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data)
+int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data)
 {
 	struct mmio_request *mmio = &io_req->reqs.mmio;
 	struct pci_vdev *vdev;
@@ -334,65 +327,6 @@ static int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *
 	return ret;
 }
 
-
-/**
-* @pre vdev != NULL
-* @pre vdev->pdev != NULL
-* @pre vdev->pdev->msix.table_bar < (PCI_BAR_COUNT - 1U)
-*/
-static void vmsix_init_helper(struct pci_vdev *vdev)
-{
-	uint32_t i;
-	uint64_t addr_hi, addr_lo;
-	struct pci_msix *msix = &vdev->msix;
-	struct pci_pdev *pdev = vdev->pdev;
-	struct pci_bar *bar;
-
-	ASSERT(vdev->pdev->msix.table_bar < (PCI_BAR_COUNT - 1U), "msix->table_bar out of range");
-
-	msix->table_bar = pdev->msix.table_bar;
-	msix->table_offset = pdev->msix.table_offset;
-	msix->table_count = pdev->msix.table_count;
-
-	/* Mask all table entries */
-	for (i = 0U; i < msix->table_count; i++) {
-		msix->tables[i].vector_control = PCIM_MSIX_VCTRL_MASK;
-		msix->tables[i].addr = 0U;
-		msix->tables[i].data = 0U;
-	}
-
-	bar = &pdev->bar[msix->table_bar];
-	if (bar != NULL) {
-		vdev->msix.mmio_hpa = bar->base;
-		vdev->msix.mmio_gpa = sos_vm_hpa2gpa(bar->base);
-		vdev->msix.mmio_size = bar->size;
-	}
-
-	if (msix->mmio_gpa != 0U) {
-		/*
-			* PCI Spec: a BAR may also map other usable address space that is not associated
-			* with MSI-X structures, but it must not share any naturally aligned 4 KB
-			* address range with one where either MSI-X structure resides.
-			* The MSI-X Table and MSI-X PBA are permitted to co-reside within a naturally
-			* aligned 4 KB address range.
-			*
-			* If PBA or others reside in the same BAR with MSI-X Table, devicemodel could
-			* emulate them and maps these memory range at the 4KB boundary. Here, we should
-			* make sure only intercept the minimum number of 4K pages needed for MSI-X table.
-			*/
-
-		/* The higher boundary of the 4KB aligned address range for MSI-X table */
-		addr_hi = msix->mmio_gpa + msix->table_offset + (msix->table_count * MSIX_TABLE_ENTRY_SIZE);
-		addr_hi = round_page_up(addr_hi);
-
-		/* The lower boundary of the 4KB aligned address range for MSI-X table */
-		addr_lo = round_page_down(msix->mmio_gpa + msix->table_offset);
-
-		(void)register_mmio_emulation_handler(vdev->vpci->vm, vmsix_table_mmio_access_handler,
-			addr_lo, addr_hi, vdev);
-	}
-}
-
 /**
  * @pre vdev != NULL
  */
@@ -402,12 +336,13 @@ void vmsix_init(struct pci_vdev *vdev)
 
 	vdev->msix.capoff = pdev->msix.capoff;
 	vdev->msix.caplen = pdev->msix.caplen;
+	vdev->msix.table_bar = pdev->msix.table_bar;
+	vdev->msix.table_offset = pdev->msix.table_offset;
+	vdev->msix.table_count = pdev->msix.table_count;
 
 	if (has_msix_cap(vdev)) {
 		(void)memcpy_s((void *)&vdev->cfgdata.data_8[pdev->msix.capoff], pdev->msix.caplen,
 			(void *)&pdev->msix.cap[0U], pdev->msix.caplen);
-
-		vmsix_init_helper(vdev);
 	}
 }
 

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -69,7 +69,7 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 	info.vmsi_addr.full = vdev->msix.tables[index].addr;
 	info.vmsi_data.full = (enable) ? vdev->msix.tables[index].data : 0U;
 
-	ret = ptirq_msix_remap(vdev->vpci->vm, vdev->vbdf.value, (uint16_t)index, &info);
+	ret = ptirq_msix_remap(vdev->vpci->vm, vdev->vbdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
 	if (ret == 0) {
 		/* Write the table entry to the physical structure */
 		hva = hpa2hva(vdev->msix.mmio_hpa + vdev->msix.table_offset);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -67,21 +67,29 @@ static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset
 	vdev->cfgdata.data_32[offset >> 2U] = val;
 }
 
+/**
+ * @pre vdev != NULL
+ */
+static inline bool has_msix_cap(const struct pci_vdev *vdev)
+{
+	return (vdev->msix.capoff != 0U);
+}
+
 void vdev_hostbridge_init(struct pci_vdev *vdev);
 int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev);
 
-void vdev_pt_init(const struct pci_vdev *vdev);
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void vdev_pt_deinit(const struct pci_vdev *vdev);
 
 void vmsi_init(struct pci_vdev *vdev);
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void vmsi_deinit(const struct pci_vdev *vdev);
 void vmsix_init(struct pci_vdev *vdev);
+void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev);
+int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void vmsix_deinit(const struct pci_vdev *vdev);

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -47,6 +47,7 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
  *
  * @param[in] vm pointer to acrn_vm
  * @param[in] virt_bdf virtual bdf associated with the passthrough device
+ * @param[in] phys_bdf virtual bdf associated with the passthrough device
  * @param[in] entry_nr indicate coming vectors, entry_nr = 0 means first vector
  * @param[in] info structure used for MSI/MSI-x remapping
  *
@@ -60,7 +61,8 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
  * @pre info != NULL
  *
  */
-int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t entry_nr, struct ptirq_msi_info *info);
+int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_t phys_bdf,
+				uint16_t entry_nr, struct ptirq_msi_info *info);
 
 
 /**

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -211,6 +211,7 @@ void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config);
 void launch_vms(uint16_t pcpu_id);
 bool is_valid_vm(const struct acrn_vm *vm);
 bool is_sos_vm(const struct acrn_vm *vm);
+bool is_prelaunched_vm(const struct acrn_vm *vm);
 uint16_t find_free_vm_id(void);
 struct acrn_vm *get_vm_from_vmid(uint16_t vm_id);
 struct acrn_vm *get_sos_vm(void);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -91,9 +91,6 @@ void init_default_irqs(uint16_t cpu_id);
 
 void dispatch_exception(struct intr_excp_ctx *ctx);
 void dispatch_interrupt(const struct intr_excp_ctx *ctx);
-#ifdef CONFIG_PARTITION_MODE
-void partition_mode_dispatch_interrupt(struct intr_excp_ctx *ctx);
-#endif
 
 void setup_notification(void);
 void setup_posted_intr_notification(void);


### PR DESCRIPTION
This patch series achieves three goals
1) Support Interrupt Remapping for Pre-launched VMs MSI interrupts in ACRN software
2) Support VT-d Interrupt Remapping for Pre-launched VMs MSI interrupts
3) Remove the need for separate interrupt dispatch routine for Pre-launched VMs

Tracked-On: #2879
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>