### PR TITLE
Vpci: refine init_vdevs

### DIFF
--- a/doc/developer-guides/sw_design_guidelines.rst
+++ b/doc/developer-guides/sw_design_guidelines.rst
@@ -290,7 +290,7 @@ The rules of error detection and error handling on a module level are shown in
    |                    |           | array size and non-null    |                           |                         |
    |                    |           | pointer.                   |                           |                         |
    +--------------------+-----------+----------------------------+---------------------------+-------------------------+
-   | Configuration data | Corrupted | No.                        | The bootloader initializes| 'vm_config->pci_ptdevs' |
+   | Configuration data | Corrupted | No.                        | The bootloader initializes| 'vm_config->pci_devs'   |
    | of the VM          | VM config | The related pre-conditions | hypervisor (including     | is configured           |
    |                    |           | are required.              | code, data, and bss) and  | statically.             |
    |                    |           | Note: VM configuration data| verifies the integrity of |                         |
@@ -328,19 +328,19 @@ a module level.
           struct acrn_vpci *vpci = (struct acrn_vpci *)&(vm->vpci);
           struct pci_vdev *vdev;
           struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
-          struct acrn_vm_pci_ptdev_config *ptdev_config;
+          struct acrn_vm_pci_dev_config *pci_dev_config;
           uint32_t i;
 
