### PR TITLE
Acrn config tools

### DIFF
--- a/misc/acrn-config/README
+++ b/misc/acrn-config/README
@@ -1,0 +1,8 @@
+folder structure
+
+	Kconfig		: Select working scenario and target board, configure ACRN hypervisor capabilities and features.
+	target		: Get target board information under native Linux environment and generate board_info XML.
+	board_config	: Parse board_info XML and scenario XML to generate board related configuration files under hypervisor/arch/x86/configs/$(BOARD)/ folder.
+	scenario_config	: Parse board_info XML and scenario XML to generate scenario based VM configuration files under hypervisor/scenarios/$(SCENARIO)/ folder.
+	launch_config	: Parse board_info XML, scenario XML and devicemodel param XML to generate launch script for post-launched vm under devicesmodel/samples/$(BOARD)/ folder.
+	library		: The folder stores shared software modules or libs for acrn-config offline tool.

--- a/misc/acrn-config/board_config/README
+++ b/misc/acrn-config/board_config/README
@@ -1,0 +1,5 @@
+Please run board_cfg_gen.py to generate board related configuration patch, the patch would be applied on current acrn-hypervisor git tree automatically.
+
+usage: python3 board_cfg_gen.py [h] --board <board_info_file>
+positional arguments:
+  board_info_file  : file name of the board info XML

--- a/misc/acrn-config/board_config/acpi_platform_h.py
+++ b/misc/acrn-config/board_config/acpi_platform_h.py
@@ -1,0 +1,158 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import board_cfg_lib
+
+PLATFORM_HEADER = r"""/* DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU ARE DOING!
+ */
+
+#ifndef PLATFORM_ACPI_INFO_H
+#define PLATFORM_ACPI_INFO_H
+"""
+
+PLATFORM_END_HEADER = "\n#endif /* PLATFORM_ACPI_INFO_H */"
+
+class OverridAccessSize():
+    """The Pm access size which are needed to redefine"""
+    def __init__(self):
+        self.pm1a_cnt_ac_sz = True
+        self.pm1b_cnt_ac_sz = True
+        self.pm1b_evt_ac_sz = True
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.pm1a_cnt_ac_sz = True
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.pm1a_cnt_ac_sz = True
+
+
+def multi_parser(line, s_line, pm_ac_sz, config):
+    """Multi parser the line"""
+    addr = ['PM1A_EVT_ADDRESS', 'PM1B_EVT_ADDRESS', 'PM1A_CNT_ADDRESS', 'PM1B_CNT_ADDRESS']
+    space_id = ['PM1A_EVT_SPACE_ID', 'PM1B_EVT_SPACE_ID', 'PM1A_CNT_SPACE_ID', 'PM1B_CNT_SPACE_ID']
+
+    if line.split()[1] in space_id and line.split()[1] == s_line.split()[1]:
+        if line.split()[2] != s_line.split()[2]:
+            print("#undef {}".format(s_line.split()[1]), file=config)
+            print("{}".format(s_line.strip()), file=config)
+        return
+
+    if line.split()[1] in addr and line.split()[1] == s_line.split()[1]:
+        if int(line.split()[2].strip('UL'), 16) != \
+                int(s_line.split()[2].strip('UL'), 16) and \
+                int(s_line.split()[2].strip('UL'), 16) != 0:
+            print("#undef {}".format(s_line.split()[1]), file=config)
+            print("{}".format(s_line.strip()), file=config)
+        else:
+            if "PM1B_EVT" in line.split()[1]:
+                pm_ac_sz.pm1b_evt_ac_sz = False
+            if "PM1B_CNT" in line.split()[1]:
+                pm_ac_sz.pm1b_cnt_ac_sz = False
+
+        return
+
+    if line.split()[1] == s_line.split()[1]:
+        if "PM1B_EVT" in line.split()[1] and not pm_ac_sz.pm1b_evt_ac_sz:
+            return
+
+        if "PM1B_CNT" in line.split()[1] and not pm_ac_sz.pm1b_cnt_ac_sz:
+            return
+
+        if "PM1A_CNT" in line.split()[1] and not pm_ac_sz.pm1a_cnt_ac_sz:
+            return
+
+        if int(line.split()[2].strip('U'), 16) != int(s_line.split()[2].strip('U'), 16):
+            print("#undef {}".format(s_line.split()[1]), file=config)
+            print("{}".format(s_line.strip()), file=config)
+
+
+def multi_info_parser(config, default_platform, msg_s, msg_e):
+    """Parser multi information"""
+    write_direct = ['PM1A_EVT_ACCESS_SIZE', 'PM1A_EVT_ADDRESS', 'PM1A_CNT_ADDRESS']
+
+    pm_ac_sz = OverridAccessSize()
+    multi_lines = board_cfg_lib.get_info(board_cfg_lib.BOARD_INFO_FILE, msg_s, msg_e)
+
+    for s_line in multi_lines:
+        if s_line.split()[1] in write_direct:
+            if "PM1A_CNT" in s_line.split()[1] and int(s_line.split()[2].strip('UL'), 16) == 0:
+                pm_ac_sz.pm1a_cnt_ac_sz = False
+
+            print("{}".format(s_line.strip()), file=config)
+            continue
+
+        with open(default_platform, 'r') as default:
+            while True:
+                line = default.readline()
+
+                if not line:
+                    break
+
+                if len(line.split()) < 2:
+                    continue
+
+                multi_parser(line, s_line, pm_ac_sz, config)
+
+
+def write_direct_info_parser(config, msg_s, msg_e):
+    """Direct to write"""
+    vector_lines = board_cfg_lib.get_info(board_cfg_lib.BOARD_INFO_FILE, msg_s, msg_e)
+
+    for vector in vector_lines:
+        print("{}".format(vector.strip()), file=config)
+
+    print("", file=config)
+
+
+def drhd_info_parser(config):
+    """Parser DRHD information"""
+    prev_num = 0
+
+    drhd_lines = board_cfg_lib.get_info(
+        board_cfg_lib.BOARD_INFO_FILE, "<DRHD_INFO>", "</DRHD_INFO>")
+
+    # write DRHD
+    print("/* DRHD of DMAR */", file=config)
+    for drhd in drhd_lines:
+        cur_num = drhd.strip().split()[1][4:5]
+
+        if drhd.strip().split()[1] == "DRHD_COUNT":
+            print("", file=config)
+            print("{}".format(drhd.strip()), file=config)
+            continue
+
+        if cur_num != prev_num:
+            print("", file=config)
+
+        print("{}".format(drhd.strip()), file=config)
+        prev_num = cur_num
+
+
+def platform_info_parser(config, default_platform):
+    """Parser ACPI information"""
+    print("\n/* pm sstate data */", file=config)
+    multi_info_parser(config, default_platform, "<PM_INFO>", "</PM_INFO>")
+    multi_info_parser(config, default_platform, "<S3_INFO>", "</S3_INFO>")
+    multi_info_parser(config, default_platform, "<S5_INFO>", "</S5_INFO>")
+    print("", file=config)
+
+    write_direct_info_parser(config, "<WAKE_VECTOR_INFO>", "</WAKE_VECTOR_INFO>")
+    write_direct_info_parser(config, "<RESET_REGISTER_INFO>", "</RESET_REGISTER_INFO>")
+    drhd_info_parser(config)
+
+
+def generate_file(config, default_platform):
+    """write board_name_acpi_info.h"""
+    print("{}".format(board_cfg_lib.HEADER_LICENSE), file=config)
+
+    print("{}".format(PLATFORM_HEADER), file=config)
+
+    board_cfg_lib.handle_bios_info(config)
+    # parser for the platform info
+    platform_info_parser(config, default_platform)
+
+    print("{}".format(PLATFORM_END_HEADER), file=config)

