### PR TITLE
acrn-config: vcpu_affinity to keep align with master branch source code

### DIFF
--- a/misc/acrn-config/board_config/board_cfg_gen.py
+++ b/misc/acrn-config/board_config/board_cfg_gen.py
@@ -18,9 +18,6 @@ import new_board_kconfig
 ACRN_PATH = board_cfg_lib.SOURCE_ROOT_DIR
 ACRN_CONFIG = ACRN_PATH + "hypervisor/arch/x86/configs/"
 
-BOARD_NAMES = ['apl-mrb', 'apl-nuc', 'apl-up2', 'dnv-cb2', 'nuc6cayh',
-               'nuc7i7dnb', 'kbl-nuc-i7', 'icl-rvp']
-
 ACRN_DEFAULT_PLATFORM = ACRN_PATH + "hypervisor/include/arch/x86/default_acpi_info.h"
 GEN_FILE = ["pci_devices.h", "board.c", "_acpi_info.h", "misc_cfg.h", "ve820.c", ".config"]
 
@@ -55,7 +52,7 @@ def main(args):
         return err_dic
 
     config_dirs.append(ACRN_CONFIG + board)
-    if board not in BOARD_NAMES:
+    if board not in board_cfg_lib.BOARD_NAMES:
         for config_dir in config_dirs:
             if not os.path.exists(config_dir):
                 os.makedirs(config_dir)
@@ -101,7 +98,7 @@ def main(args):
             return err_dic
 
     # generate new board_name.config
-    if board not in BOARD_NAMES:
+    if board not in board_cfg_lib.BOARD_NAMES:
         with open(config_board_kconfig, 'w+') as config:
             err_dic = new_board_kconfig.generate_file(config)
             if err_dic:
@@ -110,7 +107,7 @@ def main(args):
     # move changes to patch, and apply to the source code
     err_dic = board_cfg_lib.gen_patch(config_srcs, board)
 
-    if board not in BOARD_NAMES and not err_dic:
+    if board not in board_cfg_lib.BOARD_NAMES and not err_dic:
         print("Config patch for NEW board {} is committed successfully!".format(board))
     elif not err_dic:
         print("Config patch for {} is committed successfully!".format(board))

