### PR TITLE
ACRN: DM: Add new options for NUC launch_uos script.

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -7,6 +7,74 @@ if [ -e "/dev/acrn_hsm" ]; then
 offline_path="/sys/class/acrn/acrn_hsm"
 fi
 
+
+function run_container()
+{
+vm_name=vm1
+config_src="/usr/share/acrn/samples/nuc/runC.json"
+shell="/usr/share/acrn/conf/add/$vm_name.sh"
+arg_file="/usr/share/acrn/conf/add/$vm_name.args"
+runc_bundle="/usr/share/acrn/conf/add/runc/$vm_name"
+rootfs_dir="/usr/share/acrn/conf/add/runc/rootfs"
+config_dst="$runc_bundle/config.json"
+
+
+input=$(runc list -f table | awk '{print $1}''{print $3}')
+arr=(${input// / })
+
+for((i=0;i<${#arr[@]};i++))
+do
+	if [ "$vm_name" = "${arr[$i]}" ]; then
+		if [ "running" = "${arr[$i+1]}" ]; then
+			echo "runC instance ${arr[$i]} is running"
+			exit
+		else
+			runc kill ${arr[$i]}
+			runc delete ${arr[$i]}
+		fi
+	fi
+done
+vmsts=$(acrnctl list)
+vms=(${vmsts// / })
+for((i=0;i<${#vms[@]};i++))
+do
+	if [ "$vm_name" = "${vms[$i]}" ]; then
+		if [ "stopped" != "${vms[$i+1]}" ]; then
+			echo "Uos ${vms[$i]} ${vms[$i+1]}"
+			acrnctl stop ${vms[$i]}
+	        fi
+	fi
+done
+
+
+if [ ! -f "$shell" ]; then
+	echo "Pls add the vm at first!"
+	exit
+fi
+
+if [ ! -f "$arg_file" ]; then
+	echo "Pls add the vm args!"
+	exit
+fi
+
+
+if [ ! -d "$rootfs_dir" ]; then
+	mkdir -p "$rootfs_dir"
+fi
+if [ ! -d "$runc_bundle" ]; then
+	mkdir -p "$runc_bundle"
+fi
+if [ ! -f "$config_dst" ]; then
+	cp  "$config_src"  "$config_dst"
+	args=$(sed '{s/-C//g;s/^[ \t]*//g;s/^/\"/;s/ /\",\"/g;s/$/\"/}' ${arg_file})
+	sed -i "s|\"sh\"|\"$shell\", $args|" $config_dst
+fi
+runc run --bundle $runc_bundle -d $vm_name
+echo "The runC container is running in backgroud"
+echo "'#runc exec <vmname> bash' to login the container bash"
+exit
+}
+
 function launch_clear()
 {
 mac=$(cat /sys/class/net/e*/address)
@@ -60,4 +128,10 @@ for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
         fi
 done
 
-launch_clear 1 1 "64 448 8" 0x070F00
+
+if [ "$1" = "-C" ];then
+	echo "runc_container"
+	run_container
+else
+	launch_clear 1 1 "64 448 8" 0x070F00
+fi


### PR DESCRIPTION
The patch adds new argument for launch_uos script for NUC.
In the patch add "-C" parameter for launch_uos script. When launch
the script with the parameter the ACRN-dm will be launched in the
runC container. For more information about this please refer to
ACRN-dm QoS document.

Tracked-On: #2020
Signed-off-by: Long Liu <long.liu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>