### PR TITLE
hv: cleanup vmcs.h

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -323,8 +323,7 @@ static inline bool is_vmx_disabled(void)
 
 static inline bool pcpu_has_vmx_unrestricted_guest_cap(void)
 {
-	return ((msr_read(MSR_IA32_VMX_MISC) & VMX_SUPPORT_UNRESTRICTED_GUEST)
-									!= 0UL);
+	return ((msr_read(MSR_IA32_VMX_MISC) & MSR_IA32_MISC_UNRESTRICTED_GUEST) != 0UL);
 }
 
 static int32_t check_vmx_mmu_cap(void)

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -6,6 +6,7 @@
 
 #include <types.h>
 #include <errno.h>
+#include <vmx.h>
 #include <guest_memory.h>
 #include <vcpu.h>
 #include <vm.h>

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -11,7 +11,6 @@
 #include <cpuid.h>
 #include <vcpu.h>
 #include <vm.h>
-#include <vmcs.h>
 #include <vmx.h>
 #include <sgx.h>
 #include <guest_pm.h>

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -5,7 +5,7 @@
  */
 
 #include <vm.h>
-#include <vmcs.h>
+#include <vmx.h>
 #include <schedule.h>
 #include <version.h>
 #include <reloc.h>

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -127,6 +127,10 @@
 /*Bits in EFER special registers */
 #define EFER_LMA 0x00000400U    /* Long mode active (R) */
 
+#define RFLAGS_C (1U<<0U)
+#define RFLAGS_Z (1U<<6U)
+#define RFLAGS_AC (1U<<18U)
+
 /* CPU clock frequencies (FSB) */
 #define CPU_FSB_83KHZ           83200
 #define CPU_FSB_100KHZ          99840

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -378,6 +378,11 @@ static inline bool is_vcpu_bsp(const struct acrn_vcpu *vcpu)
 	return (vcpu->vcpu_id == BOOT_CPU_ID);
 }
 
+static inline enum vm_cpu_mode get_vcpu_mode(const struct acrn_vcpu *vcpu)
+{
+	return vcpu->arch.cpu_mode;
+}
+
 /* do not update Guest RIP for next VM Enter */
 static inline void vcpu_retain_rip(struct acrn_vcpu *vcpu)
 {

--- a/hypervisor/include/arch/x86/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/guest/vmcs.h
@@ -12,7 +12,6 @@
 
 #ifndef ASSEMBLER
 #include <types.h>
-#include <vmx.h>
 #include <vcpu.h>
 
 #define VMX_VMENTRY_FAIL                0x80000000U
@@ -21,11 +20,6 @@
 #define APIC_ACCESS_TYPE                0xF000UL  /* 15:12, access type */
 #define TYPE_LINEAR_APIC_INST_READ      (0UL << 12U)
 #define TYPE_LINEAR_APIC_INST_WRITE     (1UL << 12U)
-
-static inline uint32_t vmx_eoi_exit(uint32_t vector)
-{
-	return (VMX_EOI_EXIT0_FULL + ((vector >> 6U) * 2U));
-}
 
 /* VM exit qulifications for APIC-access
  * Access type:
@@ -46,22 +40,9 @@ static inline uint64_t apic_access_offset(uint64_t qual)
 {
 	return (qual & APIC_ACCESS_OFFSET);
 }
-
-#define RFLAGS_C (1U<<0U)
-#define RFLAGS_Z (1U<<6U)
-#define RFLAGS_AC (1U<<18U)
-
-#define VMX_SUPPORT_UNRESTRICTED_GUEST (1U<<5U)
-
 void init_vmcs(struct acrn_vcpu *vcpu);
 
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu);
-
-static inline enum vm_cpu_mode get_vcpu_mode(const struct acrn_vcpu *vcpu)
-{
-	return vcpu->arch.cpu_mode;
-}
-
 #endif /* ASSEMBLER */
 
 #endif /* VMCS_H_ */

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -563,6 +563,9 @@
 #define MSR_IA32_MISC_ENABLE_xTPR		(1UL << 23U)
 #define MSR_IA32_MISC_ENABLE_XD_DISABLE		(1UL << 34U)
 
+/* Miscellaneous data */
+#define MSR_IA32_MISC_UNRESTRICTED_GUEST	(1U<<5U)
+
 #ifndef ASSEMBLER
 static inline bool pat_mem_type_invalid(uint64_t x)
 {


### PR DESCRIPTION
-- move 'RFLAGS_AC' to cpu.h
-- move 'VMX_SUPPORT_UNRESTRICTED_GUEST' to msr.h
   and rename it to 'MSR_IA32_MISC_UNRESTRICTED_GUEST'
-- move 'get_vcpu_mode' to vcpu.h
-- remove deadcode 'vmx_eoi_exit()'

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>