### PR TITLE
hv: check vm state before creating a VM

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -308,6 +308,7 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 
 /**
  * @pre vm_id < CONFIG_MAX_VM_NUM && vm_config != NULL && rtn_vm != NULL
+ * @pre vm->state == VM_STATE_INVALID
  */
 int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_vm **rtn_vm)
 {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -154,7 +154,8 @@ int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param)
 	(void)memset((void *)&cv, 0U, sizeof(cv));
 	if (copy_from_gpa(vm, &cv, param, sizeof(cv)) == 0) {
 		vm_id = get_vmid_by_uuid(&cv.uuid[0]);
-		if (vm_id < CONFIG_MAX_VM_NUM) {
+		if ((vm_id < CONFIG_MAX_VM_NUM)
+			&& (!is_valid_vm(get_vm_from_vmid(vm_id)))) {
 			vm_config = get_vm_config(vm_id);
 			vm_config->guest_flags |= cv.vm_flag;
 


### PR DESCRIPTION
If launch two UOS with same UUID by acrn-dm, current code path will
return same VM instance to the acrn-dm, this will crash the two UOS.

Check VM state and make sure it's in VM_STATE_INVALID state before
creating a VM.

Tracked-On: #2984
Signed-off-by: Cai Yulong <yulongc@hwtc.com.cn>