### PR TITLE
dm: virtio-i2c: fix native_adapter memory leak

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_i2c.c
+++ b/devicemodel/hw/pci/virtio/virtio_i2c.c
@@ -449,7 +449,7 @@ native_adapter_create(int bus, uint16_t slave_addr[], int n_slave)
 	fd = open(native_path, O_RDWR);
 	if (fd < 0) {
 		WPRINTF("virtio_i2c: failed to open %s\n", native_path);
-		return NULL;
+		goto fail;
 	}
 	native_adapter->fd = fd;
 	native_adapter->bus = bus;


### PR DESCRIPTION
If failed to create native_adapter, free allocated native_adapter memory before return.

Tracked-On: #3543
Signed-off-by: Yifan Luo <luoyifan@cmss.chinamobile.com>