### PR TITLE
DM: Fix minor issue of USB vendor ID

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -4036,8 +4036,8 @@ pci_xhci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 	xdev->excap_ptr = excap_group_dft;
 
-	xdev->vid = XHCI_PCI_DEVICE_ID_DFLT;
-	xdev->pid = XHCI_PCI_VENDOR_ID_DFLT;
+	xdev->vid = XHCI_PCI_VENDOR_ID_DFLT;
+	xdev->pid = XHCI_PCI_DEVICE_ID_DFLT;
 
 	xdev->rtsregs.mfindex = 0;
 	clock_gettime(CLOCK_MONOTONIC, &xdev->mf_prev_time);


### PR DESCRIPTION
Provide a minor fix for following issue:
Emulated USB controller Vendor ID and Device ID are swapped.

Tracked-On: #3053
Signed-off-by: Arindam Roy <arindam.roy@intel.com>
Reviewed-by: Xu, Anthony <anthony.xu@intel.com>