### PR TITLE
dm: reduce potential crash caused by LIST_FOREACH

### DIFF
--- a/devicemodel/hw/pci/gsi_sharing.c
+++ b/devicemodel/hw/pci/gsi_sharing.c
@@ -13,6 +13,7 @@
 #include <pciaccess.h>
 
 #include "pci_core.h"
+#include "mevent.h"
 
 #define MAX_DEV_PER_GSI 4
 
@@ -117,7 +118,7 @@ create_gsi_sharing_groups(void)
 	uint8_t gsi;
 	char *dev_name;
 	int i, error, msi_support;
-	struct gsi_sharing_group *group = NULL;
+	struct gsi_sharing_group *group = NULL, *temp = NULL;
 
 	error = pciaccess_init();
 	if (error < 0)
@@ -144,7 +145,7 @@ create_gsi_sharing_groups(void)
 	 * clean up gsg_head - the list for gsi_sharing_group
 	 * delete the element without gsi sharing condition (shared_dev_num < 2)
 	 */
-	LIST_FOREACH(group, &gsg_head, gsg_list) {
+	list_foreach_safe(group, &gsg_head, gsg_list, temp) {
 		if (group->shared_dev_num < 2) {
 			LIST_REMOVE(group, gsg_list);
 			free(group);
@@ -181,7 +182,7 @@ update_pt_info(uint16_t phys_bdf)
 int
 check_gsi_sharing_violation(void)
 {
-	struct gsi_sharing_group *group;
+	struct gsi_sharing_group *group, *temp;
 	int i, error, violation;
 
 	error = 0;
@@ -226,7 +227,7 @@ check_gsi_sharing_violation(void)
 	}
 
 	/* destroy the gsg_head after all the checks have been done */
-	LIST_FOREACH(group, &gsg_head, gsg_list) {
+	list_foreach_safe(group, &gsg_head, gsg_list, temp) {
 		LIST_REMOVE(group, gsg_list);
 		free(group);
 	}

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -502,10 +502,10 @@ vmei_del_me_client(struct vmei_me_client *mclient)
 static void
 vmei_me_client_destroy_host_clients(struct vmei_me_client *mclient)
 {
-	struct vmei_host_client *e;
+	struct vmei_host_client *e, *temp;
 
 	pthread_mutex_lock(&mclient->list_mutex);
-	LIST_FOREACH(e, &mclient->connections, list) {
+	list_foreach_safe(e, &mclient->connections, list, temp) {
 		vmei_host_client_put(e);
 	}
 	LIST_INIT(&mclient->connections);
@@ -643,10 +643,10 @@ vmei_find_host_client(struct virtio_mei *vmei,
 
 static void vmei_free_me_clients(struct virtio_mei *vmei)
 {
-	struct vmei_me_client *e;
+	struct vmei_me_client *e, *temp;
 
 	pthread_mutex_lock(&vmei->list_mutex);
-	LIST_FOREACH(e, &vmei->active_clients, list) {
+	list_foreach_safe(e, &vmei->active_clients, list, temp) {
 		vmei_me_client_put(e);
 	}
 	LIST_INIT(&vmei->active_clients);
@@ -937,7 +937,7 @@ static void
 vmei_virtual_fw_reset(struct virtio_mei *vmei)
 {
 	DPRINTF("Firmware reset\n");
-	struct vmei_me_client *e;
+	struct vmei_me_client *e, *temp;
 
 	vmei_set_status(vmei, VMEI_STS_RESET);
 	vmei->config->hw_ready = 0;
@@ -948,7 +948,7 @@ vmei_virtual_fw_reset(struct virtio_mei *vmei)
 
 	/* disconnect all */
 	pthread_mutex_lock(&vmei->list_mutex);
-	LIST_FOREACH(e, &vmei->active_clients, list) {
+	list_foreach_safe(e, &vmei->active_clients, list, temp) {
 		vmei_me_client_destroy_host_clients(e);
 	}
 	pthread_mutex_unlock(&vmei->list_mutex);


### PR DESCRIPTION
When removing node in list, list_foreach_safe will be safer than
LIST_FOREACH.

Tracked-On: #3778
Signed-off-by: Junhao Gao <junhao.gao@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>