### PR TITLE
update using_sbl_on_up2 doc and create-up2-images.sh

### DIFF
--- a/doc/tutorials/create-up2-images.sh
+++ b/doc/tutorials/create-up2-images.sh
@@ -34,13 +34,13 @@ create_sos_images() {
 
     mountpoint sos_rootfs || return 1
 
-    swupd verify --install --path=sos_rootfs --contenturl=$MIRRORURL --versionurl=$MIRRORURL --format=staging -m ${VERSION} ||
+    swupd os-install --path=sos_rootfs --contenturl=$MIRRORURL --versionurl=$MIRRORURL --format=staging -V ${VERSION} -N -b ||
     {
         echo "Failed to swupd install"
         return 1
     }
 
-    swupd bundle-add $SOS_BUNDLE_LIST --path=sos_rootfs --contenturl=$MIRRORURL --versionurl=$MIRRORURL --format=staging ||
+    swupd bundle-add --path=sos_rootfs --contenturl=$MIRRORURL --versionurl=$MIRRORURL --format=staging $SOS_BUNDLE_LIST ||
     {
         echo "Failed to swupd bundle add"
         return 1
@@ -48,7 +48,7 @@ create_sos_images() {
 
     if [[ ! ${ACRN_SBL} || ! -f ${ACRN_SBL} ]]
     then
-        ACRN_SBL=sos_rootfs/usr/lib/acrn/acrn.apl-up2.sbl
+        ACRN_SBL=sos_rootfs/usr/lib/acrn/acrn.apl-up2.sbl.sdc.32.out
     fi
 
     if [ ${ACRN_HV_CODE_PATH} ]

--- a/doc/tutorials/using_sbl_on_up2.rst
+++ b/doc/tutorials/using_sbl_on_up2.rst
@@ -56,7 +56,7 @@ BIOS binary file ``<SBL_IFWI_IMAGE>``, which is the new IFWI image with SBL in B
 Flash SBL on the UP2
 ********************
 
-#. Download the appropriate BIOS update for `UP2 Board <https://downloads.up-community.org/download/up-board-uefi-bios-upc1dm15/>`_.
+#. Download the appropriate BIOS update for `UP2 Board <https://downloads.up-community.org/download/up-board-uefi-bios-upc1dm17/>`_.
 #. Put the empty USB flash drive in your PC and format it as FAT32.
 #. Decompress the BIOS zip file into the formatted drive.
 #. Attach the USB disk and keyboard to the board and power it on.
@@ -95,14 +95,14 @@ An example of the configuration file ``uos.json``:
                              { "disk" : "clearlinux.img", "partition" : 2, "type" : "ext4" } ],
        "PartitionMountPoints" : [ { "disk" : "clearlinux.img", "partition" : 1, "mount" : "/boot" },
            		          { "disk" : "clearlinux.img", "partition" : 2, "mount" : "/" } ],
-       "Version": 30690,
+       "Version": 31030,
        "Bundles": ["kernel-iot-lts2018", "openssh-server", "x11-server", "os-core", "os-core-update"]
    }
 
 .. note::
    To generate the image with a specified version, please modify
    the "Version" argument, ``"Version": 3****`` instead
-   of ``"Version": 30690`` for example.
+   of ``"Version": 31030`` for example.
 
 
 Build SOS and LaaG image:
@@ -111,7 +111,7 @@ Build SOS and LaaG image:
 
    $ sudo -s
    # chmod +x create-up2-images.sh
-   # ./create-up2-images.sh --images-type all --clearlinux-version 30690 --laag-json uos.json
+   # ./create-up2-images.sh --images-type all --clearlinux-version 31030 --laag-json uos.json
 
 .. note::
    You must have root privileges to run ``create-up2-images.sh``.
@@ -122,7 +122,7 @@ Build SOS and LaaG image:
 
 .. note::
    When building images, you can modify the ``--clearlinux-version`` argument
-   to a specific version (such as 30690). To generate the images of SOS only,
+   to a specific version (such as 31030). To generate the images of SOS only,
    modify the ``--images-type`` argument to ``sos``.
 
 This step will generate the images of SOS and LaaG:


### PR DESCRIPTION
1. Fix the broken link to download UP2 Board BIOS
2. In Clear Linux 31030 the acrn.apl-up2.sbl name is changed to
   acrn.apl-up2.sbl.sdc.32.out, so we need to update the creaet-up2-imgages.sh
3. Command "swupd verify --install -m" has been superseded, use "swupd
   os-install -V" instead.

Signed-off-by: Lei, Lu <leix.lu@intel.com>