### PR TITLE
HV: patch set to enable Zephyr as pre-launched VM

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
@@ -10,6 +10,27 @@
 #define ROOTFS_0		"root=/dev/sda3 "
 #define ROOTFS_1		"root=/dev/mmcblk1p1 "
 
+#define SOS_ROOTFS		ROOTFS_1
 #define SOS_CONSOLE		"console=ttyS2 "
+
+#ifndef CONFIG_RELEASE
+#define BOOTARG_DEBUG		"hvlog=2M@0x6de00000 "	\
+				"memmap=0x400000$0x6da00000 "	\
+				"ramoops.mem_address=0x6da00000 "	\
+				"ramoops.mem_size=0x400000 "	\
+				"ramoops.console_size=0x200000 "	\
+				"reboot_panic=p,w "
+#else
+#define BOOTARG_DEBUG		""
+#endif
+
+#define SOS_BOOTARGS_DIFF	BOOTARG_DEBUG	\
+				"module_blacklist=dwc3_pci "	\
+				"i915.enable_initial_modeset=1 "	\
+				"i915.enable_guc=0x02 "	\
+				"video=DP-1:d "	\
+				"video=DP-2:d "	\
+				"cma=64M@0- "	\
+				"panic_print=0x1f"
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MISC_CFG_H
+#define MISC_CFG_H
+
+#define ROOTFS_0		"root=/dev/sda3 "
+#define ROOTFS_1		"root=/dev/mmcblk1p1 "
+
+#define SOS_CONSOLE		"console=ttyS2 "
+
+#endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/apl-mrb/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/ve820.c
@@ -22,8 +22,8 @@ static const struct e820_entry ve820_entry[VE820_ENTRIES_APL_MRB] = {
 	},
 
 	{	/* lowmem */
-		.baseaddr = 0x200000UL,		/* 2MB */
-		.length   = 0x1FE00000UL,	/* 510MB */
+		.baseaddr = 0x100000UL,		/* 1MB */
+		.length   = 0x1FF00000UL,	/* 511MB */
 		.type     = E820_TYPE_RAM
 	},
 

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -10,6 +10,23 @@
 #define ROOTFS_0		"root=/dev/sda3 "
 #define ROOTFS_1		"root=/dev/mmcblk0p1 "
 
+#define SOS_ROOTFS		ROOTFS_1
 #define SOS_CONSOLE		"console=ttyS0 "
+
+#ifndef CONFIG_RELEASE
+#define BOOTARG_DEBUG		"hvlog=2M@0x6de00000 "	\
+				"memmap=0x400000$0x6da00000 "	\
+				"ramoops.mem_address=0x6da00000 "	\
+				"ramoops.mem_size=0x400000 "	\
+				"ramoops.console_size=0x200000 "	\
+				"reboot_panic=p,w "
+#else
+#define BOOTARG_DEBUG		""
+#endif
+
+#define SOS_BOOTARGS_DIFF	BOOTARG_DEBUG	\
+				"module_blacklist=dwc3_pci "	\
+				"i915.enable_guc=0x02 "	\
+				"cma=64M@0- "
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MISC_CFG_H
+#define MISC_CFG_H
+
+#define ROOTFS_0		"root=/dev/sda3 "
+#define ROOTFS_1		"root=/dev/mmcblk0p1 "
+
+#define SOS_CONSOLE		"console=ttyS0 "
+
+#endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MISC_CFG_H
+#define MISC_CFG_H
+
+#define ROOTFS_0		"root=/dev/sda3 "
+
+#define SOS_CONSOLE		"console=ttyS0 "
+
+#endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
@@ -9,6 +9,13 @@
 
 #define ROOTFS_0		"root=/dev/sda3 "
 
+#define SOS_ROOTFS		ROOTFS_0
 #define SOS_CONSOLE		"console=ttyS0 "
+
+#ifndef CONFIG_RELEASE
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000"
+#else
+#define SOS_BOOTARGS_DIFF	""
+#endif
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
@@ -22,8 +22,8 @@ static const struct e820_entry ve820_entry[VE820_ENTRIES_DNV_CB2] = {
 	},
 
 	{	/* lowmem */
-		.baseaddr = 0x200000UL,		/* 2MB */
-		.length   = 0x7FE00000UL,	/* 2046MB */
+		.baseaddr = 0x100000UL,		/* 1MB */
+		.length   = 0x7FF00000UL,	/* 2047MB */
 		.type     = E820_TYPE_RAM
 	},
 

