### PR TITLE
HV: minor changes on pci devices config

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/pci_devices.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/pci_devices.h
@@ -8,13 +8,8 @@
 #define PCI_DEVICES_H_
 
 #define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-#define SATA_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x00U}
-#define USB_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U}
-
-#define STORAGE_CONTROLLER_0	SATA_CONTROLLER
-#define STORAGE_CONTROLLER_1	USB_CONTROLLER
-
+#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x00U}
+#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U}
 #define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x00U}
-#define ETHERNET_CONTROLLER_1
 
 #endif /* PCI_DEVICES_H_ */

--- a/hypervisor/arch/x86/configs/dnv-cb2/pci_devices.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/pci_devices.h
@@ -8,12 +8,8 @@
 #define PCI_DEVICES_H_
 
 #define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-#define SATA_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
-#define USB_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U}
-
-#define STORAGE_CONTROLLER_0	SATA_CONTROLLER
-#define STORAGE_CONTROLLER_1	USB_CONTROLLER
-
+#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
+#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U}
 #define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x00U}
 #define ETHERNET_CONTROLLER_1	.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x01U}
 

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/pci_devices.h
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/pci_devices.h
@@ -8,13 +8,8 @@
 #define PCI_DEVICES_H_
 
 #define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-#define SATA_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x17U, .f = 0x00U}
-#define USB_CONTROLLER		.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
-
-#define STORAGE_CONTROLLER_0	SATA_CONTROLLER
-#define STORAGE_CONTROLLER_1	USB_CONTROLLER
-
+#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x17U, .f = 0x00U}
+#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
 #define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x1fU, .f = 0x06U}
-#define ETHERNET_CONTROLLER_1
 
 #endif /* PCI_DEVICES_H_ */

--- a/hypervisor/scenarios/logical_partition/pt_dev.c
+++ b/hypervisor/scenarios/logical_partition/pt_dev.c
@@ -15,11 +15,11 @@ struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
-		STORAGE_CONTROLLER_0
+		VM0_STORAGE_CONTROLLER
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
-		ETHERNET_CONTROLLER_0
+		VM0_NETWORK_CONTROLLER
 	},
 };
 
@@ -30,10 +30,12 @@ struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM] = {
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
-		STORAGE_CONTROLLER_1
+		VM1_STORAGE_CONTROLLER
 	},
+#if defined(VM1_NETWORK_CONTROLLER)
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
-		ETHERNET_CONTROLLER_1
+		VM1_NETWORK_CONTROLLER
 	},
+#endif
 };

--- a/hypervisor/scenarios/logical_partition/vm_configurations.h
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.h
@@ -7,6 +7,8 @@
 #ifndef VM_CONFIGURATIONS_H
 #define VM_CONFIGURATIONS_H
 
+#include <pci_devices.h>
+
 /* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
 #define DM_OWNED_GUEST_FLAG_MASK	0UL
 
@@ -29,7 +31,6 @@
 #define VM0_CONFIG_OS_BOOTARG_ROOT		"root=/dev/sda3 "
 #define VM0_CONFIG_OS_BOOTARG_MAXCPUS		"maxcpus=2 "
 #define VM0_CONFIG_OS_BOOTARG_CONSOLE		"console=ttyS0 "
-#define VM0_CONFIG_PCI_PTDEV_NUM		3U
 
 #define VM1_CONFIG_PCPU_BITMAP			(PLUG_CPU(1) | PLUG_CPU(3))
 #define VM1_CONFIG_NUM_CPUS			2U
@@ -38,6 +39,29 @@
 #define VM1_CONFIG_OS_BOOTARG_ROOT		"root=/dev/sda3 "
 #define VM1_CONFIG_OS_BOOTARG_MAXCPUS		"maxcpus=2 "
 #define VM1_CONFIG_OS_BOOTARG_CONSOLE		"console=ttyS0 "
+
+/* VM pass-through devices assign policy:
+ * VM0: one Mass Storage controller, one Network controller;
+ * VM1: one Mass Storage controller, one Network controller(if a secondary Network controller class device exist);
+ */
+#define VM0_STORAGE_CONTROLLER			SATA_CONTROLLER_0
+#define VM0_NETWORK_CONTROLLER			ETHERNET_CONTROLLER_0
+#define VM0_CONFIG_PCI_PTDEV_NUM		3U
+
+#define VM1_STORAGE_CONTROLLER			USB_CONTROLLER_0
+#if defined(ETHERNET_CONTROLLER_1)
+/* if a secondary Ethernet controller subclass exist, assign to VM1 */
+#define VM1_NETWORK_CONTROLLER			ETHERNET_CONTROLLER_1
+#elif defined(NETWORK_CONTROLLER_0)
+/* if a Network controller subclass exist(usually it is a wireless network card), assign to VM1 */
+#define VM1_NETWORK_CONTROLLER			NETWORK_CONTROLLER_0
+#endif
+
+#if defined(VM1_NETWORK_CONTROLLER)
 #define VM1_CONFIG_PCI_PTDEV_NUM		3U
+#else
+/* no network controller could be assigned to VM1 */
+#define VM1_CONFIG_PCI_PTDEV_NUM		2U
+#endif
 
 #endif /* VM_CONFIGURATIONS_H */


### PR DESCRIPTION
- The pci device config is related to VM configurations, so move the device
mapping MACROs from pci_devices.h to vm_configurations.h. Also considering
pci_devices.h should be generated by offline parse tool, this code change
would decouple the relationship between VM configuration tool and target
paser tool;

- Another minor change is add post-fix in number for each PCI device subclass
name to make target parse tool interface friendly;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>