### PR TITLE
hv: vpci: refine vPCI BAR initialization

### DIFF
--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -85,6 +85,8 @@
 #define PCIM_BAR_MEM_BASE     0xFFFFFFF0U
 #define PCIR_CAP_PTR          0x34U
 #define PCIR_CAP_PTR_CARDBUS  0x14U
+#define PCI_BASE_ADDRESS_MEM_MASK (~0x0fUL)
+#define PCI_BASE_ADDRESS_IO_MASK  (~0x03UL)
 
 /* config registers for header type 1 (PCI-to-PCI bridge) devices */
 #define PCIR_PRIBUS_1         0x18U
@@ -209,7 +211,6 @@ struct pci_msix_cap {
 struct pci_pdev {
 	/* The bar info of the physical PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
-	struct pci_bar bar[PCI_BAR_COUNT];
 
 	/* The bus/device/function triple of the physical PCI device. */
 	union pci_bdf bdf;


### PR DESCRIPTION
Initialize vBAR configure space when doing vPCI BAR initialization. At this time,
we access the physical device as we needs, no need to cache physical PCI device
BAR information beforehand.

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>