### PR TITLE
Makefile: build default acrn.efi with nuc6cayh

### DIFF
--- a/misc/efi-stub/Makefile
+++ b/misc/efi-stub/Makefile
@@ -91,7 +91,7 @@ all: $(EFIBIN)
 install: $(EFIBIN) install-conf
 	install -D $(EFIBIN) $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).efi
 # this is to keep the compatible with original output files
-ifeq ($(BOARD), apl-nuc)
+ifeq ($(BOARD), nuc6cayh)
     ifeq ($(SCENARIO), sdc)
 	install -D $(EFIBIN) $(DESTDIR)/usr/lib/acrn/$(HV_FILE).efi
     endif
@@ -101,7 +101,7 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
 	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).efi.out
 	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).efi.map
 # this is to keep the compatible with original output files
-ifeq ($(BOARD), apl-nuc)
+ifeq ($(BOARD), nuc6cayh)
     ifeq ($(SCENARIO), sdc)
 	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).efi.out
 	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).efi.map


### PR DESCRIPTION
To be back compatible, the default acrn.efi should be built when
BOARD param is nuc6cayh, because apl-nuc was overridden to nuc6cayh
in acrn-hypervisor/Makefile;

Tracked-On: #3602

Signed-off-by: Victor Sun <victor.sun@intel.com>