### PR TITLE
hv: check vector count when set/reset msix info

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -952,12 +952,14 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t pa
 		if (irq.type == IRQ_INTX) {
 			ret = ptirq_add_intx_remapping(target_vm, irq.is.intx.virt_pin,
 					irq.is.intx.phys_pin, irq.is.intx.pic_pin);
-		} else if ((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) {
+		} else if (((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) &&
+				(irq.is.msix.vector_cnt <= CONFIG_MAX_MSIX_TABLE_NUM)) {
 			ret = ptirq_add_msix_remapping(target_vm,
 					irq.virt_bdf, irq.phys_bdf,
 					irq.is.msix.vector_cnt);
 		} else {
-			pr_err("%s: Invalid irq type: %u\n", __func__, irq.type);
+			pr_err("%s: Invalid irq type: %u or MSIX vector count: %u\n",
+					__func__, irq.type, irq.is.msix.vector_cnt);
 			ret = -1;
 		}
 	}
@@ -993,7 +995,8 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 			ptirq_remove_intx_remapping(target_vm,
 					irq.is.intx.virt_pin,
 					irq.is.intx.pic_pin);
-		} else if ((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) {
+		} else if (((irq.type == IRQ_MSI) || (irq.type == IRQ_MSIX)) &&
+				(irq.is.msix.vector_cnt <= CONFIG_MAX_MSIX_TABLE_NUM)) {
 
 			/*
 			 * Inform vPCI about the interupt info changes
@@ -1007,7 +1010,8 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 					irq.virt_bdf,
 					irq.is.msix.vector_cnt);
 		} else {
-			pr_err("%s: Invalid irq type: %u\n", __func__, irq.type);
+			pr_err("%s: Invalid irq type: %u or MSIX vector count: %u\n",
+					__func__, irq.type, irq.is.msix.vector_cnt);
 			ret = -1;
 		}
 	} else {


### PR DESCRIPTION
'vector_cnt' is vector count of MSI/MSIX, and it come from 'table_count'
in the the pci_msix struct. 'CONFIG_MAX_MSIX_TABLE_NUM' is the maximum
number of MSI-X tables per device, so 'vector_cnt' must be less then
or equal to 'CONFIG_MAX_MSIX_TABLE_NUM'.

Tracked-On: #2881
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>