### PR TITLE
Vlapic: minor fix about APICv feature setting

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -316,6 +316,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 
 	/*Disable VM_EXIT for CR3 access*/
 	value32 &= ~(VMX_PROCBASED_CTLS_CR3_LOAD | VMX_PROCBASED_CTLS_CR3_STORE);
+	value32 &= ~(VMX_PROCBASED_CTLS_CR8_LOAD | VMX_PROCBASED_CTLS_CR8_STORE);
 
 	/*
 	 * Disable VM_EXIT for invlpg execution.
@@ -330,9 +331,8 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	 * guest (optional)
 	 */
 	value32 = check_vmx_ctrl(MSR_IA32_VMX_PROCBASED_CTLS2,
-			 VMX_PROCBASED_CTLS2_VAPIC | VMX_PROCBASED_CTLS2_EPT |
-			 VMX_PROCBASED_CTLS2_RDTSCP | VMX_PROCBASED_CTLS2_UNRESTRICT |
-			 VMX_PROCBASED_CTLS2_VAPIC_REGS);
+			VMX_PROCBASED_CTLS2_VAPIC | VMX_PROCBASED_CTLS2_EPT |
+			VMX_PROCBASED_CTLS2_RDTSCP | VMX_PROCBASED_CTLS2_UNRESTRICT);
 
 	if (vcpu->arch.vpid != 0U) {
 		value32 |= VMX_PROCBASED_CTLS2_VPID;
@@ -342,6 +342,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 
 	if (is_apicv_advanced_feature_supported()) {
 		value32 |= VMX_PROCBASED_CTLS2_VIRQ;
+		value32 |= VMX_PROCBASED_CTLS2_VAPIC_REGS;
 	} else {
 		/*
 		 * This field exists only on processors that support
@@ -601,9 +602,10 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 		exec_vmwrite32(VMX_TPR_THRESHOLD, 0U);
 
 		value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS2);
-		value32 &= ~VMX_PROCBASED_CTLS2_VAPIC_REGS;
+		value32 &= ~VMX_PROCBASED_CTLS2_VAPIC;
 		if (is_apicv_advanced_feature_supported()) {
 			value32 &= ~VMX_PROCBASED_CTLS2_VIRQ;
+			value32 &= ~VMX_PROCBASED_CTLS2_VAPIC_REGS;
 		}
 		exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS2, value32);
 


### PR DESCRIPTION
    1) Shouldn't try to set APIC-register virtualization if the physical doesn't
    support APICV advanced mode.
    2) Remove all APICv features VMCS setting when LAPIC is passed through to guest.

    However, if emulated this in MRB board, the android can't boot because when switch to trusty world, 
    it will check  "Delivery Status" in ICR first. It turns out that this Bit Test instruction is not emulated  
    correctly.  This's because not every instruction supports the operand-size bit (w). This patch try to 
    correct what done in commit-id 9df8790 by setting a flag VIE_OP_F_BYTE_OP to indicate which
    instruction supports the operand-size bit (w).

    Tracked-On: #1842
    Signed-off-by: Li, Fei1 <fei1.li@intel.com>