### PR TITLE
hv: Use virtual APIC IDs for Pre-launched VMs

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -166,21 +166,16 @@ vlapic_build_id(const struct acrn_vlapic *vlapic)
 	const struct acrn_vcpu *vcpu = vlapic->vcpu;
 	uint32_t vlapic_id, lapic_regs_id;
 
-#ifdef CONFIG_PARTITION_MODE
-	/*
-	 * Partition mode UOS is forced to use physical mode in xAPIC
-	 * Hence ACRN needs to maintain physical APIC ids for partition
-	 * mode.
-	 */
-	vlapic_id = per_cpu(lapic_id, vcpu->pcpu_id);
-#else
 	if (is_sos_vm(vcpu->vm)) {
-		/* Get APIC ID sequence format from cpu_storage */
+		/*
+		 * For SOS_VM type, pLAPIC IDs need to be used because
+		 * host ACPI tables are passthru to SOS.
+		 * Get APIC ID sequence format from cpu_storage
+		 */
 		vlapic_id = per_cpu(lapic_id, vcpu->vcpu_id);
 	} else {
 		vlapic_id = (uint32_t)vcpu->vcpu_id;
 	}
-#endif
 
 	if (is_x2apic_enabled(vlapic)) {
 		lapic_regs_id = vlapic_id;

--- a/hypervisor/dm/vmptable.c
+++ b/hypervisor/dm/vmptable.c
@@ -115,7 +115,7 @@ int32_t mptable_build(struct acrn_vm *vm)
 
 		(void *)memcpy_s((void *)(mptable->proc_entry_array + i), sizeof(struct proc_entry),
 			(const void *)&proc_entry_template, sizeof(struct proc_entry));
-		mptable->proc_entry_array[i].apic_id = per_cpu(lapic_id, pcpu_id);
+		mptable->proc_entry_array[i].apic_id = (uint8_t) i;
 		if (i == 0) {
 			mptable->proc_entry_array[i].cpu_flags |= PROCENTRY_FLAG_BP;
 		}


### PR DESCRIPTION
For Pre-launched VMs, ACRN uses mptable for reporting APIC IDs to guest OS.
In current code, ACRN uses physical LAPIC IDs for vLAPIC IDs.
This patch is to let ACRN use vCPU id for vLAPIC IDs  and also report the same
when building mptable. ACRN should still use physical LAPIC IDs for SOS
because host ACPI tables are passthru to SOS.

Tracked-On: #2934
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@Intel.com>