--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -85,6 +85,10 @@ def generate_file(config):
     """
     board_cfg_lib.get_valid_irq(board_cfg_lib.BOARD_INFO_FILE)
 
+    # get cpu processor list
+    cpu_list = board_cfg_lib.get_processor_info()
+    max_cpu_num = len(cpu_list)
+
     # get the vuart0/vuart1 which user chosed from scenario.xml of board_private section
     (err_dic, ttys_n) = board_cfg_lib.parser_vuart_console()
     if err_dic:
@@ -116,6 +120,9 @@ def generate_file(config):
     # start to generate misc_cfg.h
     print("{0}".format(board_cfg_lib.HEADER_LICENSE), file=config)
     print("{}".format(MISC_CFG_HEADER), file=config)
+
+    # define CONFIG_MAX_PCPCU_NUM
+    print("#define CONFIG_MAX_PCPU_NUM\t{}U".format(max_cpu_num), file=config)
 
     # define rootfs with macro
     for i in range(root_dev_num):

--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -299,6 +299,26 @@ $().ready(function(){
         show_com_target(id, value);
     })
 
+    $(document).on('click', "button:contains('+')", function() {
+        var add_vcpu_id = $(this).attr('id');
+        var id = add_vcpu_id.replace('add_vcpu_', '');
+        var config_item = $(this).parent().parent();
+        var config_item_added = config_item.clone();
+        var id_added = (parseInt(id)+1).toString();
+        config_item_added.find("button:contains('+')").attr('id', 'add_vcpu_'+id_added);
+        config_item_added.find("button:contains('-')").attr('id', 'remove_vcpu_'+id_added);
+        config_item_added.find("button:contains('-')").prop("disabled", false);
+        config_item_added.find("label:first").text("");
+        config_item_added.find('.bootstrap-select').replaceWith(function() { return $('select', this); });
+        config_item_added.find('.selectpicker').selectpicker('render');
+        config_item_added.insertAfter(config_item);
+    });
+
+    $(document).on('click', "button:contains('-')", function() {
+        var config_item = $(this).parent().parent();
+        config_item.remove();
+    });
+
 })
 
 
@@ -330,7 +350,7 @@ function show_com_target(id, value) {
 
 
 function save_scenario(generator=null){
-    var board_info = $("select#board_info").val();
+    var board_info = $("text#board_type").text();
     if (board_info==null || board_info=='') {
         alert("Please select one board info before this operation.");
         return;
@@ -346,7 +366,7 @@ function save_scenario(generator=null){
     	var value = $(this).val();
     	if(id!='new_scenario_name' && id!='board_info_file'
     	    && id!='board_info_upload' && id!="scenario_file") {
-    	    scenario_config[id] = $(this).val();
+            scenario_config[id] = value;
     	}
     })
 
@@ -355,16 +375,22 @@ function save_scenario(generator=null){
     	var value = $(this).val();
     	if(id!='new_scenario_name' && id!='board_info_file'
     	    && id!='board_info_upload' && id!="scenario_file") {
-    	    scenario_config[id] = $(this).val();
+            scenario_config[id] = value;
     	}
     })
 
     $("select").each(function(){
         var id = $(this).attr('id');
-    	var value = $(this).val();
-    	if(id!='board_info') {
-    	    scenario_config[$(this).attr('id')] = $(this).val();
-    	}
+        var value = $(this).val();
+        if(id.indexOf('pcpu_id')>=0) {
+            if(id in scenario_config) {
+                scenario_config[id].push(value);
+            } else {
+                scenario_config[id] = [value];
+            }
+        } else if(id!='board_info') {
+            scenario_config[id] = value;
+        }
     })
 
     $.ajax({
@@ -442,7 +468,7 @@ function save_scenario(generator=null){
 }
 
 function save_launch(generator=null) {
-    var board_info = $("select#board_info").val();
+    var board_info = $("text#board_type").text();
     var scenario_name = $("select#scenario_name").val();
     if (board_info==null || board_info=='' || scenario_name==null || scenario_name=='') {
         alert("Please select one board and scenario before this operation.");
@@ -461,7 +487,7 @@ function save_launch(generator=null) {
     	if(id!='new_launch_name' && id!='board_info_file'
     	    && id!='board_info_upload' && id!='scenario_name'
     	    && id!="launch_file") {
-    	    launch_config[id] = $(this).val();
+            launch_config[id] = value;
     	}
     })
 
@@ -469,7 +495,7 @@ function save_launch(generator=null) {
         var id = $(this).attr('id');
     	var value = $(this).val();
     	if(id!='board_info') {
-    	    launch_config[$(this).attr('id')] = $(this).val();
+            launch_config[id] = value;
     	}
     })
 
@@ -478,7 +504,7 @@ function save_launch(generator=null) {
     	var value = $(this).val();
     	if(id!='new_scenario_name' && id!='board_info_file'
     	    && id!='board_info_upload' && id!="scenario_file") {
-    	    launch_config[id] = $(this).val();
+            launch_config[id] = value;
     	}
     })
 

--- a/misc/acrn-config/config_app/templates/scenario.html
+++ b/misc/acrn-config/config_app/templates/scenario.html
@@ -147,20 +147,19 @@
                                 <div class="form-group">
                                     {% if 'id' not in elem.attrib %}
                                         {% if not first_child %}
-                                        {% do first_child.append(1) %}
                                         <label class="col-sm-1 control-label" data-toggle="tooltip"
-                                               title="{{sub_elem.attrib['desc'] if 'desc' in sub_elem.attrib else sub_elem.tag}}">
+                                               title="{{elem.attrib['desc'] if 'desc' in elem.attrib else elem.tag}}">
                                             {{elem.tag}}</label>
                                         {% else %}
                                         <label class="col-sm-1 control-label" data-toggle="tooltip"
-                                               title="{{sub_elem.attrib['desc'] if 'desc' in sub_elem.attrib else sub_elem.tag}}">
+                                               title="{{elem.attrib['desc'] if 'desc' in elem.attrib else elem.tag}}">
                                         </label>
                                         {% endif %}
-
                                         <label class="col-sm-2 control-label" data-toggle="tooltip"
                                                title="{{sub_elem.attrib['desc'] if 'desc' in sub_elem.attrib else sub_elem.tag}}">
                                             {{sub_elem.tag}}</label>
-                                        {% if ','.join(['vm', elem.tag, sub_elem.tag]) not in scenario_item_values %}
+
+                                        {% if ','.join(['vm', elem.tag, sub_elem.tag]) not in scenario_item_values and elem.tag != 'vcpu_affinity' %}
                                             {% if sub_elem.tag in ['bootargs', 'kern_args'] %}
                                                 <div class="col-sm-6">
                                                 {% if 'readonly' in sub_elem.attrib and sub_elem.attrib['readonly'] == 'true' %}
@@ -186,6 +185,8 @@
                                                 </div>
                                             {% endif %}
                                         {% else %}
+                                            {% set item_key = ','.join(['vm', elem.tag, sub_elem.tag]) if elem.tag != 'vcpu_affinity' else
+                                            ','.join(['vm', elem.tag])%}
                                             <div class="dropdown col-sm-6">
                                                 {% if 'readonly' in sub_elem.attrib and sub_elem.attrib['readonly'] == 'true' %}
                                                 <select class="selectpicker" data-width="auto"
@@ -194,7 +195,7 @@
                                                 <select class="selectpicker" data-width="auto"
                                                         id="{{'vm:id='+vm.attrib['id']+','+elem.tag+','+sub_elem.tag}}">
                                                 {% endif %}
-                                                {% for item_value in scenario_item_values[','.join(['vm', elem.tag, sub_elem.tag])] %}
+                                                {% for item_value in scenario_item_values[item_key] %}
                                                     {% if item_value == sub_elem_text %}
                                                     <option value="{{item_value}}" selected="selected">{{item_value}}</option>
                                                     {% else %}
@@ -202,8 +203,18 @@
                                                     {% endif %}
                                                 {% endfor %}
                                                 </select>
+
+                                                {% if elem.tag == 'vcpu_affinity' %}
+                                                <button type="button" class="btn" id="add_vcpu_{{first_child|length}}">+</button>
+                                                {% if not first_child %}
+                                                <button type="button" disabled class="btn" id="remove_vcpu_{{first_child|length}}">-</button>
+                                                {% else %}
+                                                <button type="button" class="btn" id="remove_vcpu_{{first_child|length}}">-</button>
+                                                {% endif %}
+                                                {% endif%}
                                             </div>
                                         {% endif %}
+                                        {% do first_child.append(1) %}
                                         <p id="{{'vm:id='+vm.attrib['id']+','+elem.tag+','+sub_elem.tag}}_err" class="col-sm-3"></p>
                                     {% else %}
                                         {% if not first_child %}

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -15,6 +15,9 @@ BIOS_INFO = ['BIOS Information', 'Vendor:', 'Version:', 'Release Date:', 'BIOS R
 
 BASE_BOARD = ['Base Board Information', 'Manufacturer:', 'Product Name:', 'Version:']
 
+BOARD_NAMES = ['apl-mrb', 'apl-nuc', 'apl-up2', 'dnv-cb2', 'nuc6cayh',
+               'nuc7i7dnb', 'kbl-nuc-i7', 'icl-rvp']
+
 TTY_CONSOLE = {
     'ttyS0':'0x3F8',
     'ttyS1':'0x2F8',
@@ -430,3 +433,30 @@ def get_vuart_info_id(config_file, idx):
             vm_id += 1
 
     return tmp_tag
+
+
+def get_processor_info():
+    """
+    Get cpu processor list
+    :param board_info: it is a file what contains board information
+    :return: cpu processor list
+    """
+    processor_list = []
+    tmp_list = []
+    processor_info = get_info(BOARD_INFO_FILE, "<CPU_PROCESSOR_INFO>", "</CPU_PROCESSOR_INFO>")
+
+    if not processor_info:
+        key = "CPU PROCESSOR_INFO error:"
+        ERR_LIST[key] = "CPU core is not exists"
+        return processor_list
+
+    for processor_line in processor_info:
+        if not processor_line:
+            break
+
+        processor_list = processor_line.strip().split(',')
+        for processor in processor_list:
+            tmp_list.append(processor.strip())
+        break
+
+    return tmp_list

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -251,13 +251,13 @@ def get_order_type_by_vmid(idx):
     """
     This is get pre launched vm count
     :param idx: index of vm id
