### PR TITLE
Vpci: refine vPCI device BAR access

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -327,15 +327,14 @@ static struct pci_vdev *find_vdev(const struct acrn_vpci *vpci, union pci_bdf bd
 
 static void vpci_init_pt_dev(struct pci_vdev *vdev)
 {
+	/*
+	 * init_vdev_pt() must be called before init_vmsix() because init_vmsix
+	 * assigns BAR base hpa to MSI-X mmio_hpa which is initialized in init_vdev_pt().
+	 */
+	init_vdev_pt(vdev);
 	init_vmsi(vdev);
 	init_vmsix(vdev);
 
-	/*
-	 * Here init_vdev_pt() needs to be called after init_vmsix() for the following reason:
-	 * init_vdev_pt() will indirectly call has_msix_cap(), which
-	 * requires init_vmsix() to be called first.
-	 */
-	init_vdev_pt(vdev);
 	assign_vdev_pt_iommu_domain(vdev);
 }
 

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -288,6 +288,7 @@ static uint32_t pci_pdev_read_bar(union pci_bdf bdf, uint32_t idx, struct pci_ba
 	}
 
 	bar->size = size;
+	bar->base_hpa = base;
 
 	return (type == PCIBAR_MEM64)?2U:1U;
 }

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -185,6 +185,7 @@ struct pci_bar {
 	/* Base Address Register */
 	union pci_bar_reg reg;
 	uint64_t size;
+	uint64_t base_hpa;
 	bool is_64bit_high; /* true if this is the upper 32-bit of a 64-bit bar */
 };
 


### PR DESCRIPTION
1) PCI BAR physical base address will never changed. Cache it to avoid calculating
    it every time when we access it.
2) vPCI device should use its virtual configure space to access its BAR after vPCI
    device initialized.
    This patch also remove corner case "vPCI device will use its 64 bits BAR high idx
    to access its BAR base address".

    Tracked-On: #3475
    Signed-off-by: Li, Fei1 <fei1.li@intel.com>