### PR TITLE
hv:change function parameter for invept

### DIFF
--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -374,7 +374,10 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 	} else {
 
 		if (bitmap_test_and_clear_lock(ACRN_REQUEST_EPT_FLUSH, pending_req_bits)) {
-			invept(vcpu);
+			invept(vcpu->vm->arch_vm.nworld_eptp);
+			if (vcpu->vm->sworld_control.flag.active != 0UL) {
+				invept(vcpu->vm->arch_vm.sworld_eptp);
+			}
 		}
 
 		if (bitmap_test_and_clear_lock(ACRN_REQUEST_VPID_FLUSH,	pending_req_bits)) {

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -35,7 +35,6 @@
 #include <mmu.h>
 #include <vmx.h>
 #include <reloc.h>
-#include <vcpu.h>
 #include <vm.h>
 #include <ld_sym.h>
 #include <logmsg.h>
@@ -123,19 +122,13 @@ void flush_vpid_global(void)
 	local_invvpid(VMX_VPID_TYPE_ALL_CONTEXT, 0U, 0UL);
 }
 
-void invept(const struct acrn_vcpu *vcpu)
+void invept(const void *eptp)
 {
 	struct invept_desc desc = {0};
 
 	if (pcpu_has_vmx_ept_cap(VMX_EPT_INVEPT_SINGLE_CONTEXT)) {
-		desc.eptp = hva2hpa(vcpu->vm->arch_vm.nworld_eptp) |
-				(3UL << 3U) | 6UL;
+		desc.eptp = hva2hpa(eptp) | (3UL << 3U) | 6UL;
 		local_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
-		if (vcpu->vm->sworld_control.flag.active != 0UL) {
-			desc.eptp = hva2hpa(vcpu->vm->arch_vm.sworld_eptp)
-				| (3UL << 3U) | 6UL;
-			local_invept(INVEPT_TYPE_SINGLE_CONTEXT, desc);
-		}
 	} else if (pcpu_has_vmx_ept_cap(VMX_EPT_INVEPT_GLOBAL_CONTEXT)) {
 		local_invept(INVEPT_TYPE_ALL_CONTEXTS, desc);
 	} else {

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -165,11 +165,11 @@ void flush_address_space(void *addr, uint64_t size);
 /**
  * @brief Guest-physical mappings and combined mappings invalidation
  *
- * @param[in] vcpu the pointer that points the vcpu data structure
+ * @param[in] eptp the pointer that points the eptp
  *
  * @return None
  */
-void invept(const struct acrn_vcpu *vcpu);
+void invept(const void *eptp);
 
 static inline void cache_flush_invalidate_all(void)
 {

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -186,7 +186,7 @@ static inline void *hpa2hva(uint64_t x)
  *
  * @return The translated host-physical address
  */
-static inline uint64_t hva2hpa(void *x)
+static inline uint64_t hva2hpa(const void *x)
 {
 	return (uint64_t)x;
 }


### PR DESCRIPTION
change the input parameter from *vcpu to *eptp in order to let this api
more generic, no need to care normal world or secure world.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>