### PR TITLE
doc: optimize Clear Linux "ACRN builder" container image

### DIFF
--- a/doc/getting-started/Dockerfile
+++ b/doc/getting-started/Dockerfile
@@ -1,5 +1,40 @@
-FROM clearlinux:latest
+# Build container based on Clearlinux
+FROM clearlinux:base
 
-RUN swupd bundle-add os-clr-on-clr os-core-dev python3-basic
+# Tools (bundles) to build the ACRN hypervisor, Device Model, tools and doc
+# - bundles needed to build kernels: bc, lz4, diffutils and devpkg-elfutils, devpkg-ncurses
+# - bundles needed to build the documentation: doxygen, graphviz, desktop-apps
+RUN swupd update -b && \
+	swupd bundle-add -b c-basic \
+			python3-basic \
+			which \
+			git \
+			devpkg-systemd \
+			devpkg-telemetrics-client \
+			devpkg-e2fsprogs \
+			devpkg-libxml2 \
+			devpkg-openssl \
+			devpkg-util-linux \
+			devpkg-libevent \
+			devpkg-libusb \
+			devpkg-libpciaccess \
+			devpkg-gnu-efi \
+			bc \
+			lz4 \
+			diffutils \
+			devpkg-elfutils \
+			doxygen \
+			devpkg-ncurses \
+			desktop-apps \
+	&& rm -rf /var/lib/swupd/*
+
 RUN pip3 install kconfiglib
+# End of section installing build tools (bundles)
+
+# Additional tools (Python) to build the documentation
+RUN curl -O https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/doc/scripts/requirements.txt && \
+	pip3 install -r requirements.txt && \
+	rm requirements.txt
+# End of documentation generation tools
+
 WORKDIR /workspace

--- a/doc/getting-started/building_acrn_in_docker.rst
+++ b/doc/getting-started/building_acrn_in_docker.rst
@@ -132,7 +132,7 @@ Build the ACRN User VM PREEMPT_RT Kernel in Docker
       $ git clone -b 4.19/preempt-rt https://github.com/projectacrn/acrn-kernel preempt-rt
       $ cd preempt-rt
 
-#. Buildthe ACRN User VM PREEMPT_RT kernel:
+#. Build the ACRN User VM PREEMPT_RT kernel:
 
    For the Docker image built from Dockerfile, use this command to build ACRN:
 
@@ -154,3 +154,21 @@ Build the ACRN User VM PREEMPT_RT Kernel in Docker
 
    The commands build the bootable kernel image as ``arch/x86/boot/bzImage``,
    and the loadable kernel modules under the ``./out/`` folder.
+
+Build the ACRN documentation
+****************************
+
+#. Make sure you have both the ``acrn-hypervisor`` and ``acrn-kernel`` repositories already available in your workspace
+   (see steps above for instructions on how to clone them).
+
+#. Build the ACRN documentation:
+
+   .. code-block:: none
+
+      $ cd ~/workspace
+      $ docker run -u`id -u`:`id -g` --rm  -v $PWD:/workspace \
+        acrn/clearlinux-acrn-builder:latest \
+        bash -c "cd acrn-hypervisor && make clean && make doc"
+
+   The HTML documentation can be found in ``acrn-hypervisor/build/doc/html``
+      


### PR DESCRIPTION
Optimize the size of the Clear Linux container that can be used to build ACRN.

This patch reduces the size of the container from approx. 10.8GB down to a
little less than 1.4GB.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>