### PR TITLE
doc: add "-f/--force' optional arg to 'acrnctl' documentation

### DIFF
--- a/misc/acrn-manager/README.rst
+++ b/misc/acrn-manager/README.rst
@@ -24,7 +24,7 @@ You can see the available ``acrnctl`` commands by running:
    support:
      list
      start
-     stop
+     stop [--force/-f]
      del
      add
      pause
@@ -106,6 +106,15 @@ Use the ``stop`` command to stop one or more running VM:
 .. code-block:: none
 
    # acrnctl stop vm-yocto vm1-14:59:30 vm-android
+
+Use the optional ``-f`` or ``--force`` argument to force the stop operation.
+This will trigger an immediate shutdown of the User VM by the ACRN Device Model
+and can be useful when the User VM is in a bad state and not shutting down
+gracefully by itself.
+
+.. code-block:: none
+
+   # acrnctl stop -f vm-yocto
 
 RESCAN BLOCK DEVICE
 ===================


### PR DESCRIPTION
Add the new and optional "-f/--force" flag to the 'acrnctl'
documentation.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>