### PR TITLE
Apl sdc stable: fix some issues reported by penetration test

### DIFF
--- a/devicemodel/hw/block_if.c
+++ b/devicemodel/hw/block_if.c
@@ -662,7 +662,7 @@ blockif_open(const char *optstr, const char *ident)
 		if (size < DEV_BSIZE || (size & (DEV_BSIZE - 1))) {
 			WPRINTF(("%s size not corret, should be multiple of %d\n",
 						nopt, DEV_BSIZE));
-			return 0;
+			goto err;
 		}
 		psectsz = sbuf.st_blksize;
 	}

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -844,6 +844,7 @@ dsdt_line(const char *fmt, ...)
 	return;
 
 err_exit:
+	va_end(ap);
 	dsdt_error = -1;
 }
 

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -254,7 +254,7 @@ void send_dest_ipi_mask(uint32_t dest_mask, uint32_t vector)
 
 	pcpu_id = ffs64(mask);
 
-	while (pcpu_id != INVALID_BIT_INDEX) {
+	while (pcpu_id < CONFIG_MAX_PCPU_NUM) {
 		bitmap32_clear_nolock(pcpu_id, &mask);
 		if (bitmap_test(pcpu_id, &pcpu_active_bitmap)) {
 			icr.value_32.hi_32 = per_cpu(lapic_id, pcpu_id);

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -37,7 +37,7 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 	/* wait for previous smp call complete, which may run on other cpus */
 	while (atomic_cmpxchg64(&smp_call_mask, 0UL, mask & INVALID_BIT_INDEX) != 0UL);
 	pcpu_id = ffs64(mask);
-	while (pcpu_id != INVALID_BIT_INDEX) {
+	while (pcpu_id < CONFIG_MAX_PCPU_NUM) {
 		bitmap_clear_nolock(pcpu_id, &mask);
 		if (bitmap_test(pcpu_id, &pcpu_active_bitmap)) {
 			smp_call = &per_cpu(smp_call_info, pcpu_id);

--- a/tools/acrn-crashlog/common/log_sys.c
+++ b/tools/acrn-crashlog/common/log_sys.c
@@ -21,10 +21,14 @@ void debug_log(const int level, const char *func, const int line, ...)
 
 	va_start(args, line);
 	fmt = va_arg(args, char *);
-	if (!fmt)
+	if (!fmt) {
+		va_end(args);
 		return;
-	if (vasprintf(&msg, fmt, args) == -1)
+	}
+	if (vasprintf(&msg, fmt, args) == -1) {
+		va_end(args);
 		return;
+	}
 	va_end(args);
 
 	if (asprintf(&head, "<%-20s%5d>: ", func, line) == -1) {

--- a/tools/acrn-crashlog/usercrash/crash_dump.c
+++ b/tools/acrn-crashlog/usercrash/crash_dump.c
@@ -36,11 +36,11 @@ static void loginfo(int fd, const char *fmt, ...)
 
 	va_start(ap, fmt);
 	len = vasprintf(&buf, fmt, ap);
+	va_end(ap);
 	if (len == -1) {
 		LOGE("write to buf failed\n");
 		return;
 	}
-	va_end(ap);
 
 	ret = write(fd, buf, len);
 	if (ret != len) {


### PR DESCRIPTION
These patches fix some issues reported by penetration test.

1, hv:  fix some potential array overflow risk
2, dm: fix variable argument list read without ending with va_end
3, tools: fix variable argument list read without ending with va_end
4, dm: fix some possible memory leak

Tracked-On: #3407
Tracked-On: #3406
Tracked-On: #3405

Signed-off-by: Tianhua Sun tianhuax.s.sun@intel.com
Reviewed-by: Yonghua Huang yonghua.huang@intel.com
Acked-by: Gang Chen gang.c.chen@intel.com