### PR TITLE
HV: Fix OVMF hang issue when boot with lapic_pt

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -485,7 +485,7 @@ int32_t hcall_inject_msi(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 		} else {
 			/* For target cpu with lapic pt, send ipi instead of injection via vlapic */
 			if (is_lapic_pt_configured(target_vm)) {
-				enum vm_vlapic_state vlapic_state = check_vm_vlapic_state(vm);
+				enum vm_vlapic_state vlapic_state = check_vm_vlapic_state(target_vm);
 				if (vlapic_state == VM_VLAPIC_X2APIC) {
 					/*
 					 * All the vCPUs of VM are in x2APIC mode and LAPIC is PT


### PR DESCRIPTION
In hcall_inject_msi, we check vlapic state of SOS by mistake.
If the SOS's vlapic state doesn't equal to target_vm's, the OVMF will
hang when boot up. Instead, we should check the target_vm's
vlapic state.

Tracked-On: #3069
Acked-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Signed-off-by: Kaige Fu <kaige.fu@intel.com>