### PR TITLE
hv: fix Violations touched ACRN Coding Guidelines

### DIFF
--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -32,12 +32,12 @@
 #define BOOT_ARG_LEN 2048
 
 /* E820 memory types */
-#define E820_TYPE_RAM           1   /* EFI 1, 2, 3, 4, 5, 6, 7 */
+#define E820_TYPE_RAM           1U   /* EFI 1, 2, 3, 4, 5, 6, 7 */
 /* EFI 0, 11, 12, 13 (everything not used elsewhere) */
-#define E820_TYPE_RESERVED      2
-#define E820_TYPE_ACPI_RECLAIM  3   /* EFI 9 */
-#define E820_TYPE_ACPI_NVS      4   /* EFI 10 */
-#define E820_TYPE_UNUSABLE      5   /* EFI 8 */
+#define E820_TYPE_RESERVED      2U
+#define E820_TYPE_ACPI_RECLAIM  3U   /* EFI 9 */
+#define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
+#define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
 #define NUM_E820_ENTRIES        8
 #define LOWRAM_E820_ENTRY       2

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -20,10 +20,10 @@ struct acrn_vm_config *get_vm_config(uint16_t vm_id)
 
 static inline bool uuid_is_equal(const uint8_t *uuid1, const uint8_t *uuid2)
 {
-	uint64_t uuid1_h = *(uint64_t *)uuid1;
-	uint64_t uuid1_l = *(uint64_t *)(uuid1 + 8);
-	uint64_t uuid2_h = *(uint64_t *)uuid2;
-	uint64_t uuid2_l = *(uint64_t *)(uuid2 + 8);
+	uint64_t uuid1_h = *(const uint64_t *)uuid1;
+	uint64_t uuid1_l = *(const uint64_t *)(uuid1 + 8);
+	uint64_t uuid2_h = *(const uint64_t *)uuid2;
+	uint64_t uuid2_l = *(const uint64_t *)(uuid2 + 8);
 
 	return ((uuid1_h == uuid2_h) && (uuid1_l == uuid2_l));
 }
@@ -37,7 +37,7 @@ bool vm_has_matched_uuid(uint16_t vmid, const uint8_t *uuid)
 {
 	struct acrn_vm_config *vm_config = get_vm_config(vmid);
 
-	return (uuid_is_equal(&vm_config->uuid[0], uuid));
+	return (uuid_is_equal(vm_config->uuid, uuid));
 }
 
 /**

--- a/hypervisor/arch/x86/configs/vmptable.c
+++ b/hypervisor/arch/x86/configs/vmptable.c
@@ -69,7 +69,7 @@ static uint8_t mpt_compute_checksum(const void *base, size_t len)
 {
 	uint8_t	sum = 0U;
 	size_t length;
-	const uint8_t *bytes = base;
+	const uint8_t *bytes = (const uint8_t *)base;
 
 	for (length = len; length > 0U; length--) {
 		sum += *bytes;
@@ -109,7 +109,7 @@ int32_t mptable_build(struct acrn_vm *vm)
 			+ MPE_NUM_BUSES * (uint16_t)sizeof(struct bus_entry)
 			+ MPEII_NUM_LOCAL_IRQ * (uint16_t)sizeof(struct int_entry);
 
-	mptable_length = sizeof(struct mpfps) + mptable->mpch.base_table_length;
+	mptable_length = sizeof(struct mpfps) + (uint32_t)mptable->mpch.base_table_length;
 	if (mptable_length <= MPTABLE_MAX_LENGTH) {
 		for (i = 0U; i < vcpu_num; i++) {
 			uint16_t pcpu_id = ffs64(pcpu_bitmap);

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -520,7 +520,7 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 
 void ptirq_softirq(uint16_t pcpu_id)
 {
-	struct acrn_vcpu *vcpu = (struct acrn_vcpu *)per_cpu(vcpu, pcpu_id);
+	struct acrn_vcpu *vcpu = per_cpu(vcpu, pcpu_id);
 	struct acrn_vm *vm = vcpu->vm;
 
 	while (1) {

--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -573,8 +573,8 @@ static void vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum cpu_reg_name seg,
 	 * In 64-bit mode all segments except %fs and %gs have a segment
 	 * base address of 0.
 	 */
