### PR TITLE
DM USB: fix memory leak during reboot

### DIFF
--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -102,6 +102,8 @@ struct usb_dev_sys_ctx_info {
 	usb_dev_sys_cb notify_cb;
 	usb_dev_sys_cb intr_cb;
 
+	libusb_device **devlist;
+
 	/*
 	 * private data from HCD layer
 	 */


### PR DESCRIPTION
1. free memory during pci_xhci_dev_destroy.
2. add libusb_free_device_list to free the list of devices previously
discovered using libusb_get_device_list().
3. fix possible memory corruption.

Tracked-On: #2892
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>