### PR TITLE
dm: virtio: bugfix for polling mode

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -86,6 +86,8 @@ virtio_poll_timer(void *arg, uint64_t nexp)
 
 	for (i = 0; i < base->vops->nvq; i++) {
 		vq = &base->queues[i];
+		if(!vq_ring_ready(vq))
+			continue;
 		vq->used->flags |= VRING_USED_F_NO_NOTIFY;
 		/* TODO: call notify when necessary */
 		if (vq->notify)


### PR DESCRIPTION
In vxworks, virtio-console FE driver only initiate 2 virtqueues, but BE
creates 2+ virtqueues for it. So the rest of the virtqueues are not
initiated. vq->used->flags cannot be used directly without any
condition.

Tracked-On: #3203
Signed-off-by: Gao Junhao <junhao.gao@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>