### PR TITLE
doc: remove modernizr.min.js

### DIFF
--- a/doc/static/js/modernizr.min.js
+++ b/doc/static/js/modernizr.min.js
@@ -1,0 +1,5 @@
+/* modernizr.min.js is causing unnecessary reloads of a page causing
+ * flashing of the browser window during page load.  This empty script
+ * effectively wipes out the modernizr.min.js loaded by the Sphinx
+ * rtd theme
+ */


### PR DESCRIPTION
modernizr.min.js is no longer used by Sphinx's rtd theme and is causing
some browsers to have a noticable flash when pages are loaded. While we
can't easily remove it from the RTD theme, we can replace the script
with an empty file instead.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>