### PR TITLE
hv:enable the O2 option for HV

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -74,6 +74,7 @@ CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone
 CFLAGS += -nostdinc -nostdlib -fno-common
 CFLAGS += -Werror
+CFLAGS += -O2
 ifeq (y, $(CONFIG_RELOC))
 CFLAGS += -fpie
 else


### PR DESCRIPTION
commit 5d19962d removed O2 option improperly,
this patch re-enable it.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>