-	if (cpu_mode == CPU_MODE_64BIT && seg != CPU_REG_FS &&
-	    seg != CPU_REG_GS) {
+	if ((cpu_mode == CPU_MODE_64BIT) && (seg != CPU_REG_FS) &&
+	    (seg != CPU_REG_GS)) {
 		segbase = 0UL;
 	} else {
 		segbase = desc->base;

--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -39,7 +39,7 @@ int32_t validate_pstate(const struct acrn_vm *vm, uint64_t perf_ctl)
 			max_px_ctl_val = ((px_data[0].control & 0xff00UL) >> 8U);
 
 			/* get min px control value, should be for p(px_cnt-1), i.e. LFM. */
-			min_px_ctl_val = ((px_data[px_cnt - 1].control & 0xff00UL) >> 8U);
+			min_px_ctl_val = ((px_data[px_cnt - 1U].control & 0xff00UL) >> 8U);
 
 			px_target_val = ((perf_ctl & 0xff00UL) >> 8U);
 			if ((px_target_val <= max_px_ctl_val) && (px_target_val >= min_px_ctl_val)) {

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -67,9 +67,9 @@ void vcpu_set_rip(struct acrn_vcpu *vcpu, uint64_t val)
 	bitmap_set_lock(CPU_REG_RIP, &vcpu->reg_updated);
 }
 
-uint64_t vcpu_get_rsp(struct acrn_vcpu *vcpu)
+uint64_t vcpu_get_rsp(const struct acrn_vcpu *vcpu)
 {
-	struct run_context *ctx =
+	const struct run_context *ctx =
 		&vcpu->arch.contexts[vcpu->arch.cur_context].run_ctx;
 
 	return ctx->guest_cpu_regs.regs.rsp;
@@ -147,7 +147,7 @@ void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val)
 /*
  * Write the eoi_exit_bitmaps to VMCS fields
  */
-void vcpu_set_vmcs_eoi_exit(struct acrn_vcpu *vcpu)
+void vcpu_set_vmcs_eoi_exit(const struct acrn_vcpu *vcpu)
 {
 	pr_dbg("%s", __func__);
 
@@ -474,8 +474,9 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu)
 		pr_info("VM %d Starting VCPU %hu",
 				vcpu->vm->vm_id, vcpu->vcpu_id);
 
-		if (vcpu->arch.vpid != 0U)
+		if (vcpu->arch.vpid != 0U) {
 			exec_vmwrite16(VMX_VPID, vcpu->arch.vpid);
+		}
 
 		/*
 		 * A power-up or a reset invalidates all linear mappings,
@@ -491,8 +492,9 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu)
 		 * currently, there is no other place to do vmcs switch
 		 * Please add IBPB set for future vmcs switch case(like trusty)
 		 */
-		if (ibrs_type == IBRS_RAW)
+		if (ibrs_type == IBRS_RAW) {
 			msr_write(MSR_IA32_PRED_CMD, PRED_SET_IBPB);
+		}
 
 #ifdef CONFIG_L1D_FLUSH_VMENTRY_ENABLED
 		cpu_l1d_flush();

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2138,7 +2138,7 @@ int32_t vlapic_x2apic_write(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val)
 	return error;
 }
 
-int32_t vlapic_create(struct acrn_vcpu *vcpu)
+void vlapic_create(struct acrn_vcpu *vcpu)
 {
 	vcpu->arch.vlapic.vm = vcpu->vm;
 	vcpu->arch.vlapic.vcpu = vcpu;
@@ -2159,7 +2159,6 @@ int32_t vlapic_create(struct acrn_vcpu *vcpu)
 	}
 
 	vlapic_init(vcpu_vlapic(vcpu));
-	return 0;
 }
 
 /*

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -348,8 +348,8 @@ void dispatch_interrupt(const struct intr_excp_ctx *ctx)
 		desc = &irq_desc_array[irq];
 		per_cpu(irq_count, get_pcpu_id())[irq]++;
 
-		if (vr == desc->vector &&
-			bitmap_test((uint16_t)(irq & 0x3FU), irq_alloc_bitmap + (irq >> 6U)) != 0U) {
+		if ((vr == desc->vector) &&
+			bitmap_test((uint16_t)(irq & 0x3FU), irq_alloc_bitmap + (irq >> 6U))) {
 #ifdef PROFILING_ON
 			/* Saves ctx info into irq_desc */
 			desc->ctx_rip = ctx->rip;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -454,7 +454,7 @@ void vcpu_set_rip(struct acrn_vcpu *vcpu, uint64_t val);
  *
  * @return the value of RSP.
  */
-uint64_t vcpu_get_rsp(struct acrn_vcpu *vcpu);
+uint64_t vcpu_get_rsp(const struct acrn_vcpu *vcpu);
 
 /**
  * @brief set vcpu RSP value
@@ -546,7 +546,7 @@ void vcpu_set_guest_msr(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val);
  *
  * @return None
  */
-void vcpu_set_vmcs_eoi_exit(struct acrn_vcpu *vcpu);
+void vcpu_set_vmcs_eoi_exit(const struct acrn_vcpu *vcpu);
 
 /**
  * @brief reset all eoi_exit_bitmaps

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -184,7 +184,7 @@ void vlapic_receive_intr(struct acrn_vm *vm, bool level, uint32_t dest,
 		bool phys, uint32_t delmode, uint32_t vec, bool rh);
 
 uint32_t vlapic_get_apicid(const struct acrn_vlapic *vlapic);
-int32_t vlapic_create(struct acrn_vcpu *vcpu);
+void vlapic_create(struct acrn_vcpu *vcpu);
 /*
  *  @pre vcpu != NULL
  */

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -31,8 +31,8 @@ struct per_cpu_region {
 	uint64_t irq_count[NR_IRQS];
 	uint64_t softirq_pending;
 	uint64_t spurious;
-	void *vcpu;
-	void *ever_run_vcpu;
+	struct acrn_vcpu *vcpu;
+	struct acrn_vcpu *ever_run_vcpu;
 #ifdef STACK_PROTECTOR
 	struct stack_canary stk_canary;
 #endif


### PR DESCRIPTION
fix violations touched below:
1.Cast operation on a constant value
2.signed/unsigned implicity conversion
3.return value unused.

V1->V2:
1.bitmap api will return boolean type, not need to check "!= 0", deleted.
2.The behaves ~(uint32_t)X and (uint32_t)~X are not defined in ACRN hypervisor Coding Guidelines,
removed the change of it.
Tracked-On: #861
Signed-off-by: Huihuang Shi <huihuang.shi@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>