### PR TITLE
hv: refine the function pointer type of port I/O request handlers

### DIFF
--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -345,8 +345,10 @@ static void dm_emulate_io_complete(struct acrn_vcpu *vcpu)
 
 /**
  * @pre width < 8U
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
  */
-static bool pio_default_read(__unused struct acrn_vm *vm, struct acrn_vcpu *vcpu,
+static bool pio_default_read(struct acrn_vcpu *vcpu,
 	__unused uint16_t addr, size_t width)
 {
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
@@ -356,7 +358,12 @@ static bool pio_default_read(__unused struct acrn_vm *vm, struct acrn_vcpu *vcpu
 	return true;
 }
 
-static bool pio_default_write(__unused struct acrn_vm *vm, __unused uint16_t addr,
+/**
+ * @pre width < 8U
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool pio_default_write(__unused struct acrn_vcpu *vcpu, __unused uint16_t addr,
 	__unused size_t width, __unused uint32_t v)
 {
 	return true; /* ignore write */
@@ -436,11 +443,11 @@ hv_emulate_pio(struct acrn_vcpu *vcpu, struct io_request *io_req)
 	}
 
 	if ((pio_req->direction == REQUEST_WRITE) && (io_write != NULL)) {
-		if (io_write(vm, port, size, pio_req->value)) {
+		if (io_write(vcpu, port, size, pio_req->value)) {
 			status = 0;
 		}
 	} else if ((pio_req->direction == REQUEST_READ) && (io_read != NULL)) {
-		if (io_read(vm, vcpu, port, size)) {
+		if (io_read(vcpu, port, size)) {
 			status = 0;
 		}
 	} else {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -52,13 +52,13 @@ static void pci_cfg_clear_cache(struct pci_addr_info *pi)
 }
 
 /**
- * @pre vm != NULL
  * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
  */
-static bool pci_cfgaddr_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes)
+static bool pci_cfgaddr_io_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes)
 {
 	uint32_t val = ~0U;
-	struct acrn_vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vcpu->vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
 
@@ -77,11 +77,12 @@ static bool pci_cfgaddr_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint
 }
 
 /**
- * @pre vm != NULL
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
  */
-static bool pci_cfgaddr_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes, uint32_t val)
+static bool pci_cfgaddr_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes, uint32_t val)
 {
-	struct acrn_vpci *vpci = &vm->vpci;
+	struct acrn_vpci *vpci = &vcpu->vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 
 	if ((addr == (uint16_t)PCI_CONFIG_ADDR) && (bytes == 4U)) {
@@ -109,13 +110,15 @@ static inline bool vpci_is_valid_access(uint32_t offset, uint32_t bytes)
 }
 
 /**
- * @pre vm != NULL
  * @pre vcpu != NULL
- * @pre vm->vm_id < CONFIG_MAX_VM_NUM
- * @pre (get_vm_config(vm->vm_id)->load_order == PRE_LAUNCHED_VM) || (get_vm_config(vm->vm_id)->load_order == SOS_VM)
+ * @pre vcpu->vm != NULL
+ * @pre vcpu->vm->vm_id < CONFIG_MAX_VM_NUM
+ * @pre (get_vm_config(vcpu->vm->vm_id)->load_order == PRE_LAUNCHED_VM)
+ *	|| (get_vm_config(vcpu->vm->vm_id)->load_order == SOS_VM)
  */
-static bool pci_cfgdata_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes)
+static bool pci_cfgdata_io_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes)
 {
+	struct acrn_vm *vm = vcpu->vm;
 	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 	uint16_t offset = addr - PCI_CONFIG_DATA;
@@ -147,12 +150,15 @@ static bool pci_cfgdata_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint
 }
 
 /**
- * @pre vm != NULL
- * @pre vm->vm_id < CONFIG_MAX_VM_NUM
- * @pre (get_vm_config(vm->vm_id)->load_order == PRE_LAUNCHED_VM) || (get_vm_config(vm->vm_id)->load_order == SOS_VM)
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ * @pre vcpu->vm->vm_id < CONFIG_MAX_VM_NUM
+ * @pre (get_vm_config(vcpu->vm->vm_id)->load_order == PRE_LAUNCHED_VM)
+ *	|| (get_vm_config(vcpu->vm->vm_id)->load_order == SOS_VM)
  */
