### PR TITLE
Flush CPU cacheline on EPT entry change for VT-d

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -429,9 +429,9 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 
 	init_ept_mem_ops(vm);
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);
-	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp);
+	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp, &vm->arch_vm.ept_mem_ops);
 
-	/* Register default handlers for PIO & MMIO if it is SOS VM or Pre-launched VM */
+	/* Register default handlers for PIO & MMIO if it is, SOS VM or Pre-launched VM */
 	if ((vm_config->load_order == SOS_VM) || (vm_config->load_order == PRE_LAUNCHED_VM)) {
 		register_pio_default_emulation_handler(vm);
 		register_mmio_default_emulation_handler(vm);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -148,16 +148,16 @@ static inline uint64_t get_sanitized_page(void)
 	return hva2hpa(sanitized_page);
 }
 
-void sanitize_pte_entry(uint64_t *ptep)
+void sanitize_pte_entry(uint64_t *ptep, const struct memory_ops *mem_ops)
 {
-	set_pgentry(ptep, get_sanitized_page());
+	set_pgentry(ptep, get_sanitized_page(), mem_ops);
 }
 
-void sanitize_pte(uint64_t *pt_page)
+void sanitize_pte(uint64_t *pt_page, const struct memory_ops *mem_ops)
 {
 	uint64_t i;
 	for (i = 0UL; i < PTRS_PER_PTE; i++) {
-		sanitize_pte_entry(pt_page + i);
+		sanitize_pte_entry(pt_page + i, mem_ops);
 	}
 }
 
@@ -294,7 +294,7 @@ void init_paging(void)
 	enable_paging();
 
 	/* set ptep in sanitized_page point to itself */
-	sanitize_pte((uint64_t *)sanitized_page);
+	sanitize_pte((uint64_t *)sanitized_page, &ppt_mem_ops);
 }
 
 /*

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1300,9 +1300,6 @@ int32_t move_pt_device(const struct iommu_domain *from_domain, struct iommu_doma
 
 void enable_iommu(void)
 {
-	if (!iommu_page_walk_coherent) {
-		cache_flush_invalidate_all();
-	}
 	do_action_for_iommus(dmar_enable);
 }
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -102,8 +102,8 @@ enum _page_table_level {
 #define PAGE_SIZE_2M	MEM_2M
 #define PAGE_SIZE_1G	MEM_1G
 
-void sanitize_pte_entry(uint64_t *ptep);
-void sanitize_pte(uint64_t *pt_page);
+void sanitize_pte_entry(uint64_t *ptep, const struct memory_ops *mem_ops);
+void sanitize_pte(uint64_t *pt_page, const struct memory_ops *mem_ops);
 /**
  * @brief MMU paging enable
  *
@@ -176,12 +176,12 @@ static inline void cache_flush_invalidate_all(void)
 	asm volatile ("   wbinvd\n" : : : "memory");
 }
 
-static inline void clflush(volatile void *p)
+static inline void clflush(const volatile void *p)
 {
 	asm volatile ("clflush (%0)" :: "r"(p));
 }
 
-static inline void clflushopt(volatile void *p)
+static inline void clflushopt(const volatile void *p)
 {
 	asm volatile ("clflushopt (%0)" :: "r"(p));
 }

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -71,6 +71,7 @@ struct memory_ops {
 	struct page *(*get_pd_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	struct page *(*get_pt_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	void *(*get_sworld_memory_base)(const union pgtable_pages_info *info);
+	void (*clflush_pagewalk)(const void *p);
 };
 
 extern const struct memory_ops ppt_mem_ops;

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -257,9 +257,10 @@ static inline uint64_t get_pgentry(const uint64_t *pte)
 /*
  * pgentry may means pml4e/pdpte/pde/pte
  */
-static inline void set_pgentry(uint64_t *ptep, uint64_t pte)
+static inline void set_pgentry(uint64_t *ptep, uint64_t pte, const struct memory_ops *mem_ops)
 {
 	*ptep = pte;
+	mem_ops->clflush_pagewalk(ptep);
 }
 
 static inline uint64_t pde_large(uint64_t pde)

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -549,7 +549,7 @@ struct iommu_domain;
  * @brief Assign a device specified by bus & devfun to a iommu domain.
  *
  * Remove the device from the from_domain (if non-NULL), and add it to the to_domain (if non-NULL).
- * API silently fails to add/remove devices to/from domains that are under "Ignored" DMAR units. 
+ * API silently fails to add/remove devices to/from domains that are under "Ignored" DMAR units.
  *
  * @param[in]    from_domain iommu domain from which the device is removed from
  * @param[in]    to_domain iommu domain to which the device is assgined to
@@ -665,6 +665,18 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
  *
  */
 void dmar_free_irte(struct intr_source intr_src, uint16_t index);
+
+/**
+ * @brief Flash cacheline(s) for a specific address with specific size.
+ *
+ * Flash cacheline(s) for a specific address with specific size,
+ * if all IOMMUs active support page-walk coherency, cacheline(s) are not fluashed.
+ *
+ * @param[in] p the address of the buffer, whose cache need to be invalidated
+ * @param[in] size the size of the buffer
+ *
+ */
+void iommu_flush_cache(const void *p, uint32_t size);
 /**
   * @}
   */


### PR DESCRIPTION
Some VT-d hardware implementation doesn't support page-walk coherency. When the translation table entries are modified,
the cacheline of the entries should be flushed, so that the modificiation is visible to VT-d hardware.
In current code, VT-d shares the EPT table of a VM, considering no GPA to HPA mapping change after VM started, hypervisor
globally invalidate cache per VM when creating the VM.
However, when RTVM in industry scenario is introduced, a global cache invalidation may affect the cache usage of RTVM.
The patch series flush cacheline on EPT entry change, and remove the global cache invalidation per VM.

Tracked-On: #3607 