### PR TITLE
to support S5 through vuart

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -92,6 +92,7 @@ SRCS += hw/platform/ioapic.c
 SRCS += hw/platform/cmos_io.c
 SRCS += hw/platform/ioc.c
 SRCS += hw/platform/ioc_cbc.c
+SRCS += hw/platform/pty_vuart.c
 SRCS += hw/platform/acpi/acpi.c
 SRCS += hw/platform/acpi/acpi_pm.c
 SRCS += hw/platform/rpmb/rpmb_sim.c

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -141,6 +141,7 @@ SRCS += core/sw_load_elf.c
 SRCS += core/mevent.c
 SRCS += core/gc.c
 SRCS += core/pm.c
+SRCS += core/pm_vuart.c
 SRCS += core/console.c
 SRCS += core/inout.c
 SRCS += core/mem.c

--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -352,7 +352,7 @@ static void handle_stop(struct mngr_msg *msg, int client_fd, void *param)
 	ack.msgid = msg->msgid;
 	ack.timestamp = msg->timestamp;
 
-	if (msg->data.acrnd_stop.force) {
+	if (msg->data.acrnd_stop.force && !is_rtvm) {
 		vm_set_suspend_mode(VM_SUSPEND_POWEROFF);
 		ack.data.err = 0;
 	} else {

--- a/devicemodel/core/pm_vuart.c
+++ b/devicemodel/core/pm_vuart.c
@@ -1,0 +1,208 @@
+/*
+ * Project Acrn
+ * Acrn-dm: pm-vuart
+ *
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+/* vuart can be used communication between SOS and UOS, here it is used as power manager control. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "vmmapi.h"
+#include "monitor.h"
+#include "pty_vuart.h"
+#include "log.h"
+
+#define SHUTDOWN_UOS_CMD  "shutdown"
+#define SHUTDOWN_CMD_ACK   "acked"
+#define CMD_LEN 16
+#define WAIT_SND_CNT  3
+#define WAIT_ACK_CNT  5
+#define MAX_NODE_PATH  128
+
+static const char * const node_name[] = {
+	"pty",
+	"tty",
+};
+
+enum node_type_t {
+	PTY_NODE,
+	TTY_NODE,
+	MAX_NODE_CNT,
+};
+
+static uint8_t node_index = MAX_NODE_CNT;
+static char node_path[MAX_NODE_PATH];
+static int node_fd = -1;
+static bool shutdown_uos_thread_started = false;
+static pthread_t shutdown_uos_thread_pid;
+
+static int vm_stop_handler(void *arg);
+static struct monitor_vm_ops vm_ops = {
+	.stop = vm_stop_handler,
+};
+
+/*
+ * --pm_vuart configuration is in the following 2 forms:
+ * A: pty-link, like: pty,/run/acrn/vuart-vm1, (also set it in -l com2,/run/acrn/vuart-vm1)
+ * the SOS and UOS will communicate by: SOS:pty-link-node <--> SOS:com2 <--> UOS: /dev/ttyS1
+ * B: tty-node, like: tty,/dev/ttyS1, SOS and UOS communicate by: SOS:ttyS1 <--> HV <-->UOS:ttySn
+ */
+int parse_pm_by_vuart(const char *opts)
+{
+	int i, error = -1;
+	char *str, *cpy, *type;
+
+	str = cpy = strdup(opts);
+	type = strsep(&str, ",");
+
+	if (type != NULL) {
+		for (i = 0; i < MAX_NODE_CNT; i++) {
+			if (strcasecmp(type, node_name[i]) == 0) {
+				node_index = i;
+				error = 0;
+				break;
+			}
+		}
+	}
+
+	pr_info("pm by vuart node-index = %d\n", node_index);
+	strncpy(node_path, str, MAX_NODE_PATH - 1);
+
+	free(cpy);
+	return error;
+}
+
+void pm_by_vuart_init(struct vmctx *ctx)
+{
+	assert(node_index < MAX_NODE_CNT);
+
+	if (node_index == PTY_NODE) {
+		node_fd = pty_open_virtual_uart(node_path);
+	} else if (node_index == TTY_NODE) {
+		node_fd = open(node_path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+	}
+
+	if (node_fd > 0) {
+		if (monitor_register_vm_ops(&vm_ops, ctx, "pm-vuart") < 0) {
+			pr_err("%s: pm-vuart register to VM monitor failed\n", node_path);
+			close(node_fd);
+			node_fd = -1;
+		}
+	} else {
+		pr_err("%s open failed, fd=%d\n", node_path, node_fd);
+	}
+}
+
+void pm_by_vuart_deinit(struct vmctx *ctx)
+{
+	close(node_fd);
+	node_fd = -1;
+}
+
+/* it read from vuart, and if end is '\0' or '\n' or len = buff-len it will return */
+static int read_bytes(int fd, uint8_t *buffer, int buf_len)
+{
+	int rc, offset = 0;
+
+	do {
+		rc = read(fd, buffer + offset, buf_len - offset);
+		if (rc > 0) {
+			offset += rc;
+
+			if ((buffer[offset - 1] == '\0') || (buffer[offset - 1] == '\n') ||
+				(offset == buf_len)) {
+				break;
+			}
+		}
+	} while (rc > 0);
+
+	return offset;
+}
+
+/* thread to send shutdown cmd to uos and wait acked from it */
+static void *shutdown_uos_thread(void *arg)
+{
+	int rc, wait_snd, wait_ack;
+	char buffer[CMD_LEN];
+
+	wait_snd = WAIT_SND_CNT;
+	while (wait_snd > 0) {
+		rc = write(node_fd, SHUTDOWN_UOS_CMD, strlen(SHUTDOWN_UOS_CMD));
+		if (rc < 0) {
+			pr_err("send shutdown cmd to uos failed!\n");
+			break;
+		}
+
+		sleep(1); /* wait 1 second to communicate with UOS */
+
+		wait_ack = WAIT_ACK_CNT;
+		while (wait_ack > 0) {
+			rc = read_bytes(node_fd, (uint8_t *)buffer, CMD_LEN - 1);
+			if ((rc > 0) && strncmp(buffer, SHUTDOWN_CMD_ACK, strlen(SHUTDOWN_CMD_ACK)) == 0) {
+				pr_info("received acked from UOS\n");
+				break;
+			}
+
+			sleep(1);
+			wait_ack--;
+		}
+
+		if (wait_ack > 0) {
+			break;
+		}
+
+		wait_snd--;
+	}
+
+	if ((wait_snd == 0) && (wait_ack == 0)) {
+		pr_err("not received acked from UOS\n");
+	}
+
+	shutdown_uos_thread_started = false;
+	return NULL;
+}
+
+/* called when acrn-dm receive stop command */
+static int vm_stop_handler(void *arg)
+{
+	int ret;
+
+	pr_info("pm-vuart stop handler called: node-index=%d\n", node_index);
+	assert(node_index < MAX_NODE_CNT);
+
+	if (node_fd <= 0) {
+		pr_err("no vuart node opened!\n");
+		return -1;
+	}
+
+	if (shutdown_uos_thread_started) {
+		pr_info("stop cmd send thread started!\n");
+		return -1;
+	}
+
+	shutdown_uos_thread_started = true;
+	ret = pthread_create(&shutdown_uos_thread_pid, NULL, shutdown_uos_thread, NULL);
+	if (ret) {
+		pr_err("failed %s %d\n", __func__, __LINE__);
+		shutdown_uos_thread_pid = 0;
+		shutdown_uos_thread_started = false;
+		return -1;
+	}
+
+	pr_info("created shutdown uos thread.\n");
+	pthread_setname_np(shutdown_uos_thread_pid, "shutdown_uos");
+
+	return 0;
+}

--- a/devicemodel/hw/platform/ioc.c
+++ b/devicemodel/hw/platform/ioc.c
@@ -55,7 +55,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <pty.h>
 #include <string.h>
 #include <stdbool.h>
 #include <types.h>
@@ -63,6 +62,8 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include "pty_vuart.h"
 
 #include "dm.h"
 #include "ioc.h"
@@ -710,83 +711,6 @@ ioc_open_native_ch(const char *dev_name)
 }
 
 /*
- * Check and create the directory.
- * To avoid symlink failure if the directory does not exist.
- */
-static int
-check_dir(const char *file)
-{
-	char *tmp, *dir;
-
-	tmp = strdup(file);
-	if (!tmp) {
-		DPRINTF("ioc falied to dup file, error:%s\r\n",
-				strerror(errno));
-		return -1;
-	}
-
-	dir = dirname(tmp);
-	if (access(dir, F_OK) && mkdir(dir, 0666)) {
-		DPRINTF("ioc falied to create dir:%s, erorr:%s\r\n", dir,
-				strerror(errno));
-		free(tmp);
-		return -1;
-	}
-	free(tmp);
-	return 0;
-}
-
-/*
- * Open PTY master device for IOC mediator and the PTY slave device for virtual
- * UART. The pair(master/slave) can work as a communication channel between
- * IOC mediator and virtual UART.
- */
-static int
-ioc_open_virtual_uart(const char *dev_name)
-{
-	int fd;
-	char *slave_name;
-	struct termios attr;
-
-	fd = open("/dev/ptmx", O_RDWR | O_NOCTTY | O_NONBLOCK);
-	if (fd < 0)
-		goto open_err;
-	if (grantpt(fd) < 0)
-		goto pty_err;
-	if (unlockpt(fd) < 0)
-		goto pty_err;
-	slave_name = ptsname(fd);
-	if (!slave_name)
-		goto pty_err;
-	if ((unlink(dev_name) < 0) && errno != ENOENT)
-		goto pty_err;
-	/*
-	 * The check_dir restriction is that only create one directory
-	 * not support multi-level directroy.
-	 */
-	if (check_dir(dev_name) < 0)
-		goto pty_err;
-	if (symlink(slave_name, dev_name) < 0)
-		goto pty_err;
-	if (chmod(dev_name, 0660) < 0)
-		goto attr_err;
-	if (tcgetattr(fd, &attr) < 0)
-		goto attr_err;
-	cfmakeraw(&attr);
-	attr.c_cflag |= CLOCAL;
-	if (tcsetattr(fd, TCSANOW, &attr) < 0)
-		goto attr_err;
-	return fd;
-
-attr_err:
-	unlink(dev_name);
-pty_err:
-	close(fd);
-open_err:
-	return -1;
-}
-
-/*
  * Open native CBC cdevs and virtual UART.
  */
 static int
@@ -807,7 +731,7 @@ ioc_ch_init(struct ioc_dev *ioc)
 			fd = ioc_open_native_ch(chl->name);
 			break;
 		case IOC_VIRTUAL_UART:
-			fd = ioc_open_virtual_uart(virtual_uart_path);
+			fd = pty_open_virtual_uart(virtual_uart_path);
 			break;
 		case IOC_LOCAL_EVENT:
 			if (!pipe(pipe_fds)) {
@@ -823,7 +747,7 @@ ioc_ch_init(struct ioc_dev *ioc)
 		 */
 		case IOC_NATIVE_DUMMY0:
 			if (ioc_debug_enable) {
-				fd = ioc_open_virtual_uart(chl->name);
+				fd = pty_open_virtual_uart(chl->name);
 				dummy0_sfd = open(chl->name, O_RDWR | O_NOCTTY |
 						O_NONBLOCK);
 			} else
@@ -831,7 +755,7 @@ ioc_ch_init(struct ioc_dev *ioc)
 			break;
 		case IOC_NATIVE_DUMMY1:
 			if (ioc_debug_enable) {
-				fd = ioc_open_virtual_uart(chl->name);
+				fd = pty_open_virtual_uart(chl->name);
 				dummy1_sfd = open(chl->name, O_RDWR | O_NOCTTY |
 						O_NONBLOCK);
 			} else
@@ -839,7 +763,7 @@ ioc_ch_init(struct ioc_dev *ioc)
 			break;
 		case IOC_NATIVE_DUMMY2:
 			if (ioc_debug_enable) {
-				fd = ioc_open_virtual_uart(chl->name);
+				fd = pty_open_virtual_uart(chl->name);
 				dummy2_sfd = open(chl->name, O_RDWR | O_NOCTTY |
 						O_NONBLOCK);
 			} else

--- a/devicemodel/hw/platform/pty_vuart.c
+++ b/devicemodel/hw/platform/pty_vuart.c
@@ -1,0 +1,96 @@
+/*
+ * Project Acrn
+ * Acrn-dm-pty
+ *
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <termios.h>
+#include <stdbool.h>
+#include <libgen.h>
+
+#include "log.h"
+
+/*
+ * Check and create the directory.
+ * To avoid symlink failure if the directory does not exist.
+ */
+static int check_dir(const char *file)
+{
+	char *tmp, *dir;
+
+	tmp = strdup(file);
+	if (!tmp) {
+		pr_err("failed to dup file, error:%s\n", strerror(errno));
+		return -1;
+	}
+
+	dir = dirname(tmp);
+	if (access(dir, F_OK) && mkdir(dir, 0666)) {
+		pr_err("failed to create dir:%s, erorr:%s\n", dir, strerror(errno));
+		free(tmp);
+		return -1;
+	}
+	free(tmp);
+	return 0;
+}
+
+/*
+ * Open PTY master device to used by caller and the PTY slave device for virtual
+ * UART. The pair(master/slave) can work as a communication channel between
+ * the caller and virtual UART.
+ */
+int pty_open_virtual_uart(const char *dev_name)
+{
+	int fd;
+	char *slave_name;
+	struct termios attr;
+
+	fd = open("/dev/ptmx", O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd < 0)
+		goto open_err;
+	if (grantpt(fd) < 0)
+		goto pty_err;
+	if (unlockpt(fd) < 0)
+		goto pty_err;
+	slave_name = ptsname(fd);
+	if (!slave_name)
+		goto pty_err;
+	if ((unlink(dev_name) < 0) && errno != ENOENT)
+		goto pty_err;
+	/*
+	 * The check_dir restriction is that only create one directory
+	 * not support multi-level directroy.
+	 */
+	if (check_dir(dev_name) < 0)
+		goto pty_err;
+	if (symlink(slave_name, dev_name) < 0)
+		goto pty_err;
+	if (chmod(dev_name, 0660) < 0)
+		goto attr_err;
+	if (tcgetattr(fd, &attr) < 0)
+		goto attr_err;
+	cfmakeraw(&attr);
+	attr.c_cflag |= CLOCAL;
+	if (tcsetattr(fd, TCSANOW, &attr) < 0)
+		goto attr_err;
+	return fd;
+
+attr_err:
+	unlink(dev_name);
+pty_err:
+	close(fd);
+open_err:
+	return -1;
+}

--- a/devicemodel/include/pm_vuart.h
+++ b/devicemodel/include/pm_vuart.h
@@ -1,0 +1,18 @@
+/*
+ * Project Acrn
+ * Acrn-dm: pm-vuart
+ *
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef	__PM_VUART__
+#define	__PM_VUART__
+
+int parse_pm_by_vuart(const char *opts);
+void pm_by_vuart_init(struct vmctx *ctx);
+void pm_by_vuart_deinit(struct vmctx *ctx);
+
+#endif

--- a/devicemodel/include/pty_vuart.h
+++ b/devicemodel/include/pty_vuart.h
@@ -1,0 +1,16 @@
+/*
+ * Project Acrn
+ * Acrn-dm-pty
+ *
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef __PTY_H__
+#define __PTY_H__
+
+int pty_open_virtual_uart(const char *dev_name);
+
+#endif

--- a/devicemodel/samples/nuc/launch_hard_rt_vm.sh
+++ b/devicemodel/samples/nuc/launch_hard_rt_vm.sh
@@ -30,6 +30,11 @@ echo ${passthru_vpid["sata"]} > /sys/bus/pci/drivers/pci-stub/new_id
 echo ${passthru_bdf["sata"]} > /sys/bus/pci/devices/${passthru_bdf["sata"]}/driver/unbind
 echo ${passthru_bdf["sata"]} > /sys/bus/pci/drivers/pci-stub/bind
 
+# for pm setting
+pm_channel="--pm_notify_channel uart "
+pm_by_vuart="--pm_by_vuart tty,/dev/ttyS1"
+
+
 /usr/bin/acrn-dm -A -m $mem_size -c $1 -s 0:0,hostbridge \
   -k /usr/lib/kernel/default-iot-lts2018-preempt-rt \
    --lapic_pt \
@@ -37,6 +42,7 @@ echo ${passthru_bdf["sata"]} > /sys/bus/pci/drivers/pci-stub/bind
    --virtio_poll 1000000 \
    -s 2,passthru,0/17/0 \
    -s 3,virtio-console,@stdio:stdio_port \
+   $pm_channel $pm_by_vuart \
   -B "root=/dev/sda3 rw rootwait maxcpus=$1 nohpet console=hvc0 \
   no_timer_check ignore_loglevel log_buf_len=16M \
   consoleblank=0 tsc=reliable x2apic_phys" hard_rtvm

--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -92,6 +92,11 @@ fi
 #logger_setting, format: logger_name,level; like following
 logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
 
+#for pm by vuart setting
+pm_channel="--pm_notify_channel uart "
+pm_by_vuart="--pm_by_vuart pty,/run/acrn/life_mngr_"$vm_name
+pm_vuart_node=" -s 1:0,lpc -l com2,/run/acrn/life_mngr_"$vm_name
+
 #for memsize setting
 mem_size=2048M
 
@@ -103,7 +108,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf ./OVMF.fd \
-  --pm_notify_channel power_button \
+  $pm_channel $pm_by_vuart $pm_vuart_node \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -331,9 +331,27 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
      - This option is used to define which channel could be used DM to
        communicate with VM about power management event.
 
-       ACRN supports two channels: ``ioc`` and ``power button``.
+       ACRN supports three channels: ``ioc``, ``power button`` and ``uart``.
 
        usage::
           --pm_notify_channel ioc
 
        Use ioc as power management event motify channel.
+
+   * - :kbd:`--pm_by_vuart [pty|tty],<node_path>`
+     - This option is used to set a user OS power management by virtual UART.
+       With acrn-dm UART emulation and hypervisor UART emulation and configure,
+       service OS can communicate with user OS through virtual UART. By this
+       option, service OS can notify user OS to shutdown itself by vUART.
+
+       It need work with `--pm_notify_channel` and PCI UART setting (lpc and -l).
+
+       Example::
+
+        for general UOS, like LaaG or WaaG, it need set:
+          --pm_notify_channel uart --pm_by_vuart pty,/run/acrn/life_mngr_vm1
+          -l com2,/run/acrn/life_mngr_vm1
+        for RTVM, like RT-Linux:
+          --pm_notify_channel uart --pm_by_vuart tty,/dev/ttyS1
+
+       For different UOS, it can be configured as needed.


### PR DESCRIPTION
1. Separate pty master/slave operation from IOC module 
2. Use pty in vuart (com2) for UOS S5; it register into vm-ops. when received UOS shutdown command, it will send "shutdown" to UOS,  and wait "acked" from UOS.
3. Add the setting into launch script for NUC platform
4. Update user guide.

Tracked-On: #3564
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>