### PR TITLE
Remove sharing_mode/partition_mode from vpci code

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -43,8 +43,10 @@ static inline uint32_t get_bar_base(uint32_t bar)
 
 /**
  * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
  */
-int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
+int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	int32_t ret = -ENODEV;

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -50,7 +50,7 @@ int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	int32_t ret = -ENODEV;
 
 	/* PCI BARs is emulated */
-	if (pci_bar_access(offset)) {
+	if (is_prelaunched_vm(vdev->vpci->vm) && pci_bar_access(offset)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
 		ret = 0;
 	}
@@ -254,7 +254,7 @@ int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	int32_t ret = -ENODEV;
 
 	/* PCI BARs are emulated */
-	if (pci_bar_access(offset)) {
+	if (is_prelaunched_vm(vdev->vpci->vm) && pci_bar_access(offset)) {
 		vdev_pt_cfgwrite_bar(vdev, offset, bytes, val);
 		ret = 0;
 	}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -251,8 +251,10 @@ static void vdev_pt_cfgwrite_bar(struct pci_vdev *vdev, uint32_t offset,
 
 /**
  * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
  */
-int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
+int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
 	int32_t ret = -ENODEV;

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -30,6 +30,9 @@
 #include <vm.h>
 #include "vpci_priv.h"
 
+/**
+ * @pre vdev != NULL
+ */
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
 {
 	uint32_t val;
@@ -49,6 +52,9 @@ uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_
 	return val;
 }
 
+/**
+ * @pre vdev != NULL
+ */
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	switch (bytes) {

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -121,7 +121,7 @@ int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
+int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
 	int32_t ret = -ENODEV;

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -102,7 +102,7 @@ void deinit_vhostbridge(__unused const struct pci_vdev *vdev)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
+int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	int32_t ret = -ENODEV;

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -45,7 +45,7 @@
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-void vhostbridge_init(struct pci_vdev *vdev)
+void init_vhostbridge(struct pci_vdev *vdev)
 {
 	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
 		/* PCI config space */

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -36,71 +36,103 @@
 
 #include <vm.h>
 #include <pci.h>
+#include <errno.h>
 #include "vpci_priv.h"
 
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ */
 void vhostbridge_init(struct pci_vdev *vdev)
 {
-	/* PCI config space */
-	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
-	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x5af0U);
+	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
+		/* PCI config space */
+		pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
+		pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x5af0U);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xbU);
+		pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xbU);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)PCIM_HDRTYPE_NORMAL
-		| PCIM_MFDEV);
-	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
-	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_HOST);
+		pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)PCIM_HDRTYPE_NORMAL
+			| PCIM_MFDEV);
+		pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
+		pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_HOST);
 
