### PR TITLE
acrn-config: refine ttyS info of board file

### DIFF
--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -170,7 +170,7 @@ def get_ttys_info(board_info):
             break
 
         #ttys_dev = " ".join(ttys_line.strip().split()[:-2])
-        ttys_dev = ttys_line.split()[1].split(':')[1]
+        ttys_dev = ttys_line.split()[0].split(':')[1]
         ttys_list.append(ttys_dev)
 
     return ttys_list

--- a/misc/acrn-config/target/misc.py
+++ b/misc/acrn-config/target/misc.py
@@ -19,6 +19,7 @@ ttys_type = {
 
 ttys_irqs = []
 
+
 def read_ttys_node(path):
         with open(path, 'rt') as info:
             ret_value = info.readline().strip()
@@ -47,30 +48,6 @@ def detected_ttys():
     return tty_used_list
 
 
-def irq2bdf(irq_n):
-    cmd = 'lspci -vv'
-    res = parser_lib.cmd_execute(cmd)
-    bdf = ''
-    irq = 0
-    while True:
-        line = res.stdout.readline().decode('ascii')
-        if not line:
-            break
-
-        if ':' not in line:
-            continue
-
-        if '.' in line.split()[0]:
-            bdf = line.split()[0]
-
-        if "Interrupt:" in line.strip():
-            irq = line.split()[-1]
-            if irq == irq_n and bdf:
-                break
-
-    return bdf
-
-
 def dump_ttys_info(ttys_list, config):
     for ttys in ttys_list:
         ttys_n = ttys.split('/')[-1]
@@ -79,17 +56,16 @@ def dump_ttys_info(ttys_list, config):
 
         irq_path = '{}{}/irq'.format(TTY_PATH, ttys_n)
         irq = read_ttys_node(irq_path)
+        ttys_irqs.append(irq)
 
         if ttys_type[serial_type] == 'PORT':
             base_path = '{}{}/port'.format(TTY_PATH, ttys_n)
+            base = read_ttys_node(base_path)
+            print("\tseri:{} type:portio base:{} irq:{}".format(ttys, base, irq), file=config)
         elif ttys_type[serial_type] == 'MMIO':
             base_path = '{}{}/iomem_base'.format(TTY_PATH, ttys_n)
-
-        base = read_ttys_node(base_path)
-
-        ttys_irqs.append(irq)
-        bdf = irq2bdf(irq)
-        print("\tBDF:({}) seri:{} base:{} irq:{}".format(bdf, ttys, base, irq), file=config)
+            base = read_ttys_node(base_path)
+            print("\tseri:{} type:mmio base:{} irq:{}".format(ttys, base, irq), file=config)
 
 
 def dump_ttys(config):

--- a/misc/acrn-config/xmls/board-xmls/apl-mrb.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-mrb.xml
@@ -301,9 +301,9 @@
 	</BLOCK_DEVICE_INFO>
 
 	<TTYS_INFO>
-	BDF:(00:18.0) seri:/dev/ttyS0 base:0xB3640000 irq:4
-	BDF:(00:18.2) seri:/dev/ttyS2 base:0x80E00000 irq:6
-	BDF:(00:18.3) seri:/dev/ttyS3 base:0xB363A000 irq:7
+	seri:/dev/ttyS0 type:mmio base:0xB3640000 irq:4
+	seri:/dev/ttyS2 type:mmio base:0x80E00000 irq:6
+	seri:/dev/ttyS3 type:mmio base:0xB363A000 irq:7
 	</TTYS_INFO>
 
 	<AVAILABLE_IRQ_INFO>

--- a/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
@@ -280,8 +280,8 @@
 	</BLOCK_DEVICE_INFO>
 
 	<TTYS_INFO>
-	BDF:(00:18.0) seri:/dev/ttyS0 base:0x91526000 irq:4
-	BDF:(00:18.1) seri:/dev/ttyS1 base:0x91524000 irq:5
+	seri:/dev/ttyS0 type:mmio base:0x91526000 irq:4
+	seri:/dev/ttyS1 type:mmio base:0x91524000 irq:5
 	</TTYS_INFO>
 
 	<AVAILABLE_IRQ_INFO>

--- a/misc/acrn-config/xmls/board-xmls/apl-up2.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2.xml
@@ -280,8 +280,8 @@
 	</BLOCK_DEVICE_INFO>
 
 	<TTYS_INFO>
-	BDF:(00:18.0) seri:/dev/ttyS0 base:0x91526000 irq:4
-	BDF:(00:18.1) seri:/dev/ttyS1 base:0x91524000 irq:5
+	seri:/dev/ttyS0 type:mmio base:0x91526000 irq:4
+	seri:/dev/ttyS1 type:mmio base:0x91524000 irq:5
 	</TTYS_INFO>
 
 	<AVAILABLE_IRQ_INFO>

--- a/misc/acrn-config/xmls/board-xmls/nuc6cayh.xml
+++ b/misc/acrn-config/xmls/board-xmls/nuc6cayh.xml
@@ -236,7 +236,7 @@
 	</BLOCK_DEVICE_INFO>
 
 	<TTYS_INFO>
-	BDF:(00:18.0) seri:/dev/ttyS0 base:0x91420000 irq:4
+	seri:/dev/ttyS0 type:mmio base:0x91420000 irq:4
 	</TTYS_INFO>
 
 	<AVAILABLE_IRQ_INFO>

--- a/misc/acrn-config/xmls/board-xmls/nuc7i7dnb.xml
+++ b/misc/acrn-config/xmls/board-xmls/nuc7i7dnb.xml
@@ -231,8 +231,8 @@
 	</BLOCK_DEVICE_INFO>
 
 	<TTYS_INFO>
-	BDF:(02:00.0) seri:/dev/ttyS0 base:0x3F8 irq:4
-	BDF:(00:16.3) seri:/dev/ttyS4 base:0xF0A0 irq:19
+	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
+	seri:/dev/ttyS4 type:portio base:0xF0A0 irq:19
 	</TTYS_INFO>
 
 	<AVAILABLE_IRQ_INFO>


### PR DESCRIPTION
The previous method to handle ttyS info has an assumption that PCI
serial devices are all mmio type, this caused incorrect BDF info in
board XML file.
This patch fix this issue by dropping serial device BDF info and
replace it with IO type.

Tracked-On: #3900
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>