### PR TITLE
DM: virtio-gpio: fix falling or rising irq can't work

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -965,12 +965,11 @@ gpio_irq_set_pin_state(int fd __attribute__((unused)),
 	struct gpioevent_data data;
 	struct virtio_gpio *gpio;
 	struct gpio_irq_desc *desc;
-	int last_level, err;
+	int err;
 
 	assert(arg != NULL);
 	desc = (struct gpio_irq_desc *) arg;
 	gpio = (struct virtio_gpio *) desc->data;
-	last_level = desc->level;
 
 	/* get pin state */
 	memset(&data, 0, sizeof(data));
@@ -987,7 +986,7 @@ gpio_irq_set_pin_state(int fd __attribute__((unused)),
 		desc->level = 1;
 
 		/* jitter protection */
-		if (((desc->mode & IRQ_TYPE_EDGE_RISING) && (last_level == 0))
+		if ((desc->mode & IRQ_TYPE_EDGE_RISING)
 				|| (desc->mode & IRQ_TYPE_LEVEL_HIGH)) {
 			gpio_irq_generate_intr(gpio, desc->pin);
 		}
@@ -997,7 +996,7 @@ gpio_irq_set_pin_state(int fd __attribute__((unused)),
 		desc->level = 0;
 
 		/* jitter protection */
-		if (((desc->mode & IRQ_TYPE_EDGE_FALLING) && (last_level == 1))
+		if ((desc->mode & IRQ_TYPE_EDGE_FALLING)
 				|| (desc->mode & IRQ_TYPE_LEVEL_LOW)) {
 			gpio_irq_generate_intr(gpio, desc->pin);
 		}


### PR DESCRIPTION
When UOS set failling irq type, gpio BE will only request GPIOEVENT_REQUEST_FAILLING_EDGE
event from native gpio driver which will cause the last_level value is always 0.
So last_level can't be used to check whether interrupt should be injected or not.
It is the same for rising irq type.

v2: refine commit message.

Tracked-On: #3010
Reviewed-by: Yuan Liu <yuan1.liu@intel.com>
Signed-off-by: fuyongjie <fuyongjie@neusoft.com>
Acked-by: Yu Wang <yu1.wang@intel.com>