### PR TITLE
acrn-config: Fix web ui and filter out eth/wifi device to webUI

### DIFF
--- a/misc/acrn-config/config_app/templates/launch.html
+++ b/misc/acrn-config/config_app/templates/launch.html
@@ -134,7 +134,7 @@
                         {% endif %}
                     </div>
                     {% else %}
-                    <div class="dropdown col-sm-9">
+                    <div class="dropdown col-sm-6">
                         {% if 'readonly' in elem.attrib and elem.attrib['readonly'] == 'true' %}
                         <select class="selectpicker" data-width="auto" title="" disabled
                                 id="{{'uos:id='+vm.attrib['id']+','+elem.tag}}">
@@ -152,6 +152,7 @@
                         </select>
                     </div>
                     {% endif %}
+                    <p id="{{'uos:id='+vm.attrib['id']+','+elem.tag}}_err" class="col-sm-3"></p>
                 </div>
                 {% elif elem.getchildren() != [] %}
                     {% if 'multiselect' not in elem.attrib or elem.attrib['multiselect'] != 'true' %}
@@ -189,7 +190,7 @@
                                         {% endif %}
                                     </div>
                                     {% else %}
-                                    <div class="dropdown col-sm-9">
+                                    <div class="dropdown col-sm-6">
                                         {% if 'readonly' in sub_elem.attrib and sub_elem.attrib['readonly'] == 'true' %}
                                         <select class="selectpicker" data-width="auto" disabled
                                                 id="{{'uos:id='+vm.attrib['id']+','+elem.tag+','+sub_elem.tag}}">
@@ -207,6 +208,7 @@
                                         </select>
                                     </div>
                                     {% endif %}
+                                    <p id="{{'uos:id='+vm.attrib['id']+','+elem.tag+','+sub_elem.tag}}_err" class="col-sm-3"></p>
                                 {% else %}
                                     {% if not first_child %}
                                     {% do first_child.append(1) %}
@@ -236,7 +238,7 @@
                                         {% endif %}
                                     </div>
                                     {% else %}
-                                    <div class="dropdown col-sm-9">
+                                    <div class="dropdown col-sm-6">
                                         {% if 'readonly' in sub_elem.attrib and sub_elem.attrib['readonly'] == 'true' %}
                                         <select class="selectpicker" data-width="auto" disabled
                                                 id="{{'uos:id='+vm.attrib['id']+','+elem.tag+':id='+elem.attrib['id']+','+sub_elem.tag}}">
@@ -253,6 +255,8 @@
                                         {% endfor %}
                                         </select>
                                     </div>
+                                    <p id="{{'uos:id='+vm.attrib['id']+','+elem.tag+':id='+elem.attrib['id']+','+sub_elem.tag}}_err"
+                                           class="col-sm-3"></p>
                                 {% endif %}
                             {% endif %}
                             </div>
@@ -292,6 +296,7 @@
                             {% endif %}
                             </select>
                         </div>
+                        <p id="{{'uos:id='+vm.attrib['id']+','+elem.tag+','+elem.tag[:-1]}}_err" class="col-sm-3"></p>
                     </div>
                     {% endif %}
                 {% endif %}

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -32,9 +32,10 @@ PT_SUB_PCI['cse'] = ['Communication controller']
 PT_SUB_PCI['audio'] = ['Audio device', 'Multimedia audio controller']
 PT_SUB_PCI['audio_codec'] = ['Signal processing controller']
 PT_SUB_PCI['sd_card'] = ['SD Host controller']
-PT_SUB_PCI['wifi'] = ['Ethernet controller']
+PT_SUB_PCI['wifi'] = ['Ethernet controller', 'Network controller', '802.1a controller',
+                        '802.1b controller', 'Wireless controller']
 PT_SUB_PCI['bluetooth'] = ['Signal processing controller']
