### PR TITLE
hv: vlapic: add encapsulation APIs for APICv operation

### DIFF
--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -94,9 +94,6 @@ an interrupt, for example:
 
 These APIs will finish by making a request for *ACRN_REQUEST_EVENT.*
 
-.. doxygenfunction:: vlapic_get_deliverable_intr
-  :project: Project ACRN
-
 .. doxygenfunction:: vlapic_find_deliverable_intr
   :project: Project ACRN
 

--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -94,9 +94,6 @@ an interrupt, for example:
 
 These APIs will finish by making a request for *ACRN_REQUEST_EVENT.*
 
-.. doxygenfunction:: vlapic_find_deliverable_intr
-  :project: Project ACRN
-
 .. doxygenfunction:: vlapic_set_local_intr
   :project: Project ACRN
 

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -165,6 +165,8 @@ static void detect_apicv_cap(void)
 	}
 
 	cpu_caps.apicv_features = features;
+
+	vlapic_set_apicv_ops();
 }
 
 static void detect_vmx_mmu_cap(void)

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1353,7 +1353,7 @@ static inline uint32_t vlapic_find_highest_irr(const struct acrn_vlapic *vlapic)
  *	   result of calling this function.
  *	   This function is only for case that APICv/VID is NOT supported.
  */
-bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr)
+static bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr)
 {
 	const struct lapic_regs *lapic = &(vlapic->apic_page);
 	uint32_t vec;
@@ -2313,6 +2313,30 @@ bool vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool
 	return apicv_ops->inject_intr(vlapic, guest_irq_enabled, injected);
 }
 
+static bool apicv_basic_has_pending_delivery_intr(struct acrn_vcpu *vcpu)
+{
+	uint32_t vector;
+	struct acrn_vlapic *vlapic = vcpu_vlapic(vcpu);
+
+	/* check and raise request if we have a deliverable irq in LAPIC IRR */
+	if (vlapic_find_deliverable_intr(vlapic, &vector)) {
+		/* we have pending IRR */
+		vcpu_make_request(vcpu, ACRN_REQUEST_EVENT);
+	}
+
+	return vcpu->arch.pending_req != 0UL;
+}
+
+static bool apicv_advanced_has_pending_delivery_intr(__unused struct acrn_vcpu *vcpu)
+{
+	return false;
+}
+
+bool vlapic_has_pending_delivery_intr(struct acrn_vcpu *vcpu)
+{
+	return apicv_ops->has_pending_delivery_intr(vcpu);
+}
+
 int32_t apic_access_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	int32_t err = 0;
@@ -2505,11 +2529,13 @@ int32_t tpr_below_threshold_vmexit_handler(struct acrn_vcpu *vcpu)
 static const struct acrn_apicv_ops apicv_basic_ops = {
 	.accept_intr = apicv_basic_accept_intr,
 	.inject_intr = apicv_basic_inject_intr,
+	.has_pending_delivery_intr = apicv_basic_has_pending_delivery_intr,
 };
 
 static const struct acrn_apicv_ops apicv_advanced_ops = {
 	.accept_intr = apicv_advanced_accept_intr,
 	.inject_intr = apicv_advanced_inject_intr,
+	.has_pending_delivery_intr = apicv_advanced_has_pending_delivery_intr,
 };
 
 /*

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -86,6 +86,10 @@ struct acrn_apicv_ops {
 	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
 	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 	bool (*has_pending_delivery_intr)(struct acrn_vcpu *vcpu);
+	bool (*apic_read_access_may_valid)(uint32_t offset);
+	bool (*apic_write_access_may_valid)(uint32_t offset);
+	bool (*x2apic_read_msr_may_valid)(uint32_t offset);
+	bool (*x2apic_write_msr_may_valid)(uint32_t offset);
 };
 
 #endif /* VLAPIC_PRIV_H */

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -84,6 +84,7 @@
 
 struct acrn_apicv_ops {
 	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
+	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 };
 
 #endif /* VLAPIC_PRIV_H */

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -85,6 +85,7 @@
 struct acrn_apicv_ops {
 	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
 	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
+	bool (*has_pending_delivery_intr)(struct acrn_vcpu *vcpu);
 };
 
 #endif /* VLAPIC_PRIV_H */

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -82,4 +82,8 @@
 #define APIC_OFFSET_TIMER_DCR	0x3E0U	/* Timer's Divide Configuration	*/
 #define APIC_OFFSET_SELF_IPI    0x3F0U  /* Self IPI Register */
 
+struct acrn_apicv_ops {
+	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
+};
+
 #endif /* VLAPIC_PRIV_H */

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -110,6 +110,7 @@ struct acrn_vlapic {
 	uint32_t	lvt_last[VLAPIC_MAXLVT_INDEX + 1];
 } __aligned(PAGE_SIZE);
 
