### PR TITLE
HV: Enable vART support by intercepting TSC_ADJUST MSR

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -437,8 +437,11 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	/* Set up executive VMCS pointer - pg 2905 24.6.10 */
 	exec_vmwrite64(VMX_EXECUTIVE_VMCS_PTR_FULL, 0UL);
 
-	/* Setup Time stamp counter offset - pg 2902 24.6.5 */
-	exec_vmwrite64(VMX_TSC_OFFSET_FULL, 0UL);
+	/* Setup Time stamp counter offset - pg 2902 24.6.5
+	 * VMCS.OFFSET = vAdjust - pAdjust
+	 */
+	value64 = vcpu_get_guest_msr(vcpu, MSR_IA32_TSC_ADJUST) - cpu_msr_read(MSR_IA32_TSC_ADJUST);
+	exec_vmwrite64(VMX_TSC_OFFSET_FULL, value64);
 
 	/* Set up the link pointer */
 	exec_vmwrite64(VMX_VMS_LINK_PTR_FULL, 0xFFFFFFFFFFFFFFFFUL);


### PR DESCRIPTION
The policy of vART is that software in native can run in
VM too. And in native side, the relationship between the
ART hardware and TSC is:

  pTSC = (pART * M) / N + pAdjust

The vART solution is:
  - Present the ART capability to guest through CPUID leaf
    15H for M/N which identical to the physical values.
  - PT devices see the pART (vART = pART).
  - Guest expect: vTSC = vART * M / N + vAdjust.
  - VMCS.OFFSET = vTSC - pTSC = vAdjust - pAdjust.

So to support vART, we should do the following:
  1. if vAdjust and vTSC are changed by guest, we should change
     VMCS.OFFSET accordingly.
  2. Make the assumption that the pAjust is never touched by ACRN.

For #1, commit "a958fea hv: emulate IA32_TSC_ADJUST MSR" has implementation
it. And for #2, acrn never touch pAdjust.

--
 v2 -> v3:
   - Add comment when handle guest TSC_ADJUST and TSC accessing.
   - Initialize the VMCS.OFFSET = vAdjust - pAdjust.

 v1 -> v2
   Refine commit message to describe the whole vART solution.

Tracked-On: #3501
Signed-off-by: Kaige Fu <kaige.fu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>