-static bool pci_cfgdata_io_write(struct acrn_vm *vm, uint16_t addr, size_t bytes, uint32_t val)
+static bool pci_cfgdata_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t bytes, uint32_t val)
 {
+	struct acrn_vm *vm = vcpu->vm;
 	struct acrn_vpci *vpci = &vm->vpci;
 	struct pci_addr_info *pi = &vpci->addr_info;
 	uint16_t offset = addr - PCI_CONFIG_DATA;

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -718,11 +718,15 @@ static int32_t vpic_master_handler(struct acrn_vpic *vpic, bool in, uint16_t por
 	return ret;
 }
 
-static bool vpic_master_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vpic_master_io_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
 {
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
 
-	if (vpic_master_handler(vm_pic(vm), true, addr, width, &pio_req->value) < 0) {
+	if (vpic_master_handler(vm_pic(vcpu->vm), true, addr, width, &pio_req->value) < 0) {
 		pr_err("pic master read port 0x%x width=%d failed\n",
 				addr, width);
 	}
@@ -730,12 +734,16 @@ static bool vpic_master_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint
 	return true;
 }
 
-static bool vpic_master_io_write(struct acrn_vm *vm, uint16_t addr, size_t width,
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vpic_master_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t width,
 				uint32_t v)
 {
 	uint32_t val = v;
 
-	if (vpic_master_handler(vm_pic(vm), false, addr, width, &val) < 0) {
+	if (vpic_master_handler(vm_pic(vcpu->vm), false, addr, width, &val) < 0) {
 		pr_err("%s: write port 0x%x width=%d value 0x%x failed\n",
 				__func__, addr, width, val);
 	}
@@ -762,23 +770,31 @@ static int32_t vpic_slave_handler(struct acrn_vpic *vpic, bool in, uint16_t port
 	return ret;
 }
 
-static bool vpic_slave_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vpic_slave_io_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
 {
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
 
-	if (vpic_slave_handler(vm_pic(vm), true, addr, width, &pio_req->value) < 0) {
+	if (vpic_slave_handler(vm_pic(vcpu->vm), true, addr, width, &pio_req->value) < 0) {
 		pr_err("pic slave read port 0x%x width=%d failed\n",
 				addr, width);
 	}
 	return true;
 }
 
-static bool vpic_slave_io_write(struct acrn_vm *vm, uint16_t addr, size_t width,
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vpic_slave_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t width,
 				uint32_t v)
 {
 	uint32_t val = v;
 
-	if (vpic_slave_handler(vm_pic(vm), false, addr, width, &val) < 0) {
+	if (vpic_slave_handler(vm_pic(vcpu->vm), false, addr, width, &val) < 0) {
 		pr_err("%s: write port 0x%x width=%d value 0x%x failed\n",
 				__func__, addr, width, val);
 	}
@@ -830,23 +846,31 @@ static int32_t vpic_elc_handler(struct acrn_vpic *vpic, bool in, uint16_t port, 
 	return ret;
 }
 
-static bool vpic_elc_io_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vpic_elc_io_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
 {
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
 
-	if (vpic_elc_handler(vm_pic(vm), true, addr, width, &pio_req->value) < 0) {
+	if (vpic_elc_handler(vm_pic(vcpu->vm), true, addr, width, &pio_req->value) < 0) {
 		pr_err("pic elc read port 0x%x width=%d failed", addr, width);
 	}
 
 	return true;
 }
 
-static bool vpic_elc_io_write(struct acrn_vm *vm, uint16_t addr, size_t width,
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vpic_elc_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t width,
 				uint32_t v)
 {
 	uint32_t val = v;
 
-	if (vpic_elc_handler(vm_pic(vm), false, addr, width, &val) < 0) {
+	if (vpic_elc_handler(vm_pic(vcpu->vm), false, addr, width, &val) < 0) {
 		pr_err("%s: write port 0x%x width=%d value 0x%x failed\n",
 				__func__, addr, width, val);
 	}

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -44,10 +44,15 @@ static uint8_t cmos_get_reg_val(uint8_t addr)
 	return reg;
 }
 
-static bool vrtc_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr, __unused size_t width)
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vrtc_read(struct acrn_vcpu *vcpu, uint16_t addr, __unused size_t width)
 {
 	uint8_t offset;
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
+	struct acrn_vm *vm = vcpu->vm;
 
 	offset = vm->vrtc_offset;
 
@@ -60,11 +65,15 @@ static bool vrtc_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t addr,
 	return true;
 }
 
-static bool vrtc_write(struct acrn_vm *vm, uint16_t addr, size_t width,
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vrtc_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t width,
 			uint32_t value)
 {
 	if ((width == 1U) && (addr == CMOS_ADDR_PORT)) {
-		vm->vrtc_offset = value & 0x7FU;
+		vcpu->vm->vrtc_offset = (uint8_t)value & 0x7FU;
 	}
 
 	return true;

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -339,11 +339,15 @@ static void write_reg(struct acrn_vuart *vu, uint16_t reg, uint8_t value_u8)
 	vuart_unlock(vu, rflags);
 }
 
-static bool vuart_write(struct acrn_vm *vm, uint16_t offset_arg,
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vuart_write(struct acrn_vcpu *vcpu, uint16_t offset_arg,
 			__unused size_t width, uint32_t value)
 {
 	uint16_t offset = offset_arg;
-	struct acrn_vuart *vu = find_vuart_by_port(vm, offset);
+	struct acrn_vuart *vu = find_vuart_by_port(vcpu->vm, offset);
 	uint8_t value_u8 = (uint8_t)value;
 	struct acrn_vuart *target_vu = NULL;
 	uint64_t rflags;
@@ -366,12 +370,15 @@ static bool vuart_write(struct acrn_vm *vm, uint16_t offset_arg,
 	return true;
 }
 
-static bool vuart_read(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t offset_arg,
-			__unused size_t width)
+/**
+ * @pre vcpu != NULL
+ * @pre vcpu->vm != NULL
+ */
+static bool vuart_read(struct acrn_vcpu *vcpu, uint16_t offset_arg, __unused size_t width)
 {
 	uint16_t offset = offset_arg;
 	uint8_t iir, reg, intr_reason;
-	struct acrn_vuart *vu = find_vuart_by_port(vm, offset);
+	struct acrn_vuart *vu = find_vuart_by_port(vcpu->vm, offset);
 	struct pio_request *pio_req = &vcpu->req.reqs.pio;
 	uint64_t rflags;
 

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -49,10 +49,10 @@ struct acrn_vm;
 struct acrn_vcpu;
 
 typedef
-bool (*io_read_fn_t)(struct acrn_vm *vm, struct acrn_vcpu *vcpu, uint16_t port, size_t size);
+bool (*io_read_fn_t)(struct acrn_vcpu *vcpu, uint16_t port, size_t size);
 
 typedef
-bool (*io_write_fn_t)(struct acrn_vm *vm, uint16_t port, size_t size, uint32_t val);
+bool (*io_write_fn_t)(struct acrn_vcpu *vcpu, uint16_t port, size_t size, uint32_t val);
 
 /**
  * @brief Describes a single IO handler description entry.


### PR DESCRIPTION
 From the view of port i/o handler, struct acrn_vm * pointer
 is redundant as input, as context of acrn_vm is aleady linked
 in struct acrn_vcpu * by vcpu->vm, 'vm' is not required as input.

 this patch removes argument '*vm' from 'io_read_fn_t' &
 'io_write_fn_t', use '*vcpu' for them instead.

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>