### PR TITLE
virtio-blk rescan feature

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -390,6 +390,35 @@ static void handle_query(struct mngr_msg *msg, int client_fd, void *param)
 	mngr_send_msg(client_fd, &ack, NULL, ACK_TIMEOUT);
 }
 
+static void handle_blkrescan(struct mngr_msg *msg, int client_fd, void *param)
+{
+	struct mngr_msg ack;
+	struct vm_ops *ops;
+	int ret = 0;
+	int count = 0;
+
+	ack.magic = MNGR_MSG_MAGIC;
+	ack.msgid = msg->msgid;
+	ack.timestamp = msg->timestamp;
+
+	wakeup_reason = msg->data.reason;
+
+	LIST_FOREACH(ops, &vm_ops_head, list) {
+		if (ops->ops->rescan) {
+			ret += ops->ops->rescan(ops->arg, msg->data.devargs);
+			count++;
+		}
+	}
+
+	if (!count) {
+		ack.data.err = -1;
+		fprintf(stderr, "No handler for id:%u\r\n", msg->msgid);
+	} else
+		ack.data.err = ret;
+
+	mngr_send_msg(client_fd, &ack, NULL, ACK_TIMEOUT);
+}
+
 static struct monitor_vm_ops pmc_ops = {
 	.stop       = NULL,
 	.resume     = vm_monitor_resume,
@@ -431,6 +460,7 @@ int monitor_init(struct vmctx *ctx)
 	ret += mngr_add_handler(monitor_fd, DM_PAUSE, handle_pause, NULL);
 	ret += mngr_add_handler(monitor_fd, DM_CONTINUE, handle_continue, NULL);
 	ret += mngr_add_handler(monitor_fd, DM_QUERY, handle_query, NULL);
+	ret += mngr_add_handler(monitor_fd, DM_BLKRESCAN, handle_blkrescan, NULL);
 
 	if (ret) {
 		fprintf(stderr, "%s %d\r\n", __FUNCTION__, __LINE__);

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -2390,6 +2390,25 @@ pci_emul_dior(struct vmctx *ctx, int vcpu, struct pci_vdev *dev, int baridx,
 	return value;
 }
 
+struct pci_vdev*
+pci_get_vdev_info(int slot)
+{
+	struct businfo *bi;
+	struct slotinfo *si;
+	struct pci_vdev *dev = NULL;
+
+	bi = pci_businfo[0];
+	assert(bi != NULL);
+
+	si = &bi->slotinfo[slot];
+	if (si != NULL)
+		dev = si->si_funcs[0].fi_devi;
+	else
+		fprintf(stderr, "slot=%d is empty!\n", slot);
+
+	return dev;
+}
+
 struct pci_vdev_ops pci_dummy = {
 	.class_name	= "dummy",
 	.vdev_init	= pci_emul_dinit,

--- a/devicemodel/include/monitor.h
+++ b/devicemodel/include/monitor.h
@@ -25,6 +25,7 @@ struct monitor_vm_ops {
 	int (*pause) (void *arg);
 	int (*unpause) (void *arg);
 	int (*query) (void *arg);
+	int (*rescan)(void *arg, char *devargs);
 };
 
 int monitor_register_vm_ops(struct monitor_vm_ops *ops, void *arg,
@@ -34,4 +35,5 @@ int monitor_register_vm_ops(struct monitor_vm_ops *ops, void *arg,
 unsigned get_wakeup_reason(void);
 int set_wakeup_timer(time_t t);
 int acrn_parse_intr_monitor(const char *opt);
+int vm_monitor_blkrescan(void *arg, char *devargs);
 #endif

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -321,6 +321,7 @@ int	check_gsi_sharing_violation(void);
 int	pciaccess_init(void);
 void	pciaccess_cleanup(void);
 int	parse_bdf(char *s, int *bus, int *dev, int *func, int base);
+struct pci_vdev *pci_get_vdev_info(int slot);
 
 
 /**

--- a/doc/developer-guides/primer.rst
+++ b/doc/developer-guides/primer.rst
@@ -795,6 +795,35 @@ To use the Virtio-blk device, use the following command:
          nohpet console=hvc0 no_timer_check ignore_loglevel \
          log_buf_len=16M consoleblank=0 tsc=reliable" vm1
 
+Virtio-blk also supports rescan feature. Virtio-blk rescan is helpful
+when the size/path of the Virtio-blk device's backing file (on the host)
+changes and the guest needs to refresh its internal data structures to
+pick up this change. Using rescan feature is simple, add Virtio-blk
+device with dummy backend using "**nodisk**" keyword instead of a backing
+file.
+
+To create a Virtio-blk device with dummy backend,
+use the following command:
+
+.. code-block:: bash
+
+   ./acrn-dm -A -m 1168M \
+      -s 0:0,hostbridge \
+      -s 1,virtio-blk,**nodisk** \
+      -k bzImage -B "root=/dev/vda rw rootwait noxsave maxcpus=0 \
+         nohpet console=hvc0 no_timer_check ignore_loglevel \
+         log_buf_len=16M consoleblank=0 tsc=reliable" vm1
+
+After VM launch, user can replace the dummy backend file with the
+actual file using acrnctl "blkrescan" cmd as shown below,
+
+.. code-block:: bash
+
+   acrnctl blkrescan vm1 1,actual_file.img
+
+Please refer to :ref:`acrnctl` for further details on
+``acrnctl blkrescan`` command.
+
 To verify the result, you should expect the user OS to boot
 successfully.
 

--- a/tools/acrn-manager/README.rst
+++ b/tools/acrn-manager/README.rst
@@ -32,6 +32,7 @@ You can see the available ``acrnctl`` commands by running:
      suspend
      resume
      reset
+     blkrescan
    Use acrnctl [cmd] help for details
 
 Here are some usage examples:
@@ -92,6 +93,27 @@ Use the ``stop`` command to stop one or more running VM:
 .. code-block:: none
 
    # acrnctl stop vm-yocto vm1-14:59:30 vm-android
+
+RESCAN BLOCK DEVICE
+===================
+
+Use the ``blkrescan`` command to trigger a rescan of
+virtio-blk device by guest VM, in order to revalidate and
+update the backend file.
+
+.. code-block:: none
+
+   # acrnctl blkrescan vmname slot,newfilepath
+   vmname:     Name of VM with dummy backend file attached to virtio-blk device.
+   slot:       Slot number of the virtio-blk device.
+   newfilepath: File path for the backend of virtio-blk device.
+
+   acrnctl blkrescan vm1 6,actual_file.img
+
+.. note:: blkrescan is only supported when VM is launched with
+   empty backend file (using **nodisk**) for virtio-blk device.
+   Replacing a valid backend file is not supported and will
+   result in error.
 
 .. _acrnd:
 

--- a/tools/acrn-manager/acrn_mngr.h
+++ b/tools/acrn-manager/acrn_mngr.h
@@ -19,11 +19,18 @@
 #define ACRN_DM_BASE_PATH	"/run/acrn"
 #define ACRN_DM_SOCK_PATH	"/run/acrn/mngr"
 
+/* TODO: Revisit PARAM_LEN and see if size can be reduced */
+#define PARAM_LEN	256
+
 struct mngr_msg {
 	unsigned long long magic;	/* Make sure you get a mngr_msg */
 	unsigned int msgid;
 	unsigned long timestamp;
 	union {
+
+		/* Arguments to rescan virtio-blk device */
+		char devargs[PARAM_LEN];
+
 		/* ack of DM_STOP, DM_SUSPEND, DM_RESUME, DM_PAUSE, DM_CONTINUE,
 		   ACRND_TIMER, ACRND_STOP, ACRND_RESUME, RTC_TIMER */
 		int err;
@@ -82,6 +89,7 @@ enum dm_msgid {
 	DM_PAUSE,		/* Freeze this virtual machine */
 	DM_CONTINUE,		/* Unfreeze this virtual machine */
 	DM_QUERY,		/* Ask power state of this UOS */
+	DM_BLKRESCAN,		/* Rescan virtio-blk device for any changes in UOS */
 	DM_MAX,
 };
 

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -456,3 +456,22 @@ int resume_vm(const char *vmname, unsigned reason)
 
 	return ack.data.err;
 }
+
+int blkrescan_vm(const char *vmname, char *devargs)
+{
+	struct mngr_msg req;
+	struct mngr_msg ack;
+
+	req.magic = MNGR_MSG_MAGIC;
+	req.msgid = DM_BLKRESCAN;
+	req.timestamp = time(NULL);
+	strncpy(req.data.devargs, devargs, strlen(devargs)+1);
+
+	send_msg(vmname, &req, &ack);
+
+	if (ack.data.err) {
+		printf("Unable to rescan virtio-blk device in vm. errno(%d)\n", ack.data.err);
+	}
+
+	return ack.data.err;
+}

--- a/tools/acrn-manager/acrnctl.h
+++ b/tools/acrn-manager/acrnctl.h
@@ -59,5 +59,6 @@ int pause_vm(const char *vmname);
 int continue_vm(const char *vmname);
 int suspend_vm(const char *vmname);
 int resume_vm(const char *vmname, unsigned reason);
+int blkrescan_vm(const char *vmname, char *devargs);
 
 #endif				/* _ACRNCTL_H_ */


### PR DESCRIPTION
The following patches adds rescan support for virtio-blk device.
This feature stems from the kata container requirement, which hot-plugs container rootfs to the guest VM. 
1. Tools patch adds a new acrnctl command called "blkrescan" to 
   initiate rescan of virtio-blk device.

2. DM patch updates the virtio-blk device launched with 
   dummy backend file with correct backend file, size
   and triggers the guest OS to revalidate the disk resulting
   in adding blk device to guest VM.