### PR TITLE
hv: vioapic: fix interrupt lost of external device

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -391,6 +391,7 @@ static struct ptirq_remapping_info *add_intx_remapping(struct acrn_vm *vm, uint3
 			if (is_sos_vm(entry->vm)) {
 				entry->vm = vm;
 				entry->virt_sid.value = virt_sid.value;
+				entry->polarity = 0U;
 			} else {
 				pr_err("INTX pin%d already in vm%d with vpin%d, not able to add into vm%d with vpin%d",
 					phys_pin, entry->vm->vm_id, entry->virt_sid.intx_id.pin, vm->vm_id, virt_pin);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -326,6 +326,13 @@ static void vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr, 
 			dev_dbg(ACRN_DBG_IOAPIC, "ioapic pin%hhu: redir table entry %#lx",
 				pin, vioapic->rtbl[pin].full);
 
+			/* remap for ptdev */
+			if ((new.bits.intr_mask == IOAPIC_RTE_MASK_CLR) || (last.bits.intr_mask  == IOAPIC_RTE_MASK_CLR)) {
+				/* VM enable intr */
+				/* NOTE: only support max 256 pin */
+				(void)ptirq_intx_pin_remap(vioapic->vm, pin, PTDEV_VPIN_IOAPIC);
+			}
+
 			/*
 			 * Generate an interrupt if the following conditions are met:
 			 * - pin is not masked
@@ -337,13 +344,6 @@ static void vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr, 
 				vioapic_need_intr(vioapic, (uint16_t)pin)) {
 				dev_dbg(ACRN_DBG_IOAPIC, "ioapic pin%hhu: asserted at rtbl write", pin);
 				vioapic_generate_intr(vioapic, pin);
-			}
-
-			/* remap for ptdev */
-			if ((new.bits.intr_mask == IOAPIC_RTE_MASK_CLR) || (last.bits.intr_mask  == IOAPIC_RTE_MASK_CLR)) {
-				/* VM enable intr */
-				/* NOTE: only support max 256 pin */
-				(void)ptirq_intx_pin_remap(vioapic->vm, pin, PTDEV_VPIN_IOAPIC);
 			}
 		}
 	}


### PR DESCRIPTION
Need to set correct initial pin state of vioapic, and avoid generate
redundant interrupt into the guest:
1. set initial pin state accoring to rte attributes, ignore the value of
   entry->polarity because entry->polarity is uninitialized.
2. since vioapic_generate_intr relys on rte, we should build rte
   beforegenerating an interrput.

This patch fix the interrupt lost, typically the first interrput of
external device, and fix the redundant interrupts generated into guest.

Tracked-On: #3362
Signed-off-by: Cai Yulong <yulongc@hwtc.com.cn>