### PR TITLE
HV: fix MISRA violation of host_pm.h

### DIFF
--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -6,6 +6,8 @@
 #ifndef	HOST_PM_H
 #define	HOST_PM_H
 
+#include <acrn_common.h>
+
 #define	BIT_SLP_TYPx	10U
 #define	BIT_SLP_EN	13U
 #define	BIT_WAK_STS	15U


### PR DESCRIPTION
The header need struct pm_s_state_data info which declared in acrn_common.h;

Tracked-On: #1842

Signed-off-by: Victor Sun <victor.sun@intel.com>