### PR TITLE
HV: change param type of init_pcpu_pre

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -94,12 +94,13 @@ uint64_t get_active_pcpu_bitmap(void)
 	return pcpu_active_bitmap;
 }
 
-void init_pcpu_pre(uint16_t pcpu_id_args)
+void init_pcpu_pre(bool is_bsp)
 {
-	uint16_t pcpu_id = pcpu_id_args;
+	uint16_t pcpu_id;
 	int32_t ret;
 
-	if (pcpu_id == BOOT_CPU_ID) {
+	if (is_bsp) {
+		pcpu_id = BOOT_CPU_ID;
 		start_tsc = rdtsc();
 
 		/* Clear BSS */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -82,7 +82,7 @@ void init_primary_pcpu(void)
 {
 	uint64_t rsp;
 
-	init_pcpu_pre(BOOT_CPU_ID);
+	init_pcpu_pre(true);
 
 	/* Switch to run-time stack */
 	rsp = (uint64_t)(&get_cpu_var(stack)[CONFIG_STACK_SIZE - 1]);
@@ -94,7 +94,7 @@ void init_secondary_pcpu(void)
 {
 	uint16_t pcpu_id;
 
-	init_pcpu_pre(INVALID_CPU_ID);
+	init_pcpu_pre(false);
 
 	pcpu_id = get_pcpu_id();
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -265,7 +265,7 @@ void cpu_do_idle(void);
 void cpu_dead(void);
 void trampoline_start16(void);
 void load_pcpu_state_data(void);
-void init_pcpu_pre(uint16_t pcpu_id_args);
+void init_pcpu_pre(bool is_bsp);
 void init_pcpu_post(uint16_t pcpu_id);
 bool start_pcpus(uint64_t mask);
 void wait_pcpus_offline(uint64_t mask);


### PR DESCRIPTION
When initialize secondary pcpu, pass INVALID_CPU_ID as param of init_pcpu_pre()
looks weird, so change the param type to bool to represent whether the pcpu is
a BSP or AP.

Tracked-On: #3420

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>