### PR TITLE
Correct atomic API using

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -154,7 +154,7 @@ void init_pcpu_pre(uint16_t pcpu_id_args)
 		}
 	}
 
-	bitmap_set_nolock(pcpu_id, &pcpu_active_bitmap);
+	bitmap_set_lock(pcpu_id, &pcpu_active_bitmap);
 
 	/* Set state for this CPU to initializing */
 	pcpu_set_current_state(pcpu_id, PCPU_STATE_INITIALIZING);
@@ -387,7 +387,7 @@ void cpu_dead(void)
 
 		/* Set state to show CPU is dead */
 		pcpu_set_current_state(pcpu_id, PCPU_STATE_DEAD);
-		bitmap_clear_nolock(pcpu_id, &pcpu_active_bitmap);
+		bitmap_clear_lock(pcpu_id, &pcpu_active_bitmap);
 
 		/* Halt the CPU */
 		do {

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -362,7 +362,7 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 	 * vcpu->vcpu_id = vm->hw.created_vcpus;
 	 * vm->hw.created_vcpus++;
 	 */
-	vcpu_id = atomic_xadd16(&vm->hw.created_vcpus, 1U);
+	vcpu_id = vm->hw.created_vcpus;
 	if (vcpu_id < CONFIG_MAX_VCPUS_PER_VM) {
 		/* Allocate memory for VCPU */
 		vcpu = &(vm->hw.vcpu_array[vcpu_id]);
@@ -422,9 +422,9 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 
 		reset_vcpu_regs(vcpu);
 		(void)memset((void *)&vcpu->req, 0U, sizeof(struct io_request));
+		vm->hw.created_vcpus++;
 		ret = 0;
 	} else {
-		vm->hw.created_vcpus -= 1U;
 		pr_err("%s, vcpu id is invalid!\n", __func__);
 		ret = -EINVAL;
 	}

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -620,7 +620,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 	vcpu->state = new_state;
 
 	if (atomic_load32(&vcpu->running) == 1U) {
-		remove_from_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
+		remove_from_cpu_runqueue(&vcpu->sched_obj);
 
 		if (is_lapic_pt_enabled(vcpu)) {
 			make_reschedule_request(vcpu->pcpu_id, DEL_MODE_INIT);
@@ -636,7 +636,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 			}
 		}
 	} else {
-		remove_from_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
+		remove_from_cpu_runqueue(&vcpu->sched_obj);
 		release_schedule_lock(vcpu->pcpu_id);
 	}
 }

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -168,7 +168,7 @@ void vcpu_set_eoi_exit_bitmap(struct acrn_vcpu *vcpu, uint32_t vector)
 {
 	pr_dbg("%s", __func__);
 
-	if (!bitmap_test_and_set_nolock((uint16_t)(vector & 0x3fU),
+	if (!bitmap_test_and_set_lock((uint16_t)(vector & 0x3fU),
 			&(vcpu->arch.eoi_exit_bitmap[(vector & 0xffU) >> 6U]))) {
 		vcpu_make_request(vcpu, ACRN_REQUEST_EOI_EXIT_BITMAP_UPDATE);
 	}
@@ -178,7 +178,7 @@ void vcpu_clear_eoi_exit_bitmap(struct acrn_vcpu *vcpu, uint32_t vector)
 {
 	pr_dbg("%s", __func__);
 
-	if (bitmap_test_and_clear_nolock((uint16_t)(vector & 0x3fU),
+	if (bitmap_test_and_clear_lock((uint16_t)(vector & 0x3fU),
 			&(vcpu->arch.eoi_exit_bitmap[(vector & 0xffU) >> 6U]))) {
 		vcpu_make_request(vcpu, ACRN_REQUEST_EOI_EXIT_BITMAP_UPDATE);
 	}

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -88,7 +88,7 @@ void default_idle(__unused struct sched_object *obj)
 	while (1) {
 		if (need_reschedule(pcpu_id)) {
 			schedule();
-		} else if (need_offline(pcpu_id) != 0) {
+		} else if (need_offline(pcpu_id)) {
 			cpu_dead();
 		} else if (need_shutdown_vm(pcpu_id)) {
 			shutdown_vm_from_idle(pcpu_id);

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -24,7 +24,6 @@ void init_scheduler(void)
 	for (i = 0U; i < pcpu_nums; i++) {
 		ctx = &per_cpu(sched_ctx, i);
 
-		spinlock_init(&ctx->runqueue_lock);
 		spinlock_init(&ctx->scheduler_lock);
 		INIT_LIST_HEAD(&ctx->runqueue);
 		ctx->flags = 0UL;
@@ -74,33 +73,25 @@ void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id)
 {
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 
-	spinlock_obtain(&ctx->runqueue_lock);
 	if (list_empty(&obj->run_list)) {
 		list_add_tail(&obj->run_list, &ctx->runqueue);
 	}
-	spinlock_release(&ctx->runqueue_lock);
 }
 
-void remove_from_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id)
+void remove_from_cpu_runqueue(struct sched_object *obj)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-
-	spinlock_obtain(&ctx->runqueue_lock);
 	list_del_init(&obj->run_list);
-	spinlock_release(&ctx->runqueue_lock);
 }
 
 static struct sched_object *get_next_sched_obj(struct sched_context *ctx)
 {
 	struct sched_object *obj = NULL;
 
-	spinlock_obtain(&ctx->runqueue_lock);
 	if (!list_empty(&ctx->runqueue)) {
 		obj = get_first_item(&ctx->runqueue, struct sched_object, run_list);
 	} else {
 		obj = &get_cpu_var(idle);
 	}
-	spinlock_release(&ctx->runqueue_lock);
 
 	return obj;
 }

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -136,7 +136,7 @@ void make_pcpu_offline(uint16_t pcpu_id)
 	}
 }
 
-int32_t need_offline(uint16_t pcpu_id)
+bool need_offline(uint16_t pcpu_id)
 {
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -112,7 +112,7 @@ void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode)
 {
 	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
 
-	bitmap_set_nolock(NEED_RESCHEDULE, &ctx->flags);
+	bitmap_set_lock(NEED_RESCHEDULE, &ctx->flags);
 	if (get_pcpu_id() != pcpu_id) {
 		switch (delmode) {
 		case DEL_MODE_IPI:
@@ -192,7 +192,7 @@ void schedule(void)
 
 	get_schedule_lock(pcpu_id);
 	next = get_next_sched_obj(ctx);
-	bitmap_clear_nolock(NEED_RESCHEDULE, &ctx->flags);
+	bitmap_clear_lock(NEED_RESCHEDULE, &ctx->flags);
 
 	if (prev == next) {
 		release_schedule_lock(pcpu_id);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -358,7 +358,7 @@ struct acrn_vcpu {
 
 	struct sched_object sched_obj;
 	bool launched; /* Whether the vcpu is launched on target pcpu */
-	uint32_t running; /* vcpu is picked up and run? */
+	bool running; /* vcpu is picked up and run? */
 
 	struct instr_emul_ctxt inst_ctxt;
 	struct io_request req; /* used by io/ept emulation */

--- a/hypervisor/include/arch/x86/lib/atomic.h
+++ b/hypervisor/include/arch/x86/lib/atomic.h
@@ -33,32 +33,6 @@
 
 #define	BUS_LOCK	"lock ; "
 
-#define build_atomic_load(name, size, type)		\
-static inline type name(const volatile type *ptr)	\
-{							\
-	type ret;					\
-	asm volatile("mov" size " %1,%0"		\
-			: "=r" (ret)			\
-			: "m" (*ptr)			\
-			: "cc", "memory");		\
-	return ret;					\
-}
-build_atomic_load(atomic_load16, "w", uint16_t)
-build_atomic_load(atomic_load32, "l", uint32_t)
-build_atomic_load(atomic_load64, "q", uint64_t)
-
-#define build_atomic_store(name, size, type)		\
-static inline void name(volatile type *ptr, type v)	\
-{							\
-	asm volatile("mov" size " %1,%0"		\
-			: "=m" (*ptr)			\
-			: "r" (v)			\
-			: "cc", "memory");		\
-}
-build_atomic_store(atomic_store16, "w", uint16_t)
-build_atomic_store(atomic_store32, "l", uint32_t)
-build_atomic_store(atomic_store64, "q", uint64_t)
-
 #define build_atomic_inc(name, size, type)		\
 static inline void name(type *ptr)			\
 {							\
@@ -80,69 +54,6 @@ static inline void name(type *ptr)			\
 build_atomic_dec(atomic_dec16, "w", uint16_t)
 build_atomic_dec(atomic_dec32, "l", uint32_t)
 build_atomic_dec(atomic_dec64, "q", uint64_t)
-
-/**
- *  #define atomic_set32(P, V)		(*(uint32_t *)(P) |= (V))
- * 
- *  Parameters:
- *  uint32_t*	p	A pointer to memory area that stores source
- *			value and setting result;
- *  uint32_t	v	The value needs to be set.
- */
-static inline void atomic_set32(uint32_t *p, uint32_t v)
-{
-	__asm __volatile(BUS_LOCK "orl %1,%0"
-			:  "+m" (*p)
-			:  "r" (v)
-			:  "cc", "memory");
-}
-
-/*
- *  #define atomic_clear32(P, V)		(*(uint32_t *)(P) &= ~(V))
- *  Parameters:
- *  uint32_t*	p	A pointer to memory area that stores source
- *			value and clearing result;
- *  uint32_t	v	The value needs to be cleared.
- */
-static inline void atomic_clear32(uint32_t *p, uint32_t v)
-{
-	__asm __volatile(BUS_LOCK "andl %1,%0"
-			:  "+m" (*p)
-			:  "r" (~v)
-			:  "cc", "memory");
-}
-
-/*
- *  #define atomic_set64(P, V)		(*(uint64_t *)(P) |= (V))
- *
- *  Parameters:
- *  uint64_t*   p       A pointer to memory area that stores source
- *                      value and setting result;
- *  uint64_t    v       The value needs to be set.
- */
-static inline void atomic_set64(uint64_t *p, uint64_t v)
-{
-	__asm __volatile(BUS_LOCK "orq %1,%0"
-			:  "+m" (*p)
-			:  "r" (v)
-			:  "cc", "memory");
-}
-
-/*
- *  #define atomic_clear64(P, V)	(*(uint64_t *)(P) &= ~(V))
- *
- *  Parameters:
- *  uint64_t*   p       A pointer to memory area that stores source
- *                      value and clearing result;
- *  uint64_t    v       The value needs to be cleared.
- */
-static inline void atomic_clear64(uint64_t *p, uint64_t v)
-{
-	__asm __volatile(BUS_LOCK "andq %1,%0"
-			:  "+m" (*p)
-			:  "r" (~v)
-			:  "cc", "memory");
-}
 
 #define build_atomic_swap(name, size, type)		\
 static inline type name(type *ptr, type v)		\

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -49,7 +49,7 @@ void remove_from_cpu_runqueue(struct sched_object *obj);
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);
 void make_pcpu_offline(uint16_t pcpu_id);
-int32_t need_offline(uint16_t pcpu_id);
+bool need_offline(uint16_t pcpu_id);
 void make_shutdown_vm_request(uint16_t pcpu_id);
 bool need_shutdown_vm(uint16_t pcpu_id);
 

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -28,11 +28,10 @@ struct sched_object {
 };
 
 struct sched_context {
-	spinlock_t runqueue_lock;
 	struct list_head runqueue;
 	uint64_t flags;
 	struct sched_object *curr_obj;
-	spinlock_t scheduler_lock;
+	spinlock_t scheduler_lock;	/* to protect sched_context and sched_object */
 };
 
 void init_scheduler(void);
@@ -45,7 +44,7 @@ uint16_t allocate_pcpu(void);
 void free_pcpu(uint16_t pcpu_id);
 
 void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
-void remove_from_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
+void remove_from_cpu_runqueue(struct sched_object *obj);
 
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);


### PR DESCRIPTION
v5:
1) detail some comments why we need or not atomic operations
2) remove pcpu_id parameter for remove_from_cpu_runqueue

v4:
Correct atomic API using on vCPU layer
1) schedule fields which under lock protection don't need to operate atomically;
otherwises, schedule fields which has no lock protection need to operate atomically.
2) remove unnecessary atomic APIs, like atomic_load/store and atomic_set/clear.

v3:
1) revert secondary cpu start up sync logic, add a wmb to enforce sync_up visable to APs
2) add comments to detail io_req state update logic
3) add comments to detail which field in vLAPIC could be accessed simultaneously

v2:
1) remove atomic APIs in io_req. Instead add a write memory barrier to guarantee
io req_buf consistent
2) refine secondary cpu start up sync logic
3) clear up atomic using in vLPAIC

v1:
Now atomic APIs are used in some places where them don't needed or are used wrong
to plan to guarantte the access to the corresponding structure is atomic.
This patch is just a beginning, it tries to remove the unnecessary atomic using and
correct a wrong using case.

Tracked-On: #1842
Signed-off-by: Li, Fei1 <fei1.li@intel.com>