### PR TITLE
doc: Add "uart=disabled" in acrn quick setup script

### DIFF
--- a/doc/getting-started/acrn_quick_setup.sh
+++ b/doc/getting-started/acrn_quick_setup.sh
@@ -114,7 +114,7 @@ function upgrade_sos()
         fi
 
         echo "Add new ACRN efi boot event"
-        efibootmgr -c -l "\EFI\acrn\acrn.efi" -d $partition -p 1 -L "ACRN" >/dev/null
+        efibootmgr -c -l "\EFI\acrn\acrn.efi" -d $partition -p 1 -L "ACRN" -u "uart=disabled" >/dev/null
 
         echo "Service OS setup done!"
     else


### PR DESCRIPTION
HV won't boot from NVMe until we add ``uart=disabled`` parameter in the ``efibootmgr``
configuration.

Signed-off-by: lirui34 <ruix.li@intel.com>