### PR TITLE
hv: add scenario for the industry use case

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -44,6 +44,8 @@ ifeq ($(CONFIG_SDC),y)
 SCENARIO_NAME := sdc
 else ifeq ($(CONFIG_LOGICAL_PARTITION),y)
 SCENARIO_NAME := logical_partition
+else ifeq ($(CONFIG_INDUSTRY),y)
+SCENARIO_NAME := industry
 endif
 
 LD_IN_TOOL = scripts/genld.sh

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -15,6 +15,13 @@ config LOGICAL_PARTITION
 	help
 	  This scenario will run two pre-launched VMs.
 
+config INDUSTRY 
+	bool "Industry VMs"
+	help
+	  This scenario is a typical scenario for industry usage with 3 VMs: 
+	  one pre-launched SOS VM, one post-launched Normal VM for HMI and one
+	  post-launched  RT VM for real-time control.
+
 endchoice
 
 config BOARD

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm_config.h>
+#include <vm_configurations.h>
+#include <acrn_common.h>
+#include <vuart.h>
+
+struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
+	{
+		.type = SOS_VM,
+		.name = "ACRN SOS VM",
+		.uuid = {0xdbU, 0xbbU, 0xd4U, 0x34U, 0x7aU, 0x57U, 0x42U, 0x16U,	\
+			 0xa1U, 0x2cU, 0x22U, 0x01U, 0xf1U, 0xabU, 0x02U, 0x40U},
+			/* dbbbd434-7a57-4216-a12c-2201f1ab0240 */
+		.guest_flags = GUEST_FLAG_IO_COMPLETION_POLLING,
+		.clos = 0U,
+		.memory = {
+			.start_hpa = 0UL,
+			.size = CONFIG_SOS_RAM_SIZE,
+		},
+		.os_config = {
+			.name = "ACRN Service OS",
+		},
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = CONFIG_COM_BASE,
+			.irq = CONFIG_COM_IRQ,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+	},
+	{
+		.type = POST_LAUNCHED_VM,
+		.uuid = {0xd2U, 0x79U, 0x54U, 0x38U, 0x25U, 0xd6U, 0x11U, 0xe8U,	\
+			 0x86U, 0x4eU, 0xcbU, 0x7aU, 0x18U, 0xb3U, 0x46U, 0x43U},
+			/* d2795438-25d6-11e8-864e-cb7a18b34643 */
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+
+	},
+	{
+		.type = POST_LAUNCHED_VM,
+		.uuid = {0x49U, 0x5aU, 0xe2U, 0xe5U, 0x26U, 0x03U, 0x4dU, 0x64U,	\
+			 0xafU, 0x76U, 0xd4U, 0xbcU, 0x5aU, 0x8eU, 0xc0U, 0xe5U},
+			/* 495ae2e5-2603-4d64-af76-d4bc5a8ec0e5 */
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+
+	}
+};

--- a/hypervisor/scenarios/industry/vm_configurations.h
+++ b/hypervisor/scenarios/industry/vm_configurations.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef VM_CONFIGURATIONS_H
+#define VM_CONFIGURATIONS_H
+
+#define CONFIG_MAX_VM_NUM	3U
+
+/* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
+#define DM_OWNED_GUEST_FLAG_MASK	(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | \
+						GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING)
+
+
+#endif /* VM_CONFIGURATIONS_H */


### PR DESCRIPTION
This scenario is typical for industry usage with 3 VMs: 1 pre-launched SOS VM,
1 post-launched user VM for HMI and 1 post-launched  RT VM for real-time control.

Tracked-On: #3039
Signed-off-by: Yan, Like <like.yan@intel.com>