### PR TITLE
DM: Increase hugetlbfs MAX_PATH_LEN from 128 to 256

### DIFF
--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -45,7 +45,7 @@ extern char *vmname;
 #define HUGETLB_LV2		1
 #define HUGETLB_LV_MAX	2
 
-#define MAX_PATH_LEN 128
+#define MAX_PATH_LEN 256
 
 #define HUGETLBFS_MAGIC       0x958458f6
 
@@ -410,7 +410,7 @@ static int mount_hugetlbfs(int level)
 static void umount_hugetlbfs(int level)
 {
 	char path[MAX_PATH_LEN];
-	
+
 	if (level >= HUGETLB_LV_MAX) {
 		perror("exceed max hugetlb level");
 		return;


### PR DESCRIPTION
Current hugetlbfs code has a limitation on file path length.
The path string comprises of mount path + vm name.
Something like /run/hugepage/acrn/huge_lv1/vm1.
To this UUID (32 bytes) is added and the total path length
should be less than 128.

This works fine but in cases where the VM name is large as
in case kata, this check fails. Kata passes a sandbox-id
as VM name and so path + 32 for UUID easily exceed 128 bytes.
“/run/hugepage/acrn/huge_lv1/
sandbox-6d455fa48788eae82dee42410fc3d38849c2a5196f930b3d6944805aed8d24c7"

To address this, increase the size of MAX_PATH_LEN from
128 to 256 bytes.

Tracked-On: #3379
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>