### PR TITLE
 DM: enable debug macro and remap watchdog reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ sbl-hypervisor:
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-sbl/apl-up2 BOARD=apl-up2 FIRMWARE=sbl RELEASE=$(RELEASE)
 
 devicemodel: tools
-	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) clean
-	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER)
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) RELEASE=$(RELEASE) clean
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER) RELEASE=$(RELEASE)
 
 tools:
 	mkdir -p $(TOOLS_OUT)

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -9,6 +9,7 @@ DM_BUILD_VERSION ?=
 DM_BUILD_TAG ?=
 
 CC ?= gcc
+RELEASE ?= 0
 
 CFLAGS := -g -O0 -std=gnu11
 CFLAGS += -D_GNU_SOURCE
@@ -45,6 +46,10 @@ else
 CFLAGS += -fstack-protector
 endif
 endif
+endif
+
+ifeq ($(RELEASE),0)
+CFLAGS += -DDM_DEBUG
 endif
 
 LDFLAGS += -Wl,-z,noexecstack

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -322,12 +322,14 @@ delete_cpu(struct vmctx *ctx, int vcpu)
 	return CPU_EMPTY(&cpumask);
 }
 
+#ifdef DM_DEBUG
 void
 notify_vmloop_thread(void)
 {
 	pthread_kill(mt_vmm_info[0].mt_thr, SIGCONT);
 	return;
 }
+#endif
 
 static void
 vmexit_inout(struct vmctx *ctx, struct vhm_request *vhm_req, int *pvcpu)

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -322,6 +322,13 @@ delete_cpu(struct vmctx *ctx, int vcpu)
 	return CPU_EMPTY(&cpumask);
 }
 
+void
+notify_vmloop_thread(void)
+{
+	pthread_kill(mt_vmm_info[0].mt_thr, SIGCONT);
+	return;
+}
+
 static void
 vmexit_inout(struct vmctx *ctx, struct vhm_request *vhm_req, int *pvcpu)
 {

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -136,9 +136,13 @@ wdt_expired_handler(void *arg, uint64_t nexp)
 			wdt_timeout = 1;
 
 			/* watchdog timer out, set the uos to reboot */
+#ifdef DM_DEBUG
 			vm_set_suspend_mode(VM_SUSPEND_SYSTEM_RESET);
 			/* Notify vm thread to handle VM_SUSPEND_SYSTEM_RESET request */
 			notify_vmloop_thread();
+#else
+			vm_set_suspend_mode(VM_SUSPEND_FULL_RESET);
+#endif
 			mevent_notify();
 		} else {
 			/* if not need reboot, just loop timer */

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -136,7 +136,9 @@ wdt_expired_handler(void *arg, uint64_t nexp)
 			wdt_timeout = 1;
 
 			/* watchdog timer out, set the uos to reboot */
-			vm_set_suspend_mode(VM_SUSPEND_FULL_RESET);
+			vm_set_suspend_mode(VM_SUSPEND_SYSTEM_RESET);
+			/* Notify vm thread to handle VM_SUSPEND_SYSTEM_RESET request */
+			notify_vmloop_thread();
 			mevent_notify();
 		} else {
 			/* if not need reboot, just loop timer */

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -101,6 +101,7 @@ int	vm_attach_ioreq_client(struct vmctx *ctx);
 int	vm_notify_request_done(struct vmctx *ctx, int vcpu);
 void	vm_clear_ioreq(struct vmctx *ctx);
 void	vm_set_suspend_mode(enum vm_suspend_how how);
+void	notify_vmloop_thread(void);
 int	vm_get_suspend_mode(void);
 void	vm_destroy(struct vmctx *ctx);
 int	vm_parse_memsize(const char *optarg, size_t *memsize);

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -101,7 +101,9 @@ int	vm_attach_ioreq_client(struct vmctx *ctx);
 int	vm_notify_request_done(struct vmctx *ctx, int vcpu);
 void	vm_clear_ioreq(struct vmctx *ctx);
 void	vm_set_suspend_mode(enum vm_suspend_how how);
+#ifdef DM_DEBUG
 void	notify_vmloop_thread(void);
+#endif
 int	vm_get_suspend_mode(void);
 void	vm_destroy(struct vmctx *ctx);
 int	vm_parse_memsize(const char *optarg, size_t *memsize);


### PR DESCRIPTION
the patches are used when UOS watchdog reset happens, DM will trigger a
warm reset first, let UOS gets a chance to dump system info for debug.

it is ported from apl_sdc_stable branch and  just used for debug build.

Wei Liu (1):
  acrn-dm: enable debug option for acrn-dm

enable acrn-dm debug option via RELEASE=0(by default)

    Tracked-On: #2939
    Reviewed-by: Minggui Cao <minggui.cao@intel.com>
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Yu Wang <yu1.wang@intel.com>

Yin Fengwei (1):
  watchdog: map the watchdog reset to warm reset

    Per debugging requirement, map the watchdog reset to warm reset.
    So the ramconsole could be used to capture the kernel log of UOS
    before watchdog is hit.

    Tracked-On: #2471
    Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
    Acked-by: Yu Wang <yu1.wang@intel.com>

