### PR TITLE
Fix hvc console handle sigpipe

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -785,6 +785,13 @@ main(int argc, char *argv[])
 		fprintf(stderr, "cannot register handler for SIGHUP\n");
 	if (signal(SIGINT, sig_handler_term) == SIG_ERR)
 		fprintf(stderr, "cannot register handler for SIGINT\n");
+	/*
+	 * Ignore SIGPIPE signal and handle the error directly when write()
+	 * function fails. this will help us to catch the write failure rather
+	 * than crashing the UOS.
+	 */
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
+		fprintf(stderr, "cannot register handler for SIGPIPE\n");
 
 	while ((c = getopt_long(argc, argv, optstr, long_options,
 			&option_idx)) != -1) {


### PR DESCRIPTION
When virtio-console is used as console port with socket backend,
guest kernel tries to hook it up with hvc console and sets it up.
It doesn't check if a client is connected and can result in ENOTCONN
with virtio-console backend being reset. This will prevent client
connection at a later point. To avoid this, ignore ENOTCONN error.

PS: For Kata, the runtime first launches VM and then proxy which acts
as a client connects to this socket. If this error is not handled,
proxy will never be able to connect as the backend itself will be reset.

Tracked-On: #3189
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>