### PR TITLE
Enable logic partition scenario on KBL NUC i7

### DIFF
--- a/efi-stub/boot.h
+++ b/efi-stub/boot.h
@@ -57,6 +57,8 @@
 #define MSR_IA32_SYSENTER_ESP               0x00000175  /* ESP for sysenter */
 #define MSR_IA32_SYSENTER_EIP               0x00000176  /* EIP for sysenter */
 
+#define UEFI_BOOT_LOADER_NAME "ACRN UEFI loader"
+
 /* Read MSR */
 #define CPU_MSR_READ(reg, msr_val_ptr)                      \
 {                                                           \
@@ -77,15 +79,17 @@ typedef void(*hv_func)(int32_t, struct multiboot_info*);
 #define MBOOT_MMAP_SIZE (sizeof(struct multiboot_mmap) * MBOOT_MMAP_NUMS)
 #define MBOOT_INFO_SIZE (sizeof(struct multiboot_info))
 #define BOOT_CTX_SIZE  (sizeof(struct uefi_context))
+#define BOOT_LOADER_NAME_SIZE 17U
 #define EFI_BOOT_MEM_SIZE \
-	(MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE)
+	(MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE + BOOT_LOADER_NAME_SIZE)
 #define MBOOT_MMAP_PTR(addr) \
 	((struct multiboot_mmap *)((VOID *)(addr)))
 #define MBOOT_INFO_PTR(addr)  \
 	((struct multiboot_info *)((VOID *)(addr) + MBOOT_MMAP_SIZE))
 #define BOOT_CTX_PTR(addr)	\
 	((struct uefi_context *)((VOID *)(addr) + MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE))
-
+#define BOOT_LOADER_NAME_PTR(addr)	\
+	((char *)((VOID *)(addr) + MBOOT_MMAP_SIZE + MBOOT_INFO_SIZE + BOOT_CTX_SIZE))
 
 struct efi_info {
 	UINT32 efi_loader_signature;

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/pci_devices.h
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/pci_devices.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PCI_DEVICES_H_
+#define PCI_DEVICES_H_
+
+#define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
+#define SATA_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x17U, .f = 0x00U}
+#define USB_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
+
+#define STORAGE_CONTROLLER_0	SATA_CONTROLLER
+#define STORAGE_CONTROLLER_1	USB_CONTROLLER
+
+#define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x1fU, .f = 0x06U}
+#define ETHERNET_CONTROLLER_1
+
+#endif /* PCI_DEVICES_H_ */

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
@@ -4,13 +4,46 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <e820.h>
 #include <vm.h>
 
+#define VE820_ENTRIES_KBL_NUC_i7  5U
+static const struct e820_entry ve820_entry[VE820_ENTRIES_KBL_NUC_i7] = {
+	{	/* usable RAM under 1MB */
+		.baseaddr = 0x0UL,
+		.length   = 0xF0000UL,		/* 960KB */
+		.type     = E820_TYPE_RAM
+	},
+
+	{	/* mptable */
+		.baseaddr = 0xF0000UL,		/* 960KB */
+		.length   = 0x10000UL,		/* 16KB */
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{	/* lowmem */
+		.baseaddr = 0x200000UL,		/* 2MB */
+		.length   = 0x1FE00000UL,	/* 510MB */
+		.type     = E820_TYPE_RAM
+	},
+
+	{	/* between lowmem and PCI hole */
+		.baseaddr = 0x20000000UL,	/* 512MB */
+		.length   = 0xA0000000UL,	/* 2560MB */
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{	/* between PCI hole and 4GB */
+		.baseaddr = 0xe0000000UL,	/* 3.5GB */
+		.length   = 0x20000000UL,	/* 512MB */
+		.type     = E820_TYPE_RESERVED
+	},
+};
 /**
  * @pre vm != NULL
  */
 void create_prelaunched_vm_e820(struct acrn_vm *vm)
 {
-	vm->e820_entry_num = 0U;
-	vm->e820_entries = NULL;
+	vm->e820_entry_num = VE820_ENTRIES_KBL_NUC_i7;
+	vm->e820_entries = (struct e820_entry *)ve820_entry;
 }

--- a/hypervisor/bsp/include/firmware.h
+++ b/hypervisor/bsp/include/firmware.h
@@ -8,6 +8,8 @@
 
 #define FIRMWARE_H
 
+#define NUM_FIRMWARE_SUPPORTING 4U
+
 struct acrn_vm;
 struct firmware_operations {
 	void (*init)(void);
@@ -15,6 +17,12 @@ struct firmware_operations {
 	void *(*get_rsdp)(void);
 	void (*init_irq)(void);
 	int32_t (*init_vm_boot_info)(struct acrn_vm *vm);
+};
+
+struct firmware_candidates {
+	const char name[20];
+	size_t name_sz;
+	struct firmware_operations *(*ops)(void);
 };
 
 void init_firmware_operations(void);


### PR DESCRIPTION
Enable simple logical partition mode on KBL NUC i7, there are
two pre-launched VM with virtual LAPIC and multiboot compliant
boot loader (GRUB is one candidate) need to be used to boot
hypervisor and provides the address of guest OS image, this boot
loader only runs during boot time.So the following updates need to
be made:
(1) Update efi stub to support boot loader name in the its multiboot
header;
(2) Update firware detection and operations selecting logic to detect
more multiboot compiliant firware (such as GRUB and UEFI loader)
explicitly, different operations is selected according to the
boot load name through a static mapping table between boot load name
and firmware operations. GRUB loader can use the SBL operations
to handle multiboot information parsing and vm booting since
these multiboot compiliant firmware (SBL/ABL/GRUB) which boots
hypervisor (binary format), provides multiboot information and
the start address of guest OS image(binary format) in the same way,
and only runs on boot time.
(3) Add board specific configuration to enable logic partition on KBL NUC i7.

Tracked-On: #2944

Signed-off-by: Xiangyang Wu <xiangyang.wu@linux.intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>