### PR TITLE
hv:remove some unnecessary includes

### DIFF
--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -28,7 +28,6 @@
  */
 #include <types.h>
 #include <rtl.h>
-#include <vboot.h>
 #include "acpi.h"
 #include <pgtable.h>
 #include <ioapic.h>

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -6,7 +6,6 @@
 
 #include <types.h>
 #include <logmsg.h>
-#include <host_pm.h>
 #include <io.h>
 #include <spinlock.h>
 #include "pci.h"

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -33,7 +33,6 @@
 #include <pgtable.h>
 #include <ioapic.h>
 #include <logmsg.h>
-#include <host_pm.h>
 #include <acrn_common.h>
 
 #define ACPI_SIG_RSDP             "RSD PTR " /* Root System Description Ptr */

--- a/hypervisor/boot/guest/direct_boot_info.c
+++ b/hypervisor/boot/guest/direct_boot_info.c
@@ -9,7 +9,6 @@
 #include <sprintf.h>
 #include <multiboot.h>
 #include <pgtable.h>
-#include <guest_memory.h>
 #include <zeropage.h>
 #include <seed.h>
 #include <mmu.h>

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -12,7 +12,6 @@
 #include <irq.h>
 #include <page.h>
 #include <timer.h>
-#include <instr_emul.h>
 #include <profiling.h>
 #include <logmsg.h>
 #include <gdt.h>


### PR DESCRIPTION
remove some unnecessary includes,
some can cause reverse dependency.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>

	modified:   acpi_parser/acpi_ext.c
	modified:   acpi_parser/dmar_parse.c
	modified:   boot/acpi_base.c
	modified:   boot/guest/direct_boot_info.c
	modified:   include/arch/x86/per_cpu.h