### PR TITLE
vm_load: update init gdt preparation

### DIFF
--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -604,6 +604,18 @@ void set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_vcpu_regs *vcpu_regs);
 void reset_vcpu_regs(struct acrn_vcpu *vcpu);
 
 /**
+ * @brief Initialize the protect mode vcpu registers
+ *
+ * Initialize vCPU's all registers in run_context to initial protece mode values.
+ *
+ * @param[inout] vcpu pointer to vcpu data structure
+ * @param[in] vgdt_base_gpa guest physical address of gdt for guest
+ *
+ * @return None
+ */
+void init_vcpu_protect_mode_regs(struct acrn_vcpu *vcpu, uint64_t vgdt_base_gpa);
+
+/**
  * @brief set the vCPU startup entry
  *
  * Set target vCPU's startup entry in run_context.


### PR DESCRIPTION
Now, we use native gdt saved in boot context for guest and assume
it could be put to same address of guest. But it may not be true
after the pre-launched VM is introduced.

This patch is used to put the init gdt by following
kernel/bootarg/ramdisk images. Which should be safe for any guest
configuration.

Tracked-On: #3532

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>