### PR TITLE
hv: enable vMCE from guest CPUID

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -366,9 +366,6 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 				}
 			}
 
-			/* mask Machine Check Exception */
-			*edx &= ~CPUID_EDX_MCE;
-
 			/* mask Debug Store feature */
 			*edx &= ~CPUID_EDX_DTES;
 

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -44,6 +44,9 @@ static const uint32_t emulated_guest_msrs[NUM_GUEST_MSRS] = {
 	MSR_IA32_APIC_BASE,
 	MSR_IA32_PERF_CTL,
 	MSR_IA32_FEATURE_CONTROL,
+
+	MSR_IA32_MCG_CAP,
+	MSR_IA32_MCG_STATUS,
 };
 
 #define NUM_MTRR_MSRS	13U
@@ -443,6 +446,12 @@ int32_t rdmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 		v = MSR_IA32_FEATURE_CONTROL_LOCK;
 		break;
 	}
+	case MSR_IA32_MCG_CAP:
+	case MSR_IA32_MCG_STATUS:
+	{
+		v = 0U;
+		break;
+	}
 	default:
 	{
 		if (is_x2apic_msr(msr)) {
@@ -589,6 +598,8 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 		err = vlapic_set_apicbase(vcpu_vlapic(vcpu), v);
 		break;
 	}
+	case MSR_IA32_MCG_CAP:
+	case MSR_IA32_MCG_STATUS:
 	case MSR_IA32_FEATURE_CONTROL:
 	{
 		err = -EACCES;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -215,7 +215,7 @@ struct ext_context {
 #define SECURE_WORLD	1
 
 #define NUM_WORLD_MSRS		2U
-#define NUM_COMMON_MSRS		7U
+#define NUM_COMMON_MSRS		9U
 #define NUM_GUEST_MSRS		(NUM_WORLD_MSRS + NUM_COMMON_MSRS)
 
 #define EOI_EXIT_BITMAP_SIZE	256U


### PR DESCRIPTION
Enable vMCE feature to boot windows guest.

vMCE is set in EDX from Microsoft TLFS spec, to support windows guest
vMCA and vMCE should be supported by guest CPUID.

Support MSR_IA32_MCG_CAP and MSR_IA32_MCG_STATUS reading when vMCE is enabled,
but they are not emulated yet, so return 0 directly.

Tracked-On: #1867
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>