### PR TITLE
tools: enhance online and built-in help messages

### DIFF
--- a/tools/acrn-manager/README.rst
+++ b/tools/acrn-manager/README.rst
@@ -138,13 +138,15 @@ You can see the available ``acrnd`` commands by running:
 .. code-block:: none
 
    $ acrnd -h
-   acrnd - Deamon for ACRN VM Management
+   acrnd - Daemon for ACRN VM Management
    [Usage] acrnd [-t] [-d delay] [-h]
-   -h: print this message
    -t: print messages to stdout
+   -d: delay the autostarting of VMs, <0-60> in second (not available in the
+       ``RELEASE=1`` build)
+   -h: print this message
 
 Normally, ``acrnd`` runs silently (messages are directed to
-``/dev/null``).  Use the ``-t`` option to direct messages to stdout,
+``/dev/null``).  Use the ``-t`` option to direct messages to ``stdout``,
 useful for debugging.
 
 The ``acrnd`` daemon stores pending UOS work to ``/usr/share/acrn/conf/timer_list``

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -679,14 +679,18 @@ static const char optString[] = "td:h";
 
 static void display_usage(void)
 {
-	printf("acrnd - Deamon for ACRN VM Management\n"
+	printf("acrnd - Daemon for ACRN VM Management\n"
+#ifdef MNGR_DEBUG
 	       "[Usage] acrnd [-t] [-d delay] [-h]\n\n"
+#else
+	       "[Usage] acrnd [-t] [-h]\n\n"
+#endif
 	       "[Options]\n"
-	       "\t-h: print this message\n"
 	       "\t-t: print messages to stdout\n"
 #ifdef MNGR_DEBUG
-	       "\t-d: delay time of auto start, <0-60> in second.\n"
+	       "\t-d: delay the autostarting of VMs, <0-60> in second\n"
 #endif
+	       "\t-h: print this message\n"
 	       "\n");
 }
 
@@ -718,7 +722,7 @@ static int parse_opt(int argc, char *argv[])
 			ret = -EINVAL;
 			break;
 		default:
-			printf("Ingrone unknown opt: %c\n", opt);
+			printf("Ignore unknown option: %c\n", opt);
 			ret = -EINVAL;
 		}
 	}


### PR DESCRIPTION
Enhance and re-order the help messages for the `acrnd` tools (daemon for
ACRN VM management). Fix a few typos in the process.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>