### PR TITLE
 HV: Implement wbinvd instruction emulation

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -386,6 +386,9 @@ int32_t detect_hardware_support(void)
 	} else if (!pcpu_has_cap(X86_FEATURE_MTRR)) {
 		pr_fatal("%s, MTRR not supported\n", __func__);
 		ret = -ENODEV;
+	} else if (!pcpu_has_cap(X86_FEATURE_CLFLUSHOPT)) {
+		pr_fatal("%s, CLFLUSHOPT not supported\n", __func__);
+		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_PAGE1GB)) {
 		pr_fatal("%s, not support 1GB page\n", __func__);
 		ret = -ENODEV;

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -157,6 +157,23 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t 
 }
 
 /**
+ * @pre pge != NULL && size > 0.
+ */
+void ept_flush_leaf_page(uint64_t *pge, uint64_t size)
+{
+	uint64_t hpa = INVALID_HPA;
+	void *hva = NULL;
+
+	if ((*pge & EPT_MT_MASK) != EPT_UNCACHED) {
+		hpa = (*pge & (~(size - 1UL)));
+		hva = hpa2hva(hpa);
+		stac();
+		flush_address_space(hva, size);
+		clac();
+	}
+}
+
+/**
  * @pre: vm != NULL.
  */
 void *get_ept_entry(struct acrn_vm *vm)

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -854,3 +854,19 @@ enum vm_vlapic_state check_vm_vlapic_state(const struct acrn_vm *vm)
 	vlapic_state = vm->arch_vm.vlapic_state;
 	return vlapic_state;
 }
+
+/**
+ * if there is RT VM return true otherwise return false.
+ */
+bool has_rt_vm(void)
+{
+	uint16_t vm_id;
+
+	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
+		if (is_rt_vm(get_vm_from_vmid(vm_id))) {
+			break;
+		}
+	}
+
+	return ((vm_id == CONFIG_MAX_VM_NUM) ? false : true);
+}

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -347,8 +347,10 @@ static int32_t xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 
 static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 {
-	if (!iommu_snoop_supported(vcpu->vm->iommu)) {
+	if (has_rt_vm() == false) {
 		cache_flush_invalidate_all();
+	} else {
+		walk_ept_table(vcpu->vm, ept_flush_leaf_page);
 	}
 
 	return 0;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -294,3 +294,16 @@ void init_paging(void)
 	/* set ptep in sanitized_page point to itself */
 	sanitize_pte((uint64_t *)sanitized_page);
 }
+
+/*
+ * @pre: addr != NULL  && size != 0
+ */
+void flush_address_space(void *addr, uint64_t size)
+{
+	uint64_t n = 0UL;
+
+	while (n < size) {
+		clflushopt((char *)addr + n);
+		n += CACHE_LINE_SIZE;
+	}
+}

--- a/hypervisor/include/arch/x86/cpufeatures.h
+++ b/hypervisor/include/arch/x86/cpufeatures.h
@@ -76,6 +76,7 @@
 #define X86_FEATURE_INVPCID	((FEAT_7_0_EBX << 5U) + 10U)
 #define X86_FEATURE_CAT        ((FEAT_7_0_EBX << 5U) + 15U)
 #define X86_FEATURE_SMAP	((FEAT_7_0_EBX << 5U) + 20U)
+#define X86_FEATURE_CLFLUSHOPT	((FEAT_7_0_EBX << 5U) + 23U)
 
 /* Intel-defined CPU features, CPUID level 0x00000007 (EDX)*/
 #define X86_FEATURE_IBRS_IBPB	((FEAT_7_0_EDX << 5U) + 26U)

--- a/hypervisor/include/arch/x86/guest/ept.h
+++ b/hypervisor/include/arch/x86/guest/ept.h
@@ -107,6 +107,17 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size);
 
 /**
+ * @brief Flush address space from the page entry
+ *
+ * @param[in] pge the pointer that points to the page entry
+ *
+ * @param[in] size the size of the page
+ *
+ * @return None
+ */
+void ept_flush_leaf_page(uint64_t *pge, uint64_t size);
+
+/**
  * @brief Get EPT pointer of the vm
  *
  * @param[in] vm the pointer that points to VM data structure

--- a/hypervisor/include/arch/x86/guest/ept.h
+++ b/hypervisor/include/arch/x86/guest/ept.h
@@ -8,6 +8,8 @@
 #define EPT_H
 #include <types.h>
 
+typedef void (*pge_handler)(uint64_t *pgentry, uint64_t size);
+
 /**
  * Invalid HPA is defined for error checking,
  * according to SDM vol.3A 4.1.4, the maximum
@@ -103,6 +105,28 @@ void ept_modify_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
  */
 void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
 		uint64_t size);
