### PR TITLE
dm: bugfix for remote launch guest issue

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -906,19 +906,25 @@ virtio_console_add_backend(struct virtio_console *console, char *opt)
 			be->evp = mevent_add(fd, EVF_READ,
 					virtio_console_accept_new_connection, be,
 					virtio_console_teardown_backend, be);
+			if (be->evp == NULL) {
+				WPRINTF(("vtcon: mevent_add failed\n"));
+				error = -1;
+				goto out;
+			}
+			console->ref_count++;
 		}
 		else if (isatty(fd) || (be->be_type == VIRTIO_CONSOLE_BE_SOCKET
 			&& !strcmp(be->socket_type,"client"))) {
 			be->evp = mevent_add(fd, EVF_READ,
 					virtio_console_backend_read, be,
 					virtio_console_teardown_backend, be);
+			if (be->evp == NULL) {
+				WPRINTF(("vtcon: mevent_add failed\n"));
+				error = -1;
+				goto out;
+			}
+			console->ref_count++;
 		}
-		if (be->evp == NULL) {
-			WPRINTF(("vtcon: mevent_add failed\n"));
-			error = -1;
-			goto out;
-		}
-		console->ref_count++;
 	}
 
 	virtio_console_open_port(be->port, true);


### PR DESCRIPTION
when stdio is set as a virtio-console, guest run in backend, the open
file descriptor is not referring to a terminal.

Tracked-On: #3473
Signed-off-by: Gao Junhao <junhao.gao@intel.com>
Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>