### PR TITLE
apl_sdc_stable:hv: fix symbols not stripped from release binaries

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -52,6 +52,9 @@ LDFLAGS += -Wl,-z,noexecstack
 LDFLAGS += -Wl,-z,relro,-z,now
 LDFLAGS += -pie
 LDFLAGS += -L$(TOOLS_OUT)
+ifeq ($(RELEASE),1)
+LDFLAGS += -s
+endif
 
 LIBS = -lrt
 LIBS += -lpthread

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -18,6 +18,7 @@ BASEDIR := $(shell pwd)
 HV_OBJDIR ?= $(CURDIR)/build
 HV_FILE := acrn
 SUB_MAKEFILES := $(wildcard */Makefile)
+RELEASE ?= 0
 
 LIB_DEBUG = $(HV_OBJDIR)/debug/libdebug.a
 LIB_RELEASE = $(HV_OBJDIR)/release/librelease.a
@@ -88,6 +89,10 @@ ifeq (y, $(CONFIG_RELOC))
 LDFLAGS += -pie -z noreloc-overflow
 else
 LDFLAGS += -static
+endif
+
+ifeq ($(RELEASE),y)
+LDFLAGS += -s
 endif
 
 ARCH_CFLAGS += -gdwarf-2

--- a/tools/acrn-manager/Makefile
+++ b/tools/acrn-manager/Makefile
@@ -47,6 +47,9 @@ LDFLAGS += -pie
 LDFLAGS += -L$(OUT_DIR)
 LDFLAGS +=  -lpthread
 LDFLAGS += -lacrn-mngr
+ifeq ($(RELEASE),1)
+LDFLAGS += -s
+endif
 
 .PHONY: all
 ifeq ($(RELEASE),0)


### PR DESCRIPTION
In release environment, binary files must be stripped in
order to remove debugging code sections and symbol information
that aid attackers in the process of disassembly and reverse
engineering.
Use '-s' linking option to remove symbol table and relocation
information from release binaries.

Tracked-On: #3433
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>