### PR TITLE
HV: check security mitigation support for SSBD

### DIFF
--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -53,6 +53,7 @@ bool check_cpu_security_cap(void)
 {
 	bool ret = true;
 	bool mds_no = false;
+	bool ssb_no = false;
 	uint64_t x86_arch_capabilities;
 
 	detect_ibrs();
@@ -63,11 +64,21 @@ bool check_cpu_security_cap(void)
 			& IA32_ARCH_CAP_SKIP_L1DFL_VMENTRY) != 0UL);
 
 		mds_no = ((x86_arch_capabilities & IA32_ARCH_CAP_MDS_NO) != 0UL);
+
+		/* SSB_NO: Processor is not susceptble to Speculative Store Bypass(SSB) */
+		ssb_no = ((x86_arch_capabilities & IA32_ARCH_CAP_SSB_NO) != 0UL);
 	}
 
 	if ((!pcpu_has_cap(X86_FEATURE_L1D_FLUSH)) && (!skip_l1dfl_vmentry)) {
 		/* Processor is affected by L1TF CPU vulnerability,
 		 * but no L1D_FLUSH command support.
+		 */
+		ret = false;
+	}
+
+	if ((!pcpu_has_cap(X86_FEATURE_SSBD)) && (!ssb_no)) {
+		/* Processor is susceptble to Speculative Store Bypass(SSB),
+		 * but no support for Speculative Store Bypass Disable(SSBD).
 		 */
 		ret = false;
 	}

--- a/hypervisor/include/arch/x86/cpufeatures.h
+++ b/hypervisor/include/arch/x86/cpufeatures.h
@@ -84,6 +84,7 @@
 #define X86_FEATURE_STIBP	((FEAT_7_0_EDX << 5U) + 27U)
 #define X86_FEATURE_L1D_FLUSH	((FEAT_7_0_EDX << 5U) + 28U)
 #define X86_FEATURE_ARCH_CAP	((FEAT_7_0_EDX << 5U) + 29U)
+#define X86_FEATURE_SSBD	((FEAT_7_0_EDX << 5U) + 31U)
 
 /* Intel-defined CPU features, CPUID level 0x80000001 (EDX)*/
 #define X86_FEATURE_NX		((FEAT_8000_0001_EDX << 5U) + 20U)


### PR DESCRIPTION
Hypervisor exposes mitigation technique for Speculative
Store Bypass(SSB) to guests and allows a guest to determine
whether to enable SSBD mitigation by providing direct guest
access to IA32_SPEC_CTRL.

Before that, hypervisor should check the SSB mitigation support
on underlying processor, this patch is to add this capability check.

Tracked-On: #3385
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>