### PR TITLE
HV: move AP_MASK to cpu.h

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -30,8 +30,6 @@
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
 
-#define AP_MASK			(((1UL << phys_cpu_num) - 1UL) & ~(1UL << 0U))
-
 struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM] __aligned(PAGE_SIZE);
 static uint16_t phys_cpu_num = 0U;
 static uint64_t pcpu_sync = 0UL;

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -20,8 +20,6 @@
  #include <lapic.h>
  #include <vcpu.h>
 
-#define AP_MASK		(((1UL << get_pcpu_nums()) - 1UL) & ~(1UL << 0U))
-
 struct cpu_context cpu_ctx;
 
 /* The values in this structure should come from host ACPI table */

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -139,6 +139,8 @@
 
 #define	BUS_LOCK	"lock ; "
 
+#define AP_MASK			(((1UL << get_pcpu_nums()) - 1UL) & ~(1UL << 0U))
+
 /**
  *
  * Identifiers for architecturally defined registers.


### PR DESCRIPTION
It is better to use an unified MACRO. So, this patch moves AP_MASK to cpu.h
and removes the defination of the MACRO spanning different source files.

Tracked-On: #2991
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>