### PR TITLE
HV:fix simple violations

### DIFF
--- a/hypervisor/arch/x86/configs/vmptable.c
+++ b/hypervisor/arch/x86/configs/vmptable.c
@@ -100,7 +100,7 @@ int32_t mptable_build(struct acrn_vm *vm)
 	mptable = &vm_mptables[vm->vm_id];
 	vcpu_num = vm->hw.created_vcpus;
 	pcpu_bitmap = vm_config->pcpu_bitmap;
-	(void *)memcpy_s((void *)mptable, sizeof(struct mptable_info),
+	(void)memcpy_s((void *)mptable, sizeof(struct mptable_info),
 		(const void *)&mptable_template, sizeof(struct mptable_info));
 
 	mptable->mpch.entry_count = vcpu_num + MPE_NUM_BUSES + MPEII_NUM_LOCAL_IRQ;
@@ -117,17 +117,17 @@ int32_t mptable_build(struct acrn_vm *vm)
 	for (i = 0U; i < vcpu_num; i++) {
 		uint16_t pcpu_id = ffs64(pcpu_bitmap);
 
-		(void *)memcpy_s((void *)(mptable->proc_entry_array + i), sizeof(struct proc_entry),
+		(void)memcpy_s((void *)(mptable->proc_entry_array + i), sizeof(struct proc_entry),
 			(const void *)&proc_entry_template, sizeof(struct proc_entry));
 		mptable->proc_entry_array[i].apic_id = (uint8_t) i;
-		if (i == 0) {
+		if (i == 0U) {
 			mptable->proc_entry_array[i].cpu_flags |= PROCENTRY_FLAG_BP;
 		}
 		bitmap_clear_lock(pcpu_id, &pcpu_bitmap);
 	}
 
 	/* Copy mptable info into guest memory */
-	copy_to_gpa(vm, (void *)mptable, MPTABLE_BASE, mptable_length);
+	(void)copy_to_gpa(vm, (void *)mptable, MPTABLE_BASE, mptable_length);
 
 	startaddr = (char *)gpa2hva(vm, MPTABLE_BASE);
 	curraddr = startaddr;

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -402,7 +402,7 @@ static struct ptirq_remapping_info *add_intx_remapping(struct acrn_vm *vm, uint3
 			entry_is_updated = false;
 		}
 
-		if (entry != NULL && entry_is_updated) {
+		if ((entry != NULL) && entry_is_updated) {
 			if (pic_pin) {
 				vm->arch_vm.vpic.vpin_to_pt_entry[virt_pin] = entry;
 			} else {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -518,7 +518,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		/* Populate return VM handle */
 		*rtn_vm = vm;
 		vm->sw.io_shared_page = NULL;
-		if ((vm_config->load_order == POST_LAUNCHED_VM) && (vm_config->guest_flags & GUEST_FLAG_IO_COMPLETION_POLLING) != 0U) {
+		if ((vm_config->load_order == POST_LAUNCHED_VM) && ((vm_config->guest_flags & GUEST_FLAG_IO_COMPLETION_POLLING) != 0U)) {
 			/* enable IO completion polling mode per its guest flags in vm_config. */
 			vm->sw.is_completion_polling = true;
 		}

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1182,7 +1182,7 @@ static int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t s
 
 			context_entry = context + devfun;
 
-			if (context == NULL || context_entry == NULL) {
+			if ((context == NULL) || (context_entry == NULL)) {
 				pr_err("dmar context entry is invalid");
 				ret = -EINVAL;
 			} else if ((uint16_t)dmar_get_bitslice(context_entry->hi_64, CTX_ENTRY_UPPER_DID_MASK, CTX_ENTRY_UPPER_DID_POS) != vmid_to_domainid(domain->vm_id)) {

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -168,8 +168,9 @@ static struct acpi_table_rsdp *get_rsdp(void)
 			rsdp = found_rsdp((char *)hpa2hva(0xe0000UL), 0x20000);
 		}
 
-		if (rsdp == NULL)
+		if (rsdp == NULL) {
 			panic("No RSDP is found");
+		}
 
 		/* After RSDP is parsed, it will be assigned to acpi_rsdp */
 		acpi_rsdp = rsdp;

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -298,7 +298,7 @@ static int32_t depri_boot_sw_loader(struct acrn_vm *vm)
 	 * We copy the info saved in depri_boot to boot_context and
 	 * init bsp with boot_context.
 	 */
-	memcpy_s(&(vcpu_regs->gprs), sizeof(struct acrn_gp_regs),
+	(void)memcpy_s(&(vcpu_regs->gprs), sizeof(struct acrn_gp_regs),
 		&(depri_boot_ctx->vcpu_regs.gprs), sizeof(struct acrn_gp_regs));
 
 	vcpu_regs->rip = depri_boot_ctx->vcpu_regs.rip;

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -34,8 +34,9 @@ static uint8_t cmos_get_reg_val(uint8_t addr)
 	spinlock_obtain(&cmos_lock);
 
 	/* Make sure an update isn't in progress */
-	while (cmos_update_in_progress() && tries--)
-	;
+	while (cmos_update_in_progress() && (tries != 0)) {
+		tries -= 1;
+	}
 
 	reg = cmos_read(addr);
 

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -508,11 +508,13 @@ static struct acrn_vuart *find_active_target_vuart(struct vuart_config *vu_confi
 
 	target_vmid = vu_config->t_vuart.vm_id;
 	target_vuid = vu_config->t_vuart.vuart_id;
-	if (target_vmid < CONFIG_MAX_VM_NUM)
+	if (target_vmid < CONFIG_MAX_VM_NUM) {
 		target_vm = get_vm_from_vmid(target_vmid);
+	}
 
-	if (target_vuid < MAX_VUART_NUM_PER_VM)
+	if (target_vuid < MAX_VUART_NUM_PER_VM) {
 		target_vu = &target_vm->vuart[target_vuid];
+	}
 
 	if ((target_vu != NULL) && (target_vu->active)) {
 		ret_vu = target_vu;


### PR DESCRIPTION
Fix the violations not touched the logical.
1.Function return value not checked.
2.Logical conjuctions need brackets.
3.No brackets to then/else.
4.Type conversion without cast.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>