### PR TITLE
debug/release: Enable enable -g option for debug build

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -11,7 +11,7 @@ DM_BUILD_TAG ?=
 CC ?= gcc
 RELEASE ?= 0
 
-CFLAGS := -g -O0 -std=gnu11
+CFLAGS := -O0 -std=gnu11
 CFLAGS += -D_GNU_SOURCE
 CFLAGS += -DNO_OPENSSL
 CFLAGS += -m64
@@ -45,7 +45,7 @@ endif
 endif
 
 ifeq ($(RELEASE),0)
-CFLAGS += -DDM_DEBUG
+CFLAGS += -DDM_DEBUG -g
 endif
 
 LDFLAGS += -Wl,-z,noexecstack


### PR DESCRIPTION
1. debug/release: Enable enable -g option for debug build
  -g option should only be enabled for debug build and disabled
  for release build.


Tracked-On: #3164 
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>