### PR TITLE
acrn-config: define vm name while generating launch script for preempt RT

### DIFF
--- a/misc/acrn-config/board_config/pci_devices_h.py
+++ b/misc/acrn-config/board_config/pci_devices_h.py
@@ -61,23 +61,6 @@ def parser_pci():
     return (pci_dev_dic, pci_bar_dic, sub_name_count)
 
 
-
-def undline_name(name):
-    """
-    This convert name which has contain '-' to '_'
-    :param name: name which contain '-' and ' '
-    :return: name_str which contain'_'
-    """
-    # convert '-' to '_' in name string
-    name_str = "_".join(name.split('-')).upper()
-
-    # stitch '_' while ' ' in name string
-    if ' ' in name_str:
-        name_str = "_".join(name_str.split()).upper()
-
-    return name_str
-
-
 def write_pbdf(i_cnt, bdf, subname, config):
     """
     Parser and generate pbdf
@@ -91,7 +74,7 @@ def write_pbdf(i_cnt, bdf, subname, config):
         tmp_sub_name = "_".join(subname.split()).upper()
     else:
         if '-' in subname:
-            tmp_sub_name = undline_name(subname) + "_" + str(i_cnt)
+            tmp_sub_name = board_cfg_lib.undline_name(subname) + "_" + str(i_cnt)
         else:
             tmp_sub_name = "_".join(subname.split()).upper() + "_" + str(i_cnt)
 

--- a/misc/acrn-config/board_config/ve820_c.py
+++ b/misc/acrn-config/board_config/ve820_c.py
@@ -11,19 +11,6 @@ TOTAL_MEM_SIZE = 4 * 1024 * 1024 * 1024
 LOW_MEM_TO_PCI_HOLE = 0x20000000
 
 
-def undline_board_name(board_name):
-    """
-    This convert board name which has contain '-' to '_'
-    :param board_name:
-    :return:
-    """
-    name_list = board_name
-    if '-' in board_name:
-        name_list = "_".join(board_name.split('-'))
-
-    return name_list
-
-
 def ve820_per_launch(config, hpa_size):
     """
     Start to generate board.c
@@ -33,7 +20,7 @@ def ve820_per_launch(config, hpa_size):
     if err_dic:
         return err_dic
 
-    board_name = undline_board_name(board_name)
+    board_name = board_cfg_lib.undline_name(board_name)
 
     low_mem_to_pci_hole_len = '0xA0000000'
     low_mem_to_pci_hole = '0x20000000'
@@ -46,9 +33,9 @@ def ve820_per_launch(config, hpa_size):
     print("#include <e820.h>", file=config)
     print("#include <vm.h>", file=config)
     print("", file=config)
-    print("#define VE820_ENTRIES_{}\t{}U".format(board_name.upper(), 5), file=config)
+    print("#define VE820_ENTRIES_{}\t{}U".format(board_name, 5), file=config)
     print("static const struct e820_entry ve820_entry[{}] = {{".format(
-        "VE820_ENTRIES_{}".format(board_name.upper())), file=config)
+        "VE820_ENTRIES_{}".format(board_name)), file=config)
     print("\t{\t/* usable RAM under 1MB */", file=config)
     print("\t\t.baseaddr = 0x0UL,", file=config)
     print("\t\t.length   = 0xF0000UL,\t\t/* 960KB */", file=config)
@@ -96,7 +83,7 @@ def ve820_per_launch(config, hpa_size):
     print("*/", file=config)
     print("void create_prelaunched_vm_e820(struct acrn_vm *vm)", file=config)
     print("{", file=config)
-    print("\tvm->e820_entry_num = VE820_ENTRIES_{};".format(board_name.upper()), file=config)
+    print("\tvm->e820_entry_num = VE820_ENTRIES_{};".format(board_name), file=config)
     print("\tvm->e820_entries = ve820_entry;", file=config)
     print("}", file=config)
 

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -21,6 +21,7 @@ def tap_uos_net(names, vmid, config):
     uos_type = names['uos_types'][vmid]
     board_name = names['board_name']
 
+    vm_name = launch_cfg_lib.undline_name(uos_type).lower()
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
         if board_name in ("apl-mrb", "apl-up2"):
             print('if [ ! -f "/data/$3/$3.img" ]; then', file=config)
@@ -35,7 +36,7 @@ def tap_uos_net(names, vmid, config):
         print("", file=config)
 
     if uos_type in ("VXWORKS", "ZEPHYR", "WINDOWS"):
