### PR TITLE
fix cbm length calculation, Extended model judge,  print info error

### DIFF
--- a/hypervisor/arch/x86/cat.c
+++ b/hypervisor/arch/x86/cat.c
@@ -44,7 +44,7 @@ int32_t init_cat_cap_info(void)
 		 *  CPUID.(EAX=0x10,ECX=ResID):EDX[15:0] reports the maximun CLOS supported
 		 */
 		cpuid_subleaf(CPUID_RSD_ALLOCATION, cat_cap_info.res_id, &eax, &ebx, &ecx, &edx);
-		cat_cap_info.cbm_len = (uint16_t)((eax & 0xfU) + 1U);
+		cat_cap_info.cbm_len = (uint16_t)((eax & 0x1fU) + 1U);
 		cat_cap_info.bitmask = ebx;
 		cat_cap_info.clos_max = (uint16_t)(edx & 0xffffU);
 

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -220,7 +220,7 @@ void init_pcpu_capabilities(void)
 	boot_cpu_data.family = (uint8_t)family;
 
 	model = (eax >> 4U) & 0xfU;
-	if (family >= 0x06U) {
+	if (family == 0x06U || family == 0xFU) {
 		model += ((eax >> 16U) & 0xfU) << 4U;
 	}
 	boot_cpu_data.model = (uint8_t)model;

--- a/misc/acrn-manager/acrnctl.c
+++ b/misc/acrn-manager/acrnctl.c
@@ -67,7 +67,7 @@ static int check_name(const char *name)
 	/* Name should start with a letter */
 	if ((name[0] < 'a' || name[0] > 'z')
 	    && (name[0] < 'A' || name[0] > 'Z')) {
-		printf("name not started with latter!\n");
+		printf("name not started with letter!\n");
 		return -1;
 	}
 


### PR DESCRIPTION
CPUID(EAX = 10H, ECX = ResID=1 or 2).EAX Bits 04 - 00: Length of the capacity bit mask for the corresponding ResID using minus-one notation
The Extended Model ID needs to be examined only when the Family ID is 06H or 0FH
check_name function, print info error
Tracked-On:#3675
Signed-off-by: Andy andyx.liu@intel.com