### PR TITLE
hv: Remove CONFIG_PARTITION_MODE used to compile out irq enable/disable

### DIFF
--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -322,25 +322,17 @@ static inline void asm_hlt(void)
 	asm volatile ("hlt");
 }
 
-#ifdef CONFIG_PARTITION_MODE
-#define CPU_IRQ_DISABLE()
-#else
 /* Disables interrupts on the current CPU */
 #define CPU_IRQ_DISABLE()                                   \
 {                                                           \
 	asm volatile ("cli\n" : : : "cc");                  \
 }
-#endif
 
-#ifdef CONFIG_PARTITION_MODE
-#define CPU_IRQ_ENABLE()
-#else
 /* Enables interrupts on the current CPU */
 #define CPU_IRQ_ENABLE()                                    \
 {                                                           \
 	asm volatile ("sti\n" : : : "cc");                  \
 }
-#endif
 
 /* This macro writes the stack pointer. */
 static inline void cpu_sp_write(uint64_t *stack_ptr)


### PR DESCRIPTION
ACRN uses CONFIG_PARTITION_MODE  macro to compile out CPU_IRQ_ENABLE/DISABLE
APIs. With vector remapping enabled for pre-launched VMs, this is of no use.
And for VMs with LAPIC pass-thru, interrupts stay disabled in vmexit loop
with the help of is_lapic_pt() API.

Tracked-On: #2903
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>