### PR TITLE
VPCI code function renaming and fix comment

### DIFF
--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -38,7 +38,7 @@
 #include <pci.h>
 #include "vpci_priv.h"
 
-void vdev_hostbridge_init(struct pci_vdev *vdev)
+void vhostbridge_init(struct pci_vdev *vdev)
 {
 	/* PCI config space */
 	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
@@ -83,11 +83,11 @@ void vdev_hostbridge_init(struct pci_vdev *vdev)
 	pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
 }
 
-void vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev)
+void vhostbridge_deinit(__unused const struct pci_vdev *vdev)
 {
 }
 
-int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
+int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
@@ -95,7 +95,7 @@ int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
+int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
 	if (!pci_bar_access(offset)) {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -398,7 +398,7 @@ int32_t partition_mode_vpci_init(struct acrn_vm *vm)
 		vdev->vbdf.value = ptdev_config->vbdf.value;
 
 		if (is_hostbridge(vdev)) {
-			vdev_hostbridge_init(vdev);
+			vhostbridge_init(vdev);
 		} else {
 			partition_mode_pdev_init(vdev, ptdev_config->pbdf);
 
@@ -424,7 +424,7 @@ void partition_mode_vpci_deinit(const struct acrn_vm *vm)
 		vdev = (struct pci_vdev *) &(vm->vpci.pci_vdevs[i]);
 
 		if (is_hostbridge(vdev)) {
-			vdev_hostbridge_deinit(vdev);
+			vhostbridge_deinit(vdev);
 		} else {
 			remove_vdev_pt_iommu_domain(vdev);
 
@@ -445,7 +445,7 @@ void partition_mode_cfgread(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 
 	if (vdev != NULL) {
 		if (is_hostbridge(vdev)) {
-			(void)vdev_hostbridge_cfgread(vdev, offset, bytes, val);
+			(void)vhostbridge_cfgread(vdev, offset, bytes, val);
 		} else {
 			if ((vdev_pt_cfgread(vdev, offset, bytes, val) != 0)
 				&& (vmsi_cfgread(vdev, offset, bytes, val) != 0)
@@ -468,7 +468,7 @@ void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 
 	if (vdev != NULL) {
 		if (is_hostbridge(vdev)) {
-			(void)vdev_hostbridge_cfgwrite(vdev, offset, bytes, val);
+			(void)vhostbridge_cfgwrite(vdev, offset, bytes, val);
 		} else {
 			if ((vdev_pt_cfgwrite(vdev, offset, bytes, val) != 0)
 				&& (vmsi_cfgwrite(vdev, offset, bytes, val) != 0)

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -220,8 +220,8 @@ void vpci_init(struct acrn_vm *vm)
 	if (ret == 0) {
 		/*
 		 * SOS: intercept port CF8 only.
-		 * UOS or partition mode: register handler for CF8 only and I/O requests to CF9/CFA/CFB are
-		 *      not handled by vpci.
+		 * UOS or pre-launched VM: register handler for CF8 only and I/O requests to CF9/CFA/CFB are
+		 * not handled by vpci.
 		 */
 		register_pio_emulation_handler(vm, PCI_CFGADDR_PIO_IDX, &pci_cfgaddr_range,
 			pci_cfgaddr_io_read, pci_cfgaddr_io_write);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -75,10 +75,10 @@ static inline bool has_msix_cap(const struct pci_vdev *vdev)
 	return (vdev->msix.capoff != 0U);
 }
 
-void vdev_hostbridge_init(struct pci_vdev *vdev);
-int32_t vdev_hostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vdev_hostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void vdev_hostbridge_deinit(__unused const struct pci_vdev *vdev);
+void vhostbridge_init(struct pci_vdev *vdev);
+int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void vhostbridge_deinit(__unused const struct pci_vdev *vdev);
 
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);


### PR DESCRIPTION
Rename hostbridge related functions
    vdev_hostbridge_init --> vhostbridge_init
    vdev_hostbridge_cfgread --> vhostbridge_cfgread
    vdev_hostbridge_cfgwrite --> vhostbridge_cfgwrite
    vdev_hostbridge_deinit --> vhostbridge_deinit

Replace partition mode with pre-launched VM in comments

Tracked-On: #3056