### PR TITLE
DM: make LaaG launch script use the OVMF.fd from the Service VM

### DIFF
--- a/devicemodel/samples/nuc/launch_uos.sh
+++ b/devicemodel/samples/nuc/launch_uos.sh
@@ -107,7 +107,7 @@ acrn-dm -A -m $mem_size -c $2 -s 0:0,hostbridge \
   -s 3,virtio-blk,/home/clear/uos/uos.img \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
-  --ovmf ./OVMF.fd \
+  --ovmf /usr/share/acrn/bios/OVMF.fd \
   $pm_channel $pm_by_vuart $pm_vuart_node \
   $logger_setting \
   --mac_seed $mac_seed \


### PR DESCRIPTION
Adjust the 'launch_uos.sh' script used to start a LaaG User VM to user the
OVMF.fd bios file installed under /usr/share/acrn/bios. It currently points
at a file in the local folder but neither our instructions nor our installation
script file puts it in this location. That results in an error when you try
to launch it.

Tracked-On: #3673
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>