### PR TITLE
acrn-config: change default apl up2 support to N4200

### DIFF
--- a/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
@@ -1,0 +1,298 @@
+<acrn-config board="apl-up2-n3350">
+	<BIOS_INFO>
+	BIOS Information
+	Vendor: American Megatrends Inc.
+	Version: UPA1AM46
+	Release Date: 08/14/2019
+	BIOS Revision: 5.12
+	</BIOS_INFO>
+
+	<BASE_BOARD_INFO>
+	Base Board Information
+	Manufacturer: AAEON
+	Product Name: UP-APL01
+	Version: V0.4
+	</BASE_BOARD_INFO>
+
+	<PCI_DEVICE>
+	00:00.0 Host bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Host Bridge (rev 0b)
+	00:02.0 VGA compatible controller: Intel Corporation Device 5a85 (rev 0b)
+	Region 0: Memory at 90000000 (64-bit, non-prefetchable) [size=16M]
+	Region 2: Memory at 80000000 (64-bit, prefetchable) [size=256M]
+	00:0e.0 Multimedia audio controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)
+	Region 0: Memory at 91510000 (64-bit, non-prefetchable) [size=16K]
+	Region 4: Memory at 91200000 (64-bit, non-prefetchable) [size=1M]
+	00:0f.0 Communication controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Trusted Execution Engine (rev 0b)
+	Region 0: Memory at 9153c000 (64-bit, non-prefetchable) [size=4K]
+	00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)
+	Region 0: Memory at 91514000 (32-bit, non-prefetchable) [size=8K]
+	Region 1: Memory at 91539000 (32-bit, non-prefetchable) [size=256]
+	Region 5: Memory at 91538000 (32-bit, non-prefetchable) [size=2K]
+	00:13.0 PCI bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PCI Express Port A #1 (rev fb)
+	00:13.1 PCI bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PCI Express Port A #2 (rev fb)
+	00:13.2 PCI bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PCI Express Port A #3 (rev fb)
+	00:13.3 PCI bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PCI Express Port A #4 (rev fb)
+	00:14.0 PCI bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PCI Express Port B #1 (rev fb)
+	00:14.1 PCI bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PCI Express Port B #2 (rev fb)
+	00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)
+	Region 0: Memory at 91500000 (64-bit, non-prefetchable) [size=64K]
+	00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)
+	Region 0: Memory at 91000000 (64-bit, non-prefetchable) [disabled] [size=2M]
+	Region 2: Memory at 91537000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:16.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #1 (rev 0b)
+	Region 0: Memory at 91536000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91535000 (64-bit, non-prefetchable) [size=4K]
+	00:16.1 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #2 (rev 0b)
+	Region 0: Memory at 91534000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91533000 (64-bit, non-prefetchable) [size=4K]
+	00:16.2 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #3 (rev 0b)
+	Region 0: Memory at 91532000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91531000 (64-bit, non-prefetchable) [size=4K]
+	00:16.3 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #4 (rev 0b)
+	Region 0: Memory at 91530000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 9152f000 (64-bit, non-prefetchable) [size=4K]
+	00:17.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #5 (rev 0b)
+	Region 0: Memory at 9152e000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 9152d000 (64-bit, non-prefetchable) [size=4K]
+	00:17.1 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #6 (rev 0b)
+	Region 0: Memory at 9152c000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 9152b000 (64-bit, non-prefetchable) [size=4K]
+	00:17.2 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #7 (rev 0b)
+	Region 0: Memory at 9152a000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91529000 (64-bit, non-prefetchable) [size=4K]
+	00:17.3 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #8 (rev 0b)
+	Region 0: Memory at 91528000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91527000 (64-bit, non-prefetchable) [size=4K]
+	00:18.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #1 (rev 0b)
+	Region 0: Memory at 91526000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91525000 (64-bit, non-prefetchable) [size=4K]
+	00:18.1 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #2 (rev 0b)
+	Region 0: Memory at 91524000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91523000 (64-bit, non-prefetchable) [size=4K]
+	00:19.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SPI Controller #1 (rev 0b)
+	Region 0: Memory at 91522000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91521000 (64-bit, non-prefetchable) [size=4K]
+	00:19.1 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SPI Controller #2 (rev 0b)
+	Region 0: Memory at 91520000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 9151f000 (64-bit, non-prefetchable) [size=4K]
+	00:19.2 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SPI Controller #3 (rev 0b)
+	Region 0: Memory at 9151e000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 9151d000 (64-bit, non-prefetchable) [size=4K]
+	00:1a.0 Serial bus controller [0c80]: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series PWM Pin Controller (rev 0b)
+	Region 0: Memory at 9151c000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 9151b000 (64-bit, non-prefetchable) [size=4K]
+	00:1c.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series eMMC Controller (rev 0b)
+	Region 0: Memory at 9151a000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91519000 (64-bit, non-prefetchable) [size=4K]
+	00:1e.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SDIO Controller (rev 0b)
+	Region 0: Memory at 91518000 (64-bit, non-prefetchable) [size=4K]
+	Region 2: Memory at 91517000 (64-bit, non-prefetchable) [size=4K]
+	00:1f.0 ISA bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Low Pin Count Interface (rev 0b)
+	00:1f.1 SMBus: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SMBus Controller (rev 0b)
+	Region 0: Memory at 91516000 (64-bit, non-prefetchable) [size=256]
+	02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)
+	Region 2: Memory at 91404000 (64-bit, non-prefetchable) [size=4K]
+	Region 4: Memory at 91400000 (64-bit, prefetchable) [size=16K]
+	03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)
+	Region 2: Memory at 91304000 (64-bit, non-prefetchable) [size=4K]
+	Region 4: Memory at 91300000 (64-bit, prefetchable) [size=16K]
+	</PCI_DEVICE>
+
+	<PCI_VID_PID>
+	00:00.0 0600: 8086:5af0 (rev 0b)
+	00:02.0 0300: 8086:5a85 (rev 0b)
+	00:0e.0 0401: 8086:5a98 (rev 0b)
+	00:0f.0 0780: 8086:5a9a (rev 0b)
+	00:12.0 0106: 8086:5ae3 (rev 0b)
+	00:13.0 0604: 8086:5ad8 (rev fb)
+	00:13.1 0604: 8086:5ad9 (rev fb)
+	00:13.2 0604: 8086:5ada (rev fb)
+	00:13.3 0604: 8086:5adb (rev fb)
+	00:14.0 0604: 8086:5ad6 (rev fb)
+	00:14.1 0604: 8086:5ad7 (rev fb)
+	00:15.0 0c03: 8086:5aa8 (rev 0b)
+	00:15.1 0c03: 8086:5aaa (rev 0b)
+	00:16.0 1180: 8086:5aac (rev 0b)
+	00:16.1 1180: 8086:5aae (rev 0b)
+	00:16.2 1180: 8086:5ab0 (rev 0b)
+	00:16.3 1180: 8086:5ab2 (rev 0b)
+	00:17.0 1180: 8086:5ab4 (rev 0b)
+	00:17.1 1180: 8086:5ab6 (rev 0b)
+	00:17.2 1180: 8086:5ab8 (rev 0b)
+	00:17.3 1180: 8086:5aba (rev 0b)
+	00:18.0 1180: 8086:5abc (rev 0b)
+	00:18.1 1180: 8086:5abe (rev 0b)
+	00:19.0 1180: 8086:5ac2 (rev 0b)
+	00:19.1 1180: 8086:5ac4 (rev 0b)
+	00:19.2 1180: 8086:5ac6 (rev 0b)
+	00:1a.0 0c80: 8086:5ac8 (rev 0b)
+	00:1c.0 0805: 8086:5acc (rev 0b)
+	00:1e.0 0805: 8086:5ad0 (rev 0b)
+	00:1f.0 0601: 8086:5ae8 (rev 0b)
+	00:1f.1 0c05: 8086:5ad4 (rev 0b)
+	02:00.0 0200: 10ec:8168 (rev 0c)
+	03:00.0 0200: 10ec:8168 (rev 0c)
+	</PCI_VID_PID>
+
+	<WAKE_VECTOR_INFO>
+	#define WAKE_VECTOR_32          0x79CB108CUL
+	#define WAKE_VECTOR_64          0x79CB1098UL
+	</WAKE_VECTOR_INFO>
+
+	<RESET_REGISTER_INFO>
+	#define RESET_REGISTER_ADDRESS  0xCF9UL
+	#define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
+	#define RESET_REGISTER_VALUE    0x6U
+	</RESET_REGISTER_INFO>
+
+	<PM_INFO>
+	#define PM1A_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_EVT_BIT_WIDTH      0x20U
+	#define PM1A_EVT_BIT_OFFSET     0x0U
+	#define PM1A_EVT_ADDRESS        0x400UL
+	#define PM1A_EVT_ACCESS_SIZE    0x2U
+	#define PM1B_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_EVT_BIT_WIDTH      0x0U
+	#define PM1B_EVT_BIT_OFFSET     0x0U
+	#define PM1B_EVT_ADDRESS        0x0UL
+	#define PM1B_EVT_ACCESS_SIZE    0x2U
+	#define PM1A_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_CNT_BIT_WIDTH      0x10U
+	#define PM1A_CNT_BIT_OFFSET     0x0U
+	#define PM1A_CNT_ADDRESS        0x404UL
+	#define PM1A_CNT_ACCESS_SIZE    0x2U
+	#define PM1B_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_CNT_BIT_WIDTH      0x0U
+	#define PM1B_CNT_BIT_OFFSET     0x0U
+	#define PM1B_CNT_ADDRESS        0x0UL
+	#define PM1B_CNT_ACCESS_SIZE    0x2U
+	</PM_INFO>
+
+	<S3_INFO>
+	#define S3_PKG_VAL_PM1A         0x5U
+	#define S3_PKG_VAL_PM1B         0U
+	#define S3_PKG_RESERVED         0x0U
+	</S3_INFO>
+
+	<S5_INFO>
+	#define S5_PKG_VAL_PM1A         0x7U
+	#define S5_PKG_VAL_PM1B         0U
+	#define S5_PKG_RESERVED         0x0U
+	</S5_INFO>
+
+	<DRHD_INFO>
+	#define DRHD_COUNT              2U
+	#define DRHD0_DEV_CNT           1U
+	#define DRHD0_SEGMENT           0U
+	#define DRHD0_FLAGS             0U
+	#define DRHD0_REG_BASE          0xFED64000UL
+	#define DRHD0_IGNORE            false
+	#define DRHD0_DEVSCOPE0_BUS     0x0U
+	#define DRHD0_DEVSCOPE0_PATH    0x10U
+	#define DRHD0_DEVSCOPE1_BUS     0x0U
+	#define DRHD0_DEVSCOPE1_PATH    0x0U
+	#define DRHD0_DEVSCOPE2_BUS     0x0U
+	#define DRHD0_DEVSCOPE2_PATH    0x0U
+	#define DRHD0_DEVSCOPE3_BUS     0x0U
+	#define DRHD0_DEVSCOPE3_PATH    0x0U
+	#define DRHD1_DEV_CNT           2U
+	#define DRHD1_SEGMENT           0U
+	#define DRHD1_FLAGS             1U
+	#define DRHD1_REG_BASE          0xFED65000UL
+	#define DRHD1_IGNORE            false
+	#define DRHD1_DEVSCOPE0_BUS     0xfaU
+	#define DRHD1_DEVSCOPE0_PATH    0xf8U
+	#define DRHD1_DEVSCOPE1_BUS     0x0U
+	#define DRHD1_DEVSCOPE1_PATH    0xffU
+	#define DRHD1_DEVSCOPE2_BUS     0x0U
+	#define DRHD1_DEVSCOPE2_PATH    0x0U
+	#define DRHD1_DEVSCOPE3_BUS     0x0U
+	#define DRHD1_DEVSCOPE3_PATH    0x0U
+	#define DRHD1_IOAPIC_ID         1U
+	#define DRHD2_DEV_CNT           0U
+	#define DRHD2_SEGMENT           0U
+	#define DRHD2_FLAGS             0U
+	#define DRHD2_REG_BASE          0x00UL
+	#define DRHD2_IGNORE            false
+	#define DRHD2_DEVSCOPE0_BUS     0x0U
+	#define DRHD2_DEVSCOPE0_PATH    0x0U
+	#define DRHD2_DEVSCOPE1_BUS     0x0U
+	#define DRHD2_DEVSCOPE1_PATH    0x0U
+	#define DRHD2_DEVSCOPE2_BUS     0x0U
+	#define DRHD2_DEVSCOPE2_PATH    0x0U
+	#define DRHD2_DEVSCOPE3_BUS     0x0U
+	#define DRHD2_DEVSCOPE3_PATH    0x0U
+	#define DRHD3_DEV_CNT           0U
+	#define DRHD3_SEGMENT           0U
+	#define DRHD3_FLAGS             0U
+	#define DRHD3_REG_BASE          0x00UL
+	#define DRHD3_IGNORE            false
+	#define DRHD3_DEVSCOPE0_BUS     0x0U
+	#define DRHD3_DEVSCOPE0_PATH    0x0U
+	#define DRHD3_DEVSCOPE1_BUS     0x0U
+	#define DRHD3_DEVSCOPE1_PATH    0x0U
+	#define DRHD3_DEVSCOPE2_BUS     0x0U
+	#define DRHD3_DEVSCOPE2_PATH    0x0U
+	#define DRHD3_DEVSCOPE3_BUS     0x0U
+	#define DRHD3_DEVSCOPE3_PATH    0x0U
+	</DRHD_INFO>
+
+	<CPU_BRAND>
+	"Intel(R) Celeron(R) CPU N3350 @ 1.10GHz"
+	</CPU_BRAND>
+
+	<CX_INFO>
+	{{SPACE_FFixedHW, 0x00U, 0x00U, 0x00U, 0x00UL}, 0x01U, 0x01U, 0x00U},	/* C1 */
+	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x415UL}, 0x02U, 0x32U, 0x00U},	/* C2 */
+	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x419UL}, 0x03U, 0x96U, 0x00U},	/* C3 */
+	</CX_INFO>
+
+	<PX_INFO>
+	{0x44DUL, 0x00UL, 0x0AUL, 0x0AUL, 0x001800UL, 0x001800UL},	/* P0 */
+	{0x44CUL, 0x00UL, 0x0AUL, 0x0AUL, 0x000B00UL, 0x000B00UL},	/* P1 */
+	{0x3E8UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000A00UL, 0x000A00UL},	/* P2 */
+	{0x384UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000900UL, 0x000900UL},	/* P3 */
+	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P4 */
+	</PX_INFO>
+
+	<CLOS_INFO>
+	clos supported by cache:L2
+	clos max:4
+	</CLOS_INFO>
+
+	<SYSTEM_RAM_INFO>
+	00001000-0003efff : System RAM
+	00040000-0009dfff : System RAM
+	00100000-0fffffff : System RAM
+	12151000-70ecd017 : System RAM
+	70ecd018-70edd057 : System RAM
+	70edd058-77b2efff : System RAM
+	7a09b000-7a408fff : System RAM
+	7a424000-7a964fff : System RAM
+	7a967000-7affffff : System RAM
+	100000000-17fffffff : System RAM
+	</SYSTEM_RAM_INFO>
+
+	<BLOCK_DEVICE_INFO>
+	/dev/sda3: LABEL="root" UUID="7de2c654-069b-4a56-b93f-70b2f7662bd0" TYPE="ext4" PARTLABEL="/" PARTUUID="712932d4-3420-4cca-b361-3606a40f3b89"
+	/dev/mmcblk0p3: LABEL="root" UUID="045f2013-b4c4-4817-a1aa-dc4416ca800f" TYPE="ext4" PARTLABEL="/" PARTUUID="517bf93d-1cb5-4d72-9550-a0144a2fcdbc"
+	</BLOCK_DEVICE_INFO>
+
+	<TTYS_INFO>
+	BDF:(00:18.0) seri:/dev/ttyS0 base:0x91526000 irq:4
+	BDF:(00:18.1) seri:/dev/ttyS1 base:0x91524000 irq:5
+	</TTYS_INFO>
+
+	<AVAILABLE_IRQ_INFO>
+	3, 6, 7, 10, 11, 12, 13, 15
+	</AVAILABLE_IRQ_INFO>
+
+	<TOTAL_MEM_INFO>
+	3937756 kB
+	</TOTAL_MEM_INFO>
+
+	<CPU_PROCESSOR_INFO>
+	0, 1
+	</CPU_PROCESSOR_INFO>
+
+</acrn-config>

