### PR TITLE
HV: remove instr_emul.c dead code

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -497,17 +497,6 @@ static void vm_get_seg_desc(enum cpu_reg_name seg, struct seg_desc *desc)
 	desc->access = exec_vmread32(tdesc.access_field);
 }
 
-static void get_guest_paging_info(struct acrn_vcpu *vcpu, uint32_t csar)
-{
-	uint8_t cpl;
-	struct instr_emul_ctxt *emul_ctxt = &vcpu->inst_ctxt;
-
-	cpl = (uint8_t)((csar >> 5U) & 3U);
-	emul_ctxt->paging.cr3 = exec_vmread(VMX_GUEST_CR3);
-	emul_ctxt->paging.cpl = cpl;
-	emul_ctxt->paging.paging_mode = get_vcpu_paging_mode(vcpu);
-}
-
 static int32_t vie_canonical_check(enum vm_cpu_mode cpu_mode, uint64_t gla)
 {
 	int32_t ret = 0;
@@ -2371,7 +2360,6 @@ int32_t decode_instruction(struct acrn_vcpu *vcpu)
 	} else {
 
 		csar = exec_vmread32(VMX_GUEST_CS_ATTR);
-		get_guest_paging_info(vcpu, csar);
 		cpu_mode = get_vcpu_mode(vcpu);
 
 		retval = local_decode_instruction(cpu_mode, seg_desc_def32(csar), &emul_ctxt->vie);

--- a/hypervisor/include/arch/x86/guest/instr_emul.h
+++ b/hypervisor/include/arch/x86/guest/instr_emul.h
@@ -86,15 +86,8 @@ struct instr_emul_vie {
 	uint64_t	dst_gpa;	/* saved dst operand gpa. Only for movs */
 };
 
-struct vm_guest_paging {
-	uint64_t	cr3;
-	uint8_t		cpl;
-	enum vm_paging_mode paging_mode;
-};
-
 struct instr_emul_ctxt {
 	struct instr_emul_vie vie;
-	struct vm_guest_paging paging;
 };
 
 int32_t emulate_instruction(struct acrn_vcpu *vcpu);


### PR DESCRIPTION
ACRN Coding guidelines requires no dead code.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>