### PR TITLE
HV:Modularize vpic code to remove usage of acrn_vm

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -253,7 +253,7 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		ioapic_get_rte(phys_irq, &phys_rte);
 		rte = phys_rte;
 		rte.bits.trigger_mode = IOAPIC_RTE_TRGRMODE_EDGE;
-		vpic_get_irqline_trigger_mode(vm, (uint32_t)virt_sid->intx_id.pin, &trigger);
+		vpic_get_irqline_trigger_mode(vm_pic(vm), (uint32_t)virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
 			rte.bits.trigger_mode = IOAPIC_RTE_TRGRMODE_LEVEL;
 		}
@@ -497,11 +497,11 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 		enum vpic_trigger trigger;
 
 		/* VPIN_PIC src means we have vpic enabled */
-		vpic_get_irqline_trigger_mode(vm, virt_sid->intx_id.pin, &trigger);
+		vpic_get_irqline_trigger_mode(vm_pic(vm), virt_sid->intx_id.pin, &trigger);
 		if (trigger == LEVEL_TRIGGER) {
-			vpic_set_irqline(vm, virt_sid->intx_id.pin, GSI_SET_HIGH);
+			vpic_set_irqline(vm_pic(vm), virt_sid->intx_id.pin, GSI_SET_HIGH);
 		} else {
-			vpic_set_irqline(vm, virt_sid->intx_id.pin, GSI_RAISING_PULSE);
+			vpic_set_irqline(vm_pic(vm), virt_sid->intx_id.pin, GSI_RAISING_PULSE);
 		}
 		break;
 	}
@@ -577,7 +577,7 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src)
 			}
 			break;
 		case PTDEV_VPIN_PIC:
-			vpic_set_irqline(vm, virt_pin, GSI_SET_LOW);
+			vpic_set_irqline(vm_pic(vm), virt_pin, GSI_SET_LOW);
 			break;
 		default:
 			/*

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -139,14 +139,14 @@ static bool vcpu_do_pending_extint(const struct acrn_vcpu *vcpu)
 	primary = vcpu_from_vid(vm, BOOT_CPU_ID);
 	if (vcpu == primary) {
 
-		vpic_pending_intr(vcpu->vm, &vector);
+		vpic_pending_intr(vm_pic(vcpu->vm), &vector);
 		if (vector <= NR_MAX_VECTOR) {
 			dev_dbg(ACRN_DBG_INTR, "VPIC: to inject PIC vector %d\n",
 					vector & 0xFFU);
 			exec_vmwrite32(VMX_ENTRY_INT_INFO_FIELD,
 					VMX_INT_INFO_VALID |
 					(vector & 0xFFU));
-			vpic_intr_accepted(vcpu->vm, vector);
+			vpic_intr_accepted(vm_pic(vcpu->vm), vector);
 			ret = true;
 		}
 	}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -395,7 +395,7 @@ int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 				 * number #2 to PIC IRQ #0.
 				 */
 				irq_pic = (ops->gsi == 2U) ? 0U : ops->gsi;
-				vpic_set_irqline(target_vm, irq_pic, ops->op);
+				vpic_set_irqline(vm_pic(target_vm), irq_pic, ops->op);
 		        }
 
 			/* handle IOAPIC irqline */

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -171,7 +171,7 @@ void vuart_toggle_intr(const struct acrn_vuart *vu)
 		operation = (intr_reason != IIR_NOPEND) ? GSI_SET_HIGH : GSI_SET_LOW;
 	}
 
-	vpic_set_irqline(vu->vm, vu->irq, operation);
+	vpic_set_irqline(vm_pic(vu->vm), vu->irq, operation);
 	vioapic_set_irqline_lock(vu->vm, vu->irq, operation);
 }
 

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -149,39 +149,40 @@ void vpic_init(struct acrn_vm *vm);
 /**
  * @brief Set vPIC IRQ line status.
  *
- * @param[in] vm        Pointer to target VM
+ * @param[in] vpic      Pointer to target VM's vpic table
  * @param[in] irqline   Target IRQ number
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @return None
  */
-void vpic_set_irqline(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
+void vpic_set_irqline(struct acrn_vpic *vpic, uint32_t irqline, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
  *
- * @param[in]    vm     Pointer to target VM
+ * @param[in]    vpic   Pointer to target VM's vpic table
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *			with eligible vector if any.
  *
  * @return None
  */
-void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr);
+void vpic_pending_intr(struct acrn_vpic *vpic, uint32_t *vecptr);
 
 /**
  * @brief Accept virtual interrupt for vPIC.
  *
- * @param[in] vm     Pointer to target VM
+ * @param[in] vpic     Pointer to target VM's vpic table
  * @param[in] vector Target virtual interrupt vector
  *
  * @return None
  *
  * @pre vm != NULL
  */
-void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector);
-void vpic_get_irqline_trigger_mode(const struct acrn_vm *vm, uint32_t irqline, enum vpic_trigger *trigger);
+void vpic_intr_accepted(struct acrn_vpic *vpic, uint32_t vector);
+void vpic_get_irqline_trigger_mode(const struct acrn_vpic *vpic, uint32_t irqline, enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
+struct acrn_vpic *vm_pic(const struct acrn_vm *vm);
 
 /**
  * @}


### PR DESCRIPTION
V1:Initial Patch
Modularize vpic. The current patch reduces the usage
of acrn_vm inside the vpic.c file.
Due to the global natire of register_pio_handler, where
acrn_vm is being passed, some usage remains.
These needs to be a separate "interface" file.
That will come in smaller newer patch provided
this patch is accepted.

V2:
Incorporated comments from Jason.

Tracked-On: #1842
Signed-off-by: Arindam Roy <arindam.roy@intel.com>
Reviewed-by: Xu, Anthony <anthony.xu@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>