### PR TITLE
DM USB: fix potential crash risk due to null pointer

### DIFF
--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -962,6 +962,11 @@ usb_dev_request(void *pdata, struct usb_data_xfer *xfer)
 
 	blk = usb_dev_prepare_ctrl_xfer(xfer);
 	data = blk ? blk->buf : NULL;
+	if (data == NULL) {
+		xfer->status = USB_ERR_IOERROR;
+		UPRINTF(LFTL, "%s unexpected NULL data\r\n", __func__);
+		goto out;
+	}
 
 	UPRINTF(LDBG, "%d-%s: urb: type 0x%x req 0x%x val 0x%x idx %d len %d "
 			"data %d\r\n", udev->info.path.bus,


### PR DESCRIPTION
Fix potential risk to crash due to null pointer.

Tracked-On: #3612
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>