### PR TITLE
hv: vpci: remove pci_find_vdev_by_pbdf

### DIFF
--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -91,25 +91,3 @@ struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_b
 
 	return vdev;
 }
-
-/**
- * @pre vpci != NULL
- * @pre vpci->pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
- */
-struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf)
-{
-	struct pci_vdev *vdev, *tmp;
-	uint32_t i;
-
-	vdev = NULL;
-	for (i = 0U; i < vpci->pci_vdev_cnt; i++) {
-		tmp = (struct pci_vdev *)&(vpci->pci_vdevs[i]);
-
-		if ((tmp->pdev != NULL) && bdf_is_equal((union pci_bdf *)&(tmp->pdev->bdf), &pbdf)) {
-			vdev = tmp;
-			break;
-		}
-	}
-
-	return vdev;
-}

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -153,6 +153,4 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 
 struct pci_vdev *pci_find_vdev_by_vbdf(const struct acrn_vpci *vpci, union pci_bdf vbdf);
 
-struct pci_vdev *pci_find_vdev_by_pbdf(const struct acrn_vpci *vpci, union pci_bdf pbdf);
-
 #endif /* VPCI_PRIV_H_ */


### PR DESCRIPTION
It's better to search vPCI device by vBDF which provides better isolation between
vCPI and pPCI.
Besides, when assigning a device from SOS to UOS, we should change the vPCI device's
vBDF and pBDF in UOS, not the SOS's. However, there needs great efforts. Now just
remove the modify for SOS.

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>