### PR TITLE
More vpci cleanup

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -131,14 +131,14 @@ static uint64_t get_pbar_base(const struct pci_pdev *pdev, uint32_t idx)
  */
 int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
-	int32_t ret = -ENODEV;
-
-	if (is_bar_offset(vdev->nr_bars, offset)) {
+	/* bar access must be 4 bytes and offset must also be 4 bytes aligned */
+	if ((bytes == 4U) && ((offset & 0x3U) == 0U)) {
 		*val = pci_vdev_read_cfg(vdev, offset, bytes);
-		ret = 0;
+	} else {
+		*val = ~0U;
 	}
 
-	return ret;
+	return 0;
 }
 
 /**
@@ -442,15 +442,12 @@ static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t 
  */
 int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	int32_t ret = -ENODEV;
-
-	/* bar write access must be 4 bytes and offset must also be 4 bytes aligned*/
-	if (is_bar_offset(vdev->nr_bars, offset) && (bytes == 4U) && ((offset & 0x3U) == 0U)) {
+	/* bar write access must be 4 bytes and offset must also be 4 bytes aligned */
+	if ((bytes == 4U) && ((offset & 0x3U) == 0U)) {
 		vdev_pt_write_vbar(vdev, offset, val);
-		ret = 0;
 	}
 
-	return ret;
+	return 0;
 }
 
 /**

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -129,7 +129,7 @@ static uint64_t get_pbar_base(const struct pci_pdev *pdev, uint32_t idx)
 /**
  * @pre vdev != NULL
  */
-int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+void vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* bar access must be 4 bytes and offset must also be 4 bytes aligned */
 	if ((bytes == 4U) && ((offset & 0x3U) == 0U)) {
@@ -137,8 +137,6 @@ int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t 
 	} else {
 		*val = ~0U;
 	}
-
-	return 0;
 }
 
 /**
@@ -440,14 +438,12 @@ static void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t offset, uint32_t 
  * @pre vdev != NULL
  * bar write access must be 4 bytes and offset must also be 4 bytes aligned, it will be dropped otherwise
  */
-int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+void vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	/* bar write access must be 4 bytes and offset must also be 4 bytes aligned */
 	if ((bytes == 4U) && ((offset & 0x3U) == 0U)) {
 		vdev_pt_write_vbar(vdev, offset, val);
 	}
-
-	return 0;
 }
 
 /**

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -101,12 +101,10 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 /**
  * @pre vdev != NULL
  */
-int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* For PIO access, we emulate Capability Structures only */
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
-
-	return 0;
 }
 
 /**
@@ -114,7 +112,7 @@ int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t byt
  *
  * @pre vdev != NULL
  */
-int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	bool message_changed = false;
 	bool enable;
@@ -141,8 +139,6 @@ int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, u
 			(void)vmsi_remap(vdev, true);
 		}
 	}
-
-	return 0;
 }
 
 /**

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -166,12 +166,10 @@ static int32_t vmsix_remap_one_entry(const struct pci_vdev *vdev, uint32_t index
 /**
  * @pre vdev != NULL
  */
-int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* For PIO access, we emulate Capability Structures only */
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
-
-	return 0;
 }
 
 /**
@@ -180,7 +178,7 @@ int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t by
  * @pre vdev != NULL
  * @pre vdev->pdev != NULL
  */
-int32_t vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	uint32_t msgctrl;
 
@@ -203,8 +201,6 @@ int32_t vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 			pci_pdev_write_cfg(vdev->pdev->bdf, offset, 2U, val);
 		}
 	}
-
-	return 0;
 }
 
 /**

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -355,11 +355,11 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t val)
 {
 	if (vbar_access(vdev, offset)) {
-		(void)vdev_pt_write_cfg(vdev, offset, bytes, val);
+		vdev_pt_write_cfg(vdev, offset, bytes, val);
 	} else if (msicap_access(vdev, offset)) {
-		(void)vmsi_write_cfg(vdev, offset, bytes, val);
+		vmsi_write_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		(void)vmsix_write_cfg(vdev, offset, bytes, val);
+		vmsix_write_cfg(vdev, offset, bytes, val);
 	} else {
 		/* passthru to physical device */
 		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
