### PR TITLE
Revert "dm: add "noapic" to rt-linux kernel parameters"

### DIFF
--- a/devicemodel/samples/nuc/launch_hard_rt_vm.sh
+++ b/devicemodel/samples/nuc/launch_hard_rt_vm.sh
@@ -39,7 +39,7 @@ echo ${passthru_bdf["sata"]} > /sys/bus/pci/drivers/pci-stub/bind
    -s 3,virtio-console,@stdio:stdio_port \
   -B "root=/dev/sda3 rw rootwait maxcpus=$1 nohpet console=hvc0 \
   no_timer_check ignore_loglevel log_buf_len=16M \
-  consoleblank=0 tsc=reliable x2apic_phys noapic" hard_rtvm
+  consoleblank=0 tsc=reliable x2apic_phys" hard_rtvm
 }
 
 # offline SOS CPUs except BSP before launch UOS


### PR DESCRIPTION
This reverts commit c42b41fe2b723a0d24b2084a780be41e0a7dff5c.
Kernel will stay in xapic mode with this boot arg, lapic won't be passthru, so revert.

Tracked-On: #3227