### PR TITLE
dm: expand default WaaG memory to 4G

### DIFF
--- a/devicemodel/samples/nuc/launch_win.sh
+++ b/devicemodel/samples/nuc/launch_win.sh
@@ -17,7 +17,7 @@ echo "8086:9d71" > /sys/bus/pci/drivers/pci-stub/new_id
 echo "0000:00:1f.3" > /sys/bus/pci/drivers/pci-stub/bind
 
 #for memsize setting
-mem_size=2048M
+mem_size=4096M
 
 acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$3" \


### PR DESCRIPTION
This patch is used to expand WaaG memory from 2G to 4G in launch script.

Tracked-On: #3576
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>