-	pci_vdev_write_cfg_u8(vdev, 0x34U, (uint8_t)0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0x3cU, (uint8_t)0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0x48U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0x4aU, (uint8_t)0xd1U);
-	pci_vdev_write_cfg_u8(vdev, 0x4bU, (uint8_t)0xfeU);
-	pci_vdev_write_cfg_u8(vdev, 0x50U, (uint8_t)0xc1U);
-	pci_vdev_write_cfg_u8(vdev, 0x51U, (uint8_t)0x2U);
-	pci_vdev_write_cfg_u8(vdev, 0x54U, (uint8_t)0x33U);
-	pci_vdev_write_cfg_u8(vdev, 0x58U, (uint8_t)0x7U);
-	pci_vdev_write_cfg_u8(vdev, 0x5aU, (uint8_t)0xf0U);
-	pci_vdev_write_cfg_u8(vdev, 0x5bU, (uint8_t)0x7fU);
-	pci_vdev_write_cfg_u8(vdev, 0x60U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0x63U, (uint8_t)0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0xabU, (uint8_t)0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xacU, (uint8_t)0x2U);
-	pci_vdev_write_cfg_u8(vdev, 0xb0U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xb3U, (uint8_t)0x7cU);
-	pci_vdev_write_cfg_u8(vdev, 0xb4U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xb6U, (uint8_t)0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xb7U, (uint8_t)0x7bU);
-	pci_vdev_write_cfg_u8(vdev, 0xb8U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xbbU, (uint8_t)0x7bU);
-	pci_vdev_write_cfg_u8(vdev, 0xbcU, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xbfU, (uint8_t)0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xe0U, (uint8_t)0x9U);
-	pci_vdev_write_cfg_u8(vdev, 0xe2U, (uint8_t)0xcU);
-	pci_vdev_write_cfg_u8(vdev, 0xe3U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
-	pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
-	pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0x34U, (uint8_t)0xe0U);
+		pci_vdev_write_cfg_u8(vdev, 0x3cU, (uint8_t)0xe0U);
+		pci_vdev_write_cfg_u8(vdev, 0x48U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0x4aU, (uint8_t)0xd1U);
+		pci_vdev_write_cfg_u8(vdev, 0x4bU, (uint8_t)0xfeU);
+		pci_vdev_write_cfg_u8(vdev, 0x50U, (uint8_t)0xc1U);
+		pci_vdev_write_cfg_u8(vdev, 0x51U, (uint8_t)0x2U);
+		pci_vdev_write_cfg_u8(vdev, 0x54U, (uint8_t)0x33U);
+		pci_vdev_write_cfg_u8(vdev, 0x58U, (uint8_t)0x7U);
+		pci_vdev_write_cfg_u8(vdev, 0x5aU, (uint8_t)0xf0U);
+		pci_vdev_write_cfg_u8(vdev, 0x5bU, (uint8_t)0x7fU);
+		pci_vdev_write_cfg_u8(vdev, 0x60U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0x63U, (uint8_t)0xe0U);
+		pci_vdev_write_cfg_u8(vdev, 0xabU, (uint8_t)0x80U);
+		pci_vdev_write_cfg_u8(vdev, 0xacU, (uint8_t)0x2U);
+		pci_vdev_write_cfg_u8(vdev, 0xb0U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0xb3U, (uint8_t)0x7cU);
+		pci_vdev_write_cfg_u8(vdev, 0xb4U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0xb6U, (uint8_t)0x80U);
+		pci_vdev_write_cfg_u8(vdev, 0xb7U, (uint8_t)0x7bU);
+		pci_vdev_write_cfg_u8(vdev, 0xb8U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0xbbU, (uint8_t)0x7bU);
+		pci_vdev_write_cfg_u8(vdev, 0xbcU, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0xbfU, (uint8_t)0x80U);
+		pci_vdev_write_cfg_u8(vdev, 0xe0U, (uint8_t)0x9U);
+		pci_vdev_write_cfg_u8(vdev, 0xe2U, (uint8_t)0xcU);
+		pci_vdev_write_cfg_u8(vdev, 0xe3U, (uint8_t)0x1U);
+		pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
+		pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
+		pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
+	}
 }
 
 void vhostbridge_deinit(__unused const struct pci_vdev *vdev)
 {
 }
 
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ */
 int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
-	*val = pci_vdev_read_cfg(vdev, offset, bytes);
+	int32_t ret = -ENODEV;
 
-	return 0;
+	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
+		*val = pci_vdev_read_cfg(vdev, offset, bytes);
+		ret = 0;
+	}
+
+	return ret;
 }
 
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ */
 int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
-	if (!pci_bar_access(offset)) {
-		pci_vdev_write_cfg(vdev, offset, bytes, val);
+	int32_t ret = -ENODEV;
+
+	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
+		if (!pci_bar_access(offset)) {
+			pci_vdev_write_cfg(vdev, offset, bytes, val);
+		}
+
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -92,7 +92,7 @@ void init_vhostbridge(struct pci_vdev *vdev)
 	}
 }
 
-void vhostbridge_deinit(__unused const struct pci_vdev *vdev)
+void deinit_vhostbridge(__unused const struct pci_vdev *vdev)
 {
 }
 

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -57,6 +57,12 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 	return ret;
 }
 
+/**
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ * @pre vdev->pdev != NULL
+ */
 static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 {
 	struct ptirq_msi_info info;
@@ -172,6 +178,11 @@ int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, u
 	return ret;
 }
 
+/**
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ */
 void deinit_vmsi(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
@@ -194,6 +205,10 @@ static void buf_write32(uint8_t buf[], uint32_t val)
 	buf[3] = (uint8_t)((val >> 24U) & 0xFFU);
 }
 
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
 void init_vmsi(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev = vdev->pdev;

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -188,7 +188,7 @@ static void buf_write32(uint8_t buf[], uint32_t val)
 	buf[3] = (uint8_t)((val >> 24U) & 0xFFU);
 }
 
-void vmsi_init(struct pci_vdev *vdev)
+void init_vmsi(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev = vdev->pdev;
 	uint32_t val;

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -115,7 +115,10 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 	return ret;
 }
 
-int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+/**
+ * @pre vdev != NULL
+ */
+int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret = -ENODEV;
 

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -166,7 +166,7 @@ int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, ui
 	return ret;
 }
 
