### PR TITLE
Add support for 64-bit bar emulation and enable bar emulation for SOS

### DIFF
--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -83,7 +83,7 @@ struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_b
 	for (i = 0U; i < vpci->pci_vdev_cnt; i++) {
 		tmp = (struct pci_vdev *)&(vpci->pci_vdevs[i]);
 
-		if (bdf_is_equal(&(tmp->vbdf), &vbdf)) {
+		if (bdf_is_equal(&(tmp->bdf), &vbdf)) {
 			vdev = tmp;
 			break;
 		}

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -98,7 +98,7 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 		info.vmsi_data.full = 0U;
 	}
 
-	ret = ptirq_msix_remap(vm, vdev->vbdf.value, pbdf.value, 0U, &info);
+	ret = ptirq_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info);
 	if (ret == 0) {
 		/* Update MSI Capability structure to physical device */
 		pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR, 0x4U, (uint32_t)info.pmsi_addr.full);
@@ -185,7 +185,7 @@ int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, u
 void deinit_vmsi(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
-		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, 1U);
+		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->bdf.value, 1U);
 	}
 }
 

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -77,7 +77,7 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 	info.vmsi_addr.full = vdev->msix.table_entries[index].addr;
 	info.vmsi_data.full = (enable) ? vdev->msix.table_entries[index].data : 0U;
 
-	ret = ptirq_msix_remap(vdev->vpci->vm, vdev->vbdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
+	ret = ptirq_msix_remap(vdev->vpci->vm, vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
 	if (ret == 0) {
 		/* Write the table entry to the physical structure */
 		hva = hpa2hva(vdev->msix.mmio_hpa + vdev->msix.table_offset);
@@ -383,7 +383,7 @@ void deinit_vmsix(const struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {
-			ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->vbdf.value, vdev->msix.table_count);
+			ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->bdf.value, vdev->msix.table_count);
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -436,10 +436,6 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const struct acrn_vm *vm)
 		 */
 		init_vdev_pt(vdev);
 
-		if (has_msix_cap(vdev)) {
-			vdev_pt_remap_msix_table_bar(vdev);
-		}
-
 		/*
 		 *  For pre-launched VM, the host bridge is fully virtualized and it does not have a physical
 		 * host bridge counterpart.

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -419,10 +419,10 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const struct acrn_vm *vm)
 
 		if (ptdev_config != NULL) {
 			/* vbdf is defined in vm_config */
-			vdev->vbdf.value = ptdev_config->vbdf.value;
+			vdev->bdf.value = ptdev_config->vbdf.value;
 		} else {
 			/* vbdf is not defined in vm_config, set it to equal to pbdf */
-			vdev->vbdf.value = pdev->bdf.value;
+			vdev->bdf.value = pdev->bdf.value;
 		}
 
 		init_vhostbridge(vdev);
@@ -523,7 +523,7 @@ static void deinit_postlaunched_vm_vpci(const struct acrn_vm *vm)
 			vdev->vpci = (struct acrn_vpci *) &sos_vm->vpci;
 
 			/* vbdf equals to pbdf in sos */
-			vdev->vbdf.value = vdev->pdev->bdf.value;
+			vdev->bdf.value = vdev->pdev->bdf.value;
 		}
 	}
 }
@@ -544,7 +544,7 @@ void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, ui
 	} else {
 		/* UOS may do BDF mapping */
 		vdev->vpci = (struct acrn_vpci *)&(target_vm->vpci);
-		vdev->vbdf.value = vbdf;
+		vdev->bdf.value = vbdf;
 		vdev->pdev->bdf.value = pbdf;
 	}
 }
@@ -571,7 +571,7 @@ void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, 
 			vdev->vpci = &vm->vpci;
 
 			/* vbdf equals to pbdf in sos */
-			vdev->vbdf.value = vdev->pdev->bdf.value;
+			vdev->bdf.value = vdev->pdev->bdf.value;
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -116,7 +116,6 @@ int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, u
 void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
-void vdev_pt_remap_msix_table_bar(struct pci_vdev *vdev);
 int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -98,7 +98,7 @@ static inline bool has_msix_cap(const struct pci_vdev *vdev)
  */
 static inline bool is_hostbridge(const struct pci_vdev *vdev)
 {
-	return (vdev->vbdf.value == 0U);
+	return (vdev->bdf.value == 0U);
 }
 
 void init_vhostbridge(struct pci_vdev *vdev);

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -287,7 +287,6 @@ static uint32_t pci_pdev_read_bar(union pci_bdf bdf, uint32_t idx, struct pci_ba
 	}
 
 	bar->size = size;
-	bar->type = type;
 
 	return (type == PCIBAR_MEM64)?2U:1U;
 }

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -67,7 +67,7 @@ union pci_cfgdata {
 struct pci_vdev {
 	const struct acrn_vpci *vpci;
 	/* The bus/device/function triple of the virtual PCI device. */
-	union pci_bdf vbdf;
+	union pci_bdf bdf;
 
 	struct pci_pdev *pdev;
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -183,7 +183,6 @@ struct pci_bar {
 	/* Base Address Register */
 	union pci_bar_reg reg;
 	uint64_t size;
-	enum pci_bar_type type;
 	bool is_64bit_high; /* true if this is the upper 32-bit of a 64-bit bar */
 };
 
@@ -270,7 +269,7 @@ static inline enum pci_bar_type pci_get_bar_type(uint32_t val)
  * Given bar size and raw bar value, return bar base address by masking off its lower flag bits
  * size/val: all in 64-bit values to accommodate 64-bit MMIO bar size masking
  */
-static inline uint64_t pci_base_from_size_mask(uint64_t size, uint64_t val)
+static inline uint64_t git_size_masked_bar_base(uint64_t size, uint64_t val)
 {
 	uint64_t mask;
 
@@ -306,22 +305,6 @@ static inline uint8_t pci_devfn(uint16_t bdf)
 static inline bool bdf_is_equal(const union pci_bdf *a, const union pci_bdf *b)
 {
 	return (a->value == b->value);
-}
-
-/**
- * @pre bar != NULL
- */
-static inline bool is_mmio_bar(const struct pci_bar *bar)
-{
-	return (bar->type == PCIBAR_MEM32) || (bar->type == PCIBAR_MEM64);
-}
-
-/**
- * @pre bar != NULL
- */
-static inline bool is_valid_bar_size(const struct pci_bar *bar)
-{
-	return (bar->size > 0UL) && (bar->size <= 0xffffffffU);
 }
 
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);


### PR DESCRIPTION
Current bar emulation code requires bar size <= 4GB, and report 64-bit bar as 32-bar to 
VMs. Also, currently bar emulation is only enabled for pre-launched VMs.

This PR fixed the above 2 issues:
Adds support for 64-bit bar emulation and enabled bar emulation for SOS.
Enabled PIO bar emulation.

Tracked-On: #3241
Signed-off-by: dongshen <dongsheng.x.zhang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>