### PR TITLE
hv: vmcs: refine CR4 guest/host mask setting

### DIFF
--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -311,6 +311,7 @@ void init_cr0_cr4_host_mask(void)
 		cr0_host_owned_bits = ~(fixed0 ^ fixed1);
 		/* Add the bit hv wants to trap */
 		cr0_host_owned_bits |= CR0_TRAP_MASK;
+		cr0_host_owned_bits &= ~CR0_RESERVED_MASK;
 		/* CR0 clear PE/PG from always on bits due to "unrestructed guest" feature */
 		cr0_always_on_mask = fixed0 & (~(CR0_PE | CR0_PG));
 		cr0_always_off_mask = ~fixed1;
@@ -327,6 +328,7 @@ void init_cr0_cr4_host_mask(void)
 		cr4_host_owned_bits = ~(fixed0 ^ fixed1);
 		/* Add the bit hv wants to trap */
 		cr4_host_owned_bits |= CR4_TRAP_MASK;
+		cr4_host_owned_bits &= ~CR4_RESERVED_MASK;
 		cr4_always_on_mask = fixed0;
 		/* Record the bit fixed to 0 for CR4, including reserved bits */
 		cr4_always_off_mask = ~fixed1;

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -26,7 +26,7 @@
 			   CR0_NE |  CR0_ET | CR0_TS | CR0_EM | CR0_MP | CR0_PE)
 
 /* CR4 bits hv want to trap to track status change */
-#define CR4_TRAP_MASK (CR4_PSE | CR4_PAE | CR4_VMXE | CR4_PCIDE)
+#define CR4_TRAP_MASK (CR4_PSE | CR4_PAE | CR4_VMXE | CR4_PCIDE | CR4_SMEP | CR4_SMAP | CR4_PKE)
 #define	CR4_RESERVED_MASK ~(CR4_VME | CR4_PVI | CR4_TSD | CR4_DE | CR4_PSE | \
 				CR4_PAE | CR4_MCE | CR4_PGE | CR4_PCE |     \
 				CR4_OSFXSR | CR4_PCIDE | CR4_OSXSAVE |       \


### PR DESCRIPTION
v2:
1) make the patch more readable: only add the bits which want to trap for FuSa.
2) still trap the bit which is 0 in IA32_VMX_CR4_FIXED1 (except the reserved bits).
3) don't touch CR4.MCE which need to trap when the guest wants to hide this capability.

v1:
We set CR4 guest/host mask to trap "MOV to CR4" for three reasons:
1) We need to make extra effort besides setting CR4:
  a) invalidate the TLB (CR4_PSE | CR4_SMEP | CR4_SMAP | CR4_PKE)
  b) track paging mode (CR4_PAE)
2) We need to always mask some bits in CR4 which is 1 in IA32_VMX_CR4_FIXED0.
CR4_VMXE for now.
3) We need to unmask some bits in CR4 which we want to hide the capability
from guest. (CR4_PCIDE, CR4_MCE for some type guest).

The others bits in CR4, as well as the reserved bits and bit is 0 in
IA32_VMX_CR4_FIXED1, we don't need to trap them.

The motive behides this patch is that FuSa requires to detail when we need to
invalidate the TLB if setting CR4. The test results show that changing SMAP on
native will invalidate the TLB, but doesn't in non-root mode. However, setting
SMEP on native and in non-root mode will always invalidate the TLB.

According to Chap 4.10.4.1 Operations that Invalidate TLBs and Paging-Structure
Caches, Vol 3, SDM:
MOV to CR4. The behavior of the instruction depends on the bits being modified:
— The instruction invalidates all TLB entries (including global entries) and all
entries in all paging-structure caches (for all PCIDs) if (1) it changes the value
of CR4.PGE;2 or (2) it changes the value of the CR4.PCIDE from 1 to 0.
— The instruction invalidates all TLB entries and all entries in all paging-structure
caches for the current PCID if (1) it changes the value of CR4.PAE; or (2) it changes
the value of CR4.SMEP from 0 to 1.
We assume that changing PGE, PCIDE, PAE, setting SMEP will always invalidate the TLB,
but clearing SMEP and changing others bits in CR4 can't guarantee TLB will be invalidated.
So trap them to invalidate the TLB in root mode.

Tracked-On: #2561
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>