### PR TITLE
doc: update documentation to the latest TAP name (no acrn_ prefix)

### DIFF
--- a/doc/developer-guides/hld/virtio-net.rst
+++ b/doc/developer-guides/hld/virtio-net.rst
@@ -428,7 +428,7 @@ You can check the files with prefix 50- in the SOS
 
 - `50-acrn.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/acrn.netdev>`__
 - `50-acrn.network <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/acrn.network>`__
-- `50-acrn_tap0.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/acrn_tap0.netdev>`__
+- `50-tap0.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/tap0.netdev>`__
 - `50-eth.network <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/eth.network>`__
 
 When the SOS is started, run ``ifconfig`` to show the devices created by
@@ -445,7 +445,7 @@ this systemd configuration:
       collisions:0 txqueuelen:1000
       RX bytes:100457754 (95.8 Mb) TX bytes:83481244 (79.6 Mb)
 
-   acrn_tap0 Link encap:Ethernet HWaddr F6:A7:7E:52:50:C6
+   tap0 Link encap:Ethernet HWaddr F6:A7:7E:52:50:C6
       UP BROADCAST MULTICAST MTU:1500 Metric:1
       RX packets:0 errors:0 dropped:0 overruns:0 frame:0
       TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
@@ -476,7 +476,7 @@ Run ``brctl show`` to see the bridge ``acrn-br0`` and attached devices:
 
    bridge name   bridge id STP       enabled   interfaces
 
-   acrn-br0      8000.b25041fef7a3   no        acrn_tap0
+   acrn-br0      8000.b25041fef7a3   no        tap0
                                                enp3s0
 
 Add a pci slot to the device model acrn-dm command line (mac address is

--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -293,7 +293,7 @@ ACRN Network Bridge
 ===================
 
 ACRN bridge has been setup as a part of systemd services for device communication. The default
-bridge creates ``acrn_br0`` which is the bridge and ``acrn_tap0`` as an initial setup. The files can be
+bridge creates ``acrn_br0`` which is the bridge and ``tap0`` as an initial setup. The files can be
 found in ``/usr/lib/systemd/network``. No additional setup is needed since systemd-networkd is
 automatically enabled after a system restart.
 

--- a/doc/tutorials/agl-vms.rst
+++ b/doc/tutorials/agl-vms.rst
@@ -316,20 +316,20 @@ Setting up AGLs
 
         # create a unique tap device for each VM
         tap=tap2
-        tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+        tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
         if [ "$tap_exist"x != "x" ]; then
-          echo "tap device existed, reuse acrn_$tap"
+          echo "tap device existed, reuse $tap"
         else
-          ip tuntap add dev acrn_$tap mode tap
+          ip tuntap add dev $tap mode tap
         fi
 
         # if acrn-br0 exists, add VM's unique tap device under it
         br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
         if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
           echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-          ip link set acrn_"$tap" master acrn-br0
-          ip link set dev acrn_"$tap" down
-          ip link set dev acrn_"$tap" up
+          ip link set "$tap" master acrn-br0
+          ip link set dev "$tap" down
+          ip link set dev "$tap" up
         fi
 
         #for memsize setting
@@ -385,11 +385,11 @@ Setting up AGLs
         # create a unique tap device for each VM
         tap=tap1
 
-        tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+        tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
         if [ "$tap_exist"x != "x" ]; then
-          echo "tap device existed, reuse acrn_$tap"
+          echo "tap device existed, reuse $tap"
         else
-          ip tuntap add dev acrn_$tap mode tap
+          ip tuntap add dev $tap mode tap
         fi
 
 
@@ -398,9 +398,9 @@ Setting up AGLs
         br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
         if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
           echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-          ip link set acrn_"$tap" master acrn-br0
-          ip link set dev acrn_"$tap" down
-          ip link set dev acrn_"$tap" up
+          ip link set "$tap" master acrn-br0
+          ip link set dev "$tap" down
+          ip link set dev "$tap" up
         fi
 
         #for memsize setting

--- a/doc/tutorials/launch_uos.sh
+++ b/doc/tutorials/launch_uos.sh
@@ -44,20 +44,20 @@ mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 #check if the vm is running or not
@@ -180,20 +180,20 @@ mac_seed=${mac:9:8}-${vm_name}
 
 # create a unique tap device for each VM
 tap=tap_$6
-tap_exist=$(ip a | grep acrn_"$tap" | awk '{print $1}')
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
 if [ "$tap_exist"x != "x" ]; then
-  echo "tap device existed, reuse acrn_$tap"
+  echo "tap device existed, reuse $tap"
 else
-  ip tuntap add dev acrn_$tap mode tap
+  ip tuntap add dev $tap mode tap
 fi
 
 # if acrn-br0 exists, add VM's unique tap device under it
 br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
 if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
   echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
-  ip link set acrn_"$tap" master acrn-br0
-  ip link set dev acrn_"$tap" down
-  ip link set dev acrn_"$tap" up
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
 fi
 
 #Use MMC name + serial for ADB serial no., same as native android

--- a/doc/tutorials/static-ip.rst
+++ b/doc/tutorials/static-ip.rst
@@ -14,7 +14,7 @@ ACRN Network Setup
 
 The ACRN Service OS is based on `Clear Linux OS`_ and it uses `systemd-networkd`_
 to set up the Service OS networking. A few files are responsible for setting up the
-ACRN bridge (``acrn-br0``), the TAP device (``acrn_tap0``), and how these are all
+ACRN bridge (``acrn-br0``), the TAP device (``tap0``), and how these are all
 connected. Those files are installed in ``/usr/lib/systemd/network``
 on the target device and can also be found under ``tools/acrnbridge`` in the source code.
 

--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -313,9 +313,7 @@ script example shows how to set this up (verified in Ubuntu 16.04 and 18.04 as t
     #setup bridge for uos network
     br=$(brctl show | grep acrn-br0)
     br=${br-:0:6}
-    ip tuntap add dev acrn_tap0 mode tap
-
-    taps=$(ifconfig | grep acrn_ | awk '{print $1}')
+    ip tuntap add dev tap0 mode tap
 
     # if bridge not existed
     if [ "$br"x != "acrn-br0"x ]; then
@@ -324,17 +322,11 @@ script example shows how to set this up (verified in Ubuntu 16.04 and 18.04 as t
     brctl addif acrn-br0 enp3s0
     ifconfig enp3s0 0
     dhclient acrn-br0
-    # add existing tap devices under the bridge
-      for tap in $taps; do
-        ip tuntap add dev acrn_$tap mode tap
-        brctl addif acrn-br0 $tap
-        ip link set dev $tap down
-        ip link set dev $tap up
-      done
     fi
 
-    brctl addif acrn-br0 acrn_tap0
-    ip link set dev acrn_tap0 up
+    # Add TAP device to the bridge
+    brctl addif acrn-br0 tap0
+    ip link set dev tap0 up
 
 .. note::
    The SOS network interface is called ``enp3s0`` in the script above. You will need


### PR DESCRIPTION
Update the documentation, and associated scripts to reflect the fact
that the TAP device used by 'acrn-dm' no longer use the "acrn_" prefix.

Tracked-On: #2509
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>