+
+/**
+ * @brief Get EPT pointer of the vm
+ *
+ * @param[in] vm the pointer that points to VM data structure
+ *
+ * @retval If the current context of vm is SECURE_WORLD, return EPT pointer of
+ *            secure world, otherwise return EPT pointer of normal world.
+ */
+void *get_ept_entry(struct acrn_vm *vm);
+
+/**
+ * @brief Walking through EPT table
+ *
+ * @param[in] vm the pointer that points to VM data structure
+ * @param[in] cb the pointer that points to walk_ept_table callback, the callback
+ * 		will be invoked when getting a present page entry from EPT, and
+ *		the callback could get the page entry and page size parameters.
+ *
+ * @return None
+ */
+void walk_ept_table(struct acrn_vm *vm, pge_handler cb);
 
 /**
  * @brief EPT misconfiguration handling

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -224,6 +224,7 @@ void vrtc_init(struct acrn_vm *vm);
 
 bool is_lapic_pt_configured(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
+bool has_rt_vm(void);
 bool is_highest_severity_vm(const struct acrn_vm *vm);
 bool vm_hide_mtrr(const struct acrn_vm *vm);
 void update_vm_vlapic_state(struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -169,6 +169,11 @@ static inline void clflush(volatile void *p)
 	asm volatile ("clflush (%0)" :: "r"(p));
 }
 
+static inline void clflushopt(volatile void *p)
+{
+	asm volatile ("clflushopt (%0)" :: "r"(p));
+}
+
 /* get PDPT address from CR3 vaule in PAE mode */
 static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)
 {

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -150,6 +150,18 @@ void flush_vpid_single(uint16_t vpid);
  * @return None
  */
 void flush_vpid_global(void);
+
+/**
+ * @brief Flush address space
+ *
+ * @param[in] addr the specified virtual address
+ *
+ * @param[in] size the specified size to flush
+ *
+ * @return None
+ */
+void flush_address_space(void *addr, uint64_t size);
+
 /**
  * @brief Guest-physical mappings and combined mappings invalidation
  *


### PR DESCRIPTION
wbinvd is used to write back all modified cache lines in the processor's
internal cache to main memory and invalidates(flushes) the internal caches.

Using clflushopt instructions to emulate wbinvd, and if clflushopt instruction
is not supported, boot will fail.

v2: 1) flush cache by walking through ETP instead seperated memory regions
    2) Check RT VM firstly before wbinvd emulation, if there is no RT VM,
       invoke wbinvd instruction directly.
    3) Do not flush uncached page.
    4) It also needs to emulate wbinvd instruction for SOS, not only UOS.

v3: 1) Add CLFLUSHOPT supporting check in boot time.
    2) Refine walking ept table interface.
    3) Add flush_cache interface in mmu.c
    4) Add get_ept and ept_mr_flush interfaces.

v4: 1) Splite the patch.
    2) Add comments for API.
    3) Remove sfence.
    4) Refine code style.

v5: 1) Rename ept_flush_address_space to ept_flush_leaf_page.
    2) Rename walk_ept_mr to walk_ept_table.
    3) Add get_ept_entry API.

v6: 1) Rename has_running_rt_vm to has_rt_vm.
    2) Add comment for has_rt_vm.

Yuan Liu (6):
  HV: Add CLFLUSHOPT instruction.
  HV: Add flush_address_space API.
  HV: Add walk_ept_table and get_ept_entry APIs
  HV: Add ept_flush_leaf_page API
  HV: Add has_rt_vm API
  HV: implement wbinvd instruction emulation

Tracked-On: #3263
Signed-off-by: Jack Ren <jack.ren@intel.com>
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>