### PR TITLE
acrn-dm: enable debug option for acrn-dm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ sbl-hypervisor:
 	make -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl BOARD=apl-mrb FIRMWARE=sbl RELEASE=$(RELEASE)
 
 devicemodel: tools
-	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
-	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG)
+	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) RELEASE=$(RELEASE) clean
+	make -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) RELEASE=$(RELEASE)
 
 tools:
 	mkdir -p $(TOOLS_OUT)

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -9,6 +9,7 @@ DM_BUILD_VERSION ?=
 DM_BUILD_TAG ?=
 
 CC ?= gcc
+RELEASE ?= 0
 
 CFLAGS := -g -O0 -std=gnu11
 CFLAGS += -D_GNU_SOURCE
@@ -41,6 +42,10 @@ else
 CFLAGS += -fstack-protector
 endif
 endif
+endif
+
+ifeq ($(RELEASE),0)
+CFLAGS += -DDM_DEBUG
 endif
 
 LDFLAGS += -Wl,-z,noexecstack

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -312,12 +312,14 @@ delete_cpu(struct vmctx *ctx, int vcpu)
 	return CPU_EMPTY(&cpumask);
 }
 
+#ifdef DM_DEBUG
 void
 notify_vmloop_thread(void)
 {
 	pthread_kill(mt_vmm_info[0].mt_thr, SIGCONT);
 	return;
 }
+#endif
 
 static void
 vmexit_inout(struct vmctx *ctx, struct vhm_request *vhm_req, int *pvcpu)

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -136,8 +136,13 @@ wdt_expired_handler(void *arg)
 			wdt_timeout = 1;
 
 			/* watchdog timer out, set the uos to reboot */
+#ifdef DM_DEBUG
 			vm_set_suspend_mode(VM_SUSPEND_SYSTEM_RESET);
+			/* Notify vm thread to handle VM_SUSPEND_SYSTEM_RESET request */
 			notify_vmloop_thread();
+#else
+			vm_set_suspend_mode(VM_SUSPEND_FULL_RESET);
+#endif
 			mevent_notify();
 		} else {
 			/* if not need reboot, just loop timer */

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -100,7 +100,9 @@ int	vm_attach_ioreq_client(struct vmctx *ctx);
 int	vm_notify_request_done(struct vmctx *ctx, int vcpu);
 void	vm_clear_ioreq(struct vmctx *ctx);
 void	vm_set_suspend_mode(enum vm_suspend_how how);
+#ifdef DM_DEBUG
 void	notify_vmloop_thread(void);
+#endif
 int	vm_get_suspend_mode(void);
 void	vm_destroy(struct vmctx *ctx);
 int	vm_parse_memsize(const char *optarg, size_t *memsize);


### PR DESCRIPTION
enable acrn-dm debug option via RELEASE=0(by default)

Tracked-on: #2939
Reviewed-by: Minggui Cao <minggui.cao@intel.com>
Signed-off-by: Wei Liu <weix.w.liu@intel.com>