### PR TITLE
dm: fix possible null pointer dereference in pci_gvt_deinit

### DIFF
--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -262,18 +262,20 @@ pci_gvt_deinit(struct vmctx *ctx, struct pci_vdev *pi, char *opts)
 	int ret;
 	struct pci_gvt *gvt = pi->arg;
 
-	if (gvt && gvt->host_config) {
-		/* Free the allocated host_config */
-		free(gvt->host_config);
-		gvt->host_config = NULL;
+	if (gvt) {
+		if (gvt->host_config) {
+			/* Free the allocated host_config */
+			free(gvt->host_config);
+			gvt->host_config = NULL;
+		}
+
+		ret = gvt_destroy_instance(gvt);
+		if (ret)
+			WPRINTF(("GVT: %s: failed: errno=%d\n", __func__, ret));
+
+		free(gvt);
+		pi->arg = NULL;
 	}
-
-	ret = gvt_destroy_instance(gvt);
-	if (ret)
-		WPRINTF(("GVT: %s: failed: errno=%d\n", __func__, ret));
-
-	free(gvt);
-	pi->arg = NULL;
 }
 
 struct pci_vdev_ops pci_ops_gvt = {


### PR DESCRIPTION
  will access null pointer if 'gvt' is null.

Tracked-On: #1479
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: He, Min <min.he@intel.com>