### PR TITLE
 tools: acrn-crashlog: refine IO operation

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/tools/acrn-crashlog/acrnprobe/Makefile
@@ -37,7 +37,8 @@ $(BUILDDIR)/acrnprobe/bin/acrnprobe: $(BUILDDIR)/acrnprobe/obj/main.o \
 	$(BUILDDIR)/acrnprobe/obj/probeutils.o \
 	$(BUILDDIR)/acrnprobe/obj/history.o \
 	$(BUILDDIR)/acrnprobe/obj/android_events.o \
-	$(BUILDDIR)/acrnprobe/obj/loop.o
+	$(BUILDDIR)/acrnprobe/obj/loop.o \
+	$(BUILDDIR)/acrnprobe/obj/vmrecord.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 .PHONY: clean

--- a/tools/acrn-crashlog/acrnprobe/android_events.c
+++ b/tools/acrn-crashlog/acrnprobe/android_events.c
@@ -18,6 +18,7 @@
 #include "fsutils.h"
 #include "history.h"
 #include "loop.h"
+#include "vmrecord.h"
 
 #define VM_WARNING_LINES 2000
 
@@ -106,110 +107,6 @@ static char *next_vm_event(const char *cursor, const char *data,
 	return line_to_sync;
 }
 
-#define VMRECORD_HEAD_LINES 7
-#define VMRECORD_TAG_LEN 9
-#define VMRECORD_TAG_WAITING_SYNC	"      <=="
-#define VMRECORD_TAG_NOT_FOUND		"NOT_FOUND"
-#define VMRECORD_TAG_MISS_LOG		"MISS_LOGS"
-#define VMRECORD_TAG_SUCCESS		"         "
-static int generate_log_vmrecord(const char *path)
-{
-	const char * const head =
-		"/* DONT EDIT!\n"
-		" * This file records VM id synced or about to be synched,\n"
-		" * the tag \"<==\" indicates event waiting to sync.\n"
-		" * the tag \"NOT_FOUND\" indicates event not found in UOS.\n"
-		" * the tag \"MISS_LOGS\" indicates event miss logs in UOS.\n"
-		" */\n\n";
-
-	LOGD("Generate (%s)\n", path);
-	return overwrite_file(path, head);
-}
-
-enum stage1_refresh_type_t {
-	MM_ONLY,
-	MM_FILE
-};
-
-/**
- * There are 2 stages in vm events sync.
- * Stage1: record events to log_vmrecordid file.
- * Stage2: call sender's callback for each recorded events.
- *
- * The design reason is to give UOS some time to log to storage.
- */
-static int refresh_key_synced_stage1(const struct sender_t *sender,
-					struct vm_t *vm, const char *key,
-					size_t klen,
-					enum stage1_refresh_type_t type)
-{
-	char log_new[64];
-	char *log_vmrecordid;
-	int nlen;
-
-	log_vmrecordid = sender->log_vmrecordid;
-	/* the length of key must be 20, and its value can not be
-	 * 00000000000000000000.
-	 */
-	if ((klen == ANDROID_EVT_KEY_LEN) &&
-	    strcmp(key, "00000000000000000000")) {
-		memcpy(vm->last_synced_line_key[sender->id], key, klen);
-		vm->last_synced_line_key[sender->id][klen] = '\0';
-		if (type == MM_ONLY)
-			return 0;
-
-		/* create a log file, so we can locate
-		 * the right place in case of reboot
-		 */
-		if (!file_exists(log_vmrecordid))
-			generate_log_vmrecord(log_vmrecordid);
-
-		nlen = snprintf(log_new, sizeof(log_new), "%s %s %s\n",
-				vm->name, key,
-				VMRECORD_TAG_WAITING_SYNC);
-		if (s_not_expect(nlen, sizeof(log_new))) {
-			LOGE("failed to construct record, key (%s)\n", key);
-			return -1;
-		}
-
-		if (append_file(log_vmrecordid, log_new,
-				strnlen(log_new, 64)) < 0) {
-			LOGE("failed to add new record (%s) to (%s)\n",
-			     log_new, log_vmrecordid);
-			return -1;
-		}
-		return 0;
-	}
-
-	LOGE("try to record an invalid key (%s) for (%s)\n",
-	     key, vm->name);
-	return -1;
-}
-
-enum stage2_refresh_type_t {
-	SUCCESS,
-	NOT_FOUND,
-	MISS_LOG
-};
-
-static int refresh_key_synced_stage2(char *line, size_t len,
-					enum stage2_refresh_type_t type)
-{
-	/* re-mark symbol "<==" for synced key */
-	char *tag = line + len - VMRECORD_TAG_LEN;
-
-	if (type == SUCCESS)
-		memcpy(tag, VMRECORD_TAG_SUCCESS, VMRECORD_TAG_LEN);
-	else if (type == NOT_FOUND)
-		memcpy(tag, VMRECORD_TAG_NOT_FOUND, VMRECORD_TAG_LEN);
-	else if (type == MISS_LOG)
-		memcpy(tag, VMRECORD_TAG_MISS_LOG, VMRECORD_TAG_LEN);
-	else
-		return -1;
-
-	return 0;
-}
-
 static int get_vms_history(const struct sender_t *sender)
 {
 	struct vm_t *vm;
@@ -256,7 +153,7 @@ static int get_vms_history(const struct sender_t *sender)
 	return 0;
 }
 
