### PR TITLE
HV: remove mptable in vm_config

### DIFF
--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -89,8 +89,6 @@ bool sanitize_vm_config(void)
 			} else if (((vm_config->guest_flags & GUEST_FLAG_LAPIC_PASSTHROUGH) != 0U)
 					&& ((vm_config->guest_flags & GUEST_FLAG_RT) == 0U)) {
 				ret = false;
-			} else if (vm_config->mptable == NULL) {
-				ret = false;
 			} else {
 				pre_launch_pcpu_bitmap |= vm_config->pcpu_bitmap;
 			}

--- a/hypervisor/dm/vmptable.c
+++ b/hypervisor/dm/vmptable.c
@@ -9,6 +9,8 @@
 #include <mptable.h>
 #include <default_acpi_info.h>
 
+static struct mptable_info vm_mptables[CONFIG_MAX_VM_NUM];
+
 static struct mptable_info mptable_template = {
 			.mpfp = {
 				.signature = MPFP_SIG,
@@ -80,7 +82,6 @@ static uint8_t mpt_compute_checksum(void *base, size_t len)
 /**
  * @pre vm != NULL
  * @pre vm->vm_id < CONFIG_MAX_VM_NUM
- * @pre vm_configs[vm->vm_id].mptable != NULL
  */
 int32_t mptable_build(struct acrn_vm *vm)
 {
@@ -96,7 +97,7 @@ int32_t mptable_build(struct acrn_vm *vm)
 	struct acrn_vm_config *vm_config;
 
 	vm_config = get_vm_config(vm->vm_id);
-	mptable = vm_config->mptable;
+	mptable = &vm_mptables[vm->vm_id];
 	vcpu_num = vm_config->cpu_num;
 	pcpu_bitmap = vm_config->pcpu_bitmap;
 	(void *)memcpy_s((void *)mptable, sizeof(struct mptable_info),

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -89,7 +89,6 @@ struct acrn_vm_config {
 	uint16_t clos;					/* if guest_flags has GUEST_FLAG_CLOS_REQUIRED, then VM use this CLOS */
 
 	struct vuart_config vuart[MAX_VUART_NUM_PER_VM];/* vuart configuration for VM */
-	struct mptable_info	*mptable;		/* Pointer to mptable struct if VM type is pre-launched */
 } __aligned(8);
 
 struct acrn_vm_config *get_vm_config(uint16_t vm_id);

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -10,8 +10,6 @@
 extern struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM];
 extern struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM];
 
-static struct mptable_info vm_mptables[CONFIG_MAX_VM_NUM];
-
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM0 */
 		.load_order = PRE_LAUNCHED_VM,
@@ -49,7 +47,6 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		},
 		.pci_ptdev_num = VM0_CONFIG_PCI_PTDEV_NUM,
 		.pci_ptdevs = vm0_pci_ptdevs,
-		.mptable = &vm_mptables[0],
 	},
 	{	/* VM1 */
 		.load_order = PRE_LAUNCHED_VM,
@@ -88,6 +85,5 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		},
 		.pci_ptdev_num = VM1_CONFIG_PCI_PTDEV_NUM,
 		.pci_ptdevs = vm1_pci_ptdevs,
-		.mptable = &vm_mptables[1],
 	},
 };


### PR DESCRIPTION
Define a static mptable array and each VM could index its vmptable by
vm id, then mptable is not needed in vm configurations;

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>