### PR TITLE
 Enforce no interrupt to RT VM via vlapic once lapic pt

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -601,7 +601,7 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 		vcpu->arch.cur_context = NORMAL_WORLD;
 
 		vlapic = vcpu_vlapic(vcpu);
-		vlapic_reset(vlapic);
+		vlapic_reset(vlapic, apicv_ops);
 
 		reset_vcpu_regs(vcpu);
 	}

--- a/hypervisor/arch/x86/guest/vlapic_priv.h
+++ b/hypervisor/arch/x86/guest/vlapic_priv.h
@@ -82,14 +82,4 @@
 #define APIC_OFFSET_TIMER_DCR	0x3E0U	/* Timer's Divide Configuration	*/
 #define APIC_OFFSET_SELF_IPI    0x3F0U  /* Self IPI Register */
 
-struct acrn_apicv_ops {
-	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
-	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
-	bool (*has_pending_delivery_intr)(struct acrn_vcpu *vcpu);
-	bool (*apic_read_access_may_valid)(uint32_t offset);
-	bool (*apic_write_access_may_valid)(uint32_t offset);
-	bool (*x2apic_read_msr_may_valid)(uint32_t offset);
-	bool (*x2apic_write_msr_may_valid)(uint32_t offset);
-};
-
 #endif /* VLAPIC_PRIV_H */

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -34,7 +34,6 @@
 #include <timer.h>
 #include <apicreg.h>
 
-
 /**
  * @file vlapic.h
  *
@@ -85,6 +84,8 @@ struct acrn_vlapic {
 
 	uint64_t	msr_apicbase;
 
+	const struct acrn_apicv_ops *ops;
+
 	/*
 	 * Copies of some registers in the virtual APIC page. We do this for
 	 * a couple of different reasons:
@@ -95,6 +96,17 @@ struct acrn_vlapic {
 	uint32_t	lvt_last[VLAPIC_MAXLVT_INDEX + 1];
 } __aligned(PAGE_SIZE);
 
+struct acrn_apicv_ops {
+	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
+	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
+	bool (*has_pending_delivery_intr)(struct acrn_vcpu *vcpu);
+	bool (*apic_read_access_may_valid)(uint32_t offset);
+	bool (*apic_write_access_may_valid)(uint32_t offset);
+	bool (*x2apic_read_msr_may_valid)(uint32_t offset);
+	bool (*x2apic_write_msr_may_valid)(uint32_t offset);
+};
+
+extern const struct acrn_apicv_ops *apicv_ops;
 void vlapic_set_apicv_ops(void);
 
 /**
@@ -182,7 +194,7 @@ void vlapic_free(struct acrn_vcpu *vcpu);
  * @pre vlapic->vcpu->vcpu_id < CONFIG_MAX_VCPUS_PER_VM
  */
 void vlapic_init(struct acrn_vlapic *vlapic);
-void vlapic_reset(struct acrn_vlapic *vlapic);
+void vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops);
 void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs);
 uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);


### PR DESCRIPTION
Because we depend on guest OS to switch x2apic mode to enable lapic pass-thru, vlapic is working at the early stage of booting, eg: in virtual boot loader.
After lapic pass-thru enabled, no interrupt should be injected via vlapic any more.

To enforce that, this series add an ops pointer in vlapic structure and reset the vlapic to clear the pending status and assign the ops with invalid ptapic_ops.

Tracked-On: #3227