### PR TITLE
doc: fix doc build errors previously masked

### DIFF
--- a/doc/developer-guides/hld/hld-security.rst
+++ b/doc/developer-guides/hld/hld-security.rst
@@ -152,7 +152,7 @@ before launching.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 As shown in :numref:`security-bootflow-uefi`, in this boot sequence,UEFI
 authenticates and starts the ACRN hypervisor firstly,and hypervisor will return
-to UEFI enviorment to authenticate and load SOS kernel bootloader.
+to UEFI environment to authenticate and load SOS kernel bootloader.
 
 .. figure:: images/security-image-bootflow-uefi.png
    :width: 900px
@@ -204,7 +204,8 @@ systems. To minimize the attack surfaces and achieve the goal of
 "defense in depth", there are many common guidelines to ensure the
 security of SOS system.
 
-As shown in :numref:`security-bootflow` above, the integrity of the UOS
+As shown in :numref:`security-bootflow-sbl` and
+:numref:`security-bootflow-uefi` above, the integrity of the UOS
 depends on the integrity of the DM module and vBIOS/vOSloader in the
 SOS. Hence, SOS integrity is critical to the entire UOS security. If the
 SOS system is compromised, all the other guest UOS VMs may be
@@ -833,8 +834,9 @@ Hypercall - Trusty Initialization
 
 When a UOS is created by the DM in the SOS, if this UOS supports a
 secure isolated world, then this hypercall will be invoked by OSLoader
-(it could be Android OS loader in :numref:`security-bootflow` above) to
-create / initialize the secure world (Trusty/TEE).
+(it could be Android OS loader in :numref:`security-bootflow-sbl` and
+:numref:`security-bootflow-uefi` above) to create / initialize the
+secure world (Trusty/TEE).
 
 .. figure:: images/security-image9.png
    :width: 900px

--- a/doc/developer-guides/hld/hv-cpu-virt.rst
+++ b/doc/developer-guides/hld/hv-cpu-virt.rst
@@ -187,9 +187,6 @@ lifecycle:
 .. doxygenfunction:: create_vcpu
    :project: Project ACRN
 
-.. doxygenfunction:: schedule_vcpu
-   :project: Project ACRN
-
 .. doxygenfunction:: pause_vcpu
    :project: Project ACRN
 

--- a/doc/developer-guides/hld/hv-virt-interrupt.rst
+++ b/doc/developer-guides/hld/hv-virt-interrupt.rst
@@ -98,7 +98,7 @@ an interrupt, for example:
 - from an emulated device for a MSI
 
 These APIs will finish by making a vCPU request.
-_
+
 .. doxygenfunction:: vlapic_inject_intr
   :project: Project ACRN
 

--- a/doc/developer-guides/hld/index.rst
+++ b/doc/developer-guides/hld/index.rst
@@ -21,7 +21,6 @@ system.
    Device Model <hld-devicemodel>
    Emulated Devices <hld-emulated-devices>
    Virtio Devices <hld-virtio-devices>
-   VM Management <hld-vm-management>
    Power Management <hld-power-management>
    Tracing and Logging <hld-trace-log>
    Virtual Bootloader <hld-vsbl>

--- a/doc/developer-guides/hld/vuart-virt-hld.rst
+++ b/doc/developer-guides/hld/vuart-virt-hld.rst
@@ -1,7 +1,7 @@
 .. _vuart_virtualization:
 
 vUART Virtualization
-###################
+####################
 
 Architecture
 ************

--- a/doc/tutorials/using_windows_as_uos.rst
+++ b/doc/tutorials/using_windows_as_uos.rst
@@ -329,7 +329,9 @@ together with the script used to install Windows 10.
    - Change ``-s 3,virtio-blk,./win10-ltsc-virtio.img`` to your path to the Windows 10 image.
    - Change ``-s 8,ahci,cd:./windows10-17763-107-LTSC-Virtio-Gfx.iso`` to the ISO you re-generated above.
    - Change ``-s 9,ahci,cd:./virtio-win-0.1.141.iso`` to your path to the virtio-win iso.
-   Or used Oracle driver
+
+   Or if you used the Oracle driver:
+
    - Change ``-s 9,ahci,cd:./winvirtio.iso`` to your path to the winvirtio iso.
 
 #. Run ``install_vga.sh`` and connect to the Windows guest using a vnc client.::


### PR DESCRIPTION
As reported in PR #3959, doc build errors were being masked by a script
error.  This PR fixes a chunk of them.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>