### PR TITLE
Abstract scheduler from sched module and polish sched framework

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -216,6 +216,7 @@ HW_C_SRCS += arch/x86/cat.c
 HW_C_SRCS += arch/x86/sgx.c
 HW_C_SRCS += common/softirq.c
 HW_C_SRCS += common/schedule.c
+HW_C_SRCS += common/sched_noop.c
 HW_C_SRCS += hw/pci.c
 HW_C_SRCS += arch/x86/configs/vm_config.c
 HW_C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/board.c

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -409,6 +409,7 @@ void cpu_dead(void)
 	int32_t halt = 1;
 	uint16_t pcpu_id = get_pcpu_id();
 
+	deinit_sched(pcpu_id);
 	if (bitmap_test(pcpu_id, &pcpu_active_bitmap)) {
 		/* clean up native stuff */
 		vmx_off();

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -729,17 +729,14 @@ static void context_switch_in(struct thread_object *next)
 	vcpu->running = true;
 }
 
-void schedule_vcpu(struct acrn_vcpu *vcpu)
+void launch_vcpu(struct acrn_vcpu *vcpu)
 {
 	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
 
 	vcpu->state = VCPU_RUNNING;
 	pr_dbg("vcpu%hu scheduled on pcpu%hu", vcpu->vcpu_id, pcpu_id);
 
-	get_schedule_lock(pcpu_id);
-	insert_thread_obj(&vcpu->thread_obj, pcpu_id);
-	make_reschedule_request(pcpu_id, DEL_MODE_IPI);
-	release_schedule_lock(pcpu_id);
+	wake_thread(&vcpu->thread_obj);
 }
 
 /* help function for vcpu create */
@@ -761,6 +758,7 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		vcpu->thread_obj.switch_out = context_switch_out;
 		vcpu->thread_obj.switch_in = context_switch_in;
+		init_thread_data(&vcpu->thread_obj);
 	}
 
 	return ret;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -598,6 +598,11 @@ void offline_vcpu(struct acrn_vcpu *vcpu)
 	vcpu->state = VCPU_OFFLINE;
 }
 
+void kick_vcpu(const struct acrn_vcpu *vcpu)
+{
+	kick_thread(&vcpu->thread_obj);
+}
+
 /*
 * @pre (&vcpu->stack[CONFIG_STACK_SIZE] & (CPU_STACK_ALIGN - 1UL)) == 0
 */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -106,21 +106,8 @@ static bool is_guest_irq_enabled(struct acrn_vcpu *vcpu)
 
 void vcpu_make_request(struct acrn_vcpu *vcpu, uint16_t eventid)
 {
-	uint16_t pcpu_id = pcpuid_from_vcpu(vcpu);
-
 	bitmap_set_lock(eventid, &vcpu->arch.pending_req);
-	/*
-	 * if current hostcpu is not the target vcpu's hostcpu, we need
-	 * to invoke IPI to wake up target vcpu
-	 *
-	 * TODO: Here we just compare with cpuid, since cpuid currently is
-	 *  global under pCPU / vCPU 1:1 mapping. If later we enabled vcpu
-	 *  scheduling, we need change here to determine it target vcpu is
-	 *  VMX non-root or root mode
-	 */
-	if (get_pcpu_id() != pcpu_id) {
-		send_single_ipi(pcpu_id, VECTOR_NOTIFY_VCPU);
-	}
+	kick_vcpu(vcpu);
 }
 
 /*

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1172,7 +1172,7 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 				set_vcpu_startup_entry(target_vcpu, (icr_low & APIC_VECTOR_MASK) << 12U);
 				/* init vmcs after set_vcpu_startup_entry */
 				init_vmcs(target_vcpu);
