### PR TITLE
dm: remove unsupported "pincpu" option

### DIFF
--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -160,14 +160,6 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
        ``seed_string=${mac:9:8}-${vm_name}``
 
-   * - :kbd:`-p, --pincpu <vcpu:hostcpu>`
-     - Pin host CPU to appointed vCPU:
-
-       - ``vcpu`` is the ID of the CPU seen by the UOS, and
-       - ``hostcpu`` is the physical CPU ID on the system.
-
-       Example: ``-p  "1:2"`` means pin the 2nd physical cpu to 1st vcpu in UOS
-
    * - :kbd:`--part_info <part_info_name>`
      - Set guest partition info path.
 


### PR DESCRIPTION
ACRN-DM does not support "pincpu" option to pin 'vcpu' to 'hostcpu', ACRN support vcpu to pcpu static mapping
via vm_config.
This commit removes the "pincpu" option.

Tracked-On: #3598
Signed-off-by: Yan, Like <like.yan@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>