--- a/misc/acrn-config/xmls/board-xmls/apl-up2.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2.xml
@@ -2,8 +2,8 @@
 	<BIOS_INFO>
 	BIOS Information
 	Vendor: American Megatrends Inc.
-	Version: UPA1AM40
-	Release Date: 08/06/2018
+	Version: UPA1AM46
+	Release Date: 08/14/2019
 	BIOS Revision: 5.12
 	</BIOS_INFO>
 
@@ -16,7 +16,7 @@
 
 	<PCI_DEVICE>
 	00:00.0 Host bridge: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Host Bridge (rev 0b)
-	00:02.0 VGA compatible controller: Intel Corporation Device 5a85 (rev 0b)
+	00:02.0 VGA compatible controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Integrated Graphics Controller (rev 0b)
 	Region 0: Memory at 90000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at 80000000 (64-bit, prefetchable) [size=256M]
 	00:0e.0 Multimedia audio controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)
@@ -37,8 +37,8 @@
 	00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)
 	Region 0: Memory at 91500000 (64-bit, non-prefetchable) [size=64K]
 	00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)
-	Region 0: Memory at 91000000 (64-bit, non-prefetchable) [size=2M]
-	Region 2: Memory at 91537000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 91000000 (64-bit, non-prefetchable) [disabled] [size=2M]
+	Region 2: Memory at 91537000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:16.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #1 (rev 0b)
 	Region 0: Memory at 91536000 (64-bit, non-prefetchable) [size=4K]
 	Region 2: Memory at 91535000 (64-bit, non-prefetchable) [size=4K]
