### PR TITLE
tools: add check to verify that running with root privileges

### DIFF
--- a/tools/acrn-manager/README.rst
+++ b/tools/acrn-manager/README.rst
@@ -35,6 +35,9 @@ You can see the available ``acrnctl`` commands by running:
      blkrescan
    Use acrnctl [cmd] help for details
 
+.. note::
+   You must run ``acrnctl`` with root privileges.
+
 Here are some usage examples:
 
 Add a VM
@@ -132,6 +135,9 @@ list and launches the UOSs at the right time.
 A ``systemd`` service file (``acrnd.service``) is installed by default that will
 start the ``acrnd`` daemon when the Service OS comes up.
 You can restart/stop acrnd service using ``systemctl``
+
+.. note::
+   You must run ``acrnd`` with root privileges.
 
 Build and Install
 *****************

--- a/tools/acrn-manager/acrnctl.c
+++ b/tools/acrn-manager/acrnctl.c
@@ -807,6 +807,11 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+	if (getuid() != 0) {
+		printf("Please run acrnctl with root privileges. Exiting.\n");
+		return -1;
+	}
+
 	acrnctl_bin_path = argv[0];
 
 	/* first check acrnctl reserved operations */

--- a/tools/acrn-manager/acrnd.c
+++ b/tools/acrn-manager/acrnd.c
@@ -730,6 +730,12 @@ int main(int argc, char *argv[])
 {
 	int ret;
 
+       if (getuid() != 0) {
+               printf("Please run acrnd with root privileges. Exiting.\n");
+               return -1;
+       }
+
+
 	if (parse_opt(argc, argv))
 		return -1;
 	


### PR DESCRIPTION
Add a check to acrnd and acrnctl to make sure we are running with root
privileges. If not, print out a message instructing the user to run with root
privileges and exit returning an error (-1).

Add notes to the documentation as well to make it more obvious.


Tracked-On: #3330
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>