### PR TITLE
doc: add note to indicate that vSBL is only supported on APL platforms

### DIFF
--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -253,6 +253,9 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
        first, and trusty OS will then load and verify Android OS according to
        Android OS verification mechanism.
 
+       .. note::
+          vSBL is currently only supported on Apollo Lake processors.
+
        usage::
 
           --vsbl /usr/share/acrn/bios/VSBL.bin


### PR DESCRIPTION
Using vSBL is only supported on Apollo Lake (APL) platforms at the
present. It cannot be used on other platforms supported by ACRN such as
KBL. Make this explicit with an additional note in the documentation.

Tracked-On: #2798
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>