### PR TITLE
DOC: change hv shell cmd sos_console to vm_console

### DIFF
--- a/doc/developer-guides/hld/hv-partitionmode.rst
+++ b/doc/developer-guides/hld/hv-partitionmode.rst
@@ -339,7 +339,7 @@ For details on how hypervisor console works, refer to
 :ref:`hv-console`.
 
 For a guest console in partition mode, ACRN provides an option to pass
-``vmid`` as an argument to ``sos_console``. vmid is same as the one
+``vmid`` as an argument to ``vm_console``. vmid is same as the one
 developer uses in the guest configuration.
 
 Guests w/o LAPIC pass-thru

--- a/doc/tutorials/debug.rst
+++ b/doc/tutorials/debug.rst
@@ -108,7 +108,7 @@ just instrumented with additional log information), and check the log as follows
 
 Then we use the command, on the ACRN console::
 
-   sos_console
+   vm_console
 
 to switch to the SOS console. Then we use the command::
 

--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -360,7 +360,7 @@ Switch between privileged VMs
 Connect the serial port on the UP2 board to the development workstation.
 If you set the BDF of the serial port right while building the ACRN hypervisor,
 you should see the output from the ACRN serial console as below.
-You could then log in to the privileged VMs by ``sos_console`` command,
+You could then log in to the privileged VMs by ``vm_console`` command,
 and press :kbd:`CTRL+Space` keys to return to the ACRN serial console.
 
 .. code-block:: console
@@ -379,7 +379,7 @@ and press :kbd:`CTRL+Space` keys to return to the ACRN serial console.
   [21885195us][cpu=0][sev=3][seq=34]:vlapic: Start Secondary VCPU1 for VM[1]...
   [21889889us][cpu=3][sev=3][seq=35]:vlapic: Start Secondary VCPU1 for VM[2]...
   ACRN:\>
-  ACRN:\>sos_console 0
+  ACRN:\>vm_console 0
 
   ----- Entering Guest 1 Shell -----
   [    1.997439] systemd[1]: Listening on Network Service Netlink Socket.
@@ -396,7 +396,7 @@ and press :kbd:`CTRL+Space` keys to return to the ACRN serial console.
   root@clr-932c8a3012ec4dc6af53790b7afbf6ba ~ #
 
    ---Entering ACRN SHELL---
-  ACRN:\>sos_console 1
+  ACRN:\>vm_console 1
 
   ----- Entering Guest 2 Shell -----
   [    1.490122] usb 1-4: new full-speed USB device number 2 using xhci_hcd

--- a/doc/user-guides/acrn-shell.rst
+++ b/doc/user-guides/acrn-shell.rst
@@ -22,8 +22,8 @@ The ACRN hypervisor shell supports the following commands:
    * - dumpmem <hva> <length>
      - Dump host memory, starting at a given address, and for a given length
        (in bytes)
-   * - sos_console
-     - Switch to the SOS's console. Use :kbd:`Ctrl+Spacebar` to return to the ACRN
+   * - vm_console
+     - Switch to the VM's console. Use :kbd:`Ctrl+Spacebar` to return to the ACRN
        shell console
    * - int
      - List interrupt information per CPU
@@ -129,10 +129,10 @@ pCPU number is 0x0000000000000004.
 
    acrn map information
 
-sos_console
+vm_console
 ===========
 
-The ``sos_console`` command switches the ACRN's console to become the SOS's console.
+The ``vm_console`` command switches the ACRN's console to become the VM's console.
 Use a :kbd:`Ctrl-Spacebar` to return to the ACRN shell console.
 
 vioapic


### PR DESCRIPTION
Change shell command 'sos_console' to 'vm_console' as it is not only
used to switch console to SOS.

Tracked-On: #2987
Signed-off-by: Conghui Chen <conghui.chen@intel.com>