### PR TITLE
HV: remove unsafe API and strip symbols from image

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -51,7 +51,10 @@ endif
 
 ifeq ($(RELEASE),0)
 CFLAGS += -DDM_DEBUG
+else
+LDFLAGS += -s
 endif
+
 
 LDFLAGS += -Wl,-z,noexecstack
 LDFLAGS += -Wl,-z,relro,-z,now

--- a/efi-stub/boot.c
+++ b/efi-stub/boot.c
@@ -347,7 +347,7 @@ static inline EFI_STATUS isspace(CHAR8 ch)
     return ((uint8_t)ch <= ' ');
 }
 
-#define DEFAULT_UEFI_OS_LOADER_NAME "\\EFI\\org.clearlinux\\bootloaderx64.efi"
+#define DEFAULT_UEFI_OS_LOADER_NAME L"\\EFI\\org.clearlinux\\bootloaderx64.efi"
 /**
  * efi_main - The entry point for the OS loader image.
  * @image: firmware-allocated handle that identifies the image
@@ -392,13 +392,13 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 
 	/* convert the options to cmdline */
 	if (options_size > 0)
-		cmdline = ch16_2_ch8(options);
+		cmdline = ch16_2_ch8(options, StrnLen(options, options_size));
 
 	/* First check if we were given a bootloader name
 	 * E.g.: "bootloader=\EFI\org.clearlinux\bootloaderx64.efi"
 	 */
 	cmdline16 = StrDuplicate(options);
-	bootloader_name = strstr_16(cmdline16, bootloader_param);
+	bootloader_name = strstr_16(cmdline16, bootloader_param, StrLen(bootloader_param));
 	if (bootloader_name) {
 		bootloader_name = bootloader_name + StrLen(bootloader_param);
 		n = bootloader_name;
@@ -413,11 +413,11 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 		 * bootloader name to be used. Fall back to the default bootloader
 		 * as specified in config.h
 		 */
-		bootloader_name = ch8_2_ch16(DEFAULT_UEFI_OS_LOADER_NAME);
+		bootloader_name = DEFAULT_UEFI_OS_LOADER_NAME;
 	}
 
 	section = ".hv";
-	err = get_pe_section(info->ImageBase, section, &sec_addr, &sec_size);
+	err = get_pe_section(info->ImageBase, section, strlen(section), &sec_addr, &sec_size);
 	if (EFI_ERROR(err)) {
 		Print(L"Unable to locate section of ACRNHV %r ", err);
 		goto failed;

--- a/efi-stub/boot.h
+++ b/efi-stub/boot.h
@@ -68,7 +68,7 @@
 	*msr_val_ptr = ((uint64_t)msrh << 32U) | msrl;           \
 }
 
-EFI_STATUS get_pe_section(CHAR8 *base, char *section, UINTN *vaddr, UINTN *size);
+EFI_STATUS get_pe_section(CHAR8 *base, char *section_name, UINTN section_name_len, UINTN *vaddr, UINTN *size);
 typedef void(*hv_func)(int32_t, struct multiboot_info*);
 
 /*

--- a/efi-stub/pe.c
+++ b/efi-stub/pe.c
@@ -107,7 +107,8 @@ struct PeSectionHeader {
 } __attribute__((packed));
 
 
-EFI_STATUS get_pe_section(CHAR8 *base, char *section, UINTN *vaddr, UINTN *size)
+EFI_STATUS get_pe_section(CHAR8 *base, char *section_name,
+		UINTN section_name_len, UINTN *vaddr, UINTN *size)
 {
         struct PeSectionHeader *ph;
         struct DosFileHeader *dh;
@@ -132,7 +133,7 @@ EFI_STATUS get_pe_section(CHAR8 *base, char *section, UINTN *vaddr, UINTN *size)
 
         for (i = 0; i < pe->mNumberOfSections; i++) {
                 ph = (struct PeSectionHeader *)&base[offset];
-                if (CompareMem(ph->mName, section, strlen(section)) == 0) {
+                if (CompareMem(ph->mName, section_name, section_name_len) == 0) {
 			*vaddr = (UINTN)ph->mVirtualAddress;
                          *size = (UINTN)ph->mVirtualSize;
 			break;

--- a/efi-stub/stdlib.h
+++ b/efi-stub/stdlib.h
@@ -73,11 +73,10 @@ static inline int32_t strlen(const char *str)
 	return len;
 }
 
-static inline CHAR16 *strstr_16(CHAR16 *haystack, CHAR16 *needle)
+static inline CHAR16 *strstr_16(CHAR16 *haystack, CHAR16 *needle, UINTN len)
 {
 	CHAR16 *p;
 	CHAR16 *word = NULL;
-	UINTN len = StrLen(needle);
 
 	if (!len)
 		return NULL;
@@ -94,28 +93,11 @@ static inline CHAR16 *strstr_16(CHAR16 *haystack, CHAR16 *needle)
 	return (CHAR16*)word;
 }
 
-static inline CHAR16 *ch8_2_ch16(char *str8)
+static inline char *ch16_2_ch8(CHAR16 *str16, UINTN len)
 {
-	UINTN len, i;
-	CHAR16 *str16;
-
-	len = strlen(str8);
-	str16 = AllocatePool((len + 1) * sizeof(CHAR16));
-
-	for (i = 0; i < len; i++)
-		str16[i] = str8[i];
-
-	str16[len] = 0;
-
-	return str16;
-}
-
-static inline char *ch16_2_ch8(CHAR16 *str16)
-{
-	UINTN len, i;
+	UINTN i;
 	char *str8;
 
-	len = StrLen(str16);
 	str8 = AllocatePool((len + 1) * sizeof(char));
 
 	for (i = 0; i < len; i++)

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -19,6 +19,7 @@ HV_OBJDIR ?= $(CURDIR)/build
 HV_MODDIR ?= $(HV_OBJDIR)/modules
 HV_FILE := acrn
 SUB_MAKEFILES := $(wildcard */Makefile)
+RELEASE ?= 0
 
 LIB_MOD = $(HV_MODDIR)/lib_mod.a
 BOOT_MOD = $(HV_MODDIR)/boot_mod.a
@@ -106,6 +107,10 @@ ifeq (y, $(CONFIG_RELOC))
 LDFLAGS += -pie -z noreloc-overflow
 else
 LDFLAGS += -static
+endif
+
+ifeq ($(RELEASE),y)
+LDFLAGS += -s
 endif
 
 ARCH_CFLAGS += -gdwarf-2

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -49,6 +49,8 @@ endif
 
 ifeq ($(RELEASE),0)
 MANAGER_CFLAGS += -g -DMNGR_DEBUG
+else
+MANAGER_LDFLAGS += -s
 endif
 
 MANAGER_LDFLAGS := -Wl,-z,noexecstack


### PR DESCRIPTION
fix some issues reported by penetration test
1, update string operation in efi-stub
2, fix symbols not stripped from release image.

Tracked-On: #3427
Tracked-On: #3276 
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>