### PR TITLE
bug fix to boot waag

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -417,7 +417,9 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		/* Create virtual uart;*/
 		vuart_init(vm, vm_config->vuart);
 
-		vrtc_init(vm);
+		if (is_rt_vm(vm) || !is_postlaunched_vm(vm)) {
+			vrtc_init(vm);
+		}
 
 		vpci_init(vm);
 


### PR DESCRIPTION
v2-v3:
back to v1. Conghui will take care of the vioapic/vpic initialization.

v1-v2:
Add fix about vioapic and vpic initialization when create a VM. For prelaunched VM
and postlaunched RT VM, we don't support ioapic and pic, so we don't need to do
vioapic and vpic initialization when create a VM.

v1:
1. Windows will call OVMF to report guest memory size in nvram cells through RTC ioport.
However, the vRTC emulated in hypervisor doesn't provide this feature. It's only used for
pre-launched VM. For the post-launched VM, we need the DM to emulate the vRTC for us.
2. The previous implement of TPR virtualization has two bugs: a) we need to retain the RIP
b) we need to update the PPR before finding a deliverable interrupt.


    Tracked-On: #1842
    Signed-off-by: Li, Fei1 <fei1.li@intel.com>
    Reviewed-by: Yu Wang <yu1.wang@intel.com>
    Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
    Acked-by: Anthony Xu <anthony.xu@intel.com>
