### PR TITLE
HV: hotfix for wrong bdf of network controller of nuc7i7dnb

### DIFF
--- a/hypervisor/arch/x86/configs/nuc7i7dnb/pci_devices.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/pci_devices.h
@@ -20,7 +20,7 @@
 #define ETHERNET_CONTROLLER_0	.pbdf.bits = {.b = 0x00U, .d = 0x1fU, .f = 0x06U},	\
 				.vbar_base[0] = 0xdf200000UL
 
-#define NETWORK_CONTROLLER_0	.pbdf.bits = {.b = 0x10U, .d = 0x00U, .f = 0x00U},	\
+#define NETWORK_CONTROLLER_0	.pbdf.bits = {.b = 0x01U, .d = 0x00U, .f = 0x00U},	\
 				.vbar_base[0] = 0xdf100000UL
 
 #endif /* PCI_DEVICES_H_ */


### PR DESCRIPTION
The bus number of NETWORK_CONTROLLER_0 should be 0x01, not 0x10.

Tracked-On: #2291

Signed-off-by: Victor Sun <victor.sun@intel.com>