### PR TITLE
doc: Add ACRN tag or Clear Linux version info for some tutorials

### DIFF
--- a/doc/tutorials/acrn-dm_QoS.rst
+++ b/doc/tutorials/acrn-dm_QoS.rst
@@ -70,6 +70,8 @@ the maximal CPU resource for the VM0 or VM1 is 33% of the entire CPU resource.
 
 How to use ACRN-DM QoS
 **********************
+#. Follow :ref:`getting-started-apl-nuc` to boot "The ACRN Service OS" based on Clear Linux 29970 (ACRN tag v1.1).
+
 #. Add these parameters to the ``runC.json`` file:
 
    .. code-block:: none

--- a/doc/tutorials/using_partition_mode_on_nuc.rst
+++ b/doc/tutorials/using_partition_mode_on_nuc.rst
@@ -34,7 +34,7 @@ Prerequisites
   filesystem. Set up each VM by following the `Install Clear Linux
   OS on bare metal with live server
   <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install-server>`_
-  and install Clear Linux OS first on a SATA disk and then again
+  and install Clear Linux OS (version: 29970) first on a SATA disk and then again
   on a storage device with a USB interface. The two pre-launched
   VMs will mount the root file systems via the SATA controller and
   the USB controller respectively.
@@ -140,12 +140,14 @@ Update ACRN hypervisor Image
    Please refer :ref:`getting-started-building` to setup ACRN build environment
    on your development workstation.
 
-   Clone the ACRN source code:
+   Clone the ACRN source code and checkout to the tag v1.1:
 
    .. code-block:: none
 
       $ git clone https://github.com/projectacrn/acrn-hypervisor.git
-      $ cd acrn-hypervisor/hypervisor
+      $ cd acrn-hypervisor
+      $ git checkout v1.1
+      $ cd hypervisor
 
    Configure the build options:
 

--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -26,6 +26,7 @@ To set up the Linux root filesystems for each VM, follow the Clear Linux OS
 to install Clear Linux OS on a **SATA disk** and a **USB flash disk** prior the setup,
 as the two privileged VMs will mount the root filesystems via the SATA controller
 and the USB controller respectively.
+This tutorial is verified on a tagged ACRN v0.6.
 
 Build kernel and modules for partition mode UOS
 ***********************************************
@@ -148,7 +149,9 @@ Enable partition mode in ACRN hypervisor
    .. code-block:: none
 
      $ git clone https://github.com/projectacrn/acrn-hypervisor.git
-     $ cd acrn-hypervisor/hypervisor
+     $ cd acrn-hypervisor
+     $ git checkout v0.6
+     $ cd hypervisor
      $ make menuconfig
 
    Set the ``Hypervisor mode`` option to ``Partition mode``, and depending

--- a/doc/tutorials/using_vxworks_as_uos.rst
+++ b/doc/tutorials/using_vxworks_as_uos.rst
@@ -4,7 +4,8 @@ Using VxWorks* as User OS
 #########################
 
 `VxWorks`_\* is a real-time proprietary OS designed for use in embedded systems requiring real-time, deterministic
-performance. This tutorial describes how to run VxWorks as the User OS on the ACRN hypervisor.
+performance. This tutorial describes how to run VxWorks as the User OS on the ACRN hypervisor
+based on Clear Linux 29970 (ACRN tag v1.1).
 
 .. note:: You'll need to be a WindRiver* customer and have purchased VxWorks to follow this tutorial.
 

--- a/doc/tutorials/using_zephyr_as_uos.rst
+++ b/doc/tutorials/using_zephyr_as_uos.rst
@@ -86,7 +86,8 @@ Steps for Using Zephyr as User OS
    You now have a virtual disk image with a bootable Zephyr in ``zephyr.img``. If the Zephyr build system is not
    the ACRN SOS, then you will need to transfer this image to the ACRN SOS (via, e.g, a USB stick or network )
 
-#. Follow :ref:`getting-started-apl-nuc` to boot "The ACRN Service OS"
+#. Follow :ref:`getting-started-apl-nuc` to boot "The ACRN Service OS" based on Clear Linux OS 28620
+   (ACRN tag: acrn-2019w14.3-140000p)
 
 #. Boot Zephyr as User OS
 


### PR DESCRIPTION
Neither ACRN tag nor Clear Linux version is specified in some tutorials.
Declare those information for those tutorials.

Signed-off-by: lirui34 <ruix.li@intel.com>