### PR TITLE
hv: ept: mask EPT leaf entry bit 52 to bit 63 in gpa2hpa

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -44,7 +44,7 @@ uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 	eptp = get_ept_entry(vm);
 	pgentry = lookup_address((uint64_t *)eptp, gpa, &pg_size, &vm->arch_vm.ept_mem_ops);
 	if (pgentry != NULL) {
-		hpa = ((*pgentry & (~(pg_size - 1UL)))
+		hpa = (((*pgentry & (~EPT_PFN_HIGH_MASK)) & (~(pg_size - 1UL)))
 				| (gpa & (pg_size - 1UL)));
 	}
 

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -111,6 +111,8 @@
 /* VTD: Second-Level Paging Entries: Snoop Control */
 #define EPT_SNOOP_CTRL		(1UL << 11U)
 #define EPT_VE			(1UL << 63U)
+/* EPT leaf entry bits (bit 52 - bit 63) should be maksed  when calculate PFN */
+#define EPT_PFN_HIGH_MASK	0xFFF0000000000000UL
 
 #define PML4E_SHIFT		39U
 #define PTRS_PER_PML4E		512UL


### PR DESCRIPTION
According to SDM, bit N (physical address width) to bit 63 should be masked when calculate
host page frame number.
Currently, hypervisor doesn't set any of these bits, so gpa2hpa can work as expectd.
However, any of these bit set, gpa2hpa return wrong value.

Hypervisor never sets bit N to bit 51 (reserved bits), for simplicity, just mask bit 52 to bit 63.

Tracked-On: #3352
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Eddie Dong<eddie.dong@intel.com>