### PR TITLE
Domain id and name added to launch_uos.sh

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -176,6 +176,8 @@ acrn-dm -A -m $mem_size -c $2$boot_GVT_option"$GVT_args" -s 0:0,hostbridge -s 1:
   -i /run/acrn/ioc_$vm_name,0x20 \
   -l com2,/run/acrn/ioc_$vm_name \
   -B "root=/dev/vda2 rw rootwait maxcpus=$2 nohpet console=hvc0 \
+  snd_soc_skl_virtio_fe.domain_id=1 \
+  snd_soc_skl_virtio_fe.domain_name="GuestOS" \
   console=ttyS0 no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable i915.avail_planes_per_pipe=$4 i915.enable_guc_loading=0 \
   i915.enable_hangcheck=0 i915.nuclear_pageflip=1 \
@@ -323,6 +325,8 @@ fi
 
 kernel_cmdline_generic="maxcpus=$2 nohpet tsc=reliable intel_iommu=off \
    androidboot.serialno=$ser \
+   snd_soc_skl_virtio_fe.domain_id=1 \
+   snd_soc_skl_virtio_fe.domain_name="GuestOS" \
    i915.enable_rc6=1 i915.enable_fbc=1 i915.enable_guc_loading=0 i915.avail_planes_per_pipe=$4 \
    i915.enable_hangcheck=0 use_nuclear_flip=1 i915.enable_guc_submission=0 i915.enable_guc=0"
 


### PR DESCRIPTION
For multiple guest os and particular audio features support domain id
and name is required.

Tracked-On: #2924
reviewed-by: Yu Wang <yu1.wang@intel.com>
reviewed-by: Yakui zhao <yakui.zhao@intel.com>
reviewed-by: Binbin Wu <binbin.wu@intel.com>
Signed-off-by: Marcin Pietraszko <marcin.pietraszko@intel.com>