### PR TITLE
dm: Solve the problem of repeat mount hugetblfs

### DIFF
--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -108,7 +108,8 @@ int	vm_map_memseg_vma(struct vmctx *ctx, size_t len, vm_paddr_t gpa,
 	uint64_t vma, int prot);
 int	vm_setup_memory(struct vmctx *ctx, size_t len);
 void	vm_unsetup_memory(struct vmctx *ctx);
-bool	check_hugetlb_support(void);
+bool	init_hugetlb(void);
+void	uninit_hugetlb(void);
 int	hugetlb_setup_memory(struct vmctx *ctx);
 void	hugetlb_unsetup_memory(struct vmctx *ctx);
 void	*vm_map_gpa(struct vmctx *ctx, vm_paddr_t gaddr, size_t len);


### PR DESCRIPTION
If you run two acrn-dm processes at the same time,
hugetblfs will be mounted twice, which will cause a memory leak.
The specific solution is :different virtual machines mount hugetblfs
into different directories.

Tracked-On:#2854
Signed-off-by: bing.li <bingx.li@intel.com>
Reviewed-by: Minggui Cao<minggui.cao@intel.com>
Acked-by: Yin Fengwei<fengwei.yin@intel.com>