### PR TITLE
acrn-config: keep_gsi set for android only

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -383,8 +383,12 @@ def set_dm_pt(names, sel, vmid, config):
             sel.bdf["bluetooth"][vmid][3:5], sel.bdf["bluetooth"][vmid][6:7]), file=config)
 
     if sel.bdf['wifi'][vmid] and sel.slot['wifi'][vmid]:
-        print("   -s {},passthru,{}/{}/{},keep_gsi \\".format(sel.slot["wifi"][vmid], sel.bdf["wifi"][vmid][0:2], \
-            sel.bdf["wifi"][vmid][3:5], sel.bdf["wifi"][vmid][6:7]), file=config)
+        if uos_type == "ANDROID":
+            print("   -s {},passthru,{}/{}/{},keep_gsi \\".format(sel.slot["wifi"][vmid], sel.bdf["wifi"][vmid][0:2], \
+                sel.bdf["wifi"][vmid][3:5], sel.bdf["wifi"][vmid][6:7]), file=config)
+        else:
+            print("   -s {},passthru,{}/{}/{} \\".format(sel.slot["wifi"][vmid], sel.bdf["wifi"][vmid][0:2], \
+                sel.bdf["wifi"][vmid][3:5], sel.bdf["wifi"][vmid][6:7]), file=config)
 
     if sel.bdf['ipu'][vmid] or sel.bdf['ipu_i2c'][vmid]:
         print("   $boot_ipu_option      \\", file=config)

--- a/misc/acrn-config/launch_config/pt.py
+++ b/misc/acrn-config/launch_config/pt.py
@@ -172,14 +172,22 @@ def audio_pt(uos_type, sel, vmid, config):
             print('    echo ${passthru_bdf["audio_codec"]} > /sys/bus/pci/drivers/pci-stub/bind', file=config)
             print("", file=config)
 
-            print('    boot_audio_option="-s {},passthru,{}/{}/{},keep_gsi '.format(
-                slot_audio, bus, dev, fun), end="", file=config)
+            if uos_type == "ANDROID":
+                print('    boot_audio_option="-s {},passthru,{}/{}/{},keep_gsi '.format(
+                    slot_audio, bus, dev, fun), end="", file=config)
+            else:
+                print('    boot_audio_option="-s {},passthru,{}/{}/{} '.format(
+                    slot_audio, bus, dev, fun), end="", file=config)
             print('-s {},passthru,{}/{}/{}"'.format(
                 slot_codec, bus_codec, dev_codec, fun_codec), file=config)
         else:
             # only select audio device to pass through to vm
-            print('    boot_audio_option="-s {},passthru,{}/{}/{},keep_gsi"'.format(
-                slot_audio, bus, dev, fun), file=config)
+            if uos_type == "ANDROID":
+                print('    boot_audio_option="-s {},passthru,{}/{}/{},keep_gsi"'.format(
+                    slot_audio, bus, dev, fun), file=config)
+            else:
+                print('    boot_audio_option="-s {},passthru,{}/{}/{}"'.format(
+                    slot_audio, bus, dev, fun), file=config)
 
         print("else", file=config)
         print('    boot_audio_option="-s {},virtio-audio"'.format(slot_audio), file=config)


### PR DESCRIPTION
- acrn-config: 'keep_gsi' flag set for Android vm

    Tracked-On: #3955
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
