### PR TITLE
DM: Keep consistency between HV and DM about PM1A_CNT_ADDR

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -364,7 +364,7 @@ basl_fwrite_fadt(FILE *fp, struct vmctx *ctx)
 	    PM1A_EVT_ADDR);
 	EFPRINTF(fp, "[0004]\t\tPM1B Event Block Address : 00000000\n");
 	EFPRINTF(fp, "[0004]\t\tPM1A Control Block Address : %08X\n",
-	    PM1A_CNT_ADDR);
+	    VIRTUAL_PM1A_CNT_ADDR);
 	EFPRINTF(fp, "[0004]\t\tPM1B Control Block Address : 00000000\n");
 	EFPRINTF(fp, "[0004]\t\tPM2 Control Block Address : 00000000\n");
 	EFPRINTF(fp, "[0004]\t\tPM Timer Block Address : %08X\n",
@@ -466,7 +466,7 @@ basl_fwrite_fadt(FILE *fp, struct vmctx *ctx)
 	EFPRINTF(fp, "[0001]\t\tBit Offset : 00\n");
 	EFPRINTF(fp, "[0001]\t\tEncoded Access Width : 02 [Word Access:16]\n");
 	EFPRINTF(fp, "[0008]\t\tAddress : 00000000%08X\n",
-	    PM1A_CNT_ADDR);
+	    VIRTUAL_PM1A_CNT_ADDR);
 	EFPRINTF(fp, "\n");
 
 	EFPRINTF(fp,

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -36,7 +36,6 @@
 #define	ACPI_DISABLE		0xa1
 
 #define	PM1A_EVT_ADDR		0x400
-#define	PM1A_CNT_ADDR		0x404
 
 #define	IO_PMTMR		0x408	/* 4-byte i/o port for the timer */
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -55,9 +55,11 @@
 #define GUEST_FLAG_RT				(1UL << 5U)     /* Whether the vm is RT-VM */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
-#define VIRTUAL_PM1A_CNT_ADDR	0x404U
-#define VIRTUAL_PM1A_SLP_TYP	0x1c00U
-#define VIRTUAL_PM1A_SLP_EN	0x2000U
+#define VIRTUAL_PM1A_CNT_ADDR		0x404U
+#define	VIRTUAL_PM1A_SCI_EN		0x0001
+#define VIRTUAL_PM1A_SLP_TYP		0x1c00U
+#define VIRTUAL_PM1A_SLP_EN		0x2000U
+#define	VIRTUAL_PM1A_ALWAYS_ZERO	0xc003
 
 /**
  * @brief Hypercall


### PR DESCRIPTION
To keep consistency between HV and DM about PM1A_CNT_ADDR,
it is better to replace the PM1A_CNT related MACROs used in DM
with VIRTUAL_PM1A_CNT related MACROs in acrn_common.h.

Tracked-On: #2865
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <Eddie.dong@intel.com>