--- a/misc/acrn-config/board_config/board_c.py
+++ b/misc/acrn-config/board_config/board_c.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import sys
+import board_cfg_lib
+
+
+def clos_info_parser():
+    """Parser CLOS information"""
+
+    cache_support = False
+    clos_max = 0
+
+    cat_lines = board_cfg_lib.get_info(
+        board_cfg_lib.BOARD_INFO_FILE, "<CLOS_INFO>", "</CLOS_INFO>")
+
+    for line in cat_lines:
+        if line.split(':')[0] == "clos supported by cache":
+            cache_support = line.split(':')[1].strip()
+        elif line.split(':')[0] == "clos max":
+            clos_max = int(line.split(':')[1])
+
+    return (cache_support, clos_max)
+
+
+def gen_cat(config):
+    """Get CAT information"""
+    (cache_support, clos_max) = clos_info_parser()
+
+    print("\n#include <board.h>", file=config)
+    print("#include <acrn_common.h>", file=config)
+
+    if cache_support == "False" or clos_max == 0:
+        print("\nstruct platform_clos_info platform_clos_array[0];", file=config)
+        print("uint16_t platform_clos_num = 0;", file=config)
+    else:
+        print("\nstruct platform_clos_info platform_clos_array[{0}] = {{".format(
+            clos_max), file=config)
+        for i_cnt in range(clos_max):
+            print("\t{", file=config)
+
+            print("\t\t.clos_mask = {0},".format(hex(0xff)), file=config)
+            if cache_support == "L2":
+                print("\t\t.msr_index = MSR_IA32_{0}_MASK_{1},".format(
+                    cache_support, i_cnt), file=config)
+            elif cache_support == "L3":
+                print("\t\t.msr_index = {0}U,".format(hex(0x00000C90+i_cnt)), file=config)
+            else:
+                board_cfg_lib.print_red("The input of board_info.txt was corrupted!")
+                sys.exit(1)
+            print("\t},", file=config)
+
+        print("};\n", file=config)
+        print("uint16_t platform_clos_num = ", file=config, end="")
+        print("(uint16_t)(sizeof(platform_clos_array)/sizeof(struct platform_clos_info));",
+              file=config)
+
+    print("", file=config)
+
+
+def gen_px_cx(config):
+    """Get Px/Cx and store them to board.c"""
+    cpu_brand_lines = board_cfg_lib.get_info(
+        board_cfg_lib.BOARD_INFO_FILE, "<CPU_BRAND>", "</CPU_BRAND>")
+    cx_lines = board_cfg_lib.get_info(board_cfg_lib.BOARD_INFO_FILE, "<CX_INFO>", "</CX_INFO>")
+    px_lines = board_cfg_lib.get_info(board_cfg_lib.BOARD_INFO_FILE, "<PX_INFO>", "</PX_INFO>")
+
+    cx_len = len(cx_lines)
+    px_len = len(px_lines)
+    #print("#ifdef CONFIG_CPU_POWER_STATES_SUPPORT", file=config)
+    print("static const struct cpu_cx_data board_cpu_cx[%s] = {"%str(cx_len), file=config)
+    for cx_l in cx_lines:
+        print("\t{0}".format(cx_l.strip()), file=config)
+    print("};\n", file=config)
+
+    print("static const struct cpu_px_data board_cpu_px[%s] = {"%str(px_len), file=config)
+    for px_l in px_lines:
+        print("\t{0}".format(px_l.strip()), file=config)
+    print("};\n", file=config)
+
+    for brand_line in cpu_brand_lines:
+        cpu_brand = brand_line
+
+    print("const struct cpu_state_table board_cpu_state_tbl = {", file=config)
+    print("\t{0},".format(cpu_brand.strip()), file=config)
+    print("\t{(uint8_t)ARRAY_SIZE(board_cpu_px), board_cpu_px,", file=config)
+    print("\t(uint8_t)ARRAY_SIZE(board_cpu_cx), board_cpu_cx}", file=config)
+    print("};", file=config)
+    #print("#endif", file=config)
+
+
+def generate_file(config):
+    """Start to generate board.c"""
+    print("{0}".format(board_cfg_lib.HEADER_LICENSE), file=config)
+
+    # insert bios info into board.c
+    board_cfg_lib.handle_bios_info(config)
+
+    # start to parser to get CAT info
+    gen_cat(config)
+
+    # start to parser PX/CX info
+    gen_px_cx(config)

--- a/misc/acrn-config/board_config/board_cfg_gen.py
+++ b/misc/acrn-config/board_config/board_cfg_gen.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+import os
+import sys
+import shutil
+import subprocess
+import board_cfg_lib
+import board_c
+import pci_devices_h
+import acpi_platform_h
+
+ACRN_PATH = "../../../"
+ACRN_CONFIG = ACRN_PATH + "hypervisor/arch/x86/configs/"
+
+BOARD_NAMES = ['apl-mrb', 'apl-nuc', 'apl-up2', 'dnv-cb2', 'nuc6cayh',
+               'nuc7i7dnb', 'kbl-nuc-i7', 'icl-rvp']
+
+ACRN_DEFAULT_PLATFORM = ACRN_PATH + "hypervisor/include/arch/x86/default_acpi_info.h"
+GEN_FILE = ["vm_configurations.h", "vm_configurations.c", "pt_dev.c", "pci_devices.h",
+            "board.c", "_acpi_info.h"]
+
+PY_CACHES = ["__pycache__", "board_config/__pycache__"]
+BIN_LIST = ['git']
+
+
+def prepare():
+    """Prepare to check the environment"""
+    for excute in BIN_LIST:
+        res = subprocess.Popen("which {}".format(excute), shell=True, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, close_fds=True)
+
+        line = res.stdout.readline().decode('ascii')
+
+        if not line:
+            board_cfg_lib.print_yel("'{}' not found, please install it!".format(excute))
+            sys.exit(1)
+
+        if excute == "git":
+            res = subprocess.Popen("git tag -l", shell=True, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, close_fds=True)
+            line = res.stdout.readline().decode("ascii")
+
+            if "acrn" not in line:
+                board_cfg_lib.print_red("Run this tool in acrn-hypervisor mainline source code!")
+                sys.exit(1)
+
+    for py_cache in PY_CACHES:
+        if os.path.exists(py_cache):
+            shutil.rmtree(py_cache)
+
+
+def gen_patch(srcs_list, board_name):
+    """Generate patch and apply to local source code"""
+    changes = ' '.join(srcs_list)
+    git_add = "git add {}".format(changes)
+    subprocess.call(git_add, shell=True, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, close_fds=True)
+
+    # commit this changes
+    git_commit = 'git commit -sm "acrn-config: config board patch for {}"'.format(board_name)
+    subprocess.call(git_commit, shell=True, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, close_fds=True)
+
+
+def main(board_info_file):
+    """This is main function to start generate source code related with board"""
+    board = ''
+    config_srcs = []
+    config_dirs = []
+
+    # get board name
+    board = board_cfg_lib.get_board_name(board_info_file)
+
+    config_dirs.append(ACRN_CONFIG + board)
+    if board not in BOARD_NAMES:
+        for config_dir in config_dirs:
+            if not os.path.exists(config_dir):
+                os.makedirs(config_dir)
+
+    config_pci = config_dirs[0] + '/' + GEN_FILE[3]
+    config_board = config_dirs[0] + '/' + GEN_FILE[4]
+    config_platform = config_dirs[0] + '/' + board + GEN_FILE[5]
+
+    config_srcs.append(config_pci)
+    config_srcs.append(config_board)
+    config_srcs.append(config_platform)
+
+    # generate board.c
+    with open(config_board, 'w+') as config:
+        board_c.generate_file(config)
+
+    # generate pci_devices.h
+    with open(config_pci, 'w+') as config:
+        pci_devices_h.generate_file(config)
+
+    # generate acpi_platform.h
+    with open(config_platform, 'w+') as config:
+        acpi_platform_h.generate_file(config, ACRN_DEFAULT_PLATFORM)
+
+    # move changes to patch, and applay to the source code
+    gen_patch(config_srcs, board)
+
+    if board not in BOARD_NAMES:
+        print("Config patch for NEW board {} is committed successfully!".format(board))
+    else:
+        print("Config patch for {} is committed successfully!".format(board))
+
+
+def usage():
+    """This is usage for how to use this tool"""
+    print("usage= [h] --board <board_info_file>'")
+    print('board_info_file, :  file name of the board info"')
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    prepare()
+
+    ARGS = sys.argv[1:]
+
+    if ARGS[0] != '--board':
+        usage()
+        sys.exit(1)
+
+    BOARD_INFO_FILE = ARGS[1]
+    if not os.path.exists(BOARD_INFO_FILE):
+        board_cfg_lib.print_red("{} is not exist!".format(BOARD_INFO_FILE))
+        sys.exit(1)
+
+    # board_info.txt will be override
+    board_cfg_lib.BOARD_INFO_FILE = BOARD_INFO_FILE
+
+    main(BOARD_INFO_FILE)

--- a/misc/acrn-config/board_config/board_cfg_lib.py
+++ b/misc/acrn-config/board_config/board_cfg_lib.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import sys
+
+HV_LICENSE_FILE = '../library/hypervisor_license'
+BOARD_INFO_FILE = "board_info.txt"
+
+BIOS_INFO = ['BIOS Information', 'Vendor:', 'Version:', 'Release Date:', 'BIOS Revision:']
+
+BASE_BOARD = ['Base Board Information', 'Manufacturer:', 'Product Name:', 'Version:']
+
+
+def open_license():
+    """Get the license"""
+    with open(HV_LICENSE_FILE, 'r') as f_licence:
+        license_s = f_licence.read().strip()
+        return license_s
+
+
+HEADER_LICENSE = open_license() + "\n"
+
+#LOGICAL_PT_PROFILE = {}
+#LOGICAL_PCI_DEV = {}
+#LOGICAL_PCI_LINE = {}
+
+
+def print_yel(msg, warn=False):
+    """Print the message with color of yellow"""
+    if warn:
+        print("\033[1;33mWarning\033[0m:"+msg)
+    else:
+        print("\033[1;33m{0}\033[0m".format(msg))
+
+
+def print_red(msg, err=False):
+    """Print the message with color of red"""
+    if err:
+        print("\033[1;31mError\033[0m:"+msg)
+    else:
+        print("\033[1;31m{0}\033[0m".format(msg))
+
+
+def get_board_name(board_info):
+    """Get board name"""
+    with open(board_info, 'rt') as f_board:
+        line = f_board.readline()
+        if not "board=" in line:
+            print_red("acrn-config board info xml was corrupted!")
+            sys.exit(1)
+
+        board = line.split('"')[1].strip('"')
+        return board
+
+
+def get_info(board_info, msg_s, msg_e):
+    """Get information which specify by argument"""
+    info_start = False
+    info_end = False
+    info_lines = []
+    num = len(msg_s.split())
+
+    try:
+        with open(board_info, 'rt') as f_board:
+            while True:
+
+                line = f_board.readline()
+                if not line:
+                    break
+
+                if " ".join(line.split()[0:num]) == msg_s:
+                    info_start = True
+                    info_end = False
+                    continue
+
+                if " ".join(line.split()[0:num]) == msg_e:
+                    info_start = False
+                    info_end = True
+                    continue
+
+                if info_start and not info_end:
+                    info_lines.append(line)
+                    continue
+
+                if not info_start and info_end:
+                    return info_lines
+
+    except IOError as err:
+        print_red(str(err), err=True)
+        sys.exit(1)
+
+
+def handle_bios_info(config):
+    """Handle bios information"""
+    bios_lines = get_info(BOARD_INFO_FILE, "<BIOS_INFO>", "</BIOS_INFO>")
+    board_lines = get_info(BOARD_INFO_FILE, "<BASE_BOARD_INFO>", "</BASE_BOARD_INFO>")
+    print("/*", file=config)
+
+    if not bios_lines or not board_lines:
+        print(" * DMI info is not found", file=config)
+    else:
+        i_cnt = 0
+        bios_board = BIOS_INFO + BASE_BOARD
+
+        # remove the same value and keep origin sort
+        bios_board_info = list(set(bios_board))
+        bios_board_info.sort(key=bios_board.index)
+
+        bios_board_lines = bios_lines + board_lines
+        bios_info_len = len(bios_lines)
+        for line in bios_board_lines:
+            if i_cnt == bios_info_len:
+                print(" *", file=config)
+
+            i_cnt += 1
+
+            for mics_info in bios_board_info:
+                if mics_info == " ".join(line.split()[0:1]) or mics_info == \
+                        " ".join(line.split()[0:2]) or mics_info == " ".join(line.split()[0:3]):
+                    print(" * {0}".format(line.strip()), file=config)
+
+    print(" */", file=config)

