### PR TITLE
Fix pthread_cond_wait() usage

### DIFF
--- a/devicemodel/hw/block_if.c
+++ b/devicemodel/hw/block_if.c
@@ -925,8 +925,9 @@ blockif_close(struct blockif_ctxt *bc)
 	 */
 	pthread_mutex_lock(&bc->mtx);
 	bc->closing = 1;
-	pthread_mutex_unlock(&bc->mtx);
 	pthread_cond_broadcast(&bc->cond);
+	pthread_mutex_unlock(&bc->mtx);
+
 	for (i = 0; i < BLOCKIF_NUMTHR; i++)
 		pthread_join(bc->btid[i], &jval);
 

--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -304,10 +304,13 @@ virtio_vq_init(struct virtio_base *base, uint32_t pfn)
 	/* ... and the last page(s) are the used ring. */
 	vq->used = (struct vring_used *)vb;
 
-	/* Mark queue as allocated, and start at 0 when we use it. */
-	vq->flags = VQ_ALLOC;
+	/* Start at 0 when we use it. */
 	vq->last_avail = 0;
 	vq->save_used = 0;
+
+	/* Mark queue as allocated after initialization is complete. */
+	mb();
+	vq->flags = VQ_ALLOC;
 }
 
 /*
@@ -346,13 +349,16 @@ virtio_vq_enable(struct virtio_base *base)
 	vb = paddr_guest2host(base->dev->vmctx, phys, size);
 	vq->used = (struct vring_used *)vb;
 
-	/* Mark queue as allocated, and start at 0 when we use it. */
-	vq->flags = VQ_ALLOC;
+	/* Start at 0 when we use it. */
 	vq->last_avail = 0;
 	vq->save_used = 0;
 
 	/* Mark queue as enabled. */
 	vq->enabled = true;
+
+	/* Mark queue as allocated after initialization is complete. */
+	mb();
+	vq->flags = VQ_ALLOC;
 }
 
 /*

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -201,7 +201,7 @@ virtio_blk_done(struct blockif_req *br, int err)
 	 */
 	pthread_mutex_lock(&blk->mtx);
 	vq_relchain(&blk->vq, io->idx, 1);
-	vq_endchains(&blk->vq, 0);
+	vq_endchains(&blk->vq, !vq_has_descs(&blk->vq));
 	pthread_mutex_unlock(&blk->mtx);
 }
 

