### PR TITLE
DM: Adjust the priority related with ioreq emulation for Android Guest

### DIFF
--- a/devicemodel/samples/apl-mrb/launch_uos.sh
+++ b/devicemodel/samples/apl-mrb/launch_uos.sh
@@ -378,7 +378,16 @@ echo "dm_run: after passthru dev preparing" > /dev/kmsg
    -l com2,/run/acrn/ioc_$vm_name \
    $boot_image_option \
    --enable_trusty \
-   -B "$kernel_cmdline" $vm_name
+   -B "$kernel_cmdline" $vm_name &
+
+sleep 10
+ps -lLcA | grep acrngt_emulatio | awk -F' ' '{print $6}' | while read line; do cat /proc/$line/comm; renice -n -10 $line; done
+ps -lLcA | grep vcpu | awk -F' ' '{print $6}' | while read line; do cat /proc/$line/comm; renice -n -10 $line; done
+ps -lLcA | grep ioreq | awk -F' ' '{print $6}' | while read line; do cat /proc/$line/comm; renice -n -10 $line; done
+ps -lLcA | grep gvt | awk -F' ' '{print $6}' | while read line; do cat /proc/$line/comm; renice -n -10 $line; done
+
+wait
+
 }
 
 function launch_alios()


### PR DESCRIPTION
When the IO/MMIO acccess on Android guest causes the trap to hypervisor,
it will be blocked until the ioreq emulation is completed.
In order to get the better performance, it will be better that the ioreq
emulation can be completed ASAP. As it is handled in SOS kernel, the
corresponding thread priority will be raised.

Tracked-On:#3242
Signed-off-by: Liu, Shuo <shuo.liu@intel.com>
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>