### PR TITLE
hv: vtd: fix a logic error when set iommu page walk coherent

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -495,7 +495,7 @@ static int32_t dmar_register_hrhd(struct dmar_drhd_rt *dmar_unit)
 		pr_fatal("%s: dmar unit doesn't support Extended Interrupt Mode!", __func__);
 		ret = -ENODEV;
 	} else {
-		if ((iommu_ecap_c(dmar_unit->ecap) == 0U) && (dmar_unit->drhd->ignore != 0U)) {
+		if ((iommu_ecap_c(dmar_unit->ecap) == 0U) && (!dmar_unit->drhd->ignore)) {
 			iommu_page_walk_coherent = false;
 		}
 


### PR DESCRIPTION
Fix a logic error when set iommu page walk coherent.

Tracked-On: #3160 
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>