### PR TITLE
Schedule noop preparation 

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -218,8 +218,6 @@ void init_pcpu_post(uint16_t pcpu_id)
 			pr_fatal("Please apply the latest CPU uCode patch!");
 		}
 
-		init_scheduler();
-
 		/* Initialize interrupts */
 		init_interrupt(BOOT_CPU_ID);
 
@@ -257,6 +255,8 @@ void init_pcpu_post(uint16_t pcpu_id)
 		/* Wait for boot processor to signal all secondary cores to continue */
 		wait_sync_change(&pcpu_sync, 0UL);
 	}
+
+	init_sched(pcpu_id);
 
 	setup_clos(pcpu_id);
 

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -143,17 +143,6 @@ void destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem)
 	}
 }
 
-static inline void save_fxstore_guest_area(struct ext_context *ext_ctx)
-{
-	asm volatile("fxsave (%0)"
-			: : "r" (ext_ctx->fxstore_guest_area) : "memory");
-}
-
-static inline void rstor_fxstore_guest_area(const struct ext_context *ext_ctx)
-{
-	asm volatile("fxrstor (%0)" : : "r" (ext_ctx->fxstore_guest_area));
-}
-
 static void save_world_ctx(struct acrn_vcpu *vcpu, struct ext_context *ext_ctx)
 {
 	uint32_t i;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -639,7 +639,6 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 		vcpu->arch.exception_info.exception = VECTOR_INVALID;
 		vcpu->arch.cur_context = NORMAL_WORLD;
 		vcpu->arch.irq_window_enabled = false;
-		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		(void)memset((void *)vcpu->arch.vmcs, 0U, PAGE_SIZE);
 
 		for (i = 0; i < NR_WORLD; i++) {

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -387,7 +387,6 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 
 		/* Initialize CPU ID for this VCPU */
 		vcpu->vcpu_id = vcpu_id;
-		vcpu->pcpu_id = pcpu_id;
 		per_cpu(ever_run_vcpu, pcpu_id) = vcpu;
 
 		/* Initialize the parent VM reference */
@@ -403,8 +402,8 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 
 		per_cpu(vcpu, pcpu_id) = vcpu;
 
-		pr_info("PCPU%d is working as VM%d VCPU%d, Role: %s",
-				vcpu->pcpu_id, vcpu->vm->vm_id, vcpu->vcpu_id,
+		pr_info("Create VM%d-VCPU%d, Role: %s",
+				vcpu->vm->vm_id, vcpu->vcpu_id,
 				is_vcpu_bsp(vcpu) ? "PRIMARY" : "SECONDARY");
 
 		/*
@@ -585,7 +584,7 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu)
 void offline_vcpu(struct acrn_vcpu *vcpu)
 {
 	vlapic_free(vcpu);
-	per_cpu(ever_run_vcpu, vcpu->pcpu_id) = NULL;
+	per_cpu(ever_run_vcpu, pcpuid_from_vcpu(vcpu)) = NULL;
 	vcpu->state = VCPU_OFFLINE;
 }
 
@@ -656,49 +655,51 @@ void reset_vcpu(struct acrn_vcpu *vcpu)
 
 void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 {
-	uint16_t pcpu_id = get_pcpu_id();
+	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
 
 	pr_dbg("vcpu%hu paused, new state: %d",
 		vcpu->vcpu_id, new_state);
 
-	get_schedule_lock(vcpu->pcpu_id);
+	get_schedule_lock(pcpu_id);
 	vcpu->prev_state = vcpu->state;
 	vcpu->state = new_state;
 
 	if (vcpu->running) {
-		remove_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
+		remove_thread_obj(&vcpu->thread_obj, pcpu_id);
 
 		if (is_lapic_pt_enabled(vcpu)) {
-			make_reschedule_request(vcpu->pcpu_id, DEL_MODE_INIT);
+			make_reschedule_request(pcpu_id, DEL_MODE_INIT);
 		} else {
-			make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
+			make_reschedule_request(pcpu_id, DEL_MODE_IPI);
 		}
 
-		release_schedule_lock(vcpu->pcpu_id);
+		release_schedule_lock(pcpu_id);
 
-		if (vcpu->pcpu_id != pcpu_id) {
+		if (pcpu_id != get_pcpu_id()) {
 			while (vcpu->running) {
 				asm_pause();
 			}
 		}
 	} else {
-		remove_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
-		release_schedule_lock(vcpu->pcpu_id);
+		remove_thread_obj(&vcpu->thread_obj, pcpu_id);
+		release_schedule_lock(pcpu_id);
 	}
 }
 
 void resume_vcpu(struct acrn_vcpu *vcpu)
 {
+	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
+
 	pr_dbg("vcpu%hu resumed", vcpu->vcpu_id);
 
-	get_schedule_lock(vcpu->pcpu_id);
+	get_schedule_lock(pcpu_id);
 	vcpu->state = vcpu->prev_state;
 
 	if (vcpu->state == VCPU_RUNNING) {
-		insert_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
-		make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
+		insert_thread_obj(&vcpu->thread_obj, pcpu_id);
+		make_reschedule_request(pcpu_id, DEL_MODE_IPI);
 	}
-	release_schedule_lock(vcpu->pcpu_id);
+	release_schedule_lock(pcpu_id);
 }
 
 static void context_switch_out(struct thread_object *prev)
@@ -728,13 +729,15 @@ static void context_switch_in(struct thread_object *next)
 
 void schedule_vcpu(struct acrn_vcpu *vcpu)
 {
-	vcpu->state = VCPU_RUNNING;
-	pr_dbg("vcpu%hu scheduled", vcpu->vcpu_id);
+	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
 
-	get_schedule_lock(vcpu->pcpu_id);
-	insert_thread_obj(&vcpu->thread_obj, vcpu->pcpu_id);
-	make_reschedule_request(vcpu->pcpu_id, DEL_MODE_IPI);
-	release_schedule_lock(vcpu->pcpu_id);
+	vcpu->state = VCPU_RUNNING;
+	pr_dbg("vcpu%hu scheduled on pcpu%hu", vcpu->vcpu_id, pcpu_id);
+
+	get_schedule_lock(pcpu_id);
+	insert_thread_obj(&vcpu->thread_obj, pcpu_id);
+	make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+	release_schedule_lock(pcpu_id);
 }
 
 /* help function for vcpu create */
@@ -748,13 +751,23 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 	if (ret == 0) {
 		snprintf(thread_name, 16U, "vm%hu:vcpu%hu", vm->vm_id, vcpu->vcpu_id);
 		(void)strncpy_s(vcpu->thread_obj.name, 16U, thread_name, 16U);
+		vcpu->thread_obj.sched_ctl = &per_cpu(sched_ctl, pcpu_id);
 		vcpu->thread_obj.thread_entry = vcpu_thread;
+		vcpu->thread_obj.pcpu_id = pcpu_id;
 		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		vcpu->thread_obj.switch_out = context_switch_out;
 		vcpu->thread_obj.switch_in = context_switch_in;
 	}
 
 	return ret;
+}
+
+/**
+ * @pre vcpu != NULL
+ */
+uint16_t pcpuid_from_vcpu(const struct acrn_vcpu *vcpu)
+{
+	return sched_get_pcpuid(&vcpu->thread_obj);
 }
 
 uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask)
@@ -766,7 +779,7 @@ uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask)
 	for (vcpu_id = 0U; vcpu_id < vm->hw.created_vcpus; vcpu_id++) {
 		if ((vdmask & (1UL << vcpu_id)) != 0UL) {
 			vcpu = vcpu_from_vid(vm, vcpu_id);
-			bitmap_set_nolock(vcpu->pcpu_id, &dmask);
+			bitmap_set_nolock(pcpuid_from_vcpu(vcpu), &dmask);
 		}
 	}
 

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -611,7 +611,7 @@ static uint64_t build_stack_frame(struct acrn_vcpu *vcpu)
 	frame -= 1;
 
 	frame->magic = SP_BOTTOM_MAGIC;
