### PR TITLE
Acrnctl support force stop VM

### DIFF
--- a/misc/acrn-manager/acrn_vm_ops.c
+++ b/misc/acrn-manager/acrn_vm_ops.c
@@ -366,7 +366,7 @@ int start_vm(const char *vmname)
 	return system(cmd);
 }
 
-int stop_vm(const char *vmname)
+int stop_vm(const char *vmname, int force)
 {
 	struct mngr_msg req;
 	struct mngr_msg ack;
@@ -374,6 +374,7 @@ int stop_vm(const char *vmname)
 	req.magic = MNGR_MSG_MAGIC;
 	req.msgid = DM_STOP;
 	req.timestamp = time(NULL);
+	req.data.acrnd_stop.force = force;
 
 	send_msg(vmname, &req, &ack);
 	if (ack.data.err) {

--- a/misc/acrn-manager/acrnctl.c
+++ b/misc/acrn-manager/acrnctl.c
@@ -442,6 +442,7 @@ static int acrnctl_do_blkrescan(int argc, char *argv[])
 static int acrnctl_do_stop(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
+	int force = 0;
 
 	s = vmmngr_find(argv[1]);
 	if (!s) {
@@ -452,7 +453,7 @@ static int acrnctl_do_stop(int argc, char *argv[])
 		printf("%s is already (%s)\n", argv[1], state_str[s->state]);
 		return -1;
 	}
-	return stop_vm(argv[1]);
+	return stop_vm(argv[1], force);
 
 }
 
@@ -697,7 +698,7 @@ static int acrnctl_do_reset(int argc, char *argv[])
 	switch(s->state) {
 		case VM_STARTED:
 		case VM_SUSPENDED:
-			ret = stop_vm(argv[1]);
+			ret = stop_vm(argv[1], 0);
 			if (ret != 0) {
 				break;
 			}

--- a/misc/acrn-manager/acrnctl.c
+++ b/misc/acrn-manager/acrnctl.c
@@ -29,7 +29,7 @@
 /* vm life cycle cmd description */
 #define LIST_DESC      "List all the virtual machines added"
 #define START_DESC     "Start virtual machine VM_NAME"
-#define STOP_DESC      "Stop virtual machine VM_NAME"
+#define STOP_DESC      "Stop virtual machine VM_NAME, [--force/-f, force to stop VM]"
 #define DEL_DESC       "Delete virtual machine VM_NAME"
 #define ADD_DESC       "Add one virtual machine with SCRIPTS and OPTIONS"
 #define PAUSE_DESC     "Block all vCPUs of virtual machine VM_NAME"
@@ -442,18 +442,34 @@ static int acrnctl_do_blkrescan(int argc, char *argv[])
 static int acrnctl_do_stop(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
-	int force = 0;
+	int i, force = 0;
+	const char *vmname = NULL;
 
-	s = vmmngr_find(argv[1]);
+	for (i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--force") && strcmp(argv[i], "-f")) {
+			if (vmname == NULL)
+				vmname = argv[i];
+		} else {
+			force = 1;
+		}
+	}
+
+	if (!vmname) {
+		printf("Please give a VM name\n");
+		return -1;
+	}
+
+	s = vmmngr_find(vmname);
 	if (!s) {
-		printf("can't find %s\n", argv[1]);
+		printf("can't find %s\n", vmname);
 		return -1;
 	}
 	if (s->state == VM_CREATED) {
-		printf("%s is already (%s)\n", argv[1], state_str[s->state]);
+		printf("%s is already (%s)\n", vmname, state_str[s->state]);
 		return -1;
 	}
-	return stop_vm(argv[1], force);
+
+	return stop_vm(vmname, force);
 
 }
 

--- a/misc/acrn-manager/acrnctl.h
+++ b/misc/acrn-manager/acrnctl.h
@@ -52,7 +52,7 @@ extern struct vmmngr_list_struct vmmngr_head;
 
 /* vm life cycle ops */
 int list_vm(void);
-int stop_vm(const char *vmname);
+int stop_vm(const char *vmname, int force);
 int start_vm(const char *vmname);
 int pause_vm(const char *vmname);
 int continue_vm(const char *vmname);

--- a/misc/acrn-manager/acrnd.c
+++ b/misc/acrn-manager/acrnd.c
@@ -289,7 +289,7 @@ static void stop_all_vms(void)
 	vmmngr_update();
 
 	LIST_FOREACH(vm, &vmmngr_head, list) {
-		err = stop_vm(vm->name);
+		err = stop_vm(vm->name, 0);
 		if (err != 0) {
 			fprintf(stderr, "Fail to send stop cmd to vm %s\n", vm->name);
 		} else {


### PR DESCRIPTION
 Run 'acrnctl stop VM_NAME --force‘ to force stop VM

When run 'acrnctl stop VM_NAME', acrn-dm let guest OS to shutdown
itself. If something wrong with guest OS, it can't shutdown, we can
run 'acrnctl stop VM_NAME --force', thus acrn-dm directly set suspend
mode to VM_SUSPEND_POWEROFF and quit main loop.

Tracked-On: #3484
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Reviewed-by: Yan, Like <like.yan@intel.com>