### PR TITLE
doc: Remove "or newer/higher" descriptions for other release notes an…

### DIFF
--- a/doc/release_notes/release_notes_0.6.rst
+++ b/doc/release_notes/release_notes_0.6.rst
@@ -30,7 +30,7 @@ with a specific release: generated v0.6 documents can be found at
 https://projectacrn.github.io/0.6/.  Documentation for the latest
 (master) branch is found at https://projectacrn.github.io/latest/.
 
-ACRN v0.6 requires Clear Linux OS version 27600 or newer.  Please follow the
+ACRN v0.6 requires Clear Linux OS version 27600. Please follow the
 instructions in the :ref:`getting-started-apl-nuc`.
 
 Version 0.6 new features

--- a/doc/release_notes/release_notes_0.7.rst
+++ b/doc/release_notes/release_notes_0.7.rst
@@ -30,7 +30,7 @@ with a specific release: generated v0.7 documents can be found at
 https://projectacrn.github.io/0.7/.  Documentation for the latest
 (master) branch is found at https://projectacrn.github.io/latest/.
 
-ACRN v0.7 requires Clear Linux OS version 28260 or newer.  Please follow the
+ACRN v0.7 requires Clear Linux OS version 28260. Please follow the
 instructions in the :ref:`getting-started-apl-nuc`.
 
 Version 0.7 new features

--- a/doc/release_notes/release_notes_0.8.rst
+++ b/doc/release_notes/release_notes_0.8.rst
@@ -30,7 +30,7 @@ with a specific release: generated v0.8 documents can be found at
 https://projectacrn.github.io/0.8/.  Documentation for the latest
 (master) branch is found at https://projectacrn.github.io/latest/.
 
-ACRN v0.8 requires Clear Linux OS version 28600 or newer.  Please follow the
+ACRN v0.8 requires Clear Linux OS version 28600. Please follow the
 instructions in the :ref:`getting-started-apl-nuc`.
 
 Version 0.8 new features

--- a/doc/release_notes/release_notes_1.0.rst
+++ b/doc/release_notes/release_notes_1.0.rst
@@ -31,7 +31,7 @@ or use Git clone and checkout commands::
 The project's online technical documentation is also tagged to correspond
 with a specific release: generated v1.0 documents can be found at https://projectacrn.github.io/1.0/.
 Documentation for the latest (master) branch is found at https://projectacrn.github.io/latest/.
-ACRN v1.0 requires Clear Linux* OS version 29070 or newer. Please follow the
+ACRN v1.0 requires Clear Linux* OS version 29070. Please follow the
 instructions in the :ref:`getting-started-apl-nuc`.
 
 Version 1.0 major features

--- a/doc/release_notes/release_notes_1.1.rst
+++ b/doc/release_notes/release_notes_1.1.rst
@@ -22,7 +22,7 @@ or use Git clone and checkout commands::
 The project's online technical documentation is also tagged to correspond
 with a specific release: generated v1.1 documents can be found at https://projectacrn.github.io/1.1/.
 Documentation for the latest (master) branch is found at https://projectacrn.github.io/latest/.
-ACRN v1.1 requires Clear Linux* OS version 29970 or newer. Please follow the
+ACRN v1.1 requires Clear Linux* OS version 29970. Please follow the
 instructions in the :ref:`getting-started-apl-nuc`.
 
 Version 1.1 major features

--- a/doc/tutorials/open_vswitch.rst
+++ b/doc/tutorials/open_vswitch.rst
@@ -9,7 +9,7 @@ use `Open Virtual Switch (OVS)
 
 .. note::
    OVS is provided as part of the ``service-os``
-   bundle.  Use ClearLinux OS version ``29660`` or higher.
+   bundle.  Use ClearLinux OS version ``29660``.
 
 What is OVS
 ***********

--- a/doc/tutorials/rt_linux.rst
+++ b/doc/tutorials/rt_linux.rst
@@ -44,8 +44,8 @@ system on Intel KBL NUC with a SATA SSD as ``/dev/sda`` and an NVME SSD as
 1. Follow the :ref:`set-up-CL` instructions in the
    :ref:`getting-started-apl-nuc` to:
 
-   a. Install Clear Linux (version 29400 or higher) onto the NVMe
-   #. Install Clear Linux (version 29400 or higher) onto the SATA SSD
+   a. Install Clear Linux (version 29400) onto the NVMe
+   #. Install Clear Linux (version 29400) onto the SATA SSD
    #. Set up Clear Linux on the SATA SSD as the Service OS (SOS) following
       the :ref:`add-acrn-to-efi` instructions in the same guide.
 

--- a/doc/tutorials/using_celadon_as_uos.rst
+++ b/doc/tutorials/using_celadon_as_uos.rst
@@ -11,7 +11,7 @@ on the ACRN hypervisor. We are using Kaby Lake-based NUC (model NUC7i7DNHE) in t
 Prerequisites
 *************
 
-* Ubuntu 18.04 or higher with at least 150G free disk space
+* Ubuntu 18.04 with at least 150G free disk space
 * Intel Kaby Lake NUC7ixDNHE ( Reference Platforms: :ref:`ACRN supported platforms <hardware>` )
 * BIOS version 0059 or later firmware should be flashed on the NUC system,
   and the ``Device Mode`` option is selected on the USB category of the Devices tab,


### PR DESCRIPTION
…d some tutorials.

ACRN tag is ONLY specific to one Clear Linux version.
For the tutorials, we just need to make sure the validated version is functional.

Signed-off-by: lirui34 <ruix.li@intel.com>