### PR TITLE
hv: clean up pci

### DIFF
--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -37,7 +37,7 @@ static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
 		for (pci_idx = 0U; pci_idx < vm_config->pci_dev_num; pci_idx++) {
 			dev_config = &vm_config->pci_devs[pci_idx];
 			if ((dev_config->emu_type == PCI_DEV_TYPE_PTDEV) &&
-					bdf_is_equal(&dev_config->pbdf, &pdev->bdf)) {
+					bdf_is_equal(dev_config->pbdf, pdev->bdf)) {
 				dev_config->pdev = pdev;
 				found = true;
 				break;

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -607,6 +607,7 @@ int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t phys_bd
 	struct ptirq_remapping_info *entry;
 	DEFINE_MSI_SID(virt_sid, virt_bdf, entry_nr);
 	int32_t ret = -ENODEV;
+	union pci_bdf vbdf;
 
 	/*
 	 * Device Model should pre-hold the mapping entries by calling
@@ -673,9 +674,10 @@ int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t phys_bd
 
 			if (ret == 0) {
 				entry->msi = *info;
+				vbdf.value = virt_bdf;
 				dev_dbg(ACRN_DBG_IRQ, "PCI %x:%x.%x MSI VR[%d] 0x%x->0x%x assigned to vm%d",
-					pci_bus(virt_bdf), pci_slot(virt_bdf), pci_func(virt_bdf), entry_nr,
-					info->vmsi_data.bits.vector, irq_to_vector(entry->allocated_pirq), entry->vm->vm_id);
+					vbdf.bits.b, vbdf.bits.d, vbdf.bits.f, entry_nr, info->vmsi_data.bits.vector,
+					irq_to_vector(entry->allocated_pirq), entry->vm->vm_id);
 			}
 		}
 	}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -867,13 +867,13 @@ int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret;
-	uint16_t bdf;
+	union pci_bdf bdf;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	bool bdf_valid = true;
 
 	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (param < 0x10000UL) {
-			bdf = (uint16_t) param;
+			bdf.value = (uint16_t)param;
 		} else {
 			if (copy_from_gpa(vm, &bdf, param, sizeof(bdf)) != 0) {
 				pr_err("%s: Unable copy param from vm %d\n",
@@ -884,8 +884,7 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	        }
 
 		if (bdf_valid) {
-			ret = move_pt_device(vm->iommu, target_vm->iommu,
-				(uint8_t)(bdf >> 8U), (uint8_t)(bdf & 0xffU));
+			ret = move_pt_device(vm->iommu, target_vm->iommu, bdf.fields.bus, bdf.fields.devfun);
 		}
 	} else {
 		pr_err("%s, target vm is invalid\n", __func__);
@@ -910,13 +909,13 @@ int32_t hcall_assign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 {
 	int32_t ret = -1;
-	uint16_t bdf;
+	union pci_bdf bdf;
 	bool bdf_valid = true;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
 	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (param < 0x10000UL) {
-			bdf = (uint16_t) param;
+			bdf.value = (uint16_t)param;
 		} else {
 			if (copy_from_gpa(vm, &bdf, param, sizeof(bdf)) != 0) {
 				pr_err("%s: Unable copy param to vm\n", __func__);
@@ -925,8 +924,7 @@ int32_t hcall_deassign_ptdev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 		}
 
 		if (bdf_valid) {
-			ret = move_pt_device(target_vm->iommu, vm->iommu,
-				(uint8_t)(bdf >> 8U), (uint8_t)(bdf & 0xffU));
+			ret = move_pt_device(target_vm->iommu, vm->iommu, bdf.fields.bus, bdf.fields.devfun);
 		}
 	}
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1032,7 +1032,7 @@ static void get_ptdev_info(char *str_arg, size_t str_max)
 	uint64_t dest;
 	bool lvl_tm;
 	uint32_t pin, vpin;
-	uint32_t bdf, vbdf;
+	union pci_bdf bdf, vbdf;
 
 	len = snprintf(str, size, "\r\nVM\tTYPE\tIRQ\tVEC\tDEST\tTM\tPIN\tVPIN\tBDF\tVBDF");
 	if (len >= size) {
@@ -1044,9 +1044,8 @@ static void get_ptdev_info(char *str_arg, size_t str_max)
 	for (idx = 0U; idx < CONFIG_MAX_PT_IRQ_ENTRIES; idx++) {
 		entry = &ptirq_entries[idx];
 		if (is_entry_active(entry)) {
-			get_entry_info(entry, type, &irq, &vector,
-					&dest, &lvl_tm, &pin, &vpin,
-					&bdf, &vbdf);
+			get_entry_info(entry, type, &irq, &vector, &dest, &lvl_tm, &pin, &vpin,
+					(uint32_t *)&bdf, (uint32_t *)&vbdf);
 			len = snprintf(str, size, "\r\n%d\t%s\t%d\t0x%X\t0x%X",
 					entry->vm->vm_id, type, irq, vector, dest);
 			if (len >= size) {
@@ -1057,10 +1056,8 @@ static void get_ptdev_info(char *str_arg, size_t str_max)
 
 			len = snprintf(str, size, "\t%s\t%hhu\t%hhu\t%x:%x.%x\t%x:%x.%x",
 					is_entry_active(entry) ? (lvl_tm ? "level" : "edge") : "none",
-					pin, vpin, (bdf & 0xff00U) >> 8U,
-					(bdf & 0xf8U) >> 3U, bdf & 0x7U,
-					(vbdf & 0xff00U) >> 8U,
-					(vbdf & 0xf8U) >> 3U, vbdf & 0x7U);
+					pin, vpin, bdf.bits.b, bdf.bits.d, bdf.bits.f,
+					vbdf.bits.b, vbdf.bits.d, vbdf.bits.f);
 			if (len >= size) {
 				goto overflow;
 			}

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -83,7 +83,7 @@ struct pci_vdev *pci_find_vdev(const struct acrn_vpci *vpci, union pci_bdf vbdf)
 	for (i = 0U; i < vpci->pci_vdev_cnt; i++) {
 		tmp = (struct pci_vdev *)&(vpci->pci_vdevs[i]);
 
-		if (bdf_is_equal(&(tmp->bdf), &vbdf)) {
+		if (bdf_is_equal(tmp->bdf, vbdf)) {
 			vdev = tmp;
 			break;
 		}

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -141,6 +141,10 @@ union pci_bdf {
 		uint8_t d : 5; /* BITs 3-7 */
 		uint8_t b; /* BITs 8-15 */
 	} bits;
+	struct {
+		uint8_t devfun; /* BITs 0-7 */
+		uint8_t bus;   /* BITs 8-15 */
+	} fields;
 };
 
 enum pci_bar_type {
@@ -276,26 +280,6 @@ static inline uint64_t git_size_masked_bar_base(uint64_t size, uint64_t val)
 	mask = ~(size - 1UL);
 
 	return (mask & val);
-}
-
-static inline uint8_t pci_bus(uint16_t bdf)
-{
-	return (uint8_t)((bdf >> 8U) & 0xFFU);
-}
-
-static inline uint8_t pci_slot(uint16_t bdf)
-{
-	return (uint8_t)((bdf >> 3U) & 0x1FU);
-}
-
-static inline uint8_t pci_func(uint16_t bdf)
-{
-	return (uint8_t)(bdf & 0x7U);
-}
-
-static inline uint8_t pci_devfn(uint16_t bdf)
-{
-	return (uint8_t)(bdf & 0xFFU);
 }
 
 /**

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -282,13 +282,9 @@ static inline uint64_t git_size_masked_bar_base(uint64_t size, uint64_t val)
 	return (mask & val);
 }
 
-/**
- * @pre a != NULL
- * @pre b != NULL
- */
-static inline bool bdf_is_equal(const union pci_bdf *a, const union pci_bdf *b)
+static inline bool bdf_is_equal(union pci_bdf a, union pci_bdf b)
 {
-	return (a->value == b->value);
+	return (a.value == b.value);
 }
 
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);


### PR DESCRIPTION
- add one more filed in "union pci_bdf"
- remove following interfaces:
      * pci_bus
      * pci_slot
      * pci_func
      * pci_devfn

 - update the argument type to union for function "bdf_is_equal"
      Declaring argument as pointer is not necessary since it
      only does the comparison.

Tracked-On: #1842
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>