### PR TITLE
fix some security issues

### DIFF
--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -196,7 +196,7 @@ register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 	struct mmio_rb_range *entry, *mrp;
 	int err;
 
-	err = 0;
+	err = -1;
 
 	mrp = malloc(sizeof(struct mmio_rb_range));
 
@@ -210,8 +210,7 @@ register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 		pthread_rwlock_unlock(&mmio_rwlock);
 		if (err)
 			free(mrp);
-	} else
-		err = -1;
+	}
 
 	return err;
 }

--- a/devicemodel/hw/pci/virtio/virtio_audio.c
+++ b/devicemodel/hw/pci/virtio/virtio_audio.c
@@ -121,6 +121,7 @@ virtio_audio_kernel_dev_set(struct vbs_dev_info *kdev, const char *name,
 {
 	/* init kdev */
 	strncpy(kdev->name, name, VBS_NAME_LEN);
+	kdev->name[VBS_NAME_LEN - 1] = '\0';
 	kdev->vmid = vmid;
 	kdev->nvq = nvq;
 	kdev->negotiated_features = feature;

--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -625,7 +625,8 @@ virtio_console_accept_new_connection(int fd __attribute__((unused)),
 
 	memset(&addr, 0, sizeof(addr));
 	addr.sun_family = AF_UNIX;
-	strcpy(addr.sun_path, be->portpath);
+	strncpy(addr.sun_path, be->portpath, sizeof(addr.sun_path));
+	addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
 
 	len = sizeof(addr);
 	accepted_fd = accept(be->fd, (struct sockaddr *)&addr, &len);
@@ -728,7 +729,8 @@ virtio_console_config_backend(struct virtio_console_backend *be)
 
 		memset(&addr, 0, sizeof(addr));
 		addr.sun_family = AF_UNIX;
-		strcpy(addr.sun_path, be->portpath);
+		strncpy(addr.sun_path, be->portpath, sizeof(addr.sun_path));
+		addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
 
 		if (be->socket_type == NULL || !strcmp(be->socket_type,"server")) {
 			unlink(be->portpath);

--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -652,10 +652,10 @@ virtio_gpio_proc(struct virtio_gpio *gpio, struct iovec *iov, int n)
 			 * command line paremeter, then provide it to UOS,
 			 * otherwise provide the physical name of gpio to UOS.
 			 */
-			if (strlen(line->vname))
+			if (strnlen(line->vname, sizeof(line->vname)))
 				strncpy(data[i].name, line->vname,
 						sizeof(data[0].name) - 1);
-			else if (strlen(line->name))
+			else if (strnlen(line->name, sizeof(line->name)))
 				strncpy(data[i].name, line->name,
 						sizeof(data[0].name) - 1);
 		}

--- a/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
+++ b/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
@@ -116,6 +116,7 @@ virtio_hyper_dmabuf_k_dev_set(const char *name, int vmid, int nvq,
 {
 	/* init kdev */
 	strncpy(kdev.name, name, VBS_NAME_LEN);
+	kdev.name[VBS_NAME_LEN - 1] = '\0';
 	kdev.vmid = vmid;
 	kdev.nvq = nvq;
 	kdev.negotiated_features = feature;

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -652,8 +652,10 @@ virtio_net_tap_open(char *devname)
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
 
-	if (*devname)
+	if (*devname) {
 		strncpy(ifr.ifr_name, devname, IFNAMSIZ);
+		ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+	}
 
 	rc = ioctl(tunfd, TUNSETIFF, (void *)&ifr);
 	if (rc < 0) {

--- a/devicemodel/hw/pci/virtio/virtio_rnd.c
+++ b/devicemodel/hw/pci/virtio/virtio_rnd.c
@@ -217,6 +217,7 @@ virtio_rnd_kernel_dev_set(struct vbs_dev_info *kdev, const char *name,
 
 	/* init kdev */
 	strncpy(kdev->name, name, VBS_NAME_LEN);
+	kdev->name[VBS_NAME_LEN - 1] = '\0';
 	kdev->vmid = vmid;
 	kdev->nvq = nvq;
 	kdev->negotiated_features = feature;

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -4126,6 +4126,8 @@ errout:
 			free(xdev->portregs);
 			xdev->portregs = NULL;
 		}
+		if (rc < -2 && s)
+			free(s);
 		UPRINTF(LFTL, "fail to parse xHCI options, rc=%d\r\n", rc);
 
 		if (opts)


### PR DESCRIPTION
During static code analysis for ACRN hypervisor source code,
there have some issues.
1, buffer overflow - array index out of bounds
2, use of banned functions in source code
3, potential memory leak found.

Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>