### PR TITLE
HV: shell: fix temp_str out of bounds buffer access

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -252,7 +252,7 @@ static uint16_t sanitize_vmid(uint16_t vmid)
 	char temp_str[TEMP_STR_SIZE];
 
 	if (vmid >= CONFIG_MAX_VM_NUM) {
-		snprintf(temp_str, MAX_STR_SIZE,
+		snprintf(temp_str, TEMP_STR_SIZE,
 			"VM ID given exceeds the MAX_VM_NUM(%u), using 0 instead\r\n",
 			CONFIG_MAX_VM_NUM);
 		shell_puts(temp_str);


### PR DESCRIPTION
String buffer temp_str is defined with size TEMP_STR_SIZE(60U) but accessed with MAX_STR_SIZE(256U). Better to limit the access bound to TEMP_STR_SIZE to prevent potential issue.

Tracked-On: #3549
Signed-off-by: Yifan Luo <luoyifan@cmss.chinamobile.com>