### PR TITLE
HV: move vbar info to board specific pci_devices.h

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/pci_devices.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/pci_devices.h
@@ -8,8 +8,17 @@
 #define PCI_DEVICES_H_
 
 #define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x00U}
-#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U}
-#define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x00U}
+
+#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x00U},	\
+				.vbar_base[0] = 0xb3f10000UL,				\
+				.vbar_base[1] = 0xb3f53000UL,				\
+				.vbar_base[5] = 0xb3f52000UL
+
+#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U},	\
+				.vbar_base[0] = 0xb3f00000UL
+
+#define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x02U, .d = 0x00U, .f = 0x00U},	\
+				.vbar_base[0] = 0xb3c00000UL,				\
+				.vbar_base[3] = 0xb3c80000UL
 
 #endif /* PCI_DEVICES_H_ */

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/pci_devices.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/pci_devices.h
@@ -8,8 +8,19 @@
 #define PCI_DEVICES_H_
 
 #define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x17U, .f = 0x00U}
-#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
-#define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x1fU, .f = 0x06U}
+
+#define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x17U, .f = 0x00U},	\
+				.vbar_base[0] = 0xdf248000UL, 				\
+				.vbar_base[1] = 0xdf24c000UL,				\
+				.vbar_base[5] = 0xdf24b000UL
+
+#define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}, 	\
+				.vbar_base[0] = 0xdf230000UL
+
+#define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x1fU, .f = 0x06U},	\
+				.vbar_base[0] = 0xdf200000UL
+
+#define NETWORK_CONTROLLER_0	.pbdf.bits = {.b = 0x10U, .d = 0x00U, .f = 0x00U},	\
+				.vbar_base[0] = 0xdf100000UL
 
 #endif /* PCI_DEVICES_H_ */

--- a/hypervisor/scenarios/logical_partition/pt_dev.c
+++ b/hypervisor/scenarios/logical_partition/pt_dev.c
@@ -7,6 +7,11 @@
 #include <vm_config.h>
 #include <pci_devices.h>
 
+/* The vbar_base info of pt devices is included in device MACROs which defined in
+ *           arch/x86/configs/$(CONFIG_BOARD)/pci_devices.h.
+ * The memory range of vBAR should exactly match with the e820 layout of VM.
+ */
+
 struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
@@ -14,15 +19,10 @@ struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
-		.vbar_base[0] = 0xc0084000UL,
-		.vbar_base[1] = 0xc0086000UL,
-		.vbar_base[5] = 0xc0087000UL,
 		VM0_STORAGE_CONTROLLER
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
-		.vbar_base[0] = 0xc0000000UL,
-		.vbar_base[3] = 0xc0080000UL,
 		VM0_NETWORK_CONTROLLER
 	},
 };
@@ -34,7 +34,6 @@ struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM] = {
 	},
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
-		.vbar_base[0] = 0xc0000000UL,
 		VM1_STORAGE_CONTROLLER
 	},
 #if defined(VM1_NETWORK_CONTROLLER)


### PR DESCRIPTION
The vbar info which hard-coded in scenarios/logical_partition/pt_dev.c
is board specific actually, so move these information to
arch/x86/configs/$(CONFIG_BOARD)/pci_devices.h.

Please be aware that the memory range of vBAR should exactly match with
the e820 layout of VM.

Tracked-On: #3214

Signed-off-by: Victor Sun <victor.sun@intel.com>