### PR TITLE
Vpci: add PCI MSI-X table BAR re-programming support

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -18,6 +18,18 @@
 
 #define ACRN_DBG_EPT	6U
 
+bool ept_is_mr_valid(const struct acrn_vm *vm, uint64_t base, uint64_t size)
+{
+	bool valid = true;
+	uint64_t end = base + size;
+	uint64_t top_address_space = vm->arch_vm.ept_mem_ops.info->ept.top_address_space;
+	if ((end <= base) || (end > top_address_space)) {
+		valid = false;
+	}
+
+	return valid;
+}
+
 void destroy_ept(struct acrn_vm *vm)
 {
 	/* Destroy secure world */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -439,7 +439,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	(void)memset((void *)vm, 0U, sizeof(struct acrn_vm));
 	vm->vm_id = vm_id;
 	vm->hw.created_vcpus = 0U;
-	vm->emul_mmio_regions = 0U;
 
 	init_ept_mem_ops(&vm->arch_vm.ept_mem_ops, vm->vm_id);
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -626,7 +626,6 @@ static int32_t add_vm_memory_region(struct acrn_vm *vm, struct acrn_vm *target_v
 static int32_t set_vm_memory_region(struct acrn_vm *vm,
 	struct acrn_vm *target_vm, const struct vm_memory_region *region)
 {
-	uint64_t gpa_end;
 	uint64_t *pml4_page;
 	int32_t ret;
 
@@ -635,8 +634,7 @@ static int32_t set_vm_memory_region(struct acrn_vm *vm,
 			__func__, target_vm->vm_id, region->size);
 	        ret = -EINVAL;
 	} else {
-		gpa_end = region->gpa + region->size;
-		if (gpa_end > target_vm->arch_vm.ept_mem_ops.info->ept.top_address_space) {
+		if (!ept_is_mr_valid(target_vm, region->gpa, region->size)) {
 				pr_err("%s, invalid gpa: 0x%llx, size: 0x%llx, top_address_space: 0x%llx", __func__,
 					region->gpa, region->size,
 					target_vm->arch_vm.ept_mem_ops.info->ept.top_address_space);

--- a/hypervisor/include/arch/x86/guest/ept.h
+++ b/hypervisor/include/arch/x86/guest/ept.h
@@ -19,6 +19,17 @@ typedef void (*pge_handler)(uint64_t *pgentry, uint64_t size);
 #define INVALID_GPA	(0x1UL << 52U)
 /* External Interfaces */
 /**
+ * @brief Check guest-physical memory region mapping valid
+ *
+ * @param[in] vm the pointer that points to VM data structure
+ * @param[in] base The specified start guest physical address of guest
+ *                physical memory region
+ * @param[in] size The size of guest physical memory region
+ *
+ * @retval true if the guest-physical memory region mapping valid, false otherwise.
+ */
+bool ept_is_mr_valid(const struct acrn_vm *vm, uint64_t base, uint64_t size);
+/**
  * @brief EPT page tables destroy
  *
  * @param[inout] vm the pointer that points to VM data structure

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -125,7 +125,7 @@ struct acrn_vm {
 	struct iommu_domain *iommu;	/* iommu domain of this VM */
 	spinlock_t vm_lock;	/* Spin-lock used to protect VM modifications */
 
-	uint16_t emul_mmio_regions; /* Number of emulated mmio regions */
+	uint16_t max_emul_mmio_regions;	/* max index of the emulated mmio_region */
 	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
 
 	struct vm_io_handler_desc emul_pio[EMUL_PIO_IDX_MAX];

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -251,7 +251,7 @@ void   register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
 /**
  * @brief Register a MMIO handler
  *
- * This API registers a MMIO handler to \p vm before it is launched.
+ * This API registers a MMIO handler to \p vm.
  *
  * @param vm The VM to which the MMIO handler is registered
  * @param read_write The handler for emulating accesses to the given range
@@ -264,6 +264,20 @@ void   register_pio_emulation_handler(struct acrn_vm *vm, uint32_t pio_idx,
 void register_mmio_emulation_handler(struct acrn_vm *vm,
 	hv_mem_io_handler_t read_write, uint64_t start,
 	uint64_t end, void *handler_private_data);
+
+/**
+ * @brief Unregister a MMIO handler
+ *
+ * This API unregisters a MMIO handler to \p vm
+ *
+ * @param vm The VM to which the MMIO handler is unregistered
+ * @param start The base address of the range which wants to unregister
+ * @param end The end of the range (exclusive) which wants to unregister
+ *
+ * @return None
+ */
+void unregister_mmio_emulation_handler(struct acrn_vm *vm,
+					uint64_t start, uint64_t end);
 
 /**
  * @}


### PR DESCRIPTION
ToDo:
preserve concurrent access for PCI configuration space

v4:
1. minor refine input parameter mmio_idx for register_mmio_emulation_handler
2. detail comment for vdev_pt_remap_msix_table_vbar

v3:
1. refine unregister_mmio_emulation_handler implementation
2. delete the MSI-X table BAR EPT memory region mapping for pre-launched VM
3. move EPT operation out of mmio emulation handler register function.

v2:
1. rename is_ept_mr_valid to ept_is_mr_valid
2. add unregister_mmio_emulation_handler API
3. add PCI MSI-X table BAR re-programming support

v1:
add PCI BAR re-programing address check

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>