-void vmsi_deinit(const struct pci_vdev *vdev)
+void deinit_vmsi(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
 		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -131,7 +131,10 @@ int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t byt
 	return ret;
 }
 
-int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+/**
+ * @pre vdev != NULL
+ */
+int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	bool message_changed = false;
 	bool enable;

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -351,7 +351,7 @@ void init_vmsix(struct pci_vdev *vdev)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-void vmsix_deinit(const struct pci_vdev *vdev)
+void deinit_vmsix(const struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -174,7 +174,11 @@ int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t by
 	return ret;
 }
 
-int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+int32_t vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	uint32_t msgctrl;
 	int32_t ret = -ENODEV;

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -158,7 +158,10 @@ static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index
 	return ret;
 }
 
-int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+/**
+ * @pre vdev != NULL
+ */
+int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret = -ENODEV;
 	/* For PIO access, we emulate Capability Structures only */

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -53,11 +53,20 @@ static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)
 	return ret;
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline bool msixtable_access(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return in_range(offset, vdev->msix.table_offset, vdev->msix.table_count * MSIX_TABLE_ENTRY_SIZE);
 }
 
+/**
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ * @pre vdev->pdev != NULL
+ */
 static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bool enable)
 {
 	struct msix_table_entry *pentry;
@@ -92,6 +101,10 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 	return ret;
 }
 
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
 static inline void enable_disable_msix(const struct pci_vdev *vdev, bool enable)
 {
 	uint32_t msgctrl;
@@ -105,7 +118,11 @@ static inline void enable_disable_msix(const struct pci_vdev *vdev, bool enable)
 	pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
 }
 
-/* Do MSI-X remap for all MSI-X table entries in the target device */
+/**
+ * Do MSI-X remap for all MSI-X table entries in the target device
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
 static int32_t vmsix_remap(const struct pci_vdev *vdev, bool enable)
 {
 	uint32_t index;
@@ -132,7 +149,11 @@ static int32_t vmsix_remap(const struct pci_vdev *vdev, bool enable)
 	return ret;
 }
 
-/* Do MSI-X remap for one MSI-X table entry only */
+/**
+ * Do MSI-X remap for one MSI-X table entry only
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
 static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index, bool enable)
 {
 	uint32_t msgctrl;
@@ -336,6 +357,7 @@ int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler
 
 /**
  * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
  */
 void init_vmsix(struct pci_vdev *vdev)
 {

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -330,7 +330,7 @@ int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler
 /**
  * @pre vdev != NULL
  */
-void vmsix_init(struct pci_vdev *vdev)
+void init_vmsix(struct pci_vdev *vdev)
 {
 	struct pci_pdev *pdev = vdev->pdev;
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -51,7 +51,8 @@ static void pci_cfg_clear_cache(struct pci_addr_info *pi)
 }
 
 /**
- * @pre vm != NULL && vcpu != NULL
+ * @pre vm != NULL
+ * @pre vcpu != NULL
  */
 static bool pci_cfgaddr_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes)
 {
@@ -147,7 +148,7 @@ static bool pci_cfgdata_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint
 /**
  * @pre vm != NULL
  * @pre vm->vm_id < CONFIG_MAX_VM_NUM
- * @pre (get_vm_config(vm->vm_id)->type == PRE_LAUNCHED_VM) || (get_vm_config(vm->vm_id)->type == SOS_VM)
+ * @pre (get_vm_config(vm->vm_id)->load_order == PRE_LAUNCHED_VM) || (get_vm_config(vm->vm_id)->load_order == SOS_VM)
  */
 static bool pci_cfgdata_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes, uint32_t val)
 {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -435,13 +435,13 @@ void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	}
 }
 
