### PR TITLE
doc: add 'zlib1g-dev' to list of dependencies in Debian

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -85,7 +85,8 @@ each with their own way to install development tools:
           python3-pip \
           libblkid-dev \
           e2fslibs-dev \
-          pkg-config
+          pkg-config \
+          zlib1g-dev
      $ sudo pip3 install kconfiglib
 
   .. note::


### PR DESCRIPTION
Add 'zlib1g-dev' to the list of build tools and dependencies to be installed
in Debian in order to build the ACRN project.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>