### PR TITLE
hv[v2]: remove registration of default port IO and MMIO  handlers

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -445,12 +445,6 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);
 	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp, &vm->arch_vm.ept_mem_ops);
 
-	/* Register default handlers for PIO & MMIO if it is, SOS VM or Pre-launched VM */
-	if ((vm_config->load_order == SOS_VM) || (vm_config->load_order == PRE_LAUNCHED_VM)) {
-		register_pio_default_emulation_handler(vm);
-		register_mmio_default_emulation_handler(vm);
-	}
-
 	(void)memcpy_s(&vm->uuid[0], sizeof(vm->uuid),
 		&vm_config->uuid[0], sizeof(vm_config->uuid));
 

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -127,11 +127,8 @@ struct acrn_vm {
 
 	uint16_t emul_mmio_regions; /* Number of emulated mmio regions */
 	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
-	hv_mem_io_handler_t default_read_write;
 
 	struct vm_io_handler_desc emul_pio[EMUL_PIO_IDX_MAX];
-	io_read_fn_t default_io_read;
-	io_write_fn_t default_io_write;
 
 	uint8_t uuid[16];
 	struct secure_world_control sworld_control;

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -266,20 +266,6 @@ void register_mmio_emulation_handler(struct acrn_vm *vm,
 	uint64_t end, void *handler_private_data);
 
 /**
- * @brief Register port I/O default handler
- *
- * @param vm      The VM to which the port I/O handlers are registered
- */
-void register_pio_default_emulation_handler(struct acrn_vm *vm);
-
-/**
- * @brief Register MMIO default handler
- *
- * @param vm The VM to which the MMIO handler is registered
- */
-void register_mmio_default_emulation_handler(struct acrn_vm *vm);
-
-/**
  * @}
  */
 


### PR DESCRIPTION
 - The default behaviors of PIO & MMIO handlers are same
   for all VMs, no need to expose dedicated APIs to register
   default hanlders for SOS and prelaunched VM.

Tracked-On: #3904
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Junjie Mao <junjie.mao@intel.com>