### PR TITLE
fix violations violate Coding guideline

### DIFF
--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -472,7 +472,7 @@ static bool vuart_register_io_handler(struct acrn_vm *vm, uint16_t port_base, ui
 }
 
 static void vuart_setup(struct acrn_vm *vm,
-		struct vuart_config *vu_config, uint16_t vuart_idx)
+		const struct vuart_config *vu_config, uint16_t vuart_idx)
 {
 	uint32_t divisor;
 	struct acrn_vuart *vu = &vm->vuart[vuart_idx];
@@ -500,7 +500,7 @@ static void vuart_setup(struct acrn_vm *vm,
 	}
 }
 
-static struct acrn_vuart *find_active_target_vuart(struct vuart_config *vu_config)
+static struct acrn_vuart *find_active_target_vuart(const struct vuart_config *vu_config)
 {
 	struct acrn_vm *target_vm = NULL;
 	struct acrn_vuart *target_vu = NULL, *ret_vu = NULL;
@@ -523,7 +523,7 @@ static struct acrn_vuart *find_active_target_vuart(struct vuart_config *vu_confi
 }
 
 static void vuart_setup_connection(struct acrn_vm *vm,
-		struct vuart_config *vu_config, uint16_t vuart_idx)
+		const struct vuart_config *vu_config, uint16_t vuart_idx)
 {
 	struct acrn_vuart *vu, *t_vu;
 
@@ -545,7 +545,7 @@ void vuart_deinit_connect(struct acrn_vuart *vu)
 	vu->target_vu = NULL;
 }
 
-bool is_vuart_intx(struct acrn_vm *vm, uint32_t intx_pin)
+bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_pin)
 {
 	uint8_t i;
 	bool ret = false;
@@ -558,7 +558,7 @@ bool is_vuart_intx(struct acrn_vm *vm, uint32_t intx_pin)
 	return ret;
 }
 
-void vuart_init(struct acrn_vm *vm, struct vuart_config *vu_config)
+void vuart_init(struct acrn_vm *vm, const struct vuart_config *vu_config)
 {
 	uint8_t i;
 

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -81,12 +81,12 @@ struct acrn_vuart {
 	spinlock_t lock;	/* protects all softc elements */
 };
 
-void vuart_init(struct acrn_vm *vm, struct vuart_config *vu_config);
+void vuart_init(struct acrn_vm *vm, const struct vuart_config *vu_config);
 void vuart_deinit(struct acrn_vm *vm);
 
 void vuart_putchar(struct acrn_vuart *vu, char ch);
 char vuart_getchar(struct acrn_vuart *vu);
 void vuart_toggle_intr(const struct acrn_vuart *vu);
 
-bool is_vuart_intx(struct acrn_vm *vm, uint32_t intx_pin);
+bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_pin);
 #endif /* VUART_H */


### PR DESCRIPTION
fix violations touched in vuart.c vcpu.c and vmptables.
fix the violations below:
1.parameter needs to add const.
2.Function shall have one return entry.
3.Do not use -- or ++ opertaion.
4.For loop should be simple,shall not use comma operations.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>