-static struct pci_vdev *sharing_mode_find_vdev_sos(union pci_bdf pbdf)
+static struct pci_vdev *find_vdev_for_sos(union pci_bdf bdf)
 {
 	struct acrn_vm *vm;
 
 	vm = get_sos_vm();
 
-	return pci_find_vdev_by_pbdf(&vm->vpci, pbdf);
+	return pci_find_vdev_by_pbdf(&vm->vpci, bdf);
 }
 
 /**
@@ -450,7 +450,7 @@ static struct pci_vdev *sharing_mode_find_vdev_sos(union pci_bdf pbdf)
 void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val)
 {
-	struct pci_vdev *vdev = sharing_mode_find_vdev_sos(bdf);
+	struct pci_vdev *vdev = find_vdev_for_sos(bdf);
 
 	*val = ~0U;
 
@@ -471,7 +471,7 @@ void sharing_mode_cfgread(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	struct pci_vdev *vdev = sharing_mode_find_vdev_sos(bdf);
+	struct pci_vdev *vdev = find_vdev_for_sos(bdf);
 
 	if (vdev != NULL) {
 		if ((vmsi_cfgwrite(vdev, offset, bytes, val) != 0)
@@ -607,7 +607,7 @@ void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, ui
 	union pci_bdf bdf;
 
 	bdf.value = pbdf;
-	vdev = sharing_mode_find_vdev_sos(bdf);
+	vdev = find_vdev_for_sos(bdf);
 	if (vdev == NULL) {
 		pr_err("%s, can't find PCI device for vm%d, vbdf (0x%x) pbdf (0x%x)", __func__,
 			target_vm->vm_id, vbdf, pbdf);
@@ -629,7 +629,7 @@ void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, 
 	union pci_bdf bdf;
 
 	bdf.value = pbdf;
-	vdev = sharing_mode_find_vdev_sos(bdf);
+	vdev = find_vdev_for_sos(bdf);
 	if (vdev == NULL) {
 		pr_err("%s, can't find PCI device for vm%d, vbdf (0x%x) pbdf (0x%x)", __func__,
 			target_vm->vm_id, vbdf, pbdf);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -262,14 +262,6 @@ void vpci_cleanup(const struct acrn_vm *vm)
 
 /**
  * @pre vdev != NULL
- */
-static inline bool is_hostbridge(const struct pci_vdev *vdev)
-{
-	return (vdev->vbdf.value == 0U);
-}
-
-/**
- * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  * @pre vdev->vpci->vm->iommu != NULL

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -37,31 +37,49 @@ static inline bool in_range(uint32_t value, uint32_t lower, uint32_t len)
 	return ((value >= lower) && (value < (lower + len)));
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline uint8_t pci_vdev_read_cfg_u8(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return vdev->cfgdata.data_8[offset];
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline uint16_t pci_vdev_read_cfg_u16(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return vdev->cfgdata.data_16[offset >> 1U];
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline uint32_t pci_vdev_read_cfg_u32(const struct pci_vdev *vdev, uint32_t offset)
 {
 	return vdev->cfgdata.data_32[offset >> 2U];
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline void pci_vdev_write_cfg_u8(struct pci_vdev *vdev, uint32_t offset, uint8_t val)
 {
 	vdev->cfgdata.data_8[offset] = val;
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline void pci_vdev_write_cfg_u16(struct pci_vdev *vdev, uint32_t offset, uint16_t val)
 {
 	vdev->cfgdata.data_16[offset >> 1U] = val;
 }
 
+/**
+ * @pre vdev != NULL
+ */
 static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset, uint32_t val)
 {
 	vdev->cfgdata.data_32[offset >> 2U] = val;

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -83,7 +83,7 @@ static inline bool is_hostbridge(const struct pci_vdev *vdev)
 	return (vdev->vbdf.value == 0U);
 }
 
-void vhostbridge_init(struct pci_vdev *vdev);
+void init_vhostbridge(struct pci_vdev *vdev);
 int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void vhostbridge_deinit(__unused const struct pci_vdev *vdev);
@@ -92,11 +92,12 @@ void init_vdev_pt(struct pci_vdev *vdev);
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
-void vmsi_init(struct pci_vdev *vdev);
+void init_vmsi(struct pci_vdev *vdev);
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void vmsi_deinit(const struct pci_vdev *vdev);
-void vmsix_init(struct pci_vdev *vdev);
+
+void init_vmsix(struct pci_vdev *vdev);
 void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev);
 int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
@@ -110,14 +111,12 @@ struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_b
 
 struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf);
 
-int32_t partition_mode_vpci_init(struct acrn_vm *vm);
 void partition_mode_cfgread(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
 void partition_mode_vpci_deinit(const struct acrn_vm *vm);
 
-int32_t sharing_mode_vpci_init(struct acrn_vm *vm);
 void sharing_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -75,6 +75,14 @@ static inline bool has_msix_cap(const struct pci_vdev *vdev)
 	return (vdev->msix.capoff != 0U);
 }
 
+/**
+ * @pre vdev != NULL
+ */
+static inline bool is_hostbridge(const struct pci_vdev *vdev)
+{
+	return (vdev->vbdf.value == 0U);
+}
+
 void vhostbridge_init(struct pci_vdev *vdev);
 int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -84,23 +84,23 @@ static inline bool is_hostbridge(const struct pci_vdev *vdev)
 }
 
 void init_vhostbridge(struct pci_vdev *vdev);
