### PR TITLE
hv:move some APIs related host reset to pm.c

### DIFF
--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -35,7 +35,6 @@
 #include <host_pm.h>
 #include <acrn_common.h>
 #include <vcpu.h>
-#include <vm_reset.h>
 
 /* Per ACPI spec:
  * There are two fundamental types of ACPI tables:

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -64,9 +64,26 @@ static struct pm_s_state_data host_pm_s_state = {
 	.wake_vector_64 = (uint64_t *)WAKE_VECTOR_64
 };
 
+/* host reset register defined in ACPI */
+static struct acpi_reset_reg host_reset_reg = {
+	.reg = {
+		.space_id = RESET_REGISTER_SPACE_ID,
+		.bit_width = RESET_REGISTER_BIT_WIDTH,
+		.bit_offset = RESET_REGISTER_BIT_OFFSET,
+		.access_size = RESET_REGISTER_ACCESS_SIZE,
+		.address = RESET_REGISTER_ADDRESS,
+	},
+	.val = RESET_REGISTER_VALUE
+};
+
 struct pm_s_state_data *get_host_sstate_data(void)
 {
 	return &host_pm_s_state;
+}
+
+struct acpi_reset_reg *get_host_reset_reg_data(void)
+{
+	return &host_reset_reg;
 }
 
 void restore_msrs(void)
@@ -180,5 +197,44 @@ void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, u
 	/* online all APs again */
 	if (!start_pcpus(AP_MASK)) {
 		panic("Failed to start all APs!");
+	}
+}
+
+void reset_host(void)
+{
+	struct acpi_generic_address *gas = &(host_reset_reg.reg);
+
+
+	/* TODO: gracefully shut down all guests before doing host reset. */
+
+	/*
+	 * UEFI more likely sets the reset value as 0x6 (not 0xe) for 0xcf9 port.
+	 * This asserts PLTRST# to reset devices on the platform, but not the
+	 * SLP_S3#/4#/5# signals, which power down the systems. This might not be
+	 * enough for us.
+	 */
+	if ((gas->space_id == SPACE_SYSTEM_IO) &&
+		(gas->bit_width == 8U) && (gas->bit_offset == 0U) &&
+		(gas->address != 0U) && (gas->address != 0xcf9U)) {
+		pio_write8(host_reset_reg.val, (uint16_t)host_reset_reg.reg.address);
+	}
+
+	/*
+	 * Fall back
+	 * making sure bit 2 (RST_CPU) is '0', when the reset command is issued.
+	 */
+	pio_write8(0x2U, 0xcf9U);
+	pio_write8(0xeU, 0xcf9U);
+
+	/*
+	 * Fall back
+	 * keyboard controller might cause the INIT# being asserted,
+	 * and not power cycle the system.
+	 */
+	pio_write8(0xfeU, 0x64U);
+
+	pr_fatal("%s(): can't reset host.", __func__);
+	while (1) {
+		asm_pause();
 	}
 }

--- a/hypervisor/include/arch/x86/guest/vm_reset.h
+++ b/hypervisor/include/arch/x86/guest/vm_reset.h
@@ -9,14 +9,8 @@
 
 #include <acrn_common.h>
 
-struct acpi_reset_reg {
-	struct acpi_generic_address reg;
-	uint8_t val;
-};
-
 void register_reset_port_handler(struct acrn_vm *vm);
 void shutdown_vm_from_idle(uint16_t pcpu_id);
 void triple_fault_shutdown_vm(struct acrn_vcpu *vcpu);
-struct acpi_reset_reg *get_host_reset_reg_data(void);
 
 #endif /* VM_RESET_H_ */

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -24,10 +24,17 @@ struct cpu_state_table {
 	struct cpu_state_info	state_info;
 };
 
+struct acpi_reset_reg {
+	struct acpi_generic_address reg;
+	uint8_t val;
+};
+
 struct pm_s_state_data *get_host_sstate_data(void);
 void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
 extern void asm_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
 extern void restore_s3_context(void);
 struct cpu_state_info *get_cpu_pm_state_info(void);
+struct acpi_reset_reg *get_host_reset_reg_data(void);
+void reset_host(void);
 
 #endif	/* HOST_PM_H */


### PR DESCRIPTION
move some data structures and APIs related host reset
from vm_reset.c to pm.c, these are not related with guest.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>