### PR TITLE
Correct atomic API using

### DIFF
--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -34,6 +34,7 @@
 #include <logmsg.h>
 #include <host_pm.h>
 #include <acrn_common.h>
+#include <vcpu.h>
 #include <vm_reset.h>
 
 /* Per ACPI spec:

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -34,7 +34,6 @@
 struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM] __aligned(PAGE_SIZE);
 static uint16_t phys_cpu_num = 0U;
 static uint64_t pcpu_sync = 0UL;
-static uint16_t up_count = 0U;
 static uint64_t startup_paddr = 0UL;
 
 /* physical cpu active bitmap, support up to 64 cpus */
@@ -72,16 +71,9 @@ static void pcpu_set_current_state(uint16_t pcpu_id, enum pcpu_boot_state state)
 {
 	/* Check if state is initializing */
 	if (state == PCPU_STATE_INITIALIZING) {
-		/* Increment CPU up count */
-		atomic_inc16(&up_count);
 
 		/* Save this CPU's logical ID to the TSC AUX MSR */
 		set_current_pcpu_id(pcpu_id);
-	}
-
-	/* If cpu is dead, decrement CPU up count */
-	if (state == PCPU_STATE_DEAD) {
-		atomic_dec16(&up_count);
 	}
 
 	/* Set state for the specified CPU */

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -32,20 +32,12 @@ struct acpi_reset_reg *get_host_reset_reg_data(void)
 /**
  * @pre vm != NULL
  */
-void triple_fault_shutdown_vm(struct acrn_vm *vm)
+void triple_fault_shutdown_vm(struct acrn_vcpu *vcpu)
 {
-	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
+	struct acrn_vm *vm = vcpu->vm;
 
 	if (is_postlaunched_vm(vm)) {
 		struct io_request *io_req = &vcpu->req;
-
-		/*
-		 * Hypervisor sets VM_POWERING_OFF to authenticate that the reboot request is
-		 * actually from the guest itself, not from external entities. (for example acrn-dm)
-		 */
-		if (is_rt_vm(vm)) {
-			vm->state = VM_POWERING_OFF;
-		}
 
 		/* Device model emulates PM1A for post-launched VMs */
 		io_req->io_type = REQ_PORTIO;
@@ -258,9 +250,6 @@ void register_reset_port_handler(struct acrn_vm *vm)
 void shutdown_vm_from_idle(uint16_t pcpu_id)
 {
 	struct acrn_vm *vm = get_vm_from_vmid(per_cpu(shutdown_vm_id, pcpu_id));
-	const struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
 
-	if (vcpu->pcpu_id == pcpu_id) {
-		(void)shutdown_vm(vm);
-	}
+	(void)shutdown_vm(vm);
 }

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -255,7 +255,7 @@ static int32_t triple_fault_vmexit_handler(struct acrn_vcpu *vcpu)
 {
 	pr_fatal("VM%d: triple fault @ guest RIP 0x%016llx, exit qualification: 0x%016llx",
 		vcpu->vm->vm_id, exec_vmread(VMX_GUEST_RIP), exec_vmread(VMX_EXIT_QUALIFICATION));
-	triple_fault_shutdown_vm(vcpu->vm);
+	triple_fault_shutdown_vm(vcpu);
 
 	return 0;
 }

--- a/hypervisor/include/arch/x86/guest/vm_reset.h
+++ b/hypervisor/include/arch/x86/guest/vm_reset.h
@@ -16,7 +16,7 @@ struct acpi_reset_reg {
 
 void register_reset_port_handler(struct acrn_vm *vm);
 void shutdown_vm_from_idle(uint16_t pcpu_id);
-void triple_fault_shutdown_vm(struct acrn_vm *vm);
+void triple_fault_shutdown_vm(struct acrn_vcpu *vcpu);
 struct acpi_reset_reg *get_host_reset_reg_data(void);
 
 #endif /* VM_RESET_H_ */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -11,8 +11,6 @@
 #include <pci.h>
 #include <timer.h>
 
-#define ACTIVE_FLAG 0x1U /* any non zero should be okay */
-
 #define PTDEV_INTR_MSI		(1U << 0U)
 #define PTDEV_INTR_INTX		(1U << 1U)
 
@@ -133,7 +131,7 @@ struct ptirq_remapping_info {
 	union source_id phys_sid;
 	union source_id virt_sid;
 	struct acrn_vm *vm;
-	uint32_t active;	/* 1=active, 0=inactive and to free*/
+	bool active;	/* true=active, false=inactive*/
 	uint32_t allocated_pirq;
 	uint32_t polarity; /* 0=active high, 1=active low*/
 	struct list_head softirq_node;
@@ -144,10 +142,14 @@ struct ptirq_remapping_info {
 	ptirq_arch_release_fn_t release_cb;
 };
 
+static inline bool is_entry_active(const struct ptirq_remapping_info *entry)
+{
+	return entry->active;
+}
+
 extern struct ptirq_remapping_info ptirq_entries[CONFIG_MAX_PT_IRQ_ENTRIES];
 extern spinlock_t ptdev_lock;
 
-bool is_entry_active(const struct ptirq_remapping_info *entry);
 void ptirq_softirq(uint16_t pcpu_id);
 void ptdev_init(void);
 void ptdev_release_all_entries(const struct acrn_vm *vm);


### PR DESCRIPTION
Now atomic APIs are used in some places where them don't needed or are used wrong
to plan to guarantte the access to the corresponding structure is atomic.
This patch is just a beginning, it tries to remove the unnecessary atomic using and
correct a wrong using case.

Li, Fei1 (4):
  hv: ptdev: refine ptdev active flag
  hv: cpu: remove CPU up count
  hv: vm_manage: minor fix about triple_fault_shutdown_vm
  hv: io_req: refine vhm_req status setting
Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
