### PR TITLE
Improve the performance of isochronous transfer

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2875,6 +2875,9 @@ retry:
 					XHCI_GADDR(xdev, trb->qwTrb0)),
 					trb->dwTrb2 & 0x1FFFF, (void *)addr,
 					ccs);
+
+			if (trb->dwTrb3 & XHCI_TRB_3_CHAIN_BIT)
+				xfer_block->chained = 1;
 			break;
 
 		case XHCI_TRB_TYPE_STATUS_STAGE:

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -19,8 +19,8 @@
 #define LOG_TAG "USBPM: "
 
 static struct usb_dev_sys_ctx_info g_ctx;
-static inline uint8_t usb_dev_get_ep_type(struct usb_dev *udev, int pid,
-		int epnum);
+static uint8_t usb_dev_get_ep_type(struct usb_dev *udev, int pid, int epnum);
+static uint16_t usb_dev_get_ep_maxp(struct usb_dev *udev, int pid, int epnum);
 
 static bool
 usb_get_native_devinfo(struct libusb_device *ldev,
@@ -480,6 +480,28 @@ usb_dev_get_ep_type(struct usb_dev *udev, int pid, int epnum)
 		return ep->type;
 }
 
+static inline void
+usb_dev_set_ep_maxp(struct usb_dev *udev, int pid, int epnum, uint16_t maxp)
+{
+	struct usb_dev_ep *ep;
+
+	ep = usb_dev_get_ep(udev, pid, epnum);
+	if (ep)
+		ep->maxp = maxp;
+}
+
+static inline uint16_t
+usb_dev_get_ep_maxp(struct usb_dev *udev, int pid, int epnum)
+{
+	struct usb_dev_ep *ep;
+
+	ep = usb_dev_get_ep(udev, pid, epnum);
+	if (!ep)
+		return 0;
+	else
+		return ep->maxp;
+}
+
 static void
 usb_dev_reset_ep(struct usb_dev *udev)
 {
@@ -515,6 +537,10 @@ usb_dev_update_ep(struct usb_dev *udev)
 					USB_EP_PID(desc),
 					USB_EP_NR(desc),
 					USB_EP_TYPE(desc));
+			usb_dev_set_ep_maxp(udev,
+					USB_EP_PID(desc),
+					USB_EP_NR(desc),
+					USB_EP_MAXP(desc));
 		}
 	}
 	libusb_free_config_descriptor(cfg);

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -170,7 +170,7 @@ libusb_speed_to_usb_speed(int libusb_speed)
 }
 
 static void
