### PR TITLE
doc: Add three new glossaries

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -86,6 +86,11 @@ Glossary of Terms
    High GM
       See :term:`Hidden GM`
 
+   Hybrid Mode
+      One of three operation modes (hybrid, partition, sharing) that ACRN supports.
+      In this mixed mode, physical hardware resources can be both partitioned to
+      individual user VMs and shared across user VMs.
+
    I2C
       Inter-Integrated Circuit
 
@@ -123,6 +128,10 @@ Glossary of Terms
       Physical devices (typically PCI) exclusively assigned to a guest.  In
       the Project ACRN architecture, pass-through devices are owned by the
       foreground OS.
+
+   Partition Mode
+      One of three operation modes (partition, sharing, hybrid) that ACRN supports.
+      Physical hardware resources are partitioned to individual user VMs.
 
    PCI
       Peripheral Component Interface.
@@ -179,6 +188,10 @@ Glossary of Terms
       The Service VM is generally the first VM launched by ACRN and can
       access hardware resources directly by running native drivers and
       provides device sharing services to User VMs via the Device Model.
+
+   Sharing Mode
+      One of three operation modes (sharing, hybrid, partition) that ACRN supports.
+      Most of the physical hardware resources are shared across user VMs.
 
    SOS
       Obsolete, see :term:`Service VM`


### PR DESCRIPTION
Add three new glossaries: "Hybrid Mode", "Partition Mode", "Sharing Mode".

Signed-off-by: lirui34 <ruix.li@intel.com>