### PR TITLE
hv: vpci: remove pci_msi_cap in pci_pdev

### DIFF
--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -231,15 +231,7 @@ static void pci_read_cap(struct pci_pdev *pdev)
 		if ((cap == PCIY_MSI) || (cap == PCIY_MSIX)) {
 			offset = ptr;
 			if (cap == PCIY_MSI) {
-				pdev->msi.capoff = offset;
-				msgctrl = pci_pdev_read_cfg(pdev->bdf, offset + PCIR_MSI_CTRL, 2U);
-				len = ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) ? 14U : 10U;
-				pdev->msi.caplen = len;
-
-				/* Copy MSI capability struct into buffer */
-				for (idx = 0U; idx < len; idx++) {
-					pdev->msi.cap[idx] = (uint8_t)pci_pdev_read_cfg(pdev->bdf, offset + idx, 1U);
-				}
+				pdev->msi_capoff = offset;
 			} else {
 				pdev->msix.capoff = offset;
 				pdev->msix.caplen = MSIX_CAPLEN;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -128,7 +128,6 @@
 #define PCIM_MSIX_BIR_MASK    0x7U
 #define PCIM_MSIX_VCTRL_MASK  0x1U
 
-#define MSI_MAX_CAPLEN        14U
 #define MSIX_CAPLEN           12U
 #define MSIX_TABLE_ENTRY_SIZE 16U
 
@@ -195,13 +194,6 @@ struct pci_bar {
 	bool is_64bit_high; /* true if this is the upper 32-bit of a 64-bit bar */
 };
 
-/* Basic MSI capability info */
-struct pci_msi_cap {
-	uint32_t  capoff;
-	uint32_t  caplen;
-	uint8_t   cap[MSI_MAX_CAPLEN];
-};
-
 /* Basic MSIX capability info */
 struct pci_msix_cap {
 	uint32_t  capoff;
@@ -219,7 +211,7 @@ struct pci_pdev {
 	/* The bus/device/function triple of the physical PCI device. */
 	union pci_bdf bdf;
 
-	struct pci_msi_cap msi;
+	uint32_t msi_capoff;
 
 	struct pci_msix_cap msix;
 };


### PR DESCRIPTION
The MSI Message Address and Message Data have no valid data after Power-ON. So
there's no need to initialize them by reading the data from physical PCI configuration
space.

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>