### PR TITLE
HV: introduce relative vm id for hcall api

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -337,6 +337,7 @@ int32_t hcall_reset_vm(uint16_t vmid)
  * @param param guest physical address. This gpa points to
  *              struct acrn_vcpu_regs
  *
+ * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
 int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
@@ -407,6 +408,9 @@ int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 	return ret;
 }
 
+/**
+ *@pre Pointer vm shall point to SOS_VM
+ */
 static void inject_msi_lapic_pt(struct acrn_vm *vm, const struct acrn_msi_entry *vmsi)
 {
 	union apic_icr icr;
@@ -578,7 +582,9 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 	return ret;
 }
 
-
+/**
+ *@pre Pointer vm shall point to SOS_VM
+ */
 static int32_t add_vm_memory_region(struct acrn_vm *vm, struct acrn_vm *target_vm,
 				    const struct vm_memory_region *region,uint64_t *pml4_page)
 {

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -180,6 +180,16 @@ static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_
 	return target_vcpu;
 }
 
+/* Convert relative vm id to absolute vm id */
+static inline uint16_t rel_vmid_2_vmid(uint16_t sos_vmid, uint16_t rel_vmid) {
+	return (sos_vmid + rel_vmid);
+}
+
+/* Convert absolute vm id to relative vm id */
+static inline uint16_t vmid_2_rel_vmid(uint16_t sos_vmid, uint16_t vmid) {
+	return (vmid - sos_vmid);
+}
+
 int32_t shutdown_vm(struct acrn_vm *vm);
 void pause_vm(struct acrn_vm *vm);
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);


### PR DESCRIPTION
On SDC scenario, SOS VM id is fixed to 0 so some hypercalls from guest
    are using hardcoded "0" to represent SOS VM, this would bring issues
    for HYBRID scenario which SOS VM id is non-zero.
    
    Now introducing a new VM id concept for DM/VHM hypercall APIs, that
    return a relative VM id which is from SOS view when create VM for post-
    launched VMs. DM/VHM could always treat their own vm id is "0". When they
    make hypercalls, hypervisor will convert the VM id to the absolute id
    when dispatch the hypercalls.
    
Tracked-On: #3214
    
Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@Intel.com>
