### PR TITLE
tools: acrn-manager: fix mngr_send_msg() return 0 when read ack fail

### DIFF
--- a/tools/acrn-manager/acrn_mngr.c
+++ b/tools/acrn-manager/acrn_mngr.c
@@ -611,8 +611,10 @@ int mngr_send_msg(int fd, struct mngr_msg *req, struct mngr_msg *ack,
 	else
 		select(socket_fd + 1, &rfd, NULL, NULL, NULL);
 
-	if (!FD_ISSET(socket_fd, &rfd))
-		return 0;
+	if (!FD_ISSET(socket_fd, &rfd)) {
+		printf("%s %d\n", __FUNCTION__, __LINE__);
+		return -1;
+	}
 
 	ret = read(socket_fd, ack, sizeof(struct mngr_msg));
 


### PR DESCRIPTION
Ported from apl_sdc_stable branch.
When do IPC with mngr_send_msg(), and ack is required but failed to
get ack,  mngr_send_msg() still return 0, that is not correct.

Tracked-On: #2398
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>