@@ -100,7 +100,7 @@
 
 	<PCI_VID_PID>
 	00:00.0 0600: 8086:5af0 (rev 0b)
-	00:02.0 0300: 8086:5a85 (rev 0b)
+	00:02.0 0300: 8086:5a84 (rev 0b)
 	00:0e.0 0401: 8086:5a98 (rev 0b)
 	00:0f.0 0780: 8086:5a9a (rev 0b)
 	00:12.0 0106: 8086:5ae3 (rev 0b)
@@ -135,8 +135,8 @@
 	</PCI_VID_PID>
 
 	<WAKE_VECTOR_INFO>
-	#define WAKE_VECTOR_32          0x79CB308CUL
-	#define WAKE_VECTOR_64          0x79CB3098UL
+	#define WAKE_VECTOR_32          0x79CA108CUL
+	#define WAKE_VECTOR_64          0x79CA1098UL
 	</WAKE_VECTOR_INFO>
 
 	<RESET_REGISTER_INFO>
@@ -238,7 +238,7 @@
 	</DRHD_INFO>
 
 	<CPU_BRAND>
-	"Intel(R) Celeron(R) CPU N3350 @ 1.10GHz"
+	"Intel(R) Pentium(R) CPU N4200 @ 1.10GHz"
 	</CPU_BRAND>
 
 	<CX_INFO>
