### PR TITLE
HV: hotfix for acpi.c compile error

### DIFF
--- a/hypervisor/boot/acpi.c
+++ b/hypervisor/boot/acpi.c
@@ -35,6 +35,7 @@
 #include <ioapic.h>
 #include <logmsg.h>
 #include <host_pm.h>
+#include <acrn_common.h>
 
 #define ACPI_SIG_RSDP             "RSD PTR " /* Root System Description Ptr */
 #define ACPI_OEM_ID_SIZE           6


### PR DESCRIPTION
In commit b68aee6ef1d8217f592df0cdd3446618d5a770f9, acpi.c
removed "hypervisor.h" which includes "acrn_common.h", but
commit e2d723d4fa914071fa99c801c7e3ef93ab7ec269 is depend on
"acrn_common.h", this caused build error
Tracked-On: #3073

Signed-off-by: Victor Sun <victor.sun@intel.com>