### PR TITLE
change schedule related structs and vars naming for scheduler abstraction

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -668,7 +668,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 	vcpu->state = new_state;
 
 	if (vcpu->running) {
-		remove_from_cpu_runqueue(&vcpu->thread_obj);
+		remove_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
 
 		if (is_lapic_pt_enabled(vcpu)) {
 			make_reschedule_request(vcpu->pcpu_id, DEL_MODE_INIT);
@@ -684,7 +684,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 			}
 		}
 	} else {
-		remove_from_cpu_runqueue(&vcpu->thread_obj);
+		remove_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
 		release_schedule_lock(vcpu->pcpu_id);
 	}
 }
@@ -697,7 +697,7 @@ void resume_vcpu(struct acrn_vcpu *vcpu)
 	vcpu->state = vcpu->prev_state;
 
 	if (vcpu->state == VCPU_RUNNING) {
-		add_to_cpu_runqueue(&vcpu->thread_obj, vcpu->pcpu_id);
+		insert_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
 		make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
 	}
 	release_schedule_lock(vcpu->pcpu_id);
@@ -734,7 +734,7 @@ void schedule_vcpu(struct acrn_vcpu *vcpu)
 	pr_dbg("vcpu%hu scheduled", vcpu->vcpu_id);
 
 	get_schedule_lock(vcpu->pcpu_id);
-	add_to_cpu_runqueue(&vcpu->thread_obj, vcpu->pcpu_id);
+	insert_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
 	make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
 	release_schedule_lock(vcpu->pcpu_id);
 }
@@ -748,7 +748,6 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 
 	ret = create_vcpu(pcpu_id, vm, &vcpu);
 	if (ret == 0) {
-		INIT_LIST_HEAD(&vcpu->thread_obj.run_list);
 		snprintf(thread_name, 16U, "vm%hu:vcpu%hu", vm->vm_id, vcpu->vcpu_id);
 		(void)strncpy_s(vcpu->thread_obj.name, 16U, thread_name, 16U);
 		vcpu->thread_obj.thread_entry = vcpu_thread;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -611,7 +611,7 @@ static uint64_t build_stack_frame(struct acrn_vcpu *vcpu)
 	frame->r13 = 0UL;
 	frame->r14 = 0UL;
 	frame->r15 = 0UL;
-	frame->rdi = (uint64_t)&vcpu->sched_obj;
+	frame->rdi = (uint64_t)&vcpu->thread_obj;
 
 	ret = &frame->rdi;
 
@@ -640,7 +640,7 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 		vcpu->arch.exception_info.exception = VECTOR_INVALID;
 		vcpu->arch.cur_context = NORMAL_WORLD;
 		vcpu->arch.irq_window_enabled = false;
-		vcpu->sched_obj.host_sp = build_stack_frame(vcpu);
+		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		(void)memset((void *)vcpu->arch.vmcs, 0U, PAGE_SIZE);
 
 		for (i = 0; i < NR_WORLD; i++) {
@@ -668,7 +668,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 	vcpu->state = new_state;
 
 	if (vcpu->running) {
-		remove_from_cpu_runqueue(&vcpu->sched_obj);
+		remove_from_cpu_runqueue(&vcpu->thread_obj);
 
 		if (is_lapic_pt_enabled(vcpu)) {
 			make_reschedule_request(vcpu->pcpu_id, DEL_MODE_INIT);
@@ -684,7 +684,7 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 			}
 		}
 	} else {
-		remove_from_cpu_runqueue(&vcpu->sched_obj);
+		remove_from_cpu_runqueue(&vcpu->thread_obj);
 		release_schedule_lock(vcpu->pcpu_id);
 	}
 }
@@ -697,15 +697,15 @@ void resume_vcpu(struct acrn_vcpu *vcpu)
 	vcpu->state = vcpu->prev_state;
 
 	if (vcpu->state == VCPU_RUNNING) {
-		add_to_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
+		add_to_cpu_runqueue(&vcpu->thread_obj, vcpu->pcpu_id);
 		make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
 	}
 	release_schedule_lock(vcpu->pcpu_id);
 }
 
