### PR TITLE
doc: remove 'reboot' command from ACRN shell user guide

### DIFF
--- a/doc/user-guides/acrn-shell.rst
+++ b/doc/user-guides/acrn-shell.rst
@@ -42,8 +42,6 @@ The ACRN hypervisor shell supports the following commands:
          loglevels for the remaining areas will not be changed
    * - cpuid <leaf> [subleaf]
      - Display the CPUID leaf [subleaf], in hexadecimal
-   * - reboot
-     - Trigger a system reboot (immediately)
    * - rdmsr [-p<pcpu_id>] <msr_index>
      - Read the Model-Specific Register (MSR) at index ``msr_index`` (in
        hexadecimal) for CPU ID ``pcpu_id``


### PR DESCRIPTION
The 'reboot' command from the ACRN shell has been removed. Remove the
corresponding documentation from the ACRN Shell user guide.

Tracked-On: #3210
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>