-    :return: idx and vm type mapping
+    :return: vm type of index to vmid
     """
-    (err_dic, order_id_dic) = common.get_load_order_by_vmid(SCENARIO_INFO_FILE, VM_COUNT, idx)
+    (err_dic, order_type) = common.get_load_order_by_vmid(SCENARIO_INFO_FILE, VM_COUNT, idx)
     if err_dic:
         ERR_LIST.update(err_dic)
 
-    return order_id_dic
+    return order_type
 
 
 def get_valid_irq(board_info):

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -114,7 +114,7 @@ def get_processor_info(board_info):
     processor_info = get_info(board_info, "<CPU_PROCESSOR_INFO>", "</CPU_PROCESSOR_INFO>")
 
     if not processor_info:
-        key = "vm:id=0,pcpu_ids"
+        key = "vm:id=0,vcpu_affinity"
         ERR_LIST[key] = "CPU core is not exists"
         return processor_list
 
@@ -637,14 +637,14 @@ def cpus_assignment(cpus_per_vm, index):
     for i in range(len(cpus_per_vm[index])):
         if i == 0:
             if len(cpus_per_vm[index]) == 1:
-                cpu_str = "(PLUG_CPU({0}))".format(cpus_per_vm[index][0])
+                cpu_str = "{{AFFINITY_CPU({0}U)}}".format(cpus_per_vm[index][0])
             else:
-                cpu_str = "(PLUG_CPU({0})".format(cpus_per_vm[index][0])
+                cpu_str = "{{AFFINITY_CPU({0}U)".format(cpus_per_vm[index][0])
         else:
             if i == len(cpus_per_vm[index]) - 1:
-                cpu_str = cpu_str + " | PLUG_CPU({0}))".format(cpus_per_vm[index][i])
+                cpu_str = cpu_str + " , AFFINITY_CPU({0}U)}}".format(cpus_per_vm[index][i])
             else:
-                cpu_str = cpu_str + " | PLUG_CPU({0})".format(cpus_per_vm[index][i])
+                cpu_str = cpu_str + " , AFFINITY_CPU({0}U)".format(cpus_per_vm[index][i])
 
     vm_cpu_bmp['cpu_map'] = cpu_str
     vm_cpu_bmp['cpu_num'] = len(cpus_per_vm[index])

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -34,7 +34,7 @@ def get_scenario_item_values(board_info, scenario_info):
     # pre scenario
     guest_flags = copy.deepcopy(scenario_cfg_lib.GUEST_FLAG)
     guest_flags.remove('0UL')
-    scenario_item_values["vm,pcpu_ids"] = hw_info.get_processor_val()
+    scenario_item_values["vm,vcpu_affinity"] = hw_info.get_processor_val()
     scenario_item_values["vm,guest_flags"] = guest_flags
     scenario_item_values["vm,clos"] = hw_info.get_clos_val()
     scenario_item_values["vm,os_config,kern_type"] = scenario_cfg_lib.KERN_TYPE_LIST

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -67,15 +67,15 @@ class HwInfo:
 
 class CfgOsKern:
     """ This is Abstract of class of configuration of vm os kernel setting """
-    kern_name = []
-    kern_type = []
-    kern_mod = []
-    kern_args = []
-    kern_console = []
-    kern_load_addr = []
-    kern_entry_addr = []
-    kern_root_dev = []
-    kern_args_append = []
+    kern_name = {}
+    kern_type = {}
+    kern_mod = {}
+    kern_args = {}
+    kern_console = {}
+    kern_load_addr = {}
+    kern_entry_addr = {}
+    kern_root_dev = {}
+    kern_args_append = {}
 
     def __init__(self, scenario_file):
         self.scenario_info = scenario_file
@@ -85,38 +85,37 @@ class CfgOsKern:
         Get all items which belong to this class
         :return: None
         """
