### PR TITLE
doc: update CODEOWNERS for doc, misc reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /hypervisor/                             @anthonyzxu @dongyaozu
 /devicemodel/                            @anthonyzxu @dongyaozu
-/doc/                                    @dbkinder @deb-intel
-/tools/acrn-crashlog/                    @dizhang417 @chengangc
+/doc/                                    @dbkinder @deb-intel @NanlinXie
+/misc/                                   @terryzouhao @szhen11
 
 *.rst                                    @dbkinder @deb-intel


### PR DESCRIPTION
Add Nanlin (@NanlinXie) as a reviewer for ACRN documentation.
Add Terry and Shuang (@terryzouhao @szhen11) as the reviewers for misc component.

Tracked-On: #3419
Signed-off-by: lirui34 <ruix.li@intel.com>