### PR TITLE
doc: Add tutorial to learn to sign binaries of a Clear Linux image.

### DIFF
--- a/doc/scripts/sign_image.sh
+++ b/doc/scripts/sign_image.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright (C) 2019 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+
+help() {
+	echo "==================================================================================================="
+	echo "Usage:"
+	echo "$SIGN_SCRIPT param1 param2 param3"
+	echo "    param1: path to clear linux image"
+	echo "    param2: path to the key"
+	echo "    param3: path to the cert"
+	echo ""
+	echo "Pre-requisites:"
+	echo "    1. install sbsigntool: https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/"
+	echo "    2. download clear linux release for VM and extract the image: https://cdn.download.clearlinux.org/releases/"
+	echo "    3. run this script with sudo"
+	echo "==================================================================================================="
+}
+
+sign_binaries_under_dir() {
+	local DIR=$1
+	for file in $DIR/*
+	do
+		if test -f $file
+		then
+			echo $file
+			(sbsign --key $SIGN_KEY --cert $SIGN_CRT --output $file $file) && (echo "sign $file succeed")
+		else
+			sign_binaries_under_dir $file
+		fi
+	done
+}
+
+
+SIGN_SCRIPT=$0
+CLEAR_UOS_IMAGE=$1
+SIGN_KEY=$2
+SIGN_CRT=$3
+BOOT_PART="p1"
+MNT_POINT=/mnt
+
+if [[ ! -f $1 || ! -f $2 || ! -f $3 ]]
+then
+	help
+	exit
+fi
+
+if [ "$(id -u)" != "0" ]
+then
+	echo "This script requires root privilege. Please run it with sudo or switch to root user."
+	exit
+fi
+
+CLEAR_UOS_IMAGE_SIGNED=$CLEAR_UOS_IMAGE.signed
+
+cp $CLEAR_UOS_IMAGE $CLEAR_UOS_IMAGE_SIGNED
+
+LOOP_DEV=`losetup -f -P --show $CLEAR_UOS_IMAGE_SIGNED`
+
+if [ ! -d $MNT_POINT ]
+then
+	mkdir $MNT_POINT
+fi
+
+(mount $LOOP_DEV$BOOT_PART $MNT_POINT) && (sign_binaries_under_dir $MNT_POINT/EFI)
+
+umount /mnt
+sync
+losetup -d $LOOP_DEV

--- a/doc/tutorials/sign_clear_linux_image.rst
+++ b/doc/tutorials/sign_clear_linux_image.rst
@@ -1,0 +1,38 @@
+.. _sign_clear_linux_image:
+
+How to sign binaries of the Clear Linux image
+#############################################
+
+In this tutorial, you will see how to sign the binaries of a Clear Linux image so that you can
+boot it through a secure boot enabled OVMF.
+
+Prerequisites
+*************
+* Install **sbsigntool** on Ubuntu (Verified on 18.04)::
+
+  $ sudo apt install sbsigntool
+
+* Download and extract the Clear Linux image from the `release <https://cdn.download.clearlinux.org/releases/>`_::
+
+  $ export https_proxy=<your https proxy>:<port>
+  $ wget https://cdn.download.clearlinux.org/releases/29880/clear/clear-29880-kvm.img.xz
+  $ unxz clear-29880-kvm.img.xz
+
+* Download script `sign_image.sh
+  <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/doc/scripts/>`_ on Ubuntu.
+
+Steps to sign the binaries of the Clear Linux image
+***************************************************
+#. Follow the `KeyGeneration <https://wiki.ubuntu.com/UEFI/SecureBoot/KeyManagement/KeyGeneration>`_ to generate
+   the key and certification which will be used to sign the binaries.
+
+#. Get these files from the previous step:
+
+   * archive-subkey-private.key
+   * archive-subkey-public.crt
+
+#. Use the script to sign binaries in the Clear Linux image::
+
+   $ sudo sh sign_image.sh $PATH_TO_CLEAR_IMAGE $PATH_TO_KEY $PATH_TO_CERT
+
+#. **clear-xxx-kvm.img.signed** will be generated in the same folder as the original clear-xxx-kvm.img.


### PR DESCRIPTION
This tutorial will describe steps to sign binaries of
a Clear Linux image that allows user to launch VM
throught the secure boot enabled OVMF.

Signed-off-by: lirui34 <ruix.li@intel.com>