### PR TITLE
VPCI code cleanup/reorg

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -26,9 +26,6 @@
 *
 * $FreeBSD$
 */
-
-/* Passthrough PCI device related operations */
-
 #include <vm.h>
 #include <errno.h>
 #include <ept.h>
@@ -46,8 +43,7 @@ static inline uint32_t get_bar_base(uint32_t bar)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
-	uint32_t bytes, uint32_t *val)
+int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	int32_t ret = -ENODEV;
 
@@ -167,14 +163,14 @@ void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev)
 }
 
 /**
- * @brief Remaps guest BARs other than MSI-x Table BAR
+ * @brief Remaps guest MMIO BARs other than MSI-x Table BAR
  * This API is invoked upon guest re-programming PCI BAR with MMIO region
+ * after a new vbar is set.
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-static void vdev_pt_remap_generic_bar(const struct pci_vdev *vdev, uint32_t idx,
-	uint32_t new_base)
+static void vdev_pt_remap_generic_mem_vbar(const struct pci_vdev *vdev, uint32_t idx, uint32_t new_base)
 {
 	struct acrn_vm *vm = vdev->vpci->vm;
 
@@ -196,64 +192,62 @@ static void vdev_pt_remap_generic_bar(const struct pci_vdev *vdev, uint32_t idx,
 
 /**
  * @pre vdev != NULL
+ * @pre (vdev->bar[idx].type == PCIBAR_NONE) || (vdev->bar[idx].type == PCIBAR_MEM32)
  */
