### PR TITLE
Fix some corner cases for USB mediator

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1321,6 +1321,7 @@ pci_xhci_portregs_write(struct pci_xhci_vdev *xdev,
 			break;
 
 		UPRINTF(LDBG, "Port new PLS: %d\r\n", newpls);
+
 		switch (newpls) {
 		case 0: /* U0 */
 		case 3: /* U3 */
@@ -2215,10 +2216,10 @@ pci_xhci_cmd_reset_ep(struct pci_xhci_vdev *xdev,
 			/* let usb_dev_comp_req to free the memory */
 			libusb_cancel_transfer(r->trn);
 	}
-	memset(xfer, 0, sizeof(*xfer));
 
-	if (devep->ep_xfer)
-		memset(devep->ep_xfer, 0, sizeof(*devep->ep_xfer));
+	xfer->ndata = 0;
+	xfer->head = 0;
+	xfer->tail = 0;
 
 	ep_ctx->dwEpCtx0 = (ep_ctx->dwEpCtx0 & ~0x7) | XHCI_ST_EPCTX_STOPPED;
 

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2684,7 +2684,7 @@ pci_xhci_xfer_complete(struct pci_xhci_vdev *xdev,
 		} else
 			rem_len += xfer->data[i].blen;
 
-		if (rem_len > 0)
+		if (err == XHCI_TRB_ERROR_SUCCESS && rem_len > 0)
 			err = XHCI_TRB_ERROR_SHORT_PKT;
 
 		/* Only interrupt if IOC or short packet */

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1323,8 +1323,8 @@ pci_xhci_portregs_write(struct pci_xhci_vdev *xdev,
 		UPRINTF(LDBG, "Port new PLS: %d\r\n", newpls);
 
 		switch (newpls) {
-		case 0: /* U0 */
-		case 3: /* U3 */
+		case UPS_PORT_LS_U0:
+		case UPS_PORT_LS_U3:
 			if (oldpls != newpls) {
 				p->portsc &= ~XHCI_PS_PLS_MASK;
 				p->portsc |= XHCI_PS_PLS_SET(newpls);
@@ -1345,7 +1345,10 @@ pci_xhci_portregs_write(struct pci_xhci_vdev *xdev,
 				}
 			}
 			break;
-
+		case UPS_PORT_LS_RESUME:
+			p->portsc &= ~XHCI_PS_PLS_MASK;
+			p->portsc |= XHCI_PS_PLS_SET(newpls);
+			break;
 		default:
 			UPRINTF(LWRN, "Unhandled change port %d PLS %u\r\n",
 				 port, newpls);


### PR DESCRIPTION
This patch series fixes some issues under WaaG and LaaG.
1. USB BT device can't do scaning
2. Need long time to enumerate certain brand USB disk.

Tracked-On: #3401
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>