### PR TITLE
dm: support VM running with more than 4 vcpus

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -643,7 +643,7 @@ vm_loop(struct vmctx *ctx)
 		if (error)
 			break;
 
-		for (vcpu_id = 0; vcpu_id < 4; vcpu_id++) {
+		for (vcpu_id = 0; vcpu_id < guest_ncpus; vcpu_id++) {
 			vhm_req = &vhm_req_buf[vcpu_id];
 			if ((atomic_load(&vhm_req->processed) == REQ_STATE_PROCESSING)
 				&& (vhm_req->client == ctx->ioreq_client))


### PR DESCRIPTION
Change hardcode of vcpu number to the real value when process VM's IO
request in DM, so we can handle all requests from different vcpus.

Tracked-On: #3425
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>