### PR TITLE
doc: add robots.txt

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -77,6 +77,7 @@ publish:
 	cp -r $(BUILDDIR)/html/* $(PUBLISHDIR)
 	cp scripts/publish-README.md $(PUBLISHDIR)/../README.md
 	cp scripts/publish-index.html $(PUBLISHDIR)/../index.html
+	cp scripts/publish-robots.txt $(PUBLISHDIR)/../robots.txt
 	cd $(PUBLISHDIR)/..; git add -A; git commit -s -m "publish $(RELEASE)"; git push origin master;
 
 

--- a/doc/scripts/publish-robots.txt
+++ b/doc/scripts/publish-robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /0.1/
+Disallow: /0.2/
+Disallow: /0.3/
+Disallow: /0.4/
+Disallow: /0.5/


### PR DESCRIPTION
use a robots.txt file to prevent search engines from indexing old
content.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>