### PR TITLE
vpci: add support for customizing special pci operations for each emulated PCI device

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -213,8 +213,8 @@ HW_C_SRCS += hw/pci.c
 HW_C_SRCS += arch/x86/configs/vm_config.c
 HW_C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/board.c
 HW_C_SRCS += scenarios/$(SCENARIO_NAME)/vm_configurations.c
-ifneq (,$(wildcard scenarios/$(SCENARIO_NAME)/pt_dev.c))
-HW_C_SRCS += scenarios/$(SCENARIO_NAME)/pt_dev.c
+ifneq (,$(wildcard scenarios/$(SCENARIO_NAME)/pci_dev.c))
+HW_C_SRCS += scenarios/$(SCENARIO_NAME)/pci_dev.c
 endif
 HW_C_SRCS += boot/acpi_base.c
 HW_C_SRCS += boot/dmar_info.c

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -7,6 +7,7 @@
 #include <vm_config.h>
 #include <pci.h>
 #include <pci_dev.h>
+#include <vpci.h>
 
 /*
  * In theory, emulated PCI device doesn't need to bind to physical PCI device.
@@ -19,6 +20,7 @@ struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM] = {
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
 		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.vdev_ops = &vhostbridge_ops,
 	},
 };
 

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -6,9 +6,21 @@
 
 #include <vm_config.h>
 #include <pci.h>
+#include <pci_dev.h>
 
-static uint16_t pcidev_config_num = 0U;
-static struct acrn_vm_pci_dev_config pcidev_config[CONFIG_MAX_PCI_DEV_NUM] = {};
+/*
+ * In theory, emulated PCI device doesn't need to bind to physical PCI device.
+ * However, now we need to search virtual PCI device by pBDF because we bind
+ * post-launched VM PTDev with SOS's.
+ * Remove the pBDF for emulated PCI device once we don't have this limit.
+ */
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM] = {
+	{
+		.emu_type = PCI_DEV_TYPE_HVEMUL,
+		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+	},
+};
 
 /*
  * @pre pdev != NULL;
@@ -51,23 +63,36 @@ static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
  */
 void fill_pci_dev_config(struct pci_pdev *pdev)
 {
+	uint16_t vmid;
+	uint32_t idx;
+	struct acrn_vm_config *vm_config;
 	struct acrn_vm_pci_dev_config *dev_config;
 
 	if (!is_allocated_to_prelaunched_vm(pdev)) {
-		dev_config = &pcidev_config[pcidev_config_num];
-		dev_config->emu_type = (pdev->bdf.value != HOST_BRIDGE_BDF) ? PCI_DEV_TYPE_PTDEV : PCI_DEV_TYPE_HVEMUL;
-		dev_config->vbdf.value = pdev->bdf.value;
-		dev_config->pbdf.value = pdev->bdf.value;
-		dev_config->pdev = pdev;
-		pcidev_config_num++;
-	}
-}
+		for (vmid = 0U; vmid < CONFIG_MAX_VM_NUM; vmid++) {
+			vm_config = get_vm_config(vmid);
+			if (vm_config->load_order != SOS_VM) {
+				continue;
+			}
 
-/*
- * @pre vm_config != NULL
- */
-void initialize_sos_pci_dev_config(struct acrn_vm_config *vm_config)
-{
-	vm_config->pci_dev_num = pcidev_config_num;
-	vm_config->pci_devs = pcidev_config;
+			/* TODO: revert me if we could split post-launched VM's PTDev from SOS's */
+			for (idx = 0U; idx < SOS_EMULATED_PCI_DEV_NUM; idx++) {
+				dev_config = &vm_config->pci_devs[idx];
+				if (bdf_is_equal(&dev_config->pbdf, &pdev->bdf)) {
+					dev_config->pdev = pdev;
+					break;
+				}
+
+			}
+
+			if (idx == SOS_EMULATED_PCI_DEV_NUM) {
+				dev_config = &vm_config->pci_devs[vm_config->pci_dev_num];
+				dev_config->emu_type = PCI_DEV_TYPE_PTDEV;
+				dev_config->vbdf.value = pdev->bdf.value;
+				dev_config->pbdf.value = pdev->bdf.value;
+				dev_config->pdev = pdev;
+				vm_config->pci_dev_num++;
+			}
+		}
+	}
 }

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -448,8 +448,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		status = init_vm_boot_info(vm);
 		if (status != 0) {
 			need_cleanup = true;
-		} else {
-			initialize_sos_pci_dev_config(vm_config);
 		}
 	} else {
 		/* For PRE_LAUNCHED_VM and POST_LAUNCHED_VM */

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -122,14 +122,9 @@ static int32_t vhostbridge_write_cfg(struct pci_vdev *vdev, uint32_t offset,
 	return 0;
 }
 
-static const struct pci_vdev_ops vhostbridge_ops = {
+const struct pci_vdev_ops vhostbridge_ops = {
 	.init_vdev	= init_vhostbridge,
 	.deinit_vdev	= deinit_vhostbridge,
 	.write_vdev_cfg	= vhostbridge_write_cfg,
 	.read_vdev_cfg	= vhostbridge_read_cfg,
 };
-
-const struct pci_vdev_ops *get_vhostbridge_ops(void)
-{
-	return &vhostbridge_ops;
-}

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -427,13 +427,13 @@ static void vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_config
 	vdev->pdev = dev_config->pdev;
 	vdev->pci_dev_config = dev_config;
 
-	if (dev_config->emu_type == PCI_DEV_TYPE_PTDEV) {
-		vdev->vdev_ops = &pci_pt_dev_ops;
-		ASSERT(dev_config->pdev != NULL,
-			"PCI PTDev %x:%x.%x is not present in the platform!",
-			dev_config->pbdf.b, dev_config->pbdf.d, dev_config->pbdf.f);
+	if (dev_config->vdev_ops != NULL) {
+		vdev->vdev_ops = dev_config->vdev_ops;
 	} else {
-		vdev->vdev_ops = get_vhostbridge_ops();
+		vdev->vdev_ops = &pci_pt_dev_ops;
+		ASSERT(dev_config->emu_type == PCI_DEV_TYPE_PTDEV,
+			"Only PCI_DEV_TYPE_PTDEV could not configure vdev_ops");
+		ASSERT(dev_config->pdev != NULL, "PCI PTDev is not present on platform!");
 	}
 
 	vdev->vdev_ops->init_vdev(vdev);

--- a/hypervisor/include/arch/x86/pci_dev.h
+++ b/hypervisor/include/arch/x86/pci_dev.h
@@ -7,11 +7,13 @@
 #ifndef PCI_DEV_H_
 #define PCI_DEV_H_
 
-#include <vpci.h>
+#include <vm_config.h>
 
-struct acrn_vm_config;
+#define SOS_EMULATED_PCI_DEV_NUM	1U
 
+extern struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
+
+struct pci_pdev;
 void fill_pci_dev_config(struct pci_pdev *pdev);
-void initialize_sos_pci_dev_config(struct acrn_vm_config *vm_config);
 
 #endif /* PCI_DEV_H_ */

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -88,6 +88,7 @@ struct acrn_vm_pci_dev_config {
 	union pci_bdf pbdf;				/* physical BDF of PCI device */
 	uint64_t vbar_base[PCI_BAR_COUNT];		/* vbar base address of PCI device */
 	struct pci_pdev *pdev;				/* the physical PCI device if it's a PT device */
+	const struct pci_vdev_ops *vdev_ops;		/* operations for PCI CFG read/write */
 } __aligned(8);
 
 struct acrn_vm_config {

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -111,11 +111,10 @@ struct acrn_vpci {
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };
 
+extern const struct pci_vdev_ops vhostbridge_ops;
 void vpci_init(struct acrn_vm *vm);
 void vpci_cleanup(const struct acrn_vm *vm);
 void vpci_set_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
-
-const struct pci_vdev_ops *get_vhostbridge_ops(void);
 
 #endif /* VPCI_H_ */

--- a/hypervisor/scenarios/hybrid/vm_configurations.c
+++ b/hypervisor/scenarios/hybrid/vm_configurations.c
@@ -6,6 +6,7 @@
 
 #include <vm_config.h>
 #include <vuart.h>
+#include <pci_dev.h>
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM0 */
@@ -41,6 +42,8 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vm_id = 1U,
 			.t_vuart.vuart_id = 1U,
 		},
+		.pci_dev_num = SOS_EMULATED_PCI_DEV_NUM,
+		.pci_devs = sos_pci_devs,
 	},
 	{	/* VM1 */
 		.load_order = SOS_VM,

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -6,6 +6,7 @@
 
 #include <vm_config.h>
 #include <vuart.h>
+#include <pci_dev.h>
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{
@@ -34,7 +35,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.vuart[1] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = INVALID_COM_BASE,
-		}
+		},
+		.pci_dev_num = SOS_EMULATED_PCI_DEV_NUM,
+		.pci_devs = sos_pci_devs,
 	},
 	{
 		.load_order = POST_LAUNCHED_VM,

--- a/hypervisor/scenarios/logical_partition/pci_dev.c
+++ b/hypervisor/scenarios/logical_partition/pci_dev.c
@@ -6,6 +6,7 @@
 
 #include <vm_config.h>
 #include <pci_devices.h>
+#include <vpci.h>
 
 /* The vbar_base info of pt devices is included in device MACROs which defined in
  *           arch/x86/configs/$(CONFIG_BOARD)/pci_devices.h.
@@ -16,6 +17,7 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.vdev_ops = &vhostbridge_ops,
 	},
 	{
 		.emu_type = PCI_DEV_TYPE_PTDEV,
@@ -33,6 +35,7 @@ struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
+		.vdev_ops = &vhostbridge_ops,
 	},
 	{
 		.emu_type = PCI_DEV_TYPE_PTDEV,

--- a/hypervisor/scenarios/logical_partition/pci_dev.c
+++ b/hypervisor/scenarios/logical_partition/pci_dev.c
@@ -12,7 +12,7 @@
  * The memory range of vBAR should exactly match with the e820 layout of VM.
  */
 
-struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM] = {
+struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
@@ -29,7 +29,7 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM] = {
 	},
 };
 
-struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_PTDEV_NUM] = {
+struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
 		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -7,8 +7,8 @@
 #include <vm_config.h>
 #include <vuart.h>
 
-extern struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_PTDEV_NUM];
-extern struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_PTDEV_NUM];
+extern struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM];
+extern struct acrn_vm_pci_dev_config vm1_pci_devs[VM1_CONFIG_PCI_DEV_NUM];
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM0 */
@@ -46,7 +46,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vm_id = 1U,
 			.t_vuart.vuart_id = 1U,
 		},
-		.pci_dev_num = VM0_CONFIG_PCI_PTDEV_NUM,
+		.pci_dev_num = VM0_CONFIG_PCI_DEV_NUM,
 		.pci_devs = vm0_pci_devs,
 	},
 	{	/* VM1 */
@@ -85,7 +85,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vm_id = 0U,
 			.t_vuart.vuart_id = 1U,
 		},
-		.pci_dev_num = VM1_CONFIG_PCI_PTDEV_NUM,
+		.pci_dev_num = VM1_CONFIG_PCI_DEV_NUM,
 		.pci_devs = vm1_pci_devs,
 	},
 };

--- a/hypervisor/scenarios/logical_partition/vm_configurations.h
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.h
@@ -45,7 +45,7 @@
  */
 #define VM0_STORAGE_CONTROLLER			SATA_CONTROLLER_0
 #define VM0_NETWORK_CONTROLLER			ETHERNET_CONTROLLER_0