@@ -372,11 +372,11 @@ static int32_t vpci_read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset
 		uint32_t bytes, uint32_t *val)
 {
 	if (vbar_access(vdev, offset)) {
-		(void)vdev_pt_read_cfg(vdev, offset, bytes, val);
+		vdev_pt_read_cfg(vdev, offset, bytes, val);
 	} else if (msicap_access(vdev, offset)) {
-		(void)vmsi_read_cfg(vdev, offset, bytes, val);
+		vmsi_read_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		(void)vmsix_read_cfg(vdev, offset, bytes, val);
+		vmsix_read_cfg(vdev, offset, bytes, val);
 	} else {
 		/* passthru to physical device */
 		*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -354,7 +354,7 @@ static void vpci_deinit_pt_dev(struct pci_vdev *vdev)
 static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t val)
 {
-	if (vbar_access(vdev, offset, bytes)) {
+	if (vbar_access(vdev, offset)) {
 		(void)vdev_pt_write_cfg(vdev, offset, bytes, val);
 	} else if (msicap_access(vdev, offset)) {
 		(void)vmsi_write_cfg(vdev, offset, bytes, val);
@@ -371,7 +371,7 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 static int32_t vpci_read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
 		uint32_t bytes, uint32_t *val)
 {
-	if (vbar_access(vdev, offset, bytes)) {
+	if (vbar_access(vdev, offset)) {
 		(void)vdev_pt_read_cfg(vdev, offset, bytes, val);
 	} else if (msicap_access(vdev, offset)) {
 		(void)vmsi_read_cfg(vdev, offset, bytes, val);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -104,9 +104,9 @@ static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)
 /**
  * @pre vdev != NULL
  */
-static inline bool vbar_access(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes)
+static inline bool vbar_access(const struct pci_vdev *vdev, uint32_t offset)
 {
-	return (is_bar_offset(vdev->nr_bars, offset) && (bytes == 4U) && ((offset & 0x3U) == 0U));
+	return is_bar_offset(vdev->nr_bars, offset);
 }
 
 /**
@@ -114,7 +114,7 @@ static inline bool vbar_access(const struct pci_vdev *vdev, uint32_t offset, uin
  */
 static inline bool has_msi_cap(const struct pci_vdev *vdev)
 {
-        return (vdev->msi.capoff != 0U);
+	return (vdev->msi.capoff != 0U);
 }
 
 /**
@@ -122,7 +122,7 @@ static inline bool has_msi_cap(const struct pci_vdev *vdev)
  */
 static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 {
-       return (has_msi_cap(vdev) && in_range(offset, vdev->msi.capoff, vdev->msi.caplen));
+	return (has_msi_cap(vdev) && in_range(offset, vdev->msi.capoff, vdev->msi.caplen));
 }
 
 /**

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -134,18 +134,18 @@ static inline bool is_hostbridge(const struct pci_vdev *vdev)
 }
 
 void init_vdev_pt(struct pci_vdev *vdev);
-int32_t vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
 void init_vmsi(struct pci_vdev *vdev);
-int32_t vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
-int32_t vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-int32_t vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(const struct pci_vdev *vdev);
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);


### PR DESCRIPTION
Clean up vpci code introduced by vdev ops and enabling vhostbridge for sos:
Remove redundant function calling:
The caller function has already done the checking to make sure the req is targeted
for the called functions, so there is no need to do the same checking in called
functions.

Make functions void because their return values are always 0 and are not used.

Tracked-On: #3475
Signed-off-by: dongshen <dongsheng.x.zhang@intel.com>
