### PR TITLE
VPCI code cleanup/reorg #2

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -345,7 +345,6 @@ static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t 
 
 	switch (vdev->bar[idx].type) {
 	case PCIBAR_NONE:
-		vdev->bar[idx].base = 0UL;
 		break;
 
 	case PCIBAR_MEM32:
@@ -356,11 +355,9 @@ static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t 
 
 		if (bar_update_normal) {
 			if (is_msix_table_bar) {
-				vdev->bar[idx].base = base;
 				vdev_pt_remap_msix_table_bar(vdev);
 			} else {
 				vdev_pt_remap_generic_mem_vbar(vdev, idx);
-				vdev->bar[idx].base = base;
 			}
 		}
 		break;
@@ -444,7 +441,6 @@ void init_vdev_pt(struct pci_vdev *vdev)
 			pbar = &vdev->pdev->bar[idx];
 			vbar = &vdev->bar[idx];
 
-			vbar->base = 0UL;
 			if (is_bar_supported(pbar)) {
 				vbar->reg.value = pbar->reg.value;
 				vbar->reg.bits.mem.base = 0x0U; /* clear vbar base */

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -33,11 +33,6 @@
 #include <logmsg.h>
 #include "vpci_priv.h"
 
-static inline uint32_t get_bar_base(uint32_t bar)
-{
-	return bar & PCIM_BAR_MEM_BASE;
-}
-
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
@@ -215,13 +210,12 @@ static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t 
 		new_bar = val & mask;
 		if (bar_update_normal) {
 			if (is_msix_table_bar) {
-				vdev->bar[idx].base = get_bar_base(new_bar);
+				vdev->bar[idx].base = new_bar;
 				vdev_pt_remap_msix_table_bar(vdev);
 			} else {
-				vdev_pt_remap_generic_mem_vbar(vdev, idx,
-					get_bar_base(new_bar));
+				vdev_pt_remap_generic_mem_vbar(vdev, idx, new_bar);
 
-				vdev->bar[idx].base = get_bar_base(new_bar);
+				vdev->bar[idx].base = new_bar;
 			}
 		}
 		break;

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -286,7 +286,6 @@ static uint32_t pci_pdev_read_bar(union pci_bdf bdf, uint32_t idx, struct pci_ba
 		}
 	}
 
-	bar->base = base;
 	bar->size = size;
 	bar->type = type;
 

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -81,7 +81,7 @@ struct acrn_vm_os_config {
 struct acrn_vm_pci_ptdev_config {
 	union pci_bdf vbdf;				/* virtual BDF of PCI PT device */
 	union pci_bdf pbdf;				/* physical BDF of PCI PT device */
-	uint64_t vbar[PCI_BAR_COUNT];	/* vbar base address of PCI PT device */
+	uint64_t vbar_base[PCI_BAR_COUNT];	/* vbar base address of PCI PT device */
 } __aligned(8);
 
 struct acrn_vm_config {

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -77,6 +77,9 @@ struct pci_vdev {
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
 	struct pci_bar bar[PCI_BAR_COUNT];
 
+	/* Remember the previously mapped/registered vbar base for undo purpose */
+	uint64_t bar_base_mapped[PCI_BAR_COUNT];
+
 	struct pci_msi msi;
 	struct pci_msix msix;
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -180,7 +180,6 @@ union pci_bar_reg {
 };
 
 struct pci_bar {
-	uint64_t base;
 	/* Base Address Register */
 	union pci_bar_reg reg;
 	uint64_t size;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -266,6 +266,19 @@ static inline enum pci_bar_type pci_get_bar_type(uint32_t val)
 	return type;
 }
 
+/**
+ * Given bar size and raw bar value, return bar base address by masking off its lower flag bits
+ * size/val: all in 64-bit values to accommodate 64-bit MMIO bar size masking
+ */
+static inline uint64_t pci_base_from_size_mask(uint64_t size, uint64_t val)
+{
+	uint64_t mask;
+
+	mask = ~(size - 1UL);
+
+	return (mask & val);
+}
+
 static inline uint8_t pci_bus(uint16_t bdf)
 {
 	return (uint8_t)((bdf >> 8U) & 0xFFU);

--- a/hypervisor/scenarios/logical_partition/pt_dev.c
+++ b/hypervisor/scenarios/logical_partition/pt_dev.c
@@ -14,15 +14,15 @@ struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
-		.vbar[0] = 0xc0084000UL,
-		.vbar[1] = 0xc0086000UL,
-		.vbar[5] = 0xc0087000UL,
+		.vbar_base[0] = 0xc0084000UL,
+		.vbar_base[1] = 0xc0086000UL,
+		.vbar_base[5] = 0xc0087000UL,
 		VM0_STORAGE_CONTROLLER
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
-		.vbar[0] = 0xc0000000UL,
-		.vbar[3] = 0xc0080000UL,
+		.vbar_base[0] = 0xc0000000UL,
+		.vbar_base[3] = 0xc0080000UL,
 		VM0_NETWORK_CONTROLLER
 	},
 };
@@ -34,7 +34,7 @@ struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM] = {
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
-		.vbar[0] = 0xc0000000UL,
+		.vbar_base[0] = 0xc0000000UL,
 		VM1_STORAGE_CONTROLLER
 	},
 #if defined(VM1_NETWORK_CONTROLLER)


### PR DESCRIPTION
Extract functions from code to improve code reuse and readability
Remove uint64_t base from struct pci_bar
Add get_pbar_base()/get_vbar_base to get pbar/vbar base address in 64-bit
Remove the function get_bar_base()

Tracked-On: #3241
Signed-off-by: dongshen dongsheng.x.zhang@intel.com
Acked-by: Eddie Dong eddie.dong@intel.com