### PR TITLE
hv: Rename tables member of vPCI msix struct pci_msix

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -79,9 +79,9 @@ void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev)
 
 	/* Mask all table entries */
 	for (i = 0U; i < msix->table_count; i++) {
-		msix->tables[i].vector_control = PCIM_MSIX_VCTRL_MASK;
-		msix->tables[i].addr = 0U;
-		msix->tables[i].data = 0U;
+		msix->table_entries[i].vector_control = PCIM_MSIX_VCTRL_MASK;
+		msix->table_entries[i].addr = 0U;
+		msix->table_entries[i].data = 0U;
 	}
 
 	bar = &pdev->bar[msix->table_bar];

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -74,8 +74,8 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 	void *hva;
 	int32_t ret;
 
-	info.vmsi_addr.full = vdev->msix.tables[index].addr;
-	info.vmsi_data.full = (enable) ? vdev->msix.tables[index].data : 0U;
+	info.vmsi_addr.full = vdev->msix.table_entries[index].addr;
+	info.vmsi_data.full = (enable) ? vdev->msix.table_entries[index].data : 0U;
 
 	ret = ptirq_msix_remap(vdev->vpci->vm, vdev->vbdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
 	if (ret == 0) {
@@ -93,7 +93,7 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 		mmio_write32((uint32_t)(info.pmsi_addr.full >> 32U), (void *)((char *)&(pentry->addr) + 4U));
 
 		mmio_write32(info.pmsi_data.full, (void *)&(pentry->data));
-		mmio_write32(vdev->msix.tables[index].vector_control, (void *)&(pentry->vector_control));
+		mmio_write32(vdev->msix.table_entries[index].vector_control, (void *)&(pentry->vector_control));
 		clac();
 	}
 
@@ -246,7 +246,7 @@ static void vmsix_table_rw(const struct pci_vdev *vdev, struct mmio_request *mmi
 	index = table_offset / MSIX_TABLE_ENTRY_SIZE;
 
 	if (index < vdev->msix.table_count) {
-		entry = &vdev->msix.tables[index];
+		entry = &vdev->msix.table_entries[index];
 		entry_offset = table_offset % MSIX_TABLE_ENTRY_SIZE;
 
 		if (mmio->direction == REQUEST_READ) {

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -47,7 +47,7 @@ struct pci_msi {
 
 /* MSI-X capability structure */
 struct pci_msix {
-	struct msix_table_entry tables[CONFIG_MAX_MSIX_TABLE_NUM];
+	struct msix_table_entry table_entries[CONFIG_MAX_MSIX_TABLE_NUM];
 	uint64_t  mmio_gpa;
 	uint64_t  mmio_hpa;
 	uint64_t  mmio_size;


### PR DESCRIPTION
Rename MSI-X struct, pci_msix, member from tables to table_entries

Tracked-On: #3265
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>