### PR TITLE
Remove some unused functions in hypervisor

### DIFF
--- a/doc/developer-guides/hld/hv-memmgt.rst
+++ b/doc/developer-guides/hld/hv-memmgt.rst
@@ -430,9 +430,6 @@ Data Transferring between hypervisor and VM
 .. doxygenfunction:: copy_from_gva
    :project: Project ACRN
 
-.. doxygenfunction:: copy_to_gva
-   :project: Project ACRN
-
 Address Space Translation
 -------------------------
 

--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -209,9 +209,6 @@ ACRN hypervisor implements virtual exception injection using these APIs:
 .. doxygenfunction:: vcpu_inject_ud
   :project: Project ACRN
 
-.. doxygenfunction:: vcpu_inject_ac
-  :project: Project ACRN
-
 .. doxygenfunction:: vcpu_inject_ss
   :project: Project ACRN
 

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -426,12 +426,6 @@ int32_t copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	return copy_gva(vcpu, h_ptr, gva, size, err_code, fault_addr, 1);
 }
 
-int32_t copy_to_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
-	uint32_t size, uint32_t *err_code, uint64_t *fault_addr)
-{
-	return copy_gva(vcpu, h_ptr, gva, size, err_code, fault_addr, 0);
-}
-
 /* gpa --> hpa -->hva */
 void *gpa2hva(struct acrn_vm *vm, uint64_t x)
 {

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -535,13 +535,6 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu)
 	return status;
 }
 
-int32_t shutdown_vcpu(__unused struct acrn_vcpu *vcpu)
-{
-	/* TODO : Implement VCPU shutdown sequence */
-
-	return 0;
-}
-
 /*
  *  @pre vcpu != NULL
  */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -304,12 +304,6 @@ void vcpu_inject_ud(struct acrn_vcpu *vcpu)
 	(void)vcpu_queue_exception(vcpu, IDT_UD, 0);
 }
 
-/* Inject alignment check exception(#AC) to guest */
-void vcpu_inject_ac(struct acrn_vcpu *vcpu)
-{
-	(void)vcpu_queue_exception(vcpu, IDT_AC, 0);
-}
-
 /* Inject stack fault exception(#SS) to guest */
 void vcpu_inject_ss(struct acrn_vcpu *vcpu)
 {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -592,21 +592,6 @@ void pause_vm(struct acrn_vm *vm)
 }
 
 /**
- *  * @pre vm != NULL
- */
-void resume_vm(struct acrn_vm *vm)
-{
-	uint16_t i;
-	struct acrn_vcpu *vcpu = NULL;
-
-	foreach_vcpu(i, vm, vcpu) {
-		resume_vcpu(vcpu);
-	}
-
-	vm->state = VM_STARTED;
-}
-
-/**
  * @brief Resume vm from S3 state
  *
  * To resume vm after guest enter S3 state:

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1293,11 +1293,6 @@ void enable_iommu(void)
 	do_action_for_iommus(dmar_enable);
 }
 
-void disable_iommu(void)
-{
-	do_action_for_iommus(dmar_disable);
-}
-
 void suspend_iommu(void)
 {
 	do_action_for_iommus(dmar_suspend);

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -15,11 +15,6 @@
 #include <cpu.h>
 #include <per_cpu.h>
 
-static inline bool sbuf_is_empty(const struct shared_buf *sbuf)
-{
-	return (sbuf->head == sbuf->tail);
-}
-
 uint32_t sbuf_next_ptr(uint32_t pos_arg,
 		uint32_t span, uint32_t scope)
 {
@@ -27,30 +22,6 @@ uint32_t sbuf_next_ptr(uint32_t pos_arg,
 	pos += span;
 	pos = (pos >= scope) ? (pos - scope) : pos;
 	return pos;
-}
-
-uint32_t sbuf_get(struct shared_buf *sbuf, uint8_t *data)
-{
-	const void *from;
-	uint32_t ele_size;
-
-	stac();
-	if (sbuf_is_empty(sbuf)) {
-		clac();
-		/* no data available */
-		return 0;
-	}
-
-	from = (void *)sbuf + SBUF_HEAD_SIZE + sbuf->head;
-
-	(void)memcpy_s((void *)data, sbuf->ele_size, from, sbuf->ele_size);
-
-	sbuf->head = sbuf_next_ptr(sbuf->head, sbuf->ele_size, sbuf->size);
-
-	ele_size = sbuf->ele_size;
-	clac();
-
-	return ele_size;
 }
 
 /**

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -240,8 +240,3 @@ bool is_pci_dbg_uart(union pci_bdf bdf_value)
 
 	return ret;
 }
-
-bool is_dbg_uart_enabled(void)
-{
-	return uart_enabled;
-}

--- a/hypervisor/include/arch/x86/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/guest/guest_memory.h
@@ -95,6 +95,9 @@ int32_t copy_to_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t size
  */
 int32_t copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
+/**
+ * @}
+ */
 #endif	/* !ASSEMBLER */
 
 #endif /* GUEST_H*/

