### PR TITLE
HV: Debug: Add version command

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -18,6 +18,7 @@
 #include <vm.h>
 #include <sprintf.h>
 #include <logmsg.h>
+#include <version.h>
 
 #define TEMP_STR_SIZE		60U
 #define MAX_STR_SIZE		256U
@@ -32,6 +33,7 @@ static char shell_log_buf[SHELL_LOG_BUF_SIZE];
 #define SHELL_INPUT_LINE_OTHER(v)	(((v) + 1U) & 0x1U)
 
 static int32_t shell_cmd_help(__unused int32_t argc, __unused char **argv);
+static int32_t shell_version(__unused int32_t argc, __unused char **argv);
 static int32_t shell_list_vm(__unused int32_t argc, __unused char **argv);
 static int32_t shell_list_vcpu(__unused int32_t argc, __unused char **argv);
 static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv);
@@ -53,6 +55,12 @@ static struct shell_cmd shell_cmds[] = {
 		.cmd_param	= SHELL_CMD_HELP_PARAM,
 		.help_str	= SHELL_CMD_HELP_HELP,
 		.fcn		= shell_cmd_help,
+	},
+	{
+		.str		= SHELL_CMD_VERSION,
+		.cmd_param	= SHELL_CMD_VERSION_PARAM,
+		.help_str	= SHELL_CMD_VERSION_HELP,
+		.fcn		= shell_version,
 	},
 	{
 		.str		= SHELL_CMD_VM_LIST,
@@ -548,6 +556,21 @@ static int32_t shell_cmd_help(__unused int32_t argc, __unused char **argv)
 	}
 
 	shell_puts("\r\n");
+
+	return 0;
+}
+
+static int32_t shell_version(__unused int32_t argc, __unused char **argv)
+{
+	char temp_str[MAX_STR_SIZE];
+
+	snprintf(temp_str, MAX_STR_SIZE, "HV version %s-%s-%s %s (daily tag: %s) build by %s\r\n",
+			HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_DAILY_TAG, HV_BUILD_USER);
+	shell_puts(temp_str);
+
+	(void)memset((void *)temp_str, 0, MAX_STR_SIZE);
+	snprintf(temp_str, MAX_STR_SIZE, "API version %u.%u\r\n", HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
+	shell_puts(temp_str);
 
 	return 0;
 }

--- a/hypervisor/debug/shell_priv.h
+++ b/hypervisor/debug/shell_priv.h
@@ -40,6 +40,10 @@ struct shell {
 #define SHELL_CMD_HELP_PARAM		NULL
 #define SHELL_CMD_HELP_HELP		"Display information about supported hypervisor shell commands"
 
+#define SHELL_CMD_VERSION		"version"
+#define SHELL_CMD_VERSION_PARAM		NULL
+#define SHELL_CMD_VERSION_HELP		"Display the HV version information"
+
 #define SHELL_CMD_VM_LIST		"vm_list"
 #define SHELL_CMD_VM_LIST_PARAM		NULL
 #define SHELL_CMD_VM_LIST_HELP		"List all VMs, displaying the VM UUID, ID, name and state"


### PR DESCRIPTION
When debugging the HV, we may want to check the HV version information
frequently. In current HV shell command, there is no such kind of command
to check this information. We can only scroll up the HV console log to
get the information. If there are very huge amount of lines of log, it
will be very time-wasting to get the HV version information.

So, this patch adds 'version' command to get the HV version information
conveniently.

Tracked-On: #3310
Acked-by: Anthony Xu <anthony.xu@intel.com>
Signed-off-by: Kaige Fu <kaige.fu@intel.com>