### PR TITLE
dm:add grep -w option for uos launch sh

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -75,7 +75,7 @@ fi
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit
@@ -223,7 +223,7 @@ ser=$mmc_name$mmc_serial
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit

--- a/devicemodel/samples/apl-up2/launch_uos.sh
+++ b/devicemodel/samples/apl-up2/launch_uos.sh
@@ -64,7 +64,7 @@ fi
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit
@@ -208,7 +208,7 @@ ser=$mmc_name$mmc_serial
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -15,7 +15,7 @@ mac_seed=${mac:9:8}-${vm_name}
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit

--- a/devicemodel/samples/nuc/launch_vxworks.sh
+++ b/devicemodel/samples/nuc/launch_vxworks.sh
@@ -6,7 +6,7 @@ vm_name=vxworks_vm$1
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit

--- a/devicemodel/samples/nuc/launch_zephyr.sh
+++ b/devicemodel/samples/nuc/launch_zephyr.sh
@@ -6,7 +6,7 @@ vm_name=zephyr_vm$1
 
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit


### PR DESCRIPTION
for vm_name  with vxworks_vm1  or zephyr_vm1 or vm1
grep "vm1" will match three of them, add -w option fix this issue
Tracked-On:#3081
Signed-off-by: zhangyun <yunx.zhang@intel.com>