### PR TITLE
hv: vmexit: ecx should be checked instead of rcx when xsetbv

### DIFF
--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -306,8 +306,8 @@ static int32_t xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 		if (idx >= NR_WORLD) {
 			ret = -1;
 		} else {
-			/* to access XCR0,'rcx' should be 0 */
-			if (vcpu_get_gpreg(vcpu, CPU_REG_RCX) != 0UL) {
+			/* to access XCR0,'ecx' should be 0 */
+			if ((vcpu_get_gpreg(vcpu, CPU_REG_RCX) & 0xffffffffUL) != 0UL) {
 				vcpu_inject_gp(vcpu, 0U);
 			} else {
 				val64 = (vcpu_get_gpreg(vcpu, CPU_REG_RAX) & 0xffffffffUL) |


### PR DESCRIPTION
According to SDM, xsetbv writes the contents of registers EDX:EAX into the 64-bit
extended control register (XCR) specified in the ECX register. (On processors
that support the Intel 64 architecture, the high-order 32 bits of RCX are ignored.)

In current code, RCX is checked, should ingore the high-order 32bits.

Tracked-On: #3360
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>