### PR TITLE
Enable Isochronous transfer in Windows 10

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2663,13 +2663,13 @@ pci_xhci_xfer_complete(struct pci_xhci_vdev *xdev, struct usb_xfer *xfer,
 
 		xfer->data[i].stat = USB_BLOCK_FREE;
 		xfer->ndata--;
-		xfer->head = (xfer->head + 1) % USB_MAX_XFER_BLOCKS;
+		xfer->head = index_inc(xfer->head, USB_MAX_XFER_BLOCKS);
 		edtla += xfer->data[i].bdone;
 
 		trb->dwTrb3 = (trb->dwTrb3 & ~0x1) | (xfer->data[i].ccs);
 		if (xfer->data[i].type == USB_DATA_PART) {
 			rem_len += xfer->data[i].blen;
-			i = (i + 1) % USB_MAX_XFER_BLOCKS;
+			i = index_inc(i, USB_MAX_XFER_BLOCKS);
 
 			/* This 'continue' will delay the IOC behavior which
 			 * could decrease the number of virtual interrupts.
@@ -2688,7 +2688,7 @@ pci_xhci_xfer_complete(struct pci_xhci_vdev *xdev, struct usb_xfer *xfer,
 		    !((err == XHCI_TRB_ERROR_SHORT_PKT) &&
 		      (trb->dwTrb3 & XHCI_TRB_3_ISP_BIT))) {
 
-			i = (i + 1) % USB_MAX_XFER_BLOCKS;
+			i = index_inc(i, USB_MAX_XFER_BLOCKS);
 			continue;
 		}
 
@@ -2713,7 +2713,7 @@ pci_xhci_xfer_complete(struct pci_xhci_vdev *xdev, struct usb_xfer *xfer,
 		if (err != XHCI_TRB_ERROR_SUCCESS)
 			break;
 
-		i = (i + 1) % USB_MAX_XFER_BLOCKS;
+		i = index_inc(i, USB_MAX_XFER_BLOCKS);
 		rem_len = 0;
 	}
 

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -418,7 +418,7 @@ struct pci_xhci_vdev {
 	 * hub ports and its child external hub ports.
 	 */
 	struct pci_xhci_native_port native_ports[XHCI_MAX_VIRT_PORTS];
-	struct timespec mf_prev_time;	/* previous time of accessing MFINDEX */
+	struct timespec init_time;
 };
 
 /* portregs and devices arrays are set up to start from idx=1 */
@@ -3614,9 +3614,9 @@ pci_xhci_rtsregs_read(struct pci_xhci_vdev *xdev, uint64_t offset)
 
 	if (offset == XHCI_MFINDEX) {
 		clock_gettime(CLOCK_MONOTONIC, &t);
-		time_diff = (t.tv_sec - xdev->mf_prev_time.tv_sec) * 1000000
-			+ (t.tv_nsec - xdev->mf_prev_time.tv_nsec) / 1000;
-		xdev->mf_prev_time = t;
+		time_diff = (t.tv_sec - xdev->init_time.tv_sec) * 1000000
+			+ (t.tv_nsec - xdev->init_time.tv_nsec) / 1000;
+		xdev->init_time = t;
 		value = time_diff / 125;
 
 		if (value >= 1)
@@ -4166,7 +4166,7 @@ pci_xhci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	xdev->excap_ptr = NULL;
 
 	xdev->rtsregs.mfindex = 0;
-	clock_gettime(CLOCK_MONOTONIC, &xdev->mf_prev_time);
+	clock_gettime(CLOCK_MONOTONIC, &xdev->init_time);
 
 	/* discover devices */
 	error = pci_xhci_parse_opts(xdev, opts);

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -3033,11 +3033,7 @@ errout:
 		pci_xhci_assert_interrupt(xdev);
 
 	if (do_retry) {
-		if (epid == 1)
-			memset(xfer, 0, sizeof(*xfer));
-
-		UPRINTF(LDBG, "[%d]: retry:continuing with next TRBs\r\n",
-			 __LINE__);
+		UPRINTF(LDBG, "[%d]: retry next TRBs\r\n", __LINE__);
 		goto retry;
 	}
 	return err;

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -336,7 +336,7 @@ umouse_request(void *scarg, struct usb_xfer *xfer)
 		}
 
 		xfer->data[idx].stat = USB_BLOCK_HANDLED;
-		idx = (idx + 1) % USB_MAX_XFER_BLOCKS;
+		idx = index_inc(idx, USB_MAX_XFER_BLOCKS);
 	}
 
 	err = USB_ERR_NORMAL_COMPLETION;
