### PR TITLE
hv:add volatile keyword for some variables

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -37,7 +37,7 @@ static uint64_t pcpu_sync = 0UL;
 static uint64_t startup_paddr = 0UL;
 
 /* physical cpu active bitmap, support up to 64 cpus */
-static uint64_t pcpu_active_bitmap = 0UL;
+static volatile uint64_t pcpu_active_bitmap = 0UL;
 
 static void pcpu_xsave_init(void);
 static void set_current_pcpu_id(uint16_t pcpu_id);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -360,7 +360,7 @@ struct acrn_vcpu {
 
 	struct sched_object sched_obj;
 	bool launched; /* Whether the vcpu is launched on target pcpu */
-	bool running; /* vcpu is picked up and run? */
+	volatile bool running; /* vcpu is picked up and run? */
 
 	struct instr_emul_ctxt inst_ctxt;
 	struct io_request req; /* used by io/ept emulation */


### PR DESCRIPTION
pcpu_active_bitmap was read continuously in wait_pcpus_offline(),
acrn_vcpu->running was read continuously in pause_vcpu(),
add volatile keyword to ensure that such accesses are not
optimised away by the complier.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>