### PR TITLE
HV: Allow pause RTVM when its state is VM_CREATED

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -659,8 +659,12 @@ void pause_vm(struct acrn_vm *vm)
 
 	if (vm->state != VM_PAUSED) {
 		if (is_rt_vm(vm)) {
-			/* Only when RTVM is powering off by itself, we can pause vcpu */
-			if (vm->state == VM_POWERING_OFF) {
+			/**
+			 * For RTVM, we can only pause its vCPUs when it stays at following states:
+			 *  - It is powering off by itself
+			 *  - It is created but doesn't start
+			 */
+			if ((vm->state == VM_POWERING_OFF) || (vm->state == VM_CREATED)) {
 				foreach_vcpu(i, vm, vcpu) {
 					pause_vcpu(vcpu, VCPU_ZOMBIE);
 				}


### PR DESCRIPTION
There are a lot of works to do between create_vm (HV will mark vm's state
as VM_CREATED at this stage) and vm_run (HV will mark vm's state as VM_STARTED),
like building mptable/acpi table, initializing mevent and vdevs. If there is
something goes wrong between create_vm and vm_run, the devicemodel will jumps
to the deinit process and will try to destroy the vm. For example, if the
vm_init_vdevs failed, the devicemodel will jumps to dev_fail and then destroy
the vm.

For normal vm in above situation, it is fine to destroy vm. And we can create and
start it next time. But for RTVM, we can't destroy the vm as the vm's state is
VM_CREATED. And we can only destroy vm when its state is VM_POWERING_OFF. So, the
vm will stay at VM_CREATED state and we will never have chance to destroy it.
Consequently, we can't create and start the vm next time.

This patch fixes it by allowing to pause and then destroy RTVM when its state is VM_CREATED.

Tracked-On: #3069
Acked-by: Eddie Dong <eddie.dong@intel.com>
Signed-off-by: Kaige Fu <kaige.fu@intel.com>