### PR TITLE
Completely remove enable_bar()/disable_bar() functions

### DIFF
--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -33,7 +33,6 @@
  */
 
 #include <errno.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -51,7 +50,6 @@ struct mmio_rb_range {
 	struct mem_range	mr_param;
 	uint64_t                mr_base;
 	uint64_t                mr_end;
-	bool			enabled;
 };
 
 static RB_HEAD(mmio_rb_tree, mmio_rb_range) mmio_rb_root, mmio_rb_fallback;
@@ -168,24 +166,17 @@ emulate_mem(struct vmctx *ctx, struct mmio_request *mmio_req)
 	if (mmio_hint && paddr >= mmio_hint->mr_base &&
 			paddr <= mmio_hint->mr_end)
 		entry = mmio_hint;
-
-	if (entry == NULL) {
-		if (mmio_rb_lookup(&mmio_rb_root, paddr, &entry) == 0)
-			/* Update the per-VMU cache */
-			mmio_hint = entry;
-		else if (mmio_rb_lookup(&mmio_rb_fallback, paddr, &entry)) {
-			pthread_rwlock_unlock(&mmio_rwlock);
-			return -ESRCH;
-		}
+	else if (mmio_rb_lookup(&mmio_rb_root, paddr, &entry) == 0)
+		/* Update the per-VM cache */
+		mmio_hint = entry;
+	else if (mmio_rb_lookup(&mmio_rb_fallback, paddr, &entry)) {
+		pthread_rwlock_unlock(&mmio_rwlock);
+		return -ESRCH;
 	}
+
+	pthread_rwlock_unlock(&mmio_rwlock);
 
 	assert(entry != NULL);
-
-	if (entry->enabled == false) {
-		pthread_rwlock_unlock(&mmio_rwlock);
-		return -1;
-	}
-	pthread_rwlock_unlock(&mmio_rwlock);
 
 	if (mmio_req->direction == REQUEST_READ)
 		err = mem_read(ctx, 0, paddr, (uint64_t *)&mmio_req->value,
@@ -195,68 +186,6 @@ emulate_mem(struct vmctx *ctx, struct mmio_request *mmio_req)
 				size, &entry->mr_param);
 
 	return err;
-}
-
-int
-disable_mem(struct mem_range *memp)
-{
-	uint64_t paddr = memp->base;
-	struct mmio_rb_range *entry = NULL;
-
-	pthread_rwlock_rdlock(&mmio_rwlock);
-	/*
-	 * First check the per-VM cache
-	 */
-	if (mmio_hint && paddr >= mmio_hint->mr_base &&
-			paddr <= mmio_hint->mr_end)
-		entry = mmio_hint;
-
-	if (entry == NULL) {
-		if (mmio_rb_lookup(&mmio_rb_root, paddr, &entry) == 0)
-			/* Update the per-VMU cache */
-			mmio_hint = entry;
-		else if (mmio_rb_lookup(&mmio_rb_fallback, paddr, &entry)) {
-			pthread_rwlock_unlock(&mmio_rwlock);
-			return -ESRCH;
-		}
-	}
-
-	assert(entry != NULL);
-	entry->enabled = false;
-	pthread_rwlock_unlock(&mmio_rwlock);
-
-	return 0;
-}
-
-int
-enable_mem(struct mem_range *memp)
-{
-	uint64_t paddr = memp->base;
-	struct mmio_rb_range *entry = NULL;
-
-	pthread_rwlock_rdlock(&mmio_rwlock);
-	/*
-	 * First check the per-VM cache
-	 */
-	if (mmio_hint && paddr >= mmio_hint->mr_base &&
-			paddr <= mmio_hint->mr_end)
-		entry = mmio_hint;
-
-	if (entry == NULL) {
-		if (mmio_rb_lookup(&mmio_rb_root, paddr, &entry) == 0)
-			/* Update the per-VMU cache */
-			mmio_hint = entry;
-		else if (mmio_rb_lookup(&mmio_rb_fallback, paddr, &entry)) {
-			pthread_rwlock_unlock(&mmio_rwlock);
-			return -ESRCH;
-		}
-	}
-
-	assert(entry != NULL);
-	entry->enabled = true;
-	pthread_rwlock_unlock(&mmio_rwlock);
-
-	return 0;
 }
 
 static int
@@ -273,7 +202,6 @@ register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 		mrp->mr_param = *memp;
 		mrp->mr_base = memp->base;
 		mrp->mr_end = memp->base + memp->size - 1;
