### PR TITLE
acrn-config: correct ipu/ipu_i2c/audio/wifi default config from xml

### DIFF
--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -17,9 +17,9 @@
 		<ipu desc="vm ipu device"></ipu>
 		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
 		<cse desc="vm cse device"></cse>
-		<audio desc="vm audio device">00:0e.0 Multimedia audio controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)</audio>
+		<audio desc="vm audio device">00:0e.0 Audio device: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)</audio>
 		<audio_codec desc="vm audio codec device">00:17.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #5 (rev 0b)</audio_codec>
-		<wifi desc="vm wifi device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</wifi>
+		<wifi desc="vm wifi device">03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</wifi>
 		<bluetooth desc="vm bluetooth">00:18.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #1 (rev 0b)</bluetooth>
 		<sd_card desc="vm sd card device">00:1b.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SDXC/MMC Host Controller (rev 0b)</sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -17,9 +17,9 @@
 		<ipu desc="vm ipu device"></ipu>
 		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
 		<cse desc="vm cse device"></cse>
-		<audio desc="vm audio device">00:0e.0 Multimedia audio controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)</audio>
+		<audio desc="vm audio device">00:0e.0 Audio device: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)</audio>
 		<audio_codec desc="vm audio codec device">00:17.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #5 (rev 0b)</audio_codec>
-		<wifi desc="vm wifi device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</wifi>
+		<wifi desc="vm wifi device">03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</wifi>
 		<bluetooth desc="vm bluetooth">00:18.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series HSUART Controller #1 (rev 0b)</bluetooth>
 		<sd_card desc="vm sd card device">00:1b.0 SD Host controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SDXC/MMC Host Controller (rev 0b)</sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -16,8 +16,8 @@
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>
 		<audio desc="vm audio device"></audio>
 		<audio_codec desc="vm audio codec device"></audio_codec>
-		<ipu desc="vm ipu device">00:03.0 Multimedia controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Imaging Unit (rev 0b)</ipu>
-		<ipu_i2c desc="vm ipu_i2c device">00:16.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #1 (rev 0b)</ipu_i2c>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
 		<cse desc="vm cse device">00:0f.0 Communication controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Trusted Execution Engine (rev 0b)</cse>
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -16,8 +16,8 @@
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>
 		<audio desc="vm audio device"></audio>
 		<audio_codec desc="vm audio codec device"></audio_codec>
-		<ipu desc="vm ipu device">00:03.0 Multimedia controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Imaging Unit (rev 0b)</ipu>
-		<ipu_i2c desc="vm ipu_i2c device">00:16.0 Signal processing controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series I2C Controller #1 (rev 0b)</ipu_i2c>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
 		<cse desc="vm cse device">00:0f.0 Communication controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Trusted Execution Engine (rev 0b)</cse>
 		<wifi desc="vm wifi device"></wifi>
 		<bluetooth desc="vm bluetooth"></bluetooth>


### PR DESCRIPTION

1. acrn-config: modify ipu/ipu_i2c device launch config of apl-up2
2. acrn-config: correct launch config info for audio/wifi defice of apl-mrb

    Tracked-On: #3863
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
