### PR TITLE
Remove "or newer" reference to ensure that users know ACRN 1.2 requir…

### DIFF
--- a/doc/release_notes/release_notes_1.2.rst
+++ b/doc/release_notes/release_notes_1.2.rst
@@ -22,7 +22,7 @@ or use Git clone and checkout commands::
 The project's online technical documentation is also tagged to correspond
 with a specific release: generated v1.2 documents can be found at https://projectacrn.github.io/1.2/.
 Documentation for the latest (master) branch is found at https://projectacrn.github.io/latest/.
-ACRN v1.2 requires Clear Linux* OS version 30690 or newer. Please follow the
+ACRN v1.2 requires Clear Linux* OS version 30690. Please follow the
 instructions in the :ref:`getting-started-apl-nuc`.
 
 Version 1.2 major features


### PR DESCRIPTION
…es ONLY Clear Linux OS version 30690.

Signed-off-by: Deb Taylor <deb.taylor@intel.com>