### PR TITLE
Enable vuart console for VM2 in hybird scenario

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -95,9 +95,9 @@ logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
 #for memsize setting
 mem_size=2048M
 
-acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
+acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge \
   -s 2,pci-gvt -G "$3" \
-  -s 5,virtio-console,@pty:pty_port \
+  -s 5,virtio-console,@stdio:stdio_port \
   -s 6,virtio-hyper_dmabuf \
   -s 3,virtio-blk,/home/clear/uos/uos.img \
   -s 4,virtio-net,tap0 \

--- a/hypervisor/scenarios/hybrid/vm_configurations.c
+++ b/hypervisor/scenarios/hybrid/vm_configurations.c
@@ -79,7 +79,8 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			/* d2795438-25d6-11e8-864e-cb7a18b34643 */
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
-			.addr.port_base = INVALID_COM_BASE,
+			.addr.port_base = COM1_BASE,
+			.irq = COM1_IRQ,
 		},
 		.vuart[1] = {
 			.type = VUART_LEGACY_PIO,


### PR DESCRIPTION
1. add vuart for VM2 in hybrid scenario.
2.  Set virtio-console BE to stdio for LaaG. Remove 'com1' but still keep
    'console=ttyS0' in Laag kernel cmdline.
    'console=ttyS0' means LaaG will use ttyS0 (0x3F8) as a console port, and
    during bringup, it will access port ttyS0. When the same port is added
    to hypervisor configuration file as a console port, the output will be
    captured by hypervisor console, and can switch by "vm_console <vm_id>".
