### PR TITLE
doc: tweak doxygen precondition label

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -40,6 +40,7 @@ help:
 
 doxy:
 	$(Q)(cat acrn.doxyfile) | doxygen - > doc.log 2>&1
+	$(Q)find doxygen/xml/* | xargs sed -i 's/simplesect kind="pre"/simplesect kind="preconditions"/'
 
 content:
 	$(Q)scripts/extract_content.py . tools
@@ -50,7 +51,6 @@ kconfig:
 
 pullsource:
 	$(Q)scripts/pullsource.sh
-
 
 html: doxy content kconfig
 	-$(Q)$(SPHINXBUILD) -t $(DOC_TAG) -b html -d $(BUILDDIR)/doctrees $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(OPTS) >> doc.log 2>&1


### PR DESCRIPTION
The doxygen-collected API information about function preconditions has a
uninspired title of "pre".  This change tweaks that to be
"preconditions" in the generated HTML output by editing the generated
xml output before it is processed by Sphinx/Breathe.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>