### PR TITLE
dm: samples: use stdio as vxWorks console by default

### DIFF
--- a/devicemodel/samples/nuc/launch_vxworks.sh
+++ b/devicemodel/samples/nuc/launch_vxworks.sh
@@ -19,9 +19,10 @@ mem_size=2048M
 #      For RTVM with lapic_pt, we only support virtio devices with polling mode enabled for both
 #      front-end and back-end. The virtio devices with polling mode are not supported by VxWorks
 #      offically now and we are working on upstream the front-end drivers.
+#      OVMF console is not available with default parameters.
 
-acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
-  -s 5,virtio-console,@pty:pty_port \
+acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge \
+  -s 5,virtio-console,@stdio:stdio_port \
   -s 3,virtio-blk,./VxWorks.img \
   --virtio_poll 1000000 \
   --ovmf ./OVMF.fd \


### PR DESCRIPTION
Current launch script leave stdio to OVMF console and, vxworks console to pty, so user
need to use additional toll like minicom to connect to pty device to use vxWorks.

To be more convinient, this commit changes the vxWorks to use the stdio by default, and OVMF
is not availabe by default.

Tracked-On: #3069
Signed-off-by: Yan, Like <like.yan@intel.com>