### PR TITLE
Correct atomic API using

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -5,7 +5,6 @@
  */
 
 #include <types.h>
-#include <atomic.h>
 #include <bits.h>
 #include <page.h>
 #include <e820.h>
@@ -311,7 +310,8 @@ bool start_pcpus(uint64_t mask)
 	uint64_t expected_start_mask = mask;
 
 	/* secondary cpu start up will wait for pcpu_sync -> 0UL */
-	atomic_store64(&pcpu_sync, 1UL);
+	pcpu_sync = 1UL;
+	cpu_write_memory_barrier();
 
 	i = ffs64(expected_start_mask);
 	while (i != INVALID_BIT_INDEX) {
@@ -326,7 +326,7 @@ bool start_pcpus(uint64_t mask)
 	}
 
 	/* Trigger event to allow secondary CPUs to continue */
-	atomic_store64(&pcpu_sync, 0UL);
+	pcpu_sync = 0UL;
 
 	return ((pcpu_active_bitmap & mask) == mask);
 }

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -351,6 +351,12 @@ static inline void cpu_sp_write(uint64_t *stack_ptr)
 	asm volatile ("movq %0, %%rsp" : : "r"(rsp));
 }
 
+/* Synchronizes all write accesses to memory */
+static inline void cpu_write_memory_barrier(void)
+{
+	asm volatile ("sfence\n" : : : "memory");
+}
+
 /* Synchronizes all read and write accesses to/from memory */
 static inline void cpu_memory_barrier(void)
 {

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -64,6 +64,8 @@ struct acrn_vlapic {
 	 * to support APICv features:
 	 * - 'apic_page' MUST be 4KB aligned.
 	 * - 'pir_desc' MUST be 64 bytes aligned.
+	 * IRR, TMR and PIR could be accessed by other vCPUs when deliver
+	 * an interrupt to vLAPIC.
 	 */
 	struct lapic_regs	apic_page;
 	struct vlapic_pir_desc	pir_desc;


### PR DESCRIPTION
v3:
1) revert secondary cpu start up sync logic, add a wmb to enforce sync_up visable to APs
2) add comments to detail io_req state update logic
3) add comments to detail which field in vLAPIC could be accessed simultaneously

v2:
1) remove atomic APIs in io_req. Instead add a write memory barrier to guarantee
io req_buf consistent
2) refine secondary cpu start up sync logic
3) clear up atomic using in vLPAIC

v1:
Now atomic APIs are used in some places where them don't needed or are used wrong
to plan to guarantte the access to the corresponding structure is atomic.
This patch is just a beginning, it tries to remove the unnecessary atomic using and
correct a wrong using case.

Li, Fei1 (3):
  hv: io_req: refine vhm_req status setting
  hv: cpu: refine secondary cpu start up
  hv: vlapic: clear up where needs atomic operation in vLAPIC

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>