### PR TITLE
vm_state: Update vm state VM_STATE_INVALID to VM_POWERED_OFF

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -50,9 +50,17 @@ uint16_t get_vmid_by_uuid(const uint8_t *uuid)
 /**
  * @pre vm != NULL
  */
-bool is_valid_vm(const struct acrn_vm *vm)
+bool is_poweroff_vm(const struct acrn_vm *vm)
 {
-	return (vm->state != VM_STATE_INVALID);
+	return (vm->state == VM_POWERED_OFF);
+}
+
+/**
+ * @pre vm != NULL
+ */
+bool is_created_vm(const struct acrn_vm *vm)
+{
+	return (vm->state == VM_CREATED);
 }
 
 bool is_sos_vm(const struct acrn_vm *vm)
@@ -322,7 +330,7 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 
 /**
  * @pre vm_id < CONFIG_MAX_VM_NUM && vm_config != NULL && rtn_vm != NULL
- * @pre vm->state == VM_STATE_INVALID
+ * @pre vm->state == VM_POWERED_OFF
  */
 int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_vm **rtn_vm)
 {
@@ -439,7 +447,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		}
 	}
 
-	if (need_cleanup && is_valid_vm(vm)) {
+	if (need_cleanup) {
 		if (vm->arch_vm.nworld_eptp != NULL) {
 			(void)memset(vm->arch_vm.nworld_eptp, 0U, PAGE_SIZE);
 		}
@@ -462,7 +470,7 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 
 	/* Only allow shutdown paused vm */
 	if (vm->state == VM_PAUSED) {
-		vm->state = VM_STATE_INVALID;
+		vm->state = VM_POWERED_OFF;
 
 		foreach_vcpu(i, vm, vcpu) {
 			reset_vcpu(vcpu);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -154,7 +154,7 @@ int32_t hcall_create_vm(struct acrn_vm *vm, uint64_t param)
 	if (copy_from_gpa(vm, &cv, param, sizeof(cv)) == 0) {
 		vm_id = get_vmid_by_uuid(&cv.uuid[0]);
 		if ((vm_id < CONFIG_MAX_VM_NUM)
-			&& (!is_valid_vm(get_vm_from_vmid(vm_id)))) {
+			&& (is_poweroff_vm(get_vm_from_vmid(vm_id)))) {
 			vm_config = get_vm_config(vm_id);
 
 			/* Filter out the bits should not set by DM and then assign it to guest_flags */
@@ -205,7 +205,7 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 	int32_t ret = -1;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		/* TODO: check target_vm guest_flags */
 		ret = shutdown_vm(target_vm);
 	}
@@ -229,7 +229,7 @@ int32_t hcall_start_vm(uint16_t vmid)
 	int32_t ret = -1;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if ((is_valid_vm(target_vm)) && (is_postlaunched_vm(target_vm)) && (target_vm->sw.io_shared_page != NULL)) {
+	if ((is_created_vm(target_vm)) && (is_postlaunched_vm(target_vm)) && (target_vm->sw.io_shared_page != NULL)) {
 		/* TODO: check target_vm guest_flags */
 		start_vm(target_vm);
 		ret = 0;
@@ -254,7 +254,7 @@ int32_t hcall_pause_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	int32_t ret = -1;
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		/* TODO: check target_vm guest_flags */
 		pause_vm(target_vm);
 		ret = 0;
@@ -285,7 +285,7 @@ int32_t hcall_create_vcpu(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct acrn_create_vcpu cv;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm) && (param != 0U)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm) && (param != 0U)) {
 		if (copy_from_gpa(vm, &cv, param, sizeof(cv)) != 0) {
 			pr_err("%s: Unable copy param to vm\n", __func__);
 		} else {
@@ -318,7 +318,7 @@ int32_t hcall_reset_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	int32_t ret = -1;
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		/* TODO: check target_vm guest_flags */
 	        ret = reset_vm(target_vm);
 	}
@@ -347,7 +347,8 @@ int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	int32_t ret = -1;
 
 	/* Only allow setup init ctx while target_vm is inactive */
-	if ((is_valid_vm(target_vm)) && (param != 0U) && (is_postlaunched_vm(target_vm)) && (target_vm->state != VM_STARTED)) {
+	if ((!is_poweroff_vm(target_vm)) && (param != 0U) && (is_postlaunched_vm(target_vm)) &&
+			(target_vm->state != VM_STARTED)) {
 		if (copy_from_gpa(vm, &vcpu_regs, param, sizeof(vcpu_regs)) != 0) {
 			pr_err("%s: Unable copy param to vm\n", __func__);
 		} else if (vcpu_regs.vcpu_id >= CONFIG_MAX_VCPUS_PER_VM) {
@@ -385,7 +386,7 @@ int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	int32_t ret = -1;
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (ops->gsi < vioapic_pincount(vm)) {
 			if (ops->gsi < vpic_pincount()) {
 				/*
@@ -472,7 +473,7 @@ int32_t hcall_inject_msi(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct acrn_msi_entry msi;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		(void)memset((void *)&msi, 0U, sizeof(msi));
 		if (copy_from_gpa(vm, &msi, param, sizeof(msi)) != 0) {
 			pr_err("%s: Unable copy param to vm\n", __func__);
@@ -513,7 +514,7 @@ int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, uint16_t vmid, uint64_t param
 	int32_t ret = -1;
 
 	(void)memset((void *)&iobuf, 0U, sizeof(iobuf));
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (is_created_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (copy_from_gpa(vm, &iobuf, param, sizeof(iobuf)) != 0) {
 			pr_err("%p %s: Unable copy param to vm\n", target_vm, __func__);
 	        } else {
@@ -556,7 +557,7 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 	int32_t ret = -1;
 
 	/* make sure we have set req_buf */
-	if ((is_valid_vm(target_vm)) && (is_postlaunched_vm(target_vm)) && (target_vm->sw.io_shared_page != NULL)) {
+	if ((!is_poweroff_vm(target_vm)) && (is_postlaunched_vm(target_vm)) && (target_vm->sw.io_shared_page != NULL)) {
 		dev_dbg(ACRN_DBG_HYCALL, "[%d] NOTIFY_FINISH for vcpu %d",
 			vmid, vcpu_id);
 
@@ -695,7 +696,7 @@ int32_t hcall_set_vm_memory_regions(struct acrn_vm *vm, uint64_t param)
 		if (regions.vmid < CONFIG_MAX_VM_NUM) {
 			target_vm = get_vm_from_vmid(regions.vmid);
 		}
-		if ((target_vm != NULL) && is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+		if ((target_vm != NULL) && !is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 			idx = 0U;
 			while (idx < regions.mr_num) {
 				if (copy_from_gpa(vm, &mr, regions.regions_gpa + idx * sizeof(mr), sizeof(mr)) != 0) {
@@ -772,7 +773,7 @@ int32_t hcall_write_protect_page(struct acrn_vm *vm, uint16_t vmid, uint64_t wp_
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	int32_t ret = -1;
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		(void)memset((void *)&wp, 0U, sizeof(wp));
 
 		if (copy_from_gpa(vm, &wp, wp_gpa, sizeof(wp)) != 0) {
@@ -807,7 +808,7 @@ int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	(void)memset((void *)&v_gpa2hpa, 0U, sizeof(v_gpa2hpa));
-	if (is_valid_vm(target_vm) && (!is_prelaunched_vm(target_vm))
+	if (!is_poweroff_vm(target_vm) && (!is_prelaunched_vm(target_vm))
 			&& (copy_from_gpa(vm, &v_gpa2hpa, param, sizeof(v_gpa2hpa)) == 0)) {
 		v_gpa2hpa.hpa = gpa2hpa(target_vm, v_gpa2hpa.gpa);
 		if (v_gpa2hpa.hpa == INVALID_HPA) {
@@ -845,7 +846,7 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	bool bdf_valid = true;
 	bool iommu_valid = true;
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (param < 0x10000UL) {
 			bdf = (uint16_t) param;
 		} else {
@@ -905,7 +906,7 @@ int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	bool bdf_valid = true;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (param < 0x10000UL) {
 			bdf = (uint16_t) param;
 		} else {
@@ -942,7 +943,7 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t pa
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	(void)memset((void *)&irq, 0U, sizeof(irq));
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
 			pr_err("%s: Unable copy param to vm\n", __func__);
 		} else {
@@ -984,7 +985,7 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct hc_ptdev_irq irq;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		(void)memset((void *)&irq, 0U, sizeof(irq));
 
 		if (copy_from_gpa(vm, &irq, param, sizeof(irq)) != 0) {
@@ -1037,7 +1038,7 @@ int32_t hcall_get_cpu_pm_state(struct acrn_vm *vm, uint64_t cmd, uint64_t param)
 	if (target_vm_id < CONFIG_MAX_VM_NUM) {
 		target_vm = get_vm_from_vmid(target_vm_id);
 	}
-	if ((target_vm != NULL) && (is_valid_vm(target_vm)) && (is_postlaunched_vm(target_vm))) {
+	if ((target_vm != NULL) && (!is_poweroff_vm(target_vm)) && (is_postlaunched_vm(target_vm))) {
 		switch (cmd & PMCMD_TYPE_MASK) {
 		case PMCMD_GET_PX_CNT: {
 
@@ -1151,7 +1152,7 @@ int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	uint64_t hpa;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (is_valid_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		/* the param for this hypercall is page aligned */
 		hpa = gpa2hpa(vm, param);
 		if (hpa != INVALID_HPA) {

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -92,7 +92,7 @@ struct acrn_vuart *vuart_console_active(void)
 
 	if (console_vmid < CONFIG_MAX_VM_NUM) {
 		vm = get_vm_from_vmid(console_vmid);
-		if (is_valid_vm(vm)) {
+		if (!is_poweroff_vm(vm)) {
 			vu = vm_console_vuart(vm);
 		} else {
 			/* Console vm is invalid, switch back to HV-Shell */

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -879,7 +879,7 @@ int32_t profiling_vm_list_info(struct acrn_vm *vm, uint64_t addr)
 
 	for (j = 0U; j < CONFIG_MAX_VM_NUM; j++) {
 		tmp_vm = get_vm_from_vmid(j);
-		if (!is_valid_vm(tmp_vm)) {
+		if (is_poweroff_vm(tmp_vm)) {
 			break;
 		}
 		vm_info_list.num_vms++;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -575,12 +575,15 @@ static int32_t shell_list_vm(__unused int32_t argc, __unused char **argv)
 		case VM_PAUSED:
 			(void)strncpy_s(state, 32U, "Paused", 32U);
 			break;
+		case VM_POWERED_OFF:
+			(void)strncpy_s(state, 32U, "Off", 32U);
+			break;
 		default:
 			(void)strncpy_s(state, 32U, "Unknown", 32U);
 			break;
 		}
 		vm_config = get_vm_config(vm_id);
-		if (is_valid_vm(vm)) {
+		if (!is_poweroff_vm(vm)) {
 			int8_t i;
 
 			for (i = 0; i < 16; i++) {
@@ -611,7 +614,7 @@ static int32_t shell_list_vcpu(__unused int32_t argc, __unused char **argv)
 
 	for (idx = 0U; idx < CONFIG_MAX_VM_NUM; idx++) {
 		vm = get_vm_from_vmid(idx);
-		if (!is_valid_vm(vm)) {
+		if (is_poweroff_vm(vm)) {
 			continue;
 		}
 		foreach_vcpu(i, vm, vcpu) {
@@ -761,7 +764,7 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 	vcpu_id = (uint16_t)strtol_deci(argv[2]);
 
 	vm = get_vm_from_vmid(vm_id);
-	if (!is_valid_vm(vm)) {
+	if (is_poweroff_vm(vm)) {
 		shell_puts("No vm found in the input <vm_id, vcpu_id>\r\n");
 		status = -EINVAL;
 		goto out;
@@ -855,7 +858,7 @@ static int32_t shell_to_vm_console(int32_t argc, char **argv)
 
 	/* Get the virtual device node */
 	vm = get_vm_from_vmid(vm_id);
-	if (!is_valid_vm(vm)) {
+	if (is_poweroff_vm(vm)) {
 		shell_puts("VM is not valid \n");
 		return -EINVAL;
 	}
@@ -1067,7 +1070,7 @@ static void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 	struct acrn_vm *vm = get_vm_from_vmid(vmid);
 	uint32_t pin, pincount;
 
-	if (!is_valid_vm(vm)) {
+	if (is_poweroff_vm(vm)) {
 		len = snprintf(str, size, "\r\nvm is not exist for vmid %hu", vmid);
 		if (len >= size) {
 			goto overflow;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -81,7 +81,7 @@ struct vm_pm_info {
 #define VM_MONO_GUEST       0x01
 /* Enumerated type for VM states */
 enum vm_state {
-	VM_STATE_INVALID = 0,
+	VM_POWERED_OFF = 0,
 	VM_CREATED,	/* VM created / awaiting start (boot) */
 	VM_STARTED,	/* VM started (booted) */
 	VM_POWERING_OFF,     /* RTVM only, it is trying to poweroff by itself */
@@ -203,7 +203,8 @@ int32_t reset_vm(struct acrn_vm *vm);
 int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_vm **rtn_vm);
 void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config);
 void launch_vms(uint16_t pcpu_id);
-bool is_valid_vm(const struct acrn_vm *vm);
+bool is_poweroff_vm(const struct acrn_vm *vm);
+bool is_created_vm(const struct acrn_vm *vm);
 bool is_sos_vm(const struct acrn_vm *vm);
 bool is_postlaunched_vm(const struct acrn_vm *vm);
 bool is_prelaunched_vm(const struct acrn_vm *vm);


### PR DESCRIPTION
Replace the vm state VM_STATE_INVALID to VM_POWERED_OFF.
Also replace is_valid_vm() with is_poweroff_vm().
Add API is_created_vm() to identify VM created state.

Tracked-On: #3082
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>