### PR TITLE
README: Fix Getting Started URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ ACRN support systems:
 
 
 .. _Introduction: https://projectacrn.github.io/latest/introduction/
-.. _Getting Started Guide: https://projectacrn.github.io/latest/getting_started/
+.. _Getting Started Guide: https://projectacrn.github.io/latest/getting-started/
 .. _Contribution Guide: https://projectacrn.github.io/latest/contribute.html
 .. _Project ACRN GitHub wiki: https://github.com/projectacrn/acrn-hypervisor/wiki
 .. _PGP Key: https://www.intel.com/content/www/us/en/security-center/pgp-public-key.html


### PR DESCRIPTION
The URL for the "Getting Started Guide" needs to be updated. This patch fixes this.

Fixes #3509 

Signed-off-by: Alex Merritt <mail@alexmerritt.us>