--- a/hypervisor/include/arch/x86/guest/guest_memory.h
+++ b/hypervisor/include/arch/x86/guest/guest_memory.h
@@ -95,24 +95,6 @@ int32_t copy_to_gpa(struct acrn_vm *vm, void *h_ptr, uint64_t gpa, uint32_t size
  */
 int32_t copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
-/**
- * @brief Copy data from HV address space to VM GVA space
- *
- * @param[in] vcpu The pointer that points to vcpu data structure
- * @param[in] h_ptr The pointer that points the start HV address
- *                   of HV memory region which data is stored in
- * @param[out] gva The start GVA address of GVA memory region which data
- *                will be copied into
- * @param[in] size The size (bytes) of GVA memory region which data will
- *                 be copied into
- * @param[out] err_code The page fault flags
- * @param[out] fault_addr The GVA address that causes a page fault
- */
-int32_t copy_to_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
-	uint32_t size, uint32_t *err_code, uint64_t *fault_addr);
-/**
- * @}
- */
 #endif	/* !ASSEMBLER */
 
 #endif /* GUEST_H*/

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -618,8 +618,6 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
  */
 int32_t run_vcpu(struct acrn_vcpu *vcpu);
 
-int32_t shutdown_vcpu(struct acrn_vcpu *vcpu);
-
 /**
  * @brief unmap the vcpu with pcpu and free its vlapic
  *

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -194,7 +194,6 @@ static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_
 
 int32_t shutdown_vm(struct acrn_vm *vm);
 void pause_vm(struct acrn_vm *vm);
-void resume_vm(struct acrn_vm *vm);
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);
 void start_vm(struct acrn_vm *vm);
 int32_t reset_vm(struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -200,17 +200,6 @@ void vcpu_inject_pf(struct acrn_vcpu *vcpu, uint64_t addr, uint32_t err_code);
 void vcpu_inject_ud(struct acrn_vcpu *vcpu);
 
 /**
- * @brief Inject alignment check exeception(AC) to guest.
- *
- * @param[in] vcpu Pointer to vCPU.
- *
- * @return None
- *
- * @pre vcpu != NULL
- */
-void vcpu_inject_ac(struct acrn_vcpu *vcpu);
-
-/**
  * @brief Inject stack fault exeception(SS) to guest.
  *
  * @param[in] vcpu Pointer to vCPU.

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -605,14 +605,6 @@ void destroy_iommu_domain(struct iommu_domain *domain);
 void enable_iommu(void);
 
 /**
- * @brief Disable translation of IOMMUs.
- *
- * Disable address translation of all IOMMUs, which are not ignored on the platform.
- *
- */
-void disable_iommu(void);
-
-/**
  * @brief Suspend IOMMUs.
  *
  * Suspend all IOMMUs, which are not ignored on the platform.

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -132,6 +132,5 @@ char uart16550_getc(void);
 size_t uart16550_puts(const char *buf, uint32_t len);
 void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr);
 bool is_pci_dbg_uart(union pci_bdf bdf_value);
-bool is_dbg_uart_enabled(void);
 
 #endif /* !UART16550_H */

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -27,7 +27,6 @@ void resume_console(void) {}
 
 bool handle_dbg_cmd(__unused const char *cmd, __unused int32_t len) { return false; }
 bool is_pci_dbg_uart(__unused union pci_bdf bdf_value) { return false; }
-bool is_dbg_uart_enabled(void) { return false; }
 
 void shell_init(void) {}
 void shell_kick(void) {}


### PR DESCRIPTION
v2->v3
Keep get_sos_boot_mode. It will be used by init_vm_boot_info.
v1->v2
Address review comments. Keep ticks_to_ms, TRACE_6C, vuart_deinit and vuart_deinit_connect for future use.

yliu79 (7):
  HV: remove unused function disable_iommu
  HV: remove unused function shutdown_vcpu
  HV: remove unused function resume_vm
  HV: remove unused function copy_to_gva
  HV: remove unused function vcpu_inject_ac
  HV: remove unused function sbuf_is_empty and sbuf_get
  HV: remove unused function is_dbg_uart_enabled

 hypervisor/arch/x86/guest/guest_memory.c         |  6 -----
 hypervisor/arch/x86/guest/vcpu.c                 |  7 ------
 hypervisor/arch/x86/guest/virq.c                 |  6 -----
 hypervisor/arch/x86/guest/vm.c                   | 15 ------------
 hypervisor/arch/x86/vtd.c                        |  5 ----
 hypervisor/debug/sbuf.c                          | 29 ------------------------
 hypervisor/debug/uart16550.c                     |  5 ----
 hypervisor/include/arch/x86/guest/guest_memory.h | 18 ---------------
 hypervisor/include/arch/x86/guest/vcpu.h         |  2 --
 hypervisor/include/arch/x86/guest/vm.h           |  1 -
 hypervisor/include/arch/x86/irq.h                | 11 ---------
 hypervisor/include/arch/x86/vtd.h                |  8 -------
 hypervisor/include/debug/uart16550.h             |  1 -
 hypervisor/release/console.c                     |  1 -
 14 files changed, 115 deletions(-)
