### PR TITLE
add vpci ops to replace the device specific function invoke

### DIFF
--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -45,54 +45,52 @@
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-void init_vhostbridge(struct pci_vdev *vdev)
+static void init_vhostbridge(struct pci_vdev *vdev)
 {
-	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
-		/* PCI config space */
-		pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
-		pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x5af0U);
+	/* PCI config space */
+	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
+	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x5af0U);
 
-		pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xbU);
+	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xbU);
 
-		pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)PCIM_HDRTYPE_NORMAL
+	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)PCIM_HDRTYPE_NORMAL
 			| PCIM_MFDEV);
-		pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
-		pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_HOST);
+	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
+	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_HOST);
 
-		pci_vdev_write_cfg_u8(vdev, 0x34U, (uint8_t)0xe0U);
-		pci_vdev_write_cfg_u8(vdev, 0x3cU, (uint8_t)0xe0U);
-		pci_vdev_write_cfg_u8(vdev, 0x48U, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0x4aU, (uint8_t)0xd1U);
-		pci_vdev_write_cfg_u8(vdev, 0x4bU, (uint8_t)0xfeU);
-		pci_vdev_write_cfg_u8(vdev, 0x50U, (uint8_t)0xc1U);
-		pci_vdev_write_cfg_u8(vdev, 0x51U, (uint8_t)0x2U);
-		pci_vdev_write_cfg_u8(vdev, 0x54U, (uint8_t)0x33U);
-		pci_vdev_write_cfg_u8(vdev, 0x58U, (uint8_t)0x7U);
-		pci_vdev_write_cfg_u8(vdev, 0x5aU, (uint8_t)0xf0U);
-		pci_vdev_write_cfg_u8(vdev, 0x5bU, (uint8_t)0x7fU);
-		pci_vdev_write_cfg_u8(vdev, 0x60U, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0x63U, (uint8_t)0xe0U);
-		pci_vdev_write_cfg_u8(vdev, 0xabU, (uint8_t)0x80U);
-		pci_vdev_write_cfg_u8(vdev, 0xacU, (uint8_t)0x2U);
-		pci_vdev_write_cfg_u8(vdev, 0xb0U, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0xb3U, (uint8_t)0x7cU);
-		pci_vdev_write_cfg_u8(vdev, 0xb4U, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0xb6U, (uint8_t)0x80U);
-		pci_vdev_write_cfg_u8(vdev, 0xb7U, (uint8_t)0x7bU);
-		pci_vdev_write_cfg_u8(vdev, 0xb8U, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0xbbU, (uint8_t)0x7bU);
-		pci_vdev_write_cfg_u8(vdev, 0xbcU, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0xbfU, (uint8_t)0x80U);
-		pci_vdev_write_cfg_u8(vdev, 0xe0U, (uint8_t)0x9U);
-		pci_vdev_write_cfg_u8(vdev, 0xe2U, (uint8_t)0xcU);
-		pci_vdev_write_cfg_u8(vdev, 0xe3U, (uint8_t)0x1U);
-		pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
-		pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
-		pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
-	}
+	pci_vdev_write_cfg_u8(vdev, 0x34U, (uint8_t)0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0x3cU, (uint8_t)0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0x48U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x4aU, (uint8_t)0xd1U);
+	pci_vdev_write_cfg_u8(vdev, 0x4bU, (uint8_t)0xfeU);
+	pci_vdev_write_cfg_u8(vdev, 0x50U, (uint8_t)0xc1U);
+	pci_vdev_write_cfg_u8(vdev, 0x51U, (uint8_t)0x2U);
+	pci_vdev_write_cfg_u8(vdev, 0x54U, (uint8_t)0x33U);
+	pci_vdev_write_cfg_u8(vdev, 0x58U, (uint8_t)0x7U);
+	pci_vdev_write_cfg_u8(vdev, 0x5aU, (uint8_t)0xf0U);
+	pci_vdev_write_cfg_u8(vdev, 0x5bU, (uint8_t)0x7fU);
+	pci_vdev_write_cfg_u8(vdev, 0x60U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0x63U, (uint8_t)0xe0U);
+	pci_vdev_write_cfg_u8(vdev, 0xabU, (uint8_t)0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xacU, (uint8_t)0x2U);
+	pci_vdev_write_cfg_u8(vdev, 0xb0U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xb3U, (uint8_t)0x7cU);
+	pci_vdev_write_cfg_u8(vdev, 0xb4U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xb6U, (uint8_t)0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xb7U, (uint8_t)0x7bU);
+	pci_vdev_write_cfg_u8(vdev, 0xb8U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xbbU, (uint8_t)0x7bU);
+	pci_vdev_write_cfg_u8(vdev, 0xbcU, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xbfU, (uint8_t)0x80U);
+	pci_vdev_write_cfg_u8(vdev, 0xe0U, (uint8_t)0x9U);
+	pci_vdev_write_cfg_u8(vdev, 0xe2U, (uint8_t)0xcU);
+	pci_vdev_write_cfg_u8(vdev, 0xe3U, (uint8_t)0x1U);
+	pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
+	pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
+	pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
 }
 
-void deinit_vhostbridge(__unused const struct pci_vdev *vdev)
+static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
 {
 }
 
@@ -102,17 +100,11 @@ void deinit_vhostbridge(__unused const struct pci_vdev *vdev)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
+static int32_t vhostbridge_read_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
-	int32_t ret = -ENODEV;
-
-	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
-		*val = pci_vdev_read_cfg(vdev, offset, bytes);
-		ret = 0;
-	}
-
-	return ret;
+	*val = pci_vdev_read_cfg(vdev, offset, bytes);
+	return 0;
 }
 
 
