### PR TITLE
Apicv: prepare for wrap apicv APIs

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -388,7 +388,7 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	switch (msr) {
 	case MSR_IA32_TSC_DEADLINE:
 	{
-		err = vlapic_rdmsr(vcpu, msr, &v);
+		v = vlapic_get_tsc_deadline_msr(vcpu_vlapic(vcpu));
 		break;
 	}
 	case MSR_IA32_TSC_ADJUST:
@@ -435,7 +435,7 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	case MSR_IA32_APIC_BASE:
 	{
 		/* Read APIC base */
-		err = vlapic_rdmsr(vcpu, msr, &v);
+		v = vlapic_get_apicbase(vcpu_vlapic(vcpu));
 		break;
 	}
 	case MSR_IA32_FEATURE_CONTROL:
@@ -446,7 +446,7 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	default:
 	{
 		if (is_x2apic_msr(msr)) {
-			err = vlapic_rdmsr(vcpu, msr, &v);
+			err = vlapic_x2apic_read(vcpu, msr, &v);
 		} else {
 			pr_warn("%s(): vm%d vcpu%d reading MSR %lx not supported",
 				__func__, vcpu->vm->vm_id, vcpu->vcpu_id, msr);
@@ -526,7 +526,7 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	switch (msr) {
 	case MSR_IA32_TSC_DEADLINE:
 	{
-		err = vlapic_wrmsr(vcpu, msr, v);
+		vlapic_set_tsc_deadline_msr(vcpu_vlapic(vcpu), v);
 		break;
 	}
 	case MSR_IA32_TSC_ADJUST:
@@ -586,7 +586,7 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	}
 	case MSR_IA32_APIC_BASE:
 	{
-		err = vlapic_wrmsr(vcpu, msr, v);
+		err = vlapic_set_apicbase(vcpu_vlapic(vcpu), v);
 		break;
 	}
 	case MSR_IA32_FEATURE_CONTROL:
@@ -597,7 +597,7 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	default:
 	{
 		if (is_x2apic_msr(msr)) {
-			err = vlapic_wrmsr(vcpu, msr, v);
+			err = vlapic_x2apic_write(vcpu, msr, v);
 		} else {
 			pr_warn("%s(): vm%d vcpu%d writing MSR %lx not supported",
 				__func__, vcpu->vm->vm_id, vcpu->vcpu_id, msr);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -165,8 +165,12 @@ void vlapic_get_deliverable_intr(struct acrn_vlapic *vlapic, uint32_t vector);
  */
 uint64_t apicv_get_pir_desc_paddr(struct acrn_vcpu *vcpu);
 
-int32_t vlapic_rdmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *rval);
-int32_t vlapic_wrmsr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t wval);
+uint64_t vlapic_get_tsc_deadline_msr(const struct acrn_vlapic *vlapic);
+void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic, uint64_t val_arg);
+uint64_t vlapic_get_apicbase(const struct acrn_vlapic *vlapic);
+int32_t vlapic_set_apicbase(struct acrn_vlapic *vlapic, uint64_t new);
+int32_t vlapic_x2apic_read(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *val);
+int32_t vlapic_x2apic_write(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val);
 
 /*
  * Signals to the LAPIC that an interrupt at 'vector' needs to be generated


### PR DESCRIPTION
1) hv: vlapic: remove vlapic_rdmsr/wrmsr
    We could call vlapic API directly, remove vlapic_rdmsr/wrmsr to make things easier.
2) hv: vlapic: minor fix about vlapic write
    1) In x2apic mode, when read ICR, we want to read a 64-bits value.
    2) In x2apic mode, write self-IPI will trap out through MSR write when VID isn't enabled.

    Tracked-On: #1842
    Signed-off-by: Li, Fei1 <fei1.li@intel.com>
    Acked-by: Anthony Xu <anthony.xu@intel.com>