--- a/misc/acrn-config/board_config/pci_devices_h.py
+++ b/misc/acrn-config/board_config/pci_devices_h.py
@@ -1,0 +1,142 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import collections
+import board_cfg_lib
+
+PCI_HEADER = r"""
+#ifndef PCI_DEVICES_H_
+#define PCI_DEVICES_H_
+"""
+PCI_END_HEADER = r"""
+#endif /* PCI_DEVICES_H_ */"""
+
+
+def parser_pci():
+    """Parser PCI lines"""
+    cur_bdf = 0
+    prev_bdf = 0
+    tmp_bar_dic = {}
+    pci_dev_dic = {}
+    pci_bar_dic = {}
+    bar_value = bar_num = '0'
+
+    pci_lines = board_cfg_lib.get_info(
+        board_cfg_lib.BOARD_INFO_FILE, "<PCI_DEVICE>", "</PCI_DEVICE>")
+    for line in pci_lines:
+        # get pci bar information into pci_bar_dic
+        if "Region" in line and "Memory at" in line:
+            bar_num = line.split()[1].strip(':')
+            bar_value = line.split()[4]
+            tmp_bar_dic[int(bar_num)] = hex(int(bar_value, 16))
+        else:
+            prev_bdf = cur_bdf
+            pci_bdf = line.split()[0]
+            pci_sub_name = " ".join(line.split(':')[1].split()[1:])
+
+            # remove '[*]' in pci subname
+            if '[' in pci_sub_name:
+                pci_sub_name = pci_sub_name.rsplit('[', 1)[0]
+
+            pci_dev_dic[pci_bdf] = pci_sub_name
+            cur_bdf = pci_bdf
+            #board_cfg_lib.LOGICAL_PCI_LINE[pci_bdf] = line
+
+            # skipt the first init value
+            if not prev_bdf:
+                prev_bdf = cur_bdf
+
+            if tmp_bar_dic and cur_bdf != prev_bdf:
+                pci_bar_dic[prev_bdf] = tmp_bar_dic
+
+            # clear the tmp_bar_dic before store the next dic
+            tmp_bar_dic = {}
+
+    # output all the pci device list to pci_device.h
+    sub_name_count = collections.Counter(pci_dev_dic.values())
+
+    # share the pci profile with pt_dev
+    #board_cfg_lib.LOGICAL_PT_PROFILE = sub_name_count
+    #board_cfg_lib.LOGICAL_PCI_DEV = pci_dev_dic
+
+    if tmp_bar_dic:
+        pci_bar_dic[cur_bdf] = tmp_bar_dic
+
+    return (pci_dev_dic, pci_bar_dic, sub_name_count)
+
+
+def write_pbdf(i_cnt, bdf, subname, config):
+    """Parser and generate pbdf"""
+    # if there is only one host bridge, then will discard the index of suffix
+    if i_cnt == 0 and subname.upper() == "HOST BRIDGE":
+        tmp_sub_name = "_".join(subname.split()).upper()
+    else:
+        tmp_sub_name = "_".join(subname.split()).upper() + "_" + str(i_cnt)
+
+    bus = int(bdf.split(':')[0], 16)
+    dev = int(bdf.split(':')[1].split('.')[0], 16)
+    fun = int(bdf.split('.')[1], 16)
+    print("#define %-32s" % tmp_sub_name, end="", file=config)
+    print("        .pbdf.bits = {{.b = 0x{:02X}U, .d = 0x{:02X}U, .f = 0x{:02X}U}}".format(
+        bus, dev, fun), end="", file=config)
+
+
+def write_vbar(bdf, pci_bar_dic, config):
+    """Parser and generate vbar"""
+    tail = 0
+    align = ' ' * 48
+    if bdf in pci_bar_dic.keys():
+        bar_list = list(pci_bar_dic[bdf].keys())
+        bar_len = len(bar_list)
+        bar_num = 0
+        for bar_i in bar_list:
+            if tail == 0:
+                print(", \\", file=config)
+                tail += 1
+            bar_num += 1
+            bar_val = pci_bar_dic[bdf][bar_i]
+
+            if bar_num == bar_len:
+                print("{}.vbar_base[{}] = {}UL".format(align, bar_i, bar_val), file=config)
+            else:
+                print("{}.vbar_base[{}] = {}UL, \\".format(
+                    align, bar_i, bar_val), file=config)
+
+        # print("", file=config)
+    else:
+        print("", file=config)
+
+
+def generate_file(config):
+    """Get PCI device and generate pci_devices.h"""
+
+    # write the license into pci
+    print("{0}".format(board_cfg_lib.HEADER_LICENSE), file=config)
+
+    # add bios and base board info
+    board_cfg_lib.handle_bios_info(config)
+
+    # write the header into pci
+    print("{0}".format(PCI_HEADER), file=config)
+
+    (pci_dev_dic, pci_bar_dic, sub_name_count) = parser_pci()
+
+
+    compared_bdf = []
+    for cnt_sub_name in sub_name_count.keys():
+        i_cnt = 0
+        for bdf, subname in pci_dev_dic.items():
+            if cnt_sub_name == subname and bdf not in compared_bdf:
+                compared_bdf.append(bdf)
+            else:
+                continue
+
+            write_pbdf(i_cnt, bdf, subname, config)
+            write_vbar(bdf, pci_bar_dic, config)
+
+            i_cnt += 1
+
+    # write the end to the pci devices
+    print("{0}".format(PCI_END_HEADER), file=config)

--- a/misc/acrn-config/launch_config/README
+++ b/misc/acrn-config/launch_config/README
@@ -1,0 +1,1 @@
+TODO: parse board_info XML, scenario XML and devicemodel param XML to generate launch script for post-launched vm under devicesmodel/samples/$(BOARD)/ folder

--- a/misc/acrn-config/library/hypervisor_license
+++ b/misc/acrn-config/library/hypervisor_license
@@ -1,0 +1,5 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */

--- a/misc/acrn-config/scenario_config/README
+++ b/misc/acrn-config/scenario_config/README
@@ -1,0 +1,1 @@
+TODO: parse board_info XML and scenario XML to generate scenario based VM configuration files under hypervisor/scenarios/$(SCENARIO)/ folder

--- a/misc/acrn-config/target/README
+++ b/misc/acrn-config/target/README
@@ -1,0 +1,13 @@
+board_parser.py will collect all board related info and then generate a board info file for acrn-config host tool usage.
+
+usage: python3 board_parser.py <board_name> [--out board_info_file]
+
+board_name : the name of board that run ACRN hypervisor, like apl-up2/nuc7i7dnb. It will be used as name of the board configurations folder which created by acrn-config host tool.
+board_info_file : (optional) the name of board info file. if it is not specified, a name of <board_name>.xml will be generated under ./out/ folder by default.
+
+Please run this script under native Linux environment with root privilege.
+
+OS requirement:
+	Release:	Ubuntu 18.04+ or ClearLinux 30210+
+	Tools:		cpuid, rdmsr, lspci, dmidecode
+	kernel cmdline: "idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable"

