### PR TITLE
hv: use 'uintptr_t' to properly cast a pointer to unsigned int

### DIFF
--- a/misc/efi-stub/boot.c
+++ b/misc/efi-stub/boot.c
@@ -311,7 +311,7 @@ switch_to_guest_mode(EFI_HANDLE image, EFI_PHYSICAL_ADDRESS hv_hpa)
 	 * The host physical start address of boot loader name is stored in multiboot header.
 	 */
 	mbi->mi_flags |= MULTIBOOT_INFO_HAS_LOADER_NAME;
-	mbi->mi_loader_name = (UINT32)uefi_boot_loader_name;
+	mbi->mi_loader_name = (uintptr_t)uefi_boot_loader_name;
 
 	asm volatile ("pushf\n\t"
 		      "pop %0\n\t"

--- a/misc/efi-stub/multiboot.h
+++ b/misc/efi-stub/multiboot.h
@@ -134,7 +134,7 @@ struct multiboot_info {
 	uint32_t		unused_mi_config_table;
 
 	/* Valid if mi_flags sets MULTIBOOT_INFO_HAS_LOADER_NAME. */
-	uint32_t		mi_loader_name;
+	uintptr_t		mi_loader_name;
 
 	/* Valid if mi_flags sets MULTIBOOT_INFO_HAS_APM. */
 	uint32_t		unused_mi_apm_table;


### PR DESCRIPTION
Use 'uintptr_t' to properly cast a pointer to a UINT32.

Tracked-On: #3771
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>