--- a/hypervisor/arch/x86/configs/generic/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/generic/misc_cfg.h
@@ -10,6 +10,13 @@
 #define ROOTFS_0		"root=/dev/sda3 "
 #define ROOTFS_1		"root=/dev/mmcblk0p1 "
 
+#define SOS_ROOTFS		ROOTFS_0
 #define SOS_CONSOLE		"console=ttyS0 "
+
+#ifndef CONFIG_RELEASE
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000"
+#else
+#define SOS_BOOTARGS_DIFF	""
+#endif
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/generic/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/generic/misc_cfg.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MISC_CFG_H
+#define MISC_CFG_H
+
+#define ROOTFS_0		"root=/dev/sda3 "
+#define ROOTFS_1		"root=/dev/mmcblk0p1 "
+
+#define SOS_CONSOLE		"console=ttyS0 "
+
+#endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MISC_CFG_H
+#define MISC_CFG_H
+
+#define ROOTFS_0		"root=/dev/sda3 "
+
+#define SOS_CONSOLE		"console=ttyS0 "
+
+#endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
@@ -9,6 +9,13 @@
 
 #define ROOTFS_0		"root=/dev/sda3 "
 
+#define SOS_ROOTFS		ROOTFS_0
 #define SOS_CONSOLE		"console=ttyS0 "
+
+#ifndef CONFIG_RELEASE
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000"
+#else
+#define SOS_BOOTARGS_DIFF	""
+#endif
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/misc_cfg.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MISC_CFG_H
+#define MISC_CFG_H
+
+#define ROOTFS_0		"root=/dev/sda3 "
+#define ROOTFS_1		"root=/dev/nvme0n1p3 "
+
+#define SOS_CONSOLE		"console=ttyS0 "
+
+#endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/misc_cfg.h
@@ -10,6 +10,13 @@
 #define ROOTFS_0		"root=/dev/sda3 "
 #define ROOTFS_1		"root=/dev/nvme0n1p3 "
 
+#define SOS_ROOTFS		ROOTFS_0
 #define SOS_CONSOLE		"console=ttyS0 "
+
+#ifndef CONFIG_RELEASE
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000"
+#else
+#define SOS_BOOTARGS_DIFF	""
+#endif
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
@@ -22,8 +22,8 @@ static const struct e820_entry ve820_entry[VE820_ENTRIES_KBL_NUC_i7] = {
 	},
 
 	{	/* lowmem */
-		.baseaddr = 0x200000UL,		/* 2MB */
-		.length   = 0x1FE00000UL,	/* 510MB */
+		.baseaddr = 0x100000UL,		/* 1MB */
+		.length   = 0x1FF00000UL,	/* 511MB */
 		.type     = E820_TYPE_RAM
 	},
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -453,7 +453,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		 if (vm_config->load_order == PRE_LAUNCHED_VM) {
 			create_prelaunched_vm_e820(vm);
 			prepare_prelaunched_vm_memmap(vm, vm_config);
-			(void)init_vm_boot_info(vm);
+			status = init_vm_boot_info(vm);
 		 }
 	}
 

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -28,15 +28,16 @@
 /**
  * @pre vm != NULL && mbi != NULL
  */