-int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vhostbridge(__unused const struct pci_vdev *vdev);
 
 void init_vdev_pt(struct pci_vdev *vdev);
-int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
 void init_vmsi(struct pci_vdev *vdev);
-int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev);
 int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
-int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(const struct pci_vdev *vdev);
 
@@ -111,13 +111,9 @@ struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_b
 
 struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf);
 
-void partition_mode_cfgread(const struct acrn_vpci *vpci, union pci_bdf vbdf,
-	uint32_t offset, uint32_t bytes, uint32_t *val);
 void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
 
-void sharing_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf bdf,
-	uint32_t offset, uint32_t bytes, uint32_t *val);
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
 

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -86,7 +86,7 @@ static inline bool is_hostbridge(const struct pci_vdev *vdev)
 void init_vhostbridge(struct pci_vdev *vdev);
 int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void vhostbridge_deinit(__unused const struct pci_vdev *vdev);
+void deinit_vhostbridge(__unused const struct pci_vdev *vdev);
 
 void init_vdev_pt(struct pci_vdev *vdev);
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
@@ -95,14 +95,14 @@ int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
 void init_vmsi(struct pci_vdev *vdev);
 int32_t vmsi_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void vmsi_deinit(const struct pci_vdev *vdev);
+void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev);
 int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 int32_t vmsix_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void vmsix_deinit(const struct pci_vdev *vdev);
+void deinit_vmsix(const struct pci_vdev *vdev);
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
@@ -115,13 +115,10 @@ void partition_mode_cfgread(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
-void partition_mode_vpci_deinit(const struct acrn_vm *vm);
 
 void sharing_mode_cfgread(struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t *val);
 void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
 	uint32_t offset, uint32_t bytes, uint32_t val);
-void sharing_mode_vpci_deinit(const struct acrn_vm *vm);
-void post_launched_vm_vpci_deinit(const struct acrn_vm *vm);
 
 #endif /* VPCI_PRIV_H_ */

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -85,23 +85,23 @@ static inline bool is_hostbridge(const struct pci_vdev *vdev)
 
 void init_vhostbridge(struct pci_vdev *vdev);
 int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vhostbridge(__unused const struct pci_vdev *vdev);
 
 void init_vdev_pt(struct pci_vdev *vdev);
 int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
 void init_vmsi(struct pci_vdev *vdev);
 int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vmsi_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev);
 int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vmsix_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+int32_t vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(const struct pci_vdev *vdev);
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
@@ -110,11 +110,5 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_bdf vbdf);
 
 struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf);
-
-void partition_mode_cfgwrite(const struct acrn_vpci *vpci, union pci_bdf vbdf,
-	uint32_t offset, uint32_t bytes, uint32_t val);
-
-void sharing_mode_cfgwrite(__unused struct acrn_vpci *vpci, union pci_bdf bdf,
-	uint32_t offset, uint32_t bytes, uint32_t val);
 
 #endif /* VPCI_PRIV_H_ */

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -80,6 +80,7 @@ int32_t vhostbridge_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32
 int32_t vhostbridge_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void vhostbridge_deinit(__unused const struct pci_vdev *vdev);
 
+void init_vdev_pt(struct pci_vdev *vdev);
 int32_t vdev_pt_cfgread(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_cfgwrite(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -220,12 +220,29 @@ static inline uint8_t pci_devfn(uint16_t bdf)
 	return (uint8_t)(bdf & 0xFFU);
 }
 
-/*
- * @pre a != NULL && b != NULL
+/**
+ * @pre a != NULL
+ * @pre b != NULL
  */
 static inline bool bdf_is_equal(const union pci_bdf *a, const union pci_bdf *b)
 {
 	return (a->value == b->value);
+}
+
+/**
+ * @pre bar != NULL
+ */
+static inline bool is_mmio_bar(const struct pci_bar *bar)
+{
+	return (bar->type == PCIBAR_MEM32) || (bar->type == PCIBAR_MEM64);
+}
+
+/**
+ * @pre bar != NULL
+ */
+static inline bool is_valid_bar_size(const struct pci_bar *bar)
+{
+	return (bar->size > 0UL) && (bar->size <= 0xffffffffU);
 }
 
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);


### PR DESCRIPTION
There is no more “partition_mode” or “sharing_mode” concept so any names or strings of these should be removed. We only has pre-launched VM, SOS, post-launched_vm.

Changed partition_mode to prelaunched_vm, change sharing_mode to sos_vm, and unified the code by combing the functions if possible.

Renamed a few functions based on c coding guideline

Some misra-c fixes

Tracked-On: #3056 