### PR TITLE
dm: array bound and NULL pointer issue fix

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -619,7 +619,7 @@ virtio_console_open_backend(const char *path,
 	case VIRTIO_CONSOLE_BE_SOCKET:
 		fd = socket(AF_UNIX, SOCK_STREAM, 0);
 		if (fd < 0)
-			WPRINTF(("vtcon: socket open failed: %s\n", path));
+			WPRINTF(("vtcon: socket open failed \n"));
 		break;
 	default:
 		WPRINTF(("not supported backend %d!\n", be_type));

--- a/devicemodel/hw/pci/virtio/virtio_i2c.c
+++ b/devicemodel/hw/pci/virtio/virtio_i2c.c
@@ -444,6 +444,8 @@ native_adapter_create(int bus, uint16_t slave_addr[], int n_slave)
 	}
 
 	snprintf(native_path, sizeof(native_path), "/dev/i2c-%d", bus);
+	native_path[sizeof(native_path) - 1] = '\0';
+
 	fd = open(native_path, O_RDWR);
 	if (fd < 0) {
 		WPRINTF("virtio_i2c: failed to open %s\n", native_path);


### PR DESCRIPTION
Remove the possible NULL pointer access code for virtio-console.c
Add '\0' to end of native_patch[], to avoid the potential issue when
using %s to print the array for virtio-i2c.c

Tracked-On: #3467
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Yonghua Huang <Yonghua.huang@intel.com>