### PR TITLE
tools: acrn-manager: fix headers install for ioc cbc tools

### DIFF
--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -21,6 +21,14 @@ MANAGER_CFLAGS += -I../../devicemodel/include
 MANAGER_CFLAGS += -I../../devicemodel/include/public
 MANAGER_CFLAGS += -I../../hypervisor/include
 
+MANAGER_HEADERS := ../../devicemodel/include/dm.h
+MANAGER_HEADERS += ../../devicemodel/include/types.h
+MANAGER_HEADERS += ../../devicemodel/include/vmm.h
+MANAGER_HEADERS += ../../devicemodel/include/dm_string.h
+MANAGER_HEADERS += ../../devicemodel/include/macros.h
+MANAGER_HEADERS += ../../devicemodel/include/public/vhm_ioctl_defs.h
+MANAGER_HEADERS += ../../devicemodel/include/public/acrn_common.h
+
 GCC_MAJOR=$(shell echo __GNUC__ | $(CC) -E -x c - | tail -n 1)
 GCC_MINOR=$(shell echo __GNUC_MINOR__ | $(CC) -E -x c - | tail -n 1)
 
@@ -58,12 +66,12 @@ else
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnd
 endif
 
-$(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h
+$(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h $(MANAGER_HEADERS)
 	$(CC) $(MANAGER_CFLAGS) -c acrn_mngr.c -o $(OUT_DIR)/acrn_mngr.o
 	ar -cr $@ $(OUT_DIR)/acrn_mngr.o
 
 ifneq ($(OUT_DIR),.)
-$(OUT_DIR)/acrn_mngr.h: ./acrn_mngr.h
+$(OUT_DIR)/acrn_mngr.h: ./acrn_mngr.h $(MANAGER_HEADERS)
 	cp ./acrn_mngr.h $(OUT_DIR)/
 endif
 
@@ -98,6 +106,7 @@ ifeq ($(RELEASE),0)
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnctl
 endif
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnd
-	install -t $(DESTDIR)/usr/lib64/ $(OUT_DIR)/libacrn-mngr.a
-	install -t $(DESTDIR)/usr/include/acrn $(OUT_DIR)/acrn_mngr.h
+	install -m 0644 -t $(DESTDIR)/usr/lib64/ $(OUT_DIR)/libacrn-mngr.a
+	install -m 0644 -t $(DESTDIR)/usr/include/acrn $(OUT_DIR)/acrn_mngr.h
+	install -m 0644 -t $(DESTDIR)/usr/include/acrn $(MANAGER_HEADERS)
 	install -p -D -m 0644 $(OUT_DIR)/acrnd.service $(DESTDIR)/usr/lib/systemd/system


### PR DESCRIPTION
The ioc-cbc-tools package depends on "acrn_mgr.h". This header was
updated with new includes since b2f2d952464e ("tools: acrnctl restrict
length of vmname to 32 bytes") and  in 517707dee4ca ("DM/HV: Increase VM
name len") was updated to include dm.h

This commit add all "acrn_mngr.h" dependencies and install them to
"$(DESTDIR)/usr/include/acrn".

Also modify install mode to 0644 to headers and libacrn-mngr.a file.

This closes projectacrn/acrn-hypervisor#3368

Tracked-On: #3368
Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>
Reviewed-by: Yan, Like <like.yan@intel.com>