-	frame->rip = (uint64_t)run_sched_thread; /*return address*/
+	frame->rip = (uint64_t)vcpu->thread_obj.thread_entry; /*return address*/
 	frame->rflag = 0UL;
 	frame->rbx = 0UL;
 	frame->rbp = 0UL;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -670,46 +670,25 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 	pr_dbg("vcpu%hu paused, new state: %d",
 		vcpu->vcpu_id, new_state);
 
-	get_schedule_lock(pcpu_id);
 	vcpu->prev_state = vcpu->state;
 	vcpu->state = new_state;
 
-	if (vcpu->running) {
-		remove_thread_obj(&vcpu->thread_obj, pcpu_id);
-
-		if (is_lapic_pt_enabled(vcpu)) {
-			make_reschedule_request(pcpu_id, DEL_MODE_INIT);
-		} else {
-			make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+	sleep_thread(&vcpu->thread_obj);
+	if (pcpu_id != get_pcpu_id()) {
+		while (vcpu->running) {
+			asm_pause();
 		}
-
-		release_schedule_lock(pcpu_id);
-
-		if (pcpu_id != get_pcpu_id()) {
-			while (vcpu->running) {
-				asm_pause();
-			}
-		}
-	} else {
-		remove_thread_obj(&vcpu->thread_obj, pcpu_id);
-		release_schedule_lock(pcpu_id);
 	}
 }
 
 void resume_vcpu(struct acrn_vcpu *vcpu)
 {
-	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
-
 	pr_dbg("vcpu%hu resumed", vcpu->vcpu_id);
 
-	get_schedule_lock(pcpu_id);
 	vcpu->state = vcpu->prev_state;
-
 	if (vcpu->state == VCPU_RUNNING) {
-		insert_thread_obj(&vcpu->thread_obj, pcpu_id);
-		make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+		wake_thread(&vcpu->thread_obj);
 	}
-	release_schedule_lock(pcpu_id);
 }
 
 /* TODO:
@@ -777,6 +756,8 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		vcpu->thread_obj.sched_ctl = &per_cpu(sched_ctl, pcpu_id);
 		vcpu->thread_obj.thread_entry = vcpu_thread;
 		vcpu->thread_obj.pcpu_id = pcpu_id;
+		vcpu->thread_obj.notify_mode = is_lapic_pt_enabled(vcpu) ?
+			SCHED_NOTIFY_INIT : SCHED_NOTIFY_IPI;
 		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		vcpu->thread_obj.switch_out = context_switch_out;
 		vcpu->thread_obj.switch_in = context_switch_in;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -193,6 +193,18 @@ void vcpu_reset_eoi_exit_bitmaps(struct acrn_vcpu *vcpu)
 	vcpu_make_request(vcpu, ACRN_REQUEST_EOI_EXIT_BITMAP_UPDATE);
 }
 
+struct acrn_vcpu *get_running_vcpu(uint16_t pcpu_id)
+{
+	struct thread_object *curr = sched_get_current(pcpu_id);
+	struct acrn_vcpu *vcpu = NULL;
+
+	if ((curr != NULL) && (!is_idle_thread(curr))) {
+		vcpu = list_entry(curr, struct acrn_vcpu, thread_obj);
+	}
+
+	return vcpu;
+}
+
 struct acrn_vcpu *get_ever_run_vcpu(uint16_t pcpu_id)
 {
 	return per_cpu(ever_run_vcpu, pcpu_id);
@@ -399,8 +411,6 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 		 * specific vcpu destroy on fly, this vcpu_id assignment
 		 * needs revise.
 		 */
-
-		per_cpu(vcpu, pcpu_id) = vcpu;
 
 		pr_info("Create VM%d-VCPU%d, Role: %s",
 				vcpu->vm->vm_id, vcpu->vcpu_id,

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -106,6 +106,8 @@ static bool is_guest_irq_enabled(struct acrn_vcpu *vcpu)
 
 void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid)
 {
+	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
+
 	bitmap_set_lock(eventid, &vcpu->arch.pending_req);
 	/*
 	 * if current hostcpu is not the target vcpu's hostcpu, we need
@@ -116,8 +118,8 @@ void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid)
 	 *  scheduling, we need change here to determine it target vcpu is
 	 *  VMX non-root or root mode
 	 */
-	if (get_pcpu_id() != vcpu->pcpu_id) {
-		send_single_ipi(vcpu->pcpu_id, VECTOR_NOTIFY_VCPU);
+	if (get_pcpu_id() != pcpu_id) {
+		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1168,6 +1168,8 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 					target_vcpu->vcpu_id,
 					target_vcpu->vm->vm_id);
 				set_vcpu_startup_entry(target_vcpu, (icr_low & APIC_VECTOR_MASK) << 12U);
+				/* init vmcs after set_vcpu_startup_entry */
+				init_vmcs(target_vcpu);
 				schedule_vcpu(target_vcpu);
 			}
 		}

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -555,8 +555,8 @@ static void apicv_advanced_accept_intr(struct acrn_vlapic *vlapic, uint32_t vect
 		 */
 		bitmap_set_lock(ACRN_REQUEST_EVENT, &vlapic->vcpu->arch.pending_req);
 
-		if (get_pcpu_id() != vlapic->vcpu->pcpu_id) {
-			apicv_post_intr(vlapic->vcpu->pcpu_id);
+		if (get_pcpu_id() != pcpuid_from_vcpu(vlapic->vcpu)) {
+			apicv_post_intr(pcpuid_from_vcpu(vlapic->vcpu));
 		}
 	}
 }
@@ -2047,7 +2047,7 @@ vlapic_x2apic_pt_icr_access(struct acrn_vm *vm, uint64_t val)
 			default:
 				/* convert the dest from virtual apic_id to physical apic_id */
 				if (is_x2apic_enabled(vcpu_vlapic(target_vcpu))) {
-					papic_id = per_cpu(lapic_id, target_vcpu->pcpu_id);
+					papic_id = per_cpu(lapic_id, pcpuid_from_vcpu(target_vcpu));
 					dev_dbg(ACRN_DBG_LAPICPT,
 						"%s vapic_id: 0x%08lx papic_id: 0x%08lx icr_low:0x%08lx",
 						 __func__, vapic_id, papic_id, icr_low);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -429,7 +429,7 @@ static uint64_t lapic_pt_enabled_pcpu_bitmap(struct acrn_vm *vm)
 	if (is_lapic_pt_configured(vm)) {
 		foreach_vcpu(i, vm, vcpu) {
 			if (is_lapic_pt_enabled(vcpu)) {
-				bitmap_set_nolock(vcpu->pcpu_id, &bitmap);
+				bitmap_set_nolock(pcpuid_from_vcpu(vcpu), &bitmap);
 			}
 		}
 	}
@@ -615,8 +615,8 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 			reset_vcpu(vcpu);
 			offline_vcpu(vcpu);
 
-			if (bitmap_test(vcpu->pcpu_id, &mask)) {
-				make_pcpu_offline(vcpu->pcpu_id);
+			if (bitmap_test(pcpuid_from_vcpu(vcpu), &mask)) {
+				make_pcpu_offline(pcpuid_from_vcpu(vcpu));
 			}
 		}
 
@@ -696,8 +696,8 @@ int32_t reset_vm(struct acrn_vm *vm)
 		foreach_vcpu(i, vm, vcpu) {
 			reset_vcpu(vcpu);
 
-			if (bitmap_test(vcpu->pcpu_id, &mask)) {
-				make_pcpu_offline(vcpu->pcpu_id);
+			if (bitmap_test(pcpuid_from_vcpu(vcpu), &mask)) {
+				make_pcpu_offline(pcpuid_from_vcpu(vcpu));
 			}
 		}
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -664,6 +664,7 @@ void start_vm(struct acrn_vm *vm)
 
 	/* Only start BSP (vid = 0) and let BSP start other APs */
 	bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
+	init_vmcs(bsp);
 	schedule_vcpu(bsp);
 }
 
@@ -789,7 +790,6 @@ void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 
 	init_vmcs(bsp);
 	schedule_vcpu(bsp);
-	switch_to_idle(default_idle);
 }
 
 /**

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -47,8 +47,8 @@ void triple_fault_shutdown_vm(struct acrn_vcpu *vcpu)
 		/* Either SOS or pre-launched VMs */
 		pause_vm(vm);
 
-		per_cpu(shutdown_vm_id, vcpu->pcpu_id) = vm->vm_id;
-		make_shutdown_vm_request(vcpu->pcpu_id);
+		per_cpu(shutdown_vm_id, pcpuid_from_vcpu(vcpu)) = vm->vm_id;
+		make_shutdown_vm_request(pcpuid_from_vcpu(vcpu));
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -509,9 +509,9 @@ static void do_init_vmcs(struct acrn_vcpu *vcpu)
 	vmx_rev_id = msr_read(MSR_IA32_VMX_BASIC);
 	(void)memcpy_s(vcpu->arch.vmcs, 4U, (void *)&vmx_rev_id, 4U);
 
-	/* Execute VMCLEAR on previous un-clear VMCS */
-	if (*vmcs_ptr != NULL) {
-		vmcs_pa = hva2hpa(*vmcs_ptr);
+	/* Execute VMCLEAR VMCS of this vcpu */
+	if ((void *)vcpu->arch.vmcs != NULL) {
+		vmcs_pa = hva2hpa(vcpu->arch.vmcs);
 		exec_vmclear((void *)&vmcs_pa);
 	}
 
@@ -540,6 +540,21 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 		do_init_vmcs(vcpu);
 	} else {
 		smp_call_function((1UL << pcpu_id), (smp_call_func_t)do_init_vmcs, vcpu);
+	}
+}
+
+/**
+ * @pre vcpu != NULL
+ */
+void switch_vmcs(const struct acrn_vcpu *vcpu)
+{
+	uint64_t vmcs_pa;
+	void **vmcs_ptr = &get_cpu_var(vmcs_run);
+
+	if (vcpu->launched && (*vmcs_ptr != (void *)vcpu->arch.vmcs)) {
+		vmcs_pa = hva2hpa(vcpu->arch.vmcs);
+		exec_vmptrld((void *)&vmcs_pa);
+		*vmcs_ptr = (void *)vcpu->arch.vmcs;
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -534,7 +534,7 @@ static void do_init_vmcs(struct acrn_vcpu *vcpu)
  */
 void init_vmcs(struct acrn_vcpu *vcpu)
 {
-	uint16_t pcpu_id = vcpu->pcpu_id;
+	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
 
 	if (pcpu_id == get_pcpu_id()) {
 		do_init_vmcs(vcpu);

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -174,7 +174,7 @@ int32_t vmexit_handler(struct acrn_vcpu *vcpu)
 	uint16_t basic_exit_reason;
 	int32_t ret;
 
-	if (get_pcpu_id() != vcpu->pcpu_id) {
+	if (get_pcpu_id() != pcpuid_from_vcpu(vcpu)) {
 		pr_fatal("vcpu is not running on its pcpu!");
 		ret = -EINVAL;
 	} else {

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -298,7 +298,7 @@ static void init_msr_area(struct acrn_vcpu *vcpu)
 	vcpu->arch.msr_area.guest[MSR_AREA_TSC_AUX].msr_index = MSR_IA32_TSC_AUX;
 	vcpu->arch.msr_area.guest[MSR_AREA_TSC_AUX].value = vcpu->vcpu_id;
 	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].msr_index = MSR_IA32_TSC_AUX;
-	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].value = vcpu->pcpu_id;
+	vcpu->arch.msr_area.host[MSR_AREA_TSC_AUX].value = pcpuid_from_vcpu(vcpu);
 	vcpu->arch.msr_area.count++;
 
 	/* only load/restore MSR IA32_PQR_ASSOC when hv and guest have differnt settings */

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -49,16 +49,11 @@ static void init_debug_post(uint16_t pcpu_id)
 }
 
 /*TODO: move into guest-vcpu module */
-static void enter_guest_mode(uint16_t pcpu_id)
+static void init_guest_mode(uint16_t pcpu_id)
 {
 	vmx_on();
 
 	launch_vms(pcpu_id);
-
-	switch_to_idle(default_idle);
-
-	/* Control should not come here */
-	cpu_dead();
 }
 
 static void init_primary_pcpu_post(void)
@@ -71,7 +66,9 @@ static void init_primary_pcpu_post(void)
 
 	init_debug_post(BOOT_CPU_ID);
 
-	enter_guest_mode(BOOT_CPU_ID);
+	init_guest_mode(BOOT_CPU_ID);
+
+	run_idle_thread();
 }
 
 /* NOTE: this function is using temp stack, and after SWITCH_TO(runtime_sp, to)
@@ -101,5 +98,7 @@ void init_secondary_pcpu(void)
 
 	init_debug_post(pcpu_id);
 
-	enter_guest_mode(pcpu_id);
+	init_guest_mode(pcpu_id);
+
+	run_idle_thread();
 }

--- a/hypervisor/boot/guest/deprivilege_boot.c
+++ b/hypervisor/boot/guest/deprivilege_boot.c
@@ -14,6 +14,7 @@
 #include <vlapic.h>
 #include <lapic.h>
 #include <per_cpu.h>
+#include <guest/vm.h>
 #include <multiboot.h>
 #include <deprivilege_boot.h>
 

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -270,7 +270,7 @@ static int32_t init_general_vm_boot_info(struct acrn_vm *vm)
 static void depri_boot_spurious_handler(uint32_t vector)
 {
 	if (get_pcpu_id() == BOOT_CPU_ID) {
-		struct acrn_vcpu *vcpu = per_cpu(vcpu, BOOT_CPU_ID);
+		struct acrn_vcpu *vcpu = vcpu_from_vid(get_sos_vm(), BOOT_CPU_ID);
 
 		if (vcpu != NULL) {
 			vlapic_set_intr(vcpu, vector, LAPIC_TRIG_EDGE);

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -11,6 +11,7 @@
 #include <irq.h>
 #include <schedule.h>
 #include <profiling.h>
+#include <sprintf.h>
 #include <trace.h>
 #include <logmsg.h>
 
@@ -89,4 +90,23 @@ void default_idle(__unused struct thread_object *obj)
 			CPU_IRQ_DISABLE();
 		}
 	}
+}
+
+void run_idle_thread(void)
+{
+	uint16_t pcpu_id = get_pcpu_id();
+	struct thread_object *idle = &per_cpu(idle, pcpu_id);
+	char idle_name[16];
+
+	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
+	(void)strncpy_s(idle->name, 16U, idle_name, 16U);
+	idle->pcpu_id = pcpu_id;
+	idle->thread_entry = default_idle;
+	idle->switch_out = NULL;
+	idle->switch_in = NULL;
+
+	run_thread(idle);
+
+	/* Control should not come here */
+	cpu_dead();
 }

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -26,7 +26,7 @@ void vcpu_thread(struct thread_object *obj)
 		}
 
 		/* Don't open interrupt window between here and vmentry */
