### PR TITLE
doc: update robots.txt to exclude old docs

### DIFF
--- a/doc/scripts/publish-robots.txt
+++ b/doc/scripts/publish-robots.txt
@@ -5,3 +5,6 @@ Disallow: /0.2/
 Disallow: /0.3/
 Disallow: /0.4/
 Disallow: /0.5/
+Disallow: /0.6/
+Disallow: /0.7/
+Disallow: /0.8/


### PR DESCRIPTION
Exclude older documentation from search engines (< 1.0)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>