### PR TITLE
tools:acrn-crashlog: fix error logs writing to server

### DIFF
--- a/tools/acrn-crashlog/usercrash/client.c
+++ b/tools/acrn-crashlog/usercrash/client.c
@@ -86,7 +86,7 @@ static int usercrashd_connect(int pid, int *usercrashd_socket,
 		return -1;
 	}
 	sockfd = socket_local_client(SOCKET_NAME, strlen(SOCKET_NAME),
-			SOCK_SEQPACKET);
+			SOCK_SEQPACKET | SOCK_CLOEXEC);
 	if (sockfd == -1) {
 		LOGE("failed to connect to usercrashd, error (%s)\n",
 			strerror(errno));


### PR DESCRIPTION
This patch is to fix error logs in client sending to server via socket.
Since gdb inherits the socket descriptor of client which is used as its
stderr, in this case, the error logs from gdb will mess up server, so
closing the inheritance when the socket is created.

Tracked-On: #3200
Signed-off-by: xiaojin2 <xiaojing.liu@intel.com>
Reviewed-by: Liu, Xinwu <xinwu.liu@intel.com>
Acked-by: Chen, Gang <gang.c.chen@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>