-		mrp->enabled = true;
 		pthread_rwlock_wrlock(&mmio_rwlock);
 		if (mmio_rb_lookup(rbt, memp->base, &entry) != 0)
 			err = mmio_rb_add(rbt, mrp);

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -542,25 +542,25 @@ register_bar(struct pci_vdev *dev, int idx)
 }
 
 /* Are we decoding i/o port accesses for the emulated pci device? */
-static int
+static bool
 porten(struct pci_vdev *dev)
 {
 	uint16_t cmd;
 
 	cmd = pci_get_cfgdata16(dev, PCIR_COMMAND);
 
-	return (cmd & PCIM_CMD_PORTEN);
+	return (cmd & PCIM_CMD_PORTEN) != 0;
 }
 
 /* Are we decoding memory accesses for the emulated pci device? */
-static int
+static bool
 memen(struct pci_vdev *dev)
 {
 	uint16_t cmd;
 
 	cmd = pci_get_cfgdata16(dev, PCIR_COMMAND);
 
-	return (cmd & PCIM_CMD_MEMEN);
+	return (cmd & PCIM_CMD_MEMEN) != 0;
 }
 
 /*
@@ -570,9 +570,9 @@ memen(struct pci_vdev *dev)
  * the address range decoded by the BAR register.
  */
 static void
-update_bar_address(struct  pci_vdev *dev, uint64_t addr, int idx, int type)
+update_bar_address(struct pci_vdev *dev, uint64_t addr, int idx, int type)
 {
-	int decode;
+	bool decode;
 
 	if (dev->bar[idx].type == PCIBAR_IO)
 		decode = porten(dev);
@@ -671,7 +671,7 @@ pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx, uint64_t hostbase,
 		lobits = PCIM_BAR_MEM_SPACE | PCIM_BAR_MEM_32;
 		break;
 	default:
-		printf("pci_emul_alloc_base: invalid bar type %d\n", type);
+		printf("%s: invalid bar type %d\n", __func__, type);
 		assert(0);
 	}
 
@@ -703,7 +703,8 @@ pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx, uint64_t hostbase,
 void
 pci_emul_free_bars(struct pci_vdev *pdi)
 {
-	int i, enabled;
+	int i;
+	bool enabled;
 
 	for (i = 0; i < PCI_BARMAX; i++) {
 		if ((pdi->bar[i].type != PCIBAR_NONE) &&

--- a/devicemodel/include/inout.h
+++ b/devicemodel/include/inout.h
@@ -74,7 +74,5 @@ void	init_inout(void);
 int	emulate_inout(struct vmctx *ctx, int *pvcpu, struct pio_request *req);
 int	register_inout(struct inout_port *iop);
 int	unregister_inout(struct inout_port *iop);
-int	enable_inout(struct inout_port *iop);
-int	disable_inout(struct inout_port *iop);
 
 #endif	/* _INOUT_H_ */

--- a/devicemodel/include/mem.h
+++ b/devicemodel/include/mem.h
@@ -42,16 +42,13 @@ struct mem_range {
 	long		arg2;
 	uint64_t	base;
 	uint64_t	size;
-	bool		enabled;
 };
 #define	MEM_F_READ		0x1
 #define	MEM_F_WRITE		0x2
-#define	MEM_F_RW		0x3
+#define	MEM_F_RW		(MEM_F_READ | MEM_F_WRITE)
 #define	MEM_F_IMMUTABLE		0x4	/* mem_range cannot be unregistered */
 
 int	emulate_mem(struct vmctx *ctx, struct mmio_request *mmio_req);
-int	disable_mem(struct mem_range *memp);
-int	enable_mem(struct mem_range *memp);
 int	register_mem(struct mem_range *memp);
 int	register_mem_fallback(struct mem_range *memp);
 int	unregister_mem(struct mem_range *memp);


### PR DESCRIPTION
Following up on d648df766c263512c93356a55ff97cb3e23fe3e4, surgically remove all the functions related to enable_bar()/disable_bar() that got introduced in 8787b65fdee622639925ad75fe920913e0e7f102.

Also, make accesses to mmio_hint in mem.c thread-safe because it can potentially be accessed concurrently in emulate_mem().

Tracked-On: #2902
Signed-off-by: Peter Fang <peter.fang@intel.com>
Reviewed-by: Shuo A Liu <shuo.a.liu@intel.com>