### PR TITLE
doc: add 'rsync' to the ACRN builder container

### DIFF
--- a/doc/getting-started/Dockerfile
+++ b/doc/getting-started/Dockerfile
@@ -24,7 +24,9 @@ RUN swupd update -b && \
 			diffutils \
 			devpkg-elfutils \
 			doxygen \
+			rsync \
 			devpkg-ncurses \
+			devpkg-graphviz \
 			desktop-apps \
 	&& rm -rf /var/lib/swupd/*
 


### PR DESCRIPTION
'rsync' is missing from the ACRN Builder Container (in 'doc/getting-started/Dockerfile').
Add it and also add the 'devpkg-graphviz' bundle specifically although it is
automatically included via the 'desktop-apps' (it does not use any additional
space and makes clearer that it is needed).

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>