### PR TITLE
hv: fix failed to build release version build with Kconfig setting

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -19,7 +19,6 @@ HV_OBJDIR ?= $(CURDIR)/build
 HV_MODDIR ?= $(HV_OBJDIR)/modules
 HV_FILE := acrn
 SUB_MAKEFILES := $(wildcard */Makefile)
-RELEASE ?= 0
 
 LIB_MOD = $(HV_MODDIR)/lib_mod.a
 BOOT_MOD = $(HV_MODDIR)/boot_mod.a
@@ -111,7 +110,7 @@ else
 LDFLAGS += -static
 endif
 
-ifeq ($(RELEASE),y)
+ifeq (y, $(CONFIG_RELEASE))
 LDFLAGS += -s
 endif
 


### PR DESCRIPTION
Hardcode "RELEASE=0" will cause the value of "CONFIG_RELEASE"
to be 'n' in kconfig.mk, it will be overwritten "CONFIG_RELEASE"
with Kconfig setting.

Tracked-On: #3565
Signed-off-by: Tianhua Sun <tianhuax.s.sun@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>