### PR TITLE
No vioapic/pic for RT VM

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -915,7 +915,6 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_LAPIC_PT:
 			lapic_pt = true;
-			break;
 		case CMD_OPT_RTVM:
 			is_rtvm = true;
 			break;

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1598,29 +1598,31 @@ pci_bus_write_dsdt(int bus)
 	dsdt_line("        ,, , AddressRangeMemory, TypeStatic)");
 	dsdt_line("    })");
 
-	count = pci_count_lintr(bus);
-	if (count != 0) {
-		dsdt_indent(2);
-		dsdt_line("Name (PPRT, Package ()");
-		dsdt_line("{");
-		pci_walk_lintr(bus, pci_pirq_prt_entry, NULL);
-		dsdt_line("})");
-		dsdt_line("Name (APRT, Package ()");
-		dsdt_line("{");
-		pci_walk_lintr(bus, pci_apic_prt_entry, NULL);
-		dsdt_line("})");
-		dsdt_line("Method (_PRT, 0, NotSerialized)");
-		dsdt_line("{");
-		dsdt_line("  If (PICM)");
-		dsdt_line("  {");
-		dsdt_line("    Return (APRT)");
-		dsdt_line("  }");
-		dsdt_line("  Else");
-		dsdt_line("  {");
-		dsdt_line("    Return (PPRT)");
-		dsdt_line("  }");
-		dsdt_line("}");
-		dsdt_unindent(2);
+	if (!is_rtvm) {
+		count = pci_count_lintr(bus);
+		if (count != 0) {
+			dsdt_indent(2);
+			dsdt_line("Name (PPRT, Package ()");
+			dsdt_line("{");
+			pci_walk_lintr(bus, pci_pirq_prt_entry, NULL);
+			dsdt_line("})");
+			dsdt_line("Name (APRT, Package ()");
+			dsdt_line("{");
+			pci_walk_lintr(bus, pci_apic_prt_entry, NULL);
+			dsdt_line("})");
+			dsdt_line("Method (_PRT, 0, NotSerialized)");
+			dsdt_line("{");
+			dsdt_line("  If (PICM)");
+			dsdt_line("  {");
+			dsdt_line("    Return (APRT)");
+			dsdt_line("  }");
+			dsdt_line("  Else");
+			dsdt_line("  {");
+			dsdt_line("    Return (PPRT)");
+			dsdt_line("  }");
+			dsdt_line("}");
+			dsdt_unindent(2);
+		}
 	}
 
 	dsdt_indent(2);

--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -33,6 +33,7 @@
 #include <stdbool.h>
 #include <sys/errno.h>
 
+#include "dm.h"
 #include "vmmapi.h"
 #include "acpi.h"
 #include "inout.h"
@@ -262,20 +263,21 @@ pci_lpc_write_dsdt(struct pci_vdev *dev)
 		ldp->handler();
 	}
 
-	dsdt_line("");
-	dsdt_line("Device (PIC)");
-	dsdt_line("{");
-	dsdt_line("  Name (_HID, EisaId (\"PNP0000\"))");
-	dsdt_line("  Name (_CRS, ResourceTemplate ()");
-	dsdt_line("  {");
-	dsdt_indent(2);
-	dsdt_fixed_ioport(IO_ICU1, 2);
-	dsdt_fixed_ioport(IO_ICU2, 2);
-	dsdt_fixed_irq(2);
-	dsdt_unindent(2);
-	dsdt_line("  })");
-	dsdt_line("}");
-
+	if(!is_rtvm) {
+		dsdt_line("");
+		dsdt_line("Device (PIC)");
+		dsdt_line("{");
+		dsdt_line("  Name (_HID, EisaId (\"PNP0000\"))");
+		dsdt_line("  Name (_CRS, ResourceTemplate ()");
+		dsdt_line("  {");
+		dsdt_indent(2);
+		dsdt_fixed_ioport(IO_ICU1, 2);
+		dsdt_fixed_ioport(IO_ICU2, 2);
+		dsdt_fixed_irq(2);
+		dsdt_unindent(2);
+		dsdt_line("  })");
+		dsdt_line("}");
+	}
 	dsdt_line("");
 	dsdt_line("Device (TIMR)");
 	dsdt_line("{");

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -280,36 +280,38 @@ basl_fwrite_madt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "\n");
 	}
 
