### PR TITLE
Apl sdc stable

### DIFF
--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -205,7 +205,7 @@ register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 	struct mmio_rb_range *entry, *mrp;
 	int err;
 
-	err = 0;
+	err = -1;
 
 	mrp = malloc(sizeof(struct mmio_rb_range));
 
@@ -220,8 +220,7 @@ register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 		pthread_rwlock_unlock(&mmio_rwlock);
 		if (err)
 			free(mrp);
-	} else
-		err = -1;
+	}
 
 	return err;
 }

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -642,8 +642,10 @@ virtio_net_tap_open(char *devname)
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
 
-	if (*devname)
+	if (*devname) {
 		strncpy(ifr.ifr_name, devname, IFNAMSIZ);
+		ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+	}
 
 	rc = ioctl(tunfd, TUNSETIFF, (void *)&ifr);
 	if (rc < 0) {
@@ -654,6 +656,7 @@ virtio_net_tap_open(char *devname)
 	}
 
 	strncpy(devname, ifr.ifr_name, IFNAMSIZ);
+	devname[IFNAMSIZ - 1] = '\0';
 	return tunfd;
 }
 

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -4146,6 +4146,8 @@ errout:
 			free(xdev->portregs);
 			xdev->portregs = NULL;
 		}
+		if (rc < -2 && s)
+			free(s);
 		UPRINTF(LFTL, "fail to parse xHCI options, rc=%d\r\n", rc);
 
 		if (opts)


### PR DESCRIPTION
dm: porting patch from master to apl_sdc_stable branch

During static code analysis for ACRN hypervisor source code,
there have some issues.
1, buffer overflow - array index out of bounds
2, potential memory leak found.

Tracked-On: #3331
Tracked-On: #3333
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>