### PR TITLE
Hv s5 trap push

### DIFF
--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -148,6 +148,11 @@ void do_acpi_sx(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint
 	} while ((s1 & (1U << BIT_WAK_STS)) == 0U);
 }
 
+void host_enter_s5(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
+{
+	do_acpi_sx(sstate_data, pm1a_cnt_val, pm1b_cnt_val);
+}
+
 void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
 {
 	uint64_t pmain_entry_saved;

--- a/hypervisor/arch/x86/pm.c
+++ b/hypervisor/arch/x86/pm.c
@@ -119,7 +119,8 @@ static uint32_t acpi_gas_read(const struct acpi_generic_address *gas)
 	return ret;
 }
 
-void do_acpi_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
+/* This function supports enter S3 or S5 according to the value given to pm1a_cnt_val and pm1b_cnt_val */
+void do_acpi_sx(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
 {
 	uint32_t s1, s2;
 

--- a/hypervisor/arch/x86/wakeup.S
+++ b/hypervisor/arch/x86/wakeup.S
@@ -25,7 +25,7 @@
    .extern    restore_msrs
    .extern    cpu_ctx
    .extern    load_gdtr_and_tr
-   .extern    do_acpi_s3
+   .extern    do_acpi_sx
 
    .global    asm_enter_s3
 asm_enter_s3:
@@ -94,7 +94,7 @@ asm_enter_s3:
 	/*48U=0x30=CPU_CONTEXT_OFFSET_RSI*/
 	movq 0x30 + cpu_ctx(%rip), %rsi  /* pm1a_cnt_val */
 
-	call do_acpi_s3
+	call do_acpi_sx
 
 /*
  * When system resume from S3, trampoline_start64 will

--- a/hypervisor/include/arch/x86/host_pm.h
+++ b/hypervisor/include/arch/x86/host_pm.h
@@ -31,6 +31,7 @@ struct acpi_reset_reg {
 
 struct pm_s_state_data *get_host_sstate_data(void);
 void host_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
+void host_enter_s5(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
 extern void asm_enter_s3(struct pm_s_state_data *sstate_data, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val);
 extern void restore_s3_context(void);
 struct cpu_state_info *get_cpu_pm_state_info(void);


### PR DESCRIPTION
To support platform S5 with RTVM/safety VM, we need to trap the guest S5 request
and do necessary check before shutdown the whole platform.

Tracked-On: #3564
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
