### PR TITLE
doc: fix broken include paths

### DIFF
--- a/doc/getting-started/apl-nuc.rst
+++ b/doc/getting-started/apl-nuc.rst
@@ -576,7 +576,7 @@ Set up Reference UOS
    is also available in the acrn-hypervisor/devicemodel GitHub repo (in the samples
    folder) as shown here:
 
-   .. literalinclude:: ../../devicemodel/samples/nuc/launch_uos.sh
+   .. literalinclude:: ../../../../devicemodel/samples/nuc/launch_uos.sh
       :caption: devicemodel/samples/nuc/launch_uos.sh
       :language: bash
 

--- a/doc/tutorials/static-ip.rst
+++ b/doc/tutorials/static-ip.rst
@@ -35,7 +35,7 @@ Modify the ``[Network]`` section in the
 ``/etc/systemd/network/50-eth.network`` file you just created.
 This is the content of the file used in ACRN by default.
 
-.. literalinclude:: ../../misc/acrnbridge/eth.network
+.. literalinclude:: ../../../../misc/acrnbridge/eth.network
    :caption: misc/acrnbridge/eth.network
    :emphasize-lines: 5
 


### PR DESCRIPTION
PR #3665 moved the doc build folder, so files referenced via directives
had an incorrect path (need to add an additional ../../ to the front of
relative paths that were referencing files outside of the doc folder).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>