@@ -248,7 +248,7 @@
 	</CX_INFO>
 
 	<PX_INFO>
-	{0x44DUL, 0x00UL, 0x0AUL, 0x0AUL, 0x001800UL, 0x001800UL},	/* P0 */
+	{0x44DUL, 0x00UL, 0x0AUL, 0x0AUL, 0x001900UL, 0x001900UL},	/* P0 */
 	{0x44CUL, 0x00UL, 0x0AUL, 0x0AUL, 0x000B00UL, 0x000B00UL},	/* P1 */
 	{0x3E8UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000A00UL, 0x000A00UL},	/* P2 */
 	{0x384UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000900UL, 0x000900UL},	/* P3 */
@@ -264,18 +264,18 @@
 	00001000-0003efff : System RAM
 	00040000-0009dfff : System RAM
 	00100000-0fffffff : System RAM
-	12151000-7074c017 : System RAM
-	7074c018-7075c057 : System RAM
-	7075c058-77b30fff : System RAM
-	7a09d000-7a40afff : System RAM
-	7a426000-7a964fff : System RAM
+	12151000-70884017 : System RAM
+	70884018-70894057 : System RAM
+	70894058-77b0afff : System RAM
+	7a08b000-7a3f8fff : System RAM
+	7a424000-7a964fff : System RAM
 	7a967000-7affffff : System RAM
