### PR TITLE
vm state: reset vm state to VM_CREATED when reset_vm is called

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -591,6 +591,7 @@ int32_t reset_vm(struct acrn_vm *vm)
 		vioapic_reset(vm);
 		destroy_secure_world(vm, false);
 		vm->sworld_control.flag.active = 0UL;
+		vm->state = VM_CREATED;
 		ret = 0;
 	} else {
 		ret = -1;


### PR DESCRIPTION
When we call reset_vm() function to reset vm, the vm state
should be reset to VM_CREATED as well.

Tracked-On: #3182
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>