### PR TITLE
dm: pci: update MMIO EPT mapping when update BAR address

### DIFF
--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -64,6 +64,11 @@ struct pci_vdev_ops {
 	/* ops related to physical resources */
 	void	(*vdev_phys_access)(struct vmctx *ctx, struct pci_vdev *dev);
 
+	/* update BAR map callback */
+	void	(*vdev_update_bar_map)(struct vmctx *ctx,
+				struct pci_vdev *dev, int idx,
+				uint64_t orig_addr);
+
 	/* config space read/write callbacks */
 	int	(*vdev_cfgwrite)(struct vmctx *ctx, int vcpu,
 			       struct pci_vdev *pi, int offset,


### PR DESCRIPTION
For PCI passthrough device when guest OS updates the BAR address
the corresponding EPT mapping should be updated as well.

Tracked-On: #2962
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Signed-off-by: Liu Shuo A <shuo.a.liu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>