### PR TITLE
Device Model  'assert'  cleanup patches set

### DIFF
--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <assert.h>
 
 #include "vmmapi.h"
 
@@ -267,7 +266,6 @@ static int mmap_hugetlbfs(struct vmctx *ctx, size_t offset,
 		pg_size = hugetlb_priv[level].pg_size;
 
 		while (len > 0) {
-			assert((offset & (pg_size - 1)) == 0);
 			ret = mmap_hugetlbfs_from_level(ctx, level, len, offset, skip);
 
 			if (ret < 0 && level > HUGETLB_LV1) {
@@ -297,7 +295,6 @@ static void get_lowmem_param(struct hugetlb_info *htlb,
 static size_t adj_lowmem_param(struct hugetlb_info *htlb,
 		struct hugetlb_info *htlb_prev, int adj_size)
 {
-	assert(htlb->lowmem >= adj_size);
 	htlb->lowmem -= adj_size;
 	htlb_prev->lowmem += adj_size;
 
@@ -314,7 +311,6 @@ static void get_highmem_param(struct hugetlb_info *htlb,
 static size_t adj_highmem_param(struct hugetlb_info *htlb,
 		struct hugetlb_info *htlb_prev, int adj_size)
 {
-	assert(htlb->highmem >= adj_size);
 	htlb->highmem -= adj_size;
 	htlb_prev->highmem += adj_size;
 
@@ -331,7 +327,6 @@ static void get_biosmem_param(struct hugetlb_info *htlb,
 static size_t adj_biosmem_param(struct hugetlb_info *htlb,
 		struct hugetlb_info *htlb_prev, int adj_size)
 {
-	assert(htlb->biosmem >= adj_size);
 	htlb->biosmem -= adj_size;
 	htlb_prev->biosmem += adj_size;
 

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -33,7 +33,6 @@
 #include <errno.h>
 #include <libgen.h>
 #include <unistd.h>
-#include <assert.h>
 #include <pthread.h>
 #include <sysexits.h>
 #include <stdbool.h>
@@ -654,10 +653,15 @@ vm_loop(struct vmctx *ctx)
 	int error;
 
 	ctx->ioreq_client = vm_create_ioreq_client(ctx);
-	assert(ctx->ioreq_client > 0);
+	if (ctx->ioreq_client <= 0) {
+		pr_err("%s, failed to create IOREQ.\n", __func__);
+		return;
+	}
 
-	error = vm_run(ctx);
-	assert(error == 0);
+	if (vm_run(ctx) != 0) {
+		pr_err("%s, failed to run VM.\n", __func__);
+		return;
+	}
 
 	while (1) {
 		int vcpu_id;

--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -35,7 +35,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <string.h>
 #include <pthread.h>
 
@@ -178,7 +177,8 @@ emulate_mem(struct vmctx *ctx, struct mmio_request *mmio_req)
 
 	pthread_rwlock_unlock(&mmio_rwlock);
 
-	assert(entry != NULL);
+	if (entry == NULL)
+		return -EINVAL;
 
 	if (mmio_req->direction == REQUEST_READ)
 		err = mem_read(ctx, 0, paddr, (uint64_t *)&mmio_req->value,
@@ -238,11 +238,11 @@ unregister_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 	err = mmio_rb_lookup(rbt, memp->base, &entry);
 	if (err == 0) {
 		mr = &entry->mr_param;
-		if (strncmp(mr->name, memp->name, MEMNAMESZ)) {
+		if (strncmp(mr->name, memp->name, MEMNAMESZ)
+			|| (mr->base != memp->base) || (mr->size != memp->size)
+			|| ((mr->flags & MEM_F_IMMUTABLE) != 0)) {
 			err = -1;
 		} else {
-			assert(mr->base == memp->base && mr->size == memp->size);
-			assert((mr->flags & MEM_F_IMMUTABLE) == 0);
 			RB_REMOVE(mmio_rb_tree, rbt, entry);
 
 			/* flush Per-VM cache */

--- a/devicemodel/core/post.c
+++ b/devicemodel/core/post.c
@@ -26,8 +26,6 @@
  * $FreeBSD$
  */
 
-#include <assert.h>
-
 #include "inout.h"
 #include "lpc.h"
 
@@ -35,9 +33,7 @@ static int
 post_data_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 		  uint32_t *eax, void *arg)
 {
-	assert(in == 1);
-
-	if (bytes != 1)
+	if ((in != 1) || (bytes != 1))
 		return -1;
 
 	*eax = 0xff;		/* return some garbage */

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -121,8 +121,8 @@ acrn_parse_bootargs(char *arg)
 		with_bootargs = 1;
 		printf("SW_LOAD: get bootargs %s\n", bootargs);
 		return 0;
-	} else
-		return -1;
+	}
+	return -1;
 }
 
 char*
@@ -222,8 +222,6 @@ acrn_create_e820_table(struct vmctx *ctx, struct e820_entry *e820)
 	uint32_t removed = 0, k;
 
 	memcpy(e820, e820_default_entries, sizeof(e820_default_entries));
-
-	assert(ctx->lowmem > e820[LOWRAM_E820_ENTRY].baseaddr);
 	e820[LOWRAM_E820_ENTRY].length = ctx->lowmem -
 			e820[LOWRAM_E820_ENTRY].baseaddr;
 

--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -36,7 +36,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <stdbool.h>
 #include <elf.h>
 
@@ -95,19 +94,19 @@ struct multiboot_info {
 int
 acrn_parse_elf(char *arg)
 {
+	int err = -1;
 	size_t len = strnlen(arg, STR_LEN);
 	size_t elfsz;
 
 	if (len < STR_LEN) {
 		strncpy(elf_path, arg, len + 1);
-		assert(check_image(elf_path, 0, &elfsz) == 0);
-
-		elf_file_name = elf_path;
-
-		printf("SW_LOAD: get elf path %s\n", elf_path);
-		return 0;
-	} else
-		return -1;
+		if (check_image(elf_path, 0, &elfsz) == 0) {
+			elf_file_name = elf_path;
+			printf("SW_LOAD: get elf path %s\n", elf_path);
+			err = 0;
+		}
+	}
+	return err;
 }
 
 static int load_elf32(struct vmctx *ctx, FILE *fp, void *buf)

--- a/devicemodel/core/sw_load_vsbl.c
+++ b/devicemodel/core/sw_load_vsbl.c
@@ -28,7 +28,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <stdbool.h>
 
 #include "dm.h"
@@ -125,21 +124,19 @@ vsbl_set_bdf(int bnum, int snum, int fnum)
 int
 acrn_parse_guest_part_info(char *arg)
 {
-	int error;
+	int error = -1;
 	size_t len = strnlen(arg, STR_LEN);
 
 	if (len < STR_LEN) {
 		strncpy(guest_part_info_path, arg, len + 1);
-		error = check_image(guest_part_info_path, 0, &guest_part_info_size);
-		assert(!error);
-
-		with_guest_part_info = true;
-
-		printf("SW_LOAD: get partition blob path %s\n",
-			guest_part_info_path);
-		return 0;
-	} else
-		return -1;
+		if (check_image(guest_part_info_path, 0, &guest_part_info_size) == 0) {
+			with_guest_part_info = true;
+			printf("SW_LOAD: get partition blob path %s\n",
+						guest_part_info_path);
+			error = 0;
+		}
+	}
+	return error;
 }
 
 static int
@@ -194,21 +191,18 @@ acrn_prepare_guest_part_info(struct vmctx *ctx)
 int
 acrn_parse_vsbl(char *arg)
 {
-	int error;
+	int error = -1;
 	size_t len = strnlen(arg, STR_LEN);
 
 	if (len < STR_LEN) {
 		strncpy(vsbl_path, arg, len + 1);
-		error = check_image(vsbl_path, 8 * MB, &vsbl_size);
-		assert(!error);
-
-		vsbl_file_name = vsbl_path;
-
-		printf("SW_LOAD: get vsbl path %s\n",
-			vsbl_path);
-		return 0;
-	} else
-		return -1;
+		if (check_image(vsbl_path, 8 * MB, &vsbl_size) == 0) {
+			vsbl_file_name = vsbl_path;
+			printf("SW_LOAD: get vsbl path %s\n", vsbl_path);
+			error = 0;
+		}
+	}
+	return error;
 }
 
 static int

--- a/devicemodel/core/timer.c
+++ b/devicemodel/core/timer.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 #include <sys/timerfd.h>
 
 #include "vmmapi.h"
@@ -51,7 +50,9 @@ timer_handler(int fd __attribute__((unused)),
 		return;
 	}
 
-	assert(size > 0 && nexp > 0);
+	/* check the validity of timer expiration. */
+	if ((size == 0) || (nexp == 0))
+		return;
 
 	if ((cb = timer->callback) != NULL) {
 		(*cb)(timer->callback_param, nexp);

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <assert.h>
 #include <string.h>
 #include <ctype.h>
 #include <fcntl.h>
@@ -98,8 +97,8 @@ vm_create(const char *name, uint64_t req_buf)
 
 	memset(&create_vm, 0, sizeof(struct acrn_create_vm));
 	ctx = calloc(1, sizeof(struct vmctx) + strnlen(name, PATH_MAX) + 1);
-	assert(ctx != NULL);
-	assert(devfd == -1);
+	if ((ctx == NULL) || (devfd != -1))
+		goto err;
 
 	if (stat("/dev/acrn_vhm", &tmp_st) == 0) {
 		devfd = open("/dev/acrn_vhm", O_RDWR|O_CLOEXEC);
@@ -174,7 +173,9 @@ vm_create(const char *name, uint64_t req_buf)
 	return ctx;
 
 err:
-	free(ctx);
+	if (ctx != NULL)
+		free(ctx);
+
 	return NULL;
 }
 

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 #include <stdbool.h>
 
 #include "vmmapi.h"
@@ -252,8 +251,6 @@ static void
 pci_wdt_bar_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 		  int baridx, uint64_t offset, int size, uint64_t value)
 {
-	assert(baridx == 0);
-
 	DPRINTF("%s: addr = 0x%x, val = 0x%x, size=%d\n",
 		__func__, (int) offset, (int)value, size);
 
@@ -269,7 +266,8 @@ pci_wdt_bar_write(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 			}
 		}
 	} else if (offset == ESB_RELOAD_REG) {
-		assert(size == 2);
+		if (size != 2)
+			return;
 
 		if (value == ESB_UNLOCK1)
 			wdt_state.unlock_state = 1;
@@ -306,7 +304,6 @@ pci_wdt_bar_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 {
 	uint64_t ret = 0;
 
-	assert(baridx == 0);
 	DPRINTF("%s: addr = 0x%x, size=%d\n\r", __func__, (int) offset, size);
 
 	if (offset == ESB_GIS_REG) {
@@ -315,7 +312,8 @@ pci_wdt_bar_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 			ret |= ESB_WDT_INT_ACT;
 
 	} else if (offset == ESB_RELOAD_REG) {
-		assert(size == 2);
+		if (size != 2)
+			return 0;
 
 		DPRINTF("%s: timeout: %d\n\r", __func__, wdt_timeout);
 		if (wdt_timeout != 0)

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -857,14 +857,13 @@ void
 dsdt_indent(int levels)
 {
 	dsdt_indent_level += levels;
-	assert(dsdt_indent_level >= 0);
 }
 
 void
 dsdt_unindent(int levels)
 {
-	assert(dsdt_indent_level >= levels);
-	dsdt_indent_level -= levels;
+	if (dsdt_indent_level >= levels)
+		dsdt_indent_level -= levels;
 }
 
 void


### PR DESCRIPTION
Cleanup "assert" usages for below files in Devicemodel:
arch/x86/pm.c
core/hugetlb.c
core/main.c 
core/sw_load_common.c
core/sw_load_elf.c
core/sw_load_ovmf.c
core/sw_load_vsbl.c
hw/pci/wdt_i6300esb.c
hw/platform/acpi/acpi.c
hw/platform/rtc.c
core/mem.c 
core/post.c
core/inout.c
core/timer.c
core/vmmapi.c
hw/pci/irq.c



Tracked-On: #3252
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Shuo A Liu <shuo.a.liu@intel.com>