-	/* Always a single IOAPIC entry, with ID 0 */
-	EFPRINTF(fp, "[0001]\t\tSubtable Type : 01\n");
-	EFPRINTF(fp, "[0001]\t\tLength : 0C\n");
-	/* iasl expects a hex value for the i/o apic id */
-	EFPRINTF(fp, "[0001]\t\tI/O Apic ID : %02x\n", 0);
-	EFPRINTF(fp, "[0001]\t\tReserved : 00\n");
-	EFPRINTF(fp, "[0004]\t\tAddress : fec00000\n");
-	EFPRINTF(fp, "[0004]\t\tInterrupt : 00000000\n");
-	EFPRINTF(fp, "\n");
+	if (!is_rtvm) {
+		/* Always a single IOAPIC entry, with ID 0 */
+		EFPRINTF(fp, "[0001]\t\tSubtable Type : 01\n");
+		EFPRINTF(fp, "[0001]\t\tLength : 0C\n");
+		/* iasl expects a hex value for the i/o apic id */
+		EFPRINTF(fp, "[0001]\t\tI/O Apic ID : %02x\n", 0);
+		EFPRINTF(fp, "[0001]\t\tReserved : 00\n");
+		EFPRINTF(fp, "[0004]\t\tAddress : fec00000\n");
+		EFPRINTF(fp, "[0004]\t\tInterrupt : 00000000\n");
+		EFPRINTF(fp, "\n");
 
-	/* Legacy IRQ0 is connected to pin 2 of the IOAPIC */
-	EFPRINTF(fp, "[0001]\t\tSubtable Type : 02\n");
-	EFPRINTF(fp, "[0001]\t\tLength : 0A\n");
-	EFPRINTF(fp, "[0001]\t\tBus : 00\n");
-	EFPRINTF(fp, "[0001]\t\tSource : 00\n");
-	EFPRINTF(fp, "[0004]\t\tInterrupt : 00000002\n");
-	EFPRINTF(fp, "[0002]\t\tFlags (decoded below) : 0005\n");
-	EFPRINTF(fp, "\t\t\tPolarity : 1\n");
-	EFPRINTF(fp, "\t\t\tTrigger Mode : 1\n");
-	EFPRINTF(fp, "\n");
+		/* Legacy IRQ0 is connected to pin 2 of the IOAPIC */
+		EFPRINTF(fp, "[0001]\t\tSubtable Type : 02\n");
+		EFPRINTF(fp, "[0001]\t\tLength : 0A\n");
+		EFPRINTF(fp, "[0001]\t\tBus : 00\n");
+		EFPRINTF(fp, "[0001]\t\tSource : 00\n");
+		EFPRINTF(fp, "[0004]\t\tInterrupt : 00000002\n");
+		EFPRINTF(fp, "[0002]\t\tFlags (decoded below) : 0005\n");
+		EFPRINTF(fp, "\t\t\tPolarity : 1\n");
+		EFPRINTF(fp, "\t\t\tTrigger Mode : 1\n");
+		EFPRINTF(fp, "\n");
 
-	EFPRINTF(fp, "[0001]\t\tSubtable Type : 02\n");
-	EFPRINTF(fp, "[0001]\t\tLength : 0A\n");
-	EFPRINTF(fp, "[0001]\t\tBus : 00\n");
-	EFPRINTF(fp, "[0001]\t\tSource : %02X\n", SCI_INT);
-	EFPRINTF(fp, "[0004]\t\tInterrupt : %08X\n", SCI_INT);
-	EFPRINTF(fp, "[0002]\t\tFlags (decoded below) : 000D\n");
-	EFPRINTF(fp, "\t\t\tPolarity : 1\n");
-	EFPRINTF(fp, "\t\t\tTrigger Mode : 3\n");
-	EFPRINTF(fp, "\n");
+		EFPRINTF(fp, "[0001]\t\tSubtable Type : 02\n");
+		EFPRINTF(fp, "[0001]\t\tLength : 0A\n");
+		EFPRINTF(fp, "[0001]\t\tBus : 00\n");
+		EFPRINTF(fp, "[0001]\t\tSource : %02X\n", SCI_INT);
+		EFPRINTF(fp, "[0004]\t\tInterrupt : %08X\n", SCI_INT);
+		EFPRINTF(fp, "[0002]\t\tFlags (decoded below) : 000D\n");
+		EFPRINTF(fp, "\t\t\tPolarity : 1\n");
+		EFPRINTF(fp, "\t\t\tTrigger Mode : 3\n");
+		EFPRINTF(fp, "\n");
+	}
 
 	/* Local APIC NMI is connected to LINT 1 on all CPUs */
 	EFPRINTF(fp, "[0001]\t\tSubtable Type : 04\n");

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -477,7 +477,9 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 				register_pm1ab_handler(vm);
 			}
 		}
-		vpic_init(vm);
+		if (!is_lapic_pt_configured(vm)) {
+			vpic_init(vm);
+		}
 
 		/* Create virtual uart;*/
 		vuart_init(vm, vm_config->vuart);
@@ -495,7 +497,9 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		vm->wire_mode = VPIC_WIRE_INTR;
 
 		/* Init full emulated vIOAPIC instance */
-		vioapic_init(vm);
+		if (!is_lapic_pt_configured(vm)) {
+			vioapic_init(vm);
+		}
 
 		/* Intercept the virtual pm port for RTVM */
 		if (is_rt_vm(vm)) {

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -509,6 +509,7 @@ vpic_pincount(void)
 /**
  * @pre vm->vpic != NULL
  * @pre irqline < NR_VPIC_PINS_TOTAL
+ * @pre this function should be called after vpic_init()
  */
 void vpic_get_irqline_trigger_mode(const struct acrn_vm *vm, uint32_t irqline,
 		enum vpic_trigger *trigger)
@@ -531,6 +532,7 @@ void vpic_get_irqline_trigger_mode(const struct acrn_vm *vm, uint32_t irqline,
  * @param[inout] vecptr Pointer to vector buffer and will be filled
  *			with eligible vector if any.
  *
+ * @pre this function should be called after vpic_init()
  * @return None
  */
 void vpic_pending_intr(struct acrn_vm *vm, uint32_t *vecptr)
@@ -593,6 +595,7 @@ static void vpic_pin_accepted(struct i8259_reg_state *i8259, uint32_t pin)
  * @return None
  *
  * @pre vm != NULL
+ * @pre this function should be called after vpic_init()
  */
 void vpic_intr_accepted(struct acrn_vm *vm, uint32_t vector)
 {

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -53,6 +53,7 @@ struct acrn_vioapic {
 	struct acrn_vm	*vm;
 	spinlock_t	mtx;
 	uint32_t	id;
+	bool		ready;
 	uint32_t	ioregsel;
 	union ioapic_rte rtbl[REDIR_ENTRIES_HW];
 	/* pin_state status bitmap: 1 - high, 0 - low */


### PR DESCRIPTION
These two commits remove IOAPIC & PIC related entries in ACPI table for RT VM and skipped the initialization of vIOAPIC and vPIC.

Tracked-On: #3227