### PR TITLE
fix foldernames in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,13 +15,13 @@
 /hypervisor/                             @anthonyzxu @dongyaozu
 /devicemodel/                            @anthonyzxu @ywan170
 /doc/                                    @dbkinder @deb-intel @NanlinXie
-/misc/tools/acrn-crashlog                @chengangc @dizhang417 
-/misc/tools/acrnlog                      @lyan3
-/misc/tools/acrntrace                    @lyan3
-/misc/acrn-manager                       @lyan3
-/misc/acrnbridge                         @lyan3
-/misc/acrn-config                        @binbinwu1
+/misc/tools/acrn-crashlog/               @chengangc @dizhang417 
+/misc/tools/acrnlog/                     @lyan3
+/misc/tools/acrntrace/                   @lyan3
+/misc/acrn-manager/                      @lyan3
+/misc/acrnbridge/                        @lyan3
+/misc/acrn-config/                       @binbinwu1
 /misc/Makefile                           @binbinwu1
-/misc/efi-stub                           @jren1
+/misc/efi-stub/                          @jren1
 
 *.rst                                    @dbkinder @deb-intel @NanlinXie


### PR DESCRIPTION
Folder names need to end with a slash

Tracked-On: #3723

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>