-        self.kern_name = scenario_cfg_lib.get_sub_leaf_tag(self.scenario_info, "os_config", "name")
-        self.kern_type = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_name = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "os_config", "name")
+        self.kern_type = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "kern_type")
-        self.kern_mod = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_mod = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "kern_mod")
-        self.kern_args = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_args = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "bootargs")
-        self.kern_console = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_console = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "console")
-        self.kern_load_addr = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_load_addr = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "kern_load_addr")
-        self.kern_entry_addr = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_entry_addr = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "kern_entry_addr")
-        self.kern_root_dev = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_root_dev = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "rootfs")
-        self.kern_args_append = scenario_cfg_lib.get_sub_leaf_tag(
+        self.kern_args_append = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "boot_private", "bootargs")
 
-    @staticmethod
-    def check_item():
+    def check_item(self):
         """
         Check all items in this class
         :return: None
         """
-        scenario_cfg_lib.os_kern_name_check("name")
-        scenario_cfg_lib.os_kern_type_check("kern_type")
-        scenario_cfg_lib.os_kern_mod_check("kern_mod")
-        scenario_cfg_lib.os_kern_args_check("kern_args")
-        scenario_cfg_lib.os_kern_console_check("console")
-        scenario_cfg_lib.os_kern_load_addr_check("kern_load_addr")
-        scenario_cfg_lib.os_kern_entry_addr_check("kern_entry_addr")
-        scenario_cfg_lib.os_kern_root_dev_check("rootdev")
+        scenario_cfg_lib.os_kern_name_check(self.kern_name, "name")
+        scenario_cfg_lib.os_kern_type_check(self.kern_type, "kern_type")
+        scenario_cfg_lib.os_kern_mod_check(self.kern_mod, "kern_mod")
+        scenario_cfg_lib.os_kern_args_check(self.kern_args, "kern_args")
+        scenario_cfg_lib.os_kern_console_check(self.kern_console, "console")
+        scenario_cfg_lib.os_kern_load_addr_check(self.kern_load_addr, "kern_load_addr")
+        scenario_cfg_lib.os_kern_entry_addr_check(self.kern_entry_addr, "kern_entry_addr")
+        scenario_cfg_lib.os_kern_root_dev_check(self.kern_root_dev, "rootdev")
 
 
 class VuartTarget:
