### PR TITLE
fix cpu family calculation

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -214,9 +214,9 @@ void init_pcpu_capabilities(void)
 	cpuid(CPUID_FEATURES, &eax, &unused,
 		&boot_cpu_data.cpuid_leaves[FEAT_1_ECX],
 		&boot_cpu_data.cpuid_leaves[FEAT_1_EDX]);
-	family = (eax >> 8U) & 0xffU;
+	family = (eax >> 8U) & 0xfU;
 	if (family == 0xFU) {
-		family += (eax >> 20U) & 0xffU;
+		family += ((eax >> 20U) & 0xffU) << 4U;
 	}
 	boot_cpu_data.family = (uint8_t)family;
 

--- a/hypervisor/lib/sprintf.c
+++ b/hypervisor/lib/sprintf.c
@@ -105,8 +105,8 @@ static const char *get_flags(const char *s_arg, uint32_t *flags)
 		PRINT_FLAG_ALTERNATE_FORM,	/* # */
 		PRINT_FLAG_PAD_ZERO,	/* 0 */
 		PRINT_FLAG_LEFT_JUSTIFY,	/* - */
-		PRINT_FLAG_SIGN,	/* + */
-		PRINT_FLAG_SPACE	/* ' ' */
+		PRINT_FLAG_SPACE,	/* ' ' */
+		PRINT_FLAG_SIGN		/* + */
 	};
 	uint32_t i;
 	bool found;


### PR DESCRIPTION
1. Fix cpu family calc,  according to SDM documentation:     
            Extended Family ID bit[20-27],      Family ID bit[8-11].
2. Modifie the parameter 'fl' order .
Tracked-On:https://github.com/projectacrn/acrn-hypervisor/issues/3142
Signed-off-by: Qiang Liu cdliuqiang@gmail.com