### PR TITLE
dm: virtio-console: add subclass

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -1136,6 +1136,7 @@ virtio_console_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_DEVICE, VIRTIO_DEV_CONSOLE);
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_SIMPLECOMM);
+	pci_set_cfgdata8(dev, PCIR_SUBCLASS, PCIS_SIMPLECOMM_OTHER);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_CONSOLE);
 	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
 


### PR DESCRIPTION
Add subclass for virtio-console pci device. Without the subclass, the
device may be probed by 8250_pci serial driver,  and lead to segment
fault in acrn-dm. This issue appears when running debian as Guest OS.

But there is a potential issue, if a new serial driver, which use class
and subclass same as virtio-console, the problem may still trigger. Need
to fix it case by case.

Tracked-On: #3615
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>