### PR TITLE
Makefile: Add install for uefi firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifeq ($(FIRMWARE),sbl)
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
 endif
 ifeq ($(FIRMWARE),uefi)
-	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE) install
 	$(MAKE) -C $(T)/misc/efi-stub HV_OBJDIR=$(HV_OUT) EFI_OBJDIR=$(EFI_OUT) all install
 endif
 

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -374,6 +374,11 @@ else
 endif
 endif
 
+ifeq ($(FIRMWARE),uefi)
+install: $(HV_OBJDIR)/$(HV_FILE).32.out
+	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).32.out
+endif
+
 .PHONY: pre_build
 pre_build: $(PRE_BUILD_OBJS)
 


### PR DESCRIPTION
Add to include acrn.32.out during cl rpm
 generation as acrn.(board).efi.32.out
This is required for Hybrid mode bringup in multios

Tracked-On: #3487 
Signed-off-by: Nikhil Rane <nikhil.rane@intel.com>