### PR TITLE
watchdog: map the watchdog reset to warm reset

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -322,6 +322,13 @@ delete_cpu(struct vmctx *ctx, int vcpu)
 	return CPU_EMPTY(&cpumask);
 }
 
+void
+notify_vmloop_thread(void)
+{
+	pthread_kill(mt_vmm_info[0].mt_thr, SIGCONT);
+	return;
+}
+
 static void
 vmexit_inout(struct vmctx *ctx, struct vhm_request *vhm_req, int *pvcpu)
 {

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -136,7 +136,9 @@ wdt_expired_handler(void *arg, uint64_t nexp)
 			wdt_timeout = 1;
 
 			/* watchdog timer out, set the uos to reboot */
-			vm_set_suspend_mode(VM_SUSPEND_FULL_RESET);
+			vm_set_suspend_mode(VM_SUSPEND_SYSTEM_RESET);
+			/* Notify vm thread to handle VM_SUSPEND_SYSTEM_RESET request */
+			notify_vmloop_thread();
 			mevent_notify();
 		} else {
 			/* if not need reboot, just loop timer */

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -101,6 +101,7 @@ int	vm_attach_ioreq_client(struct vmctx *ctx);
 int	vm_notify_request_done(struct vmctx *ctx, int vcpu);
 void	vm_clear_ioreq(struct vmctx *ctx);
 void	vm_set_suspend_mode(enum vm_suspend_how how);
+void	notify_vmloop_thread(void);
 int	vm_get_suspend_mode(void);
 void	vm_destroy(struct vmctx *ctx);
 int	vm_parse_memsize(const char *optarg, size_t *memsize);


### PR DESCRIPTION
Per debugging requirement, map the watchdog reset to warm reset.
So the ramconsole could be used to capture the kernel log of UOS
before watchdog is hit.

Tracked-On: #2471
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>