@@ -175,8 +174,8 @@ class VuartInfo:
 
 class MemInfo:
     """ This is Abstract of class of memory setting information """
-    mem_start_hpa = []
-    mem_size = []
+    mem_start_hpa = {}
+    mem_size = {}
 
     def __init__(self, scenario_file):
         self.scenario_info = scenario_file
@@ -186,25 +185,24 @@ class MemInfo:
         Get all items which belong to this class
         :return: None
         """
-        self.mem_start_hpa = scenario_cfg_lib.get_sub_leaf_tag(
+        self.mem_start_hpa = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "memory", "start_hpa")
-        self.mem_size = scenario_cfg_lib.get_sub_leaf_tag(
+        self.mem_size = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "memory", "size")
 
-    @staticmethod
-    def check_item():
+    def check_item(self):
         """
         Check all items in this class
         :return: None
         """
-        scenario_cfg_lib.mem_start_hpa_check("start_hpa")
-        scenario_cfg_lib.mem_size_check("size")
+        scenario_cfg_lib.mem_start_hpa_check(self.mem_start_hpa, "start_hpa")
+        scenario_cfg_lib.mem_size_check(self.mem_size, "size")
 
 
 class CfgPci:
     """ This is Abstract of class of PCi devices setting information """
-    pci_dev_num = []
-    pci_devs = []
+    pci_dev_num = {}
+    pci_devs = {}
 
     def __init__(self, scenario_file):
         self.scenario_info = scenario_file
@@ -214,14 +212,14 @@ class CfgPci:
         Get pci device number items
         :return: None
         """
-        self.pci_dev_num = scenario_cfg_lib.get_sub_tree_tag(self.scenario_info, "pci_dev_num")
+        self.pci_dev_num = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "pci_dev_num")
 
     def get_pci_devs(self):
         """
         Get pci devices items
         :return: None
         """
