### PR TITLE
dm: virtio-i2c: minor fix

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_i2c.c
+++ b/devicemodel/hw/pci/virtio/virtio_i2c.c
@@ -443,7 +443,7 @@ native_adapter_create(int bus, uint16_t slave_addr[], int n_slave)
 		return NULL;
 	}
 
-	sprintf(native_path, "/dev/i2c-%d", bus);
+	snprintf(native_path, sizeof(native_path), "/dev/i2c-%d", bus);
 	fd = open(native_path, O_RDWR);
 	if (fd < 0) {
 		WPRINTF("virtio_i2c: failed to open %s\n", native_path);
@@ -645,7 +645,7 @@ virtio_i2c_parse(struct virtio_i2c *vi2c, char *optstr)
 			}
 			cp = t;
 		}
-		if (n_adapter > MAX_NATIVE_I2C_ADAPTER) {
+		if (n_adapter >= MAX_NATIVE_I2C_ADAPTER) {
 			WPRINTF("too many adapter, only support %d \n", MAX_NATIVE_I2C_ADAPTER);
 			return -1;
 		}


### PR DESCRIPTION
Change the condition of checking native adapter number.
Change sprintf to snprintf.

Tracked-On: #3437
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>