### PR TITLE
signal SIGINT: map SIGINT to watchdog reset

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -678,8 +678,9 @@ num_vcpus_allowed(struct vmctx *ctx)
 static void
 sig_handler_term(int signo)
 {
-	printf("Receive SIGINT to terminate application...\n");
-	vm_set_suspend_mode(VM_SUSPEND_POWEROFF);
+	printf("Receive SIGINT to full reset application...\n");
+	vm_set_watchdog_bite();
+	vm_set_suspend_mode(VM_SUSPEND_FULL_RESET);
 	mevent_notify();
 }
 

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -387,6 +387,12 @@ pci_wdt_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 }
 
+void
+vm_set_watchdog_bite(void)
+{
+	wdt_timeout = 1;
+}
+
 /* stop/reset watchdog will be invoked during guest enter/exit S3.
  * We stop watchdog timer when guest enter S3 to avoid watchdog trigger
  * guest reset when guest is in S3 state.

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -143,6 +143,7 @@ int	vm_set_vcpu_regs(struct vmctx *ctx, struct acrn_set_vcpu_regs *cpu_regs);
 
 int	vm_get_cpu_state(struct vmctx *ctx, void *state_buf);
 int	vm_intr_monitor(struct vmctx *ctx, void *intr_buf);
+void	vm_set_watchdog_bite(void);
 void	vm_stop_watchdog(struct vmctx *ctx);
 void	vm_reset_watchdog(struct vmctx *ctx);
 


### PR DESCRIPTION
Map SIGINT(2) to watchdog reset.
NOTE:
We required guest to do a full reset after detect the recent last
reset type is watchdog. This is used to resume the passthru devices
in UOS.

Tracked-On: #3103
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>