-static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t new_bar_uos)
+static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t val)
 {
 	uint32_t idx;
 	uint32_t new_bar, mask;
 	bool bar_update_normal;
 	bool is_msix_table_bar;
 
-	/* Bar access must be 4 bytes aligned */
-	if ((bytes == 4U) && ((offset & 0x3U) == 0U)) {
-		new_bar = 0U;
-		idx = (offset - pci_bar_offset(0U)) >> 2U;
-		mask = ~(vdev->bar[idx].size - 1U);
+	new_bar = 0U;
+	idx = (offset - pci_bar_offset(0U)) >> 2U;
+	mask = ~(vdev->bar[idx].size - 1U);
 
-		switch (vdev->bar[idx].type) {
-		case PCIBAR_NONE:
-			vdev->bar[idx].base = 0UL;
-			break;
+	switch (vdev->bar[idx].type) {
+	case PCIBAR_NONE:
+		vdev->bar[idx].base = 0UL;
+		break;
 
-		case PCIBAR_MEM32:
-			bar_update_normal = (new_bar_uos != (uint32_t)~0U);
-			is_msix_table_bar = (has_msix_cap(vdev) && (idx == vdev->msix.table_bar));
-			new_bar = new_bar_uos & mask;
-			if (bar_update_normal) {
-				if (is_msix_table_bar) {
-					vdev->bar[idx].base = get_bar_base(new_bar);
-					vdev_pt_remap_msix_table_bar(vdev);
-				} else {
-					vdev_pt_remap_generic_bar(vdev, idx,
-						get_bar_base(new_bar));
+	case PCIBAR_MEM32:
+		bar_update_normal = (val != (uint32_t)~0U);
+		is_msix_table_bar = (has_msix_cap(vdev) && (idx == vdev->msix.table_bar));
+		new_bar = val & mask;
+		if (bar_update_normal) {
+			if (is_msix_table_bar) {
+				vdev->bar[idx].base = get_bar_base(new_bar);
+				vdev_pt_remap_msix_table_bar(vdev);
+			} else {
+				vdev_pt_remap_generic_mem_vbar(vdev, idx,
+					get_bar_base(new_bar));
 
-					vdev->bar[idx].base = get_bar_base(new_bar);
-				}
+				vdev->bar[idx].base = get_bar_base(new_bar);
 			}
-			break;
-
-		default:
-			pr_err("Unknown bar type, idx=%d", idx);
-			break;
 		}
+		break;
 
-		pci_vdev_write_cfg_u32(vdev, offset, new_bar);
+	default:
+		/* Should never reach here, init_vdev_pt() only sets vbar type to PCIBAR_NONE and PCIBAR_MEM32 */
+		break;
 	}
+
+	pci_vdev_write_cfg_u32(vdev, offset, new_bar);
 }
 
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
+ * bar write access must be 4 bytes and offset must also be 4 bytes aligned, it will be dropped otherwise
  */
-int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset,
-	uint32_t bytes, uint32_t val)
+int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	int32_t ret = -ENODEV;
 
-	/* PCI BARs are emulated */
-	if (is_prelaunched_vm(vdev->vpci->vm) && pci_bar_access(offset)) {
-		vdev_pt_write_vbar(vdev, offset, bytes, val);
+	/* bar write access must be 4 bytes and offset must also be 4 bytes aligned */
+	if (is_prelaunched_vm(vdev->vpci->vm) && pci_bar_access(offset) && (bytes == 4U) && ((offset & 0x3U) == 0U)) {
+		vdev_pt_write_vbar(vdev, offset, val);
 		ret = 0;
 	}
 
@@ -322,7 +316,7 @@ void init_vdev_pt(struct pci_vdev *vdev)
 
 				/* Set the new vbar base */
 				if (vdev->ptdev_config->vbar[idx] != 0UL) {
-					vdev_pt_write_vbar(vdev, pci_bar_offset(idx), 4U, (uint32_t)(vdev->ptdev_config->vbar[idx]));
+					vdev_pt_write_vbar(vdev, pci_bar_offset(idx), (uint32_t)(vdev->ptdev_config->vbar[idx]));
 				}
 			} else {
 				vbar->size = 0UL;

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -127,7 +127,7 @@ int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset,
 	int32_t ret = -ENODEV;
 
 	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
-		if (!pci_bar_access(offset)) {
+		if (!is_bar_offset(PCI_BAR_COUNT, offset)) {
 			pci_vdev_write_cfg(vdev, offset, bytes, val);
 		}
 

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -394,18 +394,3 @@ static void init_pdev(uint16_t pbdf)
 		pr_err("%s, failed to alloc pci_pdev!\n", __func__);
 	}
 }
-
-struct pci_pdev *find_pci_pdev(union pci_bdf pbdf)
-{
-	struct pci_pdev *pdev = NULL;
-	uint32_t i;
-
-	for (i = 0U; i < num_pci_pdev; i++) {
-		if (bdf_is_equal(&pci_pdev_array[i].bdf, &pbdf)) {
-			pdev = &pci_pdev_array[i];
-			break;
-		}
-	}
-
-	return pdev;
-}

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -187,21 +187,21 @@ void init_pci_pdev_list(void)
 	}
 }
 
-static uint8_t pci_pdev_get_num_bars(uint8_t hdr_type)
+static uint32_t pci_pdev_get_nr_bars(uint8_t hdr_type)
 {
-	uint8_t num_bars = (uint8_t)0U;
+	uint32_t nr_bars = 0U;
 
 	switch (hdr_type & PCIM_HDRTYPE) {
 	case PCIM_HDRTYPE_NORMAL:
-		num_bars = (uint8_t)6U;
+		nr_bars = 6U;
 		break;
 
 	case PCIM_HDRTYPE_BRIDGE:
-		num_bars = (uint8_t)2U;
+		nr_bars = 2U;
 		break;
 
 	case PCIM_HDRTYPE_CARDBUS:
-		num_bars = (uint8_t)1U;
+		nr_bars = 1U;
 		break;
 
 	default:
@@ -209,7 +209,7 @@ static uint8_t pci_pdev_get_num_bars(uint8_t hdr_type)
 		break;
 	}
 
-	return num_bars;
+	return nr_bars;
 }
 
 /* Get the base address of the raw bar value (val) */
@@ -238,7 +238,7 @@ static inline uint32_t pci_pdev_get_bar_base(uint32_t bar_val)
 /*
  * @pre bar != NULL
  */
