### PR TITLE
DM: virtio-gpio: implement GPIO operations by PIO

### DIFF
--- a/devicemodel/include/gpio_dm.h
+++ b/devicemodel/include/gpio_dm.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef _GPIO_DM_H_
+#define _GPIO_DM_H_
+
+/*
+ * GPIO PIO register definition
+ *
+ * +---------------+----------+------+-----------+-------+
+ * | Configuration | Reserved | Mode | Direction | value |
+ * |      16b      |    13b   |  1b  |    1b     |  1b   |
+ * +---------------+----------+------+-----------+-------+
+ */
+
+#define PIO_GPIO_VALUE_MASK	0x1
+#define PIO_GPIO_DIR_OFFSET	1
+#define PIO_GPIO_DIR_MASK	(0x1 << PIO_GPIO_DIR_OFFSET)
+#define PIO_GPIO_MODE_OFFSET	2
+#define PIO_GPIO_MODE_MASK	(0x1 << PIO_GPIO_MODE_OFFSET)
+#define PIO_GPIO_CONFIG_OFFSET	16
+#define PIO_GPIO_CONFIG_MASK	(0xff << PIO_GPIO_CONFIG_OFFSET)
+
+/* PIO GPIO control method support */
+#define PIO_GPIO_CM_GET	"GPCG"
+#define PIO_GPIO_CM_SET	"GPCS"
+
+/* PIO GPIO operations support */
+#define PIO_GPIO_SET_VALUE(number, value) \
+	PIO_GPIO_CM_SET"("#number","#value")"
+
+#define PIO_GPIO_GET_VALUE(number) \
+	PIO_GPIO_CM_GET"("#number")"
+#endif


### PR DESCRIPTION
GPIO set/get value can be operated by accessing PIO space and the PIO
register definition for GPIO is in gpio_dm.h, frontend driver or ACPI
control methods can operate GPIO based on it.

GPIO mediator also defines ACPI control methods to support GPIO
operations, GPIO consumers can invoke PIO_GPIO_SET_VALUE/PIO_GPIO_GET_VALUE
in their own DSDT to set/get one GPIO value via ACPI control method.

v2: 1) Fix code style.
    2) Use virtio configuration space callbacks to implement GPIO PIO operations
       that replace pci_gpio_read/pci_gpio_write with virtio_cfgread/virtio_cfgwrite.
    3) Return 0xFFFFFFFF as invalid result of PIO reading instead 0.

Tracked-On: #2512
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>