-	100000000-17fffffff : System RAM
+	100000000-27fffffff : System RAM
 	</SYSTEM_RAM_INFO>
 
 	<BLOCK_DEVICE_INFO>
-	/dev/mmcblk0p3: UUID="bb0d14f3-e780-41d9-bcca-6f3ef493216c" TYPE="ext4" PARTLABEL="primary" PARTUUID="87cd7180-6c0b-4bc9-a0d0-5406a95988cc"
-	/dev/sda3: TYPE="ext4"
+	/dev/sda3: LABEL="root" UUID="7de2c654-069b-4a56-b93f-70b2f7662bd0" TYPE="ext4" PARTLABEL="/" PARTUUID="712932d4-3420-4cca-b361-3606a40f3b89"
+	/dev/mmcblk0p3: LABEL="root" UUID="07c59c89-7796-429c-aad5-75f16193747c" TYPE="ext4" PARTLABEL="/" PARTUUID="f768183d-c825-4b18-be2d-45e67d27e71d"
 	</BLOCK_DEVICE_INFO>
 
 	<TTYS_INFO>
@@ -288,11 +288,11 @@
 	</AVAILABLE_IRQ_INFO>
 
 	<TOTAL_MEM_INFO>
-	3874760 kB
+	8066364 kB
 	</TOTAL_MEM_INFO>
 
 	<CPU_PROCESSOR_INFO>
