### PR TITLE
hv: vlapic: clear which access type we support for APIC-Access VM Exit

### DIFF
--- a/hypervisor/include/arch/x86/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/guest/vmcs.h
@@ -15,7 +15,12 @@
 #include <vmx.h>
 #include <vcpu.h>
 
-#define VMX_VMENTRY_FAIL	0x80000000U
+#define VMX_VMENTRY_FAIL                0x80000000U
+
+#define APIC_ACCESS_OFFSET              0xFFFUL   /* 11:0, offset within the APIC page */
+#define APIC_ACCESS_TYPE                0xF000UL  /* 15:12, access type */
+#define TYPE_LINEAR_APIC_INST_READ      (0UL << 12U)
+#define TYPE_LINEAR_APIC_INST_WRITE     (1UL << 12U)
 
 static inline uint32_t vmx_eoi_exit(uint32_t vector)
 {
@@ -34,12 +39,12 @@ static inline uint32_t vmx_eoi_exit(uint32_t vector)
  */
 static inline uint64_t apic_access_type(uint64_t qual)
 {
-	return ((qual >> 12U) & 0xFUL);
+	return (qual & APIC_ACCESS_TYPE);
 }
 
 static inline uint64_t apic_access_offset(uint64_t qual)
 {
-	return (qual & 0xFFFUL);
+	return (qual & APIC_ACCESS_OFFSET);
 }
 
 #define RFLAGS_C (1U<<0U)


### PR DESCRIPTION
v2:
add MACRO to define APIC-Access access type

v1:
The current implement doesn't clear which access type we support for
APIC-Access VM Exit:
1) linear access for an instruction fetch
-- APIC-access page is mapped as UC which doesn't support fetch
2) linear access (read or write) during event delivery
-- Which is not happened in normal case except the guest went wrong, such as,
set the IDT table in APIC-access page. In this case, we don't need to support.
3) guest-physical access during event delivery;
   guest-physical access for an instruction fetch or during instruction execution
-- Do we plan to support enable APIC in real mode ? I don't think so.

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>