-		if (need_reschedule(vcpu->pcpu_id)) {
+		if (need_reschedule(pcpuid_from_vcpu(vcpu))) {
 			schedule();
 		}
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -21,11 +21,6 @@ void vcpu_thread(struct thread_object *obj)
 	int32_t ret = 0;
 
 	do {
-		/* If vcpu is not launched, we need to do init_vmcs first */
-		if (!vcpu->launched) {
-			init_vmcs(vcpu);
-		}
-
 		if (!is_lapic_pt_enabled(vcpu)) {
 			CPU_IRQ_DISABLE();
 		}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -408,7 +408,7 @@ static void inject_msi_lapic_pt(struct acrn_vm *vm, const struct acrn_msi_entry 
 		while (vcpu_id != INVALID_BIT_INDEX) {
 			bitmap_clear_nolock(vcpu_id, &vdmask);
 			vcpu = vcpu_from_vid(vm, vcpu_id);
-			dest |= per_cpu(lapic_ldr, vcpu->pcpu_id);
+			dest |= per_cpu(lapic_ldr, pcpuid_from_vcpu(vcpu));
 			vcpu_id = ffs64(vdmask);
 		}
 

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -27,19 +27,13 @@ uint16_t sched_get_pcpuid(const struct thread_object *obj)
 	return obj->pcpu_id;
 }
 
-void init_scheduler(void)
+void init_sched(uint16_t pcpu_id)
 {
-	struct sched_control *ctl;
-	uint32_t i;
-	uint16_t pcpu_nums = get_pcpu_nums();
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
 
-	for (i = 0U; i < pcpu_nums; i++) {
-		ctl = &per_cpu(sched_ctl, i);
-
-		spinlock_init(&ctl->scheduler_lock);
-		ctl->flags = 0UL;
-		ctl->curr_obj = NULL;
-	}
+	spinlock_init(&ctl->scheduler_lock);
+	ctl->flags = 0UL;
+	ctl->curr_obj = NULL;
 }
 
 void get_schedule_lock(uint16_t pcpu_id)

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -13,6 +13,12 @@
 #include <schedule.h>
 #include <sprintf.h>
 
+bool is_idle_thread(const struct thread_object *obj)
+{
+	uint16_t pcpu_id = obj->pcpu_id;
+	return (obj == &per_cpu(idle, pcpu_id));
+}
+
 /**
  * @pre obj != NULL
  */
@@ -65,6 +71,12 @@ void remove_thread_obj(__unused struct thread_object *obj, uint16_t pcpu_id)
 static struct thread_object *get_next_sched_obj(const struct sched_control *ctl)
 {
 	return ctl->thread_obj == NULL ? &get_cpu_var(idle) : ctl->thread_obj;
+}
+
+struct thread_object *sched_get_current(uint16_t pcpu_id)
+{
+	struct sched_control *ctl = &per_cpu(sched_ctl, pcpu_id);
+	return ctl->curr_obj;
 }
 
 /**

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -164,6 +164,36 @@ void schedule(void)
 	}
 }
 
+void sleep_thread(struct thread_object *obj)
+{
+	uint16_t pcpu_id = obj->pcpu_id;
+
+	get_schedule_lock(pcpu_id);
+	remove_thread_obj(obj, pcpu_id);
+	if (is_running(obj)) {
+		if (obj->notify_mode == SCHED_NOTIFY_INIT) {
+			make_reschedule_request(pcpu_id, DEL_MODE_INIT);
+		} else {
+			make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+		}
+	}
+	set_thread_status(obj, THREAD_STS_BLOCKED);
+	release_schedule_lock(pcpu_id);
+}
+
+void wake_thread(struct thread_object *obj)
+{
+	uint16_t pcpu_id = obj->pcpu_id;
+
+	get_schedule_lock(pcpu_id);
+	if (is_blocked(obj)) {
+		insert_thread_obj(obj, pcpu_id);
+		set_thread_status(obj, THREAD_STS_RUNNABLE);
+		make_reschedule_request(pcpu_id, DEL_MODE_IPI);
+	}
+	release_schedule_lock(pcpu_id);
+}
+
 void run_sched_thread(struct thread_object *obj)
 {
 	if (obj->thread_entry != NULL) {

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -13,6 +13,14 @@
 #include <schedule.h>
 #include <sprintf.h>
 
+/**
+ * @pre obj != NULL
+ */
+uint16_t sched_get_pcpuid(const struct thread_object *obj)
+{
+	return obj->pcpu_id;
+}
+
 void init_scheduler(void)
 {
 	struct sched_control *ctl;
@@ -141,6 +149,7 @@ void switch_to_idle(thread_entry_t idle_thread)
 
 	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
 	(void)strncpy_s(idle->name, 16U, idle_name, 16U);
+	idle->pcpu_id = pcpu_id;
 	idle->thread_entry = idle_thread;
 	idle->switch_out = NULL;
 	idle->switch_in = NULL;

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -194,29 +194,14 @@ void wake_thread(struct thread_object *obj)
 	release_schedule_lock(pcpu_id);
 }
 
-void run_sched_thread(struct thread_object *obj)
+void run_thread(struct thread_object *obj)
 {
+	get_schedule_lock(obj->pcpu_id);
+	get_cpu_var(sched_ctl).curr_obj = obj;
+	set_thread_status(obj, THREAD_STS_RUNNING);
+	release_schedule_lock(obj->pcpu_id);
+
 	if (obj->thread_entry != NULL) {
 		obj->thread_entry(obj);
 	}
-
-	ASSERT(false, "Shouldn't go here, invalid thread entry!");
-}
-
-void switch_to_idle(thread_entry_t idle_thread)
-{
-	uint16_t pcpu_id = get_pcpu_id();
-	struct thread_object *idle = &per_cpu(idle, pcpu_id);
-	char idle_name[16];
-
-	snprintf(idle_name, 16U, "idle%hu", pcpu_id);
-	(void)strncpy_s(idle->name, 16U, idle_name, 16U);
-	idle->pcpu_id = pcpu_id;
-	idle->thread_entry = idle_thread;
-	idle->switch_out = NULL;
-	idle->switch_in = NULL;
-	get_cpu_var(sched_ctl).curr_obj = idle;
-	set_thread_status(idle, THREAD_STS_RUNNING);
-
-	run_sched_thread(idle);
 }

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -67,12 +67,14 @@ struct intr_excp_ctx *crash_ctx;
 
 static void dump_guest_reg(struct acrn_vcpu *vcpu)
 {
+	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
+
 	pr_acrnlog("\n\n================================================");
 	pr_acrnlog("================================\n\n");
 	pr_acrnlog("Guest Registers:\r\n");
 	pr_acrnlog("=	VM ID %d ==== vCPU ID %hu ===  pCPU ID %d ===="
 			"world %d =============\r\n",
-			vcpu->vm->vm_id, vcpu->vcpu_id, vcpu->pcpu_id,
+			vcpu->vm->vm_id, vcpu->vcpu_id, pcpu_id,
 			vcpu->arch.cur_context);
 	pr_acrnlog("=	RIP=0x%016llx  RSP=0x%016llx "
 			"RFLAGS=0x%016llx\r\n",

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -183,9 +183,8 @@ static void show_guest_call_trace(struct acrn_vcpu *vcpu)
 
 static void dump_guest_context(uint16_t pcpu_id)
 {
-	struct acrn_vcpu *vcpu;
+	struct acrn_vcpu *vcpu = get_running_vcpu(pcpu_id);
 
-	vcpu = per_cpu(vcpu, pcpu_id);
 	if (vcpu != NULL) {
 		dump_guest_reg(vcpu);
 		dump_guest_stack(vcpu);

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -888,7 +888,7 @@ int32_t profiling_vm_list_info(struct acrn_vm *vm, uint64_t addr)
 			vm_info_list.vm_list[vm_idx].cpu_map[i].vcpu_id
 				= vcpu->vcpu_id;
 			vm_info_list.vm_list[vm_idx].cpu_map[i].pcpu_id
-				= vcpu->pcpu_id;
+				= pcpuid_from_vcpu(vcpu);
 			vm_info_list.vm_list[vm_idx].cpu_map[i].apic_id = 0;
 			vm_info_list.vm_list[vm_idx].num_vcpus++;
 		}
@@ -1369,7 +1369,7 @@ void profiling_pre_vmexit_handler(struct acrn_vcpu *vcpu)
  */
 void profiling_post_vmexit_handler(struct acrn_vcpu *vcpu)
 {
-	per_cpu(profiling_info.s_state, vcpu->pcpu_id).total_vmexit_count++;
+	per_cpu(profiling_info.s_state, pcpuid_from_vcpu(vcpu)).total_vmexit_count++;
 
 	if ((get_cpu_var(profiling_info.s_state).pmu_state == PMU_RUNNING) ||
 		(get_cpu_var(profiling_info.soc_state) == SW_RUNNING)) {

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -664,7 +664,7 @@ static int32_t shell_list_vcpu(__unused int32_t argc, __unused char **argv)
 			snprintf(temp_str, MAX_STR_SIZE,
 					"  %-9d %-10d %-7hu %-12s %-16s\r\n",
 					vm->vm_id,
-					vcpu->pcpu_id,
+					pcpuid_from_vcpu(vcpu),
 					vcpu->vcpu_id,
 					is_vcpu_bsp(vcpu) ?
 					"PRIMARY" : "SECONDARY",
@@ -767,7 +767,7 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 {
 	int32_t status = 0;
 	uint16_t vm_id;
-	uint16_t vcpu_id;
+	uint16_t vcpu_id, pcpu_id;
 	struct acrn_vm *vm;
 	struct acrn_vcpu *vcpu;
 	uint64_t mask = 0UL;
@@ -807,13 +807,14 @@ static int32_t shell_vcpu_dumpreg(int32_t argc, char **argv)
 		goto out;
 	}
 
+	pcpu_id = pcpuid_from_vcpu(vcpu);
 	dump.vcpu = vcpu;
 	dump.str = shell_log_buf;
 	dump.str_max = SHELL_LOG_BUF_SIZE;
-	if (vcpu->pcpu_id == get_pcpu_id()) {
+	if (pcpu_id == get_pcpu_id()) {
 		vcpu_dumpreg(&dump);
 	} else {
-		bitmap_set_nolock(vcpu->pcpu_id, &mask);
+		bitmap_set_nolock(pcpu_id, &mask);
 		smp_call_function(mask, vcpu_dumpreg, &dump);
 	}
 	shell_puts(shell_log_buf);

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -133,14 +133,14 @@ int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_
 			 * In this case, we cannot come back to polling status again. Currently,
 			 * it's OK as we needn't handle IO completion in zombie status.
 			 */
-			while (!need_reschedule(vcpu->pcpu_id)) {
+			while (!need_reschedule(pcpuid_from_vcpu(vcpu))) {
 				if (has_complete_ioreq(vcpu)) {
 					/* we have completed ioreq pending */
 					break;
 				}
 				asm_pause();
 			}
-		} else if (need_reschedule(vcpu->pcpu_id)) {
+		} else if (need_reschedule(pcpuid_from_vcpu(vcpu))) {
 			schedule();
 		} else {
 			ret = -EINVAL;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -538,6 +538,17 @@ static inline bool is_pae(struct acrn_vcpu *vcpu)
 	return (vcpu_get_cr4(vcpu) & CR4_PAE) != 0UL;
 }
 
+static inline void save_fxstore_guest_area(struct ext_context *ext_ctx)
+{
+	asm volatile("fxsave (%0)"
+			: : "r" (ext_ctx->fxstore_guest_area) : "memory");
+}
+
+static inline void rstor_fxstore_guest_area(const struct ext_context *ext_ctx)
+{
+	asm volatile("fxrstor (%0)" : : "r" (ext_ctx->fxstore_guest_area));
+}
+
 struct acrn_vcpu *get_running_vcpu(uint16_t pcpu_id);
 struct acrn_vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -538,6 +538,7 @@ static inline bool is_pae(struct acrn_vcpu *vcpu)
 	return (vcpu_get_cr4(vcpu) & CR4_PAE) != 0UL;
 }
 
+struct acrn_vcpu *get_running_vcpu(uint16_t pcpu_id);
 struct acrn_vcpu* get_ever_run_vcpu(uint16_t pcpu_id);
 
 /**

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -239,7 +239,6 @@ struct acrn_vcpu {
 
 	/* Architecture specific definitions for this VCPU */
 	struct acrn_vcpu_arch arch;
-	uint16_t pcpu_id;	/* Physical CPU ID of this VCPU */
 	uint16_t vcpu_id;	/* virtual identifier for VCPU */
 	struct acrn_vm *vm;		/* Reference to the VM this VCPU belongs to */
 
@@ -286,6 +285,7 @@ vcpu_vlapic(struct acrn_vcpu *vcpu)
 	return &(vcpu->arch.vlapic);
 }
 
+uint16_t pcpuid_from_vcpu(const struct acrn_vcpu *vcpu);
 void default_idle(__unused struct thread_object *obj);
 void vcpu_thread(struct thread_object *obj);
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -177,7 +177,7 @@ static inline struct acrn_vcpu *vcpu_from_pid(struct acrn_vm *vm, uint16_t pcpu_
 	struct acrn_vcpu *vcpu, *target_vcpu = NULL;
 
 	foreach_vcpu(i, vm, vcpu) {
-		if (vcpu->pcpu_id == pcpu_id) {
+		if (pcpuid_from_vcpu(vcpu) == pcpu_id) {
 			target_vcpu = vcpu;
 			break;
 		}

--- a/hypervisor/include/arch/x86/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/guest/vmcs.h
@@ -41,6 +41,7 @@ static inline uint64_t apic_access_offset(uint64_t qual)
 	return (qual & APIC_ACCESS_OFFSET);
 }
 void init_vmcs(struct acrn_vcpu *vcpu);
+void switch_vmcs(const struct acrn_vcpu *vcpu);
 
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu);
 #endif /* ASSEMBLER */

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -31,7 +31,6 @@ struct per_cpu_region {
 	uint64_t irq_count[NR_IRQS];
 	uint64_t softirq_pending;
 	uint64_t spurious;
-	struct acrn_vcpu *vcpu;
 	struct acrn_vcpu *ever_run_vcpu;
 #ifdef STACK_PROTECTOR
 	struct stack_canary stk_canary;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -13,6 +13,12 @@
 #define DEL_MODE_INIT		(1U)
 #define DEL_MODE_IPI		(2U)
 
+enum thread_object_state {
+	THREAD_STS_RUNNING = 1,
+	THREAD_STS_RUNNABLE,
+	THREAD_STS_BLOCKED
+};
+
 struct thread_object;
 typedef void (*thread_entry_t)(struct thread_object *obj);
 typedef void (*switch_t)(struct thread_object *obj);
@@ -21,6 +27,7 @@ struct thread_object {
 	uint16_t pcpu_id;
 	struct sched_control *sched_ctl;
 	thread_entry_t thread_entry;
+	volatile enum thread_object_state status;
 
 	uint64_t host_sp;
 	switch_t switch_out;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -53,7 +53,6 @@ uint16_t sched_get_pcpuid(const struct thread_object *obj);
 struct thread_object *sched_get_current(uint16_t pcpu_id);
 
 void init_sched(uint16_t pcpu_id);
-void switch_to_idle(thread_entry_t idle_thread);
 void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);
 
@@ -63,11 +62,12 @@ void remove_thread_obj(struct thread_object *obj, uint16_t pcpu_id);
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);
 
+void run_thread(struct thread_object *obj);
 void sleep_thread(struct thread_object *obj);
 void wake_thread(struct thread_object *obj);
 void schedule(void);
-void run_sched_thread(struct thread_object *obj);
 
 void arch_switch_to(void *prev_sp, void *next_sp);
+void run_idle_thread(void);
 #endif /* SCHEDULE_H */
 

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -19,6 +19,11 @@ enum thread_object_state {
 	THREAD_STS_BLOCKED
 };
 
+enum sched_notify_mode {
+	SCHED_NOTIFY_INIT,
+	SCHED_NOTIFY_IPI
+};
+
 struct thread_object;
 typedef void (*thread_entry_t)(struct thread_object *obj);
 typedef void (*switch_t)(struct thread_object *obj);
@@ -28,6 +33,7 @@ struct thread_object {
 	struct sched_control *sched_ctl;
 	thread_entry_t thread_entry;
 	volatile enum thread_object_state status;
+	enum sched_notify_mode notify_mode;
 
 	uint64_t host_sp;
 	switch_t switch_out;
@@ -57,6 +63,8 @@ void remove_thread_obj(struct thread_object *obj, uint16_t pcpu_id);
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);
 
+void sleep_thread(struct thread_object *obj);
+void wake_thread(struct thread_object *obj);
 void schedule(void);
 void run_sched_thread(struct thread_object *obj);
 

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -18,8 +18,11 @@ typedef void (*thread_entry_t)(struct thread_object *obj);
 typedef void (*switch_t)(struct thread_object *obj);
 struct thread_object {
 	char name[16];
-	uint64_t host_sp;
+	uint16_t pcpu_id;
+	struct sched_control *sched_ctl;
 	thread_entry_t thread_entry;
+
+	uint64_t host_sp;
 	switch_t switch_out;
 	switch_t switch_in;
 };
@@ -31,6 +34,8 @@ struct sched_control {
 
 	struct thread_object *thread_obj;
 };
+
+uint16_t sched_get_pcpuid(const struct thread_object *obj);
 
 void init_scheduler(void);
 void switch_to_idle(thread_entry_t idle_thread);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -39,7 +39,7 @@ bool is_idle_thread(const struct thread_object *obj);
 uint16_t sched_get_pcpuid(const struct thread_object *obj);
 struct thread_object *sched_get_current(uint16_t pcpu_id);
 
-void init_scheduler(void);
+void init_sched(uint16_t pcpu_id);
 void switch_to_idle(thread_entry_t idle_thread);
 void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -35,7 +35,9 @@ struct sched_control {
 	struct thread_object *thread_obj;
 };
 
+bool is_idle_thread(const struct thread_object *obj);
 uint16_t sched_get_pcpuid(const struct thread_object *obj);
+struct thread_object *sched_get_current(uint16_t pcpu_id);
 
 void init_scheduler(void);
 void switch_to_idle(thread_entry_t idle_thread);


### PR DESCRIPTION
  hv: sched: move pcpu_id from acrn_vcpu to thread_object
  hv: sched: use get_running_vcpu to replace per_cpu vcpu with cpu
    sharing
  hv: sched: support vcpu context switch on one pcpu
  hv: sched: move schedule initialization to each pcpu init
  hv: sched: add status for thread_object
  hv: sched: add sleep/wake for thread object
