### PR TITLE
The race condition pf monitor/mwait in wait_sync_change

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -413,21 +413,29 @@ static void print_hv_banner(void)
 	printf(boot_msg);
 }
 
+static
+inline void asm_monitor(volatile const uint64_t *addr, uint64_t ecx, uint64_t edx)
+{
+	asm volatile("monitor\n" : : "a" (addr), "c" (ecx), "d" (edx));
+}
+
+static
+inline void asm_mwait(uint64_t eax, uint64_t ecx)
+{
+	asm volatile("mwait\n" : : "a" (eax), "c" (ecx));
+}
+
 /* wait until *sync == wake_sync */
-void wait_sync_change(uint64_t *sync, uint64_t wake_sync)
+void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync)
 {
 	if (has_monitor_cap()) {
 		/* Wait for the event to be set using monitor/mwait */
-		asm volatile ("1: cmpq      %%rbx,(%%rax)\n"
-			      "   je        2f\n"
-			      "   monitor\n"
-			      "   mwait\n"
-			      "   jmp       1b\n"
-			      "2:\n"
-			      :
-			      : "a" (sync), "d"(0), "c"(0),
-			      "b"(wake_sync)
-			      : "cc");
+		while ((*sync) != wake_sync) {
+			asm_monitor(sync, 0UL, 0UL);
+			if ((*sync) != wake_sync) {
+				asm_mwait(0UL, 0UL);
+			}
+		}
 	} else {
 		/* Wait for the event to be set using pause */
 		asm volatile ("1: cmpq      %%rbx,(%%rax)\n"

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -437,16 +437,9 @@ void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync)
 			}
 		}
 	} else {
-		/* Wait for the event to be set using pause */
-		asm volatile ("1: cmpq      %%rbx,(%%rax)\n"
-			      "   je        2f\n"
-			      "   pause\n"
-			      "   jmp       1b\n"
-			      "2:\n"
-			      :
-			      : "a" (sync), "d"(0), "c"(0),
-			      "b"(wake_sync)
-			      : "cc");
+		while ((*sync) != wake_sync) {
+			asm_pause();
+		}
 	}
 }
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -270,7 +270,7 @@ void init_pcpu_post(uint16_t pcpu_id);
 bool start_pcpus(uint64_t mask);
 void wait_pcpus_offline(uint64_t mask);
 void stop_pcpus(void);
-void wait_sync_change(uint64_t *sync, uint64_t wake_sync);
+void wait_sync_change(volatile const uint64_t *sync, uint64_t wake_sync);
 
 #define CPU_SEG_READ(seg, result_ptr)						\
 {										\


### PR DESCRIPTION
monitor/mwait is used to wait for the specific write op from the other CPUS. It will firstly check whether the condition is expected before entering monitor/mwait. If it is not expected, monitor and mwait will be executed.
But if the write happens between check and monitor, it will have the possible lockup.
This is to fix the race condition of monitor/mwait in wait_sync_change