### PR TITLE
hv: initial host reset implementation

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -114,6 +114,16 @@ bool is_rt_vm(const struct acrn_vm *vm)
 /**
  * @pre vm != NULL && vm_config != NULL && vm->vmid < CONFIG_MAX_VM_NUM
  */
+bool is_highest_severity_vm(const struct acrn_vm *vm)
+{
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
+
+	return ((vm_config->guest_flags & GUEST_FLAG_HIGHEST_SEVERITY) != 0U);
+}
+
+/**
+ * @pre vm != NULL && vm_config != NULL && vm->vmid < CONFIG_MAX_VM_NUM
+ */
 bool vm_hide_mtrr(const struct acrn_vm *vm)
 {
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -218,6 +218,7 @@ void vrtc_init(struct acrn_vm *vm);
 
 bool is_lapic_pt(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
+bool is_highest_severity_vm(const struct acrn_vm *vm);
 bool vm_hide_mtrr(const struct acrn_vm *vm);
 
 #endif /* !ASSEMBLER */

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -53,6 +53,7 @@
 #define GUEST_FLAG_CLOS_REQUIRED		(1UL << 3U)     /* Whether CLOS is required */
 #define GUEST_FLAG_HIDE_MTRR			(1UL << 4U)  	/* Whether hide MTRR from VM */
 #define GUEST_FLAG_RT				(1UL << 5U)     /* Whether the vm is RT-VM */
+#define GUEST_FLAG_HIGHEST_SEVERITY		(1UL << 6U)     /* Whether has the highest severity */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
 #define VIRTUAL_PM1A_CNT_ADDR		0x404U

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -53,6 +53,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.uuid = {0x49U, 0x5aU, 0xe2U, 0xe5U, 0x26U, 0x03U, 0x4dU, 0x64U,	\
 			 0xafU, 0x76U, 0xd4U, 0xbcU, 0x5aU, 0x8eU, 0xc0U, 0xe5U},
 			/* 495ae2e5-2603-4d64-af76-d4bc5a8ec0e5 */
+
+		/* The hard RTVM must be launched as VM2 */
+		.guest_flags = GUEST_FLAG_HIGHEST_SEVERITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = INVALID_COM_BASE,

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -14,7 +14,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.uuid = {0xdbU, 0xbbU, 0xd4U, 0x34U, 0x7aU, 0x57U, 0x42U, 0x16U,	\
 			 0xa1U, 0x2cU, 0x22U, 0x01U, 0xf1U, 0xabU, 0x02U, 0x40U},
 			/* dbbbd434-7a57-4216-a12c-2201f1ab0240 */
-		.guest_flags = 0UL,
+
+		/* Allow SOS to reboot the host since there is supposed to be the highest severity guest */
+		.guest_flags = GUEST_FLAG_HIGHEST_SEVERITY,
 		.clos = 0U,
 		.memory = {
 			.start_hpa = 0UL,


### PR DESCRIPTION
- add the GUEST_FLAG_HIGHEST_SEVERITY flag to indicate that the guest has
  privilege to reboot the host system.

- this flag is statically assigned to guest(s) in vm_configurations.c in
  different scenarios.

- implement reset_host() function to reset the host. First try the ACPI
  reset register if available, then try the 0xcf9 PIO.

Tracked-On: #3145
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>