### PR TITLE
DM Assert cleanup

### DIFF
--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -103,7 +103,10 @@ lpc_uart_intr_assert(void *arg)
 {
 	struct lpc_uart_vdev *lpc_uart = arg;
 
-	assert(lpc_uart->irq >= 0);
+	if (lpc_uart->irq < 0) {
+		pr_warn("%s: Invalid irq pin lpc_uart\n", __func__);
+		return;
+	}
 
 	if (lpc_bridge)
 		vm_set_gsi_irq(lpc_bridge->vmctx,
@@ -221,7 +224,8 @@ lpc_init(struct vmctx *ctx)
 		iop.arg = lpc_uart;
 
 		error = register_inout(&iop);
-		assert(error == 0);
+		if (error)
+			goto init_failed;
 		lpc_uart->enabled = 1;
 	}
 

--- a/devicemodel/hw/pci/virtio/virtio_coreu.c
+++ b/devicemodel/hw/pci/virtio/virtio_coreu.c
@@ -60,7 +60,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 #include <pthread.h>
 #include <sysexits.h>
 #include <dlfcn.h>
@@ -181,7 +180,15 @@ virtio_coreu_thread(void *param)
 
 		do {
 			ret = vq_getchain(rvq, &idx, &iov, 1, NULL);
-			assert(ret > 0);
+			if (ret < 1) {
+				pr_err("%s: fail to getchain!\n", __func__);
+				return NULL;
+			}
+			if (ret != 1) {
+				pr_warn("%s: invalid chain!\n", __func__);
+				vq_relchain(rvq, idx, 0);
+				continue;
+			}
 
 			msg = (struct coreu_msg *)(iov.iov_base);
 

--- a/devicemodel/hw/pci/virtio/virtio_ipu.c
+++ b/devicemodel/hw/pci/virtio/virtio_ipu.c
@@ -15,7 +15,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 #include <pthread.h>
 
 #include "dm.h"
@@ -374,8 +373,8 @@ virtio_ipu_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		virtio_ipu_k_stop(ipu);
 		virtio_ipu_k_reset(ipu);
 		ipu->vbs_k.ipu_kstatus = VIRTIO_DEV_INITIAL;
-		assert(ipu->vbs_k.ipu_fd >= 0);
-		close(ipu->vbs_k.ipu_fd);
+		if (ipu->vbs_k.ipu_fd >= 0)
+			close(ipu->vbs_k.ipu_fd);
 		ipu->vbs_k.ipu_fd = -1;
 	}
 	pthread_mutex_destroy(&ipu->mtx);

--- a/devicemodel/hw/platform/cmos_io.c
+++ b/devicemodel/hw/platform/cmos_io.c
@@ -28,7 +28,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 #include <stdbool.h>
 
 #include "inout.h"
@@ -63,9 +62,6 @@ cmos_io_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 	static int buf_offset;
 	static int next_ops;  /* 0 for addr, 1 for data, in pair (addr,data)*/
 
-	assert(port == CMOS_ADDR || port == CMOS_DATA);
-	assert(bytes == 1);
-
 #ifdef CMOS_DEBUG
 	if (!dbg_file)
 		dbg_file = fopen("/tmp/cmos_log", "a+");
@@ -77,7 +73,6 @@ cmos_io_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 	if (port == CMOS_ADDR) {
 
 		/* if port is addr, ops should be 0 */
-		assert(next_ops == 0 && !in);
 		if (next_ops != 0) {
 			next_ops = 0;
 			return -1;
@@ -88,7 +83,6 @@ cmos_io_handler(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 
 	} else if (port == CMOS_DATA) {
 
-		assert(next_ops == 1);
 		if (next_ops != 1) {
 			next_ops = 0;
 			return -1;

--- a/devicemodel/hw/platform/ps2kbd.c
+++ b/devicemodel/hw/platform/ps2kbd.c
@@ -25,7 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,6 +34,7 @@
 #include "types.h"
 #include "atkbdc.h"
 #include "console.h"
+#include "log.h"
 
 /* keyboard device commands */
 #define	PS2KC_RESET_DEV		0xff
@@ -224,8 +224,6 @@ ps2kbd_keysym_queue(struct ps2kbd_info *kbd,
 		0x4d, 0x15, 0x2d, 0x1b, 0x2c, 0x3c, 0x2a, 0x1d,
 		0x22, 0x35, 0x1a, 0x54, 0x5d, 0x5b, 0x0e, 0x00,
 	};
-
-/* assert(pthread_mutex_isowned_np(&kbd->mtx)); */
 
 	switch (keysym) {
 	case 0x0 ... 0x7f:
@@ -462,8 +460,10 @@ ps2kbd_init(struct atkbdc_base *base)
 	struct ps2kbd_info *kbd;
 
 	kbd = calloc(1, sizeof(struct ps2kbd_info));
-
-	assert(kbd != NULL);
+	if (!kbd) {
+		pr_err("%s: alloc memory fail!\n", __func__);
+		return NULL;
+	}
 
 	pthread_mutex_init(&kbd->mtx, NULL);
 	fifo_init(kbd);

--- a/devicemodel/hw/platform/ps2mouse.c
+++ b/devicemodel/hw/platform/ps2mouse.c
@@ -25,7 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,6 +34,7 @@
 #include "types.h"
 #include "atkbdc.h"
 #include "console.h"
+#include "log.h"
 
 /* mouse device commands */
 #define	PS2MC_RESET_DEV		0xff
@@ -152,8 +152,6 @@ fifo_get(struct ps2mouse_info *mouse, uint8_t *val)
 static void
 movement_reset(struct ps2mouse_info *mouse)
 {
-	/* assert(pthread_mutex_isowned_np(&mouse->mtx)); */
-
 	mouse->delta_x = 0;
 	mouse->delta_y = 0;
 }
@@ -171,8 +169,6 @@ static void
 movement_get(struct ps2mouse_info *mouse)
 {
 	uint8_t val0, val1, val2;
-
-/* assert(pthread_mutex_isowned_np(&mouse->mtx)); */
 
 	val0 = PS2M_DATA_AONE;
 	val0 |= mouse->status & (PS2M_DATA_LEFT_BUTTON |
@@ -220,7 +216,6 @@ movement_get(struct ps2mouse_info *mouse)
 static void
 ps2mouse_reset(struct ps2mouse_info *mouse)
 {
-/* assert(pthread_mutex_isowned_np(&mouse->mtx)); */
 	fifo_reset(mouse);
 	movement_reset(mouse);
 	mouse->status = PS2M_STS_ENABLE_DEV;
@@ -395,8 +390,10 @@ ps2mouse_init(struct atkbdc_base *base)
 	struct ps2mouse_info *mouse;
 
 	mouse = calloc(1, sizeof(struct ps2mouse_info));
-
-	assert(mouse != NULL);
+	if (!mouse) {
+		pr_err("%s: alloc memory fail!\n", __func__);
+		return NULL;
+	}
 
 	pthread_mutex_init(&mouse->mtx, NULL);
 	fifo_init(mouse);

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -35,6 +35,7 @@
 #include <stdbool.h>
 #include "types.h"
 #include "pcireg.h"
+#include "log.h"
 
 #define	PCI_BARMAX	PCIR_MAX_BAR_0	/* BAR registers in a Type 0 header */
 #define	PCI_BDF(b, d, f) (((b & 0xFF) << 8) | ((d & 0x1F) << 3) | ((f & 0x7)))
@@ -311,7 +312,7 @@ int	pci_msix_table_bar(struct pci_vdev *pi);
 int	pci_msix_pba_bar(struct pci_vdev *pi);
 int	pci_msi_maxmsgnum(struct pci_vdev *pi);
 int	pci_parse_slot(char *opt);
-void	pci_populate_msicap(struct msicap *cap, int msgs, int nextptr);
+int	pci_populate_msicap(struct msicap *cap, int msgs, int nextptr);
 int	pci_emul_add_msixcap(struct pci_vdev *pi, int msgnum, int barnum);
 int	pci_emul_msix_twrite(struct pci_vdev *pi, uint64_t offset, int size,
 			     uint64_t value);
@@ -343,7 +344,10 @@ struct pci_vdev *pci_get_vdev_info(int slot);
 static inline void
 pci_set_cfgdata8(struct pci_vdev *dev, int offset, uint8_t val)
 {
-	assert(offset <= PCI_REGMAX);
+	if (offset > PCI_REGMAX) {
+		pr_err("%s: out of range of PCI config space!\n", __func__);
+		return;
+	}
 	*(uint8_t *)(dev->cfgdata + offset) = val;
 }
 
@@ -359,7 +363,10 @@ pci_set_cfgdata8(struct pci_vdev *dev, int offset, uint8_t val)
 static inline void
 pci_set_cfgdata16(struct pci_vdev *dev, int offset, uint16_t val)
 {
-	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
+	if ((offset > PCI_REGMAX - 1) || (offset & 1) != 0) {
+		pr_err("%s: out of range of PCI config space!\n", __func__);
+		return;
+	}
 	*(uint16_t *)(dev->cfgdata + offset) = val;
 }
 
@@ -375,7 +382,10 @@ pci_set_cfgdata16(struct pci_vdev *dev, int offset, uint16_t val)
 static inline void
 pci_set_cfgdata32(struct pci_vdev *dev, int offset, uint32_t val)
 {
-	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
+	if ((offset > PCI_REGMAX - 3) || (offset & 3) != 0) {
+		pr_err("%s: out of range of PCI config space!\n", __func__);
+		return;
+	}
 	*(uint32_t *)(dev->cfgdata + offset) = val;
 }
 
@@ -390,7 +400,10 @@ pci_set_cfgdata32(struct pci_vdev *dev, int offset, uint32_t val)
 static inline uint8_t
 pci_get_cfgdata8(struct pci_vdev *dev, int offset)
 {
-	assert(offset <= PCI_REGMAX);
+	if (offset > PCI_REGMAX) {
+		pr_err("%s: out of range of PCI config space!\n", __func__);
+		return 0xff;
+	}
 	return (*(uint8_t *)(dev->cfgdata + offset));
 }
 
@@ -405,7 +418,10 @@ pci_get_cfgdata8(struct pci_vdev *dev, int offset)
 static inline uint16_t
 pci_get_cfgdata16(struct pci_vdev *dev, int offset)
 {
-	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
+	if ((offset > PCI_REGMAX - 1) || (offset & 1) != 0) {
+		pr_err("%s: out of range of PCI config space!\n", __func__);
+		return 0xffff;
+	}
 	return (*(uint16_t *)(dev->cfgdata + offset));
 }
 
@@ -420,7 +436,10 @@ pci_get_cfgdata16(struct pci_vdev *dev, int offset)
 static inline uint32_t
 pci_get_cfgdata32(struct pci_vdev *dev, int offset)
 {
-	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
+	if ((offset > PCI_REGMAX - 3) || (offset & 3) != 0) {
+		pr_err("%s: out of range of PCI config space!\n", __func__);
+		return 0xffffffff;
+	}
 	return (*(uint32_t *)(dev->cfgdata + offset));
 }
 

--- a/devicemodel/include/types.h
+++ b/devicemodel/include/types.h
@@ -3,6 +3,7 @@
 
 #include "macros.h"
 #include <stdint.h>
+#include <stdarg.h>
 #include <sched.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
Clean up assert() in DM, changes include
 devicemodel/hw/pci/core.c                | 159 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------------------------------
 devicemodel/hw/pci/lpc.c                 |   8 ++++++--
 devicemodel/hw/pci/virtio/virtio_coreu.c |  11 +++++++++--
 devicemodel/hw/pci/virtio/virtio_hdcp.c  |  17 +++++++++++------
 devicemodel/hw/pci/virtio/virtio_ipu.c   |   5 ++---
 devicemodel/hw/pci/virtio/virtio_mei.c   |  24 +++++++++++++++++-------
 devicemodel/hw/platform/atkbdc.c         |  24 ++++++++++++++++--------
 devicemodel/hw/platform/cmos_io.c        |   6 ------
 devicemodel/hw/platform/ps2kbd.c         |  10 +++++-----
 devicemodel/hw/platform/ps2mouse.c       |  13 +++++--------
 devicemodel/include/pci_core.h           |  33 ++++++++++++++++++++++++++-------
 devicemodel/include/types.h              |   1 +
 12 files changed, 188 insertions(+), 123 deletions(-)


Tracked-On: #3252
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
