### PR TITLE
vm-manager: fix improper return value check for "strtol()"

### DIFF
--- a/misc/acrn-manager/acrn_vm_ops.c
+++ b/misc/acrn-manager/acrn_vm_ops.c
@@ -74,6 +74,7 @@ static inline int _get_vmname_pid(const char *src, char *p_vmname,
 		int max_len_vmname, int *pid)
 {
 	char *p = NULL;
+	long val64;
 
 	p = strchr(src, '.');
 	/* p - src: length of the substring "vmname" in the sting "src" */
@@ -88,10 +89,12 @@ static inline int _get_vmname_pid(const char *src, char *p_vmname,
 	else
 		p = p + strlen(".monitor.");
 
-	*pid = strtol(p, NULL, 10);
-	if ((errno == ERANGE && (*pid == LONG_MAX || *pid == LONG_MIN))
-			|| (errno != 0 && *pid == 0))
+	val64 = strtol(p, NULL, 10);
+	if ((errno == ERANGE && (val64 == LONG_MAX || val64 == LONG_MIN))
+			|| (errno != 0 && val64 == 0))
 		return -1;
+
+	*pid = (int)val64;
 
 	p = strchr(p, '.');
 	if (!p || strncmp(".socket", p, strlen(".socket")))

--- a/misc/acrn-manager/acrnd.c
+++ b/misc/acrn-manager/acrnd.c
@@ -697,6 +697,9 @@ static void display_usage(void)
 static int parse_opt(int argc, char *argv[])
 {
 	int opt, ret = 0;
+#ifdef MNGR_DEBUG
+	long delay = 0;
+#endif
 
 	while ((opt = getopt(argc, argv, optString)) != -1) {
 		switch (opt) {
@@ -705,15 +708,15 @@ static int parse_opt(int argc, char *argv[])
 			break;
 #ifdef MNGR_DEBUG
 		case 'd':
-			ret = strtol(optarg, NULL, 10);
-			if ((errno == ERANGE && (ret == LONG_MAX || ret == LONG_MIN))
-				|| (errno != 0 && ret == 0)
-				|| (ret < 0 || ret > 60)) {
+			delay = strtol(optarg, NULL, 10);
+			if ((errno == ERANGE && (delay == LONG_MAX || delay == LONG_MIN))
+				|| (errno != 0 && delay == 0)
+				|| (delay < 0 || delay > 60)) {
 				printf("'-d' invalid parameter: %s\n", optarg);
 				return -EINVAL;
 			}
 
-			autostart_delay = ret;
+			autostart_delay = (int)delay;
 			ret = 0;
 			break;
 #endif


### PR DESCRIPTION
 The return value of 'strtol()' is not checked properly
 in _get_vmname_pid() @acrn_vm_ops.c and parse_opt()@acnrd.c,
 the return type of 'strtol' is 'long int', but it is assigned
 to a variable with type of 'int' and compared to "LONG_MAX"
 and "LONG_MIN", which is always false.

 This patch is to fix above error case.

Tracked-On: #3859
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Yan, Like <like.yan@intel.com>