### PR TITLE
tools: acrn-manager: fix the possibility of creating directory at wil…

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -225,28 +225,6 @@ int acrn_parse_intr_monitor(const char *opt)
 	return 0;
 }
 
-
-/* helpers */
-/* Check if @path is a directory, and create if not exist */
-static int check_dir(const char *path)
-{
-	struct stat st;
-
-	if (stat(path, &st)) {
-		if (mkdir(path, 0666)) {
-			perror(path);
-			return -1;
-		}
-		return 0;
-	}
-
-	if (S_ISDIR(st.st_mode))
-		return 0;
-
-	fprintf(stderr, "%s exist, and not a directory!\n", path);
-	return -1;
-}
-
 struct vm_ops {
 	char name[16];
 	void *arg;
@@ -426,13 +404,13 @@ int monitor_init(struct vmctx *ctx)
 	int ret;
 	char path[128] = {};
 
-	ret = check_dir("/run/acrn/");
+	ret = check_dir(ACRN_DM_BASE_PATH, CHK_CREAT);
 	if (ret) {
 		fprintf(stderr, "%s %d\r\n", __FUNCTION__, __LINE__);
 		goto dir_err;
 	}
 
-	ret = check_dir("/run/acrn/mngr");
+	ret = check_dir(ACRN_DM_SOCK_PATH, CHK_CREAT);
 	if (ret) {
 		fprintf(stderr, "%s %d\r\n", __FUNCTION__, __LINE__);
 		goto dir_err;

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -27,26 +27,6 @@ const char *state_str[] = {
 	[VM_UNTRACKED] = "untracked",
 };
 
-/* Check if @path is a directory, and create if not exist */
-static int check_dir(const char *path)
-{
-	struct stat st;
-
-	if (stat(path, &st)) {
-		if (mkdir(path, 0666)) {
-			perror(path);
-			return -1;
-		}
-		return 0;
-	}
-
-	if (S_ISDIR(st.st_mode))
-		return 0;
-
-	fprintf(stderr, "%s exist, and not a directory!\n", path);
-	return -1;
-}
-
 /* List head of all vm */
 static pthread_mutex_t vmmngr_mutex = PTHREAD_MUTEX_INITIALIZER;
 struct vmmngr_list_struct vmmngr_head = { NULL };
@@ -131,7 +111,7 @@ static void _scan_alive_vm(void)
 	int pid;
 	int ret;
 
-	ret = check_dir(ACRN_DM_SOCK_PATH);
+	ret = check_dir(ACRN_DM_SOCK_PATH, CHK_ONLY);
 	if (ret) {
 		printf("%s: Failed to check directory %s, err: %d\n", __func__, ACRN_DM_SOCK_PATH, ret);
 		return;
@@ -228,13 +208,13 @@ static void _scan_added_vm(void)
 	char suffix[PATH_LEN];
 	int ret;
 
-	ret = check_dir(ACRN_CONF_PATH);
+	ret = check_dir(ACRN_CONF_PATH, CHK_ONLY);
 	if (ret) {
 		printf("%s: Failed to check directory %s, err: %d\n", __func__, ACRN_CONF_PATH, ret);
 		return;
 	}
 
-	ret = check_dir(ACRN_CONF_PATH_ADD);
+	ret = check_dir(ACRN_CONF_PATH_ADD, CHK_ONLY);
 	if (ret) {
 		printf("%s: Failed to check directory %s, err: %d\n", __func__, ACRN_CONF_PATH_ADD, ret);
 		return;

--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -86,7 +86,7 @@ static int check_name(const char *name)
 		return -1;
 
 	if (strnlen(name, MAX_VM_OS_NAME_LEN) >= MAX_VM_OS_NAME_LEN) {
-		printf("(%s) size exceed MAX_VM_OS_NAME_LEN:%u\n", name,MAX_VM_OS_NAME_LEN);
+		printf("(%s) size exceed MAX_VM_OS_NAME_LEN:%u\n", name, MAX_VM_OS_NAME_LEN);
 		return -1;
 	}
 
@@ -425,7 +425,7 @@ static int acrnctl_do_stop(int argc, char *argv[])
 		return -1;
 	}
 	if (s->state == VM_CREATED) {
-		printf("%s is already (%s)\n", argv[1],state_str[s->state]);
+		printf("%s is already (%s)\n", argv[1], state_str[s->state]);
 		return -1;
 	}
 	return stop_vm(argv[1]);
@@ -490,15 +490,15 @@ static int acrnctl_do_del(int argc, char *argv[])
 		return -1;
 	}
 	if (s->state != VM_CREATED) {
-		printf("can't delete %s(%s)\n", argv[1],state_str[s->state]);
+		printf("can't delete %s(%s)\n", argv[1], state_str[s->state]);
 		return -1;
 	}
-	if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.sh",ACRN_CONF_PATH_ADD, argv[1]) >= sizeof(cmd)) {
+	if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.sh", ACRN_CONF_PATH_ADD, argv[1]) >= sizeof(cmd)) {
 		printf("WARN: cmd is truncated\n");
 		return -1;
 	}
 	system(cmd);
-	if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.args",ACRN_CONF_PATH_ADD, argv[1]) >= sizeof(cmd)) {
+	if (snprintf(cmd, sizeof(cmd), "rm -f %s/%s.args", ACRN_CONF_PATH_ADD, argv[1]) >= sizeof(cmd)) {
 		printf("WARN: cmd is truncated\n");
 		return -1;
 	}
@@ -547,7 +547,7 @@ static int acrnctl_do_pause(int argc, char *argv[])
 			ret = pause_vm(argv[1]);
 			break;
 		default:
-			printf("%s current state %s, can't pause\n",argv[1], state_str[s->state]);
+			printf("%s current state %s, can't pause\n", argv[1], state_str[s->state]);
 	}
 
 	return ret;
