### PR TITLE
HV: Remove undefined CONFIG_REMAIN_1G_PAGES

### DIFF
--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -15,6 +15,8 @@
 #include <sprintf.h>
 #include <logmsg.h>
 
+#define NUM_REMAIN_1G_PAGES	3UL
+
 static void prepare_bsp_gdt(struct acrn_vm *vm)
 {
 	size_t gdt_len;
@@ -154,15 +156,11 @@ int32_t general_sw_loader(struct acrn_vm *vm)
 		 * remained 1G pages" for reserving.
 		 */
 		if (is_sos_vm(vm)) {
-			int32_t reserving_1g_pages;
+			int64_t reserving_1g_pages;
 
-#ifdef CONFIG_REMAIN_1G_PAGES
-			reserving_1g_pages = (vm_config->memory.size >> 30U) - CONFIG_REMAIN_1G_PAGES;
-#else
-			reserving_1g_pages = (vm_config->memory.size >> 30U) - 3U;
-#endif
+			reserving_1g_pages = (vm_config->memory.size >> 30U) - NUM_REMAIN_1G_PAGES;
 			if (reserving_1g_pages > 0) {
-				snprintf(dyn_bootargs, 100U, " hugepagesz=1G hugepages=%d", reserving_1g_pages);
+				snprintf(dyn_bootargs, 100U, " hugepagesz=1G hugepages=%lld", reserving_1g_pages);
 				(void)copy_to_gpa(vm, dyn_bootargs, ((uint64_t)linux_info->bootargs_load_addr
 					+ linux_info->bootargs_size),
 					(strnlen_s(dyn_bootargs, 99U) + 1U));


### PR DESCRIPTION
The definition of CONFIG_REMAIN_1G_PAGES has been removed by patch (4627cd4d HV: build: drop useless files).
So, remove the whole CONFIG_REMAIN_1G_PAGES in repo.

---
 v1 -> v2:
   Address Fei's comment about changing reserving_1g_pages from int32_t to int64_t
   Address Jason's comment about adding MACRO NUM_REMAIN_1G_PAGES

Tracked-On: #3128
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>