### PR TITLE
dm: virtio: Add Oracle subsystem vendor ID for some virtio devices.

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -544,7 +544,7 @@ virtio_blk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_STORAGE);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_BLOCK);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
 
 	if (virtio_interrupt_init(&blk->base, virtio_uses_msix())) {
 		/* call close only for valid bctxt */

--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -1137,7 +1137,7 @@ virtio_console_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_SIMPLECOMM);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_CONSOLE);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
 
 	if (virtio_interrupt_init(&console->base, virtio_uses_msix())) {
 		if (console) {

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -700,7 +700,7 @@ virtio_input_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_INPUTDEV);
 	pci_set_cfgdata8(dev, PCIR_SUBCLASS, PCIS_INPUTDEV_OTHER);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, 0x1100);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
 	pci_set_cfgdata16(dev, PCIR_REVID, 1);
 
 	if (virtio_interrupt_init(&vi->base, virtio_uses_msix())) {

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -866,7 +866,7 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_NETWORK);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_NET);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
 
 	/* Link is up if we managed to open tap device */
 	net->config.status = (opts == NULL || net->tapfd >= 0);

--- a/devicemodel/hw/pci/virtio/virtio_rnd.c
+++ b/devicemodel/hw/pci/virtio/virtio_rnd.c
@@ -449,7 +449,7 @@ virtio_rnd_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_CRYPTO);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_ENTROPY);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
 
 	if (virtio_interrupt_init(&rnd->base, virtio_uses_msix())) {
 		goto fail;

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -213,6 +213,7 @@ enum {
  * PCI vendor/device IDs
  */
 #define	INTEL_VENDOR_ID		0x8086
+#define	ORACLE_VENDOR_ID	0x108E
 #define	VIRTIO_VENDOR		0x1AF4
 #define	VIRTIO_DEV_NET		0x1000
 #define	VIRTIO_DEV_BLOCK	0x1001


### PR DESCRIPTION
After Windows 10, version 1607, the cross-signed drivers are forbiden
to load when secure boot is enabled.

Details please refer to
https://docs.microsoft.com/en-us/windows-hardware/drivers/install/kernel-mode-code-signing-policy--windows-vista-and-later-

That means the kvm-guest-drivers-windows can't work when secure boot enabled.
So we found another windows virtio FE drivers from Oracle to resolve this issue,
but have to change another subsystem vendor ID for the virtio BE services.

This patch adds Oracle subsystem vendor ID for virtio-blk, virtio-net, virtio-input,
virtio-console and virtio-rnd instead redhat. And all of virtio devices that subsystem
vendor ID use Oracle can work on Windows 10, clearlinux and vxworks.

Tracked-On: #3583
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>