### PR TITLE
dm: remove "acrn_" prefix from tap name

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -674,7 +674,7 @@ virtio_net_tap_setup(struct virtio_net *net, char *devname)
 	int vhost_fd = -1;
 	int rc;
 
-	rc = snprintf(tbuf, IFNAMSIZ, "acrn_%s", devname);
+	rc = snprintf(tbuf, IFNAMSIZ, "%s", devname);
 	if (rc < 0 || rc >= IFNAMSIZ) /* give warning if error or truncation happens */
 		WPRINTF(("Fail to set tap device name %s\n", tbuf));
 

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -57,20 +57,20 @@ mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 #check if the vm is running or not
@@ -196,20 +196,20 @@ mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 #Use MMC name + serial for ADB serial no., same as native android

--- a/devicemodel/samples/apl-up2/launch_uos.sh
+++ b/devicemodel/samples/apl-up2/launch_uos.sh
@@ -46,20 +46,20 @@ mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 #check if the vm is running or not
@@ -182,20 +182,20 @@ mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 #Use MMC name + serial for ADB serial no., same as native android

--- a/devicemodel/vmcfg/apl-mrb/mrb-env-setup.sh
+++ b/devicemodel/vmcfg/apl-mrb/mrb-env-setup.sh
@@ -15,20 +15,20 @@ fi
 
 # create a unique tap device for each VM
 tap=tap_AaaG
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 modprobe pci_stub

--- a/tools/acrnbridge/Makefile
+++ b/tools/acrnbridge/Makefile
@@ -5,12 +5,12 @@ SYSTEMD_NETWORKDIR := usr/lib
 all:
 	cp acrn.netdev $(OUT_DIR)
 	cp acrn.network $(OUT_DIR)
-	cp acrn_tap0.netdev $(OUT_DIR)
+	cp tap0.netdev $(OUT_DIR)
 	cp eth.network $(OUT_DIR)
 
 install:
 	install -d $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
 	install -p -D -m 0644 $(OUT_DIR)/acrn.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn.netdev
 	install -p -D -m 0644 $(OUT_DIR)/acrn.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn.network
-	install -p -D -m 0644 $(OUT_DIR)/acrn_tap0.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn_tap0.netdev
+	install -p -D -m 0644 $(OUT_DIR)/tap0.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-tap0.netdev
 	install -p -D -m 0644 $(OUT_DIR)/eth.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-eth.network

--- a/tools/acrnbridge/acrn.network
+++ b/tools/acrnbridge/acrn.network
@@ -1,5 +1,5 @@
 [Match]
-Name=e* acrn_tap*
+Name=e* acrn_tap* tap*
 
 [Network]
 Bridge=acrn-br0

--- a/tools/acrnbridge/tap0.netdev
+++ b/tools/acrnbridge/tap0.netdev
@@ -1,3 +1,3 @@
 [NetDev]
-Name=acrn_tap0
+Name=tap0
 Kind=tap


### PR DESCRIPTION
Some projects based on ACRN don't want tap name to contain "acrn_"
prefix. This patch removes that prefix.

Tracked-On: #2509
Signed-off-by: Jie Deng <jie.deng@intel.com>
Reviewed-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>