### PR TITLE
 Some minor VPCI code cleanup

### DIFF
--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -10,7 +10,7 @@
 
 /*
  * @pre vm_id < CONFIG_MAX_VM_NUM
- * @post return != NULL 
+ * @post return != NULL
  */
 struct acrn_vm_config *get_vm_config(uint16_t vm_id)
 {

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -74,13 +74,8 @@ void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev)
 	struct pci_msix *msix = &vdev->msix;
 	struct pci_pdev *pdev = vdev->pdev;
 	struct pci_bar *bar;
-	struct acrn_vm *vm = vdev->vpci->vm;
-	struct acrn_vm_config *vm_config;
-
-	vm_config = get_vm_config(vm->vm_id);
 
 	ASSERT(vdev->pdev->msix.table_bar < (PCI_BAR_COUNT - 1U), "msix->table_bar is out of range");
-
 
 	/* Mask all table entries */
 	for (i = 0U; i < msix->table_count; i++) {
@@ -92,14 +87,13 @@ void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev)
 	bar = &pdev->bar[msix->table_bar];
 	if (bar != NULL) {
 		msix->mmio_hpa = bar->base;
-		if (vm_config->load_order == PRE_LAUNCHED_VM) {
+		if (is_prelaunched_vm(vdev->vpci->vm)) {
 			msix->mmio_gpa = vdev->bar[msix->table_bar].base;
 		} else {
 			msix->mmio_gpa = sos_vm_hpa2gpa(bar->base);
 		}
 		msix->mmio_size = bar->size;
 	}
-
 
 	/*
 	 *    For SOS:
@@ -143,7 +137,7 @@ void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev)
 
 
 	if (msix->mmio_gpa != 0UL) {
-		if (vm_config->load_order == PRE_LAUNCHED_VM) {
+		if (is_prelaunched_vm(vdev->vpci->vm)) {
 			addr_hi = msix->mmio_gpa + msix->mmio_size;
 			addr_lo = msix->mmio_gpa;
 		} else {

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -36,8 +36,8 @@
 #include <logmsg.h>
 
 static spinlock_t pci_device_lock;
-static uint32_t num_pci_pdev;
-static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
+uint32_t num_pci_pdev;
+struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
 
 static void init_pdev(uint16_t pbdf);
 
@@ -392,17 +392,6 @@ static void init_pdev(uint16_t pbdf)
 		num_pci_pdev++;
 	} else {
 		pr_err("%s, failed to alloc pci_pdev!\n", __func__);
-	}
-}
-
-void pci_pdev_foreach(pci_pdev_enumeration_cb cb_func, const void *ctx)
-{
-	uint32_t idx;
-
-	for (idx = 0U; idx < num_pci_pdev; idx++) {
-		if (cb_func != NULL) {
-			cb_func(&pci_pdev_array[idx], ctx);
-		}
 	}
 }
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -179,7 +179,9 @@ struct pci_pdev {
 	struct pci_msix_cap msix;
 };
 
-typedef void (*pci_pdev_enumeration_cb)(struct pci_pdev *pdev, const void *data);
+extern uint32_t num_pci_pdev;
+extern struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
+
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {
@@ -249,7 +251,6 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
-void pci_pdev_foreach(pci_pdev_enumeration_cb cb, const void *ctx);
 struct pci_pdev *find_pci_pdev(union pci_bdf pbdf);
 void init_pci_pdev_list(void);
 


### PR DESCRIPTION
 Some minor VPCI code cleanup:
 - Remove function pci_pdev_foreach() per discussion with Eddie
 - Call function is_prelaunched_vm() instead to reduce code

Tracked-On: #3056 