### PR TITLE
dm: fix mutex lock issue in tpm_rbc.c

### DIFF
--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -333,12 +333,10 @@ static void crb_reg_write(struct tpm_crb_vdev *tpm_vdev, uint64_t addr, int size
 
 			if (pthread_cond_signal(&tpm_vdev->request_cond)) {
 				DPRINTF("ERROR: Failed to wait condition\n");
-				break;
 			}
 
 			if (pthread_mutex_unlock(&tpm_vdev->request_mutex)) {
 				DPRINTF("ERROR: Failed to release mutex lock\n");
-				break;
 			}
 		}
 		break;


### PR DESCRIPTION
 In function crb_reg_write() in tpm_rbc.c
 'tpm_vdev->request_mutex' will potentially kept
 in locked state after crb_reg_write() returns.

Tracked-On: #3825
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Yadong Qi <yadong.qi@intel.com>