### PR TITLE
doc: update .gitignore to reflect the new location of the tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 doc/doxygen
 doc/_build
-doc/tools
 doc/reference/kconfig/*.rst
 doc/misc
 build


### PR DESCRIPTION
Update the .gitignore file to reflect the fact that the tools are now located
under misc/ and no longer under tools/.

One of the temporary folder created during the documentation generation was
doc/tools and it was therefore ignored by Git. It is now better to *not*
ignore it as it will cause documention build issues if such previous folder
exists.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>