### PR TITLE
Fix assert

### DIFF
--- a/devicemodel/core/gc.c
+++ b/devicemodel/core/gc.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include "gc.h"
 

--- a/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
+++ b/devicemodel/hw/pci/virtio/virtio_hyper_dmabuf.c
@@ -15,7 +15,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <assert.h>
 #include <pthread.h>
 
 #include "dm.h"
@@ -343,8 +342,9 @@ virtio_hyper_dmabuf_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		virtio_hyper_dmabuf_k_stop();
 		virtio_hyper_dmabuf_k_reset();
 		kstatus = VIRTIO_DEV_INITIAL;
-		assert(vbs_k_hyper_dmabuf_fd >= 0);
-		close(vbs_k_hyper_dmabuf_fd);
+		if (vbs_k_hyper_dmabuf_fd >= 0) {
+			close(vbs_k_hyper_dmabuf_fd);
+		}
 		vbs_k_hyper_dmabuf_fd = -1;
 	}
 


### PR DESCRIPTION
Code clean up. Handle the errors more gracefully instead of assert()

If failed create the pci device, dm will not clean up the failed
device. So no chance to call .vdev_deinit(). Driver needs to handle this
case by itself. So in v2, do more clean up to address the assert() case

v2: do more clean up for gvt.

Liu Xinyun (3):
  dm: gc: clean up assert
  dm: hyper_dmabuf: clean up assert
  dm: gvt: clean up assert

 devicemodel/core/gc.c                         |  1 -
 devicemodel/hw/pci/gvt.c                      | 72 +++++++++++--------
 .../hw/pci/virtio/virtio_hyper_dmabuf.c       |  6 +-
 3 files changed, 45 insertions(+), 34 deletions(-)
