### PR TITLE
doc: update CODEOWNERS for doc reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /hypervisor/                             @anthonyzxu @dongyaozu
 /devicemodel/                            @anthonyzxu @dongyaozu
-/doc/                                    @dbkinder
+/doc/                                    @dbkinder @deb-intel
 /tools/acrn-crashlog/                    @dizhang417 @chengangc
 
-*.rst                                    @dbkinder
+*.rst                                    @dbkinder @deb-intel


### PR DESCRIPTION
Deb (@deb-intel) added as a reviewer for ACRN documentation.

Tracked-On: #3419
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>