### PR TITLE
doc: prepare for sphinx 2.0 upgrade

### DIFF
--- a/doc/.known-issues/doc/dupdecl.conf
+++ b/doc/.known-issues/doc/dupdecl.conf
@@ -3,3 +3,5 @@
 #
 #^(?P<filename>[-._/\w]+/hld/hv-cpu-virt.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
+# Sphinx 2.0
+^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration, .*


### PR DESCRIPTION
Sphinx 2.0 reports some "expected errors" differently, so add the new
message patterns to our known-errors scanning.

Also, the kerneldoc tool has a problem with sphinx 2.0, but a fix was
available.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>