@@ -573,7 +573,7 @@ static int acrnctl_do_continue(int argc, char *argv[])
 			ret = continue_vm(argv[1]);
 			break;
 		default:
-			printf("%s current state %s, can't continue\n",argv[1], state_str[s->state]);
+			printf("%s current state %s, can't continue\n", argv[1], state_str[s->state]);
 	}
 
 	return ret;
@@ -596,7 +596,7 @@ static int acrnctl_do_suspend(int argc, char *argv[])
 			ret = suspend_vm(argv[1]);
 			break;
 		default:
-			printf("%s current state %s, can't suspend\n",argv[1], state_str[s->state]);
+			printf("%s current state %s, can't suspend\n", argv[1], state_str[s->state]);
 	}
 
 	return ret;
@@ -626,7 +626,7 @@ static int acrnctl_do_resume(int argc, char *argv[])
 			printf("resume %s reason(0x%x\n", argv[1], reason);
 			break;
 		default:
-			printf("%s current state %s, can't resume\n",argv[1], state_str[s->state]);
+			printf("%s current state %s, can't resume\n", argv[1], state_str[s->state]);
 	}
 
 	return ret;
@@ -677,13 +677,13 @@ static int acrnctl_do_reset(int argc, char *argv[])
 				break;
 			}
 			if (wait_vm_stop(argv[1], STOP_TIMEOUT)) {
-				printf("Failed to stop %s in %u sec, reset failed\n",argv[1], STOP_TIMEOUT);
+				printf("Failed to stop %s in %u sec, reset failed\n", argv[1], STOP_TIMEOUT);
 				break;
 			}
 			ret = start_vm(argv[1]);
 			break;
 		default:
-			printf("%s current state: %s, can't reset\n",argv[1], state_str[s->state]);
+			printf("%s current state: %s, can't reset\n", argv[1], state_str[s->state]);
 	}
 	return ret;
 }

--- a/tools/acrn-manager/acrnctl.h
+++ b/tools/acrn-manager/acrnctl.h
@@ -10,12 +10,6 @@
 #include <acrn_common.h>
 #include "acrn_mngr.h"
 
-#define ACRN_CONF_PATH		"/usr/share/acrn/conf"
-#define ACRN_CONF_PATH_ADD	ACRN_CONF_PATH "/add"
-#define ACRN_CONF_TIMER_LIST	ACRN_CONF_PATH "/timer_list"
-
-#define ACRN_DM_SOCK_PATH	"/run/acrn/mngr"
-
 enum vm_state {
 	VM_STATE_UNKNOWN = 0,
 	VM_CREATED,		/* VM created / awaiting start (boot) */

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -670,7 +670,7 @@ static const char optString[] = "t";
 
 int main(int argc, char *argv[])
 {
-	int opt;
+	int opt, ret;
 
 	while ((opt = getopt(argc, argv, optString)) != -1) {
 		switch (opt) {
@@ -688,6 +688,18 @@ int main(int argc, char *argv[])
 		platform_has_hw_ioc = 0;
 	}
 	
+	ret = check_dir(ACRN_DM_BASE_PATH, CHK_CREAT);
+	if (ret) {
+		fprintf(stderr, "%s %d\r\n", __FUNCTION__, __LINE__);
+		return -1;
+	}
+
+	ret = check_dir(ACRN_DM_SOCK_PATH, CHK_CREAT);
+	if (ret) {
+		fprintf(stderr, "%s %d\r\n", __FUNCTION__, __LINE__);
+		return -1;
+	}
+
 	/* create listening thread */
 	acrnd_fd = mngr_open_un(ACRND_NAME, MNGR_SERVER);
 	if (acrnd_fd < 0) {


### PR DESCRIPTION
…l by no permission process

There are several duplicate definitions for check_dir, it can check or create directory at will. However, only acrnd and dm monitor can create the directory. This commit fixs the possibility of creating directory at will by no permission process, which adds a param flags to conctrl if it should create the directory. By the way, this commit collates related MACRO into the same file , deletes the duplicate definitions in another files and fixs some format issues.

Tracked-On: #2886
Signed-off-by: Mao Jiang <maox.jiang@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>