### PR TITLE
hv: rename 'interrupt_init' to 'init_interrupt'

### DIFF
--- a/doc/developer-guides/hld/hv-interrupt.rst
+++ b/doc/developer-guides/hld/hv-interrupt.rst
@@ -484,7 +484,7 @@ related operations.
    void dispatch_interrupt(struct intr_excp_ctx *ctx)
       /*  To dispatch an interrupt, an action callback will be called if registered. */
 
-   void interrupt_init(uint16_t pcpu_id)
+   void init_interrupt(uint16_t pcpu_id)
       /*  To do interrupt initialization for a cpu, will be called for
        *  each physical cpu.
        */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -214,7 +214,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 		init_scheduler();
 
 		/* Initialize interrupts */
-		interrupt_init(BOOT_CPU_ID);
+		init_interrupt(BOOT_CPU_ID);
 
 		timer_init();
 		setup_notification();
@@ -238,7 +238,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 		pr_dbg("Core %hu is up", pcpu_id);
 
 		/* Initialize secondary processor interrupts. */
-		interrupt_init(pcpu_id);
+		init_interrupt(pcpu_id);
 
 		timer_init();
 

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -447,7 +447,7 @@ static inline void set_idt(struct host_idt_descriptor *idtd)
 		      [idtd] "m"(*idtd));
 }
 
-void interrupt_init(uint16_t pcpu_id)
+void init_interrupt(uint16_t pcpu_id)
 {
 	struct host_idt_descriptor *idtd = &HOST_IDTR;
 

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -237,7 +237,7 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu);
  *
  * @param[in]	pcpu_id The id of physical cpu to initialize
  */
-void interrupt_init(uint16_t pcpu_id);
+void init_interrupt(uint16_t pcpu_id);
 
 void cancel_event_injection(struct acrn_vcpu *vcpu);
 


### PR DESCRIPTION
This patch renames 'interrupt_init' to 'init_interrupt'.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>