-static void init_vm_ramdisk_info(struct acrn_vm *vm, struct multiboot_module *mod)
+static void init_vm_ramdisk_info(struct acrn_vm *vm, const struct multiboot_module *mod)
 {
 	void *mod_addr = hpa2hva((uint64_t)mod->mm_mod_start);
-	uint32_t mod_size = mod->mm_mod_end - mod->mm_mod_start;
 
-	vm->sw.ramdisk_info.src_addr = mod_addr;
-	vm->sw.ramdisk_info.load_addr = vm->sw.kernel_info.kernel_load_addr + vm->sw.kernel_info.kernel_size;
-	vm->sw.ramdisk_info.load_addr = (void *)round_page_up((uint64_t)vm->sw.ramdisk_info.load_addr);
-	vm->sw.ramdisk_info.size = mod_size;
+	if ((mod_addr != NULL) && (mod->mm_mod_end > mod->mm_mod_start)) {
+		vm->sw.ramdisk_info.src_addr = mod_addr;
+		vm->sw.ramdisk_info.load_addr = vm->sw.kernel_info.kernel_load_addr + vm->sw.kernel_info.kernel_size;
+		vm->sw.ramdisk_info.load_addr = (void *)round_page_up((uint64_t)vm->sw.ramdisk_info.load_addr);
+		vm->sw.ramdisk_info.size = mod->mm_mod_end - mod->mm_mod_start;
+	}
 }
 
 /* There are two sources for sos_vm kernel cmdline:
@@ -88,6 +89,9 @@ static void merge_cmdline(const struct acrn_vm *vm, const char *cmdline, const c
 	}
 }
 
+/**
+ * @pre vm != NULL
+ */
 static void *get_kernel_load_addr(struct acrn_vm *vm)
 {
 	void *load_addr = NULL;
@@ -125,9 +129,9 @@ static void *get_kernel_load_addr(struct acrn_vm *vm)
 }
 
 /**
- * @pre vm != NULL && mbi != NULL
+ * @pre vm != NULL && mod != NULL
  */
