### PR TITLE
doc: remove vuart configuration in nuc and up2

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -429,7 +429,7 @@ partition. Follow these steps:
       double-check the platform boot order using ``efibootmgr -v`` and
       modify it if needed.
 
-   The ACRN hypervisor (``acrn.efi``) accepts three command-line parameters that
+   The ACRN hypervisor (``acrn.efi``) accepts two command-line parameters that
    tweak its behavior:
 
    1. ``bootloader=``: this sets the EFI executable to be loaded once the hypervisor
@@ -450,11 +450,6 @@ partition. Follow these steps:
          You should run ``dmesg |grep ttyS0`` to get port address from the output, and then
          add the ``uart`` parameter into the ``efibootmgr`` command.
 
-   #. ``vuart=ttySn@irqN``: this tells the hypervisor which virtual serial device SOS
-      will use and its IRQ number. This is used to avoid conflict with SOS passthrough
-      devices' interrupt. If UART is set to ttyS1, and its native IRQ is 5, you'd better
-      set ``vuart=ttyS1@irq5`` (Use 'dmesg | grep tty' to get IRQ information).
-      Also set ``console=ttyS1`` in ``acrn.conf`` to match the SOS boot args.
 
    Here is a more complete example of how to configure the EFI firmware to load the ACRN
    hypervisor and set these parameters.

--- a/doc/getting-started/up2.rst
+++ b/doc/getting-started/up2.rst
@@ -75,15 +75,15 @@ You will need to keep these in mind in a few places:
   .. code-block:: none
 
      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/mmcblk0 -p 1 -L "ACRN Hypervisor" \
-         -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=bdf@0:18.1 vuart=ttyS1@irq5"
+         -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=bdf@0:18.1"
 
 UP2 serial port setting
 =======================
 
 The serial port (ttyS1) in the 40-pin HAT connector is located at ``serial PCI BDF 0:18.1``.
 You can check this from the ``lspci`` output from the initial Clearlinux installation.
-Also you can use ``dmesg | grep tty`` to get its IRQ information for vuart setting; and update
-SOS bootargs ``console=ttyS1`` in acrn.conf to match with vuart setting.
+Also you can use ``dmesg | grep tty`` to get its IRQ information for console setting; and update
+SOS bootargs ``console=ttyS1`` in acrn.conf to match with console setting.
 
 .. code-block:: none
 


### PR DESCRIPTION
As the vuart config option is not support anymore, remove it.

Signed-off-by: Conghui Chen <conghui.chen@intel.com>