### PR TITLE
Fix the bug about failing to boot normal vm on the pcpu which ever run lapic_pt vm

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -107,14 +107,6 @@ config LOG_DESTINATION
 	  are 3 destinations available. Bit 0 represents the serial console, bit
 	  1 the SOS ACRN log and bit 2 NPK log. Effective only in debug builds.
 
-config CPU_UP_TIMEOUT
-	int "Timeout in ms when bringing up secondary CPUs"
-	range 100 200
-	default 100
-	help
-	  A 32-bit integer specifying the timeout in millisecond when waiting
-	  for secondary CPUs to start up.
-
 choice
 	prompt "Serial IO type"
 	depends on !RELEASE

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -27,6 +27,9 @@
 #include <cat.h>
 #include <firmware.h>
 
+#define CPU_UP_TIMEOUT		100U /* millisecond */
+#define CPU_DOWN_TIMEOUT	100U /* millisecond */
+
 struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM] __aligned(PAGE_SIZE);
 static uint16_t phys_cpu_num = 0U;
 static uint64_t pcpu_sync = 0UL;
@@ -273,7 +276,7 @@ static void start_cpu(uint16_t pcpu_id)
 	/* Wait until the pcpu with pcpu_id is running and set the active bitmap or
 	 * configured time-out has expired
 	 */