-static int32_t init_vm_kernel_info(struct acrn_vm *vm, struct multiboot_module *mod)
+static int32_t init_vm_kernel_info(struct acrn_vm *vm, const struct multiboot_module *mod)
 {
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 
@@ -136,8 +140,10 @@ static int32_t init_vm_kernel_info(struct acrn_vm *vm, struct multiboot_module *
 
 	vm->sw.kernel_type = vm_config->os_config.kernel_type;
 	vm->sw.kernel_info.kernel_src_addr = hpa2hva((uint64_t)mod->mm_mod_start);
-	vm->sw.kernel_info.kernel_size = mod->mm_mod_end - mod->mm_mod_start;
-	vm->sw.kernel_info.kernel_load_addr = get_kernel_load_addr(vm);
+	if ((vm->sw.kernel_info.kernel_src_addr != NULL) && (mod->mm_mod_end > mod->mm_mod_start)){
+		vm->sw.kernel_info.kernel_size = mod->mm_mod_end - mod->mm_mod_start;
+		vm->sw.kernel_info.kernel_load_addr = get_kernel_load_addr(vm);
+	}
 
 	return (vm->sw.kernel_info.kernel_load_addr == NULL) ? (-EINVAL) : 0;
 }
@@ -145,7 +151,7 @@ static int32_t init_vm_kernel_info(struct acrn_vm *vm, struct multiboot_module *
 /**
  * @pre vm != NULL && mbi != NULL
  */
-static void init_vm_bootargs_info(struct acrn_vm *vm, struct multiboot_info *mbi)
+static void init_vm_bootargs_info(struct acrn_vm *vm, const struct multiboot_info *mbi)
 {
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	char *bootargs = vm_config->os_config.bootargs;
@@ -171,27 +177,29 @@ static void init_vm_bootargs_info(struct acrn_vm *vm, struct multiboot_info *mbi
 	}
 
 	/* Kernel bootarg and zero page are right before the kernel image */
-	if (vm->sw.bootargs_info.size > 0) {
+	if (vm->sw.bootargs_info.size > 0U) {
 		vm->sw.bootargs_info.load_addr = vm->sw.kernel_info.kernel_load_addr - (MEM_1K * 8U);
 	} else {
 		vm->sw.bootargs_info.load_addr = NULL;
 	}
 }
 
-static uint32_t get_mod_idx_by_tag(struct multiboot_module *mods, uint32_t mods_count, const char *tag)
+/* @pre mods != NULL
+ */
+static uint32_t get_mod_idx_by_tag(const struct multiboot_module *mods, uint32_t mods_count, const char *tag)
 {
 	uint32_t i, ret = INVALID_MOD_IDX;
 	uint32_t tag_len = strnlen_s(tag, MAX_MOD_TAG_LEN);
 
-	for (i = 0; i < mods_count; i++) {
+	for (i = 0U; i < mods_count; i++) {
 		const char *mm_string = (char *)hpa2hva((uint64_t)mods[i].mm_string);
 		uint32_t mm_str_len = strnlen_s(mm_string, MAX_MOD_TAG_LEN);
 
 		/* when do file stitch by tool, the tag in mm_string might be followed with 0x0d or 0x0a */
 		if ((mm_str_len >= tag_len) && (strncmp(mm_string, tag, tag_len) == 0)
-				&& ((mm_string[tag_len] == 0x0d)
-				|| (mm_string[tag_len] == 0x0a)
-				|| (mm_string[tag_len] == 0))){
+				&& ((*(mm_string + tag_len) == 0x0d)
+				|| (*(mm_string + tag_len) == 0x0a)
+				|| (*(mm_string + tag_len) == 0))){
 			ret = i;
 			break;
 		}
@@ -201,7 +209,7 @@ static uint32_t get_mod_idx_by_tag(struct multiboot_module *mods, uint32_t mods_
 
 /* @pre vm != NULL && mbi != NULL
  */
-static int32_t init_vm_sw_load(struct acrn_vm *vm, struct multiboot_info *mbi)
+static int32_t init_vm_sw_load(struct acrn_vm *vm, const struct multiboot_info *mbi)
 {
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	struct multiboot_module *mods = (struct multiboot_module *)hpa2hva((uint64_t)mbi->mi_mods_addr);
@@ -210,9 +218,11 @@ static int32_t init_vm_sw_load(struct acrn_vm *vm, struct multiboot_info *mbi)
 
 	dev_dbg(ACRN_DBG_BOOT, "mod counts=%d\n", mbi->mi_mods_count);
 
-	mod_idx = get_mod_idx_by_tag(mods, mbi->mi_mods_count, vm_config->os_config.kernel_mod_tag);
-	if (mod_idx != INVALID_MOD_IDX) {
-		ret = init_vm_kernel_info(vm, &mods[mod_idx]);
+	if (mods != NULL) {
+		mod_idx = get_mod_idx_by_tag(mods, mbi->mi_mods_count, vm_config->os_config.kernel_mod_tag);
+		if (mod_idx != INVALID_MOD_IDX) {
+			ret = init_vm_kernel_info(vm, &mods[mod_idx]);
+		}
 	}
 
 	if (ret == 0) {

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -93,6 +93,7 @@ static void *get_kernel_load_addr(struct acrn_vm *vm)
 	void *load_addr = NULL;
 	struct vm_sw_info *sw_info = &vm->sw;
 	struct zero_page *zeropage;
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 
 	switch (sw_info->kernel_type) {
 	case KERNEL_BZIMAGE:
@@ -109,6 +110,9 @@ static void *get_kernel_load_addr(struct acrn_vm *vm)
 			zeropage = (struct zero_page *)zeropage->hdr.pref_addr;
 		}
 		load_addr = (void *)zeropage;
+		break;
+	case KERNEL_ZEPHYR:
+		load_addr = (void *)vm_config->os_config.kernel_load_addr;
 		break;
 	default:
 		pr_err("Unsupported Kernel type.");

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -142,7 +142,7 @@ static void *get_kernel_load_addr(struct acrn_vm *vm)
 	struct zero_page *zeropage;
 
 	switch (sw_info->kernel_type) {
-	case VM_LINUX_GUEST:
+	case KERNEL_BZIMAGE:
 		/* According to the explaination for pref_address
 		 * in Documentation/x86/boot.txt, a relocating
 		 * bootloader should attempt to load kernel at pref_address
@@ -171,6 +171,7 @@ static int32_t init_general_vm_boot_info(struct acrn_vm *vm)
 {
 	struct multiboot_module *mods = NULL;
 	struct multiboot_info *mbi = NULL;
+	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	int32_t ret = -EINVAL;
 
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
@@ -196,12 +197,10 @@ static int32_t init_general_vm_boot_info(struct acrn_vm *vm)
 				dev_dbg(ACRN_DBG_BOOT, "cmd addr=0x%x, str=%s", mods[0].mm_string,
 					(char *)(uint64_t)mods[0].mm_string);
 
-				vm->sw.kernel_type = VM_LINUX_GUEST;
+				vm->sw.kernel_type = vm_config->os_config.kernel_type;
 				vm->sw.kernel_info.kernel_src_addr = hpa2hva((uint64_t)mods[0].mm_mod_start);
 				vm->sw.kernel_info.kernel_size = mods[0].mm_mod_end - mods[0].mm_mod_start;
 				vm->sw.kernel_info.kernel_load_addr = get_kernel_load_addr(vm);
-
-				struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 
 				if (vm_config->load_order == PRE_LAUNCHED_VM) {
 					vm->sw.bootargs_info.src_addr = (void *)vm_config->os_config.bootargs;

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -50,6 +50,9 @@ static uint32_t create_zeropage_e820(struct zero_page *zp, const struct acrn_vm 
 	return entry_num;
 }
 
+/**
+ * @pre vm != NULL
+ */
 static uint64_t create_zero_page(struct acrn_vm *vm)
 {
 	struct zero_page *zeropage;
@@ -98,6 +101,9 @@ static uint64_t create_zero_page(struct acrn_vm *vm)
 	return gpa;
 }
 
+/**
+ * @pre vm != NULL
+ */
 static void prepare_loading_bzimage(struct acrn_vm *vm, struct acrn_vcpu *vcpu)
 {
 	uint32_t i;
@@ -150,6 +156,9 @@ static void prepare_loading_bzimage(struct acrn_vm *vm, struct acrn_vcpu *vcpu)
 			__func__, vm->vm_id, vcpu_get_gpreg(vcpu, CPU_REG_RSI));
 }
 
+/**
+ * @pre vm != NULL
+ */
 static void prepare_loading_rawimage(struct acrn_vm *vm)
 {
 	struct sw_kernel_info *sw_kernel = &(vm->sw.kernel_info);
@@ -158,6 +167,9 @@ static void prepare_loading_rawimage(struct acrn_vm *vm)
 	sw_kernel->kernel_entry_addr = (void *)vm_config->os_config.kernel_entry_addr;
 }
 
+/**
+ * @pre vm != NULL
+ */
 int32_t direct_boot_sw_loader(struct acrn_vm *vm)
 {
 	int32_t ret = 0;

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -150,6 +150,14 @@ static void prepare_loading_bzimage(struct acrn_vm *vm, struct acrn_vcpu *vcpu)
 			__func__, vm->vm_id, vcpu_get_gpreg(vcpu, CPU_REG_RSI));
 }
 
+static void prepare_loading_rawimage(struct acrn_vm *vm)
+{
+	struct sw_kernel_info *sw_kernel = &(vm->sw.kernel_info);
+	const struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
+
+	sw_kernel->kernel_entry_addr = (void *)vm_config->os_config.kernel_entry_addr;
+}
+
 int32_t direct_boot_sw_loader(struct acrn_vm *vm)
 {
 	int32_t ret = 0;
@@ -184,6 +192,9 @@ int32_t direct_boot_sw_loader(struct acrn_vm *vm)
 	switch (vm->sw.kernel_type) {
 	case KERNEL_BZIMAGE:
 		prepare_loading_bzimage(vm, vcpu);
+		break;
+	case KERNEL_ZEPHYR:
+		prepare_loading_rawimage(vm);
 		break;
 	default:
 		pr_err("%s, Loading VM SW failed", __func__);

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -180,12 +180,14 @@ int32_t direct_boot_sw_loader(struct acrn_vm *vm)
 			ramdisk_info->size);
 	}
 
-	/* See if guest is a Linux guest */
-	if (vm->sw.kernel_type == VM_LINUX_GUEST) {
+	switch (vm->sw.kernel_type) {
+	case KERNEL_BZIMAGE:
 		prepare_loading_bzimage(vm, vcpu);
-	} else {
+		break;
+	default:
 		pr_err("%s, Loading VM SW failed", __func__);
 		ret = -EINVAL;
+		break;
 	}
 
 	if (ret == 0) {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -50,7 +50,7 @@ struct sw_kernel_info {
 };
 
 struct vm_sw_info {
-	int32_t kernel_type;	/* Guest kernel type */
+	enum os_kernel_type kernel_type;	/* Guest kernel type */
 	/* Kernel information (common for all guest types) */
 	struct sw_kernel_info kernel_info;
 	struct sw_module_info bootargs_info;
@@ -69,9 +69,6 @@ struct vm_pm_info {
 	struct pm_s_state_data	*sx_state_data;	/* data for S3/S5 implementation */
 };
 
-/* VM guest types */
-#define VM_LINUX_GUEST      0x02
-#define VM_MONO_GUEST       0x01
 /* Enumerated type for VM states */
 enum vm_state {
 	VM_POWERED_OFF = 0,

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -35,16 +35,11 @@ struct vm_hw_info {
 	uint16_t created_vcpus;	/* Number of created vcpus */
 } __aligned(PAGE_SIZE);
 
-struct sw_linux {
-	void *ramdisk_src_addr;		/* HVA */
-	void *ramdisk_load_addr;	/* GPA */
-	uint32_t ramdisk_size;
-	void *bootargs_src_addr;	/* HVA */
-	void *bootargs_load_addr;	/* GPA */
-	uint32_t bootargs_size;
-	void *dtb_src_addr;		/* HVA */
-	void *dtb_load_addr;		/* GPA */
-	uint32_t dtb_size;
+struct sw_module_info {
+	/* sw modules like ramdisk, bootargs, firmware, etc. */
+	void *src_addr;			/* HVA */
+	void *load_addr;		/* GPA */
+	uint32_t size;
 };
 
 struct sw_kernel_info {
@@ -58,8 +53,8 @@ struct vm_sw_info {
 	int32_t kernel_type;	/* Guest kernel type */
 	/* Kernel information (common for all guest types) */
 	struct sw_kernel_info kernel_info;
-	/* Additional information specific to Linux guests */
-	struct sw_linux linux_info;
+	struct sw_module_info bootargs_info;
+	struct sw_module_info ramdisk_info;
 	/* HVA to IO shared page */
 	void *io_shared_page;
 	/* If enable IO completion polling mode */

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -61,8 +61,13 @@ struct vuart_config {
 	struct target_vuart t_vuart;	/* target vuart */
 } __aligned(8);
 
+enum os_kernel_type {
+	KERNEL_BZIMAGE = 1,
+};
+
 struct acrn_vm_os_config {
 	char name[MAX_VM_OS_NAME_LEN];			/* OS name, useful for debug */
+	enum os_kernel_type kernel_type;		/* used for kernel specifc loading method */
 	char bootargs[MAX_BOOTARGS_SIZE];		/* boot args/cmdline */
 } __aligned(8);
 

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -18,6 +18,7 @@
 #define PLUG_CPU(n)		(1U << (n))
 #define MAX_VUART_NUM_PER_VM	2U
 #define MAX_VM_OS_NAME_LEN	32U
+#define MAX_MOD_TAG_LEN		32U
 
 /*
  * PRE_LAUNCHED_VM is launched by ACRN hypervisor, with LAPIC_PT;
@@ -68,6 +69,8 @@ enum os_kernel_type {
 struct acrn_vm_os_config {
 	char name[MAX_VM_OS_NAME_LEN];			/* OS name, useful for debug */
 	enum os_kernel_type kernel_type;		/* used for kernel specifc loading method */
+	char kernel_mod_tag[MAX_MOD_TAG_LEN];		/* multiboot module tag for kernel */
+	char ramdisk_mod_tag[MAX_MOD_TAG_LEN];		/* multiboot module tag for ramdisk */
 	char bootargs[MAX_BOOTARGS_SIZE];		/* boot args/cmdline */
 } __aligned(8);
 

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -64,6 +64,7 @@ struct vuart_config {
 
 enum os_kernel_type {
 	KERNEL_BZIMAGE = 1,
+	KERNEL_ZEPHYR,
 };
 
 struct acrn_vm_os_config {
@@ -72,6 +73,9 @@ struct acrn_vm_os_config {
 	char kernel_mod_tag[MAX_MOD_TAG_LEN];		/* multiboot module tag for kernel */
 	char ramdisk_mod_tag[MAX_MOD_TAG_LEN];		/* multiboot module tag for ramdisk */
 	char bootargs[MAX_BOOTARGS_SIZE];		/* boot args/cmdline */
+	uint64_t kernel_load_addr;
+	uint64_t kernel_entry_addr;
+	uint64_t kernel_ramdisk_addr;
 } __aligned(8);
 
 struct acrn_vm_pci_ptdev_config {

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -22,6 +22,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		},
 		.os_config = {
 			.name = "ACRN Service OS",
+			.kernel_type = KERNEL_BZIMAGE,
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -23,6 +23,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.os_config = {
 			.name = "ACRN Service OS",
 			.kernel_type = KERNEL_BZIMAGE,
+			.kernel_mod_tag = "Linux_bzImage",
 			.bootargs = SOS_VM_BOOTARGS
 		},
 		.vuart[0] = {

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -23,6 +23,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.os_config = {
 			.name = "ACRN Service OS",
 			.kernel_type = KERNEL_BZIMAGE,
+			.bootargs = SOS_VM_BOOTARGS
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/hypervisor/scenarios/industry/vm_configurations.h
+++ b/hypervisor/scenarios/industry/vm_configurations.h
@@ -7,11 +7,25 @@
 #ifndef VM_CONFIGURATIONS_H
 #define VM_CONFIGURATIONS_H
 
+#include <misc_cfg.h>
+
 #define CONFIG_MAX_VM_NUM	4U
 
 /* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
 #define DM_OWNED_GUEST_FLAG_MASK	(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | \
 						GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING)
 
+#define SOS_VM_BOOTARGS			SOS_ROOTFS	\
+					"rw rootwait "	\
+					"console=tty0 "	\
+					SOS_CONSOLE	\
+					"consoleblank=0	"	\
+					"no_timer_check "	\
+					"quiet loglevel=3 "	\
+					"i915.nuclear_pageflip=1 " \
+					"i915.avail_planes_per_pipe=0x01010F "	\
+					"i915.domain_plane_owners=0x011111110000 " \
+					"i915.enable_gvt=1 "	\
+					SOS_BOOTARGS_DIFF
 
 #endif /* VM_CONFIGURATIONS_H */

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -26,6 +26,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		},
 		.os_config = {
 			.name = "ClearLinux",
+			.kernel_type = KERNEL_BZIMAGE,
 			.bootargs = VM0_CONFIG_OS_BOOTARG_CONSOLE	\
 				VM0_CONFIG_OS_BOOTARG_MAXCPUS		\
 				VM0_CONFIG_OS_BOOTARG_ROOT		\
@@ -64,6 +65,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		},
 		.os_config = {
 			.name = "ClearLinux",
+			.kernel_type = KERNEL_BZIMAGE,
 			.bootargs = VM1_CONFIG_OS_BOOTARG_CONSOLE	\
 				VM1_CONFIG_OS_BOOTARG_MAXCPUS		\
 				VM1_CONFIG_OS_BOOTARG_ROOT		\

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -27,6 +27,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.os_config = {
 			.name = "ClearLinux",
 			.kernel_type = KERNEL_BZIMAGE,
+			.kernel_mod_tag = "Linux_bzImage",
 			.bootargs = VM0_CONFIG_OS_BOOTARG_CONSOLE	\
 				VM0_CONFIG_OS_BOOTARG_MAXCPUS		\
 				VM0_CONFIG_OS_BOOTARG_ROOT		\
@@ -66,6 +67,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.os_config = {
 			.name = "ClearLinux",
 			.kernel_type = KERNEL_BZIMAGE,
+			.kernel_mod_tag = "Linux_bzImage",
 			.bootargs = VM1_CONFIG_OS_BOOTARG_CONSOLE	\
 				VM1_CONFIG_OS_BOOTARG_MAXCPUS		\
 				VM1_CONFIG_OS_BOOTARG_ROOT		\

--- a/hypervisor/scenarios/logical_partition/vm_configurations.h
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.h
@@ -8,6 +8,7 @@
 #define VM_CONFIGURATIONS_H
 
 #include <pci_devices.h>
+#include <misc_cfg.h>
 
 /* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
 #define DM_OWNED_GUEST_FLAG_MASK	0UL
@@ -28,7 +29,7 @@
 #define VM0_CONFIG_NUM_CPUS			2U
 #define VM0_CONFIG_MEM_START_HPA		0x100000000UL
 #define VM0_CONFIG_MEM_SIZE			0x20000000UL
-#define VM0_CONFIG_OS_BOOTARG_ROOT		"root=/dev/sda3 "
+#define VM0_CONFIG_OS_BOOTARG_ROOT		ROOTFS_0
 #define VM0_CONFIG_OS_BOOTARG_MAXCPUS		"maxcpus=2 "
 #define VM0_CONFIG_OS_BOOTARG_CONSOLE		"console=ttyS0 "
 
@@ -36,7 +37,7 @@
 #define VM1_CONFIG_NUM_CPUS			2U
 #define VM1_CONFIG_MEM_START_HPA		0x120000000UL
 #define VM1_CONFIG_MEM_SIZE			0x20000000UL
-#define VM1_CONFIG_OS_BOOTARG_ROOT		"root=/dev/sda3 "
+#define VM1_CONFIG_OS_BOOTARG_ROOT		ROOTFS_0
 #define VM1_CONFIG_OS_BOOTARG_MAXCPUS		"maxcpus=2 "
 #define VM1_CONFIG_OS_BOOTARG_CONSOLE		"console=ttyS0 "
 

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -24,6 +24,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		},
 		.os_config = {
 			.name = "ACRN Service OS",
+			.kernel_type = KERNEL_BZIMAGE,
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -25,6 +25,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.os_config = {
 			.name = "ACRN Service OS",
 			.kernel_type = KERNEL_BZIMAGE,
+			.kernel_mod_tag = "Linux_bzImage",
 			.bootargs = SOS_VM_BOOTARGS,
 		},
 		.vuart[0] = {

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -25,6 +25,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.os_config = {
 			.name = "ACRN Service OS",
 			.kernel_type = KERNEL_BZIMAGE,
+			.bootargs = SOS_VM_BOOTARGS,
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/hypervisor/scenarios/sdc/vm_configurations.h
+++ b/hypervisor/scenarios/sdc/vm_configurations.h
@@ -7,11 +7,25 @@
 #ifndef VM_CONFIGURATIONS_H
 #define VM_CONFIGURATIONS_H
 
+#include <misc_cfg.h>
+
 #define CONFIG_MAX_VM_NUM	2U
 
 /* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
 #define DM_OWNED_GUEST_FLAG_MASK	(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | \
 						GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING)
 
+#define SOS_VM_BOOTARGS			SOS_ROOTFS	\
+					"rw rootwait "	\
+					"console=tty0 " \
+					SOS_CONSOLE	\
+					"consoleblank=0 "	\
+					"no_timer_check "	\
+					"quiet loglevel=3 "	\
+					"i915.nuclear_pageflip=1 " \
+					"i915.avail_planes_per_pipe=0x01010F "	\
+					"i915.domain_plane_owners=0x011111110000 " \
+					"i915.enable_gvt=1 "	\
+					SOS_BOOTARGS_DIFF
 
 #endif /* VM_CONFIGURATIONS_H */


### PR DESCRIPTION
The patch set will try to enable Zephyr as pre-launched VM.

Currently most of struct and function in vboot part are limited in Linux so
we need to rename them first, and then we need to abstract loading method
from Linux specific to more generic interface.

Secondly, we need to relove the problem that how to distinguish the
different modules for each VM in the multiboot file. The solution is use
a tag in module string to identify the usage of the module, and user could
specify the module in VM configurations. Before implemention we need to move
SOS bootargs to vm configuration because module string of mods[0] was occupied
by SOS bootargs.

Lastly, Zephyr kernel is a stripped ram binary, its entry and load address
are explicitly defined by users, so we need to add these items in
vm configurations so that hypervisor could load Zephyr directly based on
these configurations.

Tracked-On: #3214

Signed-off-by: Victor Sun victor.sun@intel.com
Reviewed-by: Jason Chen CJ jason.cj.chen@intel.com
