### PR TITLE
Uart: enable early boot uart for debugging

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -120,6 +120,10 @@ void init_pcpu_pre(bool is_bsp)
 		 */
 		init_pcpu_capabilities();
 
+		if (detect_hardware_support() != 0) {
+			panic("hardware not support!");
+		}
+
 		init_pcpu_model_name();
 
 		load_pcpu_state_data();
@@ -127,10 +131,6 @@ void init_pcpu_pre(bool is_bsp)
 		/* Initialize the hypervisor paging */
 		init_e820();
 		init_paging();
-
-		if (!pcpu_has_cap(X86_FEATURE_X2APIC)) {
-			panic("x2APIC is not present!");
-		}
 
 		early_init_lapic();
 
@@ -198,10 +198,6 @@ void init_pcpu_post(uint16_t pcpu_id)
 		pr_acrnlog("Detect processor: %s", (get_pcpu_info())->model_name);
 
 		pr_dbg("Core %hu is up", BOOT_CPU_ID);
-
-		if (detect_hardware_support() != 0) {
-			panic("hardware not support!");
-		}
 
 		if (!sanitize_vm_config()) {
 			panic("VM Configuration Error!");

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -109,7 +109,6 @@ void init_pcpu_pre(bool is_bsp)
 
 		(void)parse_hv_cmdline();
 		/*
-		 * WARNNING: here assume that vaddr2paddr is identical mapping.
 		 * Enable UART as early as possible.
 		 * Then we could use printf for debugging on early boot stage.
 		 */
@@ -131,6 +130,12 @@ void init_pcpu_pre(bool is_bsp)
 		/* Initialize the hypervisor paging */
 		init_e820();
 		init_paging();
+
+		/*
+		 * Need update uart_base_address here for vaddr2paddr mapping may changed
+		 * WARNNING: DO NOT CALL PRINTF BETWEEN ENABLE PAGING IN init_paging AND HERE!
+		 */
+		uart16550_init(false);
 
 		early_init_lapic();
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -26,6 +26,7 @@
 #include <cat.h>
 #include <vboot.h>
 #include <sgx.h>
+#include <uart16550.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
@@ -105,6 +106,14 @@ void init_pcpu_pre(bool is_bsp)
 
 		/* Clear BSS */
 		(void)memset(&ld_bss_start, 0U, (size_t)(&ld_bss_end - &ld_bss_start));
+
+		(void)parse_hv_cmdline();
+		/*
+		 * WARNNING: here assume that vaddr2paddr is identical mapping.
+		 * Enable UART as early as possible.
+		 * Then we could use printf for debugging on early boot stage.
+		 */
+		uart16550_init(true);
 
 		/* Get CPU capabilities thru CPUID, including the physical address bit
 		 * limit which is required for initializing paging.

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -332,15 +332,15 @@ static int32_t check_vmx_mmu_cap(void)
 	int32_t ret = 0;
 
 	if (!pcpu_has_vmx_ept_cap(VMX_EPT_INVEPT)) {
-		pr_fatal("%s, invept not supported\n", __func__);
+		printf("%s, invept not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_vmx_vpid_cap(VMX_VPID_INVVPID) ||
 		!pcpu_has_vmx_vpid_cap(VMX_VPID_INVVPID_SINGLE_CONTEXT) ||
 		!pcpu_has_vmx_vpid_cap(VMX_VPID_INVVPID_GLOBAL_CONTEXT)) {
-		pr_fatal("%s, invvpid not supported\n", __func__);
+		printf("%s, invvpid not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_vmx_ept_cap(VMX_EPT_1GB_PAGE)) {
-		pr_fatal("%s, ept not support 1GB large page\n", __func__);
+		printf("%s, ept not support 1GB large page\n", __func__);
 		ret = -ENODEV;
 	} else {
 		/* No other state currently, do nothing */
@@ -361,65 +361,65 @@ int32_t detect_hardware_support(void)
 
 	/* Long Mode (x86-64, 64-bit support) */
 	if (!pcpu_has_cap(X86_FEATURE_LM)) {
-		pr_fatal("%s, LM not supported\n", __func__);
+		printf("%s, LM not supported\n", __func__);
 		ret = -ENODEV;
 	} else if ((boot_cpu_data.phys_bits == 0U) ||
 		(boot_cpu_data.virt_bits == 0U)) {
-		pr_fatal("%s, can't detect Linear/Physical Address size\n", __func__);
+		printf("%s, can't detect Linear/Physical Address size\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_TSC_DEADLINE)) {
 		/* lapic TSC deadline timer */
-		pr_fatal("%s, TSC deadline not supported\n", __func__);
+		printf("%s, TSC deadline not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_NX)) {
 		/* Execute Disable */
-		pr_fatal("%s, NX not supported\n", __func__);
+		printf("%s, NX not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_SMEP)) {
 		/* Supervisor-Mode Execution Prevention */
-		pr_fatal("%s, SMEP not supported\n", __func__);
+		printf("%s, SMEP not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_SMAP)) {
 		/* Supervisor-Mode Access Prevention */
-		pr_fatal("%s, SMAP not supported\n", __func__);
+		printf("%s, SMAP not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_MTRR)) {
-		pr_fatal("%s, MTRR not supported\n", __func__);
+		printf("%s, MTRR not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_CLFLUSHOPT)) {
-		pr_fatal("%s, CLFLUSHOPT not supported\n", __func__);
+		printf("%s, CLFLUSHOPT not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_PAGE1GB)) {
-		pr_fatal("%s, not support 1GB page\n", __func__);
+		printf("%s, not support 1GB page\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_VMX)) {
-		pr_fatal("%s, vmx not supported\n", __func__);
+		printf("%s, vmx not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!is_fast_string_erms_supported_and_enabled()) {
 		ret = -ENODEV;
 	} else if (!pcpu_has_vmx_unrestricted_guest_cap()) {
-		pr_fatal("%s, unrestricted guest not supported\n", __func__);
+		printf("%s, unrestricted guest not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!is_ept_supported()) {
-		pr_fatal("%s, EPT not supported\n", __func__);
+		printf("%s, EPT not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (!is_apicv_basic_feature_supported()) {
-		pr_fatal("%s, APICV not supported\n", __func__);
+		printf("%s, APICV not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (boot_cpu_data.cpuid_level < 0x15U) {
-		pr_fatal("%s, required CPU feature not supported\n", __func__);
+		printf("%s, required CPU feature not supported\n", __func__);
 		ret = -ENODEV;
 	} else if (is_vmx_disabled()) {
-		pr_fatal("%s, VMX can not be enabled\n", __func__);
+		printf("%s, VMX can not be enabled\n", __func__);
 		ret = -ENODEV;
 	} else if (get_pcpu_nums() > CONFIG_MAX_PCPU_NUM) {
-		pr_fatal("%s, pcpu number(%d) is out of range\n", __func__, get_pcpu_nums());
+		printf("%s, pcpu number(%d) is out of range\n", __func__, get_pcpu_nums());
+		ret = -ENODEV;
+	} else if (!pcpu_has_cap(X86_FEATURE_X2APIC)) {
+		printf("%s, x2APIC not supported\n", __func__);
 		ret = -ENODEV;
 	} else {
 		ret = check_vmx_mmu_cap();
-		if (ret == 0) {
-			pr_acrnlog("hardware support HV");
-		}
 	}
 
 	return ret;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -235,6 +235,8 @@ void init_paging(void)
 	high64_max_ram = round_pde_up(p_e820_mem_info->mem_top);
 	if ((high64_max_ram > (CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)) ||
 			(high64_max_ram < (1UL << 32U))) {
+		printf("ERROR!!! high64_max_ram: 0x%llx, top address space: 0x%llx\n",
+			high64_max_ram, CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE);
 		panic("Please configure HV_ADDRESS_SPACE correctly!\n");
 	}
 

--- a/hypervisor/boot/cmdline.c
+++ b/hypervisor/boot/cmdline.c
@@ -24,7 +24,7 @@ int32_t parse_hv_cmdline(void)
 		return -EINVAL;
 	}
 
-	mbi = (struct multiboot_info *)(hpa2hva((uint64_t)boot_regs[1]));
+	mbi = (struct multiboot_info *)(hpa2hva_early((uint64_t)boot_regs[1]));
 	dev_dbg(ACRN_DBG_PARSE, "Multiboot detected, flag=0x%x", mbi->mi_flags);
 
 	if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) == 0U) {
@@ -32,7 +32,7 @@ int32_t parse_hv_cmdline(void)
 		return -EINVAL;
 	}
 
-	start = (char *)hpa2hva((uint64_t)mbi->mi_cmdline);
+	start = (char *)hpa2hva_early((uint64_t)mbi->mi_cmdline);
 	dev_dbg(ACRN_DBG_PARSE, "hv cmdline: %s", start);
 
 	do {

--- a/hypervisor/boot/guest/deprivilege_boot.c
+++ b/hypervisor/boot/guest/deprivilege_boot.c
@@ -26,8 +26,6 @@ static void init_depri_boot(void)
 	struct multiboot_info *mbi = NULL;
 
 	if (!depri_initialized) {
-		(void)parse_hv_cmdline();
-
 		mbi = (struct multiboot_info *) hpa2hva(((uint64_t)(uint32_t)boot_regs[1]));
 		if ((mbi == NULL) || ((mbi->mi_flags & MULTIBOOT_INFO_HAS_DRIVES) == 0U)) {
 			pr_err("no multiboot drivers for depri_boot found");

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -24,7 +24,7 @@ uint16_t console_vmid = ACRN_INVALID_VMID;
 
 void console_init(void)
 {
-	uart16550_init();
+	uart16550_init(false);
 }
 
 void console_putc(const char *ch)

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -24,7 +24,6 @@ uint16_t console_vmid = ACRN_INVALID_VMID;
 
 void console_init(void)
 {
-	uart16550_init(false);
 }
 
 void console_putc(const char *ch)

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -138,6 +138,7 @@ void uart16550_init(bool eraly_boot)
 	}
 
 	if (!eraly_boot && !uart.serial_port_mapped) {
+		uart.mmio_base_vaddr = hpa2hva(hva2hpa_early(uart.mmio_base_vaddr));
 		hv_access_memory_region_update((uint64_t)uart.mmio_base_vaddr, PDE_SIZE);
 		return;
 	}
@@ -146,7 +147,7 @@ void uart16550_init(bool eraly_boot)
 	if (!uart.serial_port_mapped) {
 		serial_pci_bdf.value = get_pci_bdf_value(pci_bdf_info);
 		uart.mmio_base_vaddr =
-			hpa2hva(pci_pdev_read_cfg(serial_pci_bdf, pci_bar_offset(0), 4U) & PCIM_BAR_MEM_BASE);
+			hpa2hva_early(pci_pdev_read_cfg(serial_pci_bdf, pci_bar_offset(0), 4U) & PCIM_BAR_MEM_BASE);
 	}
 
 	spinlock_init(&uart.rx_lock);

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -152,6 +152,29 @@
  *
  * @return The translated host-virtual address
  */
+static inline void *hpa2hva_early(uint64_t x)
+{
+	return (void *)x;
+}
+/**
+ * @brief Translate host-virtual address to host-physical address
+ *
+ * @param[in] x The specified host-virtual address
+ *
+ * @return The translated host-physical address
+ */
+static inline uint64_t hva2hpa_early(void *x)
+{
+	return (uint64_t)x;
+}
+
+/**
+ * @brief Translate host-physical address to host-virtual address
+ *
+ * @param[in] x The specified host-physical address
+ *
+ * @return The translated host-virtual address
+ */
 static inline void *hpa2hva(uint64_t x)
 {
 	return (void *)x;

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -127,7 +127,7 @@
 /* UART oscillator clock */
 #define UART_CLOCK_RATE	1843200U	/* 1.8432 MHz */
 
-void uart16550_init(void);
+void uart16550_init(bool early_boot);
 char uart16550_getc(void);
 size_t uart16550_puts(const char *buf, uint32_t len);
 void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr);

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+
+void uart16550_init(__unused bool early_boot) {}


### PR DESCRIPTION
v2:
Change uart_base_address to host virtual address so that APIs doesn't need to do hpa2hva conversion for MMIO cases. And uart16550_init can achieve the different va per early boot.

v1:
Now if we configure platform ram size wrong, the platform may panic without any
warnning, enable early boot uart could help us to find why is the system goes
weird. And we should do hardware support detection as early as possible. However,
without early boot uart, the unsupported platform will hang silently too.

This serial try to enable uart when early boot and use printf to debug when there's
something wrong.

Tracked-On: #2987
Signed-off-by: Li, Fei1 <fei1.li@intel.com>