### PR TITLE
HV: fix "Casting operation to a pointer"

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/ve820.c
@@ -46,5 +46,5 @@ static const struct e820_entry ve820_entry[VE820_ENTRIES_APL_MRB] = {
 void create_prelaunched_vm_e820(struct acrn_vm *vm)
 {
 	vm->e820_entry_num = VE820_ENTRIES_APL_MRB;
-	vm->e820_entries = (struct e820_entry *)ve820_entry;
+	vm->e820_entries = ve820_entry;
 }

--- a/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/ve820.c
@@ -46,5 +46,5 @@ static const struct e820_entry ve820_entry[VE820_ENTRIES_DNV_CB2] = {
 void create_prelaunched_vm_e820(struct acrn_vm *vm)
 {
 	vm->e820_entry_num = VE820_ENTRIES_DNV_CB2;
-	vm->e820_entries = (struct e820_entry *)ve820_entry;
+	vm->e820_entries = ve820_entry;
 }

--- a/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
+++ b/hypervisor/arch/x86/configs/nuc7i7bnh/ve820.c
@@ -45,5 +45,5 @@ static const struct e820_entry ve820_entry[VE820_ENTRIES_KBL_NUC_i7] = {
 void create_prelaunched_vm_e820(struct acrn_vm *vm)
 {
 	vm->e820_entry_num = VE820_ENTRIES_KBL_NUC_i7;
-	vm->e820_entries = (struct e820_entry *)ve820_entry;
+	vm->e820_entries = ve820_entry;
 }

--- a/hypervisor/arch/x86/configs/vmptable.c
+++ b/hypervisor/arch/x86/configs/vmptable.c
@@ -85,10 +85,9 @@ static uint8_t mpt_compute_checksum(const void *base, size_t len)
  */
 int32_t mptable_build(struct acrn_vm *vm)
 {
-	char		*startaddr;
-	char		*curraddr;
 	struct mpcth	*mpch;
 	struct mpfps	*mpfp;
+	struct mptable_info *mpinfo;
 	size_t		mptable_length;
 	uint16_t	i;
 	uint16_t	vcpu_num;
@@ -127,14 +126,11 @@ int32_t mptable_build(struct acrn_vm *vm)
 		/* Copy mptable info into guest memory */
 		(void)copy_to_gpa(vm, (void *)mptable, MPTABLE_BASE, mptable_length);
 
-		startaddr = (char *)gpa2hva(vm, MPTABLE_BASE);
-		curraddr = startaddr;
+		mpinfo = (struct mptable_info *) gpa2hva(vm, MPTABLE_BASE);
 		stac();
-		mpfp = (struct mpfps *)curraddr;
+		mpfp = &mpinfo->mpfp;
 		mpfp->checksum = mpt_compute_checksum(mpfp, sizeof(struct mpfps));
-		curraddr += sizeof(struct mpfps);
-
-		mpch = (struct mpcth *)curraddr;
+		mpch = &mpinfo->mpch;
 		mpch->checksum = mpt_compute_checksum(mpch, mpch->base_table_length);
 		clac();
 		ret = 0;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -188,7 +188,7 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 	uint32_t i;
 
 	for (i = 0U; i < vm->e820_entry_num; i++) {
-		struct e820_entry *entry = &(vm->e820_entries[i]);
+		const struct e820_entry *entry = &(vm->e820_entries[i]);
 
 		if (entry->length == 0UL) {
 			break;
@@ -327,7 +327,7 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 
 	const struct e820_entry *entry;
 	uint32_t entries_count = vm->e820_entry_num;
-	struct e820_entry *p_e820 = vm->e820_entries;
+	const struct e820_entry *p_e820 = vm->e820_entries;
 	const struct e820_mem_params *p_e820_mem_info = get_e820_mem_info();
 
 	pr_dbg("sos_vm: bottom memory - 0x%llx, top memory - 0x%llx\n",

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -38,7 +38,7 @@ static uint32_t create_zeropage_e820(struct zero_page *zp, const struct acrn_vm 
 {
 	uint32_t entry_num = vm->e820_entry_num;
 	struct e820_entry *zp_e820 = zp->entries;
-	struct e820_entry *vm_e820 = vm->e820_entries;
+	const struct e820_entry *vm_e820 = vm->e820_entries;
 
 	if ((zp_e820 == NULL) || (vm_e820 == NULL) || (entry_num == 0U) || (entry_num > E820_MAX_ENTRIES)) {
 		pr_err("e820 create error");

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -89,7 +89,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	/* Check if flags specify to output to memory */
 	if (do_mem_log) {
 		uint32_t i, msg_len;
-		struct shared_buf *sbuf = (struct shared_buf *)per_cpu(sbuf, pcpu_id)[ACRN_HVLOG];
+		struct shared_buf *sbuf = per_cpu(sbuf, pcpu_id)[ACRN_HVLOG];
 
 		/* If sbuf is not ready, we just drop the massage */
 		if (sbuf != NULL) {

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -319,8 +319,7 @@ static int32_t profiling_generate_data(int32_t collector, uint32_t type)
 		__func__,  get_pcpu_id());
 
 	if (collector == COLLECT_PROFILE_DATA) {
-		sbuf = (struct shared_buf *)
-				per_cpu(sbuf, get_pcpu_id())[ACRN_SEP];
+		sbuf = per_cpu(sbuf, get_pcpu_id())[ACRN_SEP];
 
 		if (sbuf == NULL) {
 			ss->samples_dropped++;
@@ -381,21 +380,18 @@ static int32_t profiling_generate_data(int32_t collector, uint32_t type)
 			}
 
 			for (i = 0U; i < (((DATA_HEADER_SIZE - 1U) / SEP_BUF_ENTRY_SIZE) + 1U); i++) {
-				(void)sbuf_put((struct shared_buf *)sbuf,
-					(uint8_t *)&pkt_header + i * SEP_BUF_ENTRY_SIZE);
+				(void)sbuf_put(sbuf, (uint8_t *)&pkt_header + i * SEP_BUF_ENTRY_SIZE);
 			}
 
 			for (i = 0U; i < (((payload_size - 1U) / SEP_BUF_ENTRY_SIZE) + 1U); i++) {
-				(void)sbuf_put((struct shared_buf *)sbuf,
-					(uint8_t *)payload + i * SEP_BUF_ENTRY_SIZE);
+				(void)sbuf_put(sbuf, (uint8_t *)payload + i * SEP_BUF_ENTRY_SIZE);
 			}
 
 			ss->samples_logged++;
 		}
 	} else if (collector == COLLECT_POWER_DATA) {
 
-		sbuf = (struct shared_buf *)
-				per_cpu(sbuf, get_pcpu_id())[ACRN_SOCWATCH];
+		sbuf = per_cpu(sbuf, get_pcpu_id())[ACRN_SOCWATCH];
 
 		if (sbuf == NULL) {
 			dev_dbg(ACRN_DBG_PROFILING,
@@ -455,11 +451,11 @@ static int32_t profiling_generate_data(int32_t collector, uint32_t type)
 			return 0;
 		}
 		/* copy header */
-		(void)profiling_sbuf_put_variable((struct shared_buf *)sbuf,
+		(void)profiling_sbuf_put_variable(sbuf,
 			(uint8_t *)&pkt_header, (uint32_t)DATA_HEADER_SIZE);
 
 		/* copy payload */
-		(void)profiling_sbuf_put_variable((struct shared_buf *)sbuf,
+		(void)profiling_sbuf_put_variable(sbuf,
 			(uint8_t *)payload, (uint32_t)payload_size);
 
 		spinlock_irqrestore_release(sw_lock, rflags);

--- a/hypervisor/debug/sbuf.c
+++ b/hypervisor/debug/sbuf.c
@@ -85,7 +85,7 @@ int32_t sbuf_share_setup(uint16_t pcpu_id, uint32_t sbuf_id, uint64_t *hva)
 		return -EINVAL;
 	}
 
-	per_cpu(sbuf, pcpu_id)[sbuf_id] = hva;
+	per_cpu(sbuf, pcpu_id)[sbuf_id] = (struct shared_buf *) hva;
 	pr_info("%s share sbuf for pCPU[%u] with sbuf_id[%u] setup successfully",
 			__func__, pcpu_id, sbuf_id);
 

--- a/hypervisor/debug/trace.c
+++ b/hypervisor/debug/trace.c
@@ -49,8 +49,7 @@ static inline bool trace_check(uint16_t cpu_id)
 
 static inline void trace_put(uint16_t cpu_id, uint32_t evid, uint32_t n_data, struct trace_entry *entry)
 {
-	struct shared_buf *sbuf = (struct shared_buf *)
-				per_cpu(sbuf, cpu_id)[ACRN_TRACE];
+	struct shared_buf *sbuf = per_cpu(sbuf, cpu_id)[ACRN_TRACE];
 
 	entry->tsc = rdtsc();
 	entry->id = evid;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -111,7 +111,7 @@ struct acrn_vm {
 	struct vm_sw_info sw;	/* Reference to SW associated with this VM */
 	struct vm_pm_info pm;	/* Reference to this VM's arch information */
 	uint32_t e820_entry_num;
-	struct e820_entry *e820_entries;
+	const struct e820_entry *e820_entries;
 	uint16_t vm_id;		    /* Virtual machine identifier */
 	enum vm_state state;	/* VM state */
 	struct acrn_vuart vuart[MAX_VUART_NUM_PER_VM];		/* Virtual UART */

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -24,7 +24,7 @@ struct per_cpu_region {
 	uint8_t vmxon_region[PAGE_SIZE];
 	void *vmcs_run;
 #ifdef HV_DEBUG
-	uint64_t *sbuf[ACRN_SBUF_ID_MAX];
+	struct shared_buf *sbuf[ACRN_SBUF_ID_MAX];
 	char logbuf[LOG_MESSAGE_MAX_SIZE];
 	uint32_t npk_log_ref;
 #endif


### PR DESCRIPTION
ACRN Coding guidelines requires two different types pointers pointer can't convert to each other.

Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>