### PR TITLE
ACRN/HV: Initialize the depriv_boot env to avoid the uninitialized RSDP

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -119,8 +119,6 @@ void init_pcpu_pre(uint16_t pcpu_id_args)
 		 */
 		init_pcpu_capabilities();
 
-		init_vboot_operations();
-
 		init_pcpu_model_name();
 
 		load_pcpu_state_data();
@@ -134,6 +132,8 @@ void init_pcpu_pre(uint16_t pcpu_id_args)
 		}
 
 		early_init_lapic();
+
+		init_vboot();
 
 		if (!init_percpu_lapic_id()) {
 			panic("failed to init_percpu_lapic_id!");

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -64,9 +64,6 @@ static void enter_guest_mode(uint16_t pcpu_id)
 
 static void init_primary_pcpu_post(void)
 {
-	/* Perform any necessary guest vboot initialization */
-	init_vboot();
-
 	init_debug_pre();
 
 	init_pcpu_post(BOOT_CPU_ID);

--- a/hypervisor/boot/guest/deprivilege_boot.c
+++ b/hypervisor/boot/guest/deprivilege_boot.c
@@ -43,13 +43,11 @@ static void init_depri_boot(void)
 
 const struct depri_boot_context *get_depri_boot_ctx(void)
 {
-	init_depri_boot();
 	return &depri_boot_ctx;
 }
 
 const struct lapic_regs *get_depri_boot_lapic_regs(void)
 {
-	init_depri_boot();
 	return &depri_boot_lapic_regs;
 }
 

--- a/hypervisor/boot/guest/vboot_wrapper.c
+++ b/hypervisor/boot/guest/vboot_wrapper.c
@@ -29,7 +29,7 @@ static enum vboot_mode sos_boot_mode;
  * @pre: this function is called during detect mode which is very early stage,
  * other exported interfaces should not be called beforehand.
  */
-void init_vboot_operations(void)
+void init_vboot(void)
 {
 
 	struct multiboot_info *mbi;
@@ -61,15 +61,16 @@ void init_vboot_operations(void)
 			}
 		}
 	}
-}
 
-/* @pre: vboot_ops->init != NULL */
-void init_vboot(void)
-{
+	/*
+	 * vboot_ops is mandatory and it will be initialized correctly.
+	 * The vboot_ops->init is called to assure that the boot env is
+	 * initialized before calling other vboot_ops interface.
+	 */
+	vboot_ops->init();
 #ifdef CONFIG_ACPI_PARSE_ENABLED
 	acpi_fixup();
 #endif
-	vboot_ops->init();
 }
 
 /* @pre: vboot_ops != NULL */

--- a/hypervisor/boot/include/guest/vboot.h
+++ b/hypervisor/boot/include/guest/vboot.h
@@ -20,7 +20,6 @@ struct vboot_operations {
 	void (*init_irq)(void);
 };
 
-void init_vboot_operations(void);
 void init_vboot(void);
 void init_vboot_irq(void);
 uint64_t get_ap_trampoline_buf(void);


### PR DESCRIPTION
Currently when get_rsdp is called, the EFI depriv_boot env is not initialized.
In such case it will fallback to the legacy mechanism of ACPI table.
If the ACPI table based on legacy mechanism is not found, it will fail to get
the ACPI table and then the system will hang.
On the old platform it still can parse the ACPI table from legacy mechanism.
In fact when EFI RSDP exists, the EFI RSDP is preferred instead of legacy ACPI
RSDP.

Tracked-On: #3184
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>