-				schedule_vcpu(target_vcpu);
+				launch_vcpu(target_vcpu);
 			}
 		}
 	} else {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -648,7 +648,7 @@ void start_vm(struct acrn_vm *vm)
 	/* Only start BSP (vid = 0) and let BSP start other APs */
 	bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
 	init_vmcs(bsp);
-	schedule_vcpu(bsp);
+	launch_vcpu(bsp);
 }
 
 /**
@@ -772,7 +772,7 @@ void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 	set_vcpu_startup_entry(bsp, wakeup_vec);
 
 	init_vmcs(bsp);
-	schedule_vcpu(bsp);
+	launch_vcpu(bsp);
 }
 
 /**

--- a/hypervisor/common/sched_noop.c
+++ b/hypervisor/common/sched_noop.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <per_cpu.h>
+#include <schedule.h>
+
+static int32_t sched_noop_init(struct sched_control *ctl)
+{
+	struct sched_noop_control *noop_ctl = &per_cpu(sched_noop_ctl, ctl->pcpu_id);
+	ctl->priv = noop_ctl;
+
+	return 0;
+}
+
+static struct thread_object *sched_noop_pick_next(struct sched_control *ctl)
+{
+	struct sched_noop_control *noop_ctl = (struct sched_noop_control *)ctl->priv;
+	struct thread_object *next = NULL;
+
+	if (noop_ctl->noop_thread_obj != NULL) {
+		next = noop_ctl->noop_thread_obj;
+	} else {
+		next = &get_cpu_var(idle);
+	}
+	return next;
+}
+
+static void sched_noop_sleep(struct thread_object *obj)
+{
+	struct sched_noop_control *noop_ctl = (struct sched_noop_control *)obj->sched_ctl->priv;
+
+	if (noop_ctl->noop_thread_obj == obj) {
+		noop_ctl->noop_thread_obj = NULL;
+	}
+}
+
+static void sched_noop_wake(struct thread_object *obj)
+{
+	struct sched_noop_control *noop_ctl = (struct sched_noop_control *)obj->sched_ctl->priv;
+
+	if (noop_ctl->noop_thread_obj == NULL) {
+		noop_ctl->noop_thread_obj = obj;
+	}
+}
+
+struct acrn_scheduler sched_noop = {
+	.name		= "sched_noop",
+	.init		= sched_noop_init,
+	.pick_next	= sched_noop_pick_next,
+	.sleep		= sched_noop_sleep,
+	.wake		= sched_noop_wake,
+};

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -54,6 +54,7 @@ void init_sched(uint16_t pcpu_id)
 	spinlock_init(&ctl->scheduler_lock);
 	ctl->flags = 0UL;
 	ctl->curr_obj = NULL;
+	ctl->pcpu_id = pcpu_id;
 }
 
 void get_schedule_lock(uint16_t pcpu_id)

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -637,6 +637,17 @@ void resume_vcpu(struct acrn_vcpu *vcpu);
 void launch_vcpu(struct acrn_vcpu *vcpu);
 
 /**
+ * @brief kick the vcpu and let it handle pending events
+ *
+ * Kick a vCPU to handle the pending events.
+ *
+ * @param[in] vcpu pointer to vcpu data structure
+ *
+ * @return None
+ */
+void kick_vcpu(const struct acrn_vcpu *vcpu);
+
+/**
  * @brief create a vcpu for the vm and mapped to the pcpu.
  *
  * Create a vcpu for the vm, and mapped to the pcpu.

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -634,7 +634,7 @@ void resume_vcpu(struct acrn_vcpu *vcpu);
  *
  * @return None
  */