--- a/misc/acrn-config/target/acpi.py
+++ b/misc/acrn-config/target/acpi.py
@@ -1,0 +1,529 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import os
+import sys
+import subprocess
+from collections import defaultdict
+import dmar
+import parser_lib
+
+
+SYS_PATH = ['/proc/cpuinfo', '/sys/firmware/acpi/tables/', '/sys/devices/system/cpu/']
+
+ACPI_OP = {
+    'AML_ZERO_OP':0x00,
+    'AML_ONE_OP':0x01,
+    'AML_ALIAS_OP':0x06,
+    'AML_NAME_OP':0x08,
+    'AML_BYTE_OP':0x0a,
+    'AML_WORD_OP':0x0b,
+    'AML_DWORD_OP':0x0c,
+    'AML_PACKAGE_OP':0x12,
+    'AML_VARIABLE_PACKAGE_OP':0x13,
+    }
+
+SPACE_ID = {
+    0:'SPACE_SYSTEM_MEMORY',
+    1:'SPACE_SYSTEM_IO',
+    2:'SPACE_PCI_CONFIG',
+    3:'SPACE_Embedded_Control',
+    4:'SPACE_SMBUS',
+    10:'SPACE_PLATFORM_COMM',
+    0x7F:'SPACE_FFixedHW',
+    }
+
+FACP_OFF = {
+    'facs_addr':36,
+    'reset_addr':116,
+    'reset_value':128,
+    'pm1a_evt':148,
+    'pm1b_evt':160,
+    'pm1a_cnt':172,
+    'pm1b_cnt':184,
+    }
+
+class SxPkg:
+    """This is Sx state structure for power"""
+    def __init__(self):
+        # This is Sx state structure for power
+        self.val_pm1a = ''
+        self.val_pm1b = ''
+        self.reserved = ''
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.val_pm1a = ''
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.val_pm1a = ''
+
+class GasType:
+    """This is generic address structure for power"""
+    def __init__(self):
+        self.space_id_8b = 0
+        self.bit_width_8b = 0
+        self.bit_offset_8b = 0
+        self.access_size_8b = 0
+        self.address_64b = 0
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.space_id_8b = ''
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.space_id_8b = ''
+
+class PxPkg:
+    """This is Px state structure for power"""
+    def __init__(self):
+        self.core_freq = 0
+        self.power = 0
+        self.trans_latency = 0
+        self.bus_latency = 0
+        self.control = 0
+        self.status = 0
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.power = ''
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.power = ''
+
+class ResetReg:
+    """This is Reset Registers meta data"""
+    def __init__(self):
+        self.reset_reg_addr = 0
+        self.reset_reg_space_id = 0
+        self.reset_reg_val = 0
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.reset_reg_val = ''
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.reset_reg_val = ''
+
+DWORD_LEN = 4
+PACK_TYPE_LEN = 12
+WAKE_VECTOR_OFFSET_32 = 12
+WAKE_VECTOR_OFFSET_64 = 24
+
+S3_PKG = SxPkg()
+S5_PKG = SxPkg()
+PackedGas = GasType
+PackedCx = GasType
+
+
+def store_cpu_info(sysnode, config):
+    """This will get CPU information from /proc/cpuifo"""
+    with open(sysnode, 'r') as f_node:
+        line = f_node.readline()
+        while line:
+            if len(line.split(':')) >= 2:
+                if line.split(':')[0].strip() == "model name":
+                    model_name = line.split(':')[1].strip()
+                    print('\t\t"{0}"'.format(model_name), file=config)
+                    break
+            line = f_node.readline()
+
+
+def write_reset_reg(space_id, rst_reg_addr, rst_reg_space_id, rst_reg_val, config):
+    """Write reset register info"""
+    print("\t{0}".format("<RESET_REGISTER_INFO>"), file=config)
+    print("\t#define RESET_REGISTER_ADDRESS  0x{:0>2X}UL".format(
+        rst_reg_addr), file=config)
+    print("\t#define RESET_REGISTER_SPACE_ID {0}".format(
+        space_id[rst_reg_space_id]), file=config)
+    print("\t#define RESET_REGISTER_VALUE    {0}U".format(
+        rst_reg_val), file=config)
+    print("\t{0}\n".format("</RESET_REGISTER_INFO>"), file=config)
+
+
+def get_vector_reset(sysnode, config):
+    """This will get reset reg value"""
+    reset_reg = ResetReg()
+    for key, offset in FACP_OFF.items():
+        with open(sysnode, 'rb') as f_node:
+            f_node.seek(offset, 0)
+            if key == 'facs_addr':
+                packed_data = f_node.read(DWORD_LEN)
+                packed_data_32 = int.from_bytes(packed_data, 'little')+WAKE_VECTOR_OFFSET_32
+                packed_data_64 = int.from_bytes(packed_data, 'little')+WAKE_VECTOR_OFFSET_64
+                print("\t{0}".format("<WAKE_VECTOR_INFO>"), file=config)
+                print("\t#define WAKE_VECTOR_32          0x{:0>2X}UL".format(
+                    packed_data_32), file=config)
+                print("\t#define WAKE_VECTOR_64          0x{:0>2X}UL".format(
+                    packed_data_64), file=config)
+                print("\t{0}\n".format("</WAKE_VECTOR_INFO>"), file=config)
+            elif key == 'reset_addr':
+                packed_data = f_node.read(PACK_TYPE_LEN)
+                reset_reg.reset_reg_space_id = packed_data[0]
+                reset_reg.reset_reg_addr = int.from_bytes(packed_data[4:11], 'little')
+            elif key == 'reset_value':
+                packed_data = f_node.read(1)
+                reset_reg.reset_reg_val = hex(packed_data[0])
+
+    write_reset_reg(SPACE_ID, reset_reg.reset_reg_addr, reset_reg.reset_reg_space_id,
+                    reset_reg.reset_reg_val, config)
+
+
+def read_pm_sstate(sysnode, config):
+    """This will read Px state of power"""
+    get_vector_reset(sysnode, config)
+    print("\t{0}".format("<PM_INFO>"), file=config)
+    for key, offset in FACP_OFF.items():
+        with open(sysnode, 'rb') as f_node:
+            f_node.seek(offset, 0)
+
+            packed_data = f_node.read(PACK_TYPE_LEN)
+            PackedGas.space_id_8b = packed_data[0]
+            PackedGas.bit_width_8b = packed_data[1]
+            PackedGas.bit_offset_8b = packed_data[2]
+            PackedGas.access_size_8b = packed_data[3]
+            PackedGas.address_64b = int.from_bytes(packed_data[4:11], 'little')
+
+            if key == 'pm1a_evt':
+                print("\t#define PM1A_EVT_SPACE_ID       {0}".format(
+                    SPACE_ID[PackedGas.space_id_8b]), file=config)
+                print("\t#define PM1A_EVT_BIT_WIDTH      {0}U".format(
+                    hex(PackedGas.bit_width_8b)), file=config)
+                print("\t#define PM1A_EVT_BIT_OFFSET     {0}U".format(
+                    hex(PackedGas.bit_offset_8b)), file=config)
+                print("\t#define PM1A_EVT_ADDRESS        {0}UL".format(
+                    hex(PackedGas.address_64b)), file=config)
+                print("\t#define PM1A_EVT_ACCESS_SIZE    {0}U".format(
+                    hex(PackedGas.access_size_8b)), file=config)
+            elif key == 'pm1a_cnt':
+                print("\t#define PM1A_CNT_SPACE_ID       {0}".format(
+                    SPACE_ID[PackedGas.space_id_8b]), file=config)
+                print("\t#define PM1A_CNT_BIT_WIDTH      {0}U".format(
+                    hex(PackedGas.bit_width_8b)), file=config)
+                print("\t#define PM1A_CNT_BIT_OFFSET     {0}U".format(
+                    hex(PackedGas.bit_offset_8b)), file=config)
+                print("\t#define PM1A_CNT_ADDRESS        {0}UL".format(
+                    hex(PackedGas.address_64b)), file=config)
+                print("\t#define PM1A_CNT_ACCESS_SIZE    {0}U".format(
+                    hex(PackedGas.access_size_8b)), file=config)
+            elif key == 'pm1b_evt':
+                print("\t#define PM1B_EVT_SPACE_ID       {0}".format(
+                    SPACE_ID[PackedGas.space_id_8b]), file=config)
+                print("\t#define PM1B_EVT_BIT_WIDTH      {0}U".format(
+                    hex(PackedGas.bit_width_8b)), file=config)
+                print("\t#define PM1B_EVT_BIT_OFFSET     {0}U".format(
+                    hex(PackedGas.bit_offset_8b)), file=config)
+                print("\t#define PM1B_EVT_ADDRESS        {0}UL".format(
+                    hex(PackedGas.address_64b)), file=config)
+                print("\t#define PM1B_EVT_ACCESS_SIZE    {0}U".format(
+                    hex(PackedGas.access_size_8b)), file=config)
+            elif key == 'pm1b_cnt':
+                print("\t#define PM1B_CNT_SPACE_ID       {0}".format(
+                    SPACE_ID[PackedGas.space_id_8b]), file=config)
+                print("\t#define PM1B_CNT_BIT_WIDTH      {0}U".format(
+                    hex(PackedGas.bit_width_8b)), file=config)
+                print("\t#define PM1B_CNT_BIT_OFFSET     {0}U".format(
+                    hex(PackedGas.bit_offset_8b)), file=config)
+                print("\t#define PM1B_CNT_ADDRESS        {0}UL".format(
+                    hex(PackedGas.address_64b)), file=config)
+                print("\t#define PM1B_CNT_ACCESS_SIZE    {0}U".format(
+                    hex(PackedGas.access_size_8b)), file=config)
+    print("\t{0}\n".format("</PM_INFO>"), file=config)
+
+
+def if_sx_name(sx_name, f_node):
+    """If sx name in this field"""
+    need_break = need_continue = 0
+    name_buf = f_node.read(4)
+    if not name_buf:
+        need_break = True
+        return (need_break, need_continue)
+
+    try:
+        if name_buf.decode('ascii').find(sx_name) != -1:
+            pass
+        else:
+            need_continue = True
+    except ValueError:
+        need_continue = True
+        return (need_break, need_continue)
+    else:
+        pass
+
+    return (need_break, need_continue)
+
+
+def read_sx_locate(sx_name, f_node):
+    """Read the location of sx"""
+    need_continue = need_break = pkg_len = 0
+
+    (need_break, need_continue) = if_sx_name(sx_name, f_node)
+
+    tmp_char = f_node.read(1)
+    if not tmp_char:
+        need_break = True
+        return (need_break, need_continue, pkg_len)
+    if hex(int.from_bytes(tmp_char, 'little')) != hex(ACPI_OP['AML_PACKAGE_OP']):
+        need_continue = True
+        return (need_break, need_continue, pkg_len)
+
+    pkg_len = f_node.read(1)
+    if not pkg_len:
+        need_break = True
+        return (need_break, need_continue, pkg_len)
+    if int.from_bytes(pkg_len, 'little') < 5 or int.from_bytes(pkg_len, 'little') > 28:
+        need_continue = True
+        return (need_break, need_continue, pkg_len)
+
+    return (need_break, need_continue, pkg_len)
+
+
+def decode_sx_pkg(pkg_len, f_node):
+    """Parser and decode the sx pkg"""
+    pkg_val_pm1a = pkg_val_pm1b = pkg_val_resv = need_break = 0
+    pkg_buf = f_node.read(int.from_bytes(pkg_len, 'little'))
+    if hex(pkg_buf[1]) == ACPI_OP['AML_ZERO_OP'] or \
+            hex(pkg_buf[1]) == hex(ACPI_OP['AML_ONE_OP']):
+        pkg_val_pm1a = pkg_buf[1]
+        if hex(pkg_buf[2]) == hex(ACPI_OP['AML_ZERO_OP']) or \
+                hex(pkg_buf[2]) == hex(ACPI_OP['AML_ONE_OP']):
+            pkg_val_pm1b = pkg_buf[2]
+            pkg_val_resv = pkg_buf[3:5]
+        elif hex(pkg_buf[2]) == hex(ACPI_OP['AML_BYTE_OP']):
+            pkg_val_pm1b = pkg_buf[3]
+            pkg_val_resv = pkg_buf[4:6]
+        else:
+            need_break = True
+            return (pkg_val_pm1a, pkg_val_pm1b, pkg_val_resv, need_break)
+
+    elif hex(pkg_buf[1]) == hex(ACPI_OP['AML_BYTE_OP']):
+        pkg_val_pm1a = pkg_buf[2]
+        if hex(pkg_buf[3]) == hex(ACPI_OP['AML_ZERO_OP']) or \
+                hex(pkg_buf[3]) == hex(ACPI_OP['AML_ONE_OP']):
+            pkg_val_pm1b = pkg_buf[3]
+            pkg_val_resv = pkg_buf[4:6]
+        elif hex(pkg_buf[3]) == hex(ACPI_OP['AML_BYTE_OP']):
+            pkg_val_pm1b = pkg_buf[4]
+            pkg_val_resv = pkg_buf[5:7]
+        else:
+            need_break = True
+            return (pkg_val_pm1a, pkg_val_pm1b, pkg_val_resv, need_break)
+    else:
+        need_break = True
+
+    return (pkg_val_pm1a, pkg_val_pm1b, pkg_val_resv, need_break)
+
+
+def read_pm_sdata(sysnode, sx_name, config):
+    """This will read pm Sx state of power"""
+    with open(sysnode, 'rb') as f_node:
+        while True:
+            inc = f_node.read(1)
+            if inc:
+                if hex(int.from_bytes(inc, 'little')) != hex(ACPI_OP['AML_NAME_OP']):
+                    continue
+
+                (need_break, need_continue, pkg_len) = read_sx_locate(sx_name, f_node)
+                if need_break:
+                    break
+                if need_continue:
+                    continue
+
+                # decode sx pkg
+                (pkg_val_pm1a, pkg_val_pm1b, pkg_val_resv, need_break) =\
+                    decode_sx_pkg(pkg_len, f_node)
+                if need_break:
+                    break
+
+            else:
+                break
+
+            if sx_name == '_S3_':
+                S3_PKG.val_pm1a = pkg_val_pm1a
+                S3_PKG.val_pm1b = pkg_val_pm1b
+                S3_PKG.reserved = pkg_val_resv
+                print("\t#define S3_PKG_VAL_PM1A         {0}".format(
+                    hex(S3_PKG.val_pm1a))+'U', file=config)
+                print("\t#define S3_PKG_VAL_PM1B         {0}".format(
+                    S3_PKG.val_pm1b)+'U', file=config)
+                print("\t#define S3_PKG_RESERVED         {0}".format(
+                    hex(int.from_bytes(S3_PKG.reserved, 'little')))+'U', file=config)
+
+            if sx_name == "_S5_":
+                S5_PKG.val_pm1a = pkg_val_pm1a
+                S5_PKG.val_pm1b = pkg_val_pm1b
+                S5_PKG.reserved = pkg_val_resv
+                print("\t#define S5_PKG_VAL_PM1A         {0}".format(
+                    hex(S5_PKG.val_pm1a))+'U', file=config)
+                print("\t#define S5_PKG_VAL_PM1B         {0}".format(
+                    S5_PKG.val_pm1b)+'U', file=config)
+                print("\t#define S5_PKG_RESERVED         {0}".format(
+                    hex(int.from_bytes(S5_PKG.reserved, 'little')))+'U', file=config)
+
+
+def store_cx_data(sysnode1, sysnode2, config):
+    """This will get Cx data of power and store it to PackedCx"""
+    i = 0
+    state_cpus = {}
+    with open(sysnode1, 'r') as acpi_idle:
+        idle_driver = acpi_idle.read(32)
+
+        if idle_driver.find("acpi_idle") == -1:
+            if idle_driver.find("intel_idle") == 0:
+                parser_lib.print_red("The tool need to run with acpi_idle driver, " +
+                                     "please add intel_idle.max_cstate=0 in kernel " +
+                                     "cmdline to fall back to acpi_idle driver", err=True)
+            else:
+                parser_lib.print_red("acpi_idle driver is not found.", err=True)
+            sys.exit(1)
+
+    files = os.listdir(sysnode2)
+    for d_path in files:
+        if os.path.isdir(sysnode2+d_path):
+            state_cpus[d_path] = sysnode2+d_path
+
+    state_cpus = sorted(state_cpus.keys())
+    del state_cpus[0]
+    cpu_state = ['desc', 'latency', 'power']
+    acpi_hw_type = ['HLT', 'MWAIT', 'IOPORT']
+
+    cx_state = defaultdict(dict)
+    for state in state_cpus:
+        i += 1
+        for item in cpu_state:
+            cx_data_file = open(sysnode2+state+'/'+item, 'r')
+            cx_state[state][item] = cx_data_file.read().strip()
+            cx_state[state]['type'] = i
+
+        if cx_state[state][cpu_state[0]].find(acpi_hw_type[0]) != -1 or \
+             cx_state[state][cpu_state[0]].find(acpi_hw_type[1]) != -1:
+            PackedCx.space_id_8b = SPACE_ID[0x7F]
+            if cx_state[state][cpu_state[0]].find(acpi_hw_type[0]) != -1:
+                PackedCx.bit_width_8b = 0
+                PackedCx.bit_offset_8b = 0
+                PackedCx.access_size_8b = 0
+                PackedCx.address_64b = 0
+            else:
+                PackedCx.bit_width_8b = 1
+                PackedCx.bit_offset_8b = 2
+                PackedCx.access_size_8b = 1
+                PackedCx.address_64b = cx_state[state][cpu_state[0]].split()[3]
+        elif cx_state[state][cpu_state[0]].find(acpi_hw_type[2]) != -1:
+            PackedCx.space_id_8b = SPACE_ID[1]
+            PackedCx.bit_width_8b = 8
+            PackedCx.bit_offset_8b = 0
+            PackedCx.access_size_8b = 0
+            PackedCx.address_64b = cx_state[state][cpu_state[0]].split()[2]
+        print("\t\t{{{{{}, 0x{:0>2X}U, 0x{:0>2X}U, 0x{:0>2X}U, ".format(
+            PackedCx.space_id_8b, PackedCx.bit_width_8b, PackedCx.bit_offset_8b,
+            PackedCx.access_size_8b), file=config, end="")
+        print("0x{:0>2X}UL}}, 0x{:0>2X}U, 0x{:0>2X}U, 0x{:0>2X}U}},".format(
+            int(str(PackedCx.address_64b), 16),
+            cx_state[state]['type'], int(cx_state[state][cpu_state[1]]),
+            int(cx_state[state][cpu_state[2]])), file=config)
+
+
+def store_px_data(sysnode, config):
+    """This will get Px data of power and store it to px data"""
+    px_tmp = PxPkg()
+    px_data = {}
+    with open(sysnode+'cpu0/cpufreq/scaling_driver', 'r') as f_node:
+        freq_driver = f_node.read()
+        if freq_driver.find("acpi-cpufreq") == -1:
+            if freq_driver.find("intel_pstate") == 0:
+                parser_lib.print_red("The tool need to run with acpi_cpufreq driver, " +
+                                     "please add intel_pstate=disable in kernel cmdline " +
+                                     "to fall back to acpi-cpufreq driver.", err=True)
+            else:
+                parser_lib.print_red("acpi-cpufreq driver is not found.", err=True)
+            sys.exit(1)
+
+    try:
+        with open(sysnode+'cpufreq/boost', 'r') as f_node:
+            boost = f_node.read()
+    except IOError:
+        boost = 0
+        parser_lib.print_yel("CPU turbo is not enabled!")
+
+    with open(sysnode + 'cpu0/cpufreq/scaling_available_frequencies', 'r') as f_node:
+        freqs = f_node.read()
+    with open(sysnode + 'cpu0/cpufreq/cpuinfo_transition_latency') as f_node:
+        latency = int(f_node.read().strip())
+        latency = latency//1000
+
+    i = 0
+    p_cnt = 0
+    for freq in freqs.split():
+        if boost != 0 and i == 0:
+            try:
+                subprocess.check_call('/usr/sbin/rdmsr 0x1ad', shell=True, stdout=subprocess.PIPE)
+            except subprocess.CalledProcessError:
+                parser_lib.print_red("MSR 0x1ad not support in this platform!", err=True)
+                sys.exit(1)
+
+            res = subprocess.Popen('/usr/sbin/rdmsr 0x1ad', shell=True,
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+            result = res.stdout.readline().strip()
+            #max_ratio_cpu = result[-2:]
+            ctl_state = int(result[-2:], 16) << 8
+            i += 1
+        else:
+            ctl_state = int(freq)//100000 << 8
+
+        px_tmp.core_freq = int(int(freq) / 1000)
+        px_tmp.power = 0
+        px_tmp.trans_latency = latency
+        px_tmp.bus_latency = latency
+        px_tmp.control = ctl_state
+        px_tmp.status = ctl_state
+        px_data[freq] = px_tmp
+        print("\t\t{{0x{:0>2X}UL, 0x{:0>2X}UL, 0x{:0>2X}UL, ".format(
+            px_data[freq].core_freq, px_data[freq].power,
+            px_data[freq].trans_latency), file=config, end="")
+        print("0x{:0>2X}UL, 0x{:0>6X}UL, 0x{:0>6X}UL}}, /* P{} */".format(
+            px_data[freq].bus_latency, px_data[freq].control,
+            px_data[freq].status, p_cnt), file=config)
+
+        p_cnt += 1
+
+
+def gen_acpi_info(board_fp):
+    """This will parser the sys node form SYS_PATH and generate ACPI info"""
+    read_pm_sstate(SYS_PATH[1] + 'FACP', board_fp)
+
+    print("{0}".format("\t<S3_INFO>"), file=board_fp)
+    read_pm_sdata(SYS_PATH[1] + 'DSDT', '_S3_', board_fp)
+    print("{0}".format("\t</S3_INFO>\n"), file=board_fp)
+
+    print("{0}".format("\t<S5_INFO>"), file=board_fp)
+    read_pm_sdata(SYS_PATH[1] + 'DSDT', '_S5_', board_fp)
+    print("{0}".format("\t</S5_INFO>\n"), file=board_fp)
+
+    print("{0}".format("\t<DRHD_INFO>"), file=board_fp)
+    dmar.write_dmar_data(SYS_PATH[1] + 'DMAR', board_fp)
+    print("{0}".format("\t</DRHD_INFO>\n"), file=board_fp)
+
+    print("{0}".format("\t<CPU_BRAND>"), file=board_fp)
+    store_cpu_info(SYS_PATH[0], board_fp)
+    print("{0}".format("\t</CPU_BRAND>\n"), file=board_fp)
+
+    print("{0}".format("\t<CX_INFO>"), file=board_fp)
+    store_cx_data(SYS_PATH[2]+'cpuidle/current_driver', SYS_PATH[2]+'cpu0/cpuidle/', board_fp)
+    print("{0}".format("\t</CX_INFO>\n"), file=board_fp)
+
+    print("{0}".format("\t<PX_INFO>"), file=board_fp)
+    store_px_data(SYS_PATH[2], board_fp)
+    print("{0}".format("\t</PX_INFO>\n"), file=board_fp)
+
+
+def generate_info(board_file):
+    """This will generate ACPI info from board file"""
+    # Generate board info
+    with open(board_file, 'a+') as board_info:
+        gen_acpi_info(board_info)

--- a/misc/acrn-config/target/board_parser.py
+++ b/misc/acrn-config/target/board_parser.py
@@ -1,0 +1,142 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import os
+import sys
+import shutil
+import argparse
+import subprocess
+import parser_lib
+import pci_dev
+import dmi
+import acpi
+import clos
+
+OUTPUT = "./out/"
+PY_CACHE = "__pycache__"
+
+# This file store information which query from hw board
+BIN_LIST = ['cpuid', 'rdmsr', 'lspci', ' dmidecode']
+PCI_IDS = ["/usr/share/hwdata/pci.ids", "/usr/share/misc/pci.ids"]
+
+CPU_VENDOR = "GenuineIntel"
+
+
+def check_permission():
+    """Check if it is root permission"""
+    if os.getuid():
+        parser_lib.print_red("You need run with sudo!")
+        sys.exit(1)
+
+
+def native_check():
+    """Check if this is natvie os"""
+    cmd = "cpuid -r -l 0x01"
+    res = parser_lib.cmd_excute(cmd)
+    while True:
+        line = parser_lib.decode_stdout(res)
+
+        if line:
+
+            if len(line.split()) <= 2:
+                continue
+
+            reg_value = line.split()[4].split('=')[1]
+            break
+
+    return int(reg_value, 16) & 0x80000000 == 0
+
+
+def vendor_check():
+    """Check the CPU vendor"""
+    with open("/proc/cpuinfo", 'r') as f_node:
+        while True:
+            line = f_node.readline()
+            if len(line.split(':')) == 2:
+                if line.split(':')[0].strip() == "vendor_id":
+                    vendor_name = line.split(':')[1].strip()
+                    return vendor_name != CPU_VENDOR
+
+
+def check_env():
+    """Check if there is appropriate environment on this system"""
+    if os.path.exists(PY_CACHE):
+        shutil.rmtree(PY_CACHE)
+
+    # check cpu vendor id
+    if vendor_check():
+        parser_lib.print_red("Please run this tools on {}!".format(CPU_VENDOR))
+        sys.exit(1)
+
+    # check if required tools are exists
+    for excute in BIN_LIST:
+        res = subprocess.Popen("which {}".format(excute),
+                               shell=True, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, close_fds=True)
+
+        line = res.stdout.readline().decode('ascii')
+        if not line:
+            parser_lib.print_yel("'{}' not found, please install it!".format(excute))
+            sys.exit(1)
+
+        if excute == 'cpuid':
+            res = subprocess.Popen("cpuid -v",
+                                   shell=True, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, close_fds=True)
+            line = res.stdout.readline().decode('ascii')
+            version = line.split()[2]
+            if int(version) < 20170122:
+                parser_lib.print_yel("Need CPUID version >= 20170122")
+                sys.exit(1)
+
+
+    if not native_check():
+        parser_lib.print_red("Please run this tools on natvie OS!")
+        sys.exit(1)
+
+    if not os.path.exists(PCI_IDS[0]) and not os.path.exists(PCI_IDS[1]):
+        parser_lib.print_yel("pci.ids not found, please make sure lspci is installed correctly!")
+        sys.exit(1)
+
+    if os.path.exists(OUTPUT):
+        shutil.rmtree(OUTPUT)
+
+
+if __name__ == '__main__':
+    check_permission()
+
+    check_env()
+
+    # arguments to parse
+    PARSER = argparse.ArgumentParser(usage='%(prog)s <board_name> [--out board_info_file]')
+    PARSER.add_argument('board_name', help=":  the name of board that run ACRN hypervisor")
+    PARSER.add_argument('--out', help=":  the name of board info file.")
+    ARGS = PARSER.parse_args()
+
+    if not ARGS.out:
+        os.makedirs(OUTPUT)
+        BOARD_INFO = OUTPUT + ARGS.board_name + ".xml"
+    else:
+        BOARD_INFO = ARGS.out
+
+    with open(BOARD_INFO, 'w+') as f:
+        print('<acrn-config board="{}">'.format(ARGS.board_name), file=f)
+
+    # Get bios and base board info and store to board info
+    dmi.generate_info(BOARD_INFO)
+
+    # Get pci devicse table and store pci info to board info
+    pci_dev.generate_info(BOARD_INFO)
+
+    # Generate board info
+    acpi.generate_info(BOARD_INFO)
+
+    # Generate clos info
+    clos.generate_info(BOARD_INFO)
+
+    with open(BOARD_INFO, 'a+') as f:
+        print("</acrn-config>", file=f)
+
+    print("{} is generaged successfully!".format(BOARD_INFO))

--- a/misc/acrn-config/target/clos.py
+++ b/misc/acrn-config/target/clos.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import parser_lib
+
+CACHE_TYPE = {
+        "L2":4,
+        "L3":2
+    }
+
+
+def execute(cmd, reg):
+    """Execute the cmd"""
+    cache_t = ''
+
+    res = parser_lib.cmd_excute(cmd)
+    if reg == "ebx":
+        idx = 3
+
+    if reg == "edx":
+        idx = 5
+
+    while True:
+        line = parser_lib.decode_stdout(res)
+
+        if not line:
+            break
+
+        if len(line.split()) <= 2:
+            continue
+
+        reg_value = line.split()[idx].split('=')[1]
+
+        if reg == "ebx":
+            if int(reg_value, 16) & CACHE_TYPE['L2'] != 0:
+                cache_t = "L2"
+                break
+            elif int(reg_value, 16) & CACHE_TYPE['L3'] != 0:
+                cache_t = "L3"
+                break
+            else:
+                cache_t = False
+                break
+        elif reg == "edx":
+            cache_t = int(reg_value, 16) + 1
+            break
+
+    return cache_t
+
+
+def get_clos_info():
+    """Get clos max and clos cache type"""
+    clos_max = 0
+    clos_cache = False
+    cmd = "cpuid -r -l 0x10"
+    clos_cache = execute(cmd, "ebx")
+
+    if clos_cache == "L2":
+        cmd = "cpuid -r -l 0x10 --subleaf 2"
+    elif clos_cache == "L3":
+        cmd = "cpuid -r -l 0x10 --subleaf 1"
+    else:
+        clos_max = 0
+        parser_lib.print_yel("CLOS is not supported!")
+        return (clos_cache, clos_max)
+
+    clos_max = execute(cmd, "edx")
+
+    return (clos_cache, clos_max)
+
+def generate_info(board_info):
+    """Generate clos information"""
+    (clos_cache, clos_max) = get_clos_info()
+
+    with open(board_info, 'a+') as board_fp:
+        print("\t<CLOS_INFO>", file=board_fp)
+        print("\tclos supported by cache:{}".format(clos_cache), file=board_fp)
+        print("\tclos max:{}".format(clos_max), file=board_fp)
+        print("\t</CLOS_INFO>\n", file=board_fp)

--- a/misc/acrn-config/target/dmar.py
+++ b/misc/acrn-config/target/dmar.py
@@ -1,0 +1,364 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import ctypes
+
+ACPI_DMAR_TYPE = {
+    'ACPI_DMAR_TYPE_HARDWARE_UNIT':0,
+    'ACPI_DMAR_TYPE_RESERVED_MEMORY':1,
+    'ACPI_DMAR_TYPE_ROOT_ATS':2,
+    'ACPI_DMAR_TYPE_HARDWARE_AFFINITY':3,
+    'ACPI_DMAR_TYPE_NAMESPACE':4,
+    'ACPI_DMAR_TYPE_RESERVED':5,
+    }
+
+ACPI_DEV_SCOPE_TYPE = {
+    'ACPI_DMAR_SCOPE_TYPE_NOT_USED':0,
+    'ACPI_DMAR_SCOPE_TYPE_ENDPOINT':1,
+    'ACPI_DMAR_SCOPE_TYPE_BRIDGE':2,
+    'ACPI_DMAR_SCOPE_TYPE_IOAPIC':3,
+    'ACPI_DMAR_SCOPE_TYPE_HPET':4,
+    'ACPI_DMAR_SCOPE_TYPE_NAMESPACE':5,
+    'ACPI_DMAR_SCOPE_TYPE_RESERVED':6,
+    }
+
+class DmarHeader(ctypes.Structure):
+    """DMAR Header"""
+    _pack_ = 1
+    _fields_ = [
+        ('signature', ctypes.c_char*4),
+        ('length', ctypes.c_uint32),
+        ('revision', ctypes.c_ubyte),
+        ('checksum', ctypes.c_ubyte),
+        ('oem_id', ctypes.c_char*6),
+        ('oem_table_id', ctypes.c_char*8),
+        ('oem_revision', ctypes.c_uint32),
+        ('asl_compiler_id', ctypes.c_char*4),
+        ('asl_compiler_revision', ctypes.c_uint32),
+        ('host_addr_width', ctypes.c_ubyte),
+        ('flags', ctypes.c_ubyte),
+        ('reserved', ctypes.c_ubyte*10),
+    ]
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+
+class DmarSubtblHeader(ctypes.Structure):
+    """DMAR Sub Table Header"""
+    _pack_ = 1
+    _fields_ = [
+        ('type', ctypes.c_uint16),
+        ('length', ctypes.c_uint16),
+    ]
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+
+class DmarDevScope(ctypes.Structure):
+    """DMAR Device Scope"""
+    _pack_ = 1
+    _fields_ = [
+        ('entry_type', ctypes.c_uint8),
+        ('scope_length', ctypes.c_uint8),
+        ('reserved', ctypes.c_uint16),
+        ('enumeration_id', ctypes.c_uint8),
+        ('bus', ctypes.c_uint8),
+    ]
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+
+class DmarHwUnit(ctypes.Structure):
+    """DMAR Hardware Unit"""
+    _pack_ = 1
+    _fields_ = [
+        ('sub_header', DmarSubtblHeader),
+        ('flags', ctypes.c_uint8),
+        ('reserved', ctypes.c_uint8),
+        ('segment', ctypes.c_uint16),
+        ('address', ctypes.c_uint64),
+    ]
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+
+class DevScopePath(ctypes.Structure):
+    """DEVICE Scope Path"""
+    _pack_ = 1
+    _fields_ = [
+        ("device", ctypes.c_uint8),
+        ("function", ctypes.c_uint8),
+    ]
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self._pack_ = 0
+
+
+def map_file(sysnode):
+    """Map sys node to memory address"""
+    data = open(sysnode, 'rb').read()
+    buf = ctypes.create_string_buffer(data, len(data))
+    addr = ctypes.addressof(buf)
+
+    return addr
+
+class DmarHwList:
+    """DMAR HW List"""
+    def __init__(self):
+        self.hw_segment_list = []
+        self.hw_flags_list = []
+        self.hw_address_list = []
+        self.hw_ignore = {}
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.hw_ignore = {}
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.hw_ignore = {}
+
+
+class DmarDevList:
+    """DMAR DEV List"""
+    def __init__(self):
+        self.dev_scope_cnt_list = []
+        self.dev_bus_list = []
+        self.dev_path_list = []
+        self.dev_ioapic = {}
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.dev_bus_list = []
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.dev_bus_list = []
+
+
+class DmarTbl:
+    """DMAR TBL"""
+    def __init__(self):
+        self.sub_tbl_offset = 0
+        self.dmar_drhd = 0
+        self.dmar_dev_scope = 0
+        self.dev_scope_offset = 0
+        self.dev_scope_cnt = 0
+        self.path_offset = 0
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.path_offset = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.path_offset = 0
+
+
+class PathDevFun:
+    """Path Device Function meta data"""
+    def __init__(self):
+        self.path = 0
+        self.device = 0
+        self.function = 0
+
+    def style_check_1(self):
+        """Style check if have public method"""
+        self.path = 0
+
+    def style_check_2(self):
+        """Style check if have public method"""
+        self.path = 0
+
+
+def walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, n_cnt, drhd_cnt):
+    """Walk Pci bus"""
+    while n_cnt:
+        scope_path = DevScopePath.from_address(dmar_tbl.path_offset)
+        tmp_pdf.device = scope_path.device
+        tmp_pdf.function = scope_path.function
+        tmp_pdf.path = (((tmp_pdf.device & 0x1F) << 3) | ((tmp_pdf.function & 0x7)))
+        dmar_tbl.path_offset += ctypes.sizeof(DevScopePath)
+        n_cnt -= 1
+
+        # this not support to warning if no dedicated iommu for gpu
+        if ((dmar_tbl.dmar_drhd.segment << 16) | (
+                dmar_tbl.dmar_dev_scope.bus << 8) | scope_path.function) == 0x10:
+            dmar_hw_list.hw_ignore[drhd_cnt] = 'true'
+        else:
+            dmar_hw_list.hw_ignore[drhd_cnt] = 'false'
+
+    return (tmp_pdf, dmar_tbl, dmar_hw_list)
+
+
+def walk_dev_scope(dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt):
+    """Walk device scope"""
+    dmar_tbl.dev_scope_offset = dmar_tbl.sub_tbl_offset + ctypes.sizeof(DmarHwUnit)
+    scope_end = dmar_tbl.dev_scope_offset + dmar_tbl.dmar_drhd.sub_header.length
+    dmar_tbl.dev_scope_cnt = 0
+
+    while dmar_tbl.dev_scope_offset < scope_end:
+        dmar_tbl.dmar_dev_scope = DmarDevScope.from_address(dmar_tbl.dev_scope_offset)
+        if dmar_tbl.dmar_dev_scope.scope_length <= 0:
+            break
+        if dmar_tbl.dmar_dev_scope.entry_type != \
+                ACPI_DEV_SCOPE_TYPE['ACPI_DMAR_SCOPE_TYPE_NOT_USED'] and \
+                dmar_tbl.dmar_dev_scope.entry_type < \
+                ACPI_DEV_SCOPE_TYPE['ACPI_DMAR_SCOPE_TYPE_RESERVED']:
+            dmar_tbl.dev_scope_cnt += 1
+
+            # path offset is in end of device spcope
+            dmar_tbl.path_offset = dmar_tbl.dev_scope_offset + ctypes.sizeof(DmarDevScope)
+            # walk the pci bus with path deep, and find the {Device,Function}
+            tmp_pdf = PathDevFun()
+            n_cnt = (dmar_tbl.dmar_dev_scope.scope_length - ctypes.sizeof(DmarDevScope)) // 2
+            (tmp_pdf, dmar_tbl, dmar_hw_list) = walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list,
+                                                             n_cnt, drhd_cnt)
+            dmar_dev_list.dev_bus_list.append(dmar_tbl.dmar_dev_scope.bus)
+            dmar_dev_list.dev_path_list.append(tmp_pdf.path)
+
+            # if the scope entry type is ioapic, should address enumeration id
+            if dmar_tbl.dmar_dev_scope.entry_type ==\
+                    ACPI_DEV_SCOPE_TYPE['ACPI_DMAR_SCOPE_TYPE_IOAPIC']:
+                dmar_dev_list.dev_ioapic[drhd_cnt] = dmar_tbl.dmar_dev_scope.enumeration_id
+
+        dmar_tbl.dev_scope_offset += dmar_tbl.dmar_dev_scope.scope_length
+
+    return (dmar_tbl, dmar_dev_list, dmar_hw_list)
+
+
+def walk_dmar_table(dmar_tbl, dmar_hw_list, dmar_dev_list, sysnode):
+    """Walk dmar table and get information"""
+    data = open(sysnode, 'rb').read()
+    buf = ctypes.create_string_buffer(data, len(data))
+    addr = ctypes.addressof(buf)
+
+    # contain the dmar tbl_header
+    dmar_tbl_header = DmarHeader.from_address(addr)
+
+    # cytpes.c_int16.from_address(addr) reade int16 from ad1
+    # in end of tbl header is remapping structure(DRHD/sub tbl)
+    dmar_tbl.sub_tbl_offset = addr + ctypes.sizeof(DmarHeader)
+    drhd_cnt = 0
+    while True:
+        sub_dmar = DmarSubtblHeader.from_address(dmar_tbl.sub_tbl_offset)
+        sub_dmar_type = sub_dmar.type
+        sub_dmar_len = sub_dmar.length
+
+        if dmar_tbl.sub_tbl_offset - addr >= dmar_tbl_header.length:
+            break
+
+        if sub_dmar_type != ACPI_DMAR_TYPE['ACPI_DMAR_TYPE_HARDWARE_UNIT']:
+            dmar_tbl.sub_tbl_offset += sub_dmar.length
+            continue
+
+        # get one DRHD type in sub table
+        dmar_tbl.dmar_drhd = DmarHwUnit.from_address(dmar_tbl.sub_tbl_offset)
+        dmar_hw_list.hw_segment_list.append(dmar_tbl.dmar_drhd.segment)
+        dmar_hw_list.hw_flags_list.append(dmar_tbl.dmar_drhd.flags)
+        dmar_hw_list.hw_address_list.append(dmar_tbl.dmar_drhd.address)
+
+        # in end of DRHD/sub tbl header is devscope
+        (dmar_tbl, dmar_dev_list, dmar_hw_list) = walk_dev_scope(
+            dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt)
+
+        dmar_dev_list.dev_scope_cnt_list.append(dmar_tbl.dev_scope_cnt)
+        drhd_cnt += 1
+        dmar_tbl.sub_tbl_offset += sub_dmar_len
+
+    return (dmar_tbl, dmar_hw_list, dmar_dev_list, drhd_cnt)
+
+
+def write_dmar_data(sysnode, config):
+    """Write the DMAR data to board info"""
+
+    dmar_hw_list = DmarHwList()
+    dmar_dev_list = DmarDevList()
+    dmar_tbl = DmarTbl()
+
+    (dmar_tbl, dmar_hw_list, dmar_dev_list, drhd_cnt) = walk_dmar_table(
+        dmar_tbl, dmar_hw_list, dmar_dev_list, sysnode)
+
+    # num drhd and scope are hard coded
+    drhd_num = 4
+    scope_num = 4
+    # padding dev_scope_cnt_list
+    j = 0
+    if len(dmar_dev_list.dev_scope_cnt_list) < scope_num:
+        for j in range(scope_num - dmar_dev_list.dev_scope_cnt_list[j]):
+            dmar_dev_list.dev_scope_cnt_list.append(0)
+
+    # padding dev_bus_list/dev_path_list
+    for i in range(drhd_num):
+        for scope_level in range(scope_num - dmar_dev_list.dev_scope_cnt_list[i]):
+            dmar_dev_list.dev_path_list.insert(i * 4 + dmar_dev_list.dev_scope_cnt_list[i], 0)
+            dmar_dev_list.dev_bus_list.insert(i * 4 + dmar_dev_list.dev_scope_cnt_list[i], 0)
+            scope_level = scope_level
+
+    # padding the drhd count from hard code drhd_num
+    for i in range(drhd_num - drhd_cnt):
+        dmar_dev_list.dev_scope_cnt_list.append(0)
+        dmar_hw_list.hw_segment_list.append(0)
+        dmar_hw_list.hw_flags_list.append(0)
+        dmar_hw_list.hw_address_list.append(0)
+        dmar_hw_list.hw_ignore[drhd_cnt + i] = 'false'
+
+    # output the DRHD macro
+    print("\t#define DRHD_COUNT              {0}U".format(drhd_cnt), file=config)
+    for drhd_hw_i in range(drhd_num):
+        print("\t#define DRHD"+str(drhd_hw_i)+"_DEV_CNT           {0}U".format(
+            dmar_dev_list.dev_scope_cnt_list[drhd_hw_i]), file=config)
+        print("\t#define DRHD"+str(drhd_hw_i)+"_SEGMENT           {0}U".format(
+            dmar_hw_list.hw_segment_list[drhd_hw_i]), file=config)
+        print("\t#define DRHD"+str(drhd_hw_i)+"_FLAGS             {0}U".format(
+            dmar_hw_list.hw_flags_list[drhd_hw_i]), file=config)
+        print("\t#define DRHD"+str(drhd_hw_i)+"_REG_BASE          0x{:0>2X}UL".format(
+            dmar_hw_list.hw_address_list[drhd_hw_i]), file=config)
+        if drhd_hw_i in dmar_hw_list.hw_ignore.keys():
+            print("\t#define DRHD"+str(drhd_hw_i)+"_IGNORE            {0}".format(
+                dmar_hw_list.hw_ignore[drhd_hw_i]), file=config)
+        for dev_scope_i in range(scope_num):
+            print("\t#define DRHD"+str(drhd_hw_i)+"_DEVSCOPE"+str(dev_scope_i),
+                  file=config, end="")
+            print("_BUS     {0}U".format(hex(
+                dmar_dev_list.dev_bus_list[drhd_hw_i * scope_num + dev_scope_i])),
+                  file=config)
+            print("\t#define DRHD"+str(drhd_hw_i)+"_DEVSCOPE"+str(dev_scope_i),
+                  file=config, end="")
+            print("_PATH    {0}U".format(hex(
+                dmar_dev_list.dev_path_list[drhd_hw_i * scope_num + dev_scope_i])),
+                  file=config)
+        if drhd_hw_i in dmar_dev_list.dev_ioapic.keys():
+            print("\t#define DRHD"+str(drhd_hw_i)+"_IOAPIC_ID         {0}U".format(
+                dmar_dev_list.dev_ioapic[drhd_hw_i]), file=config)

