### PR TITLE
hv: fix a bug that tpr threshold is not updated

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -883,6 +883,8 @@ vlapic_process_eoi(struct acrn_vlapic *vlapic)
 			/* hook to vIOAPIC */
 			vioapic_process_eoi(vlapic->vm, vector);
 		}
+
+		vcpu_make_request(vlapic->vcpu, ACRN_REQUEST_EVENT);
 	}
 
 	dev_dbg(ACRN_DBG_LAPIC, "Gratuitous EOI");


### PR DESCRIPTION
Consider the following case when TPR shadow is used with vlapic
basic mode:
1) 2 interrupts are pending in vlapic. INTa's priority > TPR and
   INTb's priority <= TPR.
2) TPR threshold is set to zero and INTa is injected to guest.
3) Guest set TPR to the priority of INTa.
4) EOI of INTa. PPR is updated to TPR which equals INTa's priority.
   INTb cannot be injected because its priority <= PPR.
5) Guest set TPR to zero. Because TPR threshold is still zero, there is
   no TPR threshold vmexit. But since both TPR and ISRV are zero at
   this time, the PPR is zero as well. INTb still cannot be injected.
   This is a bug.

This patch adds one TPR threshold update in EOI to fix above issue.

Tracked-On: #3795
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>