### PR TITLE
doc: fix broken links after content reorg

### DIFF
--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -19,6 +19,8 @@ Configuration Tutorials
    tutorials/sign_clear_linux_image
    tutorials/static-ip
    tutorials/debug
+   tutorials/using_partition_mode_on_nuc
+   tutorials/using_partition_mode_on_up2
 
 User VM Tutorials
 *****************

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ through an open source platform.
 
    <ul class="grid">
        <li class="grid-item">
-           <a href="learn/index.html">
+           <a href="learn.html">
                <img alt="" src="_static/images/ACRNlogo.png"/>
                <h2>Learn about<br/>ACRN</h2>
            </a>
@@ -24,7 +24,7 @@ through an open source platform.
               features, and use-case scenarios</p>
        </li>
        <li class="grid-item">
-           <a href="try/index.rst">
+           <a href="try.html">
                <span class="grid-icon fa fa-map-signs"></span>
                <h2>Try using<br/>ACRN</h2>
            </a>
@@ -32,7 +32,7 @@ through an open source platform.
               samples</p>
        </li>
        <li class="grid-item">
-           <a href="develop/index.html">
+           <a href="develop.html">
                <span class="grid-icon fa fa-cogs"></span>
                <h2>Develop using<br/>ACRN</h2>
            </a>
@@ -40,7 +40,7 @@ through an open source platform.
               solutions</p>
        </li>
        <li class="grid-item">
-           <a href="contribute/index.html">
+           <a href="contribute.html">
                <span class="grid-icon fa fa-github"></span>
                <h2>Contribute to<br/>ACRN</h2>
            </a>

--- a/doc/try.rst
+++ b/doc/try.rst
@@ -23,5 +23,3 @@ Follow these getting started guides to give ACRN a try:
    getting-started/apl-nuc
    getting-started/up2
    getting-started/building-from-source
-   tutorials/using_partition_mode_on_nuc
-   tutorials/using_partition_mode_on_up2


### PR DESCRIPTION
Home page "button" links needed to be manually updated (because of the
raw html usage) after content around.

Move partition mode docs from try to develop persona pages.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>