### PR TITLE
acrn-config: add confirmation for commit of generated source in config app

### DIFF
--- a/misc/acrn-config/board_config/board_cfg_gen.py
+++ b/misc/acrn-config/board_config/board_cfg_gen.py
@@ -31,7 +31,7 @@ def main(args):
     config_srcs = []
     config_dirs = []
 
-    (err_dic, board_info_file, scenario_info_file) = board_cfg_lib.get_param(args)
+    (err_dic, board_info_file, scenario_info_file, enable_commit) = board_cfg_lib.get_param(args)
     if err_dic:
         return err_dic
 
@@ -104,22 +104,29 @@ def main(args):
             if err_dic:
                 return err_dic
 
+    config_str = 'Config files'
+    gen_str = 'generated'
     # move changes to patch, and apply to the source code
-    err_dic = board_cfg_lib.gen_patch(config_srcs, board)
+    if enable_commit:
+        err_dic = board_cfg_lib.gen_patch(config_srcs, board)
+        config_str = 'Config patch'
+        gen_str = 'committed'
 
     if board not in board_cfg_lib.BOARD_NAMES and not err_dic:
-        print("Config patch for NEW board {} is committed successfully!".format(board))
+        print("{} for NEW board {} is {} successfully!".format(config_str, board, gen_str))
     elif not err_dic:
-        print("Config patch for {} is committed successfully!".format(board))
+        print("{} for {} is {} successfully!".format(config_str, board, gen_str))
     else:
-        print("Config patch for {} is failed".format(board))
+        print("{} for {} is failed".format(config_str, board))
 
     return err_dic
 
 
-def ui_entry_api(board_info,scenario_info):
+def ui_entry_api(board_info,scenario_info, enable_commit=False):
 
     arg_list = ['board_cfg_gen.py', '--board', board_info, '--scenario', scenario_info]
+    if enable_commit:
+        arg_list.append('--enable_commit')
 
     err_dic = board_cfg_lib.prepare()
     if err_dic:

