### PR TITLE
Script: Fix snd_soc_skl typo in launch script

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -18,8 +18,8 @@ fi
 
 # use the modprobe to force loading snd-soc-skl/sst_bxt_bdf8532
 if [ ! -e $(audio_module)]; then
-modprobe -q snd-soc-skl
-modprobe -q snd-soc-sst_bxt_tdf8532
+modprobe -q snd_soc_skl
+modprobe -q snd_soc_sst_bxt_tdf8532
 else
 
 modprobe -q snd_soc_skl


### PR DESCRIPTION
fix snd_soc_sbk/snd_soc_sst_bxt_tdf8532 typo

Tracked-on: #2666
Signed-off-by: wenlingz <wenling.zhang@intel.com>