### PR TITLE
hv: Update industry scenarios configuration

### DIFF
--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -68,7 +68,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 
 		/* The hard RTVM must be launched as VM2 */
 		.guest_flags = GUEST_FLAG_HIGHEST_SEVERITY,
-		.vcpu_num = 1U,
+		.vcpu_num = 2U,
 		.vcpu_affinity = VM2_CONFIG_VCPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
@@ -83,22 +83,4 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vuart_id = 1U,
 		},
 	},
-	{
-		.load_order = POST_LAUNCHED_VM,
-		.uuid = {0x38U, 0x15U, 0x88U, 0x21U, 0x52U, 0x08U, 0x40U, 0x05U,	\
-			 0xb7U, 0x2aU, 0x8aU, 0x60U, 0x9eU, 0x41U, 0x90U, 0xd0U},
-			/* 38158821-5208-4005-b72a-8a609e4190d0 */
-		.vcpu_num = 1U,
-		.vcpu_affinity = VM3_CONFIG_VCPU_AFFINITY,
-		.vuart[0] = {
-			.type = VUART_LEGACY_PIO,
-			.addr.port_base = COM1_BASE,
-			.irq = COM1_IRQ,
-		},
-		.vuart[1] = {
-			.type = VUART_LEGACY_PIO,
-			.addr.port_base = INVALID_COM_BASE,
-		}
-
-	}
 };

--- a/hypervisor/scenarios/industry/vm_configurations.h
+++ b/hypervisor/scenarios/industry/vm_configurations.h
@@ -9,7 +9,7 @@
 
 #include <misc_cfg.h>
 
-#define CONFIG_MAX_VM_NUM		(4U + CONFIG_MAX_KATA_VM_NUM)
+#define CONFIG_MAX_VM_NUM		(3U + CONFIG_MAX_KATA_VM_NUM)
 
 /* Bits mask of guest flags that can be programmed by device model. Other bits are set by hypervisor only */
 #define DM_OWNED_GUEST_FLAG_MASK	(GUEST_FLAG_SECURE_WORLD_ENABLED | GUEST_FLAG_LAPIC_PASSTHROUGH | \
@@ -29,7 +29,6 @@
 					SOS_BOOTARGS_DIFF
 
 #define	VM1_CONFIG_VCPU_AFFINITY	{AFFINITY_CPU(1U)}
-#define	VM2_CONFIG_VCPU_AFFINITY	{AFFINITY_CPU(2U)}
-#define	VM3_CONFIG_VCPU_AFFINITY	{AFFINITY_CPU(3U)}
+#define	VM2_CONFIG_VCPU_AFFINITY	{AFFINITY_CPU(2U), AFFINITY_CPU(3U)}
 
 #endif /* VM_CONFIGURATIONS_H */


### PR DESCRIPTION
This patch makes the following changes:
  - Remove the 4th VM
  - Make the default vcpu num of RTVM as 2

Tracked-On: #3925
Signed-off-by: Yan, Like <like.yan@intel.com>
Signed-off-by: Kaige Fu <kaige.fu@intel.com>