### PR TITLE
doc: fix remaining masked doc build errors

### DIFF
--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -63,7 +63,6 @@ Enable ACRN Features
    tutorials/open_vswitch
    tutorials/rtvm_workload_design_guideline
    tutorials/sgx_virtualization
-   tutorials/virtio_i2c
    tutorials/vuart_configuration
    tutorials/skl-nuc
    tutorials/using_cat_on_up2

--- a/doc/developer-guides/hld/virtio-i2c.rst
+++ b/doc/developer-guides/hld/virtio-i2c.rst
@@ -1,4 +1,4 @@
- .. _virtio-i2c:
+.. _virtio-i2c:
 
 Virtio-i2c
 ##########

--- a/doc/release_notes/release_notes_0.6.rst
+++ b/doc/release_notes/release_notes_0.6.rst
@@ -45,7 +45,7 @@ published a tutorial.  More patches for ACRN real time support will continue.
 **Document updates**: Several new documents have been added in this release, including:
 
 * :ref:`Running Automotive Grade Linux as a VM <agl-vms>`
-* :ref:`Using PREEMPT_RT-Linux for real-time UOS <rt_linux_setup>`
+* Using PREEMPT_RT-Linux for real-time UOS
 * :ref:`Frequently Asked Questions <faq>`
 * :ref:`An introduction to Trusty and Security services on ACRN
   <trusty-security-services>`

--- a/doc/release_notes/release_notes_1.3.rst
+++ b/doc/release_notes/release_notes_1.3.rst
@@ -51,7 +51,7 @@ We have many new `reference documents available <https://projectacrn.github.io>`
 * :ref:`Running Debian as the User VM <running_deb_as_user_vm>`
 * :ref:`Running Debian as the Service VM <running_deb_as_serv_vm>`
 * :ref:`vUART configuration <vuart_config>`
-* :ref:`Enable virtio-i2c <virtio_i2c>`
+* :ref:`Enable virtio-i2c <virtio-i2c>`
 
 New Features Details
 ********************


### PR DESCRIPTION
This should get us back to a clean doc build now...

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>