### PR TITLE
acrn-config: modify SOS i915 plane setting for hybird xmls

### DIFF
--- a/hypervisor/scenarios/hybrid/vm_configurations.h
+++ b/hypervisor/scenarios/hybrid/vm_configurations.h
@@ -27,8 +27,8 @@
 					"no_timer_check "	\
 					"quiet loglevel=3 "	\
 					"i915.nuclear_pageflip=1 " \
-					"i915.avail_planes_per_pipe=0x01010F "	\
-					"i915.domain_plane_owners=0x011111110000 " \
+					"i915.avail_planes_per_pipe=0x01070F "	\
+					"i915.domain_plane_owners=0x011100001111 " \
 					"i915.enable_gvt=1 "	\
 					SOS_BOOTARGS_DIFF
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -78,7 +78,7 @@
         <console desc="ttyS console for Linux kernel">/dev/ttyS2</console>
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0x6de00000 memmap=0x600000$0x6da00000 ramoops.mem_address=0x6da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -78,7 +78,7 @@
         <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0x5de00000 memmap=0x600000$0x5da00000 ramoops.mem_address=0x5da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -78,7 +78,7 @@
         <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -78,7 +78,7 @@
         <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -78,7 +78,7 @@
         <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
         </bootargs>
     </board_private>


### PR DESCRIPTION
Change i915.domain_plane_owners and i915.avail_planes_per_pipe for
hybrid scenario;because kvm based User vm will use PipeA.

Tracked-On: #3840

Signed-off-by: Victor Sun <victor.sun@intel.com>