### PR TITLE
preparation for cpu sharing 

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -342,6 +342,19 @@ bool start_pcpus(uint64_t mask)
 	return ((pcpu_active_bitmap & mask) == mask);
 }
 
+void make_pcpu_offline(uint16_t pcpu_id)
+{
+	bitmap_set_lock(NEED_OFFLINE, &per_cpu(pcpu_flag, pcpu_id));
+	if (get_pcpu_id() != pcpu_id) {
+		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
+	}
+}
+
+bool need_offline(uint16_t pcpu_id)
+{
+	return bitmap_test_and_clear_lock(NEED_OFFLINE, &per_cpu(pcpu_flag, pcpu_id));
+}
+
 void wait_pcpus_offline(uint64_t mask)
 {
 	uint32_t timeout;

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -248,6 +248,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 		init_interrupt(pcpu_id);
 
 		timer_init();
+		ptdev_init();
 
 		/* Wait for boot processor to signal all secondary cores to continue */
 		wait_sync_change(&pcpu_sync, 0UL);

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -520,11 +520,8 @@ static void ptirq_handle_intx(struct acrn_vm *vm,
 
 void ptirq_softirq(uint16_t pcpu_id)
 {
-	struct acrn_vcpu *vcpu = per_cpu(vcpu, pcpu_id);
-	struct acrn_vm *vm = vcpu->vm;
-
 	while (1) {
-		struct ptirq_remapping_info *entry = ptirq_dequeue_softirq(vm);
+		struct ptirq_remapping_info *entry = ptirq_dequeue_softirq(pcpu_id);
 		struct ptirq_msi_info *msi;
 
 		if (entry == NULL) {
@@ -541,11 +538,11 @@ void ptirq_softirq(uint16_t pcpu_id)
 
 		/* handle real request */
 		if (entry->intr_type == PTDEV_INTR_INTX) {
-			ptirq_handle_intx(vm, entry);
+			ptirq_handle_intx(entry->vm, entry);
 		} else {
 			if (msi != NULL) {
 				/* TODO: msi destmode check required */
-				(void)vlapic_intr_msi(vm, msi->vmsi_addr.full, msi->vmsi_data.full);
+				(void)vlapic_intr_msi(entry->vm, msi->vmsi_addr.full, msi->vmsi_data.full);
 				dev_dbg(ACRN_DBG_PTIRQ, "dev-assign: irq=0x%x MSI VR: 0x%x-0x%x",
 					entry->allocated_pirq,
 					msi->vmsi_data.bits.vector,

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -478,8 +478,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	if (status == 0) {
 		prepare_epc_vm_memmap(vm);
 
-		INIT_LIST_HEAD(&vm->softirq_dev_entry_list);
-		spinlock_init(&vm->softirq_dev_lock);
 		spinlock_init(&vm->vm_lock);
 
 		vm->arch_vm.vlapic_state = VM_VLAPIC_XAPIC;

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -126,40 +126,6 @@ bool need_reschedule(uint16_t pcpu_id)
 	return bitmap_test(NEED_RESCHEDULE, &ctx->flags);
 }
 
-void make_pcpu_offline(uint16_t pcpu_id)
-{
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-
-	bitmap_set_lock(NEED_OFFLINE, &ctx->flags);
-	if (get_pcpu_id() != pcpu_id) {
-		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
-	}
-}
-
-bool need_offline(uint16_t pcpu_id)
-{
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-
-	return bitmap_test_and_clear_lock(NEED_OFFLINE, &ctx->flags);
-}
-
-void make_shutdown_vm_request(uint16_t pcpu_id)
-{
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-
-	bitmap_set_lock(NEED_SHUTDOWN_VM, &ctx->flags);
-	if (get_pcpu_id() != pcpu_id) {
-		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
-	}
-}
-
-bool need_shutdown_vm(uint16_t pcpu_id)
-{
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-
-	return bitmap_test_and_clear_lock(NEED_SHUTDOWN_VM, &ctx->flags);
-}
-
 static void prepare_switch(struct sched_object *prev, struct sched_object *next)
 {
 	if ((prev != NULL) && (prev->prepare_switch_out != NULL)) {

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -264,6 +264,11 @@ enum pcpu_boot_state {
 	PCPU_STATE_DEAD,
 };
 
+#define	NEED_OFFLINE		(1U)
+#define	NEED_SHUTDOWN_VM	(2U)
+void make_pcpu_offline(uint16_t pcpu_id);
+bool need_offline(uint16_t pcpu_id);
+
 /* Function prototypes */
 void cpu_do_idle(void);
 void cpu_dead(void);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -143,8 +143,6 @@ struct acrn_vm {
 
 	uint8_t vrtc_offset;
 
-	spinlock_t softirq_dev_lock;
-	struct list_head softirq_dev_entry_list;
 	uint64_t intr_inject_delay_delta; /* delay of intr injection */
 } __aligned(PAGE_SIZE);
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -198,6 +198,8 @@ static inline uint16_t vmid_2_rel_vmid(uint16_t sos_vmid, uint16_t vmid) {
 	return (vmid - sos_vmid);
 }
 
+void make_shutdown_vm_request(uint16_t pcpu_id);
+bool need_shutdown_vm(uint16_t pcpu_id);
 int32_t shutdown_vm(struct acrn_vm *vm);
 void pause_vm(struct acrn_vm *vm);
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -51,6 +51,7 @@ struct per_cpu_region {
 	uint32_t lapic_ldr;
 	uint32_t softirq_servicing;
 	struct smp_call_info_data smp_call_info;
+	struct list_head softirq_dev_entry_list;
 #ifdef PROFILING_ON
 	struct profiling_info_wrapper profiling_info;
 #endif

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -42,6 +42,7 @@ struct per_cpu_region {
 	struct host_gdt gdt;
 	struct tss_64 tss;
 	enum pcpu_boot_state boot_state;
+	uint64_t pcpu_flag;
 	uint8_t mc_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t df_stack[CONFIG_STACK_SIZE] __aligned(16);
 	uint8_t sf_stack[CONFIG_STACK_SIZE] __aligned(16);

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -154,7 +154,7 @@ void ptirq_softirq(uint16_t pcpu_id);
 void ptdev_init(void);
 void ptdev_release_all_entries(const struct acrn_vm *vm);
 
-struct ptirq_remapping_info *ptirq_dequeue_softirq(struct acrn_vm *vm);
+struct ptirq_remapping_info *ptirq_dequeue_softirq(uint16_t pcpu_id);
 struct ptirq_remapping_info *ptirq_alloc_entry(struct acrn_vm *vm, uint32_t intr_type);
 void ptirq_release_entry(struct ptirq_remapping_info *entry);
 int32_t ptirq_activate_entry(struct ptirq_remapping_info *entry, uint32_t phys_irq);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -9,8 +9,6 @@
 #include <spinlock.h>
 
 #define	NEED_RESCHEDULE		(1U)
-#define	NEED_OFFLINE		(2U)
-#define	NEED_SHUTDOWN_VM	(3U)
 
 #define DEL_MODE_INIT		(1U)
 #define DEL_MODE_IPI		(2U)
@@ -48,10 +46,6 @@ void remove_from_cpu_runqueue(struct sched_object *obj);
 
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);
-void make_pcpu_offline(uint16_t pcpu_id);
-bool need_offline(uint16_t pcpu_id);
-void make_shutdown_vm_request(uint16_t pcpu_id);
-bool need_shutdown_vm(uint16_t pcpu_id);
 
 void schedule(void);
 void run_sched_thread(struct sched_object *obj);


### PR DESCRIPTION
    hv: ptdev: move softirq_dev_entry_list from vm structure to per_cpu region
    
    Using per_cpu list to record ptdev interrupts is more reasonable than
    recording them per-vm. It makes dispatching such interrupts more easier
    as we now do it in softirq which happens following interrupt context of
    each pcpu.
    
    Tracked-On: #3663
    Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>
    Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
    Acked-by: Eddie Dong <eddie.dong@intel.com>