@@ -121,18 +113,23 @@ int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset,
+static int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
-	int32_t ret = -ENODEV;
-
-	if (is_hostbridge(vdev) && is_prelaunched_vm(vdev->vpci->vm)) {
-		if (!is_bar_offset(PCI_BAR_COUNT, offset)) {
-			pci_vdev_write_cfg(vdev, offset, bytes, val);
-		}
-
-		ret = 0;
+	if (!is_bar_offset(PCI_BAR_COUNT, offset)) {
+		pci_vdev_write_cfg(vdev, offset, bytes, val);
 	}
+	return 0;
+}
 
-	return ret;
+static struct pci_vdev_ops vhostbridge_ops = {
+	.init_vdev	= init_vhostbridge,
+	.deinit_vdev	= deinit_vhostbridge,
+	.write_vdev_cfg	= vhostbridge_write_cfg,
+	.read_vdev_cfg	= vhostbridge_read_cfg,
+};
+
+struct pci_vdev_ops *get_vhostbridge_ops(void)
+{
+	return &vhostbridge_ops;
 }

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -37,28 +37,6 @@
 
 /**
  * @pre vdev != NULL
- */
-static inline bool has_msi_cap(const struct pci_vdev *vdev)
-{
-	return (vdev->msi.capoff != 0U);
-}
-
-/**
- * @pre vdev != NULL
- */
-static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
-{
-	bool ret = false;
-
-	if (has_msi_cap(vdev)) {
-		ret = in_range(offset, vdev->msi.capoff, vdev->msi.caplen);
-	}
-
-	return ret;
-}
-
-/**
- * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -38,21 +38,6 @@
 #include <logmsg.h>
 #include "vpci_priv.h"
 
-
-/**
- * @pre vdev != NULL
- */
-static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)
-{
-	bool ret = false;
-
-	if (has_msix_cap(vdev)) {
-		ret = in_range(offset, vdev->msix.capoff, vdev->msix.caplen);
-	}
-
-	return ret;
-}
-
 /**
  * @pre vdev != NULL
  */

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -473,7 +473,12 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const struct acrn_vm *vm)
 			vdev->bdf.value = pdev->bdf.value;
 		}
 
-		vdev->vdev_ops = &pci_pt_dev_ops;
+		if (is_hostbridge(vdev)) {
+			vdev->vdev_ops = get_vhostbridge_ops();
+		} else {
+			vdev->vdev_ops = &pci_pt_dev_ops;
+		}
+
 		vdev->vdev_ops->init_vdev(vdev);
 	}
 }

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -96,6 +96,38 @@ static inline bool has_msix_cap(const struct pci_vdev *vdev)
 /**
  * @pre vdev != NULL
  */
+static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)
+{
+	return (has_msix_cap(vdev) && in_range(offset, vdev->msix.capoff, vdev->msix.caplen));
+}
+
+/**
+ * @pre vdev != NULL
+ */
+static inline bool vbar_access(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
+{
+	return (is_bar_offset(vdev->nr_bars, offset) && (bytes == 4U) && ((offset & 0x3U) == 0U));
+}
+
+/**
+ * @pre vdev != NULL
+ */
+static inline bool has_msi_cap(const struct pci_vdev *vdev)
+{
+        return (vdev->msi.capoff != 0U);
+}
+
+/**
+ * @pre vdev != NULL
+ */
+static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
+{
+       return (has_msi_cap(vdev) && in_range(offset, vdev->msi.capoff, vdev->msi.caplen));
+}
+
+/**
+ * @pre vdev != NULL
+ */
 static inline bool is_hostbridge(const struct pci_vdev *vdev)
 {
 	return (vdev->bdf.value == 0U);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -133,11 +133,6 @@ static inline bool is_hostbridge(const struct pci_vdev *vdev)
 	return (vdev->bdf.value == 0U);
 }
 
-void init_vhostbridge(struct pci_vdev *vdev);
-int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void deinit_vhostbridge(__unused const struct pci_vdev *vdev);
-
 void init_vdev_pt(struct pci_vdev *vdev);
 int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -64,6 +64,14 @@ union pci_cfgdata {
 	uint32_t data_32[(PCI_REGMAX + 1U) >> 4U];
 };
 
+struct pci_vdev;
+struct pci_vdev_ops {
+       void    (*init_vdev)(struct pci_vdev *vdev);
+       void    (*deinit_vdev)(struct pci_vdev *vdev);
+       int32_t (*write_vdev_cfg)(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+       int32_t (*read_vdev_cfg)(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+};
+
 struct pci_vdev {
 	const struct acrn_vpci *vpci;
 	/* The bus/device/function triple of the virtual PCI device. */
@@ -85,6 +93,9 @@ struct pci_vdev {
 
 	/* Pointer to corresponding PCI PT device's vm_config */
 	struct acrn_vm_pci_ptdev_config *ptdev_config;
+
+	/* Pointer to corressponding operations */
+	struct pci_vdev_ops *vdev_ops;
 };
 
 struct pci_addr_info {

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -116,4 +116,6 @@ void vpci_cleanup(const struct acrn_vm *vm);
 void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 
+struct pci_vdev_ops *get_vhostbridge_ops(void);
+
 #endif /* VPCI_H_ */


### PR DESCRIPTION
This patch set add pci vdev ops and invoke callback in general pci vdev config space access.

It also move the hostbridge from SOS to HV to prevent hostbridge operation from SOS impact higher severity VM.

Tracked-On: #3241
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
