### PR TITLE
DM: Ovmf NV storage writeback support

### DIFF
--- a/devicemodel/core/hugetlb.c
+++ b/devicemodel/core/hugetlb.c
@@ -773,9 +773,14 @@ int hugetlb_setup_memory(struct vmctx *ctx)
 
 	/* map ept for biosmem */
 	if (ctx->biosmem > 0) {
+		/*
+		 * The High BIOS region can behave as RAM and be
+		 * modified by the boot firmware itself (e.g. OVMF
+		 * NV data storage region).
+		 */
 		if (vm_map_memseg_vma(ctx, ctx->biosmem, 4 * GB - ctx->biosmem,
 			(uint64_t)(ctx->baseaddr + 4 * GB - ctx->biosmem),
-			PROT_READ | PROT_EXEC) < 0)
+			PROT_ALL) < 0)
 		goto err;
 	}
 

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -516,6 +516,12 @@ vrtc_fail:
 static void
 vm_deinit_vdevs(struct vmctx *ctx)
 {
+	/*
+	 * Write ovmf NV storage back to the original file from guest
+	 * memory before deinit operations.
+	 */
+	acrn_writeback_ovmf_nvstorage(ctx);
+
 	deinit_pci(ctx);
 	monitor_close();
 
@@ -535,6 +541,12 @@ vm_deinit_vdevs(struct vmctx *ctx)
 static void
 vm_reset_vdevs(struct vmctx *ctx)
 {
+	/*
+	 * Write ovmf NV storage back to the original file from guest
+	 * memory before deinit operations.
+	 */
+	acrn_writeback_ovmf_nvstorage(ctx);
+
 	/*
 	 * The current virtual devices doesn't define virtual
 	 * device reset function. So we call vdev deinit/init

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -55,6 +55,7 @@ struct e820_entry {
 
 extern const struct e820_entry e820_default_entries[NUM_E820_ENTRIES];
 extern int with_bootargs;
+extern bool writeback_nv_storage;
 
 size_t ovmf_image_size(void);
 
@@ -78,6 +79,7 @@ int acrn_sw_load_bzimage(struct vmctx *ctx);
 int acrn_sw_load_elf(struct vmctx *ctx);
 int acrn_sw_load_vsbl(struct vmctx *ctx);
 int acrn_sw_load_ovmf(struct vmctx *ctx);
+int acrn_writeback_ovmf_nvstorage(struct vmctx *ctx);
 int acrn_sw_load(struct vmctx *ctx);
 #endif
 

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -33,14 +33,12 @@
 #include <uuid/uuid.h>
 #include "types.h"
 #include "vmm.h"
+#include "macros.h"
 
 /*
  * API version for out-of-tree consumers for making compile time decisions.
  */
 #define	VMMAPI_VERSION	0103	/* 2 digit major followed by 2 digit minor */
-
-#define	MB	(1024 * 1024UL)
-#define	GB	(1024 * 1024 * 1024UL)
 
 #define ALIGN_UP(x, align)	(((x) + ((align)-1)) & ~((align)-1))
 #define ALIGN_DOWN(x, align)	((x) & ~((align)-1))


### PR DESCRIPTION
To support modification of OVMF NV storage, give write permission to guest for writeback support. Add an option "w" for --ovmf to write the changed OVMF NV storage back to the original OVMF image from guest memory before deinit operations.