--- a/devicemodel/hw/pci/virtio/virtio_coreu.c
+++ b/devicemodel/hw/pci/virtio/virtio_coreu.c
@@ -163,29 +163,39 @@ virtio_coreu_thread(void *param)
 	struct coreu_msg *msg;
 
 	for (;;) {
+		ret = 0;
 		pthread_mutex_lock(&vcoreu->rx_mtx);
-		ret = pthread_cond_wait(&vcoreu->rx_cond, &vcoreu->rx_mtx);
+
+		/*
+		 * Checking the avail ring here serves two purposes:
+		 *  - avoid vring processing due to spurious wakeups
+		 *  - catch missing notifications before acquiring rx_mtx
+		 */
+		while (!ret && !vq_has_descs(rvq))
+			ret = pthread_cond_wait(&vcoreu->rx_cond, &vcoreu->rx_mtx);
+
 		pthread_mutex_unlock(&vcoreu->rx_mtx);
 
 		if (ret)
 			break;
 
-		while(vq_has_descs(rvq)) {
-			vq_getchain(rvq, &idx, &iov, 1, NULL);
+		do {
+			ret = vq_getchain(rvq, &idx, &iov, 1, NULL);
+			assert(ret > 0);
 
 			msg = (struct coreu_msg *)(iov.iov_base);
 
 			ret = send_and_receive(vcoreu->fd, msg);
-			if (ret < 0)
-			{
+			if (ret < 0) {
 				close(vcoreu->fd);
 				vcoreu->fd = -1;
 			}
 
 			/* release this chain and handle more */
 			vq_relchain(rvq, idx, sizeof(struct coreu_msg));
-		}
+		} while (vq_has_descs(rvq));
 
+		/* at least one avail ring element has been processed */
 		vq_endchains(rvq, 1);
 	}
 

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -502,17 +502,14 @@ vmei_del_me_client(struct vmei_me_client *mclient)
 static void
 vmei_me_client_destroy_host_clients(struct vmei_me_client *mclient)
 {
-	struct vmei_host_client *e, *n;
+	struct vmei_host_client *e;
 
 	pthread_mutex_lock(&mclient->list_mutex);
-	e = LIST_FIRST(&mclient->connections);
-	while (e) {
-		n = LIST_NEXT(e, list);
+	LIST_FOREACH(e, &mclient->connections, list) {
 		vmei_host_client_put(e);
-		e = n;
 	}
-	pthread_mutex_unlock(&mclient->list_mutex);
 	LIST_INIT(&mclient->connections);
+	pthread_mutex_unlock(&mclient->list_mutex);
 }
 
 static void
@@ -645,14 +642,11 @@ vmei_find_host_client(struct virtio_mei *vmei,
 
 static void vmei_free_me_clients(struct virtio_mei *vmei)
 {
-	struct vmei_me_client *e, *n;
+	struct vmei_me_client *e;
 
 	pthread_mutex_lock(&vmei->list_mutex);
-	e = LIST_FIRST(&vmei->active_clients);
-	while (e) {
-		n = LIST_NEXT(e, list);
+	LIST_FOREACH(e, &vmei->active_clients, list) {
 		vmei_me_client_put(e);
-		e = n;
 	}
 	LIST_INIT(&vmei->active_clients);
 	pthread_mutex_unlock(&vmei->list_mutex);

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -295,9 +295,10 @@ virtio_net_tx_stop(struct virtio_net *net)
 {
 	void *jval;
 
+	pthread_mutex_lock(&net->tx_mtx);
 	net->closing = 1;
-
 	pthread_cond_broadcast(&net->tx_cond);
+	pthread_mutex_unlock(&net->tx_mtx);
 
 	pthread_join(net->tx_tid, &jval);
 }

--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -1390,7 +1390,7 @@ ioc_tx_thread(void *arg)
 	for (;;) {
 		pthread_mutex_lock(&ioc->tx_mtx);
 		while (SIMPLEQ_EMPTY(&ioc->tx_qhead)) {
-			err =  pthread_cond_wait(&ioc->tx_cond, &ioc->tx_mtx);
+			err = pthread_cond_wait(&ioc->tx_cond, &ioc->tx_mtx);
 			assert(err == 0);
 			if (ioc->closing)
 				goto exit;

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -454,24 +454,24 @@ struct virtio_vq_info {
  *
  * @param vq Pointer to struct virtio_vq_info.
  *
- * @return 0 on not ready and 1 on ready.
+ * @return false on not ready and true on ready.
  */
-static inline int
+static inline bool
 vq_ring_ready(struct virtio_vq_info *vq)
 {
-	return (vq->flags & VQ_ALLOC);
+	return ((vq->flags & VQ_ALLOC) == VQ_ALLOC);
 }
 
 /**
  * @brief Are there "available" descriptors?
  *
- * This does not count how many, just returns 1 if there is any.
+ * This does not count how many, just returns true if there is any.
  *
  * @param vq Pointer to struct virtio_vq_info.
  *
- * @return 0 on no available and 1 on available.
+ * @return false on not available and true on available.
  */
-static inline int
+static inline bool
 vq_has_descs(struct virtio_vq_info *vq)
 {
 	return (vq_ring_ready(vq) && vq->last_avail !=


### PR DESCRIPTION
pthread_cond_wait() should take care of spurious wakeups and is usually used in conjunction with a predicate. Fix the uses of pthread_cond_wait() that can result in unintended behavior (e.g. segfault).

Several minor cleanups/fixes related to the code paths involving pthread_cond_wait() are also included.

Tracked-On: #2763
Signed-off-by: Peter Fang <peter.fang@intel.com>
Reviewed-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>