### PR TITLE
hv: save/restore TSC in host's suspend/resume path

### DIFF
--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -56,6 +56,7 @@ struct per_cpu_region {
 	struct profiling_info_wrapper profiling_info;
 #endif
 	uint16_t shutdown_vm_id;
+	uint64_t tsc_suspend;
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
 extern struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM];


### PR DESCRIPTION
TSC would be reset to 0 when enter suspend state on some platform.
This will fail the secure timer checking in secure world because
secure world leverage the TSC as source of secure timer which should
be increased monotonously.

This patch save/restore TSC in host suspend/resume path to guarantee
the mono increasing TSC.

Note: There should no timer setup before TSC resumed.

Tracked-On: #3697
Signed-off-by: Qi Yadong <yadong.qi@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>