### PR TITLE
doc:add more description about application constraints

### DIFF
--- a/doc/developer-guides/c_coding_guidelines.rst
+++ b/doc/developer-guides/c_coding_guidelines.rst
@@ -3245,6 +3245,7 @@ Compliant example::
      *
      * Detailed description of the function. Detailed description of the function. Detailed description of the
      * function. Detailed description of the function.
+     * Application Constraints: Detailed description of application constraint.
      *
      * @param param_1 Parameter description for param_1.
      * @param param_2 Parameter description for param_2.

--- a/doc/developer-guides/sw_design_guidelines.rst
+++ b/doc/developer-guides/sw_design_guidelines.rst
@@ -64,7 +64,9 @@ below:
   All application constraints shall be guaranteed by external safety
   applications, such as Board Support Package, firmware, safety VM, or Hardware.
   The verification of application integration shall check whether the safety
-  application meets all application constraints.
+  application meets all application constraints. These constraints must be verified
+  during hypervisor validation test. It is optional to do error checking for
+  application constraints at hypervisor boot time.
 
   This design assumption applies to the following cases:
 
@@ -73,6 +75,12 @@ below:
 
   - Input data which is only specified by external safety application.
 
+.. note:: If input data can be specified by both a non-safety VM and a safety VM,
+   the application constraint isn't applicable to these data. Related error checking
+   and handling shall be done during hypervisor design.
+
+Refer to the :ref:`C Programming Language Coding Guidelines <c_coding_guidelines>`
+to document these design assumptions with doxygen-style comments.
 
 Architecture Level
 ==================


### PR DESCRIPTION
In the current design guidlines, it is not clear about
how to check application constraints and how to record
them.

Add description about it is optional to do error checking
for application constraints during hypversisor boot time;
Add reference about how to record design assumptions.

Signed-off-by: Xiangyang Wu <xiangyang.wu@linux.intel.com>