### PR TITLE
DM: add virtual hostbridge in launch script for RTVM

### DIFF
--- a/devicemodel/samples/nuc/launch_hard_rt_vm.sh
+++ b/devicemodel/samples/nuc/launch_hard_rt_vm.sh
@@ -30,9 +30,10 @@ echo ${passthru_vpid["sata"]} > /sys/bus/pci/drivers/pci-stub/new_id
 echo ${passthru_bdf["sata"]} > /sys/bus/pci/devices/${passthru_bdf["sata"]}/driver/unbind
 echo ${passthru_bdf["sata"]} > /sys/bus/pci/drivers/pci-stub/bind
 
-/usr/bin/acrn-dm -A -m $mem_size -c $1 \
+/usr/bin/acrn-dm -A -m $mem_size -c $1 -s 0:0,hostbridge \
   -k /root/rt_uos_kernel \
    --lapic_pt \
+   --rtvm \
    --virtio_poll 1000000 \
    -s 2,passthru,0/17/0 \
    -s 3,virtio-console,@stdio:stdio_port \


### PR DESCRIPTION
Hostbridge is necessary for passing kernel pci subsystem initialization
sanity check which is located in pci_sanity_check(). It will check
whether a host bridge exists.

BTW, set rtvm flag explicitly.

Tracked-On: #3152
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>