### PR TITLE
Let trampoline execution use 1GB pages

### DIFF
--- a/doc/reference/hardware.rst
+++ b/doc/reference/hardware.rst
@@ -19,6 +19,10 @@ Minimum System Requirements for Installing ACRN
 | Storage capabilities   | 20GB                              | 120GB or more                   |
 +------------------------+-----------------------------------+---------------------------------+
 
+Minimum Requirements for Processor
+**********************************
+1 GB Large pages
+
 Verified Platforms According to ACRN Usage
 ******************************************
 

--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -179,7 +179,8 @@ trampoline_gdt_ptr:
     .short  (trampoline_gdt_end - trampoline_gdt) - 1
     .quad   trampoline_gdt
 
-/* PML4, PDPT, and PD tables initialized to map first 4 GBytes of memory */
+/* PML4 and PDPT tables initialized to map first 4 GBytes of memory */
+/* Assumes CPU supports 1GB large pages */
     .align  4
     .global cpu_boot_page_tables_ptr
 cpu_boot_page_tables_ptr:
@@ -197,19 +198,9 @@ cpu_boot_page_tables_start:
 trampoline_pdpt_addr:
     address = 0
     .rept   4
-    /* 0x3 = (PAGE_PRESENT | PAGE_RW) */
-    .quad   trampoline_pdt_addr + address + 0x3
-    /*0x1000 = PAGE_SIZE*/
-    address = address + 0x1000
-    .endr
-    /*0x1000 = PAGE_SIZE*/
-    .align  0x1000
-trampoline_pdt_addr:
-    address = 0
-    .rept  2048
-    /* 0x83 = (PAGE_PSE | PAGE_PRESENT | PAGE_RW) */
-    .quad  address + 0x83
-    address = address + 0x200000
+    /* 0x83 = (PAGE_PRESENT | PAGE_PSE | PAGE_RW) */
+    .quad   address + 0x83
+    address = address + 0x40000000
     .endr
 
     .end

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -59,11 +59,13 @@ uint64_t get_trampoline_start16_paddr(void)
 	return trampoline_start16_paddr;
 }
 
+/*
+ * @pre pcpu_has_cap(X86_FEATURE_PAGE1GB) == true
+ */
 static void update_trampoline_code_refs(uint64_t dest_pa)
 {
 	void *ptr;
 	uint64_t val;
-	int32_t i;
 
 	/*
 	 * calculate the fixup CS:IP according to fixup target address
@@ -86,11 +88,6 @@ static void update_trampoline_code_refs(uint64_t dest_pa)
 
 	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&cpu_boot_page_tables_start));
 	*(uint64_t *)(ptr) += dest_pa;
-
-	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_pdpt_addr));
-	for (i = 0; i < 4; i++) {
-		*(uint64_t *)(ptr + sizeof(uint64_t) * i) += dest_pa;
-	}
 
 	/* update the gdt base pointer with relocated offset */
 	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_gdt_ptr));


### PR DESCRIPTION
Patch lets ACRN use 1GB large pages for trampoline code execution.
Adds a new section to doc/reference/hardware.rst to list the
requirement of 1GB large pages.

Tracked-On: #3899
Signed-off-by: Sainath Grandhi sainath.grandhi@intel.com
Acked-by: Eddie Dong eddie.dong@intel.com