--- a/misc/acrn-config/target/dmi.py
+++ b/misc/acrn-config/target/dmi.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import parser_lib
+
+CMDS = {
+    'BIOS_INFO':"dmidecode -t 0",
+    'BASE_BOARD_INFO':"dmidecode -t 2",
+    }
+
+
+def generate_info(board_info):
+    """Get bios and base board information"""
+    with open(board_info, 'a+') as config:
+        parser_lib.dump_excute(CMDS['BIOS_INFO'], 'BIOS_INFO', config)
+        print("", file=config)
+        parser_lib.dump_excute(CMDS['BASE_BOARD_INFO'], 'BASE_BOARD_INFO', config)
+        print("", file=config)

--- a/misc/acrn-config/target/parser_lib.py
+++ b/misc/acrn-config/target/parser_lib.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import os
+import subprocess
+
+BIOS_INFO_KEY = ['BIOS Information', 'Vendor:', 'Version:', 'Release Date:', 'BIOS Revision:']
+
+BASE_BOARD_KEY = ['Base Board Information', 'Manufacturer:', 'Product Name:', 'Version:']
+
+
+def check_dmi():
+    """Check if this tool run on native os"""
+    return os.path.exists("/sys/firmware/dmi")
+
+
+def print_yel(msg, warn=False):
+    """Print the msg wiht color of yellow"""
+    if warn:
+        print("\033[1;33mWarning\033[0m:"+msg)
+    else:
+        print("\033[1;33m{0}\033[0m".format(msg))
+
+
+def print_red(msg, err=False):
+    """Print the msg wiht color of red"""
+    if err:
+        print("\033[1;31mError\033[0m:"+msg)
+    else:
+        print("\033[1;31m{0}\033[0m".format(msg))
+
+
+def decode_stdout(resource):
+    """Decode stdout"""
+    line = resource.stdout.readline().decode('ascii')
+    return line
+
+
+def handle_hw_info(line, hw_info):
+    """handle the hardware information"""
+    for board_line in hw_info:
+        if board_line == " ".join(line.split()[0:1]) or \
+                board_line == " ".join(line.split()[0:2]) or \
+                board_line == " ".join(line.split()[0:3]):
+            return True
+    return False
+
+
+def handle_pci_dev(line):
+    """Handle if it is pci line"""
+    if "Region" in line and "Memory at" in line:
+        return True
+
+    if line != '\n':
+        if line.split()[0][2:3] == ':' and line.split()[0][5:6] == '.':
+            return True
+
+    return False
+
+
+def cmd_excute(cmd):
+    """Excute cmd and retrun raw"""
+    res = subprocess.Popen(cmd, shell=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+
+    return res
+
+
+def dump_excute(cmd, desc, config):
+    """Execute cmd and get information"""
+    val_dmi = check_dmi()
+    print("\t<{0}>".format(desc), file=config)
+
+    if not val_dmi and "dmidecode" in cmd:
+        print("\t\t</{0}>".format(desc), file=config)
+        return
+
+    res = cmd_excute(cmd)
+    while True:
+        line = res.stdout.readline().decode('ascii')
+
+        if not line:
+            break
+
+        if desc == "PCI_DEVICE":
+            if "prog-if" in line:
+                line = line.rsplit('(', 1)[0] + '\n'
+            ret = handle_pci_dev(line)
+            if not ret:
+                continue
+
+        if desc == "BIOS_INFO":
+            ret = handle_hw_info(line, BIOS_INFO_KEY)
+            if not ret:
+                continue
+
+        if desc == "BASE_BOARD_INFO":
+            ret = handle_hw_info(line, BASE_BOARD_KEY)
+            if not ret:
+                continue
+
+        print("\t{}".format(line.strip()), file=config)
+
+    print("\t</{0}>".format(desc), file=config)

--- a/misc/acrn-config/target/pci_dev.py
+++ b/misc/acrn-config/target/pci_dev.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import parser_lib
+
+CMDS = {
+    'PCI_DEVICE':"lspci -vv",
+    'PCI_VID_PID':"lspci -n",
+    }
+
+
+def generate_info(board_info):
+    """Get the pci info"""
+    with open(board_info, 'a+') as config:
+        parser_lib.dump_excute(CMDS['PCI_DEVICE'], 'PCI_DEVICE', config)
+        print("", file=config)
+        parser_lib.dump_excute(CMDS['PCI_VID_PID'], 'PCI_VID_PID', config)
+        print("", file=config)


### PR DESCRIPTION
1.   acrn-config: generate board information on target board

    These tools run on the target board and genearate board information.

    usage: python3 board_parser.py <board_name> [--out board_info_file]

    sample:
            $ sudo python3 board_parser.py apl-up2

    v1-v2:
    1. allow board parameter for new board

    v2-v3:
    1. add the usage descriptions for tools
    2. add description of kernel cmd line for README
    3. output informations to a xml type
    4. coding as PEP8 guildline

2.    acrn-config: generate a patch and apply to acrn-hypervisor

    the script will parser the the board information which already generated on
    target board, and apply to the acrn-hypervisor as a patch.

    usage: board_cfg_gen.py --board <board_info_file>

    sample:
            $ python3 board_cfg_gen.py --board ../target_board/board_info.xml

    v1-v2:
    1. allow to generate new board patch

    v2-v3:
    1. modify the description of generator tools
    2. parser board_name.xml file
    3. coding as PEP8 guildline

3.    acrn-config: add README for scenario_config and launch_config

    currently scenario config and launch config is not ready, leave these
    two folders for futrue useage and make folder structure clear.

    Tracked-On: #3480
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Reviewed-by: Shuang Zheng shuang.zheng@intel.com
    Acked-by: Terry Zou <terry.zou@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>

