### PR TITLE
memmap:reserve phys-addr for hvlog

### DIFF
--- a/misc/efi-stub/clearlinux/acrn.conf
+++ b/misc/efi-stub/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title The ACRN Service OS
 linux   /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.13-1901141830
-options console=tty0 console=ttyS0 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000
+options console=tty0 console=ttyS0 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000 memmap=2M$0x1FE00000


### PR DESCRIPTION
acrn.conf:add memmap phys-addr 2M for hvlog,
not mapped by kernel.

Tracked-On: projectacrn/acrn-hypervisor#3533
Signed-off-by: YanX Fu <yanx.fu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>