### PR TITLE
hv:remove accessing shared log buffer cases between stac/clac

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -49,11 +49,8 @@ uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 	if (pgentry != NULL) {
 		hpa = ((*pgentry & (~(pg_size - 1UL)))
 				| (gpa & (pg_size - 1UL)));
-		pr_dbg("GPA2HPA: 0x%llx->0x%llx", gpa, hpa);
-	} else {
-		pr_err("VM %d GPA2HPA: failed for gpa 0x%llx",
-				vm->vm_id, gpa);
 	}
+
 	/**
 	 * If specified parameter size is not NULL and
 	 * the HPA of parameter gpa is found, pg_size shall

--- a/hypervisor/arch/x86/seed/seed_sbl.c
+++ b/hypervisor/arch/x86/seed/seed_sbl.c
@@ -94,7 +94,6 @@ bool parse_seed_sbl(uint64_t addr, struct physical_seed *phy_seed)
 					 */
 					if ((entry->index != dseed_index) ||
 					    (entry->index >= BOOTLOADER_SEED_MAX_ENTRIES)) {
-						pr_warn("%s: Invalid seed index.", __func__);
 						status = false;
 						break;
 					}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1177,7 +1177,6 @@ int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 				}
 
 				status = 0;
-				pr_dbg("intr monitor:%d, cnt=%d", intr_hdr->cmd, intr_hdr->buf_cnt);
 			}
 			clac();
 		}

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -247,17 +247,15 @@ static int32_t profiling_sbuf_put_variable(struct shared_buf *sbuf,
 	 * 5. return number of bytes of data put in buffer
 	 */
 
-	stac();
 	if ((sbuf == NULL) || (data == NULL)) {
-		clac();
 		return -EINVAL;
 	}
 
 	if (size == 0U) {
-		clac();
 		return 0;
 	}
 
+	stac();
 	if (sbuf->tail >= sbuf->head) {
 		remaining_space = sbuf->size - (sbuf->tail - sbuf->head);
 	} else {

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -464,6 +464,21 @@ static inline void write_xcr(int32_t reg, uint64_t val)
 	asm volatile("xsetbv" : : "c" (reg), "a" ((uint32_t)val), "d" ((uint32_t)(val >> 32U)));
 }
 
+/*
+ * stac/clac pair is used to access guest's memory protected by SMAP,
+ * following below flow:
+ *
+ *	stac();
+ *	#access guest's memory.
+ *	clac();
+ *
+ * Notes:Avoid inserting another stac/clac pair between stac and clac,
+ *	As once clac after multiple stac will invalidate SMAP protection
+ *	and hence Page Fault crash.
+ *	Logging message to memory buffer will induce this case,
+ *	please disable SMAP temporlly or don't log messages to shared
+ *	memory buffer, if it is evitable for you for debug purpose.
+ */
 static inline void stac(void)
 {
 	asm volatile ("stac" : : : "memory");


### PR DESCRIPTION
Shared buffer is allocated by VM and is protected by SMAP.
Accessing to shared buffer between stac/clac pair will invalidate
SMAP protection.This patch is to remove these cases.
Fix minor stac/clac mis-usage,and add comments as stac/clac usage BKM

Tracked-On: #2526
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>