### PR TITLE
doc: Fix references to be Wi-Fi

### DIFF
--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -934,9 +934,9 @@ OS owns part of the devices with passthrough, as shown below:
      - Ethernet
      -
 
-   * - **WIFI**
+   * - **Wi-Fi**
      -
-     - WIFI
+     - Wi-Fi
 
    * - **Bluetooth**
      -

--- a/doc/developer-guides/hld/hv-ioc-virt.rst
+++ b/doc/developer-guides/hld/hv-ioc-virt.rst
@@ -489,7 +489,7 @@ Heartbeat frame definition is shown here:
    command 1 to 7 following the related scenarios. For example: S3 case
    needs to be set at 7 to prevent from power gating the memory.
 -  The difference between halt and reboot is related if the power rail
-   that supplies to customer peripherals (such as Fan, HDMI-in, BT/WIFI,
+   that supplies to customer peripherals (such as Fan, HDMI-in, BT/Wi-Fi,
    M.2, and Ethernet) is reset.
 
 .. figure:: images/ioc-image8.png

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -130,7 +130,7 @@ In the automotive example we described above, the User OS is the central
 hub of vehicle control and in-vehicle entertainment. It provides support
 for radio and entertainment options, control of the vehicle climate
 control, and vehicle navigation displays. It also provides connectivity
-options for using USB, Bluetooth, and WiFi for third-party device
+options for using USB, Bluetooth, and Wi-Fi for third-party device
 interaction with the vehicle, such as Android Auto\* or Apple CarPlay*,
 and many other features.
 


### PR DESCRIPTION
Correct spelling of the trademarked name is Wi-Fi

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>