### PR TITLE
 HV: vuart: Bugfix for no interrupts on THRE

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -564,6 +564,8 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 
 		vpci_cleanup(vm);
 
+		vuart_deinit(vm);
+
 		ptdev_release_all_entries(vm);
 
 		/* Free iommu */

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -271,6 +271,9 @@ static void write_reg(struct acrn_vuart *vu, uint16_t reg, uint8_t value_u8)
 			vu->thre_int_pending = true;
 			break;
 		case UART16550_IER:
+			if (((vu->ier & IER_ETBEI) == 0U) && ((value_u8 & IER_ETBEI) != 0U)) {
+				vu->thre_int_pending = true;
+			}
 			/*
 			 * Apply mask so that bits 4-7 are 0
 			 * Also enables bits 0-3 only if they're 1
@@ -481,6 +484,9 @@ static void vuart_setup(struct acrn_vm *vm,
 	vu->vm = vm;
 	vuart_fifo_init(vu);
 	vuart_lock_init(vu);
+	vu->thre_int_pending = true;
+	vu->ier = 0U;
+	vuart_toggle_intr(vu);
 	vu->target_vu = NULL;
 	if (vu_config->type == VUART_LEGACY_PIO) {
 		vu->port_base = vu_config->addr.port_base;


### PR DESCRIPTION
When enable Transmitter Holding Register Empty interrupts, vuart should
trigger interrupt when the THR is empty. In the previous code, only
after the data is written to THR, the flag thre_int_pending is set to
true. The thre_int_pending should also be true after THRE is set.
Besides, add logic to make sure interrupt is in right state when vuart
is initiated.
Add vuart_deinit to vm shutdown so that the vuart resource can be
reset, and when the Guest VM restart, it could have right state.
Tracked-On: #2987
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>