-void schedule_vcpu(struct acrn_vcpu *vcpu);
+void launch_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief create a vcpu for the vm and mapped to the pcpu.

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -37,6 +37,7 @@ struct per_cpu_region {
 #endif
 	struct per_cpu_timers cpu_timers;
 	struct sched_control sched_ctl;
+	struct sched_noop_control sched_noop_ctl;
 	struct thread_object idle;
 	struct host_gdt gdt;
 	struct tss_64 tss;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -41,6 +41,7 @@ struct thread_object {
 };
 
 struct sched_control {
+	uint16_t pcpu_id;
 	uint64_t flags;
 	struct thread_object *curr_obj;
 	spinlock_t scheduler_lock;	/* to protect sched_control and thread_object */

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -100,6 +100,7 @@ bool need_reschedule(uint16_t pcpu_id);
 void run_thread(struct thread_object *obj);
 void sleep_thread(struct thread_object *obj);
 void wake_thread(struct thread_object *obj);
+void kick_thread(const struct thread_object *obj);
 void schedule(void);
 
 void arch_switch_to(void *prev_sp, void *next_sp);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -88,8 +88,8 @@ struct thread_object *sched_get_current(uint16_t pcpu_id);
 
 void init_sched(uint16_t pcpu_id);
 void deinit_sched(uint16_t pcpu_id);
-void get_schedule_lock(uint16_t pcpu_id);
-void release_schedule_lock(uint16_t pcpu_id);
+void obtain_schedule_lock(uint16_t pcpu_id, uint64_t *rflag);
+void release_schedule_lock(uint16_t pcpu_id, uint64_t rflag);
 
 void init_thread_data(struct thread_object *obj);
 void deinit_thread_data(struct thread_object *obj);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -13,6 +13,8 @@
 #define DEL_MODE_INIT		(1U)
 #define DEL_MODE_IPI		(2U)
 
+#define THREAD_DATA_SIZE	(256U)
+
 enum thread_object_state {
 	THREAD_STS_RUNNING = 1,
 	THREAD_STS_RUNNABLE,
@@ -38,6 +40,8 @@ struct thread_object {
 	uint64_t host_sp;
 	switch_t switch_out;
 	switch_t switch_in;
+
+	uint8_t data[THREAD_DATA_SIZE];
 };
 
 struct sched_control {
@@ -45,8 +49,37 @@ struct sched_control {
 	uint64_t flags;
 	struct thread_object *curr_obj;
 	spinlock_t scheduler_lock;	/* to protect sched_control and thread_object */
+	struct acrn_scheduler *scheduler;
+	void *priv;
+};
 
-	struct thread_object *thread_obj;
+#define SCHEDULER_MAX_NUMBER 4U
+struct acrn_scheduler {
+	char name[16];
+
+	/* init scheduler */
+	int32_t	(*init)(struct sched_control *ctl);
+	/* init private data of scheduler */
+	void	(*init_data)(struct thread_object *obj);
+	/* pick the next thread object */
+	struct thread_object* (*pick_next)(struct sched_control *ctl);
+	/* put thread object into sleep */
+	void	(*sleep)(struct thread_object *obj);
+	/* wake up thread object from sleep status */
+	void	(*wake)(struct thread_object *obj);
+	/* yield current thread object */
+	void	(*yield)(struct sched_control *ctl);
+	/* prioritize the thread object */
+	void	(*prioritize)(struct thread_object *obj);
+	/* deinit private data of scheduler */
+	void	(*deinit_data)(struct thread_object *obj);
+	/* deinit scheduler */
+	void	(*deinit)(struct sched_control *ctl);
+};
+extern struct acrn_scheduler sched_noop;
+
+struct sched_noop_control {
+	struct thread_object *noop_thread_obj;
 };
 
 bool is_idle_thread(const struct thread_object *obj);
@@ -54,11 +87,12 @@ uint16_t sched_get_pcpuid(const struct thread_object *obj);
 struct thread_object *sched_get_current(uint16_t pcpu_id);
 
 void init_sched(uint16_t pcpu_id);
+void deinit_sched(uint16_t pcpu_id);
 void get_schedule_lock(uint16_t pcpu_id);
 void release_schedule_lock(uint16_t pcpu_id);
 
-void insert_thread_obj(struct thread_object *obj, uint16_t pcpu_id);
-void remove_thread_obj(struct thread_object *obj, uint16_t pcpu_id);
+void init_thread_data(struct thread_object *obj);
+void deinit_thread_data(struct thread_object *obj);
 
 void make_reschedule_request(uint16_t pcpu_id, uint16_t delmode);
 bool need_reschedule(uint16_t pcpu_id);


### PR DESCRIPTION
This patchset refines schedule module of ACRN for modularization and extendibility.
It mainly does
  1) polish vcpu and schedule modulization
  2) abstract scheduler object for schedule module to enhance scalability
  3) keep current schedule policy in a 'noop' scheduler

We also add status for thread_object. There are three valid status for thread_object now: THREAD_STS_RUNNING, THREAD_STS_RUNNABLE, THREAD_STS_BLOCKED.
In general, thread_obj starts from THREAD_STS_BLOCKED, then be changed to THREAD_STS_RUNNABLE after wake up and be changed to THREAD_STS_RUNNING by being scheduled in. THREAD_STS_RUNNING -> THREAD_STS_RUNNABLE happens in schedule out.
thread_obj will be changed to THREAD_STS_BLOCKED while doing sleep operation.

For scheduler object, we define a struct named acrn_scheduler:
struct acrn_scheduler {
        char name[16];

        /* init scheduler */
        int     (*init)(struct sched_control *ctx);
        /* init private data of scheduler */
        void    (*init_data)(struct thread_object *obj);
        /* pick the next thread object */
        struct thread_object* (*pick_next)(struct sched_control *ctx);
        /* put schedule object into sleep */
        void    (*sleep)(struct thread_object *obj);
        /* wake up schedule object from sleep status */
        void    (*wake)(struct thread_object *obj);
        /* yield current thread object */
        void    (*yield)(struct sched_control *ctx);
        /* prioritize the thread object */
        void    (*prioritize)(struct thread_object *obj);
        /* deinit private data of scheduler */
        void    (*deinit_data)(struct thread_object *obj);
        /* deinit scheduler */
        void    (*deinit)(struct sched_control *ctx);
};
We can add a new scheduler by implementing a new acrn_scheduler.

Now, the real cpu sharing function is not included in this patchset. We will add a new scheduler to support the sharing schedule policy.

V2: Merge the first two patches for renaming mainly. Rebase the rest.

V3: polish the last 6 patches.
    1) remove init_sched_data from reset_vcpu
    2) rename get_schedule_lock -> obtain_schedule_lock
    3) poke_thread -> kick_thread, poke_vcpu -> kick_vcpu
    4) make kick_vcpu do notification only


