### PR TITLE
dm: NVME bdf info update on KBLNUC7i7DNH

### DIFF
--- a/devicemodel/samples/nuc/launch_hard_rt_vm.sh
+++ b/devicemodel/samples/nuc/launch_hard_rt_vm.sh
@@ -13,7 +13,7 @@ passthru_vpid=(
 passthru_bdf=(
 ["eth"]="0000:00:1f.6"
 ["sata"]="0000:00:17.0"
-["nvme"]="0000:02:0.0"
+["nvme"]="0000:02:00.0"
 )
 
 function launch_hard_rt_vm()


### PR DESCRIPTION
Wrong NVMe bdf info of KBLNUC7i7DNH is modified by mistake; so change it back.

Tracked-On: #3827
Reviewed-by: binbin.wu@intel.com

Signed-off-by: fuzhongl <fuzhong.liu@intel.com>