### PR TITLE
make: white-list SBL firmware boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,11 @@ T := $(CURDIR)
 
 BOARD ?= apl-nuc
 
-ifeq ($(BOARD),apl-nuc)
-FIRMWARE ?= uefi
-else ifeq ($(BOARD),nuc6cayh)
-FIRMWARE ?= uefi
+ifneq (,$(filter $(BOARD),apl-mrb))
+	FIRMWARE ?= sbl
+else
+	FIRMWARE ?= uefi
 endif
-FIRMWARE ?= sbl
 
 RELEASE ?= 0
 


### PR DESCRIPTION
The top-level Makefile white-lists ``BOARD``s to generate UEFI executable by default, but more UEFI BOARDs have been supported since then. As a result, the build instructions in existing documents may not be sufficient for those new ``BOARD`` targets, if the reader misses to supply the ``FIRMWARE`` variable while building the hypervisor.

Instead of adding new UEFI BOARD types using the original long **if-else** statements, I'd like to propose to white-list SBL BOARD types, and add the new SBL BOARD types to the list while needed. The Makefile will generate ``acrn.efi`` for non-white-listed SBL boards by default.

Tracked-On: #3541
Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>