### PR TITLE
hv: use 64bit FACS table address only beyond ACPI2.0

### DIFF
--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -109,13 +109,16 @@ static void *get_facs_table(const uint8_t *facp_addr)
 {
 	uint8_t *facs_addr, *facs_x_addr;
 	uint32_t signature, length;
+	struct acpi_table_header *table = (struct acpi_table_header *)facp_addr;
 
 	facs_addr = (uint8_t *)(uint64_t)get_acpi_dt_dword(facp_addr, OFFSET_FACS_ADDR);
 
-	facs_x_addr = (uint8_t *)get_acpi_dt_qword(facp_addr, OFFSET_FACS_X_ADDR);
+	if (table->revision >= 2U) {
+		facs_x_addr = (uint8_t *)get_acpi_dt_qword(facp_addr, OFFSET_FACS_X_ADDR);
 
-	if (facs_x_addr != NULL) {
-		facs_addr = facs_x_addr;
+		if (facs_x_addr != NULL) {
+			facs_addr = facs_x_addr;
+		}
 	}
 
 	if (facs_addr != NULL) {


### PR DESCRIPTION
Since ACPI 2.0 a new field has been added to the table, X_FirmwareControl of type GAS,
which is 64bit. So use it conditionally.

Tracked-On: #3198
Signed-off-by: Tw <wei.tan@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>