-          vpci->pci_vdev_cnt = vm_config->pci_ptdev_num;
+          vpci->pci_vdev_cnt = vm_config->pci_dev_num;
 
           for (i = 0U; i < vpci->pci_vdev_cnt; i++) {
                   vdev = &vpci->pci_vdevs[i];
                   vdev->vpci = vpci;
-                  ptdev_config = &vm_config->pci_ptdevs[i];
-                  vdev->vbdf.value = ptdev_config->vbdf.value;
+                  pci_dev_config = &vm_config->pci_devs[i];
+                  vdev->vbdf.value = pci_dev_config->vbdf.value;
 
                   if (vdev->vbdf.value != 0U) {
-                          partition_mode_pdev_init(vdev, ptdev_config->pbdf);
+                          partition_mode_pdev_init(vdev, pci_dev_config->pbdf);
                           vdev->ops = &pci_ops_vdev_pt;
                   } else {
                           vdev->ops = &pci_ops_vdev_hostbridge;
@@ -367,7 +367,7 @@ pre-conditions and ``get_vm_config`` itself shall guarantee the post-condition.
   /**
    * @pre vm_id < CONFIG_MAX_VM_NUM
    * @post retval != NULL
-   * @post retval->pci_ptdev_num <= MAX_PCI_DEV_NUM
+   * @post retval->pci_dev_num <= MAX_PCI_DEV_NUM
    */
   struct acrn_vm_config *get_vm_config(uint16_t vm_id)
   {
@@ -398,9 +398,9 @@ Given the two reasons above, 'vdev' is always not NULL. So, the error checking
 codes are not required for 'vdev'.
 
 
-**Question_3: Is error checking required for 'ptdev_config'?**
+**Question_3: Is error checking required for 'pci_dev_config'?**
 
-No. 'ptdev_config' is getting data from the array 'pci_vdevs[]', which is the
+No. 'pci_dev_config' is getting data from the array 'pci_vdevs[]', which is the
 physical PCI device information coming from Board Support Package and firmware.
 For physical PCI device information, the related application constraints
 shall be defined in the design document or safety manual. For debug purpose,

--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -229,7 +229,7 @@ Enable partition mode in ACRN hypervisor
 
    PCI devices that are available to the privileged VMs
    are hardcoded in the source file ``hypervisor/arch/x86/configs/up2/pt_dev.c``.
-   You need to review and modify the ``vm0_pci_ptdevs`` and ``vm1_pci_ptdevs``
+   You need to review and modify the ``vm0_pci_devs`` and ``vm1_pci_devs``
    structures in the source code to match the PCI BDF addresses of the SATA
    controller and the USB controller noted in step 1:
 
@@ -238,7 +238,7 @@ Enable partition mode in ACRN hypervisor
      :caption: hypervisor/arch/x86/configs/up2/pt_dev.c
 
      ...
-     struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[2] = {
+     struct acrn_vm_pci_dev_config vm0_pci_devs[2] = {
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
 		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
@@ -250,7 +250,7 @@ Enable partition mode in ACRN hypervisor
      };
 
      ...
-     struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[3] = {
+     struct acrn_vm_pci_dev_config vm1_pci_devs[3] = {
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
 		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -247,6 +247,7 @@ VP_BASE_C_SRCS += boot/guest/vboot_info.c
 VP_BASE_C_SRCS += common/hv_main.c
 VP_BASE_C_SRCS += common/vm_load.c
 VP_BASE_C_SRCS += arch/x86/configs/vmptable.c
+VP_BASE_C_SRCS += arch/x86/configs/pci_dev.c
 VP_BASE_C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/ve820.c
 
 # virtual platform device model

--- a/hypervisor/arch/x86/configs/apl-mrb/pci_devices.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/pci_devices.h
@@ -7,8 +7,6 @@
 #ifndef PCI_DEVICES_H_
 #define PCI_DEVICES_H_
 
-#define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-
 #define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x12U, .f = 0x00U},	\
 				.vbar_base[0] = 0xb3f10000UL,				\
 				.vbar_base[1] = 0xb3f53000UL,				\

--- a/hypervisor/arch/x86/configs/dnv-cb2/pci_devices.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/pci_devices.h
@@ -7,7 +7,6 @@
 #ifndef PCI_DEVICES_H_
 #define PCI_DEVICES_H_
 
-#define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
 #define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x14U, .f = 0x00U}
 #define USB_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x15U, .f = 0x00U}
 #define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x03U, .d = 0x00U, .f = 0x00U}

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/pci_devices.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/pci_devices.h
@@ -7,8 +7,6 @@
 #ifndef PCI_DEVICES_H_
 #define PCI_DEVICES_H_
 
-#define HOST_BRIDGE		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
-
 #define SATA_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x17U, .f = 0x00U},	\
 				.vbar_base[0] = 0xdf248000UL, 				\
 				.vbar_base[1] = 0xdf24c000UL,				\
@@ -20,7 +18,7 @@
 #define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x1fU, .f = 0x06U},	\
 				.vbar_base[0] = 0xdf200000UL
 
-#define NETWORK_CONTROLLER_0	.pbdf.bits = {.b = 0x10U, .d = 0x00U, .f = 0x00U},	\
+#define NETWORK_CONTROLLER_0	.pbdf.bits = {.b = 0x01U, .d = 0x00U, .f = 0x00U},	\
 				.vbar_base[0] = 0xdf100000UL
 
 #endif /* PCI_DEVICES_H_ */

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm_config.h>
+#include <pci.h>
+
+static uint16_t pcidev_config_num = 0U;
+static struct acrn_vm_pci_dev_config pcidev_config[CONFIG_MAX_PCI_DEV_NUM] = {};
+
+/*
+ * @pre pdev != NULL;
+ */
+static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
+{
+	bool found = false;
+	uint16_t vmid;
+	uint32_t pci_idx;
+	struct acrn_vm_config *vm_config;
+	struct acrn_vm_pci_dev_config *dev_config;
+
+	for (vmid = 0U; vmid < CONFIG_MAX_VM_NUM; vmid++) {
+		vm_config = get_vm_config(vmid);
+		if (vm_config->load_order != PRE_LAUNCHED_VM) {
+			continue;
+		}
+
+		for (pci_idx = 0U; pci_idx < vm_config->pci_dev_num; pci_idx++) {
+			dev_config = &vm_config->pci_devs[pci_idx];
+			if ((dev_config->emu_type == PCI_DEV_TYPE_PTDEV) &&
+					bdf_is_equal(&dev_config->pbdf, &pdev->bdf)) {
+				dev_config->pdev = pdev;
+				found = true;
+				break;
+			}
+		}
+
+		if (found) {
+			break;
+		}
+	}
+
+	return found;
+}
+
+
+/*
+ * @pre: pdev != NULL
+ */
+void fill_pci_dev_config(struct pci_pdev *pdev)
+{
+	struct acrn_vm_pci_dev_config *dev_config;
+
+	if (!is_allocated_to_prelaunched_vm(pdev)) {
+		dev_config = &pcidev_config[pcidev_config_num];
+		dev_config->emu_type = (pdev->bdf.value != HOST_BRIDGE_BDF) ? PCI_DEV_TYPE_PTDEV : PCI_DEV_TYPE_HVEMUL;
+		dev_config->vbdf.value = pdev->bdf.value;
+		dev_config->pbdf.value = pdev->bdf.value;
+		dev_config->pdev = pdev;
+		pcidev_config_num++;
+	}
+}
+
+/*
+ * @pre vm_config != NULL
+ */
+void initialize_sos_pci_dev_config(struct acrn_vm_config *vm_config)
+{
+	vm_config->pci_dev_num = pcidev_config_num;
+	vm_config->pci_devs = pcidev_config;
+}

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -27,6 +27,7 @@
 #include <board.h>
 #include <sgx.h>
 #include <sbuf.h>
+#include <pci_dev.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -447,8 +448,9 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		status = init_vm_boot_info(vm);
 		if (status != 0) {
 			need_cleanup = true;
+		} else {
+			initialize_sos_pci_dev_config(vm_config);
 		}
-
 	} else {
 		/* For PRE_LAUNCHED_VM and POST_LAUNCHED_VM */
 		if ((vm_config->guest_flags & GUEST_FLAG_SECURE_WORLD_ENABLED) != 0U) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -589,9 +589,7 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 		ptdev_release_all_entries(vm);
 
 		/* Free iommu */
-		if (vm->iommu != NULL) {
-			destroy_iommu_domain(vm->iommu);
-		}
+		destroy_iommu_domain(vm->iommu);
 
 		/* Free EPT allocated resources assigned to VM */
 		destroy_ept(vm);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -874,7 +874,6 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	uint16_t bdf;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	bool bdf_valid = true;
-	bool iommu_valid = true;
 
 	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (param < 0x10000UL) {
@@ -888,24 +887,7 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 		        }
 	        }
 
-		/* create a iommu domain for target VM if not created */
-		if (bdf_valid && (target_vm->iommu == NULL)) {
-			if (target_vm->arch_vm.nworld_eptp == NULL) {
-				pr_err("%s, EPT of VM not set!\n",
-					__func__, target_vm->vm_id);
-				iommu_valid = false;
-			        ret = -EPERM;
-			} else {
-				/* TODO: how to get vm's address width? */
-				target_vm->iommu = create_iommu_domain(vmid,
-						hva2hpa(target_vm->arch_vm.nworld_eptp), 48U);
-				if (target_vm->iommu == NULL) {
-					iommu_valid = false;
-					ret = -ENODEV;
-				}
-			}
-		}
-		if (bdf_valid && iommu_valid) {
+		if (bdf_valid) {
 			ret = move_pt_device(vm->iommu, target_vm->iommu,
 				(uint8_t)(bdf >> 8U), (uint8_t)(bdf & 0xffU));
 		}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -498,7 +498,7 @@ void init_vdev_pt(struct pci_vdev *vdev)
 				vbar_base = get_pbar_base(vdev->pdev, idx);
 			} else if (idx > 0U) {
 				/* For pre-launched VMs: vbar base is predefined in vm_config */
-				vbar_base = vdev->ptdev_config->vbar_base[idx - 1U];
+				vbar_base = vdev->pci_dev_config->vbar_base[idx - 1U];
 			} else {
 				vbar_base = 0UL;
 			}
@@ -522,7 +522,7 @@ void init_vdev_pt(struct pci_vdev *vdev)
 					vbar_base = get_pbar_base(vdev->pdev, idx);
 				} else {
 					/* For pre-launched VMs: vbar base is predefined in vm_config */
-					vbar_base = vdev->ptdev_config->vbar_base[idx];
+					vbar_base = vdev->pci_dev_config->vbar_base[idx];
 				}
 				vdev_pt_write_vbar(vdev, pci_bar_offset(idx), (uint32_t)vbar_base);
 				break;

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -420,25 +420,25 @@ static void write_cfg(const struct acrn_vpci *vpci, union pci_bdf bdf,
 
 /**
  * @pre vm_config != NULL
- * @pre vm_config->pci_ptdev_num <= CONFIG_MAX_PCI_DEV_NUM
+ * @pre vm_config->pci_dev_num <= CONFIG_MAX_PCI_DEV_NUM
  */
-static struct acrn_vm_pci_ptdev_config *find_ptdev_config_by_pbdf(const struct acrn_vm_config *vm_config,
+static struct acrn_vm_pci_dev_config *find_pci_dev_config(const struct acrn_vm_config *vm_config,
 	union pci_bdf pbdf)
 {
-	struct acrn_vm_pci_ptdev_config *ptdev_config, *tmp;
+	struct acrn_vm_pci_dev_config *pci_dev_config, *tmp;
 	uint16_t i;
 
-	ptdev_config = NULL;
-	for (i = 0U; i < vm_config->pci_ptdev_num; i++) {
-		tmp = &vm_config->pci_ptdevs[i];
+	pci_dev_config = NULL;
+	for (i = 0U; i < vm_config->pci_dev_num; i++) {
+		tmp = &vm_config->pci_devs[i];
 
 		if (bdf_is_equal(&tmp->pbdf, &pbdf)) {
-			ptdev_config = tmp;
+			pci_dev_config = tmp;
 			break;
 		}
 	}
 
-	return ptdev_config;
+	return pci_dev_config;
 }
 
 /**
@@ -450,11 +450,11 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const struct acrn_vm *vm)
 {
 	const struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	struct acrn_vpci *vpci = &(((struct acrn_vm *)vm)->vpci);
-	struct acrn_vm_pci_ptdev_config *ptdev_config;
+	struct acrn_vm_pci_dev_config *pci_dev_config;
 
-	ptdev_config = find_ptdev_config_by_pbdf(vm_config, pdev->bdf);
+	pci_dev_config = find_pci_dev_config(vm_config, pdev->bdf);
 
-	if (((is_prelaunched_vm(vm) && (ptdev_config != NULL)) || is_sos_vm(vm))
+	if (((is_prelaunched_vm(vm) && (pci_dev_config != NULL)) || is_sos_vm(vm))
 		&& (vpci->pci_vdev_cnt < CONFIG_MAX_PCI_DEV_NUM)) {
 		struct pci_vdev *vdev;
 
@@ -463,11 +463,11 @@ static void init_vdev_for_pdev(struct pci_pdev *pdev, const struct acrn_vm *vm)
 
 		vdev->vpci = vpci;
 		vdev->pdev = pdev;
-		vdev->ptdev_config = ptdev_config;
+		vdev->pci_dev_config = pci_dev_config;
 
-		if (ptdev_config != NULL) {
+		if (pci_dev_config != NULL) {
 			/* vbdf is defined in vm_config */
-			vdev->bdf.value = ptdev_config->vbdf.value;
+			vdev->bdf.value = pci_dev_config->vbdf.value;
 		} else {
 			/* vbdf is not defined in vm_config, set it to equal to pbdf */
 			vdev->bdf.value = pdev->bdf.value;

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -125,14 +125,6 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 	return (has_msi_cap(vdev) && in_range(offset, vdev->msi.capoff, vdev->msi.caplen));
 }
 
-/**
- * @pre vdev != NULL
- */
-static inline bool is_hostbridge(const struct pci_vdev *vdev)
-{
-	return (vdev->bdf.value == 0U);
-}
-
 void init_vdev_pt(struct pci_vdev *vdev);
 void vdev_pt_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void vdev_pt_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -34,6 +34,7 @@
 #include <pci.h>
 #include <uart16550.h>
 #include <logmsg.h>
+#include <pci_dev.h>
 
 static spinlock_t pci_device_lock;
 uint32_t num_pci_pdev;
@@ -414,6 +415,8 @@ static void fill_pdev(uint16_t pbdf, struct pci_pdev *pdev)
 	if ((pci_pdev_read_cfg(pdev->bdf, PCIR_STATUS, 2U) & PCIM_STATUS_CAPPRESENT) != 0U) {
 		pci_read_cap(pdev, hdr_type);
 	}
+
+	fill_pci_dev_config(pdev);
 }
 
 static void init_pdev(uint16_t pbdf)

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -37,8 +37,8 @@
 #include <pci_dev.h>
 
 static spinlock_t pci_device_lock;
-uint32_t num_pci_pdev;
-struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
+static uint32_t num_pci_pdev;
+static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
 
 static void init_pdev(uint16_t pbdf);
 

--- a/hypervisor/include/arch/x86/pci_dev.h
+++ b/hypervisor/include/arch/x86/pci_dev.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PCI_DEV_H_
+#define PCI_DEV_H_
+
+#include <vpci.h>
+
+struct acrn_vm_config;
+
+void fill_pci_dev_config(struct pci_pdev *pdev);
+void initialize_sos_pci_dev_config(struct acrn_vm_config *vm_config);
+
+#endif /* PCI_DEV_H_ */

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -20,6 +20,10 @@
 #define MAX_VM_OS_NAME_LEN	32U
 #define MAX_MOD_TAG_LEN		32U
 
+#define PCI_DEV_TYPE_PTDEV	(1U << 0U)
+#define PCI_DEV_TYPE_HVEMUL	(1U << 1U)
+#define PCI_DEV_TYPE_SOSEMUL	(1U << 2U)
+
 /*
  * PRE_LAUNCHED_VM is launched by ACRN hypervisor, with LAPIC_PT;
  * SOS_VM is launched by ACRN hypervisor, without LAPIC_PT;
@@ -79,9 +83,11 @@ struct acrn_vm_os_config {
 } __aligned(8);
 
 struct acrn_vm_pci_dev_config {
+	uint32_t emu_type;				/* the type how the device is emulated. */
 	union pci_bdf vbdf;				/* virtual BDF of PCI device */
 	union pci_bdf pbdf;				/* physical BDF of PCI device */
 	uint64_t vbar_base[PCI_BAR_COUNT];		/* vbar base address of PCI device */
+	struct pci_pdev *pdev;				/* the physical PCI device if it's a PT device */
 } __aligned(8);
 
 struct acrn_vm_config {

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -78,10 +78,10 @@ struct acrn_vm_os_config {
 	uint64_t kernel_ramdisk_addr;
 } __aligned(8);
 
-struct acrn_vm_pci_ptdev_config {
-	union pci_bdf vbdf;				/* virtual BDF of PCI PT device */
-	union pci_bdf pbdf;				/* physical BDF of PCI PT device */
-	uint64_t vbar_base[PCI_BAR_COUNT];	/* vbar base address of PCI PT device */
+struct acrn_vm_pci_dev_config {
+	union pci_bdf vbdf;				/* virtual BDF of PCI device */
+	union pci_bdf pbdf;				/* physical BDF of PCI device */
+	uint64_t vbar_base[PCI_BAR_COUNT];		/* vbar base address of PCI device */
 } __aligned(8);
 
 struct acrn_vm_config {
@@ -97,8 +97,8 @@ struct acrn_vm_config {
 							 */
 	struct acrn_vm_mem_config memory;		/* memory configuration of VM */
 	struct epc_section epc;				/* EPC memory configuration of VM */
-	uint16_t pci_ptdev_num;				/* indicate how many PCI PT devices in VM */
-	struct acrn_vm_pci_ptdev_config *pci_ptdevs;	/* point to PCI PT devices BDF list */
+	uint16_t pci_dev_num;				/* indicate how many PCI devices in VM */
+	struct acrn_vm_pci_dev_config *pci_devs;	/* point to PCI devices BDF list */
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
 	uint16_t clos;					/* if guest_flags has GUEST_FLAG_CLOS_REQUIRED, then VM use this CLOS */
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -91,8 +91,8 @@ struct pci_vdev {
 	struct pci_msi msi;
 	struct pci_msix msix;
 
-	/* Pointer to corresponding PCI PT device's vm_config */
-	struct acrn_vm_pci_ptdev_config *ptdev_config;
+	/* Pointer to corresponding PCI device's vm_config */
+	struct acrn_vm_pci_dev_config *pci_dev_config;
 
 	/* Pointer to corressponding operations */
 	const struct pci_vdev_ops *vdev_ops;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -130,6 +130,8 @@
 #define MSIX_CAPLEN           12U
 #define MSIX_TABLE_ENTRY_SIZE 16U
 
+#define HOST_BRIDGE_BDF		0U
+
 union pci_bdf {
 	uint16_t value;
 	struct {

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -218,10 +218,6 @@ struct pci_pdev {
 	struct pci_msix_cap msix;
 };
 
-extern uint32_t num_pci_pdev;
-extern struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
-
-
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {
 	return PCIR_BARS + (idx << 2U);

--- a/hypervisor/scenarios/logical_partition/pt_dev.c
+++ b/hypervisor/scenarios/logical_partition/pt_dev.c
@@ -14,14 +14,16 @@
 
 struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	{
+		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
-		HOST_BRIDGE
 	},
 	{
+		.emu_type = PCI_DEV_TYPE_PTDEV,
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
 		VM0_STORAGE_CONTROLLER
 	},
 	{
+		.emu_type = PCI_DEV_TYPE_PTDEV,
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
 		VM0_NETWORK_CONTROLLER
 	},
@@ -29,15 +31,17 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 
 struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_PTDEV_NUM] = {
 	{
+		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
-		HOST_BRIDGE
 	},
 	{
+		.emu_type = PCI_DEV_TYPE_PTDEV,
 		.vbdf.bits = {.b = 0x00U, .d = 0x01U, .f = 0x00U},
 		VM1_STORAGE_CONTROLLER
 	},
 #if defined(VM1_NETWORK_CONTROLLER)
 	{
+		.emu_type = PCI_DEV_TYPE_PTDEV,
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
 		VM1_NETWORK_CONTROLLER
 	},

--- a/hypervisor/scenarios/logical_partition/pt_dev.c
+++ b/hypervisor/scenarios/logical_partition/pt_dev.c
@@ -12,7 +12,7 @@
  * The memory range of vBAR should exactly match with the e820 layout of VM.
  */
 
-struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM] = {
+struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
 		HOST_BRIDGE
@@ -27,7 +27,7 @@ struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	},
 };
 
-struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM] = {
+struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_PTDEV_NUM] = {
 	{
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
 		HOST_BRIDGE

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -7,8 +7,8 @@
 #include <vm_config.h>
 #include <vuart.h>
 
-extern struct acrn_vm_pci_ptdev_config vm0_pci_ptdevs[VM0_CONFIG_PCI_PTDEV_NUM];
-extern struct acrn_vm_pci_ptdev_config vm1_pci_ptdevs[VM1_CONFIG_PCI_PTDEV_NUM];
+extern struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM];
+extern struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_PTDEV_NUM];
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM0 */
@@ -46,8 +46,8 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vm_id = 1U,
 			.t_vuart.vuart_id = 1U,
 		},
-		.pci_ptdev_num = VM0_CONFIG_PCI_PTDEV_NUM,
-		.pci_ptdevs = vm0_pci_ptdevs,
+		.pci_dev_num = VM0_CONFIG_PCI_PTDEV_NUM,
+		.pci_devs = vm0_pci_devs,
 	},
 	{	/* VM1 */
 		.load_order = PRE_LAUNCHED_VM,
@@ -85,7 +85,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vm_id = 0U,
 			.t_vuart.vuart_id = 1U,
 		},
-		.pci_ptdev_num = VM1_CONFIG_PCI_PTDEV_NUM,
-		.pci_ptdevs = vm1_pci_ptdevs,
+		.pci_dev_num = VM1_CONFIG_PCI_PTDEV_NUM,
+		.pci_devs = vm1_pci_devs,
 	},
 };


### PR DESCRIPTION
v5:
revert "update find_vdev logic for SOS by PCI vBDF number"

v4:
1) refine PCI device type by adding PCI_DEV_TYPE_PTDEV, PCI_DEV_TYPE_HVEMUL, PCI_DEV_TYPE_SOSEMUL
2) make fill_pci_dev_config more readable
3) update find_vdev logic for SOS by PCI vBDF number

v3:
Build a global PCI device configure which doesn't contain pre-launched VM PT devices.
And assign it to SOS if there's a SOS.

v2:
Build PCI configure in VM configure for SOS to align with pre-launched VM to initialize
vPCI devices for guest.

Li, Fei1 (4):
  hv: vpci: rename ptdev_config to pci_dev_config
  hv: vm_config: build pci device configure for SOS
  hv: vpci: refine init_vdevs
  hv: vpci: create iommu domain in vpci_init for all guests

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>