@@ -716,7 +716,7 @@ umouse_data_handler(void *scarg, struct usb_xfer *xfer, int dir,
 
 		data->stat = USB_BLOCK_HANDLED;
 		data = NULL;
-		idx = (idx + 1) % USB_MAX_XFER_BLOCKS;
+		idx = index_inc(idx, USB_MAX_XFER_BLOCKS);
 	}
 	if (!data)
 		goto done;

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -336,7 +336,7 @@ umouse_request(void *scarg, struct usb_xfer *xfer)
 		}
 
 		xfer->data[idx].stat = USB_BLOCK_HANDLED;
-		idx = index_inc(idx, USB_MAX_XFER_BLOCKS);
+		idx = index_inc(idx, xfer->max_blk_cnt);
 	}
 
 	err = USB_ERR_NORMAL_COMPLETION;
@@ -716,7 +716,7 @@ umouse_data_handler(void *scarg, struct usb_xfer *xfer, int dir,
 
 		data->stat = USB_BLOCK_HANDLED;
 		data = NULL;
-		idx = index_inc(idx, USB_MAX_XFER_BLOCKS);
+		idx = index_inc(idx, xfer->max_blk_cnt);
 	}
 	if (!data)
 		goto done;

--- a/devicemodel/hw/platform/usb_mouse.c
+++ b/devicemodel/hw/platform/usb_mouse.c
@@ -308,10 +308,10 @@ umouse_init(void *pdata, char *opt)
 }
 
 static int
-umouse_request(void *scarg, struct usb_data_xfer *xfer)
+umouse_request(void *scarg, struct usb_xfer *xfer)
 {
 	struct umouse_vdev *dev;
-	struct usb_data_xfer_block *data;
+	struct usb_block *data;
 	const char *str;
 	uint16_t value;
 	uint16_t index;
@@ -335,7 +335,7 @@ umouse_request(void *scarg, struct usb_data_xfer *xfer)
 			udata = data->buf;
 		}
 
-		xfer->data[idx].processed = USB_XFER_BLK_HANDLED;
+		xfer->data[idx].stat = USB_BLOCK_HANDLED;
 		idx = (idx + 1) % USB_MAX_XFER_BLOCKS;
 	}
 
@@ -690,11 +690,11 @@ done:
 }
 
 static int
