### PR TITLE
hv: remove 'flags' field in struct vm_io_range

### DIFF
--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -222,7 +222,6 @@ static void register_gas_io_handler(struct acrn_vm *vm, uint32_t pio_idx, const 
 
 	if ((gas->address != 0UL) && (gas->space_id == SPACE_SYSTEM_IO)
 			&& (gas->access_size != 0U) && (gas->access_size <= 4U)) {
-		gas_io.flags = IO_ATTR_RW;
 		gas_io.base = (uint16_t)gas->address;
 		gas_io.len = io_len[gas->access_size];
 
@@ -273,7 +272,6 @@ void register_rt_vm_pm1a_ctl_handler(struct acrn_vm *vm)
 {
 	struct vm_io_range io_range;
 
-	io_range.flags = IO_ATTR_RW;
 	io_range.base = VIRTUAL_PM1A_CNT_ADDR;
 	io_range.len = 1U;
 

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -226,7 +226,6 @@ void register_reset_port_handler(struct acrn_vm *vm)
 		struct acpi_generic_address *gas = &(host_reset_reg.reg);
 
 		struct vm_io_range io_range = {
-			.flags = IO_ATTR_RW,
 			.len = 1U
 		};
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -193,13 +193,11 @@ static bool pci_cfgdata_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t b
 void vpci_init(struct acrn_vm *vm)
 {
 	struct vm_io_range pci_cfgaddr_range = {
-		.flags = IO_ATTR_RW,
 		.base = PCI_CONFIG_ADDR,
 		.len = 1U
 	};
 
 	struct vm_io_range pci_cfgdata_range = {
-		.flags = IO_ATTR_RW,
 		.base = PCI_CONFIG_DATA,
 		.len = 4U
 	};

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -881,17 +881,14 @@ static bool vpic_elc_io_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t widt
 static void vpic_register_io_handler(struct acrn_vm *vm)
 {
 	struct vm_io_range master_range = {
-		.flags = IO_ATTR_RW,
 		.base = 0x20U,
 		.len = 2U
 	};
 	struct vm_io_range slave_range = {
-		.flags = IO_ATTR_RW,
 		.base = 0xa0U,
 		.len = 2U
 	};
 	struct vm_io_range elcr_range = {
-		.flags = IO_ATTR_RW,
 		.base = 0x4d0U,
 		.len = 2U
 	};

--- a/hypervisor/dm/vrtc.c
+++ b/hypervisor/dm/vrtc.c
@@ -82,7 +82,7 @@ static bool vrtc_write(struct acrn_vcpu *vcpu, uint16_t addr, size_t width,
 void vrtc_init(struct acrn_vm *vm)
 {
 	struct vm_io_range range = {
-	.flags = IO_ATTR_RW, .base = CMOS_ADDR_PORT, .len = 2U};
+	.base = CMOS_ADDR_PORT, .len = 2U};
 
 	/* Initializing the CMOS RAM offset to 0U */
 	vm->vrtc_offset = 0U;

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -468,7 +468,6 @@ static bool vuart_register_io_handler(struct acrn_vm *vm, uint16_t port_base, ui
 	bool ret = true;
 
 	struct vm_io_range range = {
-		.flags = IO_ATTR_RW,
 		.base = port_base,
 		.len = 8U
 	};

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -41,7 +41,6 @@ struct io_request {
 struct vm_io_range {
 	uint16_t base;		/**< IO port base */
 	uint16_t len;		/**< IO port range */
-	uint32_t flags;		/**< IO port attributes */
 };
 
 struct vm_io_handler_desc;
@@ -104,11 +103,6 @@ struct vm_io_handler_desc {
 	 */
 	io_write_fn_t io_write;
 };
-
-
-#define IO_ATTR_R               0U
-#define IO_ATTR_RW              1U
-#define IO_ATTR_NO_ACCESS       2U
 
 /* Typedef for MMIO handler and range check routine */
 struct mmio_request;


### PR DESCRIPTION
  Currently, 'flags' is defined and set but never be used
  in the flow of handling i/o request after then.

Tracked-On: #861
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>