### PR TITLE
DM USB: xHCI: refine the failure process logic of control transfer

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -433,42 +433,6 @@ struct pci_xhci_option_elem {
 };
 
 static int xhci_in_use;
-
-/* map USB errors to XHCI */
-static const int xhci_usb_errors[USB_ERR_MAX] = {
-	[USB_ERR_NORMAL_COMPLETION]	= XHCI_TRB_ERROR_SUCCESS,
-	[USB_ERR_PENDING_REQUESTS]	= XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_NOT_STARTED]		= XHCI_TRB_ERROR_ENDP_NOT_ON,
-	[USB_ERR_INVAL]			= XHCI_TRB_ERROR_INVALID,
-	[USB_ERR_NOMEM]			= XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_CANCELLED]		= XHCI_TRB_ERROR_STOPPED,
-	[USB_ERR_BAD_ADDRESS]		= XHCI_TRB_ERROR_PARAMETER,
-	[USB_ERR_BAD_BUFSIZE]		= XHCI_TRB_ERROR_PARAMETER,
-	[USB_ERR_BAD_FLAG]		= XHCI_TRB_ERROR_PARAMETER,
-	[USB_ERR_NO_CALLBACK]		= XHCI_TRB_ERROR_STALL,
-	[USB_ERR_IN_USE]		= XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_NO_ADDR]		= XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_NO_PIPE]               = XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_ZERO_NFRAMES]          = XHCI_TRB_ERROR_UNDEFINED,
-	[USB_ERR_ZERO_MAXP]             = XHCI_TRB_ERROR_UNDEFINED,
-	[USB_ERR_SET_ADDR_FAILED]       = XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_NO_POWER]              = XHCI_TRB_ERROR_ENDP_NOT_ON,
-	[USB_ERR_TOO_DEEP]              = XHCI_TRB_ERROR_RESOURCE,
-	[USB_ERR_IOERROR]               = XHCI_TRB_ERROR_TRB,
-	[USB_ERR_NOT_CONFIGURED]        = XHCI_TRB_ERROR_ENDP_NOT_ON,
-	[USB_ERR_TIMEOUT]               = XHCI_TRB_ERROR_CMD_ABORTED,
-	[USB_ERR_SHORT_XFER]            = XHCI_TRB_ERROR_SHORT_PKT,
-	[USB_ERR_STALLED]               = XHCI_TRB_ERROR_STALL,
-	[USB_ERR_INTERRUPTED]           = XHCI_TRB_ERROR_CMD_ABORTED,
-	[USB_ERR_DMA_LOAD_FAILED]       = XHCI_TRB_ERROR_DATA_BUF,
-	[USB_ERR_BAD_CONTEXT]           = XHCI_TRB_ERROR_TRB,
-	[USB_ERR_NO_ROOT_HUB]           = XHCI_TRB_ERROR_UNDEFINED,
-	[USB_ERR_NO_INTR_THREAD]        = XHCI_TRB_ERROR_UNDEFINED,
-	[USB_ERR_NOT_LOCKED]            = XHCI_TRB_ERROR_UNDEFINED,
-};
-#define	USB_TO_XHCI_ERR(e)	((e) < USB_ERR_MAX ? xhci_usb_errors[(e)] : \
-				XHCI_TRB_ERROR_INVALID)
-
 static int pci_xhci_insert_event(struct pci_xhci_vdev *xdev,
 				 struct xhci_trb *evtrb, int do_intr);
 static void pci_xhci_dump_trb(struct xhci_trb *trb);
@@ -2982,14 +2946,9 @@ retry:
 		goto errout;
 	}
 
-	err = USB_TO_XHCI_ERR(err);
-	if (err == XHCI_TRB_ERROR_SUCCESS ||
-			err == XHCI_TRB_ERROR_SHORT_PKT ||
-			err == XHCI_TRB_ERROR_STALL) {
-		err = pci_xhci_xfer_complete(xdev, xfer, slot, epid, &do_intr);
-		if (err != XHCI_TRB_ERROR_SUCCESS)
-			do_retry = 0;
-	}
+	err = pci_xhci_xfer_complete(xdev, xfer, slot, epid, &do_intr);
+	if (err != XHCI_TRB_ERROR_SUCCESS)
+		do_retry = 0;
 
 errout:
 	if (err == XHCI_TRB_ERROR_EV_RING_FULL)

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -428,9 +428,10 @@ usb_dev_err_convert(int err)
 	switch (err) {
 	case LIBUSB_ERROR_TIMEOUT: return USB_ERR_TIMEOUT;
 	case LIBUSB_ERROR_PIPE: return USB_ERR_STALLED;
-	case LIBUSB_ERROR_NO_DEVICE: return USB_ERR_INVAL;
+	case LIBUSB_ERROR_NO_DEVICE: return USB_ERR_IOERROR;
 	case LIBUSB_ERROR_BUSY: return USB_ERR_IN_USE;
-	case LIBUSB_ERROR_OVERFLOW: return USB_ERR_TOO_DEEP;
+	case LIBUSB_ERROR_OVERFLOW: return USB_ERR_BAD_BUFSIZE;
+	case LIBUSB_ERROR_IO: return USB_ERR_IOERROR;
 	default:
 		break; /* add more when required */
 	}


### PR DESCRIPTION
The old logic to process control transfer failure only include two cases:
1 Short packet
2 Stall.
This patch includes all possible failures reported by Libusb and does
related emulation for UOS

Tracked-On: #2918
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>