### PR TITLE
hv: reset per cpu sbuf pointers during vcpu reset

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -582,6 +582,8 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 	vlapic = vcpu_vlapic(vcpu);
 	vlapic_reset(vlapic);
 
+	sbuf_reset(vcpu->pcpu_id);
+
 	reset_vcpu_regs(vcpu);
 }
 

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -121,3 +121,14 @@ int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva)
 
 	return 0;
 }
+
+void sbuf_reset(uint16_t pcpu_id)
+{
+	uint32_t sbuf_id;
+
+	if (pcpu_id < get_pcpu_nums()) {
+		for (sbuf_id = 0U; sbuf_id < ACRN_SBUF_ID_MAX; sbuf_id++) {
+			per_cpu(sbuf, pcpu_id)[sbuf_id] = 0U;
+		}
+	}
+}

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -65,6 +65,7 @@ struct shared_buf {
  */
 uint32_t sbuf_put(struct shared_buf *sbuf, uint8_t *data);
 int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva);
+void sbuf_reset(uint16_t pcpu_id);
 uint32_t sbuf_next_ptr(uint32_t pos, uint32_t span, uint32_t scope);
 
 #endif /* SHARED_BUFFER_H */

--- a/hypervisor/release/sbuf.c
+++ b/hypervisor/release/sbuf.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <sbuf.h>
+
+void sbuf_reset(__unused uint16_t pcpu_id) {}


### PR DESCRIPTION
When shutting down SOS VM, the shared sbuf is released from guest OS, but
the per cpu sbuf pointers in hypervisor keep inact. This creates a problem
that after SOS is re-launched, hypervisor could write to the shared
buffer that no longer exists.

This patch implements sbuf_reset() and call it from reset_vcpu() to
reset sbuf pointers.

Tracked-On: #2700
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>