### PR TITLE
dm: switch to launch RT_LaaG with OVMF by default

### DIFF
--- a/devicemodel/samples/nuc/launch_hard_rt_vm.sh
+++ b/devicemodel/samples/nuc/launch_hard_rt_vm.sh
@@ -8,10 +8,12 @@ declare -A passthru_bdf
 passthru_vpid=(
 ["eth"]="8086 156f"
 ["sata"]="8086 9d03"
+["nvme"]="8086 f1a6"
 )
 passthru_bdf=(
 ["eth"]="0000:00:1f.6"
 ["sata"]="0000:00:17.0"
+["nvme"]="0000:02:0.0"
 )
 
 function launch_hard_rt_vm()
@@ -26,27 +28,41 @@ modprobe pci_stub
 #echo ${passthru_bdf["eth"]} > /sys/bus/pci/drivers/pci-stub/bind
 
 # SATA pass-through
-echo ${passthru_vpid["sata"]} > /sys/bus/pci/drivers/pci-stub/new_id
-echo ${passthru_bdf["sata"]} > /sys/bus/pci/devices/${passthru_bdf["sata"]}/driver/unbind
-echo ${passthru_bdf["sata"]} > /sys/bus/pci/drivers/pci-stub/bind
+#echo ${passthru_vpid["sata"]} > /sys/bus/pci/drivers/pci-stub/new_id
+#echo ${passthru_bdf["sata"]} > /sys/bus/pci/devices/${passthru_bdf["sata"]}/driver/unbind
+#echo ${passthru_bdf["sata"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+# NVME pass-through
+echo ${passthru_vpid["nvme"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["nvme"]} > /sys/bus/pci/devices/${passthru_bdf["nvme"]}/driver/unbind
+echo ${passthru_bdf["nvme"]} > /sys/bus/pci/drivers/pci-stub/bind
 
 # for pm setting
 pm_channel="--pm_notify_channel uart "
 pm_by_vuart="--pm_by_vuart tty,/dev/ttyS1"
 
-
 /usr/bin/acrn-dm -A -m $mem_size -c $1 -s 0:0,hostbridge \
-  -k /usr/lib/kernel/default-iot-lts2018-preempt-rt \
    --lapic_pt \
    --rtvm \
    --virtio_poll 1000000 \
-   -s 2,passthru,0/17/0 \
+   -U 495ae2e5-2603-4d64-af76-d4bc5a8ec0e5 \
+   -s 2,passthru,02/0/0 \
    -s 3,virtio-console,@stdio:stdio_port \
    $pm_channel $pm_by_vuart \
-  -B "root=/dev/sda3 rw rootwait maxcpus=$1 nohpet console=hvc0 \
-  no_timer_check ignore_loglevel log_buf_len=16M \
-  consoleblank=0 tsc=reliable x2apic_phys" hard_rtvm
+   --ovmf /usr/share/acrn/bios/OVMF.fd \
+   hard_rtvm
 }
+# -s 2,passthru,0/17/0 \ #please use "lspci -nn" to check the bdf info
+
+# Depends on which partation RT_LaaG is installed in;maybe need to change 
+# /dev/nvme0n1p3 to /dev/sda3 on NUC and uncomment SATA pass-through
+# Add following RT_LaaG kernel cmdline into loader/entries/xxx.conf of EFI partation 
+#root=/dev/nvme0n1p3 rw rootwait nohpet console=hvc0 console=ttyS0 \
+#no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 \
+#clocksource=tsc tsc=reliable x2apic_phys processor.max_cstate=0 \
+#intel_idle.max_cstate=0 intel_pstate=disabled mce=ignore_ce audit=0 \
+#isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll \
+#irqaffinity=0
 
 # offline SOS CPUs except BSP before launch UOS
 for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do


### PR DESCRIPTION
The default script is for nvme passthrough to RT_LaaG; you can change it
to sata or using virtio_blk

Tracked-On: #3506

Signed-off-by: fuzhongl <fuzhong.liu@intel.com>
Reviewed-by: binbin.wu@intel.com; kaige.fu@intel.com