### PR TITLE
Makefile: override .config with specified scenario

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -360,11 +360,11 @@ endif
 all: pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 
 install: $(HV_OBJDIR)/$(HV_FILE).32.out
-	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).32.out
+	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO_NAME).32.out
 
 install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
-	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).out
-	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).map
+	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO_NAME).out
+	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO_NAME).map
 
 .PHONY: pre_build
 pre_build: $(PRE_BUILD_OBJS)

--- a/misc/efi-stub/Makefile
+++ b/misc/efi-stub/Makefile
@@ -36,6 +36,8 @@ C_SRCS = boot.c pe.c malloc.c
 ACRN_OBJS := $(patsubst %.c,$(EFI_OBJDIR)/%.o,$(C_SRCS))
 INCLUDE_PATH += $(HV_OBJDIR)/include
 
+SCENARIO ?= sdc
+
 OBJCOPY=objcopy
 
 HOST  = $(shell $(CC) -dumpmachine | sed "s/\(-\).*$$//")


### PR DESCRIPTION
1. if SCENARIO=$(SCENARIO) is specified in make param, then override
the default CONFIG_$(SCENARIO) value in existed .config. This means
we don't need to modify the default SCENARIO config in Kconfig file
to build the hypervisor;

2. Some board name shortcuts like apl-nuc/kbl-nuc-i7 need to be converted
to official board name to make sure overrides working;

3. Previously make sbl-hypervisor did not load the defconfig so the
defconfig for boards are lost, this patch fix this issue;

4. remove SCENARIO param when make hypervisor, because SCENARIO could
be got from SCENARIO_NAME which parsed from .config;

Tracked-On: #3593

Signed-off-by: Victor Sun <victor.sun@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>