### PR TITLE
HV: check vm id param when dispatching hypercall

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -47,9 +47,12 @@ uint16_t get_vmid_by_uuid(const uint8_t *uuid)
 	return vm_id;
 }
 
+/**
+ * @pre vm != NULL
+ */
 bool is_valid_vm(const struct acrn_vm *vm)
 {
-	return (vm != NULL) && (vm->state != VM_STATE_INVALID);
+	return (vm->state != VM_STATE_INVALID);
 }
 
 bool is_sos_vm(const struct acrn_vm *vm)

--- a/hypervisor/debug/vuart.c
+++ b/hypervisor/debug/vuart.c
@@ -428,11 +428,11 @@ struct acrn_vuart *vuart_console_active(void)
 
 	if (console_vmid < CONFIG_MAX_VM_NUM) {
 		vm = get_vm_from_vmid(console_vmid);
+		if (is_valid_vm(vm)) {
+			vu = vm_console_vuart(vm);
+		}
 	}
 
-	if (is_valid_vm(vm)) {
-		vu = vm_console_vuart(vm);
-	}
 	return (vu && vu->active) ? vu : NULL;
 }
 


### PR DESCRIPTION
If the vmcall param passed from guest is representing a vmid, we should
make sure it is a valid one because it is a pre-condition of following
get_vm_from_vmid(). And then we don't need to do NULL VM pointer check
in is_valid_vm() because get_vm_from_vmid() would never return NULL.

Tracked-On: #2978

Signed-off-by: Victor Sun <victor.sun@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>