### PR TITLE
dm: add virtio-rnd device to command line

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -33,6 +33,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 6,virtio-hyper_dmabuf \
   -s 3,virtio-blk,/home/clear/uos/uos.img \
   -s 4,virtio-net,tap0 \
+  -s 7,virtio-rnd \
   $logger_setting \
   --mac_seed $mac_seed \
   -k /usr/lib/kernel/default-iot-lts2018 \


### PR DESCRIPTION
When FE virtio devices work in polling mode, sshd.service can't start
normally and blocks at generating random bytes. When reading from
the random source, getrandom() blocks caused by no random bytes.

Tracked-On: #3268
Signed-off-by: Gao Junhao <junhao.gao@intel.com>
Reviewed-by: Yu Wang <yu1.wang@intel.com>