### PR TITLE
hv: fix debug message format in 'init_pci_pdev_list'

### DIFF
--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -177,7 +177,7 @@ void init_pci_pdev_list(void)
 					secondary_bus = (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_SECBUS_1, 1U);
 					if (bus_to_scan[secondary_bus] != BUS_SCAN_SKIP) {
 						pr_err("%s, bus %d may be downstream of different PCI bridges",
-							secondary_bus);
+							__func__, secondary_bus);
 					} else {
 						bus_to_scan[secondary_bus] = BUS_SCAN_PENDING;
 					}


### PR DESCRIPTION
  To fix below err format:
  "%s" is used to output 'secondary_bus' with type of 'uint8_t'

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>