### PR TITLE
dm: cleanup assert in core.c

### DIFF
--- a/devicemodel/core/vrpmb.c
+++ b/devicemodel/core/vrpmb.c
@@ -28,7 +28,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <openssl/rand.h>
 
 #include "types.h"

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -2291,7 +2291,8 @@ pci_emul_cfgdata(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
 {
 	int coff;
 
-	assert(bytes == 1 || bytes == 2 || bytes == 4);
+	if ((bytes != 1) && (bytes != 2) && (bytes != 4))
+		return -1;
 
 	coff = cfgoff + (port - CONF1_DATA_PORT);
 	if (cfgenable) {

--- a/devicemodel/hw/platform/debugexit.c
+++ b/devicemodel/hw/platform/debugexit.c
@@ -24,7 +24,6 @@
  * SUCH DAMAGE.
  */
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/devicemodel/hw/platform/tpm/tpm.c
+++ b/devicemodel/hw/platform/tpm/tpm.c
@@ -6,7 +6,6 @@
  */
 
 #include <stdlib.h>
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>

--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
-#include <assert.h>
 #include <pthread.h>
 
 #include "vmmapi.h"

--- a/devicemodel/hw/platform/tpm/tpm_emulator.c
+++ b/devicemodel/hw/platform/tpm/tpm_emulator.c
@@ -19,7 +19,6 @@
 #include <stdbool.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <assert.h>
 
 #include "vmmapi.h"
 #include "tpm_internal.h"

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "usb.h"
 #include "usbdi.h"

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -8,7 +8,6 @@
 
 #include <pthread.h>
 #include <stdio.h>
-#include <assert.h>
 #include <string.h>
 #include <unistd.h>
 #include "usb.h"

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -76,7 +76,6 @@
  */
 
 #include <sys/types.h>
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>


### PR DESCRIPTION
 - check input by condition check, instead of assert.
 - remove redundant header file including for some files.

Tracked-On: #3252
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Shuo Liu <shuo.a.liu@intel.com>