-static void sync_lines_stage1(const struct sender_t *sender)
+static void sync_lines_stage1(struct sender_t *sender)
 {
 	int id;
 	struct vm_t *vm;
@@ -313,11 +210,21 @@ static void sync_lines_stage1(const struct sender_t *sender)
 				continue;
 			}
 
+			if ((strnlen(vmkey, sizeof(vmkey)) !=
+			     ANDROID_EVT_KEY_LEN) ||
+			     !strcmp(vmkey, "00000000000000000000")) {
+				LOGE("invalid key (%s) from (%s)\n",
+				     vmkey, vm->name);
+				start = strchr(line_to_sync, '\n');
+				continue;
+			}
+
 			LOGD("stage1 %s\n", vmkey);
-			refresh_key_synced_stage1(sender, vm, vmkey,
-						  strnlen(vmkey, sizeof(vmkey)),
-						  MM_FILE);
-			start = strchr(line_to_sync, '\n');
+			*(char *)(mempcpy(vm->last_synced_line_key[sender->id],
+					  vmkey, ANDROID_EVT_KEY_LEN)) = '\0';
+			if (vmrecord_new(&sender->vmrecord, vm->name,
+					  vmkey) == -1)
+				LOGE("failed to new vm record\n");
 		}
 	}
 
@@ -332,25 +239,28 @@ static char *next_record(const struct mm_file_t *file, const char *fstart,
 	return get_line(tag, tlen, file->begin, file->size, fstart, len);
 }
 
