### PR TITLE
doc: doc build errors not being reported

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,15 +81,16 @@ author = u'Project ARCN developers'
 
 # The following code tries to extract the information by reading the
 # Makefile from the acrn-hypervisor repo by finding these lines:
-#   MAJOR_VERSION=0
-#   MINOR_VERSION=1
-#   RC_VERSION=1
+#   MAJOR_VERSION=1
+#   MINOR_VERSION=3
+#   EXTRA_VERSION=-unstable
 
 try:
     version_major = None
     version_minor = None
     version_rc = None
-    for line in open(os.path.normpath("../VERSION")) :
+
+    for line in open(os.path.realpath("../../../VERSION")) :
         # remove comments
         line = line.split('#', 1)[0]
         line = line.rstrip()
@@ -103,18 +104,14 @@ try:
               version_rc = val
            if version_major and version_minor and version_rc :
               break
-except:
-    pass
 finally:
     if version_major and version_minor :
-        version = release = "v " + version_major + '.' + version_minor
+        version = release = "v " + str(version_major) + '.' + str(version_minor)
         if version_rc :
           version = release = version + version_rc
     else:
         sys.stderr.write('Warning: Could not extract hypervisor version from VERSION file\n')
         version = release = "unknown"
-
-
 
 #
 # The short X.Y version.

--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -31,13 +31,13 @@ fi
 
 if [ -s "${LOG_FILE}" ]; then
    $KI_SCRIPT --config-dir ${CONFIG_DIR} ${LOG_FILE} > ${BUILDDIR}/doc.warnings 2>&1
-   if [ -s doc.warnings ]; then
+   if [ -s ${BUILDDIR}/doc.warnings ]; then
 	   echo
 	   echo -e "${red}New errors/warnings found, please fix them:"
 	   echo -e "=============================================="
 	   $TPUT sgr0
 	   echo
-	   cat doc.warnings
+	   cat ${BUILDDIR}/doc.warnings
 	   echo
 	   exit 1
    else


### PR DESCRIPTION
PR #3665 moved all the doc build artifacts into the _build folder and
updated scripts and Makefile to account for this, except missed a fix in
the script that checks for known issues. This patch fixes that but shows
we've got a bunch of issues that have not been being reported so we'll
need to fix those problems to resolve failing doc builds.

Also fixed processing of the VERSION file in conf.py since the path to that
file was changed by PR #3665 as well and was raising an exception that
was being masked.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>