### PR TITLE
doc: fix image proportions on home page for ie

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -233,6 +233,7 @@ kbd
 
 .grid-item img {
     max-width: 50%;
+    max-height: 50%;
     margin-bottom: 0.7rem;
 }
 


### PR DESCRIPTION
The ACRN icon on the new graphical home page looked fine with firefox,
edge, and chrome browsers, but not on IE.  This PR fixes that

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>