-umouse_data_handler(void *scarg, struct usb_data_xfer *xfer, int dir,
+umouse_data_handler(void *scarg, struct usb_xfer *xfer, int dir,
 		    int epctx)
 {
 	struct umouse_vdev *dev;
-	struct usb_data_xfer_block *data;
+	struct usb_block *data;
 	uint8_t *udata;
 	int len, i, idx;
 	int err;
@@ -714,7 +714,7 @@ umouse_data_handler(void *scarg, struct usb_data_xfer *xfer, int dir,
 		if (data->buf != NULL && data->blen != 0)
 			break;
 
-		data->processed = USB_XFER_BLK_HANDLED;
+		data->stat = USB_BLOCK_HANDLED;
 		data = NULL;
 		idx = (idx + 1) % USB_MAX_XFER_BLOCKS;
 	}
@@ -754,7 +754,7 @@ umouse_data_handler(void *scarg, struct usb_data_xfer *xfer, int dir,
 		if (len > 0) {
 			dev->newdata = 0;
 
-			data->processed = USB_XFER_BLK_HANDLED;
+			data->stat = USB_BLOCK_HANDLED;
 			data->bdone += 6;
 			memcpy(udata, &dev->um_report, 6);
 			data->blen = len - 6;

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -214,6 +214,14 @@ usb_dev_comp_cb(struct libusb_transfer *trn)
 		xfer->status = USB_ERR_SHORT_XFER;
 		goto out;
 	case LIBUSB_TRANSFER_ERROR:
+		/*
+		 * If this error happened due to device disconnecting, there is
+		 * nothing should do and just wait usb_dev_native_sys_disconn_cb
+		 * to do the 'unplugging process'.
+		 */
+		if (usb_native_is_device_existed(&info->path) == 0)
+			goto cancel_out;
+
 		is_stalled = 1;
 		xfer->status = USB_ERR_STALLED;
 		goto stall_out;

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -116,7 +116,7 @@ usb_block_append(struct usb_xfer *xfer, void *buf, int blen,
 	xb->ccs = ccs;
 	xb->stat = USB_BLOCK_FREE;
 	xb->bdone = 0;
-	xb->chained = 0;
+	xb->type = USB_DATA_NONE;
 	xfer->ndata++;
 	xfer->tail = (xfer->tail + 1) % USB_MAX_XFER_BLOCKS;
 	return xb;

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -101,19 +101,21 @@ usb_emu_finddev(char *name)
 }
 
 struct usb_block *
-usb_block_append(struct usb_xfer *xfer, void *buf, int blen,
-		void *hci_data, int ccs)
+usb_block_append(struct usb_xfer *xfer, void *buf, int blen, void *hcb,
+		int hcb_len)
 {
 	struct usb_block *xb;
 
 	if (xfer->ndata >= USB_MAX_XFER_BLOCKS)
 		return NULL;
 
+	if (hcb == NULL)
+		return NULL;
+
 	xb = &xfer->data[xfer->tail];
 	xb->buf = buf;
 	xb->blen = blen;
-	xb->hci_data = hci_data;
-	xb->ccs = ccs;
+	memcpy(xb->hcb, hcb, hcb_len);
 	xb->stat = USB_BLOCK_FREE;
 	xb->bdone = 0;
 	xb->type = USB_DATA_NONE;

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -181,6 +181,20 @@ usb_native_is_port_existed(uint8_t bus_num, uint8_t port_num)
 	return 1;
 }
 
+int
+usb_native_is_device_existed(struct usb_devpath *path)
+{
+	char _path[128];
+	int ret = 0;
+
+	if (path) {
+		snprintf(_path, sizeof(_path), "%s/%s", NATIVE_USBSYS_DEVDIR,
+				usb_dev_path(path));
+		ret = (access(_path, F_OK) == 0);
+	}
+	return ret;
+}
+
 void usb_parse_log_level(char level)
 {
 	switch (level) {

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -100,11 +100,11 @@ usb_emu_finddev(char *name)
 	return NULL;
 }
 
-struct usb_data_xfer_block *
-usb_data_xfer_append(struct usb_data_xfer *xfer, void *buf, int blen,
-		     void *hci_data, int ccs)
+struct usb_block *
+usb_block_append(struct usb_xfer *xfer, void *buf, int blen,
+		void *hci_data, int ccs)
 {
-	struct usb_data_xfer_block *xb;
+	struct usb_block *xb;
 
 	if (xfer->ndata >= USB_MAX_XFER_BLOCKS)
 		return NULL;
@@ -114,7 +114,7 @@ usb_data_xfer_append(struct usb_data_xfer *xfer, void *buf, int blen,
 	xb->blen = blen;
 	xb->hci_data = hci_data;
 	xb->ccs = ccs;
-	xb->processed = USB_XFER_BLK_FREE;
+	xb->stat = USB_BLOCK_FREE;
 	xb->bdone = 0;
 	xb->chained = 0;
 	xfer->ndata++;

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -106,7 +106,7 @@ usb_block_append(struct usb_xfer *xfer, void *buf, int blen, void *hcb,
 {
 	struct usb_block *xb;
 
-	if (xfer->ndata >= USB_MAX_XFER_BLOCKS)
+	if (xfer->ndata >= xfer->max_blk_cnt)
 		return NULL;
 
 	if (hcb == NULL)
@@ -120,7 +120,7 @@ usb_block_append(struct usb_xfer *xfer, void *buf, int blen, void *hcb,
 	xb->bdone = 0;
 	xb->type = USB_DATA_NONE;
 	xfer->ndata++;
-	xfer->tail = index_inc(xfer->tail, USB_MAX_XFER_BLOCKS);
+	xfer->tail = index_inc(xfer->tail, xfer->max_blk_cnt);
 	return xb;
 }
 

--- a/devicemodel/hw/usb_core.c
+++ b/devicemodel/hw/usb_core.c
@@ -118,7 +118,7 @@ usb_block_append(struct usb_xfer *xfer, void *buf, int blen,
 	xb->bdone = 0;
 	xb->type = USB_DATA_NONE;
 	xfer->ndata++;
-	xfer->tail = (xfer->tail + 1) % USB_MAX_XFER_BLOCKS;
+	xfer->tail = index_inc(xfer->tail, USB_MAX_XFER_BLOCKS);
 	return xb;
 }
 

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -230,6 +230,21 @@ enum USB_ERRCODE {
 
 #define USB_DROPPED_XFER_MAGIC	0xaaaaaaaa55555555
 
+inline bool
+index_valid(int head, int tail, int maxcnt, int idx) {
+	if (head <= tail)
+		return (idx >= head && idx < tail);
+	else
+		return (idx >= head && idx < maxcnt) ||
+			(idx >= 0 && idx < tail);
+}
+
+inline int
+index_inc(int idx, int maxcnt)
+{
+	return (idx + 1) % maxcnt;
+}
+
 extern int usb_log_level;
 static inline int usb_get_log_level(void)		{ return usb_log_level; }
 static inline void usb_set_log_level(int level)	{ usb_log_level = level; }

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -142,6 +142,12 @@ struct usb_hci {
 	int	hci_port;
 };
 
+enum usb_block_type {
+	USB_DATA_NONE,
+	USB_DATA_PART,
+	USB_DATA_FULL
+};
+
 /*
  * Each xfer block is mapped to the hci transfer block.
  * On input into the device handler, blen is set to the lenght of buf.
@@ -155,9 +161,9 @@ struct usb_block {
 	enum usb_block_stat	stat;      /* processed status */
 	void			*hci_data; /* HCI private reference */
 	int			ccs;
-	int			chained;
 	uint32_t		streamid;
 	uint64_t		trbnext;   /* next TRB guest address */
+	enum usb_block_type	type;
 };
 
 struct usb_xfer {

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -159,11 +159,8 @@ struct usb_block {
 	int			blen;	   /* in:len(buf), out:len(remaining) */
 	int			bdone;	   /* bytes transferred */
 	enum usb_block_stat	stat;      /* processed status */
-	void			*hci_data; /* HCI private reference */
-	int			ccs;
-	uint32_t		streamid;
-	uint64_t		trbnext;   /* next TRB guest address */
 	enum usb_block_type	type;
+	void                    *hcb;      /* host controller block */
 };
 
 struct usb_xfer {
@@ -253,7 +250,7 @@ struct usb_devemu *usb_emu_finddev(char *name);
 int usb_native_is_bus_existed(uint8_t bus_num);
 int usb_native_is_port_existed(uint8_t bus_num, uint8_t port_num);
 struct usb_block *usb_block_append(struct usb_xfer *xfer, void *buf, int blen,
-		void *hci_data, int ccs);
+		void *hcb, int hcb_len);
 int usb_get_hub_port_num(struct usb_devpath *path);
 char *usb_dev_path(struct usb_devpath *path);
 bool usb_dev_path_cmp(struct usb_devpath *p1, struct usb_devpath *p2);

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -247,6 +247,7 @@ void usb_parse_log_level(char level);
 struct usb_devemu *usb_emu_finddev(char *name);
 int usb_native_is_bus_existed(uint8_t bus_num);
 int usb_native_is_port_existed(uint8_t bus_num, uint8_t port_num);
+int usb_native_is_device_existed(struct usb_devpath *path);
 struct usb_block *usb_block_append(struct usb_xfer *xfer, void *buf, int blen,
 		void *hcb, int hcb_len);
 int usb_get_hub_port_num(struct usb_devpath *path);

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -42,8 +42,6 @@
  * By default, the native xhci driver use two segments which contain 2 * 256
  * trbs, so 1024 is enough currently.
  */
-#define	USB_MAX_XFER_BLOCKS	1024
-
 #define	USB_XFER_OUT		0
 #define	USB_XFER_IN		1
 
@@ -164,9 +162,8 @@ struct usb_block {
 };
 
 struct usb_xfer {
-	uint64_t magic;
-	struct usb_block data[USB_MAX_XFER_BLOCKS];
-	struct usb_dev_req *requests[USB_MAX_XFER_BLOCKS];
+	struct usb_block *data;
+	struct usb_dev_req **reqs;
 	struct usb_device_request *ureq;	/* setup ctl request */
 	int	ndata;				/* # of data items */
 	int	head;
@@ -174,6 +171,7 @@ struct usb_xfer {
 	void    *dev;		/* struct pci_xhci_dev_emu *dev */
 	int     epid;		/* related endpoint id */
 	int     pid;		/* token id */
+	int	max_blk_cnt;
 	int	status;
 };
 

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -61,7 +61,7 @@ struct usb_dev {
 
 /*
  * The purpose to implement struct usb_dev_req is to adapt
- * struct usb_data_xfer to make a proper data format to talk
+ * struct usb_xfer to make a proper data format to talk
  * with libusb.
  */
 struct usb_dev_req {
@@ -69,18 +69,17 @@ struct usb_dev_req {
 	int    in;
 	int    seq;
 	/*
-	 * buffer could include data from multiple
-	 * usb_data_xfer_block, so here need some
-	 * data to record it.
+	 * buffer could include data from multiple usb_block,
+	 * so here need some data to record it.
 	 */
 	uint8_t	*buffer;
 	int     buf_length;
 	int     blk_start;
 	int     blk_count;
 
-	struct usb_data_xfer *xfer;
+	struct usb_xfer *xfer;
 	struct libusb_transfer *trn;
-	struct usb_data_xfer_block *setup_blk;
+	struct usb_block *setup_blk;
 };
 
 /* callback type used by code from HCD layer */
@@ -127,7 +126,7 @@ void usb_dev_sys_deinit(void);
 void *usb_dev_init(void *pdata, char *opt);
 void usb_dev_deinit(void *pdata);
 int usb_dev_info(void *pdata, int type, void *value, int size);
-int usb_dev_request(void *pdata, struct usb_data_xfer *xfer);
+int usb_dev_request(void *pdata, struct usb_xfer *xfer);
 int usb_dev_reset(void *pdata);
-int usb_dev_data(void *pdata, struct usb_data_xfer *xfer, int dir, int epctx);
+int usb_dev_data(void *pdata, struct usb_xfer *xfer, int dir, int epctx);
 #endif

--- a/devicemodel/include/usb_pmapper.h
+++ b/devicemodel/include/usb_pmapper.h
@@ -73,9 +73,9 @@ struct usb_dev_req {
 	 * so here need some data to record it.
 	 */
 	uint8_t	*buffer;
-	int     buf_length;
-	int     blk_start;
-	int     blk_count;
+	int     buf_size;
+	int     blk_head;
+	int     blk_tail;
 
 	struct usb_xfer *xfer;
 	struct libusb_transfer *trn;

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -366,6 +366,25 @@ struct xhci_trb {
 #define	XHCI_TRB_ERROR_SPLIT_XACT	0x24
 } __aligned(8);
 
+/*
+ * The Block Event Interrupt (BEI) bit in the TRB descriptor could
+ * delay the triggering of interrupt. For most OSes, the native
+ * driver for xHCI will use this bit to optimize the IO performence,
+ * due to reduction of number of interrupts.
+ *
+ * But in Linux, the native xHCI driver for Intel brand controller
+ * doesn't use this bit. It is fine for the native scenario due to
+ * most work is completed by hardware. But in virtualization scenario,
+ * it is almost impossible to support heavy data IO such as high
+ * resolution video recording (ISOC transfer).
+ *
+ * Hence, this issue is solved by a 'quirk' when the intel hardware is
+ * emulated (when vendor id is set as 0x8086). For other cases, a
+ * virtal hardware called 'ACRN xHCI' is emulated, and both Linux and
+ * Windows will use BEI bit by default.
+ */
+#define XHCI_QUIRK_INTEL_ISOCH_NO_BEI	(1 << 0)
+
 struct xhci_dev_endpoint_trbs {
 	struct xhci_trb		trb[(XHCI_MAX_STREAMS *
 	    XHCI_MAX_TRANSFERS) + XHCI_MAX_STREAMS];

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -190,6 +190,15 @@ struct xhci_endp_ctx {
 	volatile uint32_t	dwEpCtx7;
 };
 
+#define XHCI_EPTYPE_INVALID	0
+#define XHCI_EPTYPE_ISOC_OUT	1
+#define XHCI_EPTYPE_BULK_OUT	2
+#define XHCI_EPTYPE_INT_OUT	3
+#define XHCI_EPTYPE_CTRL	4
+#define XHCI_EPTYPE_ISOC_IN	5
+#define XHCI_EPTYPE_BULK_IN	6
+#define XHCI_EPTYPE_INT_IN	7
+
 struct xhci_input_ctx {
 #define	XHCI_INCTX_NON_CTRL_MASK	0xFFFFFFFCU
 	volatile uint32_t	dwInCtx0;

--- a/devicemodel/include/xhci.h
+++ b/devicemodel/include/xhci.h
@@ -399,10 +399,11 @@ struct xhci_dev_endpoint_trbs {
 	    XHCI_MAX_TRANSFERS) + XHCI_MAX_STREAMS];
 };
 
-struct xhci_event_ring_seg {
-	volatile uint64_t	qwEvrsTablePtr;
-	volatile uint32_t	dwEvrsTableSize;
-	volatile uint32_t	dwEvrsReserved;
+
+struct xhci_erst {
+	volatile uint64_t	qwRingSegBase;
+	volatile uint32_t	dwRingSegSize;
+	volatile uint32_t	dwRingSegRsv;
 };
 
 #endif /* _XHCI_H_ */


### PR DESCRIPTION
This series of patches enable the isochronous transfer in Windows 10,
which supports devices such as USB headset, USB microphone and USB
camera.
Tracked-On: #3628
Signed-off-by: Xiaoguang Wu xiaoguang.wu@intel.com
Acked-by: Yu Wang yu1.wang@intel.com