### PR TITLE
hv: Remove unused variable in ptirq_msi_info

### DIFF
--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -89,7 +89,6 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 		addrhi = 0U;
 	}
 
-	info.is_msix = 0;
 	info.vmsi_addr.full = (uint64_t)addrlo | ((uint64_t)addrhi << 32U);
 
 	/* MSI is being enabled or disabled */

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -74,7 +74,6 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 	void *hva;
 	int32_t ret;
 
-	info.is_msix = 1;
 	info.vmsi_addr.full = vdev->msix.tables[index].addr;
 	info.vmsi_data.full = (enable) ? vdev->msix.tables[index].data : 0U;
 

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -117,7 +117,6 @@ struct ptirq_msi_info {
 	union msi_data_reg vmsi_data; /* virt msi_data */
 	union msi_addr_reg pmsi_addr; /* phys msi_addr */
 	union msi_data_reg pmsi_data; /* phys msi_data */
-	int32_t is_msix;	/* 0-MSI, 1-MSIX */
 };
 
 struct ptirq_remapping_info;


### PR DESCRIPTION
is_msix, part of ptirq_msi_info, is not used in the code.

Tracked-On: #3205
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>