### PR TITLE
hv: move msr_bitmap from acrn_vm to acrn_vcpu_arch

### DIFF
--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -297,6 +297,10 @@ struct msr_store_area {
 struct acrn_vcpu_arch {
 	/* vmcs region for this vcpu, MUST be 4KB-aligned */
 	uint8_t vmcs[PAGE_SIZE];
+
+	/* MSR bitmap region for this vcpu, MUST be 4-Kbyte aligned */
+	uint8_t msr_bitmap[PAGE_SIZE];
+
 	/* per vcpu lapic */
 	struct acrn_vlapic vlapic;
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -89,8 +89,6 @@ enum vm_state {
 struct vm_arch {
 	/* I/O bitmaps A and B for this VM, MUST be 4-Kbyte aligned */
 	uint8_t io_bitmap[PAGE_SIZE*2];
-	/* MSR bitmap region for this VM, MUST be 4-Kbyte aligned */
-	uint8_t msr_bitmap[PAGE_SIZE];
 
 	uint64_t guest_init_pml4;/* Guest init pml4 */
 	/* EPT hierarchy for Normal World */

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -581,8 +581,8 @@ struct acrn_vcpu;
 
 void init_msr_emulation(struct acrn_vcpu *vcpu);
 uint32_t vmsr_get_guest_msr_index(uint32_t msr);
-void update_msr_bitmap_x2apic_apicv(const struct acrn_vcpu *vcpu);
-void update_msr_bitmap_x2apic_passthru(const struct acrn_vcpu *vcpu);
+void update_msr_bitmap_x2apic_apicv(struct acrn_vcpu *vcpu);
+void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu);
 
 #endif /* ASSEMBLER */
 


### PR DESCRIPTION
At the time the guest is switching to X2APIC mode, different VCPUs in the
same VM could expect the setting of the per VM msr_bitmap differently,
which could cause problems.

Considering different approaches to address this issue:
1) only guest BSP can update msr_bitmap when switching to X2APIC.
2) carefully re-write the update_msr_bitmap_x2apic_xxx() functions to
   make sure any bit in the bitmap won't be toggled by the VCPUs.
3) make msr_bitmap as per VCPU.

We chose option 3) because it's simple and clean, though it takes more
memory than other options.

BTW, need to remove const modifier from update_msr_bitmap_x2apic_xxx()
functions to get it compiled.

Tracked-On: #3166
Signed-off-by: Zide Chen <zide.chen@intel.com>
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>