-static void context_switch_out(struct sched_object *prev)
+static void context_switch_out(struct thread_object *prev)
 {
-	struct acrn_vcpu *vcpu = list_entry(prev, struct acrn_vcpu, sched_obj);
+	struct acrn_vcpu *vcpu = list_entry(prev, struct acrn_vcpu, thread_obj);
 
 	vcpu->running = false;
 	/* do prev vcpu context switch out */
@@ -715,9 +715,9 @@ static void context_switch_out(struct sched_object *prev)
 	 */
 }
 
-static void context_switch_in(struct sched_object *next)
+static void context_switch_in(struct thread_object *next)
 {
-	struct acrn_vcpu *vcpu = list_entry(next, struct acrn_vcpu, sched_obj);
+	struct acrn_vcpu *vcpu = list_entry(next, struct acrn_vcpu, thread_obj);
 
 	vcpu->running = true;
 	/* FIXME:
@@ -734,7 +734,7 @@ void schedule_vcpu(struct acrn_vcpu *vcpu)
 	pr_dbg("vcpu%hu scheduled", vcpu->vcpu_id);
 
 	get_schedule_lock(vcpu->pcpu_id);
-	add_to_cpu_runqueue(&vcpu->sched_obj, vcpu->pcpu_id);
+	add_to_cpu_runqueue(&vcpu->thread_obj, vcpu->pcpu_id);
 	make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
 	release_schedule_lock(vcpu->pcpu_id);
 }
@@ -748,13 +748,13 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 
 	ret = create_vcpu(pcpu_id, vm, &vcpu);
 	if (ret == 0) {
-		INIT_LIST_HEAD(&vcpu->sched_obj.run_list);
+		INIT_LIST_HEAD(&vcpu->thread_obj.run_list);
 		snprintf(thread_name, 16U, "vm%hu:vcpu%hu", vm->vm_id, vcpu->vcpu_id);
-		(void)strncpy_s(vcpu->sched_obj.name, 16U, thread_name, 16U);
-		vcpu->sched_obj.thread = vcpu_thread;
-		vcpu->sched_obj.host_sp = build_stack_frame(vcpu);
-		vcpu->sched_obj.prepare_switch_out = context_switch_out;
-		vcpu->sched_obj.prepare_switch_in = context_switch_in;
+		(void)strncpy_s(vcpu->thread_obj.name, 16U, thread_name, 16U);
+		vcpu->thread_obj.thread_entry = vcpu_thread;
+		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
+		vcpu->thread_obj.switch_out = context_switch_out;
+		vcpu->thread_obj.switch_in = context_switch_in;
 	}
 
 	return ret;

--- a/hypervisor/arch/x86/sched.S
+++ b/hypervisor/arch/x86/sched.S
@@ -6,12 +6,12 @@
 
 /*
  * Function schedule() will finally call arch_switch_to here for x86 platform, which use
- * the pointer of previous & next sched_obj->host_sp as the input parameters (rdi & rsi).
+ * the pointer of previous & next thread_obj->host_sp as the input parameters (rdi & rsi).
  *
  * Function arch_switch_to will save rflags, rbx, rbp, r12~r15, and rdi in the previous
- * sched_obj's stack, then switch stack pointer(rsp) from previous to next sched_obj (saved
- * in sched_obj->host_sp) and restore above registers from next sched_obj's stack.
- * It make sure the execution context return to the same point of next sched_obj when it got
+ * thread_obj's stack, then switch stack pointer(rsp) from previous to next thread_obj (saved
+ * in thread_obj->host_sp) and restore above registers from next thread_obj's stack.
+ * It make sure the execution context return to the same point of next thread_obj when it got
  * scheduled last time.
  */
     .text

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -15,9 +15,9 @@
 #include <trace.h>
 #include <logmsg.h>
 
-void vcpu_thread(struct sched_object *obj)
+void vcpu_thread(struct thread_object *obj)
 {
-	struct acrn_vcpu *vcpu = list_entry(obj, struct acrn_vcpu, sched_obj);
+	struct acrn_vcpu *vcpu = list_entry(obj, struct acrn_vcpu, thread_obj);
 	uint32_t basic_exit_reason = 0U;
 	int32_t ret = 0;
 
@@ -78,7 +78,7 @@ void vcpu_thread(struct sched_object *obj)
 	} while (1);
 }
 