-PT_SUB_PCI['ethernet'] = ['Ethernet controller']
+PT_SUB_PCI['ethernet'] = ['Ethernet controller', 'Network controller']
 PT_SUB_PCI['sata'] = ['SATA controller']
 PT_SUB_PCI['nvme'] = ['Non-Volatile memory controller']
 

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -425,7 +425,7 @@ def pt_devs_check(bdf_list, vpid_list, item):
         if is_bdf_format(bdf_str):
             continue
         else:
-            key = "uos,id={},passthrough_devices,{}".format(i_cnt, item)
+            key = "uos:id={},passthrough_devices,{}".format(i_cnt, item)
             ERR_LIST[key] = "Unkonw the BDF format of {} device".format(item)
         i_cnt += 1
 
@@ -435,7 +435,7 @@ def pt_devs_check(bdf_list, vpid_list, item):
         if is_vpid_format(vpid_str):
             continue
         else:
-            key = "uos,id={},passthrough_devices,{}".format(i_cnt, item)
+            key = "uos:id={},passthrough_devices,{}".format(i_cnt, item)
             ERR_LIST[key] = "Unkonw the Vendor:Product ID format of {} device".format(item)
 
         i_cnt += 1
@@ -448,7 +448,7 @@ def empty_err(i_cnt, item):
     :param item: the item of tag from config xml
     :return: None
     """
-    key = "uos,id={},{}".format(i_cnt, item)
+    key = "uos:id={},{}".format(i_cnt, item)
     ERR_LIST[key] = "The parameter should not be empty"
 
 
@@ -473,7 +473,7 @@ def args_aval_check(arg_list, item, avl_list):
             continue
 
         if arg_str not in avl_list:
-            key = "uos,id={},{}".format(i_cnt, item)
+            key = "uos:id={},{}".format(i_cnt, item)
             ERR_LIST[key] = "The {} is invalidate".format(item)
         i_cnt += 1
 
@@ -532,7 +532,7 @@ def mem_size_check(arg_list, item):
 
         mem_size_set = int(arg_str.strip())
         if mem_size_set > total_mem_mb:
-            key = "uos,id={},{}".format(i_cnt, item)
+            key = "uos:id={},{}".format(i_cnt, item)
             ERR_LIST[key] = "{}MB should be less than total memory {}MB".format(item)
         i_cnt += 1
 

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -202,7 +202,7 @@ def check_board_private_info():
     (err_dic, private_info) = get_board_private_info(SCENARIO_INFO_FILE)
 
     if not private_info['rootfs'] and err_dic:
-        ERR_LIST['vm,id=0,boot_private,rootfs'] = "The board have to chose one rootfs partition"
+        ERR_LIST['vm:id=0,boot_private,rootfs'] = "The board have to chose one rootfs partition"
         ERR_LIST.update(err_dic)
 
 
@@ -718,14 +718,14 @@ def avl_vuart_ui_select(scenario_info):
         vm_type = get_order_type_by_vmid(vm_i)
 
         if vm_type == "SOS_VM":
-            key = "vm={},vuart=0,base".format(vm_i)
+            key = "vm={}:vuart=0,base".format(vm_i)
             tmp_vuart[key] = ['SOS_COM1_BASE', 'INVALID_COM_BASE']
-            key = "vm={},vuart=1,base".format(vm_i)
+            key = "vm={}:vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['SOS_COM2_BASE', 'INVALID_COM_BASE']
         else:
-            key = "vm={},vuart=0,base".format(vm_i)
+            key = "vm={}:vuart=0,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM1_BASE']
-            key = "vm={},vuart=1,base".format(vm_i)
+            key = "vm={}:vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM2_BASE']
 
     #print(tmp_vuart)


### PR DESCRIPTION
1.    acrn-config: filter out the proper wifi/ethernet device

    Filter out the wifi/ethernet device from webUI with below PCI device class coding rule:
    ethernet: 0200/0280;
    wifi: 0280/0d20/0d21/0d80;

    Tracked-On: #3917
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>

2. acrn-config: fix the issue no error message in launch setting
3. acrn-config: fix the wrong 'key' type returned to webUI
    Tracked-On: #3913
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
