### PR TITLE
dm: validation for input to public functions

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -2490,6 +2490,8 @@ pci_get_vdev_info(int slot)
 	bi = pci_businfo[0];
 	if (bi == NULL)
 		return NULL;
+	if (slot < 0 || slot >= MAXSLOTS)
+		return NULL;
 
 	si = &bi->slotinfo[slot];
 	if (si != NULL)


### PR DESCRIPTION
slot value should be checked in range before used to access
bi->slotinfo[].

Tracked-On: #3822
Signed-off-by: Gao Junhao <junhao.gao@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>