-        self.pci_devs = scenario_cfg_lib.get_sub_tree_tag(self.scenario_info, "pci_devs")
+        self.pci_devs = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "pci_devs")
 
     def get_info(self):
         """
@@ -231,13 +229,12 @@ class CfgPci:
         self.get_pci_dev_num()
         self.get_pci_devs()
 
-    @staticmethod
-    def check_item():
+    def check_item(self):
         """ Check all items in this class
         :return: None
         """
-        scenario_cfg_lib.pci_dev_num_check("pci_dev_num")
-        scenario_cfg_lib.pci_devs_check("pci_devs")
+        scenario_cfg_lib.pci_dev_num_check(self.pci_dev_num, "pci_dev_num")
+        scenario_cfg_lib.pci_devs_check(self.pci_devs, "pci_devs")
 
 
 class EpcSection:
@@ -248,18 +245,18 @@ class EpcSection:
         self.scenario_info = scenario_info
 
     def get_info(self):
-        self.base = scenario_cfg_lib.get_epc_base(self.scenario_info)
-        self.size = scenario_cfg_lib.get_epc_size(self.scenario_info)
+        self.base = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "epc_section", "base")
+        self.size = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "epc_section", "size")
 
 
 class VmInfo:
     """ This is Abstract of class of VM setting """
-    name = []
-    load_order = []
-    uuid = []
-    clos_set = []
-    guest_flag_idx = []
-    cpus_per_vm = []
+    name = {}
+    load_order = {}
+    uuid = {}
+    clos_set = {}
+    guest_flag_idx = {}
+    cpus_per_vm = {}
 
     def __init__(self, board_file, scenario_file):
         self.board_info = board_file
@@ -277,14 +274,14 @@ class VmInfo:
         Get all items which belong to this class
         :return: None
         """
-        self.name = scenario_cfg_lib.get_sub_tree_tag(self.scenario_info, "name")
-        self.load_order = scenario_cfg_lib.get_sub_tree_tag(self.scenario_info, "load_order")
-        self.uuid = scenario_cfg_lib.get_sub_tree_tag(self.scenario_info, "uuid")
+        self.name = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "name")
+        self.load_order = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "load_order")
+        self.uuid = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "uuid")
         self.guest_flag_idx = scenario_cfg_lib.get_sub_leaf_tag(
             self.scenario_info, "guest_flags", "guest_flag")
-        self.cpus_per_vm = scenario_cfg_lib.get_sub_leaf_tag(
+        self.cpus_per_vm = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "pcpu_ids", "pcpu_id")
-        self.clos_set = scenario_cfg_lib.get_sub_tree_tag(self.scenario_info, "clos")
+        self.clos_set = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "clos")
         self.epc_section.get_info()
         self.mem_info.get_info()
         self.os_cfg.get_info()
@@ -307,7 +304,7 @@ class VmInfo:
         scenario_cfg_lib.load_order_check(self.load_order, "load_order")
         scenario_cfg_lib.uuid_format_check(self.uuid, "uuid")
         scenario_cfg_lib.guest_flag_check(self.guest_flag_idx, "guest_flags", "guest_flag")
-        scenario_cfg_lib.cpus_per_vm_check("pcpu_id")
+        scenario_cfg_lib.cpus_per_vm_check(self.cpus_per_vm, "pcpu_id")
 
         self.mem_info.check_item()
         self.os_cfg.check_item()

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -280,7 +280,7 @@ class VmInfo:
         self.guest_flag_idx = scenario_cfg_lib.get_sub_leaf_tag(
             self.scenario_info, "guest_flags", "guest_flag")
         self.cpus_per_vm = scenario_cfg_lib.get_leaf_tag_map(
-            self.scenario_info, "pcpu_ids", "pcpu_id")
+            self.scenario_info, "vcpu_affinity", "pcpu_id")
         self.clos_set = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "clos")
         self.epc_section.get_info()
         self.mem_info.get_info()

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -38,6 +38,8 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
   </vm>
   <vm id="1">
     <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -6,9 +6,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -90,6 +90,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