-void default_idle(__unused struct sched_object *obj)
+void default_idle(__unused struct thread_object *obj)
 {
 	uint16_t pcpu_id = get_pcpu_id();
 

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -15,52 +15,52 @@
 
 void init_scheduler(void)
 {
-	struct sched_context *ctx;
+	struct sched_control *ctl;
 	uint32_t i;
 	uint16_t pcpu_nums = get_pcpu_nums();
 
 	for (i = 0U; i < pcpu_nums; i++) {
-		ctx = &per_cpu(sched_ctx, i);
+		ctl = &per_cpu(sched_ctl, i);
 
-		spinlock_init(&ctx->scheduler_lock);
-		INIT_LIST_HEAD(&ctx->runqueue);
-		ctx->flags = 0UL;
-		ctx->curr_obj = NULL;
+		spinlock_init(&ctl->scheduler_lock);
+		INIT_LIST_HEAD(&ctl->runqueue);
+		ctl->flags = 0UL;
+		ctl->curr_obj = NULL;
 	}
 }
 
 void get_schedule_lock(uint16_t pcpu_id)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-	spinlock_obtain(&ctx->scheduler_lock);
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
+	spinlock_obtain(&ctl->scheduler_lock);
 }
 
 void release_schedule_lock(uint16_t pcpu_id)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-	spinlock_release(&ctx->scheduler_lock);
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
+	spinlock_release(&ctl->scheduler_lock);
 }
 
-void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id)
+void add_to_cpu_runqueue(struct thread_object *obj, uint16_t pcpu_id)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
 
 	if (list_empty(&obj->run_list)) {
-		list_add_tail(&obj->run_list, &ctx->runqueue);
+		list_add_tail(&obj->run_list, &ctl->runqueue);
 	}
 }
 
-void remove_from_cpu_runqueue(struct sched_object *obj)
+void remove_from_cpu_runqueue(struct thread_object *obj)
 {
 	list_del_init(&obj->run_list);
 }
 
