### PR TITLE
build fix: fix build issue with latest gcc for blkrescan

### DIFF
--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -465,7 +465,8 @@ int blkrescan_vm(const char *vmname, char *devargs)
 	req.magic = MNGR_MSG_MAGIC;
 	req.msgid = DM_BLKRESCAN;
 	req.timestamp = time(NULL);
-	strncpy(req.data.devargs, devargs, strlen(devargs)+1);
+	strncpy(req.data.devargs, devargs, PARAM_LEN - 1);
+	req.data.devargs[PARAM_LEN - 1] = '\0';
 
 	send_msg(vmname, &req, &ack);
 


### PR DESCRIPTION
With latest gcc version 9.1.1 20190506 from Clear Linux, we hit
following build issue in blkrescan code:
In function ‘strncpy’,
    inlined from ‘blkrescan_vm’ at acrn_vm_ops.c:468:2:
/usr/include/bits/string_fortified.h:106:10: error: \
‘__builtin___strncpy_chk’ specified bound depends on the length \
of the source argument [-Werror=stringop-overflow=]

When calling strncpy, the size n should be set to max dest size
instead of src size.

Tracked-On: #3096
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>