+void vlapic_set_apicv_ops(void);
 
 /**
  * @brief virtual LAPIC

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -119,23 +119,8 @@ void vlapic_set_apicv_ops(void);
  * @{
  */
 
-
-/**
- * @brief Find a deliverable virtual interrupts for vLAPIC in irr.
- *
- * @param[in]    vlapic Pointer to target vLAPIC data structure
- * @param[inout] vecptr Pointer to vector buffer and will be filled
- *               with eligible vector if any.
- *
- * @retval false There is no deliverable pending vector.
- * @retval true There is deliverable vector.
- *
- * @remark The vector does not automatically transition to the ISR as a
- *	   result of calling this function.
- */
-bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
-
 bool vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
+bool vlapic_has_pending_delivery_intr(struct acrn_vcpu *vcpu);
 
 /**
  * @brief Get physical address to PIR description.

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -135,22 +135,7 @@ void vlapic_set_apicv_ops(void);
  */
 bool vlapic_find_deliverable_intr(const struct acrn_vlapic *vlapic, uint32_t *vecptr);
 
-/**
- * @brief Get a deliverable virtual interrupt from irr to isr.
- *
- * Transition 'vector' from IRR to ISR. This function is called with the
- * vector returned by 'vlapic_find_deliverable_intr()' when the guest is able to
- * accept this interrupt (i.e. RFLAGS.IF = 1 and no conditions exist that
- * block interrupt delivery).
- *
- * @param[in] vlapic Pointer to target vLAPIC data structure
- * @param[in] vector Target virtual interrupt vector
- *
- * @return None
- *
- * @pre vlapic != NULL
- */
-void vlapic_get_deliverable_intr(struct acrn_vlapic *vlapic, uint32_t vector);
+bool vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 
 /**
  * @brief Get physical address to PIR description.
@@ -231,7 +216,6 @@ void vlapic_reset(struct acrn_vlapic *vlapic);
 void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs);
 uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);
-void vlapic_apicv_inject_pir(struct acrn_vlapic *vlapic);
 int32_t apic_access_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -567,31 +567,6 @@ static inline bool is_x2apic_msr(uint32_t msr)
 	return ((msr >= 0x800U) && (msr < 0x900U));
 }
 
-static inline bool is_x2apic_read_only_msr(uint32_t msr)
-{
-	bool ret = false;
-
-	if ((msr == MSR_IA32_EXT_XAPICID) ||
-		(msr == MSR_IA32_EXT_APIC_VERSION) ||
-		(msr == MSR_IA32_EXT_APIC_PPR) ||
-		(msr == MSR_IA32_EXT_APIC_LDR) ||
-		((msr >= MSR_IA32_EXT_APIC_ISR0) &&
-		(msr <= MSR_IA32_EXT_APIC_IRR7)) ||
-		(msr == MSR_IA32_EXT_APIC_CUR_COUNT)) {
-		ret = true;
-	}
-	return ret;
-}
-
-static inline bool is_x2apic_write_only_msr(uint32_t msr)
-{
-	bool ret = false;
-	if ((msr == MSR_IA32_EXT_APIC_EOI) || (msr == MSR_IA32_EXT_APIC_SELF_IPI)) {
-		ret = true;
-	}
-	return ret;
-}
-
 struct acrn_vcpu;
 
 void init_msr_emulation(struct acrn_vcpu *vcpu);

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -561,14 +561,10 @@ static inline bool pat_mem_type_invalid(uint64_t x)
 
 static inline bool is_x2apic_msr(uint32_t msr)
 {
-	bool ret = false;
 	/*
 	 * if msr is in the range of x2APIC MSRs
 	 */
-	if ((msr >= MSR_IA32_EXT_XAPICID) && (msr <= MSR_IA32_EXT_APIC_SELF_IPI)) {
-		ret = true;
-	}
-	return ret;
+	return ((msr >= 0x800U) && (msr < 0x900U));
 }
 
 static inline bool is_x2apic_read_only_msr(uint32_t msr)


### PR DESCRIPTION
v1-v2:
1) rebase the code

v1:
ACRN will always requires to support basic APICv features ("Use TPR
shadow", "Virtualize APIC accesses"
and "Virtualize x2APIC mode"). If fully APICv features (besides the basic
features, plus "Virtual-interrupt delivery", "APIC-register virtualization" and
"Process posted interrupts") is supported, we enable fully APICv features
which names apicv advanced mode. Otherwise, we will draw back to apicv
basic mode which only enable basic APICv features.
Once the APICv features is detected in a platform, the APICv operation is
decided. We don't need to do the check on runtimes.
These patch tries to simplfy the code by (1) the default APICv operations is
used for APICV basic mode (2) once the APICv features are detected in the
platform when booting, the APICv operations will switch to used for APICv
advanced mode. Then the code could call the APICv operation directly no
matter which APICv mode we're using.

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
