### PR TITLE
hv:hotfix for register_mmio_emulation_handler

### DIFF
--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -457,7 +457,7 @@ vioapic_init(struct acrn_vm *vm)
 
 	vioapic_reset(vm);
 
-	(void)register_mmio_emulation_handler(vm,
+	register_mmio_emulation_handler(vm,
 			vioapic_mmio_access_handler,
 			(uint64_t)VIOAPIC_BASE,
 			(uint64_t)VIOAPIC_BASE + VIOAPIC_SIZE,

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -163,7 +163,7 @@ void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev)
 			addr_lo = round_page_down(msix->mmio_gpa + msix->table_offset);
 		}
 
-		(void)register_mmio_emulation_handler(vdev->vpci->vm, vmsix_table_mmio_access_handler,
+		register_mmio_emulation_handler(vdev->vpci->vm, vmsix_table_mmio_access_handler,
 			addr_lo, addr_hi, vdev);
 	}
 }

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -265,10 +265,9 @@ void   register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
  * @param end The end of the range (exclusive) \p read_write can emulate
  * @param handler_private_data Handler-specific data which will be passed to \p read_write when called
  *
- * @retval 0 Registration succeeds
- * @retval -EINVAL \p read_write is NULL, \p end is not larger than \p start or \p vm has been launched
+ * @return None
  */
-int32_t register_mmio_emulation_handler(struct acrn_vm *vm,
+void register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
 	uint64_t end, void *handler_private_data);
 


### PR DESCRIPTION
in this patch(2b79c6df) move some common APIS to io_req.c
and rename common/io_irq.c to dm/io_req.c,
this api(register_mmio_emulation_handler) has been changed
before this patch, there is no conflict when rebasing
because of the movement and rename, this patch fix it.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>