### PR TITLE
tools: acrn-crashlog: fix some possible memory leak

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -629,14 +629,17 @@ static int parse_uptime(xmlNodePtr cur, struct sender_t *sender)
 		else if (name_is(cur, "eventhours"))
 			res = load_cur_content(cur, uptime, eventhours);
 
-		if (res)
+		if (res) {
+			free(uptime);
 			return -1;
+		}
 
 		cur = cur->next;
 	}
 	res = asprintf(&uptime->path, "%s/uptime", sender->outdir);
 	if (res < 0) {
 		LOGE("build string failed\n");
+		free(uptime);
 		return -1;
 	}
 	sender->uptime = uptime;

--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -686,12 +686,12 @@ static ssize_t _file_read_key_value(char *value, const size_t limit,
 		return -errno;
 	if (!key) {
 		errno = EINVAL;
-		return -errno;
+		goto unmap;
 	}
 
 	if (op != 'l' && op != 'r') {
 		errno = EINVAL;
-		return -errno;
+		goto unmap;
 	}
 
 	if (op == 'l')


### PR DESCRIPTION
This patch is to fix some possible memory leak issues, which are
reported by static analysis tool.

1. free uptime in error case handling of function parse_uptime.
2. unmap f in error case handling of function _file_read_key_value.

Tracked-On: #2917
Reviewed-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Signed-off-by: CHEN Gang <gang.c.chen@intel.com>
Acked-by: Zhang Di <di.zhang@intel.com>