### PR TITLE
dm: reserve 16M hole for gvt in e820 table

### DIFF
--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -56,9 +56,10 @@ static char bootargs[BOOT_ARG_LEN];
  * 2:       0x100000 -  lowmem      RAM             lowmem - 1MB
  * 3:         lowmem -  0x80000000  (reserved)      2GB - lowmem
  * 4:	  0x80000000 -  0x88000000  (reserved)	    128MB
- * 5:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
- * 6:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
- * 7:    0x140000000 -  highmem     RAM             highmem - 5GB
+ * 5:     0xDF000000 -  0xE0000000  (reserved)      16MB
+ * 6:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
+ * 7:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
+ * 8:    0x140000000 -  highmem     RAM             highmem - 5GB
  */
 const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 	{	/* 0 to video memory */
@@ -89,6 +90,13 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		/* reserve for PRM resource */
 		.baseaddr = 0x80000000,
 		.length	  = 0x8000000,
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{
+		/* reserve for GVT */
+		.baseaddr = 0xDF000000,
+		.length	  = 0x1000000,
 		.type     = E820_TYPE_RESERVED
 	},
 

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        8
+#define NUM_E820_ENTRIES        9
 #define LOWRAM_E820_ENTRY       2
-#define HIGHRAM_E820_ENTRY      7
+#define HIGHRAM_E820_ENTRY      8
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {


### PR DESCRIPTION
Add 16M@0xDF000000 for GVT usage as below. Currently, use 8M for GOP
framebuf, it satisfies display resolution of 1920x1080@32bpp

start         end          size    Note
[0x 00000000, 0x 000A0000] 640K
[0x 000A0000, 0x 00100000] 384K
[0x 00100000, 0x 7ff00000] 2G-1M   lowmem-1M
[0x 80000000, 0x 88000000] 128M    [lowmem, +128M]
[0x DF000000, 0x E0000000] 16M     *gvt*
[0x e0000000, 0x100000000] 512M
[0x100000000, 0x140000000] 1G

*gvt*:
[0xDF000000, 0xDF800000] 8M      GOP FB
[0xDFFFD000, 0XE0000000] 12K     opregion

Tracked-On: #3624

Signed-off-by: Liu Xinyun <xinyun.liu@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>