### PR TITLE
doc: fix issues from moving tools to misc/tools

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -64,7 +64,7 @@ singlehtml: doxy content kconfig
 
 clean:
 	rm -fr $(BUILDDIR) doxygen
-	rm -fr tools
+	rm -fr misc
 	rm -fr reference/kconfig/*.rst
 
 # Copy material over to the GitHub pages staging repo

--- a/doc/developer-guides/hld/virtio-net.rst
+++ b/doc/developer-guides/hld/virtio-net.rst
@@ -426,10 +426,10 @@ our case, we use systemd to automatically create the network by default.
 You can check the files with prefix 50- in the SOS
 ``/usr/lib/systemd/network/``:
 
-- `50-acrn.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/acrn.netdev>`__
-- `50-acrn.network <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/acrn.network>`__
-- `50-tap0.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/tap0.netdev>`__
-- `50-eth.network <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/tools/acrnbridge/eth.network>`__
+- `50-acrn.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/misc/acrnbridge/acrn.netdev>`__
+- `50-acrn.network <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/misc/acrnbridge/acrn.network>`__
+- `50-tap0.netdev <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/misc/acrnbridge/tap0.netdev>`__
+- `50-eth.network <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/misc/acrnbridge/eth.network>`__
 
 When the SOS is started, run ``ifconfig`` to show the devices created by
 this systemd configuration:

--- a/doc/tutorials/docbuild.rst
+++ b/doc/tutorials/docbuild.rst
@@ -26,7 +26,7 @@ The project's documentation contains the following items:
 * ReStructuredText source files used to generate documentation found at the
   http://projectacrn.github.io website. All of the reStructuredText sources
   are found in the acrn-hypervisor/doc folder, or pulled in from sibling
-  folders (such as /tools/) by the build scripts.
+  folders (such as /misc/) by the build scripts.
 
 * Doxygen-generated material used to create all API-specific documents
   found at http://projectacrn.github.io/latest/api/.  The doc build


### PR DESCRIPTION
PR #3483 cleaned up the project root folder and moved stuff that was in
/tools into a new /misc folder.  There were a few references to
the old /tools folder missed in that update, addressed in this PR.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>