### PR TITLE
DM USB: fix two stability issues

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1870,7 +1870,6 @@ pci_xhci_cmd_reset_device(struct pci_xhci_vdev *xdev, uint32_t slot)
 	else {
 		dev->dev_slotstate = XHCI_ST_DEFAULT;
 
-		dev->hci.hci_address = 0;
 		dev_ctx = pci_xhci_get_dev_ctx(xdev, slot);
 		if (!dev_ctx) {
 			cmderr = XHCI_TRB_ERROR_SLOT_NOT_ON;

--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -87,6 +87,8 @@ echo "8086 5aaa" > /sys/bus/pci/drivers/pci-stub/new_id
 echo "0000:00:15.1" > /sys/bus/pci/devices/0000:00:15.1/driver/unbind
 echo "0000:00:15.1" > /sys/bus/pci/drivers/pci-stub/bind
 
+echo 100 > /sys/bus/usb/drivers/usb-storage/module/parameters/delay_use
+
 boot_ipu_option=""
 if [ $ipu_passthrough == 1 ];then
     # for ipu passthrough - ipu device 0:3.0
@@ -273,6 +275,8 @@ fi
 
 # WA for USB role switch hang issue, disable runtime PM of xHCI device
 echo on > /sys/devices/pci0000:00/0000:00:15.0/power/control
+
+echo 100 > /sys/bus/usb/drivers/usb-storage/module/parameters/delay_use
 
 boot_ipu_option=""
 if [ $ipu_passthrough == 1 ];then


### PR DESCRIPTION
This patch set fix two USB mediator stability issues.
Tracked-On: #2922
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>
