### PR TITLE
hv: vm: enable iommu after vpci init

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -432,8 +432,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	}
 
 	if (status == 0) {
-		enable_iommu();
-
 		INIT_LIST_HEAD(&vm->softirq_dev_entry_list);
 		spinlock_init(&vm->softirq_dev_lock);
 		vm->intr_inject_delay_delta = 0UL;
@@ -461,6 +459,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		}
 
 		vpci_init(vm);
+		enable_iommu();
 
 		register_reset_port_handler(vm);
 


### PR DESCRIPTION
In current code, vpci do the pci enumartion and add pci devices to the
context table of iommu.
Need to enable iommu DMA address translation later than vpci init.
Otherwise, in UEFI platform, there will be a shot time that address translation
is enabled, but the context table is not setup.
For the devices active in UEFI environment will have problem on address translation.

Tracked-On: #3160
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>