### PR TITLE
HV: correct usage of GUEST_FLAG_IO_COMPLETION_POLLING

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -430,7 +430,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		/* Populate return VM handle */
 		*rtn_vm = vm;
 		vm->sw.io_shared_page = NULL;
-		if ((vm_config->guest_flags & GUEST_FLAG_IO_COMPLETION_POLLING) != 0U) {
+		if ((vm_config->type == NORMAL_VM) && (vm_config->guest_flags & GUEST_FLAG_IO_COMPLETION_POLLING) != 0U) {
 			/* enable IO completion polling mode per its guest flags in vm_config. */
 			vm->sw.is_completion_polling = true;
 		}

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -22,7 +22,6 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			/* 26c5e0d8-8f8a-47d8-8109-f201ebd61a5e */
 		.pcpu_bitmap = VM0_CONFIG_PCPU_BITMAP,
 		.cpu_num = VM0_CONFIG_NUM_CPUS,
-		.guest_flags = GUEST_FLAG_IO_COMPLETION_POLLING,
 		.clos = 0U,
 		.memory = {
 			.start_hpa = VM0_CONFIG_MEM_START_HPA,
@@ -50,7 +49,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			/* dd87ce08-66f9-473d-bc58-7605837f935e */
 		.pcpu_bitmap = VM1_CONFIG_PCPU_BITMAP,
 		.cpu_num = VM1_CONFIG_NUM_CPUS,
-		.guest_flags = (GUEST_FLAG_RT | GUEST_FLAG_LAPIC_PASSTHROUGH | GUEST_FLAG_IO_COMPLETION_POLLING),
+		.guest_flags = (GUEST_FLAG_RT | GUEST_FLAG_LAPIC_PASSTHROUGH),
 		.clos = 0U,
 		.memory = {
 			.start_hpa = VM1_CONFIG_MEM_START_HPA,


### PR DESCRIPTION
The guest flags of GUEST_FLAG_IO_COMPLETION_POLLING work for NORMAL_VM only;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>