-static struct sched_object *get_next_sched_obj(struct sched_context *ctx)
+static struct thread_object *get_next_sched_obj(struct sched_control *ctl)
 {
-	struct sched_object *obj = NULL;
+	struct thread_object *obj = NULL;
 
-	if (!list_empty(&ctx->runqueue)) {
-		obj = get_first_item(&ctx->runqueue, struct sched_object, run_list);
+	if (!list_empty(&ctl->runqueue)) {
+		obj = get_first_item(&ctl->runqueue, struct thread_object, run_list);
 	} else {
 		obj = &get_cpu_var(idle);
 	}
@@ -73,9 +73,9 @@ static struct sched_object *get_next_sched_obj(struct sched_context *ctx)
  */
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
 
-	bitmap_set_lock(NEED_RESCHEDULE, &ctx->flags);
+	bitmap_set_lock(NEED_RESCHEDULE, &ctl->flags);
 	if (get_pcpu_id() != pcpu_id) {
 		switch (delmode) {
 		case DEL_MODE_IPI:
@@ -93,67 +93,67 @@ void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode)
 
 bool need_reschedule(uint16_t pcpu_id)
 {
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
 
-	return bitmap_test(NEED_RESCHEDULE, &ctx->flags);
+	return bitmap_test(NEED_RESCHEDULE, &ctl->flags);
 }
 
-static void prepare_switch(struct sched_object *prev, struct sched_object *next)
+static void do_switch(struct thread_object *prev, struct thread_object *next)
 {
-	if ((prev != NULL) && (prev->prepare_switch_out != NULL)) {
-		prev->prepare_switch_out(prev);
+	if ((prev != NULL) && (prev->switch_out != NULL)) {
+		prev->switch_out(prev);
 	}
 
 	/* update current object */
-	get_cpu_var(sched_ctx).curr_obj = next;
+	get_cpu_var(sched_ctl).curr_obj = next;
 
-	if ((next != NULL) && (next->prepare_switch_in != NULL)) {
-		next->prepare_switch_in(next);
+	if ((next != NULL) && (next->switch_in != NULL)) {
+		next->switch_in(next);
 	}
 }
 
 void schedule(void)
 {
 	uint16_t pcpu_id = get_pcpu_id();
-	struct sched_context *ctx = &per_cpu(sched_ctx, pcpu_id);
-	struct sched_object *next = NULL;
-	struct sched_object *prev = ctx->curr_obj;
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
+	struct thread_object *next = NULL;
+	struct thread_object *prev = ctl->curr_obj;
 
 	get_schedule_lock(pcpu_id);
-	next = get_next_sched_obj(ctx);
-	bitmap_clear_lock(NEED_RESCHEDULE, &ctx->flags);
+	next = get_next_sched_obj(ctl);
+	bitmap_clear_lock(NEED_RESCHEDULE, &ctl->flags);
 
 	if (prev == next) {
 		release_schedule_lock(pcpu_id);
 	} else {
-		prepare_switch(prev, next);
+		do_switch(prev, next);
 		release_schedule_lock(pcpu_id);
 
 		arch_switch_to(&prev->host_sp, &next->host_sp);
 	}
 }
 
-void run_sched_thread(struct sched_object *obj)
+void run_sched_thread(struct thread_object *obj)
 {
-	if (obj->thread != NULL) {
-		obj->thread(obj);
+	if (obj->thread_entry != NULL) {
+		obj->thread_entry(obj);
 	}
 
-	ASSERT(false, "Shouldn't go here, invalid thread!");
+	ASSERT(false, "Shouldn't go here, invalid thread entry!");
 }
 
-void switch_to_idle(run_thread_t idle_thread)
+void switch_to_idle(thread_entry_t idle_thread)
 {
 	uint16_t pcpu_id = get_pcpu_id();
-	struct sched_object *idle = &per_cpu(idle, pcpu_id);
+	struct thread_object *idle = &per_cpu(idle, pcpu_id);
 	char idle_name[16];
 
 	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
 	(void)strncpy_s(idle->name, 16U, idle_name, 16U);
-	idle->thread = idle_thread;
-	idle->prepare_switch_out = NULL;
-	idle->prepare_switch_in = NULL;
-	get_cpu_var(sched_ctx).curr_obj = idle;
+	idle->thread_entry = idle_thread;
+	idle->switch_out = NULL;
+	idle->switch_in = NULL;
+	get_cpu_var(sched_ctl).curr_obj = idle;
 
 	run_sched_thread(idle);
 }

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -247,7 +247,7 @@ struct acrn_vcpu {
 	volatile enum vcpu_state prev_state;
 	volatile enum vcpu_state state;	/* State of this VCPU */
 
-	struct sched_object sched_obj;
+	struct thread_object thread_obj;
 	bool launched; /* Whether the vcpu is launched on target pcpu */
 	volatile bool running; /* vcpu is picked up and run? */
 
@@ -286,8 +286,8 @@ vcpu_vlapic(struct acrn_vcpu *vcpu)
 	return &(vcpu->arch.vlapic);
 }
 
-void default_idle(__unused struct sched_object *obj);
-void vcpu_thread(struct sched_object *obj);
+void default_idle(__unused struct thread_object *obj);
+void vcpu_thread(struct thread_object *obj);
 
 int32_t vmx_vmrun(struct run_context *context, int32_t ops, int32_t ibrs);
 

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -37,8 +37,8 @@ struct per_cpu_region {
 	struct stack_canary stk_canary;
 #endif
 	struct per_cpu_timers cpu_timers;
-	struct sched_context sched_ctx;
-	struct sched_object idle;
+	struct sched_control sched_ctl;
+	struct thread_object idle;
 	struct host_gdt gdt;
 	struct tss_64 tss;
 	enum pcpu_boot_state boot_state;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -13,38 +13,38 @@
 #define DEL_MODE_INIT		(1U)
 #define DEL_MODE_IPI		(2U)
 
-struct sched_object;
-typedef void (*run_thread_t)(struct sched_object *obj);
-typedef void (*prepare_switch_t)(struct sched_object *obj);
-struct sched_object {
+struct thread_object;
+typedef void (*thread_entry_t)(struct thread_object *obj);
+typedef void (*switch_t)(struct thread_object *obj);
+struct thread_object {
 	char name[16];
 	struct list_head run_list;
 	uint64_t host_sp;
-	run_thread_t thread;
-	prepare_switch_t prepare_switch_out;
-	prepare_switch_t prepare_switch_in;
+	thread_entry_t thread_entry;
+	switch_t switch_out;
+	switch_t switch_in;
 };
 
-struct sched_context {
+struct sched_control {
 	struct list_head runqueue;
 	uint64_t flags;
-	struct sched_object *curr_obj;
-	spinlock_t scheduler_lock;	/* to protect sched_context and sched_object */
+	struct thread_object *curr_obj;
+	spinlock_t scheduler_lock;	/* to protect sched_control and thread_object */
 };
 
 void init_scheduler(void);
-void switch_to_idle(run_thread_t idle_thread);
+void switch_to_idle(thread_entry_t idle_thread);
 void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);
 
-void add_to_cpu_runqueue(struct sched_object *obj, uint16_t pcpu_id);
-void remove_from_cpu_runqueue(struct sched_object *obj);
+void add_to_cpu_runqueue(struct thread_object *obj, uint16_t pcpu_id);
+void remove_from_cpu_runqueue(struct thread_object *obj);
 
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);
 
 void schedule(void);
-void run_sched_thread(struct sched_object *obj);
+void run_sched_thread(struct thread_object *obj);
 
 void arch_switch_to(void *prev_sp, void *next_sp);
 #endif /* SCHEDULE_H */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -18,7 +18,6 @@ typedef void (*thread_entry_t)(struct thread_object *obj);
 typedef void (*switch_t)(struct thread_object *obj);
 struct thread_object {
 	char name[16];
-	struct list_head run_list;
 	uint64_t host_sp;
 	thread_entry_t thread_entry;
 	switch_t switch_out;
@@ -26,10 +25,11 @@ struct thread_object {
 };
 
 struct sched_control {
-	struct list_head runqueue;
 	uint64_t flags;
 	struct thread_object *curr_obj;
 	spinlock_t scheduler_lock;	/* to protect sched_control and thread_object */
+
+	struct thread_object *thread_obj;
 };
 
 void init_scheduler(void);
@@ -37,8 +37,8 @@ void switch_to_idle(thread_entry_t idle_thread);
 void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);
 
-void add_to_cpu_runqueue(struct thread_object *obj, uint16_t pcpu_id);
-void remove_from_cpu_runqueue(struct thread_object *obj);
+void insert_thread_obj(struct thread_object *obj, uint16_t pcpu_id);
+void remove_thread_obj(struct thread_object *obj, uint16_t pcpu_id);
 
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);


### PR DESCRIPTION
1. change naming   
    prepare_switch_out -> switch_out
    prepare_switch_in -> switch_in
    prepare_switch -> do_switch
    run_thread_t -> thread_t
    sched_object -> thread_object
    sched_object.thread -> thread_object.thread_entry
    sched_obj -> thread_obj
    sched_context -> sched_control
    sched_ctx -> sched_ctl
2. remove runqueue from current schedule logic
3. move pcpu_id from acrn_vcpu to thread_object