-	0, 1
+	0, 1, 2, 3
 	</CPU_PROCESSOR_INFO>
 
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -1,0 +1,93 @@
+<acrn-config board="apl-up2-n3350" scenario="logical_partition">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+    <uuid configurable="0" desc="vm uuid">26c5e0d8-8f8a-47d8-8109-f201ebd61a5e</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag></guest_flag>
+        <guest_flag></guest_flag>
+    </guest_flags>
+    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+        <pcpu_id>0</pcpu_id>
+    </pcpu_ids>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        </bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">vm0_pci_devs</pci_devs>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
+    <uuid configurable="0" desc="vm uuid">dd87ce08-66f9-473d-bc58-7605837f935e</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_RT</guest_flag>
+        <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
+    </guest_flags>
+    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+        <pcpu_id>1</pcpu_id>
+    </pcpu_ids>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable xapic_phys
+        </bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">vm1_pci_devs</pci_devs>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -1,0 +1,31 @@
+<acrn-config board="apl-up2-n3350" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">CLEARLINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<cpu_num desc="max cpu number for the vm">1</cpu_num>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk0p1</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">clearlinux/clearlinux.img</rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<poweroff_channel desc="the method of power off uos" readonly="true">
+	--pm_notify_channel power_button \
+	</poweroff_channel>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device">00:03.0 Multimedia controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Imaging Unit (rev 0b)</ipu>
+		<ipu_i2c desc="vm ipu_i2c device">00:16.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #1 (rev 0b)</ipu_i2c>
+		<cse desc="vm cse device">00:0f.0 Communication controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Trusted Execution Engine (rev 0b)</cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm wifi device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -77,7 +77,6 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry.xml
@@ -37,7 +37,6 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
@@ -37,7 +37,6 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc2.xml
@@ -37,7 +37,6 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
         </bootargs>
     </board_private>
   </vm>


### PR DESCRIPTION
Currently the default apl-up2 board xml is for ATOM-N3350 variant, change it to ATOM-N4200 which is a 4 cores variant.

Tracked-On: #3602

Signed-off-by: Victor Sun <victor.sun@intel.com>