-	timeout = (uint32_t)CONFIG_CPU_UP_TIMEOUT * 1000U;
+	timeout = CPU_UP_TIMEOUT * 1000U;
 	while (!is_pcpu_active(pcpu_id) && (timeout != 0U)) {
 		/* Delay 10us */
 		udelay(10U);
@@ -317,7 +320,6 @@ void stop_cpus(void)
 	uint16_t pcpu_id, expected_up;
 	uint32_t timeout;
 
-	timeout = (uint32_t)CONFIG_CPU_UP_TIMEOUT * 1000U;
 	for (pcpu_id = 0U; pcpu_id < phys_cpu_num; pcpu_id++) {
 		if (get_cpu_id() == pcpu_id) {	/* avoid offline itself */
 			continue;
@@ -327,6 +329,7 @@ void stop_cpus(void)
 	}
 
 	expected_up = 1U;
+	timeout = CPU_DOWN_TIMEOUT * 1000U;
 	while ((atomic_load16(&up_count) != expected_up) && (timeout != 0U)) {
 		/* Delay 10us */
 		udelay(10U);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -447,6 +447,7 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 {
 	uint16_t i;
 	struct acrn_vcpu *vcpu = NULL;
+	struct acrn_vm_config *vm_config = NULL;
 	int32_t ret;
 
 	pause_vm(vm);
@@ -459,6 +460,9 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 			reset_vcpu(vcpu);
 			offline_vcpu(vcpu);
 		}
+
+		vm_config = get_vm_config(vm->vm_id);
+		vm_config->guest_flags &= ~DM_OWNED_GUEST_FLAG_MASK;
 
 		ptdev_release_all_entries(vm);
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -446,9 +446,10 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 int32_t shutdown_vm(struct acrn_vm *vm)
 {
 	uint16_t i;
+	uint64_t mask = 0UL;
 	struct acrn_vcpu *vcpu = NULL;
 	struct acrn_vm_config *vm_config = NULL;
-	int32_t ret;
+	int32_t ret = 0;
 
 	pause_vm(vm);
 
@@ -459,6 +460,18 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 		foreach_vcpu(i, vm, vcpu) {
 			reset_vcpu(vcpu);
 			offline_vcpu(vcpu);
+
+			if (is_lapic_pt(vm)) {
+				bitmap_set_nolock(vcpu->pcpu_id, &mask);
+				make_pcpu_offline(vcpu->pcpu_id);
+			}
+		}
+
+		wait_pcpus_offline(mask);
+
+		if (is_lapic_pt(vm) && !start_cpus(mask)) {
+			pr_fatal("Failed to start all cpus in mask(0x%llx)", mask);
+			ret = -ETIMEDOUT;
 		}
 
 		vm_config = get_vm_config(vm->vm_id);

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -20,6 +20,8 @@
  #include <lapic.h>
  #include <vcpu.h>
 
+#define AP_MASK		(((1UL << get_pcpu_nums()) - 1UL) & ~(1UL << 0U))
+
 struct cpu_context cpu_ctx;
 
 /* The values in this structure should come from host ACPI table */
@@ -186,5 +188,7 @@ void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, u
 	clac();
 
 	/* online all APs again */
-	start_cpus();
+	if (!start_cpus(AP_MASK)) {
+		panic("Failed to start all APs!");
+	}
 }

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -156,7 +156,9 @@ int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param)
 		vm_id = get_vmid_by_uuid(&cv.uuid[0]);
 		if (vm_id < CONFIG_MAX_VM_NUM) {
 			vm_config = get_vm_config(vm_id);
-			vm_config->guest_flags |= cv.vm_flag;
+
+			/* Filter out the bits should not set by DM and then assign it to guest_flags */
+			vm_config->guest_flags |= (cv.vm_flag & DM_OWNED_GUEST_FLAG_MASK);
 
 			/* GUEST_FLAG_RT must be set if we have GUEST_FLAG_LAPIC_PASSTHROUGH set in guest_flags */
 			if (((vm_config->guest_flags & GUEST_FLAG_LAPIC_PASSTHROUGH) != 0U)

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -259,7 +259,7 @@ void trampoline_start16(void);
 void load_cpu_state_data(void);
 void init_cpu_pre(uint16_t pcpu_id_args);
 void init_cpu_post(uint16_t pcpu_id);
-void start_cpus(void);
+bool start_cpus(uint64_t mask);
 void stop_cpus(void);
 void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -260,6 +260,7 @@ void load_cpu_state_data(void);
 void init_cpu_pre(uint16_t pcpu_id_args);
 void init_cpu_post(uint16_t pcpu_id);
 bool start_cpus(uint64_t mask);
+void wait_pcpus_offline(uint64_t mask);
 void stop_cpus(void);
 void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 

--- a/hypervisor/include/lib/errno.h
+++ b/hypervisor/include/lib/errno.h
@@ -23,5 +23,7 @@
 #define ENODEV		19
 /** Indicates that argument is not valid. */
 #define EINVAL		22
+/** Indicates that timeout occurs. */
+#define ETIMEDOUT	110
 
 #endif /* ERRNO_H */

--- a/hypervisor/scenarios/logical_partition/vm_configurations.h
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.h
@@ -7,6 +7,9 @@
 #ifndef VM_CONFIGURATIONS_H
 #define VM_CONFIGURATIONS_H
 
+/* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
+#define DM_OWNED_GUEST_FLAG_MASK	0UL
+
 #define CONFIG_MAX_VM_NUM	2U
 
 /* The VM CONFIGs like:

--- a/hypervisor/scenarios/sdc/vm_configurations.h
+++ b/hypervisor/scenarios/sdc/vm_configurations.h
@@ -9,4 +9,9 @@
 
 #define CONFIG_MAX_VM_NUM	2U
 
+/* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
+#define DM_OWNED_GUEST_FLAG_MASK	(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | \
+						GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING)
+
+
 #endif /* VM_CONFIGURATIONS_H */


### PR DESCRIPTION
This patchset aims at fixing the following issues:
 - There will be some DM set flags remained after shutdown the vm. This patchset fix it by clear
   all DM set flags when shutdown the vm.

 - Since lapic is passthroughed to guest, there may be wrong lapic state after lapic_pt vm shutdown.
   For example, the lapic will disabled by linux guest when shutdown and we can't boot one normal
   vm successfully in this situation. This patchset fix by reset all physical cores when shutdown
   lapic_pt vm.

Tracked-On: #2991
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>