### PR TITLE
HV: remove unused UNDEFINED_VM

### DIFF
--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -108,7 +108,7 @@ bool sanitize_vm_config(void)
 			/* Nothing to do here for a POST_LAUNCHED_VM, break directly. */
 			break;
 		default:
-			/* Nothing to do for a UNDEFINED_VM, break directly. */
+			/* Nothing to do for a unknown VM, break directly. */
 			break;
 		}
 

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -23,8 +23,7 @@
  * POST_LAUNCHED_VM is launched by ACRN devicemodel, with/without LAPIC_PT depends on usecases.
  */
 enum acrn_vm_load_order {
-	UNDEFINED_VM = 0,
-	PRE_LAUNCHED_VM,
+	PRE_LAUNCHED_VM = 1,
 	SOS_VM,
 	POST_LAUNCHED_VM	/* Launched by Devicemodel in SOS_VM */
 };


### PR DESCRIPTION
The enum of UNDEFINED_VM has never been used, remove it;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>