### PR TITLE
hv: vlapic: add TPR below threshold implement

### DIFF
--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -174,6 +174,8 @@ static int32_t vcpu_inject_vlapic_int(struct acrn_vcpu *vcpu)
 		}
 	}
 
+	vlapic_update_tpr_threshold(vlapic);
+
 	return ret;
 }
 

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -234,7 +234,8 @@ void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);
 int32_t apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);
-int32_t tpr_below_threshold_vmexit_handler(__unused struct acrn_vcpu *vcpu);
+void vlapic_update_tpr_threshold(const struct acrn_vlapic *vlapic);
+int32_t tpr_below_threshold_vmexit_handler(struct acrn_vcpu *vcpu);
 void vlapic_calc_dest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
 void vlapic_calc_dest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
 


### PR DESCRIPTION
v5:
bug fix: set TPR threshold to 0 in tpr_below_threshold_vmexit_handler to
bypass VM-Execution Control Fields check.

v4:
back to the v1 implement since
The following check is performed if the “use TPR shadow” VM-execution control
is 1 and the “virtualize APIC accesses” and “virtual-interrupt delivery”
VM-execution controls are both 0: the value of bits 3:0 of the TPR
threshold VM-execution control field should not be greater than the value of
bits 7:4 of VTPR (see Section 29.1.1) according SDM Vol 3 26.2.1.1
VM-Execution Control Fields.

v3:
Simplify TPR threshold implement by setting TPR threshold to highest value (0xF)
to trap out the almost TPR settting.

v2:
add comments.

v1:
Add TPR below threshold implement for "Virtual-interrupt delivery" not support.
Windows will use it to delay interrupt handle.

Complete all the interrupts in IRR as long as they are higher priority than
current TPR. Once current IRR priority is less than current TPR enable TPR
threshold to IRR, so that if guest reduces the TPR threshold, it would be good
to take below TPR threshold exit and let interrupts to go thru.


Add TPR below threshold implement for "Virtual-interrupt delivery" not support.
Windows will use it to delay interrupt handle.

Complete all the interrupts in IRR as long as they are higher priority than
current TPR. Once current IRR priority is less than current TPR enable TPR
threshold to IRR, so that if guest reduces the TPR threshold, it would be good
to take below TPR threshold exit and let interrupts to go thru.

Tracked-On: #1842
Signed-off-by: Zheng, Gen <gen.zheng@intel.com>
Signed-off-by: Li, Fei1 <fei1.li@intel.com>