--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -419,19 +419,25 @@ function save_scenario(generator=null){
             })
             if(no_err == true && status == 'success') {
                 file_name = result.file_name;
+                validate_message = 'Scenario setting saved successfully with name: '
+                    +file_name+'\ninto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/.'
                 if(result.rename==true) {
-                    alert('Scenario setting existed, saved successfully with a new name: '
-                        +file_name+'\nto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/');
-                } else {
-                    alert('Scenario setting saved successfully with name: '
-                        +file_name+'\nto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/');
+                    validate_message = 'Scenario setting existed, saved successfully with a new name: '
+                        +file_name+'\ninto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/.';
                 }
                 if(generator != null) {
+                    commit_confirm_message = validate_message+'\n\nGenerate source codes from scenario setting.'
+                        +'\n\nDo you want to commit changes to local tree?'
+                    commit_confirm = 'no'
+                    if(confirm(commit_confirm_message)) {
+                        commit_confirm = 'yes'
+                    }
                     generator_config = {
                         type: generator,
                         board_info: $("select#board_info").val(),
                         board_setting: "board_setting",
-                        scenario_setting: file_name
+                        scenario_setting: file_name,
+                        commit: commit_confirm
                     }
                     $.ajax({
                         type : "POST",
@@ -442,8 +448,11 @@ function save_scenario(generator=null){
                             console.log(result);
                             status = result.status
                             error_list = result.error_list
-                            if (status == 'success' && JSON.stringify(error_list)=='{}') {
-                                alert(generator+' successfully.');
+                            if (status == 'success' && (JSON.stringify(error_list)=='{}' || JSON.stringify(error_list)=='null')) {
+                                if(commit_confirm == 'yes')
+                                    alert(generator+' with commit successfully.');
+                                else
+                                    alert(generator+' successfully.');
                             } else {
                                 alert(generator+' failed. \nError list:\n'+JSON.stringify(error_list));
                             }
@@ -456,6 +465,7 @@ function save_scenario(generator=null){
                         }
                     });
                 } else {
+                    alert(validate_message);
                     window.location = "./user_defined_" + file_name;
                 }
             }
@@ -536,20 +546,26 @@ function save_launch(generator=null) {
             })
             if(no_err == true && status == 'success') {
                 file_name = result.file_name;
+                validate_message = 'Launch setting saved successfully with name: '
+                    +file_name+'\nto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/.'
                 if(result.rename==true) {
-                    alert('Launch setting existed, saved successfully with a new name: '
-                        +file_name+'\nto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/');
-                } else {
-                    alert('Launch setting saved successfully with name: '
-                        +file_name+'\nto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/');
+                    validate_message = 'Launch setting existed, saved successfully with a new name: '
+                        +file_name+'\nto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/.';
                 }
                 if(generator != null) {
+                    commit_confirm_message = validate_message+'\n\nGenerate launch scripts from launch setting.'
+                        +'\n\nDo you want to commit changes to local tree?'
+                    commit_confirm = 'no'
+                    if(confirm(commit_confirm_message)) {
+                        commit_confirm = 'yes'
+                    }
                     generator_config = {
                         type: generator,
                         board_info: $("select#board_info").val(),
                         board_setting: "board_setting",
                         scenario_setting: $("select#scenario_name").val(),
-                        launch_setting: file_name
+                        launch_setting: file_name,
+                        commit: commit_confirm
                     }
                     $.ajax({
                         type : "POST",
@@ -560,8 +576,13 @@ function save_launch(generator=null) {
                             console.log(result);
                             status = result.status
                             error_list = result.error_list
-                            if (status == 'success' && JSON.stringify(error_list)=='{}') {
-                                alert(generator+' successfully.');
+                            if (status == 'success' && (JSON.stringify(error_list)=='{}' || JSON.stringify(error_list)=='null')) {
+                                if(commit_confirm == 'yes')
+                                    alert(generator+' successfully into '+
+                                        'acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/output/ with changes committed.');
+                                else
+                                    alert(generator+' successfully into '+
+                                        'acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/output/.');
                             } else {
                                 alert(generator+' failed. \nError list:\n'+JSON.stringify(error_list));
                             }
@@ -574,6 +595,7 @@ function save_launch(generator=null) {
                         }
                     });
                 } else {
+                    alert(validate_message);
                     window.location = "./user_defined_" + file_name;
                 }
             }

--- a/misc/acrn-config/config_app/views.py
+++ b/misc/acrn-config/config_app/views.py
@@ -360,20 +360,23 @@ def generate_src():
         launch_setting = generator_config_data['launch_setting']
         launch_setting_xml = os.path.join(current_app.config.get('CONFIG_PATH'),
                                           board_type, 'user_defined', launch_setting + '.xml')
+    commit = False
+    if 'commit' in generator_config_data and generator_config_data['commit'] == 'yes':
+        commit = True
     msg = {}
     error_list = {}
     status = 'success'
     if src_type == 'generate_board_src':
         try:
             from board_config.board_cfg_gen import ui_entry_api
-            error_list = ui_entry_api(board_info_xml, scenario_setting_xml)
+            error_list = ui_entry_api(board_info_xml, scenario_setting_xml, commit)
         except Exception as error:
             status = 'fail'
             error_list = {'board setting error': str(error)}
     elif src_type == 'generate_scenario_src':
         try:
             from scenario_config.scenario_cfg_gen import ui_entry_api
-            error_list = ui_entry_api(board_info_xml, scenario_setting_xml)
+            error_list = ui_entry_api(board_info_xml, scenario_setting_xml, commit)
         except Exception as error:
             status = 'fail'
             error_list = {'scenario setting error': str(error)}
@@ -388,7 +391,7 @@ def generate_src():
 
         try:
             from launch_config.launch_cfg_gen import ui_entry_api
-            error_list = ui_entry_api(board_info_xml, scenario_setting_xml, launch_setting_xml)
+            error_list = ui_entry_api(board_info_xml, scenario_setting_xml, launch_setting_xml, commit)
         except Exception as error:
             status = 'fail'
             error_list = {'launch setting error': str(error)}

--- a/misc/acrn-config/launch_config/launch_cfg_gen.py
+++ b/misc/acrn-config/launch_config/launch_cfg_gen.py
@@ -81,10 +81,14 @@ def validate_launch_setting(board_info, scenario_info, launch_info):
     return (launch_cfg_lib.ERR_LIST, pt_sel, dm)
 
 
-def ui_entry_api(board_info, scenario_info, launch_info):
+def ui_entry_api(board_info, scenario_info, launch_info, enable_commit=False):
 
     err_dic = {}
+
     arg_list = ['board_cfg_gen.py', '--board', board_info, '--scenario', scenario_info, '--launch', launch_info, '--uosid', '0']
+
+    if enable_commit:
+        arg_list.append('--enable_commit')
 
     err_dic = launch_cfg_lib.prepare()
     if err_dic:
@@ -139,7 +143,7 @@ def main(args):
     config_srcs = []
 
     # get parameters
-    (err_dic, board_info_file, scenario_info_file, launch_info_file, vm_th) = launch_cfg_lib.get_param(args)
+    (err_dic, board_info_file, scenario_info_file, launch_info_file, vm_th, enable_commit) = launch_cfg_lib.get_param(args)
     if err_dic:
         return err_dic
     # vm_th =[0..post_vm_max]
@@ -208,12 +212,18 @@ def main(args):
 
         commit_msg = "launch_uos_id{}.sh".format(launch_vm_count)
 
+    config_str = 'Config files'
+    gen_str = 'generated'
     # move changes to patch, and apply to the source code
-    err_dic = launch_cfg_lib.gen_patch(config_srcs, commit_msg)
+    if enable_commit:
+        err_dic = launch_cfg_lib.gen_patch(config_srcs, commit_msg)
+        config_str = 'Config patch'
+        gen_str = 'committed'
+
     if not err_dic:
-        print("Config patch for {} is committed successfully!".format(commit_msg))
+        print("{} for {} is {} successfully!".format(config_str, commit_msg, gen_str))
     else:
-        print("Config patch for {} is failed".format(commit_msg))
+        print("{} for {} is failed".format(config_str, commit_msg))
 
     return err_dic
 

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -58,9 +58,10 @@ def print_if_red(msg, err=False):
 def usage(file_name):
     """ This is usage for how to use this tool """
     print("usage= {} [h] ".format(file_name), end="")
-    print("--board <board_info_file> --scenario <scenario_info_file>")
+    print("--board <board_info_file> --scenario <scenario_info_file> [--enable_commit]")
     print('board_info_file :  file name of the board info')
     print('scenario_info_file :  file name of the scenario info')
+    print('enable_commit:  enable the flag that git add/commit the generate files to the code base. without --enable_commit will not commit this source code')
 
 
 def get_param(args):
@@ -71,34 +72,37 @@ def get_param(args):
     err_dic = {}
     board_info_file = False
     scenario_info_file = False
+    enable_commit = False
 
     if '--board' not in args or '--scenario' not in args:
         usage(args[0])
         err_dic['common error: get wrong parameter'] = "wrong usage"
-        return (err_dic, board_info_file, scenario_info_file)
+        return (err_dic, board_info_file, scenario_info_file, enable_commit)
 
     args_list = args[1:]
-    (optlist, args_list) = getopt.getopt(args_list, '', ['board=', 'scenario='])
+    (optlist, args_list) = getopt.getopt(args_list, '', ['board=', 'scenario=', 'enable_commit'])
     for arg_k, arg_v in optlist:
         if arg_k == '--board':
             board_info_file = arg_v
         if arg_k == '--scenario':
             scenario_info_file = arg_v
+        if arg_k == '--enable_commit':
+            enable_commit = True
 
     if not board_info_file or not scenario_info_file:
         usage(args[0])
         err_dic['common error: get wrong parameter'] = "wrong usage"
-        return (err_dic, board_info_file, scenario_info_file)
+        return (err_dic, board_info_file, scenario_info_file, enable_commit)
 
     if not os.path.exists(board_info_file):
         err_dic['common error: get wrong parameter'] = "{} is not exist!".format(board_info_file)
-        return (err_dic, board_info_file, scenario_info_file)
+        return (err_dic, board_info_file, scenario_info_file, enable_commit)
 
     if not os.path.exists(scenario_info_file):
         err_dic['common error: get wrong parameter'] = "{} is not exist!".format(scenario_info_file)
-        return (err_dic, board_info_file, scenario_info_file)
+        return (err_dic, board_info_file, scenario_info_file, enable_commit)
 
-    return (err_dic, board_info_file, scenario_info_file)
+    return (err_dic, board_info_file, scenario_info_file, enable_commit)
 
 
 def check_env():

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -80,11 +80,12 @@ def print_red(msg, err=False):
 def usage(file_name):
     """ This is usage for how to use this tool """
     print("usage= {} [h]".format(file_name), end="")
-    print("--board <board_info_file> --scenario <scenario_info_file> --launch <launch_info_file> --uosid <uosid id>")
+    print("--board <board_info_file> --scenario <scenario_info_file> --launch <launch_info_file> --uosid <uosid id> [--enable_commit]")
     print('board_info_file :  file name of the board info')
     print('scenario_info_file :  file name of the scenario info')
     print('launch_info_file :  file name of the launch info')
     print('uosid :  this is the relateive id for post launch vm in scenario info XML:[1..max post launch vm]')
+    print('enable_commit:  enable the flag that git add/commit the generate files to the code base. without --enable_commit will not commit this source code')
 
 
 def get_param(args):
@@ -97,15 +98,24 @@ def get_param(args):
     board_info_file = False
     scenario_info_file = False
     launch_info_file = False
+    enable_commit = False
+    param_list = ['--board', '--scenario', '--launch', '--uosid', '--enable_commit']
 
-    if '--board' not in args or '--scenario' not in args or '--launch' not in args or '--uosid' not in args:
-        usage(args[0])
-        err_dic['common error: get wrong parameter'] = "wrong usage"
-        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+    for arg_str in param_list:
+
+        if arg_str == '--enable_commit':
+            continue
+
+        if arg_str not in args:
+            usage(args[0])
+            err_dic['common error: get wrong parameter'] = "wrong usage"
+            return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
     args_list = args[1:]
-    (optlist, args_list) = getopt.getopt(args_list, '', ['board=', 'scenario=', 'launch=', 'uosid='])
+    (optlist, args_list) = getopt.getopt(args_list, '', ['board=', 'scenario=', 'launch=', 'uosid=', 'enable_commit'])
     for arg_k, arg_v in optlist:
+        if arg_k == '--enable_commit':
+            enable_commit = True
         if arg_k == '--board':
             board_info_file = arg_v
         if arg_k == '--scenario':
@@ -117,26 +127,26 @@ def get_param(args):
                 vm_th = arg_v
                 if not vm_th.isnumeric():
                     err_dic['common error: get wrong parameter'] = "--uosid should be a number"
-                    return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+                    return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
     if not board_info_file or not scenario_info_file or not launch_info_file:
         usage(args[0])
         err_dic['common error: get wrong parameter'] = "wrong usage"
-        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
     if not os.path.exists(board_info_file):
         err_dic['common error: get wrong parameter'] = "{} is not exist!".format(board_info_file)
-        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
     if not os.path.exists(scenario_info_file):
         err_dic['common error: get wrong parameter'] = "{} is not exist!".format(scenario_info_file)
-        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
     if not os.path.exists(launch_info_file):
         err_dic['common error: get wrong parameter'] = "{} is not exist!".format(launch_info_file)
-        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+        return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
-    return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th))
+    return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
 
 def get_scenario_uuid():

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -78,7 +78,7 @@ def main(args):
     err_dic = {}
     config_srcs = []
 
-    (err_dic, board_info_file, scenario_info_file) = scenario_cfg_lib.get_param(args)
+    (err_dic, board_info_file, scenario_info_file, enable_commit) = scenario_cfg_lib.get_param(args)
     if err_dic:
         return err_dic
 
@@ -127,18 +127,28 @@ def main(args):
         with open(pci_config_c, 'w') as config:
             pci_dev_c.generate_file(config)
 
+    config_str = 'Config files'
+    gen_str = 'generated'
     # move changes to patch, and apply to the source code
-    err_dic = scenario_cfg_lib.gen_patch(config_srcs, scenario)
+    if enable_commit:
+        err_dic = scenario_cfg_lib.gen_patch(config_srcs, scenario)
+        config_str = 'Config patch'
+        gen_str = 'committed'
+
     if not err_dic:
-        print("Config patch for {} is committed successfully!".format(scenario))
+        print("{} for {} is {} successfully!".format(config_str, scenario, gen_str))
     else:
-        print("Config patch for {} is failed".format(scenario))
+        print("{} for {} is failed".format(config_str, scenario))
 
     return err_dic
 
 
-def ui_entry_api(board_info, scenario_info):
+def ui_entry_api(board_info, scenario_info, enable_commit=False):
+
     arg_list = ['board_cfg_gen.py', '--board', board_info, '--scenario', scenario_info]
+    if enable_commit:
+        arg_list.append('--enable_commit')
+
     err_dic = scenario_cfg_lib.prepare()
     if err_dic:
         return err_dic


### PR DESCRIPTION
acrn-config: add confirmation for commit of generated source in config app
add a confirmation interface to let user to commit changes into local tree
or not commit after generated source codes in config app.

acrn-config: add "enable_commit" parameter for config tool
Config tool will generate files for board/scenaro/launch, some files are
part of souce code for specify board. Git add/commit these files should
be one optional of user experience. Add "--enable_commit" parameter to
enable git add/commit.
usage:
--enable_commit: flag of whether to do git commit the config file changes
to current git branch. Do commit with this flag and not do without the flag.

Tracked-On: #3834
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>