@@ -48,6 +48,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -72,6 +75,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -96,6 +102,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -6,10 +6,10 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag></guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -52,10 +52,10 @@
         <guest_flag>GUEST_FLAG_RT</guest_flag>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -48,6 +48,11 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -70,6 +75,9 @@
     <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc2.xml
@@ -48,6 +48,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -72,6 +75,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -96,6 +102,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -7,9 +7,9 @@
         <guest_flag></guest_flag>
         <guest_flag></guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>0</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -52,9 +52,9 @@
         <guest_flag>GUEST_FLAG_RT</guest_flag>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -38,6 +38,8 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
   </vm>
   <vm id="1">
     <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -6,9 +6,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -90,6 +90,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
@@ -48,6 +48,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -72,6 +75,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -96,6 +102,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -7,10 +7,10 @@
         <guest_flag></guest_flag>
         <guest_flag></guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -53,10 +53,10 @@
         <guest_flag>GUEST_FLAG_RT</guest_flag>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -48,6 +48,11 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -70,6 +75,9 @@
     <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc2.xml
@@ -48,6 +48,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -72,6 +75,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -96,6 +102,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -38,6 +38,8 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
   </vm>
   <vm id="1">
     <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -6,9 +6,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -88,6 +88,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry.xml
@@ -46,6 +46,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -70,6 +73,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -94,6 +100,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
@@ -7,10 +7,10 @@
         <guest_flag></guest_flag>
         <guest_flag></guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -53,10 +53,10 @@
         <guest_flag>GUEST_FLAG_RT</guest_flag>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
@@ -46,6 +46,11 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -68,6 +73,9 @@
     <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc2.xml
@@ -46,6 +46,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -70,6 +73,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -94,6 +100,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -38,6 +38,8 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
   </vm>
   <vm id="1">
     <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -6,9 +6,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -89,6 +89,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
@@ -47,6 +47,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -71,6 +74,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -95,6 +101,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -7,10 +7,10 @@
         <guest_flag></guest_flag>
         <guest_flag></guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -53,10 +53,10 @@
         <guest_flag>GUEST_FLAG_RT</guest_flag>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -47,6 +47,11 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -69,6 +74,9 @@
     <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc2.xml
@@ -47,6 +47,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -71,6 +74,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -95,6 +101,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -38,6 +38,8 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
   </vm>
   <vm id="1">
     <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -6,9 +6,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -89,6 +89,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -47,6 +47,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -71,6 +74,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -95,6 +101,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -7,10 +7,10 @@
         <guest_flag></guest_flag>
         <guest_flag></guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -53,10 +53,10 @@
         <guest_flag>GUEST_FLAG_RT</guest_flag>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
     </guest_flags>
-    <pcpu_ids desc="Assign physical CPU IDs to the VM" multiselect="true">
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
-    </pcpu_ids>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -47,6 +47,11 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -69,6 +74,9 @@
     <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc2.xml
@@ -47,6 +47,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -71,6 +74,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -95,6 +101,9 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>


### PR DESCRIPTION
acrn-config: update vcpu affinity in web UI
    According to the new vcpu affinity configuration method, update vcpu
    configuration in Web UI from multi-select box to seperated select box
    which can dynamically add or delete vcpus with mapped pcpus.

acrn-config: keep align with vcpu_affinity for vm config
    The pcpu sharing for vm already enabled in master branch, acrn-config
    tool for generating scenario config souce file should keep align with master branch.
    1. Add 'vcpu_affinity' tag and its vaule in config xml.
    2. Parse the 'vcpu_affinity' tag of value from config xml for generating vcpu_affinity.
    v1-v2:
        1). apl-up2-n3350 has two PCPUs, set appropriate value for vcpu_affinity.

acrn-config: refine the data type for member of class
    Unify the data type for scenario item.
    1. Unified the scenario item, the type modified from list to dictionary.
    2. remove some unused function.
    3. add 'pci_dev_num'/'pci_devs' to hybrid xml for future support.

acrn-config: grab Processor CPU number from board information
    The value of CONFIG_MAX_PCPU_NUM is stands for Processor CPU number and
    it is grabed from board information.

    Tracked-On: #3798
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>


