### PR TITLE
Makefile: add gcc option to workaround build issue with latest gcc

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -20,6 +20,7 @@ CFLAGS += -Werror
 CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 CFLAGS += -fpie
+CFLAGS += -Wno-stringop-truncation -Wno-address-of-packed-member
 
 CFLAGS += -I$(BASEDIR)/include
 CFLAGS += -I$(BASEDIR)/include/public

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -14,6 +14,7 @@ MANAGER_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
 MANAGER_CFLAGS += -fpie -fpic
 #FIXME: remove me. work-around for system() calls, which will be removed
 MANAGER_CFLAGS += -Wno-format-truncation -Wno-unused-result
+MANAGER_CFLAGS += -Wno-stringop-truncation
 MANAGER_CFLAGS += $(CFLAGS)
 
 MANAGER_CFLAGS += -I../../devicemodel/include


### PR DESCRIPTION
With latest gcc, there are build error with current ACRN code.
Fixing could involve many code changes. We use gcc option to
remove build error as temperary workaround. And will fix the
build error one by one.

Tracked-On: #3010
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>