### PR TITLE
dm: pci: fix the MMIO regions overlap when getting bar size

### DIFF
--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -32,6 +32,7 @@
 #include <sys/queue.h>
 
 #include <assert.h>
+#include <stdbool.h>
 #include "types.h"
 #include "pcireg.h"
 
@@ -104,6 +105,7 @@ struct pcibar {
 	enum pcibar_type	type;		/* io or memory */
 	uint64_t		size;
 	uint64_t		addr;
+	bool			sizing;
 };
 
 #define PI_NAMESZ	40


### PR DESCRIPTION
PCI spec says that the procedure of sizing a BAR is as follows:
1) disable the decode via command register
2) save the original value of BAR register
3) write all-1 to the BAR register
4) read BAR register back, calculate the size
5) restore the original value to BAR register
6) re-enable the decode via command register

Some driver does not disable the decode of BAR register via the
command register before sizing a BAR. This will lead to a overlay
of the BAR addresses when trying to register the intermediate
BAR address via register_bar. A stateful variable sizing is used
to keep track of such kind of BAR address changes and workaroud
this violation.

Currently this issue is only found when audio device is passed
through to Windows 10 guest. When it is fixed in the Windows
audio driver, this patch should be reverted.

v1 -> v2:
- change the commit message to add the procedure of BAR sizing from
  PCI spec

Tracked-On: #2962
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>