### PR TITLE
dm: close filepointer before return from acrn_load_elf()

### DIFF
--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -243,6 +243,7 @@ acrn_load_elf(struct vmctx *ctx, char *elf_file_name, unsigned long *entry,
 	}
 
 	*entry = elf_ehdr->e_entry;
+	fclose(fp);
 	free(elf_buf);
 
 	return ret;


### PR DESCRIPTION
 In acrn_load_elf(), file pointer 'fp' is kept in
 open state after 'load_elf32()', this patch is to
 fix this bug.

Tracked-On: #3817
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>