### PR TITLE
dm: Add Oracle subsystem vendor ID

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -87,6 +87,7 @@ char *mac_seed;
 bool stdio_in_use;
 bool lapic_pt;
 bool is_rtvm;
+bool is_winvm;
 bool skip_pci_mem64bar_workaround = false;
 
 static int guest_ncpus;
@@ -175,7 +176,9 @@ usage(int code)
 		"       --rtvm: indicate that the guest is rtvm\n"
 		"       --logger_setting: params like console,level=4;kmsg,level=3\n"
 		"       --pm_notify_channel: define the channel used to notify guest about power event\n"
-		"       --pm_by_vuart:pty,/run/acrn/vuart_vmname or tty,/dev/ttySn\n",
+		"       --pm_by_vuart:pty,/run/acrn/vuart_vmname or tty,/dev/ttySn\n"
+		"       --windows: support Oracle virtio-blk, virtio-net and virtio-input devices\n"
+		"            for windows guest with secure boot\n",
 		progname, (int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
@@ -730,6 +733,7 @@ enum {
 	CMD_OPT_LOGGER_SETTING,
 	CMD_OPT_PM_NOTIFY_CHANNEL,
 	CMD_OPT_PM_BY_VUART,
+	CMD_OPT_WINDOWS,
 };
 
 static struct option long_options[] = {
@@ -769,6 +773,7 @@ static struct option long_options[] = {
 	{"logger_setting",	required_argument,	0, CMD_OPT_LOGGER_SETTING},
 	{"pm_notify_channel",	required_argument,	0, CMD_OPT_PM_NOTIFY_CHANNEL},
 	{"pm_by_vuart",	required_argument,	0, CMD_OPT_PM_BY_VUART},
+	{"windows",		no_argument,		0, CMD_OPT_WINDOWS},
 	{0,			0,			0,  0  },
 };
 
@@ -929,6 +934,9 @@ main(int argc, char *argv[])
 		case CMD_OPT_PM_BY_VUART:
 			if (parse_pm_by_vuart(optarg) != 0)
 				errx(EX_USAGE, "invalid pm-by-vuart params %s", optarg);
+			break;
+		case CMD_OPT_WINDOWS:
+			is_winvm = true;
 			break;
 		case 'h':
 			usage(0);

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -544,7 +544,10 @@ virtio_blk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_STORAGE);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_BLOCK);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	if (is_winvm == true)
+		pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
+	else
+		pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
 
 	if (virtio_interrupt_init(&blk->base, virtio_uses_msix())) {
 		/* call close only for valid bctxt */

--- a/devicemodel/hw/pci/virtio/virtio_input.c
+++ b/devicemodel/hw/pci/virtio/virtio_input.c
@@ -700,7 +700,10 @@ virtio_input_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_INPUTDEV);
 	pci_set_cfgdata8(dev, PCIR_SUBCLASS, PCIS_INPUTDEV_OTHER);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, 0x1100);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	if (is_winvm == true)
+		pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
+	else
+		pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
 	pci_set_cfgdata16(dev, PCIR_REVID, 1);
 
 	if (virtio_interrupt_init(&vi->base, virtio_uses_msix())) {

--- a/devicemodel/hw/pci/virtio/virtio_net.c
+++ b/devicemodel/hw/pci/virtio/virtio_net.c
@@ -866,7 +866,10 @@ virtio_net_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pci_set_cfgdata16(dev, PCIR_VENDOR, VIRTIO_VENDOR);
 	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_NETWORK);
 	pci_set_cfgdata16(dev, PCIR_SUBDEV_0, VIRTIO_TYPE_NET);
-	pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+	if (is_winvm == true)
+		pci_set_cfgdata16(dev, PCIR_SUBVEND_0, ORACLE_VENDOR_ID);
+	else
+		pci_set_cfgdata16(dev, PCIR_SUBVEND_0, VIRTIO_VENDOR);
 
 	/* Link is up if we managed to open tap device */
 	net->config.status = (opts == NULL || net->tapfd >= 0);

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -48,6 +48,7 @@ extern bool stdio_in_use;
 extern char *mac_seed;
 extern bool lapic_pt;
 extern bool is_rtvm;
+extern bool is_winvm;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,
 		       int *vcpu);

--- a/devicemodel/include/virtio.h
+++ b/devicemodel/include/virtio.h
@@ -213,6 +213,7 @@ enum {
  * PCI vendor/device IDs
  */
 #define	INTEL_VENDOR_ID		0x8086
+#define	ORACLE_VENDOR_ID	0x108E
 #define	VIRTIO_VENDOR		0x1AF4
 #define	VIRTIO_DEV_NET		0x1000
 #define	VIRTIO_DEV_BLOCK	0x1001

--- a/devicemodel/samples/nuc/launch_win.sh
+++ b/devicemodel/samples/nuc/launch_win.sh
@@ -25,6 +25,7 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 4,virtio-net,tap0 \
   -s 5,passthru,00/1f/3 \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
+  --windows \
   $vm_name
 }
 


### PR DESCRIPTION
After Windows 10, version 1607, the cross-signed drivers are forbiden
to load when secure boot is enabled.

Details please refer to
https://docs.microsoft.com/en-us/windows-hardware/drivers/install/kernel-mode-code-signing-policy--windows-vista-and-later-

That means the kvm-guest-drivers-windows can't work when secure boot enabled.
So we found another windows virtio FE drivers from Oracle to resolve this issue
but have to change another subsystem vendor ID for the virtio BE services.

This patch introduces a new DM CMD line "--windows" to launch WaaG with Oracle virtio devices including
virtio-blk, virtio-net, virtio-input instead Redhat. It can make virtio-blk, virtio-net and virtio-input
devices work when WaaG enabling secure boot.

Tracked-On: #3583
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Acked-by: Yin Fengwei <fengwei.yin@intel.com>