### PR TITLE
Fix potential interrupt list issue

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -579,7 +579,6 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 		vcpu->arch.exception_info.exception = VECTOR_INVALID;
 		vcpu->arch.cur_context = NORMAL_WORLD;
 		vcpu->arch.irq_window_enabled = false;
-		vcpu->arch.inject_event_pending = false;
 		(void)memset((void *)vcpu->arch.vmcs, 0U, PAGE_SIZE);
 
 		for (i = 0; i < NR_WORLD; i++) {
@@ -645,9 +644,6 @@ void resume_vcpu(struct acrn_vcpu *vcpu)
 static void context_switch_out(struct sched_object *prev)
 {
 	struct acrn_vcpu *vcpu = list_entry(prev, struct acrn_vcpu, sched_obj);
-
-	/* cancel event(int, gp, nmi and exception) injection */
-	cancel_event_injection(vcpu);
 
 	atomic_store32(&vcpu->running, 0U);
 	/* do prev vcpu context switch out */

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -35,16 +35,17 @@ void vcpu_thread(struct sched_object *obj)
 			do_softirq();
 		}
 
+		/* Don't open interrupt window between here and vmentry */
+		if (need_reschedule(vcpu->pcpu_id)) {
+			schedule();
+			continue;
+		}
+
 		/* Check and process pending requests(including interrupt) */
 		ret = acrn_handle_pending_request(vcpu);
 		if (ret < 0) {
 			pr_fatal("vcpu handling pending request fail");
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
-			continue;
-		}
-
-		if (need_reschedule(vcpu->pcpu_id)) {
-			schedule();
 			continue;
 		}
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -264,11 +264,6 @@ struct ext_context {
 
 #define EOI_EXIT_BITMAP_SIZE	256U
 
-struct event_injection_info {
-	uint32_t intr_info;
-	uint32_t error_code;
-};
-
 struct cpu_context {
 	struct run_context run_ctx;
 	struct ext_context ext_ctx;
@@ -339,8 +334,6 @@ struct acrn_vcpu_arch {
 
 	/* interrupt injection information */
 	uint64_t pending_req;
-	bool inject_event_pending;
-	struct event_injection_info inject_info;
 
 	/* List of MSRS to be stored and loaded on VM exits or VM entries */
 	struct msr_store_area msr_area;

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -210,8 +210,6 @@ int32_t interrupt_window_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t external_interrupt_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu);
 
-void cancel_event_injection(struct acrn_vcpu *vcpu);
-
 extern uint64_t irq_alloc_bitmap[IRQ_ALLOC_BITMAP_SIZE];
 
 typedef void (*irq_action_t)(uint32_t irq, void *priv_data);


### PR DESCRIPTION
One cycle of vmexit/vmentry might lost interrupts.
This is the scenario,
  1) vmexit, vmexit_handlers
  2) softirq & disable interrupt
  3) acrn_handle_pending_request
  4) schedule if needed, then back to 1) and loop again.
  5) vmentry

The step 3) might be executed twice. The problem is at the second
execution of acrn_handle_pending_request, we might overwrite
VMX_ENTRY_INT_INFO_FIELD of current vmcs, which cause guest lost
interrupts.

The fix is moving 4) prior to 3), then we will handle the pending
requests and vmentry directly.

Tracked-On: #3374
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>