### PR TITLE
vlapic: refine IPI broadcast to support x2APIC mode

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -89,7 +89,7 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	dest = info->vmsi_addr.bits.dest_field;
 	phys = (info->vmsi_addr.bits.dest_mode == MSI_ADDR_DESTMODE_PHYS);
 
-	vlapic_calc_dest(vm, &vdmask, dest, phys, false);
+	vlapic_calc_dest(vm, &vdmask, false, dest, phys, false);
 	pdmask = vcpumask2pcpumask(vm, vdmask);
 
 	/* get physical delivery mode */
@@ -183,7 +183,7 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		/* physical destination cpu mask */
 		phys = (virt_rte.bits.dest_mode == IOAPIC_RTE_DESTMODE_PHY);
 		dest = (uint32_t)virt_rte.bits.dest_field;
-		vlapic_calc_dest(vm, &vdmask, dest, phys, false);
+		vlapic_calc_dest(vm, &vdmask, false, dest, phys, false);
 		pdmask = vcpumask2pcpumask(vm, vdmask);
 
 		/* physical delivery mode */

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -432,7 +432,7 @@ static void inject_msi_lapic_pt(struct acrn_vm *vm, const struct acrn_msi_entry 
 		 * the delivery mode of vmsi will be forwarded to ICR delievry field
 		 * and handled by hardware.
 		 */
-		vlapic_calc_dest_lapic_pt(vm, &vdmask, vdest, phys);
+		vlapic_calc_dest_lapic_pt(vm, &vdmask, false, vdest, phys);
 		dev_dbg(ACRN_DBG_LAPICPT, "%s: vcpu destination mask 0x%016llx", __func__, vdmask);
 
 		vcpu_id = ffs64(vdmask);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -206,8 +206,10 @@ int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu);
 void vlapic_update_tpr_threshold(const struct acrn_vlapic *vlapic);
 int32_t tpr_below_threshold_vmexit_handler(struct acrn_vcpu *vcpu);
-void vlapic_calc_dest(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys, bool lowprio);
-void vlapic_calc_dest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, uint32_t dest, bool phys);
+void vlapic_calc_dest(struct acrn_vm *vm, uint64_t *dmask, bool is_broadcast,
+		uint32_t dest, bool phys, bool lowprio);
+void vlapic_calc_dest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, bool is_broadcast,
+		uint32_t dest, bool phys);
 
 /**
  * @}


### PR DESCRIPTION
According to SDM 10.6.1, if dest fields is 0xffU for register
ICR operation, that means the IPI is for broadcast.

According to SDM 10.12.9, 0xffffffffU of dest fields for x2APIC
means IPI is for broadcast.

We add new parameter to vlapic_calc_dest() to show whether the
dest is for broadcast. For IPI, we will set it according to
dest fields. For ioapic and MSI, we hardcode it to false because
no broadcast for ioapic and MSI.

Tracked-On: #3003
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>