### PR TITLE
hv:fix need to make twice in hypervisor folder

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -317,6 +317,8 @@ MODULES += $(LIB_DEBUG)
 endif
 MODULES += $(SYS_INIT_MOD)
 
+.PHONY: $(MODULES)
+
 DISTCLEAN_OBJS := $(shell find $(BASEDIR) -name '*.o')
 VERSION := $(HV_OBJDIR)/include/version.h
 


### PR DESCRIPTION
now the dependency is like this in Makefile:
  acrn.bin << xxxx.a << xxxx.obj
if excute 'make' in hypervsior fold for the first time,
it can generate acrn.bin, if excute 'make' for second
time, it can not do the final link because there are
the same timestamp for acrn.bin and xxxx.a generated by
previous build, add PHONY to fix this issue.

Tracked-On: #3542
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Anthony Xu <anthony.xu@intel.com>