### PR TITLE
tools:acrn-crashlog: fix the compiling error

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/main.c
+++ b/tools/acrn-crashlog/acrnprobe/main.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 				 NULL)) != -1) {
 		switch (op) {
 		case 'c':
-			strncpy(cfg, optarg, PATH_MAX);
+			strncpy(cfg, optarg, PATH_MAX - 1);
 			break;
 		case 'h':
 			usage();


### PR DESCRIPTION
Meet compiling error:

In function ‘strncpy’,
    inlined from ‘main’ at main.c:88:4:
/usr/include/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’
specified bound 4096 equals destination size
[-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos
(__dest));
      |
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

This patch aims to fix it.

Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Acked-by: Chen, Gang <gang.c.chen@intel.com>