-static uint32_t pci_pdev_read_bar(union pci_bdf bdf, uint8_t idx, struct pci_bar *bar)
+static uint32_t pci_pdev_read_bar(union pci_bdf bdf, uint32_t idx, struct pci_bar *bar)
 {
 	uint64_t base, size;
 	enum pci_bar_type type;
@@ -296,9 +296,9 @@ static uint32_t pci_pdev_read_bar(union pci_bdf bdf, uint8_t idx, struct pci_bar
 /*
  * @pre nr_bars <= PCI_BAR_COUNT
  */
-static void pci_pdev_read_bars(union pci_bdf bdf, uint8_t nr_bars, struct pci_bar *bar)
+static void pci_pdev_read_bars(union pci_bdf bdf, uint32_t nr_bars, struct pci_bar *bar)
 {
-	uint8_t idx = 0U;
+	uint32_t idx = 0U;
 	uint32_t bar_step;
 
 	while (idx < nr_bars) {
@@ -403,16 +403,15 @@ static void pci_read_cap(struct pci_pdev *pdev, uint8_t hdr_type)
  */
 static void fill_pdev(uint16_t pbdf, struct pci_pdev *pdev)
 {
-	uint8_t  hdr_type;
-	uint8_t  nr_bars;
+	uint8_t hdr_type;
 
 	pdev->bdf.value = pbdf;
 
 	hdr_type = (uint8_t)pci_pdev_read_cfg(pdev->bdf, PCIR_HDRTYPE, 1U);
 
-	nr_bars = pci_pdev_get_num_bars(hdr_type);
+	pdev->nr_bars = pci_pdev_get_nr_bars(hdr_type);
 
-	pci_pdev_read_bars(pdev->bdf, nr_bars, &pdev->bar[0]);
+	pci_pdev_read_bars(pdev->bdf, pdev->nr_bars, &pdev->bar[0]);
 
 	if ((pci_pdev_read_cfg(pdev->bdf, PCIR_STATUS, 2U) & PCIM_STATUS_CAPPRESENT) != 0U) {
 		pci_read_cap(pdev, hdr_type);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -74,6 +74,7 @@ struct pci_vdev {
 	union pci_cfgdata cfgdata;
 
 	/* The bar info of the virtual PCI device. */
+	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
 	struct pci_bar bar[PCI_BAR_COUNT];
 
 	struct pci_msi msi;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -207,6 +207,7 @@ struct pci_msix_cap {
 
 struct pci_pdev {
 	/* The bar info of the physical PCI device. */
+	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
 	struct pci_bar bar[PCI_BAR_COUNT];
 
 	/* The bus/device/function triple of the physical PCI device. */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -227,12 +227,12 @@ static inline uint32_t pci_bar_offset(uint32_t idx)
 	return PCIR_BARS + (idx << 2U);
 }
 
-static inline bool pci_bar_access(uint32_t offset)
+static inline bool is_bar_offset(uint32_t nr_bars, uint32_t offset)
 {
 	bool ret;
 
 	if ((offset >= pci_bar_offset(0U))
-		&& (offset < pci_bar_offset(PCI_BAR_COUNT))) {
+		&& (offset < pci_bar_offset(nr_bars))) {
 		ret = true;
 	} else {
 	    ret = false;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -252,7 +252,6 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
-struct pci_pdev *find_pci_pdev(union pci_bdf pbdf);
 void init_pci_pdev_list(void);
 
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -84,6 +84,7 @@
 #define PCIM_BAR_MEM_64       0x04U
 #define PCIM_BAR_MEM_BASE     0xFFFFFFF0U
 #define PCIR_CAP_PTR          0x34U
+#define PCIR_CAP_PTR_CARDBUS  0x14U
 
 /* config registers for header type 1 (PCI-to-PCI bridge) devices */
 #define PCIR_PRIBUS_1         0x18U


### PR DESCRIPTION
Remove unused function find_pci_pdev
Add get_offset_of_caplist() function to return capability offset based on header type
Add union pci_bar and is_64bit_high to struct pci_bar
Add uint32_t nr_bars to struct struct pci_pdevpci_vdev to track # of bars

Tracked-On: #3241 
Signed-off-by: dongshen <dongsheng.x.zhang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>