### PR TITLE
HV: fix highest severity flag in hybrid mode

### DIFF
--- a/hypervisor/scenarios/hybrid/vm_configurations.c
+++ b/hypervisor/scenarios/hybrid/vm_configurations.c
@@ -49,8 +49,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			 0xa1U, 0x2cU, 0x22U, 0x01U, 0xf1U, 0xabU, 0x02U, 0x40U},
 			/* dbbbd434-7a57-4216-a12c-2201f1ab0240 */
 
-		/* Allow SOS to reboot the host since there is supposed to be the highest severity guest */
-		.guest_flags = GUEST_FLAG_HIGHEST_SEVERITY,
+		.guest_flags = 0UL,
 		.clos = 0U,
 		.memory = {
 			.start_hpa = 0UL,


### PR DESCRIPTION
In hybrid mode, pre-launched VM should have the highest severity to
handle platform reset, the flag should not be set in SOS VM;

Tracked-On: #3505

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>