### PR TITLE
vpci: fix coding style issue

### DIFF
--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -100,7 +100,7 @@ static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-static int32_t vhostbridge_read_cfg(struct pci_vdev *vdev, uint32_t offset,
+static int32_t vhostbridge_read_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
@@ -122,14 +122,14 @@ static int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-static struct pci_vdev_ops vhostbridge_ops = {
+static const struct pci_vdev_ops vhostbridge_ops = {
 	.init_vdev	= init_vhostbridge,
 	.deinit_vdev	= deinit_vhostbridge,
 	.write_vdev_cfg	= vhostbridge_write_cfg,
 	.read_vdev_cfg	= vhostbridge_read_cfg,
 };
 
-struct pci_vdev_ops *get_vhostbridge_ops(void)
+const struct pci_vdev_ops *get_vhostbridge_ops(void)
 {
 	return &vhostbridge_ops;
 }

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -346,9 +346,9 @@ static void vpci_init_pt_dev(struct pci_vdev *vdev)
 
 static void vpci_deinit_pt_dev(struct pci_vdev *vdev)
 {
-	deinit_vmsi(vdev);
-	deinit_vmsix(vdev);
 	remove_vdev_pt_iommu_domain(vdev);
+	deinit_vmsix(vdev);
+	deinit_vmsi(vdev);
 }
 
 static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
@@ -368,7 +368,7 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-static int32_t vpci_read_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
+static int32_t vpci_read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t *val)
 {
 	if (vbar_access(vdev, offset, bytes)) {
@@ -385,7 +385,7 @@ static int32_t vpci_read_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-static struct pci_vdev_ops pci_pt_dev_ops = {
+static const struct pci_vdev_ops pci_pt_dev_ops = {
 	.init_vdev	= vpci_init_pt_dev,
 	.deinit_vdev	= vpci_deinit_pt_dev,
 	.write_vdev_cfg	= vpci_write_pt_dev_cfg,

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -69,7 +69,7 @@ struct pci_vdev_ops {
        void    (*init_vdev)(struct pci_vdev *vdev);
        void    (*deinit_vdev)(struct pci_vdev *vdev);
        int32_t (*write_vdev_cfg)(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-       int32_t (*read_vdev_cfg)(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+       int32_t (*read_vdev_cfg)(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 };
 
 struct pci_vdev {
@@ -95,7 +95,7 @@ struct pci_vdev {
 	struct acrn_vm_pci_ptdev_config *ptdev_config;
 
 	/* Pointer to corressponding operations */
-	struct pci_vdev_ops *vdev_ops;
+	const struct pci_vdev_ops *vdev_ops;
 };
 
 struct pci_addr_info {
@@ -116,6 +116,6 @@ void vpci_cleanup(const struct acrn_vm *vm);
 void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 
-struct pci_vdev_ops *get_vhostbridge_ops(void);
+const struct pci_vdev_ops *get_vhostbridge_ops(void);
 
 #endif /* VPCI_H_ */


### PR DESCRIPTION
This is a followup patch to fix the coding style issue introduced
in by commit "c2d25aafb889ade954af8795df2405a94024d860":
  The unmodified pointer should be defined as const

Also addressed one comments from Fei to use reversed function call
in vpci_init_pt_dev and vpci_deinit_pt_dev.

Tracked-On: #3241
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>