### PR TITLE
HV: hot fix on usage of CONFIG_ACPI_PARSE_ENABLED

### DIFF
--- a/hypervisor/boot/guest/vboot_wrapper.c
+++ b/hypervisor/boot/guest/vboot_wrapper.c
@@ -66,7 +66,7 @@ void init_vboot_operations(void)
 /* @pre: vboot_ops->init != NULL */
 void init_vboot(void)
 {
-#ifndef CONFIG_ACPI_PARSE_ENABLED
+#ifdef CONFIG_ACPI_PARSE_ENABLED
 	acpi_fixup();
 #endif
 	vboot_ops->init();

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -36,7 +36,7 @@ struct ioapic_info;
 uint16_t parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM]);
 uint16_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array);
 
-#ifndef CONFIG_ACPI_PARSE_ENABLED
+#ifdef CONFIG_ACPI_PARSE_ENABLED
 void acpi_fixup(void);
 #endif
 


### PR DESCRIPTION
The acpi_fixup() is only called when CONFIG_ACPI_PARSE_ENABLED is enabled;

Tracked-On: #3107

Signed-off-by: Victor Sun <victor.sun@intel.com>