### PR TITLE
Hv main refine

### DIFF
--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -224,9 +224,15 @@ int32_t vmexit_handler(struct acrn_vcpu *vcpu)
 			/* exit dispatch handling */
 			if (basic_exit_reason == VMX_EXIT_REASON_EXTERNAL_INTERRUPT) {
 				/* Handling external_interrupt should disable intr */
-				CPU_IRQ_DISABLE();
+				if (!is_lapic_pt_enabled(vcpu)) {
+					CPU_IRQ_DISABLE();
+				}
+
 				ret = dispatch->handler(vcpu);
-				CPU_IRQ_ENABLE();
+
+				if (!is_lapic_pt_enabled(vcpu)) {
+					CPU_IRQ_ENABLE();
+				}
 			} else {
 				ret = dispatch->handler(vcpu);
 			}

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -361,6 +361,8 @@ void dispatch_interrupt(const struct intr_excp_ctx *ctx)
 	} else {
 		handle_spurious_interrupt(vr);
 	}
+
+	do_softirq();
 }
 
 void dispatch_exception(struct intr_excp_ctx *ctx)

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -28,11 +28,7 @@ void vcpu_thread(struct sched_object *obj)
 		}
 
 		if (!is_lapic_pt_enabled(vcpu)) {
-			/* handle pending softirq when irq enable*/
-			do_softirq();
 			CPU_IRQ_DISABLE();
-			/* handle risk softirq when disabling irq*/
-			do_softirq();
 		}
 
 		/* Don't open interrupt window between here and vmentry */

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -34,7 +34,6 @@ void vcpu_thread(struct sched_object *obj)
 		/* Don't open interrupt window between here and vmentry */
 		if (need_reschedule(vcpu->pcpu_id)) {
 			schedule();
-			continue;
 		}
 
 		/* Check and process pending requests(including interrupt) */
@@ -42,7 +41,8 @@ void vcpu_thread(struct sched_object *obj)
 		if (ret < 0) {
 			pr_fatal("vcpu handling pending request fail");
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
-			continue;
+			/* Fatal error happened (triple fault). Stop the vcpu running. */
+			schedule();
 		}
 
 		profiling_vmenter_handler(vcpu);
@@ -52,7 +52,8 @@ void vcpu_thread(struct sched_object *obj)
 		if (ret != 0) {
 			pr_fatal("vcpu resume failed");
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
-			continue;
+			/* Fatal error happened (resume vcpu failed). Stop the vcpu running. */
+			schedule();
 		}
 		basic_exit_reason = vcpu->arch.exit_reason & 0xFFFFU;
 		TRACE_2L(TRACE_VM_EXIT, basic_exit_reason, vcpu_get_rip(vcpu));

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -48,6 +48,7 @@ struct per_cpu_region {
 	uint8_t stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint32_t lapic_id;
 	uint32_t lapic_ldr;
+	uint32_t softirq_servicing;
 	struct smp_call_info_data smp_call_info;
 #ifdef PROFILING_ON
 	struct profiling_info_wrapper profiling_info;


### PR DESCRIPTION
This patch set is used to revise the hv_main loop to prevent acrn_handle_pending_request
called twice in one vmexit.

Tracked-On: #3387
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>
