### PR TITLE
HV: allow write 0 to MSR_IA32_MCG_STATUS

### DIFF
--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -635,8 +635,14 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 		err = vlapic_set_apicbase(vcpu_vlapic(vcpu), v);
 		break;
 	}
-	case MSR_IA32_MCG_CAP:
 	case MSR_IA32_MCG_STATUS:
+	{
+		if (v != 0U) {
+			err = -EACCES;
+		}
+		break;
+	}
+	case MSR_IA32_MCG_CAP:
 	case MSR_IA32_FEATURE_CONTROL:
 	case MSR_IA32_SGXLEPUBKEYHASH0:
 	case MSR_IA32_SGXLEPUBKEYHASH1:


### PR DESCRIPTION
Per SDM, writing 0 to MSR_IA32_MCG_STATUS is allowed, HV should not
return -EACCES on this case;

Tracked-On: #3454

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>