### PR TITLE
HV: add SDC2 config in hypervisor/arch/x86/Kconfig

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -51,6 +51,8 @@ include scripts/kconfig/kconfig.mk
 #initialize scenarios name
 ifeq ($(CONFIG_SDC),y)
 SCENARIO_NAME := sdc
+else ifeq ($(CONFIG_SDC2),y)
+SCENARIO_NAME := sdc2
 else ifeq ($(CONFIG_LOGICAL_PARTITION),y)
 SCENARIO_NAME := logical_partition
 else ifeq ($(CONFIG_INDUSTRY),y)

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -10,6 +10,12 @@ config SDC
 	  SDC (Software Defined Cockpit) is a typical scenario that ACRN supported.
 	  SDC will have one pre-launched SOS VM and one post-launched VM.
 
+config SDC2
+        bool "Software Defined Cockpit 2"
+        help
+          SDC2 (Software Defined Cockpit 2) is an extended scenario for automotive SDC system.
+          SDC2 will have one pre-launched SOS VM and up to three post-launched VM.
+
 config LOGICAL_PARTITION
 	bool "Logical Partition VMs"
 	help

--- a/hypervisor/scenarios/sdc2/vm_configurations.c
+++ b/hypervisor/scenarios/sdc2/vm_configurations.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm_config.h>
+#include <vuart.h>
+
+struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
+	{
+		.load_order = SOS_VM,
+		.name = "ACRN SOS VM",
+		.uuid = {0xdbU, 0xbbU, 0xd4U, 0x34U, 0x7aU, 0x57U, 0x42U, 0x16U,	\
+			 0xa1U, 0x2cU, 0x22U, 0x01U, 0xf1U, 0xabU, 0x02U, 0x40U},
+			/* dbbbd434-7a57-4216-a12c-2201f1ab0240 */
+
+		/* Allow SOS to reboot the host since there is supposed to be the highest severity guest */
+		.guest_flags = GUEST_FLAG_HIGHEST_SEVERITY,
+		.clos = 0U,
+		.memory = {
+			.start_hpa = 0UL,
+			.size = CONFIG_SOS_RAM_SIZE,
+		},
+		.os_config = {
+			.name = "ACRN Service OS",
+			.kernel_type = KERNEL_BZIMAGE,
+			.kernel_mod_tag = "Linux_bzImage",
+			.bootargs = SOS_VM_BOOTARGS,
+		},
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = CONFIG_COM_BASE,
+			.irq = CONFIG_COM_IRQ,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+	},
+	{
+		.load_order = POST_LAUNCHED_VM,
+		.uuid = {0xd2U, 0x79U, 0x54U, 0x38U, 0x25U, 0xd6U, 0x11U, 0xe8U,	\
+			 0x86U, 0x4eU, 0xcbU, 0x7aU, 0x18U, 0xb3U, 0x46U, 0x43U},
+			/* d2795438-25d6-11e8-864e-cb7a18b34643 */
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+
+	},
+		{
+		.load_order = POST_LAUNCHED_VM,
+		.uuid = {0x49U, 0x5aU, 0xe2U, 0xe5U, 0x26U, 0x03U, 0x4dU, 0x64U,	\
+			 0xafU, 0x76U, 0xd4U, 0xbcU, 0x5aU, 0x8eU, 0xc0U, 0xe5U},
+			/* 495ae2e5-2603-4d64-af76-d4bc5a8ec0e5 */
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+
+	},
+	{
+		.load_order = POST_LAUNCHED_VM,
+		.uuid = {0x38U, 0x15U, 0x88U, 0x21U, 0x52U, 0x08U, 0x40U, 0x05U,	\
+			 0xb7U, 0x2aU, 0x8aU, 0x60U, 0x9eU, 0x41U, 0x90U, 0xd0U},
+			/* 38158821-5208-4005-b72a-8a609e4190d0 */
+		.vuart[0] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		},
+		.vuart[1] = {
+			.type = VUART_LEGACY_PIO,
+			.addr.port_base = INVALID_COM_BASE,
+		}
+
+	}
+};

--- a/hypervisor/scenarios/sdc2/vm_configurations.h
+++ b/hypervisor/scenarios/sdc2/vm_configurations.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef VM_CONFIGURATIONS_H
+#define VM_CONFIGURATIONS_H
+
+#include <misc_cfg.h>
+
+#define CONFIG_MAX_VM_NUM		(4U + CONFIG_MAX_KATA_VM_NUM)
+
+/* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
+#define DM_OWNED_GUEST_FLAG_MASK	(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | \
+						GUEST_FLAG_RT | GUEST_FLAG_IO_COMPLETION_POLLING)
+
+#define SOS_VM_BOOTARGS			SOS_ROOTFS	\
+					"rw rootwait "	\
+					"console=tty0 " \
+					SOS_CONSOLE	\
+					"consoleblank=0 "	\
+					"no_timer_check "	\
+					"quiet loglevel=3 "	\
+					"i915.nuclear_pageflip=1 " \
+					"i915.avail_planes_per_pipe=0x01010F "	\
+					"i915.domain_plane_owners=0x011111110000 " \
+					"i915.enable_gvt=1 "	\
+					SOS_BOOTARGS_DIFF
+
+#endif /* VM_CONFIGURATIONS_H */


### PR DESCRIPTION
Per community requirement;up to three post-launched VM might be
needed for some automotive SDC system, so add SDC2 scenario to
satisfy this requirement.

Tracked-On: #3429
Signed-off-by: fuzhongl <fuzhong.liu@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>