### PR TITLE
HV: validate multiboot cmdline before merge cmdline

### DIFF
--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -162,7 +162,8 @@ static void init_vm_bootargs_info(struct acrn_vm *vm, const struct multiboot_inf
 		vm->sw.bootargs_info.size = strnlen_s(bootargs, MAX_BOOTARGS_SIZE);
 	} else {
 		/* vm_config->load_order == SOS_VM */
-		if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) {
+		if (((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U)
+				&& (*(char *)hpa2hva(mbi->mi_cmdline) != 0)) {
 			/*
 			 * If there is cmdline from mbi->mi_cmdline, merge it with
 			 * vm_config->os_config.bootargs


### PR DESCRIPTION
In grub 2.02, the flag of MULTIBOOT_INFO_HAS_CMDLINE is set even there is
no cmdline was configured. So we need to validate the content of cmdline
in multiboot info. If there is no cmdline exist, we should not do merge
cmdline for SOS VM.

Tracked-On: #3214

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>