### PR TITLE
tools:acrn-crashlog: fix potential memory corruption

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/event_handler.c
+++ b/tools/acrn-crashlog/acrnprobe/event_handler.c
@@ -177,7 +177,7 @@ static void *event_handle(void *unused __attribute__((unused)))
 
 		if (e->event_type == VM) {
 			vme = (struct vm_event_t *)e->private;
-			if (vme->vm_msg)
+			if (vme && vme->vm_msg)
 				free(vme->vm_msg);
 			if (vme)
 				free(vme);


### PR DESCRIPTION
Make sure vm event is not NULL before freeing vm_msg.

Tracked-On: #1024
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Liu, Xiaojing <xiaojing.liu@intel.com>
Acked-by: Chen, Gang <gang.c.chen@intel.com>