-usb_dev_comp_req(struct libusb_transfer *trn)
+usb_dev_comp_cb(struct libusb_transfer *trn)
 {
 	struct usb_dev_req *r;
 	struct usb_data_xfer *xfer;
@@ -255,6 +255,7 @@ usb_dev_comp_req(struct libusb_transfer *trn)
 	done = trn->actual_length;
 
 	while (i < r->blk_count) {
+
 		if (trn->type == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS) {
 			buf_idx = 0;
 			buf = libusb_get_iso_packet_buffer_simple(trn, j);
@@ -885,16 +886,16 @@ usb_dev_data(void *pdata, struct usb_data_xfer *xfer, int dir, int epctx)
 
 	if (type == USB_ENDPOINT_BULK) {
 		libusb_fill_bulk_transfer(r->trn, udev->handle, epid,
-				r->buffer, data_size, usb_dev_comp_req, r, 0);
+				r->buffer, data_size, usb_dev_comp_cb, r, 0);
 
 	} else if (type == USB_ENDPOINT_INT) {
 		libusb_fill_interrupt_transfer(r->trn, udev->handle, epid,
-				r->buffer, data_size, usb_dev_comp_req, r, 0);
+				r->buffer, data_size, usb_dev_comp_cb, r, 0);
 
 	} else if (type == USB_ENDPOINT_ISOC) {
 		libusb_fill_iso_transfer(r->trn, udev->handle, epid,
 				r->buffer, data_size, framecnt,
-				usb_dev_comp_req, r, 0);
+				usb_dev_comp_cb, r, 0);
 
 	} else {
 		UPRINTF(LFTL, "%s: wrong endpoint type %d\r\n", __func__, type);

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -117,6 +117,7 @@ usb_data_xfer_append(struct usb_data_xfer *xfer, void *buf, int blen,
 	xb->ccs = ccs;
 	xb->processed = USB_XFER_BLK_FREE;
 	xb->bdone = 0;
+	xb->chained = 0;
 	xfer->ndata++;
 	xfer->tail = (xfer->tail + 1) % USB_MAX_XFER_BLOCKS;
 	return xb;

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -155,6 +155,7 @@ struct usb_data_xfer_block {
 	enum usb_xfer_blk_stat	processed; /* processed status */
 	void			*hci_data; /* HCI private reference */
 	int			ccs;
+	int			chained;
 	uint32_t		streamid;
 	uint64_t		trbnext;   /* next TRB guest address */
 };

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -163,6 +163,7 @@ struct usb_data_xfer_block {
 struct usb_data_xfer {
 	uint64_t magic;
 	struct usb_data_xfer_block data[USB_MAX_XFER_BLOCKS];
+	struct usb_dev_req *requests[USB_MAX_XFER_BLOCKS];
 	struct usb_device_request *ureq;	/* setup ctl request */
 	int	ndata;				/* # of data items */
 	int	head;
@@ -171,7 +172,6 @@ struct usb_data_xfer {
 	int     epid;		/* related endpoint id */
 	int     pid;		/* token id */
 	int	status;
-	pthread_mutex_t mtx;
 };
 
 struct usb_devpath {
@@ -206,28 +206,6 @@ enum USB_ERRCODE {
 ((x)->processed = ((x)->processed & 0xFF) | (e << 8))
 
 #define	USB_DATA_OK(x, i)	((x)->data[(i)].buf != NULL)
-
-#define	USB_DATA_XFER_INIT(x)	do {					   \
-		pthread_mutexattr_t attr;				   \
-		pthread_mutexattr_init(&attr);				   \
-		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE); \
-		memset((x), 0, sizeof(*(x)));				   \
-		pthread_mutex_init(&((x)->mtx), &attr);			   \
-	} while (0)
-
-#define	USB_DATA_XFER_RESET(x)	do {					\
-			pthread_mutex_lock(&((x)->mtx));		\
-			memset((x)->data, 0, sizeof((x)->data));	\
-			(x)->ndata = 0;					\
-			(x)->head = (x)->tail = 0;			\
-			pthread_mutex_unlock((&(x)->mtx));		\
-		} while (0)
-
-#define	USB_DATA_XFER_LOCK(x)	\
-	pthread_mutex_lock(&((x)->mtx))
-
-#define	USB_DATA_XFER_UNLOCK(x)	\
-	pthread_mutex_unlock(&((x)->mtx))
 
 #define LOG_TAG "USB: "
 #define LFTL 0

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -79,7 +79,7 @@ struct usb_dev_req {
 	int     blk_count;
 
 	struct usb_data_xfer *xfer;
-	struct libusb_transfer *libusb_xfer;
+	struct libusb_transfer *trn;
 	struct usb_data_xfer_block *setup_blk;
 };
 

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -106,6 +106,8 @@ struct usb_dev_sys_ctx_info {
 	usb_dev_sys_cb disconn_cb;
 	usb_dev_sys_cb notify_cb;
 	usb_dev_sys_cb intr_cb;
+	usb_dev_sys_cb lock_ep_cb;
+	usb_dev_sys_cb unlock_ep_cb;
 
 	libusb_device **devlist;
 
@@ -118,6 +120,8 @@ struct usb_dev_sys_ctx_info {
 /* intialize the usb_dev subsystem and register callbacks for HCD layer */
 int usb_dev_sys_init(usb_dev_sys_cb conn_cb, usb_dev_sys_cb disconn_cb,
 		usb_dev_sys_cb notify_cb, usb_dev_sys_cb intr_cb,
+		usb_dev_sys_cb lock_ep_cb,
+		usb_dev_sys_cb unlock_ep_cb,
 		void *hci_data, int log_level);
 void usb_dev_sys_deinit(void);
 void *usb_dev_init(void *pdata, char *opt);

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -18,7 +18,11 @@
 #define USB_EP_PID(d) (USB_EP_ADDR(d) & USB_DIR_IN ? TOKEN_IN : TOKEN_OUT)
 #define USB_EP_TYPE(d) (USB_EP_ATTR(d) & 0x3)
 #define USB_EP_NR(d) (USB_EP_ADDR(d) & 0xF)
+#define USB_EP_MAXP(d) ((d)->wMaxPacketSize)
 #define USB_EP_ERR_TYPE 0xFF
+
+#define USB_EP_MAXP_SZ(m) ((m) & 0x7ff)
+#define USB_EP_MAXP_MT(m) (((m) >> 11) & 0x3)
 
 enum {
 	USB_INFO_VERSION,
@@ -32,6 +36,7 @@ enum {
 struct usb_dev_ep {
 	uint8_t pid;
 	uint8_t type;
+	uint16_t maxp;
 };
 
 struct usb_dev {


### PR DESCRIPTION
This patchset re-implements the USB isochronous transfer and could support
at least 800x600 real time USB camera capturing.

BTW: currently, the USB isochronous transfer could not work normally under
WaaG.
