### PR TITLE
vPCI resource cleanup for POST_LAUNCHED_VMs

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -579,7 +579,8 @@ vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf, uint16_t phys_bdf,
 }
 
 int
-vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin)
+vm_reset_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf, uint16_t phys_bdf,
+			int virt_pin, bool pic_pin)
 {
 	struct ic_ptdev_irq ptirq;
 
@@ -587,6 +588,8 @@ vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin)
 	ptirq.type = IRQ_INTX;
 	ptirq.intx.virt_pin = virt_pin;
 	ptirq.intx.is_pic_pin = pic_pin;
+	ptirq.virt_bdf = virt_bdf;
+	ptirq.phys_bdf = phys_bdf;
 
 	return ioctl(ctx->fd, IC_RESET_PTDEV_INTR_INFO, &ptirq);
 }

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -914,7 +914,10 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 	printf("vm_reset_ptdev_intx:0x%x-%x, ioapic virpin=%d.\n",
 			virt_bdf, ptdev->phys_bdf, dev->lintr.ioapic_irq);
-	vm_reset_ptdev_intx_info(ctx, dev->lintr.ioapic_irq, false);
+
+	if (dev->lintr.pin != 0) {
+		vm_reset_ptdev_intx_info(ctx, virt_bdf, ptdev->phys_bdf, dev->lintr.ioapic_irq, false);
+	}
 
 	/* unmap the physical BAR in guest MMIO space */
 	for (i = 0; i <= PCI_BARMAX; i++) {

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -137,7 +137,8 @@ int	vm_reset_ptdev_msix_info(struct vmctx *ctx, uint16_t virt_bdf, uint16_t phys
 	int vector_count);
 int	vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 	uint16_t phys_bdf, int virt_pin, int phys_pin, bool pic_pin);
-int	vm_reset_ptdev_intx_info(struct vmctx *ctx, int virt_pin, bool pic_pin);
+int	vm_reset_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
+	uint16_t phys_bdf, int virt_pin, bool pic_pin);
 
 int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
 int	vm_set_vcpu_regs(struct vmctx *ctx, struct acrn_set_vcpu_regs *cpu_regs);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -991,6 +991,7 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 		if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
 			pr_err("%s: Unable copy param to vm\n", __func__);
 		} else if (irq.type == IRQ_INTX) {
+			vpci_reset_ptdev_intr_info(target_vm, irq.virt_bdf, irq.phys_bdf);
 			ptirq_remove_intx_remapping(target_vm,
 					irq.is.intx.virt_pin,
 					irq.is.intx.pic_pin);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -250,8 +250,12 @@ void vpci_cleanup(const struct acrn_vm *vm)
 		sharing_mode_vpci_deinit(vm);
 		break;
 
+	case POST_LAUNCHED_VM:
+		post_launched_vm_vpci_deinit(vm);
+		break;
+
 	default:
-		/* Nothing to do for other vm types */
+		/* Unsupported VM type - Do nothing */
 		break;
 	}
 }
@@ -592,6 +596,52 @@ void sharing_mode_vpci_deinit(const struct acrn_vm *vm)
 		vmsi_deinit(vdev);
 
 		vmsix_deinit(vdev);
+	}
+}
+
+/**
+ * @pre vm != NULL
+ * @pre vm->vpci.pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
+ * @pre is_postlaunched_vm(vm) == true
+ */
+void post_launched_vm_vpci_deinit(const struct acrn_vm *vm)
+{
+	struct acrn_vm *sos_vm;
+	uint32_t i;
+	struct pci_vdev *vdev;
+	int32_t ret;
+	/* PCI resources
+	 * 1) IOMMU domain switch
+	 * 2) Relese UOS MSI host IRQ/IRTE
+	 * 3) Update vdev info in SOS vdev
+	 * Cleanup mentioned above is  taken care when DM releases UOS resources
+	 * during a UOS reboot or shutdown
+	 * In the following cases, where DM does not get chance to cleanup
+	 * 1) DM crash/segfault
+	 * 2) SOS triple fault/hang
+	 * 3) SOS reboot before shutting down POST_LAUNCHED_VMs
+	 * ACRN must cleanup
+	 */
+	sos_vm = get_sos_vm();
+	for (i = 0U; i < sos_vm->vpci.pci_vdev_cnt; i++) {
+		vdev = (struct pci_vdev *)&(sos_vm->vpci.pci_vdevs[i]);
+
+		if (vdev->vpci->vm == vm) {
+			ret = move_pt_device(vm->iommu, sos_vm->iommu, (uint8_t)vdev->pdev->bdf.bits.b,
+					(uint8_t)(vdev->pdev->bdf.value & 0xFFU));
+			if (ret != 0) {
+				panic("failed to assign iommu device!");
+			}
+
+			vmsi_deinit(vdev);
+
+			vmsix_deinit(vdev);
+
+			/* Move vdev pointers back to SOS*/
+			vdev->vpci = (struct acrn_vpci *) &sos_vm->vpci;
+			/* vbdf equals to pbdf in sos */
+			vdev->vbdf.value = vdev->pdev->bdf.value;
+		}
 	}
 }
 

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -114,5 +114,6 @@ void sharing_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf bdf,
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
 void sharing_mode_vpci_deinit(const struct acrn_vm *vm);
+void post_launched_vm_vpci_deinit(const struct acrn_vm *vm);
 
 #endif /* VPCI_PRIV_H_ */


### PR DESCRIPTION
PCI resources
1) IOMMU domain switch
2) Relese UOS MSI host IRQ/IRTE
3) Update vdev info in SOS vdev
Cleanup mentioned above is  taken care when DM releases UOS resources
during a UOS reboot or shutdown
In the following cases, where DM does not get chance to cleanup
1) DM crash/segfault
2) SOS triple fault/hang
3) SOS reboot before shutting down POST_LAUNCHED_VMs
ACRN must cleanup to make sure vpci data structures represent
transition of PT device back to SOS.

 Tracked-On: #2700
    Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
    Signed-off-by: Zide Chen <zide.chen@intel.com>
    Acked-by: Eddie Dong <eddie.dong@intel.com>