Conghui Chen (1):
  hv: sched: disable interrupt when grab schedule spinlock

Shuo A Liu (5):
  hv: sched: add pcpu_id in sched_control
  hv: sched: decouple scheduler from schedule framework
  hv: sched: remove do_switch
  hv: sched: support config scheduler for each VM
  hv: sched: add kick_thread to support notification

 hypervisor/Makefile                      |   1 +
 hypervisor/arch/x86/configs/vm_config.c  |   4 +
 hypervisor/arch/x86/cpu.c                |   1 +
 hypervisor/arch/x86/guest/vcpu.c         |  13 +-
 hypervisor/arch/x86/guest/virq.c         |  15 +--
 hypervisor/arch/x86/guest/vlapic.c       |   2 +-
 hypervisor/arch/x86/guest/vm.c           |   4 +-
 hypervisor/common/sched_noop.c           |  55 +++++++++
 hypervisor/common/schedule.c             | 197 +++++++++++++++++++++++--------
 hypervisor/include/arch/x86/guest/vcpu.h |  13 +-
 hypervisor/include/arch/x86/per_cpu.h    |   1 +
 hypervisor/include/arch/x86/vm_config.h  |   1 +
 hypervisor/include/common/schedule.h     |  48 +++++++-
 13 files changed, 279 insertions(+), 76 deletions(-)  create mode 100644 hypervisor/common/sched_noop.c
