### PR TITLE
HV: remove some redundant includes

### DIFF
--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -5,7 +5,6 @@
  */
 
 #include <vm_config.h>
-#include <acrn_common.h>
 #include <logmsg.h>
 #include <cat.h>
 

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <types.h>
 #include <acrn_common.h>
 #include <default_acpi_info.h>
 #include <platform_acpi_info.h>

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -50,7 +50,6 @@
 
 #ifndef ASSEMBLER
 
-#include <types.h>
 #include <acrn_common.h>
 #include <guest_memory.h>
 #include <virtual_cr.h>

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -13,10 +13,8 @@
 
 #ifndef ASSEMBLER
 
-#include <types.h>
 #include <bits.h>
 #include <spinlock.h>
-#include <acrn_common.h>
 #include <vcpu.h>
 #include <vioapic.h>
 #include <vpic.h>

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -5,8 +5,6 @@
  */
 
 #include <vm_config.h>
-#include <vm_configurations.h>
-#include <acrn_common.h>
 #include <vuart.h>
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -5,8 +5,6 @@
  */
 
 #include <vm_config.h>
-#include <vm_configurations.h>
-#include <acrn_common.h>
 #include <vuart.h>
 
 extern struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM];

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -5,8 +5,6 @@
  */
 
 #include <vm_config.h>
-#include <vm_configurations.h>
-#include <acrn_common.h>
 #include <vuart.h>
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {


### PR DESCRIPTION
vm_config.h has included types.h/acrn_common.h/vm_configurations.h,
acrn_common.h has included types.h, so remove the redundant includes;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>