### PR TITLE
hv: move vmx_rdmsr_pat/vmx_wrmsr_pat from vmcs.c to vmsr.c

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -20,46 +20,6 @@
 #include <vmexit.h>
 #include <logmsg.h>
 
-uint64_t vmx_rdmsr_pat(const struct acrn_vcpu *vcpu)
-{
-	/*
-	 * note: if run_ctx->cr0.CD is set, the actual value in guest's
-	 * IA32_PAT MSR is PAT_ALL_UC_VALUE, which may be different from
-	 * the saved value guest_msrs[MSR_IA32_PAT]
-	 */
-	return vcpu_get_guest_msr(vcpu, MSR_IA32_PAT);
-}
-
-int32_t vmx_wrmsr_pat(struct acrn_vcpu *vcpu, uint64_t value)
-{
-	uint32_t i;
-	uint64_t field;
-	int32_t ret = 0;
-
-	for (i = 0U; i < 8U; i++) {
-		field = (value >> (i * 8U)) & 0xffUL;
-		if (pat_mem_type_invalid(field) || ((PAT_FIELD_RSV_BITS & field) != 0UL)) {
-			pr_err("invalid guest IA32_PAT: 0x%016llx", value);
-			ret = -EINVAL;
-			break;
-		}
-	}
-
-	if (ret == 0) {
-		vcpu_set_guest_msr(vcpu, MSR_IA32_PAT, value);
-
-		/*
-		 * If context->cr0.CD is set, we defer any further requests to write
-		 * guest's IA32_PAT, until the time when guest's CR0.CD is being cleared
-		 */
-		if ((vcpu_get_cr0(vcpu) & CR0_CD) == 0UL) {
-			exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, value);
-		}
-	}
-
-	return ret;
-}
-
 /* rip, rsp, ia32_efer and rflags are written to VMCS in start_vcpu */
 static void init_guest_vmx(struct acrn_vcpu *vcpu, uint64_t cr0, uint64_t cr3,
 	uint64_t cr4)

--- a/hypervisor/include/arch/x86/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/guest/vmcs.h
@@ -55,9 +55,6 @@ static inline uint64_t apic_access_offset(uint64_t qual)
 
 void init_vmcs(struct acrn_vcpu *vcpu);
 
-uint64_t vmx_rdmsr_pat(const struct acrn_vcpu *vcpu);
-int32_t vmx_wrmsr_pat(struct acrn_vcpu *vcpu, uint64_t value);
-
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu);
 
 static inline enum vm_cpu_mode get_vcpu_mode(const struct acrn_vcpu *vcpu)


### PR DESCRIPTION
This patch moves vmx_rdmsr_pat/vmx_wrmsr_pat from vmcs.c to vmsr.c,
so that these two functions would become internal functions inside
vmsr.c.
This approach improves the modularity.

v1 -> v2:
 * remove 'vmx_rdmsr_pat'
 * rename 'vmx_wrmsr_pat' with 'write_pat_msr'

Tracked-On: #1842
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>