-#define VM0_CONFIG_PCI_PTDEV_NUM		3U
+#define VM0_CONFIG_PCI_DEV_NUM			3U
 
 #define VM1_STORAGE_CONTROLLER			USB_CONTROLLER_0
 #if defined(ETHERNET_CONTROLLER_1)
@@ -57,10 +57,10 @@
 #endif
 
 #if defined(VM1_NETWORK_CONTROLLER)
-#define VM1_CONFIG_PCI_PTDEV_NUM		3U
+#define VM1_CONFIG_PCI_DEV_NUM			3U
 #else
 /* no network controller could be assigned to VM1 */
-#define VM1_CONFIG_PCI_PTDEV_NUM		2U
+#define VM1_CONFIG_PCI_DEV_NUM			2U
 #endif
 
 #endif /* VM_CONFIGURATIONS_H */

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -6,6 +6,7 @@
 
 #include <vm_config.h>
 #include <vuart.h>
+#include <pci_dev.h>
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{
@@ -36,7 +37,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.vuart[1] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = INVALID_COM_BASE,
-		}
+		},
+		.pci_dev_num = SOS_EMULATED_PCI_DEV_NUM,
+		.pci_devs = sos_pci_devs,
 	},
 	{
 		.load_order = POST_LAUNCHED_VM,

--- a/hypervisor/scenarios/sdc2/vm_configurations.c
+++ b/hypervisor/scenarios/sdc2/vm_configurations.c
@@ -6,6 +6,7 @@
 
 #include <vm_config.h>
 #include <vuart.h>
+#include <pci_dev.h>
 
 struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{
@@ -36,7 +37,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.vuart[1] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = INVALID_COM_BASE,
-		}
+		},
+		.pci_dev_num = SOS_EMULATED_PCI_DEV_NUM,
+		.pci_devs = sos_pci_devs,
 	},
 	{
 		.load_order = POST_LAUNCHED_VM,


### PR DESCRIPTION
v2:
Use vm_config directly instead of the internal configure data when accessing vm configure.
Here we should access SOS pci device configure through the SOS vm configure, not the global
sos_pci_devs.

v1:
Add a field (vdev_ops) in struct acrn_vm_pci_dev_config to configure a PCI CFG
operation for an emulated PCI device. Use pci_pt_dev_ops for PCI_DEV_TYPE_PTDEV
by default if there's no such configure.

Li, Fei1 (2):
  hv: vpci: add emulated PCI device configure for SOS
  hv: vpci: add each vdev_ops for each emulated PCI device

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
