### PR TITLE
hv: Add host CR2 to exception dump

### DIFF
--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -252,6 +252,7 @@ void asm_assert(int32_t line, const char *file, const char *txt)
 void dump_intr_excp_frame(const struct intr_excp_ctx *ctx)
 {
 	const char *name = "Not defined";
+	uint64_t cr2_val;
 
 	pr_acrnlog("\n\n================================================");
 	pr_acrnlog("================================\n=\n");
@@ -278,6 +279,8 @@ void dump_intr_excp_frame(const struct intr_excp_ctx *ctx)
 			ctx->rflags, ctx->gp_regs.r14, ctx->gp_regs.r15);
 	pr_acrnlog("= ERRCODE=0x%016llX   CS=0x%016llX   SS=0x%016llX\n",
 			ctx->error_code, ctx->cs, ctx->ss);
+	asm volatile ("movq %%cr2, %0" : "=r" (cr2_val));
+	pr_acrnlog("= CR2=0x%016llX", cr2_val);
 	pr_acrnlog("\r\n");
 
 	pr_acrnlog("=====================================================");


### PR DESCRIPTION
ACRN dumps host registers in case of an exception in root mode operation.
This patch adds CR2 register to the dump. It is useful for
page-fault debug in HV to know the offending address.

Tracked-On: #2969
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>