-static void sync_lines_stage2(const struct sender_t *sender,
+static void sync_lines_stage2(struct sender_t *sender,
 			int (*fn)(const char*, size_t, const struct vm_t *))
 {
 	struct mm_file_t *recos;
 	char *record;
 	size_t recolen;
 
-	recos = mmap_file(sender->log_vmrecordid);
+	pthread_mutex_lock(&sender->vmrecord.mtx);
+	recos = mmap_file(sender->vmrecord.path);
 	if (!recos) {
-		LOGE("mmap %s failed, strerror(%s)\n", sender->log_vmrecordid,
-						       strerror(errno));
+		LOGE("failed to mmap %s, %s\n", sender->vmrecord.path,
+						strerror(errno));
+		pthread_mutex_unlock(&sender->vmrecord.mtx);
 		return;
 	}
 	if (!recos->size ||
 	    mm_count_lines(recos) < VMRECORD_HEAD_LINES) {
-		LOGE("(%s) invalid\n", sender->log_vmrecordid);
+		LOGE("(%s) invalid\n", sender->vmrecord.path);
 		goto out;
 	}
 
+	sender->vmrecord.recos = recos;
 	for (record = next_record(recos, recos->begin, &recolen); record;
 	     record = next_record(recos, record + recolen, &recolen)) {
 		const char * const record_fmt =
@@ -380,33 +290,33 @@ static void sync_lines_stage2(const struct sender_t *sender,
 				     vm->history_size[sender->id],
 				     vm->history_data, &len);
 		if (!hist_line) {
-			LOGW("mark vmevent(%s) as not-found\n", vmkey);
-			refresh_key_synced_stage2(record, recolen, NOT_FOUND);
+			vmrecord_mark(&sender->vmrecord, vmkey,
+				      strnlen(vmkey, sizeof(vmkey)), NOT_FOUND);
 			continue;
 		}
 
 		res = fn(hist_line, len + 1, vm);
 		if (res == VMEVT_HANDLED)
-			refresh_key_synced_stage2(record, recolen, SUCCESS);
+			vmrecord_mark(&sender->vmrecord, vmkey,
+				      strnlen(vmkey, sizeof(vmkey)), SUCCESS);
 		else if (res == VMEVT_MISSLOG)
-			refresh_key_synced_stage2(record, recolen, MISS_LOG);
+			vmrecord_mark(&sender->vmrecord, vmkey,
+				      strnlen(vmkey, sizeof(vmkey)), MISS_LOG);
 	}
 
 out:
 	unmap_file(recos);
+	pthread_mutex_unlock(&sender->vmrecord.mtx);
 }
 
 /* This function only for initialization */
-static void get_last_line_synced(const struct sender_t *sender)
+static void get_last_line_synced(struct sender_t *sender)
 {
 	int id;
 	struct vm_t *vm;
 
 	for_each_vm(id, vm, conf) {
-		int ret;
-		char *p;
 		char vmkey[ANDROID_WORD_LEN];
-		char vm_name[32];
 
 		if (!vm)
 			continue;
@@ -415,38 +325,19 @@ static void get_last_line_synced(const struct sender_t *sender)
 		if (vm->last_synced_line_key[sender->id][0])
 			continue;
 
-		ret = snprintf(vm_name, sizeof(vm_name), "%s ", vm->name);
-		if (s_not_expect(ret, sizeof(vm_name)))
+		if (vmrecord_last(&sender->vmrecord, vm->name, vm->name_len,
+				  vmkey, sizeof(vmkey)) == -1)
 			continue;
 
-		ret = file_read_key_value_r(vmkey, sizeof(vmkey),
-					    sender->log_vmrecordid,
-					    vm_name, strnlen(vm_name, 32));
-		if (ret == -ENOENT) {
-			LOGD("(%s) does not exist, will generate it\n",
-			     sender->log_vmrecordid);
-			generate_log_vmrecord(sender->log_vmrecordid);
-			continue;
-		} else if (ret == -ENOMSG) {
-			LOGD("couldn't find any records with (%s)\n", vm->name);
-			continue;
-		} else if (ret < 0) {
-			LOGE("failed to search records in (%s), error (%s)\n",
-			     sender->log_vmrecordid, strerror(errno));
+		if (strnlen(vmkey, sizeof(vmkey)) != ANDROID_EVT_KEY_LEN) {
+			LOGE("get an invalid vm event (%s) in (%s)\n",
+			     vmkey, sender->vmrecord.path);
 			continue;
 		}
-		p = strchr(vmkey, ' ');
-		if (p)
-			*p = 0;
 
-		ret = refresh_key_synced_stage1(sender, vm, vmkey,
-						strnlen(vmkey, sizeof(vmkey)),
-						MM_ONLY);
-		if (ret < 0) {
-			LOGE("invalid vm event (%s) in (%s)\n",
-			     vmkey, sender->log_vmrecordid);
-			continue;
-		}
+		*(char *)(mempcpy(vm->last_synced_line_key[sender->id], vmkey,
+				  ANDROID_EVT_KEY_LEN)) = '\0';
+
 	}
 }
 
@@ -507,7 +398,7 @@ static char *setup_loop_dev(void)
  * Note that: fn should return VMEVT_HANDLED to indicate event has been handled.
  *	      fn will be called in a time loop if it returns VMEVT_DEFER.
  */
-void refresh_vm_history(const struct sender_t *sender,
+void refresh_vm_history(struct sender_t *sender,
 		int (*fn)(const char*, size_t, const struct vm_t *))
 {
 	struct vm_t *vm;
@@ -521,6 +412,11 @@ void refresh_vm_history(const struct sender_t *sender,
 		if (!loop_dev)
 			return;
 		LOGI("setup loop dev successful\n");
+	}
+
+	if (vmrecord_gen_ifnot_exists(&sender->vmrecord) == -1) {
+		LOGE("failed to create vmrecord\n");
+		return;
 	}
 
 	get_last_line_synced(sender);

--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -17,6 +17,7 @@
 #include "log_sys.h"
 #include "event_handler.h"
 #include "startupreason.h"
+#include "android_events.h"
 
 /* Watchdog timeout in second*/
 #define WDT_TIMEOUT 300
@@ -135,6 +136,7 @@ static void *event_handle(void *unused __attribute__((unused)))
 	int id;
 	struct sender_t *sender;
 	struct event_t *e;
+	struct vm_event_t *vme;
 
 	while ((e = event_dequeue())) {
 		/* here we only handle internal event */
@@ -173,6 +175,13 @@ static void *event_handle(void *unused __attribute__((unused)))
 					break;
 		}
 
+		if (e->event_type == VM) {
+			vme = (struct vm_event_t *)e->private;
+			if (vme->vm_msg)
+				free(vme->vm_msg);
+			if (vme)
+				free(vme);
+		}
 		if ((e->dir))
 			free(e->dir);
 		free(e);

--- a/tools/acrn-crashlog/acrnprobe/event_queue.c
+++ b/tools/acrn-crashlog/acrnprobe/event_queue.c
@@ -9,6 +9,9 @@
 #include "event_queue.h"
 #include "log_sys.h"
 
+const char *etype_str[] = {"CRASH", "INFO", "UPTIME", "HEART_BEAT",
+					"REBOOT", "VM", "UNKNOWN"};
+
 static pthread_mutex_t eq_mtx = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t pcond = PTHREAD_COND_INITIALIZER;
 TAILQ_HEAD(, event_t) event_q;

--- a/tools/acrn-crashlog/acrnprobe/include/android_events.h
+++ b/tools/acrn-crashlog/acrnprobe/include/android_events.h
@@ -34,7 +34,7 @@ extern char *loop_dev;
 #define ANDROID_TYPE_FMT "%[[A-Z0-9_:-]{3,16}]" IGN_SPACES
 #define ANDROID_LINE_REST_FMT "%[[^\n]*]" IGN_RESTS
 
-void refresh_vm_history(const struct sender_t *sender,
+void refresh_vm_history(struct sender_t *sender,
 			int (*fn)(const char*, size_t, const struct vm_t *));
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/android_events.h
+++ b/tools/acrn-crashlog/acrnprobe/include/android_events.h
@@ -11,7 +11,12 @@ extern char *loop_dev;
 
 #define VMEVT_HANDLED 0
 #define VMEVT_DEFER -1
-#define VMEVT_MISSLOG -2
+
+struct vm_event_t {
+	char *vm_msg;
+	size_t vm_msg_len;
+	const struct vm_t *vm;
+};
 
 #define ANDROID_LOGS_DIR "/logs/"
 #define IGN_SPACES "%*[[[:space:]]*]"

--- a/tools/acrn-crashlog/acrnprobe/include/android_events.h
+++ b/tools/acrn-crashlog/acrnprobe/include/android_events.h
@@ -41,5 +41,6 @@ struct vm_event_t {
 
 void refresh_vm_history(struct sender_t *sender,
 			int (*fn)(const char*, size_t, const struct vm_t *));
-
+int android_event_analyze(const char *msg, size_t len, char **result,
+			size_t *rsize);
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/event_queue.h
+++ b/tools/acrn-crashlog/acrnprobe/include/event_queue.h
@@ -18,6 +18,8 @@ enum event_type_t {
 	UNKNOWN
 };
 
+extern const char *etype_str[];
+
 __extension__
 struct event_t {
 	int watchfd;
@@ -29,6 +31,7 @@ struct event_t {
 
 	/* dir to storage logs */
 	char *dir;
+	size_t dlen;
 	int len;
 	char path[0]; /* keep this at tail*/
 };

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -137,6 +137,7 @@ struct sender_t {
 
 	void (*send)(struct event_t *);
 	struct vmrecord_t vmrecord;
+	size_t		outdir_blocks_size;
 	int		sw_updated; /* each sender has their own record */
 };
 

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -24,6 +24,7 @@
 #define VM_EVENT_TYPE_MAX 20
 
 struct trigger_t {
+	int		id;
 	const char	*name;
 	size_t		name_len;
 	const char	*type;
@@ -33,6 +34,7 @@ struct trigger_t {
 };
 
 struct vm_t {
+	int		id;
 	const char	*name;
 	size_t		name_len;
 	const char	*channel;
@@ -49,6 +51,7 @@ struct vm_t {
 };
 
 struct log_t {
+	int		id;
 	const char	*name;
 	size_t		name_len;
 	const char	*type;
@@ -64,6 +67,7 @@ struct log_t {
 };
 
 struct crash_t {
+	int		id;
 	const char	*name;
 	size_t		name_len;
 	const char	*channel;
@@ -92,6 +96,7 @@ struct crash_t {
 };
 
 struct info_t {
+	int		id;
 	const char	*name;
 	size_t		name_len;
 	const char	*channel;
@@ -115,6 +120,7 @@ struct uptime_t {
 };
 
 struct sender_t {
+	int		id;
 	const char	*name;
 	size_t		name_len;
 	const char	*outdir;
@@ -239,7 +245,6 @@ int load_conf(const char *path);
 struct trigger_t *get_trigger_by_name(const char *name);
 struct log_t *get_log_by_name(const char *name);
 struct vm_t *get_vm_by_name(const char *name);
-int sender_id(const struct sender_t *sender);
 struct sender_t *get_sender_by_name(const char *name);
 enum event_type_t get_conf_by_wd(int wd, void **private);
 struct crash_t *get_crash_by_wd(int wd);

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -11,6 +11,7 @@
 #include <ext2fs/ext2fs.h>
 #include "event_queue.h"
 #include "probeutils.h"
+#include "vmrecord.h"
 
 #define CONTENT_MAX 10
 #define EXPRESSION_MAX 5
@@ -136,7 +137,7 @@ struct sender_t {
 	struct uptime_t *uptime;
 
 	void (*send)(struct event_t *);
-	char		*log_vmrecordid;
+	struct vmrecord_t vmrecord;
 	int		sw_updated; /* each sender has their own record */
 };
 

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -48,7 +48,7 @@ struct vm_t {
 	ext2_filsys	datafs;
 	unsigned long	history_size[SENDER_MAX];
 	char		*history_data;
-	char		last_synced_line_key[SENDER_MAX][SHORT_KEY_LENGTH + 1];
+	char		last_evt_detected[SENDER_MAX][SHORT_KEY_LENGTH + 1];
 };
 
 struct log_t {

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -92,7 +92,6 @@ struct crash_t {
 	int wd;
 	int level;
 	struct crash_t *(*reclassify)(const struct crash_t *, const char*,
-					char**, size_t *, char**, size_t *,
 					char**, size_t *);
 };
 

--- a/tools/acrn-crashlog/acrnprobe/include/probeutils.h
+++ b/tools/acrn-crashlog/acrnprobe/include/probeutils.h
@@ -48,7 +48,7 @@ void generate_crashfile(const char *dir, const char *event, size_t elen,
 			const char *type, size_t tlen, const char *data0,
 			size_t d0len, const char *data1, size_t d1len,
 			const char *data2, size_t d2len);
-char *generate_log_dir(enum e_dir_mode mode, char *hashkey);
+char *generate_log_dir(enum e_dir_mode mode, char *hashkey, size_t *dlen);
 int is_boot_id_changed(void);
 
 #endif

--- a/tools/acrn-crashlog/acrnprobe/include/vmrecord.h
+++ b/tools/acrn-crashlog/acrnprobe/include/vmrecord.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __VMRECORD_H__
+#define __VMRECORD_H__
+#include "pthread.h"
+
+#define VMRECORD_HEAD_LINES 10
+#define VMRECORD_TAG_LEN 9
+#define VMRECORD_TAG_WAITING_SYNC	"      <=="
+#define VMRECORD_TAG_NOT_FOUND		"NOT_FOUND"
+#define VMRECORD_TAG_MISS_LOG		"MISS_LOGS"
+#define VMRECORD_TAG_ON_GOING		" ON_GOING"
+#define VMRECORD_TAG_SUCCESS		"         "
+
+enum vmrecord_mark_t {
+	SUCCESS,
+	NOT_FOUND,
+	WAITING_SYNC,
+	ON_GOING,
+	MISS_LOG
+};
+
+struct vmrecord_t {
+	char		*path;
+	pthread_mutex_t	mtx;
+	struct mm_file_t *recos;
+};
+
+int vmrecord_last(struct vmrecord_t *vmrecord, const char *vm_name,
+		size_t nlen, char *vmkey, size_t ksize);
+int vmrecord_mark(struct vmrecord_t *vmrecord, const char *vmkey,
+		   size_t klen, enum vmrecord_mark_t type);
+int vmrecord_open_mark(struct vmrecord_t *vmrecord, const char *vmkey,
+		   size_t klen, enum vmrecord_mark_t type);
+int vmrecord_gen_ifnot_exists(struct vmrecord_t *vmrecord);
+int vmrecord_new(struct vmrecord_t *vmrecord, const char *vm_name,
+		  const char *key);
+
+
+#endif

--- a/tools/acrn-crashlog/acrnprobe/include/vmrecord.h
+++ b/tools/acrn-crashlog/acrnprobe/include/vmrecord.h
@@ -13,6 +13,7 @@
 #define VMRECORD_TAG_NOT_FOUND		"NOT_FOUND"
 #define VMRECORD_TAG_MISS_LOG		"MISS_LOGS"
 #define VMRECORD_TAG_ON_GOING		" ON_GOING"
+#define VMRECORD_TAG_NO_RESOURCE	"NO_RESORC"
 #define VMRECORD_TAG_SUCCESS		"         "
 
 enum vmrecord_mark_t {
@@ -20,6 +21,7 @@ enum vmrecord_mark_t {
 	NOT_FOUND,
 	WAITING_SYNC,
 	ON_GOING,
+	NO_RESRC,
 	MISS_LOG
 };
 

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -291,22 +291,6 @@ enum event_type_t get_conf_by_wd(int wd, void **private)
 
 }
 
-int sender_id(const struct sender_t *s)
-{
-	int id;
-	struct sender_t *sender;
-
-	for_each_sender(id, sender, conf) {
-		if (!sender)
-			continue;
-
-		if (s == sender)
-			return id;
-	}
-
-	return -1;
-}
-
 struct sender_t *get_sender_by_name(const char *name)
 {
 	int id;
@@ -724,6 +708,7 @@ static int parse_sender(xmlNodePtr cur, struct sender_t *sender)
 			} \
 			memset(mem, 0, sizeof(*mem)); \
 			conf.mem[id] = mem; \
+			mem->id = id; \
 			res = parse_##mem(node, mem); \
 			if (res) { \
 				free(mem); \

--- a/tools/acrn-crashlog/acrnprobe/probeutils.c
+++ b/tools/acrn-crashlog/acrnprobe/probeutils.c
@@ -368,35 +368,36 @@ void generate_crashfile(const char *dir,
  *
  * @param mode Mode for log storage.
  * @param hashkey Event id.
+ * @param[out] dir_len Length of generated dir.
  *
  * @return a pointer to generated path if successful, or NULL if not.
  */
-char *generate_log_dir(enum e_dir_mode mode, char *hashkey)
+char *generate_log_dir(enum e_dir_mode mode, char *hashkey, size_t *dir_len)
 {
 	char *path;
 	char dir[PATH_MAX];
 	unsigned int current;
-	int ret;
+	int len;
 
-	ret = reserve_log_folder(mode, dir, &current);
-	if (ret)
+	if (reserve_log_folder(mode, dir, &current))
 		return NULL;
 
-	ret = asprintf(&path, "%s%d_%s", dir, current, hashkey);
-	if (ret == -1) {
+	len = asprintf(&path, "%s%d_%s", dir, current, hashkey);
+	if (len == -1) {
 		LOGE("construct log path failed, out of memory\n");
 		hist_raise_infoerror("DIR CREATE", 10);
 		return NULL;
 	}
 
-	ret = mkdir(path, 0777);
-	if (ret == -1) {
+	if (mkdir(path, 0777) == -1) {
 		LOGE("Cannot create dir %s\n", path);
 		hist_raise_infoerror("DIR CREATE", 10);
 		free(path);
 		return NULL;
 	}
 
+	if (dir_len)
+		*dir_len = (size_t)len;
 	return path;
 }
 

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -1093,12 +1093,13 @@ int init_sender(void)
 		if (!sender)
 			continue;
 
-		ret = asprintf(&sender->log_vmrecordid, "%s/VM_eventsID.log",
+		ret = asprintf(&sender->vmrecord.path, "%s/VM_eventsID.log",
 			       sender->outdir);
 		if (ret < 0) {
 			LOGE("compute string failed, out of memory\n");
 			return -ENOMEM;
 		}
+		pthread_mutex_init(&sender->vmrecord.mtx, NULL);
 
 		if (!directory_exists(sender->outdir))
 			if (mkdir_p(sender->outdir) < 0) {

--- a/tools/acrn-crashlog/acrnprobe/sender.c
+++ b/tools/acrn-crashlog/acrnprobe/sender.c
@@ -57,7 +57,8 @@ static int crashlog_check_space(void)
 	if (!space_available(crashlog->outdir, quota))
 		return -1;
 
-	if (dir_size(crashlog->outdir, crashlog->outdir_len, &dsize) == -1) {
+	if (dir_blocks_size(crashlog->outdir, crashlog->outdir_len,
+			    &dsize) == -1) {
 		LOGE("failed to check outdir size\n");
 		return -1;
 	}

--- a/tools/acrn-crashlog/acrnprobe/vmrecord.c
+++ b/tools/acrn-crashlog/acrnprobe/vmrecord.c
@@ -72,6 +72,8 @@ int vmrecord_mark(struct vmrecord_t *vmrecord, const char *vmkey,
 		memcpy(tag, VMRECORD_TAG_WAITING_SYNC, VMRECORD_TAG_LEN);
 	else if (type == ON_GOING)
 		memcpy(tag, VMRECORD_TAG_ON_GOING, VMRECORD_TAG_LEN);
+	else if (type == NO_RESRC)
+		memcpy(tag, VMRECORD_TAG_NO_RESOURCE, VMRECORD_TAG_LEN);
 	else
 		return -1;
 

--- a/tools/acrn-crashlog/acrnprobe/vmrecord.c
+++ b/tools/acrn-crashlog/acrnprobe/vmrecord.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "log_sys.h"
+#include "fsutils.h"
+#include "strutils.h"
+#include "vmrecord.h"
+#include <stdlib.h>
+
+int vmrecord_last(struct vmrecord_t *vmrecord, const char *vm_name,
+		size_t nlen, char *vmkey, size_t ksize)
+{
+	int res;
+	char *p;
+	char *key;
+
+	if (!vmrecord || !vm_name || !nlen || !vmkey || !ksize)
+		return -1;
+
+	key = malloc(nlen + 2);
+	if (!key)
+		return -1;
+
+	memcpy(key, vm_name, nlen);
+	key[nlen] = ' ';
+	key[nlen + 1] = '\0';
+
+	pthread_mutex_lock(&vmrecord->mtx);
+	res = file_read_key_value_r(vmkey, ksize, vmrecord->path, key,
+				    nlen + 1);
+	pthread_mutex_unlock(&vmrecord->mtx);
+	free(key);
+	if (res < 0) {
+		LOGE("failed to search %s, %s\n", vmrecord->path,
+		     strerror(errno));
+		return -1;
+	}
+	p = strchr(vmkey, ' ');
+	if (p)
+		*p = 0;
+
+	return 0;
+}
+
+/* This function must be called with holding vmrecord mutex */
+int vmrecord_mark(struct vmrecord_t *vmrecord, const char *vmkey,
+			   size_t klen, enum vmrecord_mark_t type)
+{
+	size_t len;
+	char *line;
+	char *tag;
+
+	if (!vmrecord || !vmrecord->recos || !vmkey || !klen)
+		return -1;
+
+	line = get_line(vmkey, klen, vmrecord->recos->begin,
+			vmrecord->recos->size, vmrecord->recos->begin, &len);
+	if (!line)
+		return -1;
+
+	tag = line + len - VMRECORD_TAG_LEN;
+
+	if (type == SUCCESS)
+		memcpy(tag, VMRECORD_TAG_SUCCESS, VMRECORD_TAG_LEN);
+	else if (type == NOT_FOUND)
+		memcpy(tag, VMRECORD_TAG_NOT_FOUND, VMRECORD_TAG_LEN);
+	else if (type == MISS_LOG)
+		memcpy(tag, VMRECORD_TAG_MISS_LOG, VMRECORD_TAG_LEN);
+	else if (type == WAITING_SYNC)
+		memcpy(tag, VMRECORD_TAG_WAITING_SYNC, VMRECORD_TAG_LEN);
+	else if (type == ON_GOING)
+		memcpy(tag, VMRECORD_TAG_ON_GOING, VMRECORD_TAG_LEN);
+	else
+		return -1;
+
+	return 0;
+
+}
+
+int vmrecord_open_mark(struct vmrecord_t *vmrecord, const char *vmkey,
+			   size_t klen, enum vmrecord_mark_t type)
+{
+	int ret;
+
+	if (!vmrecord || !vmkey || !klen)
+		return -1;
+
+	pthread_mutex_lock(&vmrecord->mtx);
+	vmrecord->recos = mmap_file(vmrecord->path);
+	if (!vmrecord->recos) {
+		LOGE("failed to mmap %s, %s\n", vmrecord->path,
+						strerror(errno));
+		ret = -1;
+		goto unlock;
+	}
+	if (!vmrecord->recos->size ||
+	    mm_count_lines(vmrecord->recos) < VMRECORD_HEAD_LINES) {
+		LOGE("(%s) invalid\n", vmrecord->path);
+		ret = -1;
+		goto out;
+	}
+
+	ret = vmrecord_mark(vmrecord, vmkey, klen, type);
+out:
+	unmap_file(vmrecord->recos);
+unlock:
+	pthread_mutex_unlock(&vmrecord->mtx);
+	return ret;
+}
+
+int vmrecord_gen_ifnot_exists(struct vmrecord_t *vmrecord)
+{
+	const char * const head =
+		"/* DONT EDIT!\n"
+		" * This file records VM id synced or about to be synched,\n"
+		" * the tag:\n"
+		" * \"<==\" indicates event waiting to sync.\n"
+		" * \"NOT_FOUND\" indicates event not found in UOS.\n"
+		" * \"MISS_LOGS\" indicates event miss logs in UOS.\n"
+		" * \"ON_GOING\" indicates event is under syncing.\n"
+		" * \"NO_RESORC\" indicates no enough resources in SOS.\n"
+		" */\n\n";
+
+	if (!vmrecord) {
+		LOGE("vmrecord was not initialized\n");
+		return -1;
+	}
+
+	pthread_mutex_lock(&vmrecord->mtx);
+	if (!file_exists(vmrecord->path)) {
+		if (overwrite_file(vmrecord->path, head) < 0) {
+			pthread_mutex_unlock(&vmrecord->mtx);
+			LOGE("failed to create file (%s), %s\n",
+			     vmrecord->path, strerror(errno));
+			return -1;
+		}
+	}
+	pthread_mutex_unlock(&vmrecord->mtx);
+	return 0;
+}
+
+int vmrecord_new(struct vmrecord_t *vmrecord, const char *vm_name,
+			  const char *key)
+{
+	char log_new[64];
+	int nlen;
+
+	if (!vmrecord || !vm_name || !key)
+		return -1;
+
+	nlen = snprintf(log_new, sizeof(log_new), "%s %s %s\n",
+			vm_name, key, VMRECORD_TAG_WAITING_SYNC);
+	if (s_not_expect(nlen, sizeof(log_new))) {
+		LOGE("failed to construct record, key (%s)\n", key);
+		return -1;
+	}
+
+	pthread_mutex_lock(&vmrecord->mtx);
+	if (append_file(vmrecord->path, log_new, strnlen(log_new, 64)) < 0) {
+		pthread_mutex_unlock(&vmrecord->mtx);
+		LOGE("failed to append file (%s), %s\n", vmrecord->path,
+		     strerror(errno));
+		return -1;
+	}
+	pthread_mutex_unlock(&vmrecord->mtx);
+	return 0;
+}

--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -1085,11 +1085,12 @@ int find_file(const char *dir, size_t dlen, const char *target_file,
 	return -1;
 }
 
-static int _count_file_size(const char *pdir, struct dirent *dirp, void *arg)
+static int _count_file_blocks_size(const char *pdir, struct dirent *dirp,
+					void *arg)
 {
 	char file[PATH_MAX];
 	int res;
-	ssize_t fsize;
+	ssize_t fbsize;
 
 	if (dirp->d_type != DT_REG && dirp->d_type != DT_DIR)
 		return DIR_SUCCESS;
@@ -1098,22 +1099,22 @@ static int _count_file_size(const char *pdir, struct dirent *dirp, void *arg)
 	if (s_not_expect(res, sizeof(file)))
 		return DIR_ERROR;
 
-	fsize = get_file_size(file);
-	if (fsize < 0)
+	fbsize = get_file_blocks_size(file);
+	if (fbsize < 0)
 		return DIR_ERROR;
 
-	*(size_t *)arg += fsize;
+	*(size_t *)arg += fbsize;
 
 	return DIR_SUCCESS;
 }
 
-int dir_size(const char *dir, size_t dlen, size_t *size)
+int dir_blocks_size(const char *dir, size_t dlen, size_t *size)
 {
 	if (!dir || !dlen || !size)
 		return -1;
 
 	*size = 0;
-	if (dir_recursive(dir, dlen, -1, _count_file_size,
+	if (dir_recursive(dir, dlen, -1, _count_file_blocks_size,
 			  (void *)size) != DIR_SUCCESS) {
 		LOGE("failed to recursive dir (%s)\n", dir);
 		return -1;

--- a/tools/acrn-crashlog/common/include/fsutils.h
+++ b/tools/acrn-crashlog/common/include/fsutils.h
@@ -75,6 +75,19 @@ static inline ssize_t get_file_size(const char *filepath)
 	return info.st_size;
 }
 
+static inline ssize_t get_file_blocks_size(const char *filepath)
+{
+	struct stat info;
+
+	if (filepath == NULL)
+		return -ENOENT;
+
+	if (stat(filepath, &info) < 0)
+		return -errno;
+
+	return info.st_blocks * 512;
+}
+
 char *mm_get_line(struct mm_file_t *mfile, int line);
 int mkdir_p(const char *path);
 int remove_r(const char *dir);
@@ -114,7 +127,7 @@ int dir_contains(const char *dir, const char *filename, size_t flen, int exact);
 int lsdir(const char *dir, char *fullname[], int limit);
 int find_file(const char *dir, size_t dlen, const char *target_file,
 		size_t tflen, int depth, char *path[], int limit);
-int dir_size(const char *dir, size_t dlen, size_t *size);
+int dir_blocks_size(const char *dir, size_t dlen, size_t *size);
 int read_file(const char *path, unsigned long *size, void **data);
 int is_ac_filefmt(const char *file_fmt);
 int config_fmt_to_files(const char *file_fmt, char ***out);

--- a/tools/acrn-crashlog/common/include/strutils.h
+++ b/tools/acrn-crashlog/common/include/strutils.h
@@ -16,6 +16,7 @@ ssize_t strlinelen(const char *str, size_t size);
 char *strrstr(const char *s, const char *str);
 char *strtrim(char *str, size_t len);
 int strcnt(char *str, char c);
+char *strings_ind(char *strings, size_t size, int index, size_t *slen);
 int str_split_ere(const char *str, size_t slen,
 		const char *fmt, size_t flen, ...);
 #endif

--- a/tools/acrn-crashlog/common/strutils.c
+++ b/tools/acrn-crashlog/common/strutils.c
@@ -156,6 +156,39 @@ int strcnt(char *str, char c)
 	return cnt;
 }
 
+char *strings_ind(char *strings, size_t size, int index, size_t *slen)
+{
+	int i = 0;
+	size_t len;
+	char *start = strings;
+	char *str_tail;
+	size_t left;
+
+	if (!strings || !size)
+		return NULL;
+
+	str_tail = memchr((void *)strings, '\0', size);
+	if (!str_tail)
+		return NULL;
+
+	while (1) {
+		len = str_tail - start;
+		if (i++ == index)
+			break;
+		left = strings + size - str_tail - 1;
+		if (!left)
+			return NULL;
+		start = str_tail + 1;
+		str_tail = memchr((void *)start, '\0', left);
+		if (!str_tail)
+			break;
+	}
+
+	if (slen)
+		*slen = len;
+	return start;
+}
+
 static int reg_match(const char *str, const char *pattern,
 		char *matched_sub, size_t matched_space,
 		size_t *end_off)

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -17,7 +17,6 @@
 		<sender id="2" enable="true">
 			<name>telemd</name>
 			<outdir>/var/log/acrnprobe</outdir>
-			<foldersize>10</foldersize>
 			<uptime>
 				<name>UPTIME</name>
 				<frequency>5</frequency>


### PR DESCRIPTION
This patch set aims to refine the IO operation on the eMMC.
Check a folder's size need to traverse all nodes of files and subdirs,
in the case of extreme memory strain, accessing these log file nodes
frequently will highly increase the pressure of io operation.
Previously, all log files will be accessed and counted in each space
check, this patch aims to refine it by only calculating the increment of new
logs.

In order to achieve this purpose, acrnprobe must maintain one variate to
record the total size of all logs, and modify it after each time
log changed. To avoid the using of lock, the access of this variate must
be single-threaded.
So, firstly, these serial patches unify the handling process of each kind
of events to:
analyze events - request resources -  collect logs - record current log size
and then make the change of log space check.
