### PR TITLE
doc: update acrn_quick_setup.sh helper script to use new swupd commands

### DIFF
--- a/doc/getting-started/acrn_quick_setup.sh
+++ b/doc/getting-started/acrn_quick_setup.sh
@@ -72,7 +72,7 @@ function upgrade_sos()
         echo "Clear Linux version $sos_ver is already installed. Continuing to setup SOS..."
     else
         echo "Upgrading Clear Linux version from $VERSION_ID to $sos_ver ..."
-        swupd verify --fix --picky -m $sos_ver 2>/dev/null
+        swupd diagnose --fix --picky --version $sos_ver 2>/dev/null
     fi
 
     # Do the setups if previous process succeed.
@@ -146,7 +146,7 @@ function upgrade_sos()
     else
         echo "Fail to upgrade SOS to $sos_ver."
         echo "Please try upgrade SOS with this command:"
-        echo "swupd update -m $sos_ver"
+        echo "swupd update --version $sos_ver"
         exit 1
     fi
 


### PR DESCRIPTION
Clear Linux's swupd client has received a few updates that introduce new
commands which replace existing ones that will be deprecated in 6 months time.
This commit updates the acrn_quick_setup.sh script to use these new commands.

Note that this new script _may_ fail if the Clear Linux specified does *not*
provide a swupd client that implement these new commands yet.

Tracked-On: #3291
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>