### PR TITLE
hv: Avoid run-time buffer overflows with IOAPIC data structures

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -264,6 +264,11 @@ config MAX_IOAPIC_NUM
 	range 1 8
 	default 1
 
+config MAX_IOAPIC_LINES
+	int "Maximum number of interrupt lines per IOAPIC"
+	range 1 120
+	default 120
+
 config MAX_IR_ENTRIES
 	int "Maximum number of Interrupt Remapping Entries"
 	default 256

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -13,9 +13,10 @@
 #define NR_LEGACY_PIN		NR_LEGACY_IRQ
 
 struct ioapic_info {
-	uint8_t id;
-	uint32_t addr;
-	uint32_t gsi_base;
+	uint8_t id;		/* IOAPIC ID as indicated in ACPI MADT */
+	uint32_t addr;		/* IOAPIC Register address */
+	uint32_t gsi_base;	/* Global System Interrupt where this IO-APIC's interrupt input start */
+	uint32_t nr_pins;	/* Number of Interrupt inputs as determined by Max. Redir Entry Register */
 };
 
 void ioapic_setup_irqs(void);


### PR DESCRIPTION
Remove couple of run-time ASSERTs in ioapic module by checking for the
number of interrupt pins per IO-APICs against the configured MAX_IOAPIC_LINES
in the initialization flow.
Also remove the need for two MACROs specifying the max. number of
interrupt lines per IO-APIC and add a config item MAX_IOAPIC_LINES for the
same.

Tracked-On: #3299
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>