### PR TITLE
acrn-config: remove ethernet device from pass through config

### DIFF
--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</wifi>
 		<bluetooth desc="vm bluetooth">00:18.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #1 (rev 0b)</bluetooth>
 		<sd_card desc="vm sd card device">00:1b.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SDXC/MMC Host Controller (rev 0b)</sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</wifi>
 		<bluetooth desc="vm bluetooth">00:18.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #1 (rev 0b)</bluetooth>
 		<sd_card desc="vm sd card device">00:1b.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SDXC/MMC Host Controller (rev 0b)</sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device">00:1b.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SDXC/MMC Host Controller (rev 0b)</sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -19,7 +19,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -19,7 +19,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -19,7 +19,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -45,7 +45,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_3uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_3uos.xml
@@ -19,7 +19,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -45,7 +45,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -71,7 +71,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -19,7 +19,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -48,7 +48,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_3uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_3uos.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -48,7 +48,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>
@@ -75,7 +75,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -48,7 +48,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_3uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_3uos.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
@@ -48,7 +48,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>
@@ -75,7 +75,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -23,7 +23,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -20,7 +20,7 @@
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
-		<ethernet desc="vm wifi device"></ethernet>
+		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>


### PR DESCRIPTION
align with sample launch script for Preempt-RT Linux, remove ethernet
device from config file.

Tracked-On: #3751
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>