### PR TITLE
tools:acrn-crashlog: detect the panic event from all pstore files

### DIFF
--- a/tools/acrn-crashlog/acrnprobe/include/crash_reclassify.h
+++ b/tools/acrn-crashlog/acrnprobe/include/crash_reclassify.h
@@ -3,4 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+extern int crash_match_filefmt(const struct crash_t *crash,
+				const char *filefmt);
 extern void init_crash_reclassify(void);

--- a/tools/acrn-crashlog/acrnprobe/include/load_conf.h
+++ b/tools/acrn-crashlog/acrnprobe/include/load_conf.h
@@ -61,6 +61,8 @@ struct log_t {
 	size_t		path_len;
 	const char	*lines;
 	size_t		lines_len;
+	const char	*deletesource;
+	size_t		deletesource_len;
 	const char	*sizelimit;
 	size_t		sizelimit_len;
 

--- a/tools/acrn-crashlog/acrnprobe/load_conf.c
+++ b/tools/acrn-crashlog/acrnprobe/load_conf.c
@@ -71,6 +71,7 @@ static void print(void)
 			continue;
 		print_id_item(name, log, id);
 		print_id_item(type, log, id);
+		print_id_item(deletesource, log, id);
 		print_id_item(lines, log, id);
 		print_id_item(path, log, id);
 		print_id_item(sizelimit, log, id);
@@ -447,6 +448,8 @@ static int parse_log(xmlNodePtr cur, struct log_t *log)
 			res = load_cur_content(cur, log, name);
 		else if (name_is(cur, "type"))
 			res = load_cur_content(cur, log, type);
+		else if (name_is(cur, "deletesource"))
+			res = load_cur_content(cur, log, deletesource);
 		else if (name_is(cur, "path"))
 			res = load_cur_content(cur, log, path);
 		else if (name_is(cur, "lines"))

--- a/tools/acrn-crashlog/common/fsutils.c
+++ b/tools/acrn-crashlog/common/fsutils.c
@@ -842,6 +842,8 @@ int filter_filename_startswith(const struct dirent *entry,
 	if (_D_EXACT_NAMLEN(entry) < d->len)
 		return -1;
 
+	if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+		return -1;
 	return memcmp(entry->d_name, d->str, d->len);
 }
 

--- a/tools/acrn-crashlog/data/acrnprobe.xml
+++ b/tools/acrn-crashlog/data/acrnprobe.xml
@@ -29,7 +29,7 @@
 		<trigger id="1" enable="true">
 			<name>t_pstore</name>
 			<type>node</type>
-			<path>/sys/fs/pstore/console-ramoops-0</path>
+			<path>/sys/fs/pstore/[*]</path>
 		</trigger>
 		<trigger id="2" enable="true">
 			<name>t_boot</name>
@@ -67,7 +67,8 @@
 		<log id="1" enable="true">
 			<name>pstore</name>
 			<type>node</type>
-			<path>/sys/fs/pstore/console-ramoops-0</path>
+			<deletesource>true</deletesource>
+			<path>/sys/fs/pstore/[*]</path>
 		</log>
 		<log id='2' enable='true'>
 			<name>kmsg</name>
@@ -159,6 +160,17 @@
 			<channel>inotify</channel>
 			<log id='1'>kmsg</log>
 			<log id='2'>syslog</log>
+		</crash>
+		<crash id='9' inherit='0' enable='true'>
+			<name>IPANIC</name>
+			<trigger>t_pstore</trigger>
+			<channel>oneshot</channel>
+			<mightcontent expression='1' id='1'>Kernel panic - not syncing:</mightcontent>
+			<mightcontent expression='1' id='2'>BUG: unable to handle kernel</mightcontent>
+			<data id='1'>kernel BUG at</data>
+			<data id='2'>EIP is at</data>
+			<data id='3'>Comm:</data>
+			<log id='1'>pstore</log>
 		</crash>
 	</crashes>
 


### PR DESCRIPTION
As all pstore files may include the kernel panic information, this patch
tries to find the clue from all messages under /sys/fs/pstore instead of
console-ramoops-0.
To avoid the constant growing of logs, it has to remove the pstore
files after panic being detected.

Tracked-On: #3390
Signed-off-by: Liu, Xinwu <xinwu.liu@intel.com>
Reviewed-by: Zhi Jin <zhi.jin@intel.com>
Acked-by: Chen, Gang <gang.c.chen@intel.com>