### PR TITLE
hv: bugfix for sbuf reset

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -579,8 +579,6 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 	vlapic = vcpu_vlapic(vcpu);
 	vlapic_reset(vlapic);
 
-	sbuf_reset(vcpu->pcpu_id);
-
 	reset_vcpu_regs(vcpu);
 }
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -26,6 +26,7 @@
 #include <vboot_info.h>
 #include <board.h>
 #include <sgx.h>
+#include <sbuf.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -574,6 +575,10 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 
 		vm_config = get_vm_config(vm->vm_id);
 		vm_config->guest_flags &= ~DM_OWNED_GUEST_FLAG_MASK;
+
+		if (is_sos_vm(vm)) {
+			sbuf_reset();
+		}
 
 		vpci_cleanup(vm);
 

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -92,11 +92,11 @@ int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva)
 	return 0;
 }
 
-void sbuf_reset(uint16_t pcpu_id)
+void sbuf_reset(void)
 {
-	uint32_t sbuf_id;
+	uint16_t pcpu_id, sbuf_id;
 
-	if (pcpu_id < get_pcpu_nums()) {
+	for (pcpu_id = 0U; pcpu_id < get_pcpu_nums(); pcpu_id++) {
 		for (sbuf_id = 0U; sbuf_id < ACRN_SBUF_ID_MAX; sbuf_id++) {
 			per_cpu(sbuf, pcpu_id)[sbuf_id] = 0U;
 		}

--- a/hypervisor/include/debug/sbuf.h
+++ b/hypervisor/include/debug/sbuf.h
@@ -65,7 +65,7 @@ struct shared_buf {
  */
 uint32_t sbuf_put(struct shared_buf *sbuf, uint8_t *data);
 int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva);
-void sbuf_reset(uint16_t pcpu_id);
+void sbuf_reset(void);
 uint32_t sbuf_next_ptr(uint32_t pos, uint32_t span, uint32_t scope);
 
 #endif /* SHARED_BUFFER_H */

--- a/hypervisor/release/sbuf.c
+++ b/hypervisor/release/sbuf.c
@@ -4,6 +4,4 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <types.h>
-
-void sbuf_reset(__unused uint16_t pcpu_id) {}
+void sbuf_reset(void) {}


### PR DESCRIPTION
The sbuf is allocated for each pcpu by hypercall from SOS. Before launch
Guest OS, the script will offline cpus, which will trigger vcpu reset and
then reset sbuf pointer. But sbuf only initiate once by SOS, so these
cpus for Guest OS has no sbuf to use. Thus, when run 'acrntrace' on SOS,
there is no trace data for Guest OS.
To fix the issue, only reset the sbuf for SOS.

Tracked-On: #3335
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Yan, Like <like.yan@intel.com>