### PR TITLE
HV: Add prefix 'p' before 'cpu' to physical cpu related functions

### DIFF
--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -162,7 +162,7 @@ after:
     mov     %eax,%gs  // Was 32bit POC CLS
 
    /* continue with chipset level initialization */
-   call     init_primary_cpu
+   call     init_primary_pcpu
 
 loop:
     jmp loop

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -33,7 +33,7 @@
  * the macros involved are changed.
  */
 
-    .extern     init_secondary_cpu
+    .extern     init_secondary_pcpu
 
     .section     .trampoline_reset,"ax"
 
@@ -160,7 +160,7 @@ trampoline_start64:
     .align  8
     .global main_entry
 main_entry:
-    .quad   init_secondary_cpu /* default entry is AP start entry */
+    .quad   init_secondary_pcpu /* default entry is AP start entry */
 
     .global secondary_cpu_stack
 secondary_cpu_stack:

--- a/hypervisor/arch/x86/cat.c
+++ b/hypervisor/arch/x86/cat.c
@@ -22,7 +22,7 @@ int32_t init_cat_cap_info(void)
 	uint32_t eax = 0U, ebx = 0U, ecx = 0U, edx = 0U;
 	int32_t ret = 0;
 
-	if (cpu_has_cap(X86_FEATURE_CAT)) {
+	if (pcpu_has_cap(X86_FEATURE_CAT)) {
 		cpuid_subleaf(CPUID_RSD_ALLOCATION, 0, &eax, &ebx, &ecx, &edx);
 		/* If support L3 CAT, EBX[1] is set */
 		if ((ebx & 2U) != 0U) {

--- a/hypervisor/arch/x86/cpu_state_tbl.c
+++ b/hypervisor/arch/x86/cpu_state_tbl.c
@@ -131,11 +131,11 @@ struct cpu_state_info *get_cpu_pm_state_info(void)
 	return &cpu_pm_state_info;
 }
 
-void load_cpu_state_data(void)
+void load_pcpu_state_data(void)
 {
 	int32_t tbl_idx;
 	const struct cpu_state_info *state_info;
-	struct cpuinfo_x86 *cpu_info = get_cpu_info();
+	struct cpuinfo_x86 *cpu_info = get_pcpu_info();
 
 	(void)memset(&cpu_pm_state_info, 0U, sizeof(struct cpu_state_info));
 

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -37,7 +37,7 @@ uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 	const uint64_t *pgentry;
 	uint64_t pg_size = 0UL;
 	void *eptp;
-	struct acrn_vcpu *vcpu = vcpu_from_pid(vm, get_cpu_id());
+	struct acrn_vcpu *vcpu = vcpu_from_pid(vm, get_pcpu_id());
 
 	if ((vcpu != NULL) && (vcpu->arch.cur_context == SECURE_WORLD)) {
 		eptp = vm->arch_vm.sworld_eptp;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -596,7 +596,7 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 
 void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 
 	pr_dbg("vcpu%hu paused, new state: %d",
 		vcpu->vcpu_id, new_state);

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -136,7 +136,7 @@ static void init_vcpuid_entry(uint32_t leaf, uint32_t subleaf,
 		break;
 
 	case 0x16U:
-		cpu_info = get_cpu_info();
+		cpu_info = get_pcpu_info();
 		if (cpu_info->cpuid_level >= 0x16U) {
 			/* call the cpuid when 0x16 is supported */
 			cpuid_subleaf(leaf, subleaf, &entry->eax, &entry->ebx, &entry->ecx, &entry->edx);
@@ -199,7 +199,7 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 	struct vcpuid_entry entry;
 	uint32_t limit;
 	uint32_t i, j;
-	struct cpuinfo_x86 *cpu_info = get_cpu_info();
+	struct cpuinfo_x86 *cpu_info = get_pcpu_info();
 
 	init_vcpuid_entry(0U, 0U, 0U, &entry);
 	if (cpu_info->cpuid_level < 0x16U) {
@@ -407,7 +407,7 @@ void guest_cpuid(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t 
 			break;
 
 		case 0x0dU:
-			if (!cpu_has_cap(X86_FEATURE_OSXSAVE)) {
+			if (!pcpu_has_cap(X86_FEATURE_OSXSAVE)) {
 				*eax = 0U;
 				*ebx = 0U;
 				*ecx = 0U;

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -116,7 +116,7 @@ void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid)
 	 *  scheduling, we need change here to determine it target vcpu is
 	 *  VMX non-root or root mode
 	 */
-	if (get_cpu_id() != vcpu->pcpu_id) {
+	if (get_pcpu_id() != vcpu->pcpu_id) {
 		send_single_ipi(vcpu->pcpu_id, VECTOR_NOTIFY_VCPU);
 	}
 }

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -528,7 +528,7 @@ static void apicv_advanced_accept_intr(struct acrn_vlapic *vlapic, uint32_t vect
 		 */
 		bitmap_set_lock(ACRN_REQUEST_EVENT, &vlapic->vcpu->arch.pending_req);
 
-		if (get_cpu_id() != vlapic->vcpu->pcpu_id) {
+		if (get_pcpu_id() != vlapic->vcpu->pcpu_id) {
 			apicv_post_intr(vlapic->vcpu->pcpu_id);
 		}
 	}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -479,7 +479,7 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 
 		wait_pcpus_offline(mask);
 
-		if (is_lapic_pt(vm) && !start_cpus(mask)) {
+		if (is_lapic_pt(vm) && !start_pcpus(mask)) {
 			pr_fatal("Failed to start all cpus in mask(0x%llx)", mask);
 			ret = -ETIMEDOUT;
 		}

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -355,7 +355,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 		exec_vmwrite32(VMX_TPR_THRESHOLD, 0U);
 	}
 
-	if (cpu_has_cap(X86_FEATURE_OSXSAVE)) {
+	if (pcpu_has_cap(X86_FEATURE_OSXSAVE)) {
 		exec_vmwrite64(VMX_XSS_EXITING_BITMAP_FULL, 0UL);
 		value32 |= VMX_PROCBASED_CTLS2_XSVE_XRSTR;
 	}

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -172,7 +172,7 @@ int32_t vmexit_handler(struct acrn_vcpu *vcpu)
 	uint16_t basic_exit_reason;
 	int32_t ret;
 
-	if (get_cpu_id() != vcpu->pcpu_id) {
+	if (get_pcpu_id() != vcpu->pcpu_id) {
 		pr_fatal("vcpu is not running on its pcpu!");
 		ret = -EINVAL;
 	} else {

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -62,14 +62,14 @@ static void enter_guest_mode(uint16_t pcpu_id)
 	cpu_dead();
 }
 
-static void init_primary_cpu_post(void)
+static void init_primary_pcpu_post(void)
 {
 	/* Perform any necessary firmware initialization */
 	init_firmware();
 
 	init_debug_pre();
 
-	init_cpu_post(BOOT_CPU_ID);
+	init_pcpu_post(BOOT_CPU_ID);
 
 	init_seed();
 
@@ -81,27 +81,27 @@ static void init_primary_cpu_post(void)
 /* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
  * it will switch to runtime stack.
  */
-void init_primary_cpu(void)
+void init_primary_pcpu(void)
 {
 	uint64_t rsp;
 
-	init_cpu_pre(BOOT_CPU_ID);
+	init_pcpu_pre(BOOT_CPU_ID);
 
 	/* Switch to run-time stack */
 	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
 	rsp &= ~(CPU_STACK_ALIGN - 1UL);
-	SWITCH_TO(rsp, init_primary_cpu_post);
+	SWITCH_TO(rsp, init_primary_pcpu_post);
 }
 
-void init_secondary_cpu(void)
+void init_secondary_pcpu(void)
 {
 	uint16_t pcpu_id;
 
-	init_cpu_pre(INVALID_CPU_ID);
+	init_pcpu_pre(INVALID_CPU_ID);
 
-	pcpu_id = get_cpu_id();
+	pcpu_id = get_pcpu_id();
 
-	init_cpu_post(pcpu_id);
+	init_pcpu_post(pcpu_id);
 
 	init_debug_post(pcpu_id);
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -346,7 +346,7 @@ void dispatch_interrupt(const struct intr_excp_ctx *ctx)
 	 */
 	if (irq < NR_IRQS) {
 		desc = &irq_desc_array[irq];
-		per_cpu(irq_count, get_cpu_id())[irq]++;
+		per_cpu(irq_count, get_pcpu_id())[irq]++;
 
 		if (vr == desc->vector &&
 			bitmap_test((uint16_t)(irq & 0x3FU), irq_alloc_bitmap + (irq >> 6U)) != 0U) {
@@ -365,7 +365,7 @@ void dispatch_interrupt(const struct intr_excp_ctx *ctx)
 
 void dispatch_exception(struct intr_excp_ctx *ctx)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 
 	/* Obtain lock to ensure exception dump doesn't get corrupted */
 	spinlock_obtain(&exception_spinlock);

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -181,7 +181,7 @@ send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
 {
 	union apic_icr icr;
 	uint8_t shorthand;
-	struct cpuinfo_x86 *cpu_info = get_cpu_info();
+	struct cpuinfo_x86 *cpu_info = get_pcpu_info();
 
 	icr.value = 0U;
 	icr.bits.destination_mode = INTR_LAPIC_ICR_PHYSICAL;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -127,7 +127,7 @@ void invept(const struct acrn_vcpu *vcpu)
 {
 	struct invept_desc desc = {0};
 
-	if (cpu_has_vmx_ept_cap(VMX_EPT_INVEPT_SINGLE_CONTEXT)) {
+	if (pcpu_has_vmx_ept_cap(VMX_EPT_INVEPT_SINGLE_CONTEXT)) {
 		desc.eptp = hva2hpa(vcpu->vm->arch_vm.nworld_eptp) |
 				(3UL << 3U) | 6UL;
 		local_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
@@ -136,7 +136,7 @@ void invept(const struct acrn_vcpu *vcpu)
 				| (3UL << 3U) | 6UL;
 			local_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
 		}
-	} else if (cpu_has_vmx_ept_cap(VMX_EPT_INVEPT_GLOBAL_CONTEXT)) {
+	} else if (pcpu_has_vmx_ept_cap(VMX_EPT_INVEPT_GLOBAL_CONTEXT)) {
 		local_invept(INVEPT_TYPE_ALL_CONTEXTS, desc);
 	} else {
 		/* Neither type of INVEPT is supported. Skip. */

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -23,7 +23,7 @@ static void kick_notification(__unused uint32_t irq, __unused void *data)
 	/* Notification vector is used to kick taget cpu out of non-root mode.
 	 * And it also serves for smp call.
 	 */
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 
 	if (bitmap_test(pcpu_id, &smp_call_mask)) {
 		struct smp_call_info_data *smp_call =

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -151,7 +151,7 @@ void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, u
 
 	clac();
 	/* offline all APs */
-	stop_cpus();
+	stop_pcpus();
 
 	stac();
 	/* Save default main entry and we will restore it after
@@ -188,7 +188,7 @@ void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, u
 	clac();
 
 	/* online all APs again */
-	if (!start_cpus(AP_MASK)) {
+	if (!start_pcpus(AP_MASK)) {
 		panic("Failed to start all APs!");
 	}
 }

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -35,9 +35,9 @@ static void detect_ibrs(void)
 	 * should be set all the time instead of relying on retpoline
 	 */
 #ifndef CONFIG_RETPOLINE
-	if (cpu_has_cap(X86_FEATURE_IBRS_IBPB)) {
+	if (pcpu_has_cap(X86_FEATURE_IBRS_IBPB)) {
 		ibrs_type = IBRS_RAW;
-		if (cpu_has_cap(X86_FEATURE_STIBP)) {
+		if (pcpu_has_cap(X86_FEATURE_STIBP)) {
 			ibrs_type = IBRS_OPT;
 		}
 	}
@@ -56,15 +56,15 @@ bool check_cpu_security_cap(void)
 
 	detect_ibrs();
 
-	if (cpu_has_cap(X86_FEATURE_ARCH_CAP)) {
+	if (pcpu_has_cap(X86_FEATURE_ARCH_CAP)) {
 		x86_arch_capabilities = msr_read(MSR_IA32_ARCH_CAPABILITIES);
 		skip_l1dfl_vmentry = ((x86_arch_capabilities
 			& IA32_ARCH_CAP_SKIP_L1DFL_VMENTRY) != 0UL);
 
-		if ((!cpu_has_cap(X86_FEATURE_L1D_FLUSH)) && (!skip_l1dfl_vmentry)) {
+		if ((!pcpu_has_cap(X86_FEATURE_L1D_FLUSH)) && (!skip_l1dfl_vmentry)) {
 			ret = false;
-		} else if ((!cpu_has_cap(X86_FEATURE_IBRS_IBPB)) &&
-			(!cpu_has_cap(X86_FEATURE_STIBP))) {
+		} else if ((!pcpu_has_cap(X86_FEATURE_IBRS_IBPB)) &&
+			(!pcpu_has_cap(X86_FEATURE_STIBP))) {
 			ret = false;
 		} else {
 			/* No other state currently, do nothing */
@@ -84,7 +84,7 @@ void cpu_l1d_flush(void)
 	 *
 	 */
 	if (!skip_l1dfl_vmentry) {
-		if (cpu_has_cap(X86_FEATURE_L1D_FLUSH)) {
+		if (pcpu_has_cap(X86_FEATURE_L1D_FLUSH)) {
 			msr_write(MSR_IA32_FLUSH_CMD, IA32_L1D_FLUSH);
 		}
 	}

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -100,7 +100,7 @@ int32_t add_timer(struct hv_timer *timer)
 			timer->period_in_cycle = max(timer->period_in_cycle, us_to_ticks(MIN_TIMER_PERIOD_US));
 		}
 
-		pcpu_id  = get_cpu_id();
+		pcpu_id  = get_pcpu_id();
 		cpu_timer = &per_cpu(cpu_timers, pcpu_id);
 
 		/* update the physical timer if we're on the timer_list head */
@@ -185,7 +185,7 @@ static void timer_softirq(uint16_t pcpu_id)
 
 void timer_init(void)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 	int32_t retval = 0;
 
 	init_percpu_timer(pcpu_id);
@@ -260,7 +260,7 @@ static uint64_t pit_calibrate_tsc(uint32_t cal_ms_arg)
 static uint64_t native_calibrate_tsc(void)
 {
 	uint64_t tsc_hz = 0UL;
-	struct cpuinfo_x86 *cpu_info = get_cpu_info();
+	struct cpuinfo_x86 *cpu_info = get_pcpu_info();
 
 	if (cpu_info->cpuid_level >= 0x15U) {
 		uint32_t eax_denominator, ebx_numerator, ecx_hz, reserved;

--- a/hypervisor/bsp/firmware_uefi.c
+++ b/hypervisor/bsp/firmware_uefi.c
@@ -65,7 +65,7 @@ static void* uefi_get_rsdp(void)
 
 static void uefi_spurious_handler(int32_t vector)
 {
-	if (get_cpu_id() == BOOT_CPU_ID) {
+	if (get_pcpu_id() == BOOT_CPU_ID) {
 		struct acrn_vcpu *vcpu = per_cpu(vcpu, BOOT_CPU_ID);
 
 		if (vcpu != NULL) {

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -81,7 +81,7 @@ void vcpu_thread(struct sched_object *obj)
 
 void default_idle(__unused struct sched_object *obj)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 
 	while (1) {
 		if (need_reschedule(pcpu_id)) {

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -181,7 +181,7 @@ void ptirq_deactivate_entry(struct ptirq_remapping_info *entry)
 
 void ptdev_init(void)
 {
-	if (get_cpu_id() == BOOT_CPU_ID) {
+	if (get_pcpu_id() == BOOT_CPU_ID) {
 
 		spinlock_init(&ptdev_lock);
 		register_softirq(SOFTIRQ_PTDEV, ptirq_softirq);

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -113,7 +113,7 @@ void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode)
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 
 	bitmap_set_lock(NEED_RESCHEDULE, &ctx->flags);
-	if (get_cpu_id() != pcpu_id) {
+	if (get_pcpu_id() != pcpu_id) {
 		switch (delmode) {
 		case DEL_MODE_IPI:
 			send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
@@ -140,7 +140,7 @@ void make_pcpu_offline(uint16_t pcpu_id)
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 
 	bitmap_set_lock(NEED_OFFLINE, &ctx->flags);
-	if (get_cpu_id() != pcpu_id) {
+	if (get_pcpu_id() != pcpu_id) {
 		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
 	}
 }
@@ -168,7 +168,7 @@ static void prepare_switch(struct sched_object *prev, struct sched_object *next)
 
 void schedule(void)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 	struct sched_object *next = NULL;
 	struct sched_object *prev = ctx->curr_obj;
@@ -198,7 +198,7 @@ void run_sched_thread(struct sched_object *obj)
 
 void switch_to_idle(run_thread_t idle_thread)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 	struct sched_object *idle = &per_cpu(idle, pcpu_id);
 	char idle_name[16];
 

--- a/hypervisor/common/softirq.c
+++ b/hypervisor/common/softirq.c
@@ -29,12 +29,12 @@ void register_softirq(uint16_t nr, softirq_handler handler)
  */
 void fire_softirq(uint16_t nr)
 {
-	bitmap_set_lock(nr, &per_cpu(softirq_pending, get_cpu_id()));
+	bitmap_set_lock(nr, &per_cpu(softirq_pending, get_pcpu_id()));
 }
 
 void do_softirq(void)
 {
-	uint16_t cpu_id = get_cpu_id();
+	uint16_t cpu_id = get_pcpu_id();
 	volatile uint64_t *softirq_pending_bitmap =
 			&per_cpu(softirq_pending, cpu_id);
 	uint16_t nr = ffs64(*softirq_pending_bitmap);

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -236,7 +236,7 @@ static void show_host_call_trace(uint64_t rsp, uint64_t rbp_arg, uint16_t pcpu_i
 
 void asm_assert(int32_t line, const char *file, const char *txt)
 {
-	uint16_t pcpu_id = get_cpu_id();
+	uint16_t pcpu_id = get_pcpu_id();
 	uint64_t rsp = cpu_rsp_get();
 	uint64_t rbp = cpu_rbp_get();
 

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -56,7 +56,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	timestamp = ticks_to_us(timestamp);
 
 	/* Get CPU ID */
-	pcpu_id = get_cpu_id();
+	pcpu_id = get_pcpu_id();
 	buffer = per_cpu(logbuf, pcpu_id);
 
 	(void)memset(buffer, 0U, LOG_MESSAGE_MAX_SIZE);

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -133,7 +133,7 @@ out:
 
 void npk_log_write(const char *buf, size_t buf_len)
 {
-	uint32_t cpu_id = get_cpu_id();
+	uint32_t cpu_id = get_pcpu_id();
 	struct npk_chan *channel = (struct npk_chan *)base;
 	const char *p = buf;
 	int32_t sz;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -784,7 +784,7 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
 	dump.str_max = SHELL_LOG_BUF_SIZE;
-	if (vcpu->pcpu_id == get_cpu_id()) {
+	if (vcpu->pcpu_id == get_pcpu_id()) {
 		vcpu_dumpreg(&dump);
 	} else {
 		bitmap_set_nolock(vcpu->pcpu_id, &mask);
@@ -1296,7 +1296,7 @@ static int32_t shell_rdmsr(int32_t argc, char **argv)
 	uint64_t val = 0;
 	char str[MAX_STR_SIZE] = {0};
 
-	pcpu_id = get_cpu_id();
+	pcpu_id = get_pcpu_id();
 
 	switch (argc) {
 	case 3:
@@ -1332,7 +1332,7 @@ static int32_t shell_wrmsr(int32_t argc, char **argv)
 	uint32_t msr_index = 0;
 	uint64_t val = 0;
 
-	pcpu_id = get_cpu_id();
+	pcpu_id = get_pcpu_id();
 
 	switch (argc) {
 	case 4:

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -61,7 +61,7 @@ static inline void trace_put(uint16_t cpu_id, uint32_t evid, uint32_t n_data, st
 void TRACE_2L(uint32_t evid, uint64_t e, uint64_t f)
 {
 	struct trace_entry entry;
-	uint16_t cpu_id = get_cpu_id();
+	uint16_t cpu_id = get_pcpu_id();
 
 	if (!trace_check(cpu_id)) {
 		return;
@@ -75,7 +75,7 @@ void TRACE_2L(uint32_t evid, uint64_t e, uint64_t f)
 void TRACE_4I(uint32_t evid, uint32_t a, uint32_t b, uint32_t c, uint32_t d)
 {
 	struct trace_entry entry;
-	uint16_t cpu_id = get_cpu_id();
+	uint16_t cpu_id = get_pcpu_id();
 
 	if (!trace_check(cpu_id)) {
 		return;
@@ -91,7 +91,7 @@ void TRACE_4I(uint32_t evid, uint32_t a, uint32_t b, uint32_t c, uint32_t d)
 void TRACE_6C(uint32_t evid, uint8_t a1, uint8_t a2, uint8_t a3, uint8_t a4, uint8_t b1, uint8_t b2)
 {
 	struct trace_entry entry;
-	uint16_t cpu_id = get_cpu_id();
+	uint16_t cpu_id = get_pcpu_id();
 
 	if (!trace_check(cpu_id)) {
 		return;
@@ -113,7 +113,7 @@ void TRACE_6C(uint32_t evid, uint8_t a1, uint8_t a2, uint8_t a3, uint8_t a4, uin
 static inline void TRACE_16STR(uint32_t evid, const char name[])
 {
 	struct trace_entry entry;
-	uint16_t cpu_id = get_cpu_id();
+	uint16_t cpu_id = get_pcpu_id();
 	size_t len, i;
 
 	if (!trace_check(cpu_id)) {

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -256,12 +256,12 @@ enum pcpu_boot_state {
 void cpu_do_idle(void);
 void cpu_dead(void);
 void trampoline_start16(void);
-void load_cpu_state_data(void);
-void init_cpu_pre(uint16_t pcpu_id_args);
-void init_cpu_post(uint16_t pcpu_id);
-bool start_cpus(uint64_t mask);
+void load_pcpu_state_data(void);
+void init_pcpu_pre(uint16_t pcpu_id_args);
+void init_pcpu_post(uint16_t pcpu_id);
+bool start_pcpus(uint64_t mask);
 void wait_pcpus_offline(uint64_t mask);
-void stop_cpus(void);
+void stop_pcpus(void);
 void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
 
 #define CPU_SEG_READ(seg, result_ptr)						\
@@ -412,7 +412,7 @@ cpu_rdtscp_execute(uint64_t *timestamp_ptr, uint32_t *cpu_id_ptr)
  * Macro to get CPU ID
  * @pre: the return CPU ID would never equal or large than phys_cpu_num.
  */
-static inline uint16_t get_cpu_id(void)
+static inline uint16_t get_pcpu_id(void)
 {
 	uint32_t tsl, tsh, cpu_id;
 

--- a/hypervisor/include/arch/x86/cpu_caps.h
+++ b/hypervisor/include/arch/x86/cpu_caps.h
@@ -38,12 +38,12 @@ struct cpuinfo_x86 {
 
 bool has_monitor_cap(void);
 bool is_apicv_advanced_feature_supported(void);
-bool cpu_has_cap(uint32_t bit);
-bool cpu_has_vmx_ept_cap(uint32_t bit_mask);
-bool cpu_has_vmx_vpid_cap(uint32_t bit_mask);
-void init_cpu_capabilities(void);
-void init_cpu_model_name(void);
+bool pcpu_has_cap(uint32_t bit);
+bool pcpu_has_vmx_ept_cap(uint32_t bit_mask);
+bool pcpu_has_vmx_vpid_cap(uint32_t bit_mask);
+void init_pcpu_capabilities(void);
+void init_pcpu_model_name(void);
 int32_t detect_hardware_support(void);
-struct cpuinfo_x86 *get_cpu_info(void);
+struct cpuinfo_x86 *get_pcpu_info(void);
 
 #endif /* CPUINFO_H */

--- a/hypervisor/include/arch/x86/init.h
+++ b/hypervisor/include/arch/x86/init.h
@@ -9,7 +9,7 @@
 /* hypervisor stack bottom magic('intl') */
 #define SP_BOTTOM_MAGIC    0x696e746cUL
 
-void init_primary_cpu(void);
-void init_secondary_cpu(void);
+void init_primary_pcpu(void);
+void init_secondary_pcpu(void);
 
 #endif /* INIT_H*/

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -52,7 +52,7 @@
 #define CACHE_LINE_SIZE		64U
 
 /* IA32E Paging constants */
-#define IA32E_REF_MASK	((get_cpu_info())->physical_address_mask)
+#define IA32E_REF_MASK	((get_pcpu_info())->physical_address_mask)
 
 struct acrn_vcpu;
 static inline uint64_t round_page_up(uint64_t addr)

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -62,6 +62,6 @@ extern struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM];
 	(per_cpu_data[(pcpu_id)].name)
 
 /* get percpu data for current pcpu */
-#define get_cpu_var(name)	per_cpu(name, get_cpu_id())
+#define get_cpu_var(name)	per_cpu(name, get_pcpu_id())
 
 #endif


### PR DESCRIPTION
This patch adds prefix 'p' before 'cpu' to physical cpu related functions.
And there is no code logic change.

Tracked-On: #2991
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>