### PR TITLE
HV: enable hybrid for apl up2 uefi board

### DIFF
--- a/devicemodel/samples/apl-up2/launch_uos.sh
+++ b/devicemodel/samples/apl-up2/launch_uos.sh
@@ -423,13 +423,13 @@ do
 	esac
 done
 
-if [ ! -b "/dev/mmcblk0p3" ]; then
-  echo "no /dev/mmcblk0p3 data partition, exit"
+if [ ! -b "/dev/mmcblk0p1" ]; then
+  echo "no /dev/mmcblk0p1 data partition, exit"
   exit
 fi
 
 mkdir -p /data
-mount /dev/mmcblk0p3 /data
+mount /dev/mmcblk0p1 /data
 
 if [ $launch_type == 6 ]; then
 	if [ -f "/data/android/android.img" ]; then

--- a/doc/tutorials/partition_desc.ini
+++ b/doc/tutorials/partition_desc.ini
@@ -6,8 +6,13 @@
 [base]
 # The sequence matters, and the index starts from p1.
 # The fastboot ABL by default boots from the 2nd partition.
-partitions = sos_rootfs sos_boot data_partition
+partitions = data_partition sos_boot sos_rootfs
 device = auto
+
+[partition.data_partition]
+label = data_partition
+len = 20000
+type = linux
 
 [partition.sos_boot]
 label = sos_boot
@@ -16,11 +21,6 @@ type = linux
 
 [partition.sos_rootfs]
 label = sos_rootfs
-len = 4000
-type = linux
-
-[partition.data_partition]
-label = data_partition
 len = -1
 type = linux
 # ------------------ END MIX-IN DEFINITIONS ------------------

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -8,7 +8,7 @@
 #define MISC_CFG_H
 
 #define ROOTFS_0		"root=/dev/sda3 "
-#define ROOTFS_1		"root=/dev/mmcblk0p1 "
+#define ROOTFS_1		"root=/dev/mmcblk0p3 "
 
 #define SOS_ROOTFS		ROOTFS_1
 #define SOS_CONSOLE		"console=ttyS0 "

--- a/hypervisor/arch/x86/configs/apl-up2/ve820.c
+++ b/hypervisor/arch/x86/configs/apl-up2/ve820.c
@@ -6,11 +6,44 @@
 
 #include <vm.h>
 
+#define VE820_ENTRIES_APL_UP2  5U
+static const struct e820_entry ve820_entry[VE820_ENTRIES_APL_UP2] = {
+	{	/* usable RAM under 1MB */
+		.baseaddr = 0x0UL,
+		.length   = 0xF0000UL,		/* 960KB */
+		.type     = E820_TYPE_RAM
+	},
+
+	{	/* mptable */
+		.baseaddr = 0xF0000UL,		/* 960KB */
+		.length   = 0x10000UL,		/* 16KB */
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{	/* lowmem */
+		.baseaddr = 0x100000UL,		/* 1MB */
+		.length   = 0x1FF00000UL,	/* 511MB */
+		.type     = E820_TYPE_RAM
+	},
+
+	{	/* between lowmem and PCI hole */
+		.baseaddr = 0x20000000UL,	/* 512MB */
+		.length   = 0xA0000000UL,	/* 2560MB */
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{	/* between PCI hole and 4GB */
+		.baseaddr = 0xe0000000UL,	/* 3.5GB */
+		.length   = 0x20000000UL,	/* 512MB */
+		.type     = E820_TYPE_RESERVED
+	},
+};
+
 /**
  * @pre vm != NULL
  */
 void create_prelaunched_vm_e820(struct acrn_vm *vm)
 {
-	vm->e820_entry_num = 0U;
-	vm->e820_entries = NULL;
+	vm->e820_entry_num = VE820_ENTRIES_APL_UP2;
+	vm->e820_entries = (struct e820_entry *)ve820_entry;
 }


### PR DESCRIPTION
- set sos root dev of apl-up2 to mmcblk0p3;
- prepare ve820 table to enable prelaunched VM for apl-up2 board;

Tracked-On: #3214

Signed-off-by: Victor Sun <victor.sun@intel.com>