### PR TITLE
dm: Fix potential NULL pointer deference and buffer overflow issues

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2923,7 +2923,7 @@ retry:
 					trb->dwTrb2 & 0x1FFFF, (void *)addr,
 					ccs);
 
-			if (trb->dwTrb3 & XHCI_TRB_3_CHAIN_BIT)
+			if (xfer_block && (trb->dwTrb3 & XHCI_TRB_3_CHAIN_BIT))
 				xfer_block->chained = 1;
 			break;
 

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -3718,6 +3718,8 @@ pci_xhci_dev_intr(struct usb_hci *hci, int epctx)
 
 	/* HW endpoint contexts are 0-15; convert to epid based on dir */
 	epid = (epid * 2) + (dir_in ? 1 : 0);
+	if (epid >= XHCI_MAX_ENDPOINTS)
+		return 0;
 
 	dev = hci->dev;
 	xdev = dev->xdev;

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -181,6 +181,10 @@ usb_dev_comp_cb(struct libusb_transfer *trn)
 
 	/* async request */
 	r = trn->user_data;
+	if (!r) {
+		UPRINTF(LFTL, "error: user context data not found on USB transfer\r\n");
+		goto free_transfer;
+	}
 	info = &r->udev->info;
 
 	/* async transfer */
@@ -311,13 +315,14 @@ out:
 cancel_out:
 	/* unlock and release memory */
 	g_ctx.unlock_ep_cb(xfer->dev, &xfer->epid);
-	libusb_free_transfer(trn);
 
 	if (r && r->buffer)
 		free(r->buffer);
 
 	xfer->requests[r->blk_start] = NULL;
 	free(r);
+free_transfer:
+	libusb_free_transfer(trn);
 }
 
 static struct usb_dev_req *


### PR DESCRIPTION
Fix Potential NULL pointer deference and
buffer overflow issues on DM.

Tracked-On: #3434
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Xiaoguang Wu <xiaoguang.wu@intel.com>