### PR TITLE
hv: Remove need for init_fallback_iommu_domain and fallback_iommu_domain

### DIFF
--- a/doc/developer-guides/hld/hv-vt-d.rst
+++ b/doc/developer-guides/hld/hv-vt-d.rst
@@ -306,9 +306,6 @@ deinitialization:
 .. doxygenfunction:: init_iommu
    :project: Project ACRN
 
-.. doxygenfunction:: init_fallback_iommu_domain
-   :project: Project ACRN
-
 runtime
 =======
 
@@ -326,9 +323,5 @@ The following API are provided during runtime:
 .. doxygenfunction:: resume_iommu
    :project: Project ACRN
 
-.. doxygenfunction:: assign_pt_device
+.. doxygenfunction:: move_pt_device
    :project: Project ACRN
-
-.. doxygenfunction:: unassign_pt_device
-   :project: Project ACRN
-

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -341,9 +341,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		prepare_sos_vm_memmap(vm);
 
 		status = firmware_init_vm_boot_info(vm);
-		if (status == 0) {
-			init_fallback_iommu_domain(vm->iommu, vm->vm_id, vm->arch_vm.nworld_eptp);
-		} else {
+		if (status != 0) {
 			need_cleanup = true;
 		}
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -890,7 +890,7 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 			}
 		}
 		if (bdf_valid && iommu_valid) {
-			ret = assign_pt_device(target_vm->iommu,
+			ret = move_pt_device(vm->iommu, target_vm->iommu,
 				(uint8_t)(bdf >> 8U), (uint8_t)(bdf & 0xffU));
 		}
 	} else {
@@ -934,7 +934,7 @@ int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 		}
 
 		if (bdf_valid) {
-			ret = unassign_pt_device(target_vm->iommu,
+			ret = move_pt_device(target_vm->iommu, vm->iommu,
 				(uint8_t)(bdf >> 8U), (uint8_t)(bdf & 0xffU));
 		}
 	}

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -101,14 +101,14 @@ struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_b
 
 struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf);
 
-int32_t partition_mode_vpci_init(const struct acrn_vm *vm);
+int32_t partition_mode_vpci_init(struct acrn_vm *vm);
 void partition_mode_cfgread(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
 void partition_mode_vpci_deinit(const struct acrn_vm *vm);
 
-int32_t sharing_mode_vpci_init(const struct acrn_vm *vm);
+int32_t sharing_mode_vpci_init(struct acrn_vm *vm);
 void sharing_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -541,9 +541,11 @@ struct iommu_domain;
 /**
  * @brief Assign a device specified by bus & devfun to a iommu domain.
  *
- * Remove the device from the fallback iommu domain (if present), and add it to the specific domain.
+ * Remove the device from the from_domain (if non-NULL), and add it to the to_domain (if non-NULL).
+ * API silently fails to add/remove devices to/from domains that are under "Ignored" DMAR units. 
  *
- * @param[in]    domain iommu domain the device is assigned to
+ * @param[in]    from_domain iommu domain from which the device is removed from
+ * @param[in]    to_domain iommu domain to which the device is assgined to
  * @param[in]    bus the 8-bit bus number of the device
  * @param[in]    devfun the 8-bit device(5-bit):function(3-bit) of the device
  *
@@ -553,24 +555,7 @@ struct iommu_domain;
  * @pre domain != NULL
  *
  */
-int32_t assign_pt_device(struct iommu_domain *domain, uint8_t bus, uint8_t devfun);
-
-/**
- * @brief Unassign a device specified by bus & devfun from a iommu domain .
- *
- * Remove the device from the specific domain, and then add it to the fallback iommu domain (if present).
- *
- * @param[in]    domain iommu domain the device is assigned to
- * @param[in]    bus the 8-bit bus number of the device
- * @param[in]    devfun the 8-bit device(5-bit):function(3-bit) of the device
- *
- * @retval 0 on success.
- * @retval 1 fail to unassign the device
- *
- * @pre domain != NULL
- *
- */
-int32_t unassign_pt_device(const struct iommu_domain *domain, uint8_t bus, uint8_t devfun);
+int32_t move_pt_device(const struct iommu_domain *from_domain, struct iommu_domain *to_domain, uint8_t bus, uint8_t devfun);
 
 /**
  * @brief Create a iommu domain for a VM specified by vm_id.
@@ -648,23 +633,6 @@ void resume_iommu(void);
  *
  */
 int32_t init_iommu(void);
-
-/**
- * @brief Init fallback iommu domain of iommu.
- *
- * Create fallback iommu domain using the Normal World's EPT table of fallback iommu as address translation table.
- * All PCI devices are added to the fallback iommu domain when creating it.
- *
- * @param[in] iommu_dmn pointer to fallback iommu domain
- * @param[in] vm_id ID of the VM for which iommu_domain needs to be created
- * @param[in] eptp EPT hieararchy table
- *
- * @pre iommu shall point to fallback iommu domain
- *
- * @remark to reduce boot time & memory cost, a config IOMMU_INIT_BUS_LIMIT, which limit the bus number.
- *
- */
-void init_fallback_iommu_domain(struct iommu_domain *iommu_dmn, uint16_t vm_id, void *eptp);
 
 /**
  * @brief check the iommu if support cache snoop.


### PR DESCRIPTION
In the presence of SOS, ACRN uses fallback_iommu_domain which is the same
used by SOS, to assign domain to devices during ACRN init. Also it uses
fallback_iommu_domain when DM requests ACRN to remove device from UOS domain.
This patch changes the design of assign/remove_iommu_device to avoid the
concept of fallback_iommu_domain and its setup. This way ACRN can commonly
treat pre-launched VMs bringup w.r.t. IOMMU domain creation.

Tracked-On: #2965
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>