### PR TITLE
Fix some potential overflow

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -1571,13 +1571,14 @@ print_virtio_gpio_info(struct virtio_gpio_request *req,
 		struct virtio_gpio_response *rsp, bool in)
 {
 	const char *item;
-	const char *const cmd_map[] = {
+	const char *const cmd_map[GPIO_REQ_MAX + 1] = {
 		"GPIO_REQ_SET_VALUE",
 		"GPIO_REQ_GET_VALUE",
 		"GPIO_REQ_INPUT_DIRECTION",
 		"GPIO_REQ_OUTPUT_DIRECTION",
 		"GPIO_REQ_GET_DIRECTION",
 		"GPIO_REQ_SET_CONFIG",
+		"GPIO_REQ_MAX",
 	};
 
 	if (req->cmd == GPIO_REQ_SET_VALUE || req->cmd == GPIO_REQ_GET_VALUE)

--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -455,6 +455,7 @@ static inline int del_runC(char *argv)
 		return -1;
 	}
 	shell_cmd(cmd, cmd_out, sizeof(cmd_out));
+	cmd_out[PATH_LEN * 2 - 1] = '\0';
 	if (strstr(cmd_out, argv) != NULL) {
 		/* If the container is still running stop it by runc pause */
 		if (strstr(cmd_out, "stopped") == NULL) {


### PR DESCRIPTION
explicitly initialize the cmd_cap string array.

Tracked-On: #3001
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>