-        print("vm_name={}_vm$1".format(uos_type), file=config)
+        print("vm_name={}_vm$1".format(vm_name), file=config)
 
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
         if board_name in ("apl-mrb", "apl-up2"):
@@ -231,7 +232,7 @@ def log_level_set(uos_type, config):
 
 
 def launch_begin(board_name, uos_type, config):
-    launch_uos = '_'.join(uos_type.lower().split())
+    launch_uos = launch_cfg_lib.undline_name(board_name).lower()
     run_container(board_name, uos_type, config)
     print("function launch_{}()".format(launch_uos), file=config)
     print("{", file=config)
@@ -274,7 +275,7 @@ def uos_launch(names, args, vmid, config):
     board_name = names['board_name']
     gvt_args = args['gvt_args'][vmid]
     uos_type = names['uos_types'][vmid]
-    launch_uos = '_'.join(uos_type.lower().split())
+    launch_uos = launch_cfg_lib.undline_name(board_name).lower()
 
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_clr(names, vmid):
 

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -35,7 +35,7 @@ def tap_uos_net(names, vmid, config):
         print("mac_seed=${mac:9:8}-${vm_name}", file=config)
         print("", file=config)
 
-    if uos_type in ("VXWORKS", "ZEPHYR", "WINDOWS"):
+    if uos_type in ("VXWORKS", "ZEPHYR", "WINDOWS", "PREEMPT-RT LINUX"):
         print("vm_name={}_vm$1".format(vm_name), file=config)
 
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
@@ -289,7 +289,7 @@ def uos_launch(names, args, vmid, config):
         if uos_type == "VXWORKS":
             print("launch_{} 1".format(launch_uos), file=config)
         if uos_type == "PREEMPT-RT LINUX":
-            print("launch_{}".format(launch_uos), file=config)
+            print("launch_{} 1".format(launch_uos), file=config)
         if uos_type == "WINDOWS":
             print('launch_{} 1 "{}"'.format(launch_uos, gvt_args), file=config)
         if uos_type == "ZEPHYR":
@@ -518,10 +518,7 @@ def dm_arg_set(names, sel, dm, vmid, config):
         print("   --enable_trusty \\", file=config)
 
     set_dm_pt(names, sel, vmid, config)
-    if uos_type != "PREEMPT-RT LINUX":
-        print("   $vm_name", file=config)
-    else:
-        print("   hard_rtvm", file=config)
+    print("   $vm_name", file=config)
     print("}", file=config)
 
 

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -460,3 +460,12 @@ def get_processor_info():
         break
 
     return tmp_list
+
+
+def undline_name(name):
+    """
+    This convert name which has contain '-' to '_'
+    :param name: name which contain '-' and ' '
+    :return: name_str which contain'_'
+    """
+    return common.undline_name(name)

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -622,3 +622,19 @@ def get_max_clos(board_file):
             clos_max = int(line.split(':')[1])
 
     return (cache_support, clos_max)
+
+
+def undline_name(name):
+    """
+    This convert name which has contain '-' to '_'
+    :param name: name which contain '-' and ' '
+    :return: name_str which contain'_'
+    """
+    # convert '-' to '_' in name string
+    name_str = "_".join(name.split('-')).upper()
+
+    # stitch '_' while ' ' in name string
+    if ' ' in name_str:
+        name_str = "_".join(name_str.split()).upper()
+
+    return name_str

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -585,3 +585,12 @@ def get_pt_dev():
     cap_pt = PASSTHRU_DEVS
 
     return cap_pt
+
+
+def undline_name(name):
+    """
+    This convert name which has contain '-' to '_'
+    :param name: name which contain '-' and ' '
+    :return: name_str which contain'_'
+    """
+    return common.undline_name(name)

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -462,6 +462,10 @@ def args_aval_check(arg_list, item, avl_list):
     """
     # args should be set into launch xml from webUI
     i_cnt = 1
+    skip_check_list = ['gvt_args', 'rootfs_dev']
+    if item in skip_check_list:
+        return
+
     for arg_str in arg_list.values():
         if arg_str == None or not arg_str.strip():
             empty_err(i_cnt, item)


### PR DESCRIPTION

1. acrn-config: define vm name for Preempt-RT Linux in launch script
2. acrn-config: refine board name with undline_name api
3. acrn-config: acrn-config: add white list to skip item check


    Tracked-On: #3852
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
