### PR TITLE
doc: add security advisory section in ACRN introduction website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,23 @@ ACRN support systems:
   the Github issues system: https://github.com/projectacrn/acrn-hypervisor/issues.
   You can browse through the reported issues and submit issues of your own.
 
+* **Reporting a Potential Security Vulnerability**: If you have discovered potential
+  security vulnerability in ACRN, please send an e-mail to secure@intel.com. For issues
+  related to Intel Products, please visit https://security-center.intel.com.
+
+  It is important to include the following details:
+
+  - The projects and versions affected
+  - Detailed description of the vulnerability
+  - Information on known exploits
+
+  Vulnerability information is extremely sensitive. Please encrypt all security vulnerability
+  reports using our `PGP key`_.
+
+  A member of the Intel Product Security Team will review your e-mail and contact you to
+  to collaborate on resolving the issue. For more information on how Intel works to resolve
+  security issues, see: `vulnerability handling guidelines`_.
+
 * **Mailing List**: The `Project ACRN Development mailing list`_ is perhaps the most convenient
   way to track developer discussions and to ask your own support questions to
   the project ACRN community.  There are also specific `ACRN mailing list
@@ -78,5 +95,8 @@ ACRN support systems:
 .. _Getting Started Guide: https://projectacrn.github.io/latest/getting_started/
 .. _Contribution Guide: https://projectacrn.github.io/latest/contribute.html
 .. _Project ACRN GitHub wiki: https://github.com/projectacrn/acrn-hypervisor/wiki
+.. _PGP Key: https://www.intel.com/content/www/us/en/security-center/pgp-public-key.html
+.. _vulnerability handling guidelines:
+   https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html
 .. _Project ACRN Development mailing list: https://lists.projectacrn.org/g/acrn-dev
 .. _ACRN mailing list subgroups: https://lists.projectacrn.org/g/main/subgroups


### PR DESCRIPTION
Add survivability plan for ACRN Open source project.

Tracked-On: #2945
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>