### PR TITLE
Clean up vcpu

### DIFF
--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -319,7 +319,7 @@ int32_t interrupt_window_vmexit_handler(struct acrn_vcpu *vcpu)
 	/* Disable interrupt-window exiting first.
 	 * acrn_handle_pending_request will continue handle for this vcpu
 	 */
-	vcpu->arch.irq_window_enabled = 0U;
+	vcpu->arch.irq_window_enabled = false;
 	value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
 	value32 &= ~(VMX_PROCBASED_CTLS_IRQ_WIN);
 	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
@@ -446,13 +446,13 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 		 * an ExtInt or there is lapic interrupt and virtual interrupt
 		 * deliver is disabled.
 		 */
-		if (arch->irq_window_enabled != 1U) {
+		if (!arch->irq_window_enabled) {
 			if (bitmap_test(ACRN_REQUEST_EXTINT, pending_req_bits) ||
 				vlapic_has_pending_delivery_intr(vcpu)) {
 				tmp = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
 				tmp |= VMX_PROCBASED_CTLS_IRQ_WIN;
 				exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, tmp);
-				arch->irq_window_enabled = 1U;
+				arch->irq_window_enabled = true;
 			}
 		}
 	}

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -324,7 +324,7 @@ struct acrn_vcpu_arch {
 	} exception_info;
 
 	uint8_t lapic_mask;
-	uint32_t irq_window_enabled;
+	bool irq_window_enabled;
 	uint32_t nrexits;
 
 	/* VCPU context state information */


### PR DESCRIPTION
vcpu is never scan because of scan tool will be crashed!
After modulization, the vcpu can be scaned by the scan tool.
Clean up the violations in vcpu.c.
Fix the violations:

Huihuang Shi (2):
  HV:fix vcpu violations
  V1->V2:
    change the type of "vcpu->arch.irq_window_enabled" to bool.
  HV:fix vcpu more than one return entry
  V1->V2:
    change the code path to:
    if (condition) {
        normal path
    } else {
        abnormal path
    }
Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>