### PR TITLE
makefile: add dash support to build efi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,21 +54,21 @@ define build_acrn
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-$(1)/$(2) BOARD=$(2) FIRMWARE=$(1) SCENARIO=$(4) RELEASE=$(RELEASE) oldconfig
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-$(1)/$(2) BOARD=$(2) FIRMWARE=$(1) SCENARIO=$(4) RELEASE=$(RELEASE)
 	echo "building hypervisor as EFI executable..."
-	@if [ "$(1)" == "uefi" ]; then \
+	@if [ "$(1)" = "uefi" ]; then \
 	$(MAKE) -C $(T)/misc/efi-stub HV_OBJDIR=$(HV_OUT)-$(1)/$(2) SCENARIO=$(4) EFI_OBJDIR=$(HV_OUT)-$(1)/$(2)/$(EFI_OUT); \
 	fi
 endef
 
 define install_acrn
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-$(1)/$(2) BOARD=$(2) FIRMWARE=$(1) SCENARIO=$(3) RELEASE=$(RELEASE) install
-	@if [ "$(1)" == "uefi" ]; then \
+	@if [ "$(1)" = "uefi" ]; then \
 	$(MAKE) -C $(T)/misc/efi-stub HV_OBJDIR=$(HV_OUT)-$(1)/$(2) BOARD=$(2) FIRMWARE=$(1) SCENARIO=$(3) RELEASE=$(RELEASE) EFI_OBJDIR=$(HV_OUT)-$(1)/$(2)/$(EFI_OUT) install; \
 	fi
 endef
 
 define install_acrn_debug
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)-$(1)/$(2) BOARD=$(2) FIRMWARE=$(1) SCENARIO=$(3) RELEASE=$(RELEASE) install-debug
-	@if [ "$(1)" == "uefi" ]; then \
+	@if [ "$(1)" = "uefi" ]; then \
 	$(MAKE) -C $(T)/misc/efi-stub HV_OBJDIR=$(HV_OUT)-$(1)/$(2) BOARD=$(2) FIRMWARE=$(1) SCENARIO=$(3) RELEASE=$(RELEASE) EFI_OBJDIR=$(HV_OUT)-$(1)/$(2)/$(EFI_OUT) install-debug; \
 	fi
 endef


### PR DESCRIPTION
Usually We use '==' or '=' to compare strings under sh environment,
but '==' is not supported by dash which is the default sh environment
on Ubuntu, this leads efi build failure with current makefile.

Change the '==' to '=' to support both bash and dash.

Tracked-On: #3779

Signed-off-by: Victor Sun <victor.sun@intel.com>