### PR TITLE
hv: schedule: schedule to idel after SOS resume form S3

### DIFF
--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -168,6 +168,7 @@ static inline void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t 
 static bool pm1ab_io_write(struct acrn_vm *vm, uint16_t addr, size_t width, uint32_t v)
 {
 	static uint32_t pm1a_cnt_ready = 0U;
+	uint32_t pm1a_cnt_val;
 	bool to_write = true;
 
 	if (width == 2U) {
@@ -188,8 +189,9 @@ static bool pm1ab_io_write(struct acrn_vm *vm, uint16_t addr, size_t width, uint
 			&& (val == vm->pm.sx_state_data->s3_pkg.val_pm1b) && (s3_enabled(v) != 0U)) {
 
 			if (pm1a_cnt_ready != 0U) {
-				enter_s3(vm, pm1a_cnt_ready, v);
+				pm1a_cnt_val = pm1a_cnt_ready;
 				pm1a_cnt_ready = 0U;
+				enter_s3(vm, pm1a_cnt_val, v);
 			} else {
 				/* the case broke ACPI spec */
 				pr_err("PM1B_CNT write error!");

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -323,7 +323,7 @@ void reset_vcpu_regs(struct acrn_vcpu *vcpu)
 	set_vcpu_regs(vcpu, &realmode_init_regs);
 }
 
-void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry)
+void set_vcpu_startup_entry(struct acrn_vcpu *vcpu, uint64_t entry)
 {
 	struct ext_context *ectx;
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1159,7 +1159,7 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 				pr_err("Start Secondary VCPU%hu for VM[%d]...",
 					target_vcpu->vcpu_id,
 					target_vcpu->vm->vm_id);
-				set_ap_entry(target_vcpu, (icr_low & APIC_VECTOR_MASK) << 12U);
+				set_vcpu_startup_entry(target_vcpu, (icr_low & APIC_VECTOR_MASK) << 12U);
 				schedule_vcpu(target_vcpu);
 			}
 		}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -608,13 +608,13 @@ int32_t shutdown_vm(struct acrn_vm *vm)
  */
 void start_vm(struct acrn_vm *vm)
 {
-	struct acrn_vcpu *vcpu = NULL;
+	struct acrn_vcpu *bsp = NULL;
 
 	vm->state = VM_STARTED;
 
 	/* Only start BSP (vid = 0) and let BSP start other APs */
-	vcpu = vcpu_from_vid(vm, 0U);
-	schedule_vcpu(vcpu);
+	bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
+	schedule_vcpu(bsp);
 }
 
 /**
@@ -702,7 +702,7 @@ void pause_vm(struct acrn_vm *vm)
  */
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 {
-	struct acrn_vcpu *bsp = vcpu_from_vid(vm, 0U);
+	struct acrn_vcpu *bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
 
 	vm->state = VM_STARTED;
 
@@ -711,10 +711,11 @@ void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 	/* When SOS resume from S3, it will return to real mode
 	 * with entry set to wakeup_vec.
 	 */
-	set_ap_entry(bsp, wakeup_vec);
+	set_vcpu_startup_entry(bsp, wakeup_vec);
 
 	init_vmcs(bsp);
 	schedule_vcpu(bsp);
+	switch_to_idle(default_idle);
 }
 
 /**

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -202,8 +202,8 @@ static void vpic_notify_intr(struct acrn_vpic *vpic)
 		 */
 		i8259->intr_raised = true;
 		if (vpic->vm->wire_mode == VPIC_WIRE_INTR) {
-			struct acrn_vcpu *vcpu = vcpu_from_vid(vpic->vm, 0U);
-			vcpu_inject_extint(vcpu);
+			struct acrn_vcpu *bsp = vcpu_from_vid(vpic->vm, BOOT_CPU_ID);
+			vcpu_inject_extint(bsp);
 		} else {
 			/*
 			 * The input parameters here guarantee the return value of vlapic_set_local_intr is 0, means

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -604,16 +604,16 @@ void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 void reset_vcpu_regs(struct acrn_vcpu *vcpu);
 
 /**
- * @brief set the vcpu AP entry
+ * @brief set the vCPU startup entry
  *
- * Set target vCPU's AP running entry in run_context.
+ * Set target vCPU's startup entry in run_context.
  *
- * @param[inout] vcpu pointer to vcpu data structure
- * @param[in] entry the entry value for AP
+ * @param[inout] vcpu pointer to vCPU data structure
+ * @param[in] entry startup entry for the vCPU
  *
  * @return None
  */
-void set_ap_entry(struct acrn_vcpu *vcpu, uint64_t entry);
+void set_vcpu_startup_entry(struct acrn_vcpu *vcpu, uint64_t entry);
 
 static inline bool is_long_mode(struct acrn_vcpu *vcpu)
 {


### PR DESCRIPTION
After "commit f0e1c5e init vcpu host stack when reset vcpu", SOS resume form S3
wants to schedule to vcpu_thread not the point where SOS enter S3. So we should
schedule to idel first then reschedule to execute vcpu_thread.

Tracked-On: #3387
Signed-off-by: Li, Fei1 <fei1.li@intel.com>