### PR TITLE
hv: vpci: reshuffle vdev_pt_write_vbar implementation

### DIFF
--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -6,7 +6,6 @@
 #include <vm.h>
 #include <irq.h>
 #include <errno.h>
-#include <ept.h>
 #include <logmsg.h>
 
 #define ACRN_DBG_IOREQUEST	6U
@@ -695,16 +694,6 @@ void register_mmio_emulation_handler(struct acrn_vm *vm,
 			mmio_node->handler_private_data = handler_private_data;
 			mmio_node->range_start = start;
 			mmio_node->range_end = end;
-
-			/*
-			 * SOS would map all its memory at beginning, so we
-			 * should unmap it. But UOS will not, so we shouldn't
-			 * need to unmap it.
-			 */
-			if (is_sos_vm(vm)) {
-				ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, start, end - start);
-			}
-
 		}
 	}
 

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -33,6 +33,7 @@
 #include <vm.h>
 #include <errno.h>
 #include <irq.h>
+#include <ept.h>
 #include <assign.h>
 #include <logmsg.h>
 
@@ -472,6 +473,8 @@ vioapic_init(struct acrn_vm *vm)
 			(uint64_t)VIOAPIC_BASE,
 			(uint64_t)VIOAPIC_BASE + VIOAPIC_SIZE,
 			vm);
+	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
+			(uint64_t)VIOAPIC_BASE, (uint64_t)VIOAPIC_SIZE);
 	vm->arch_vm.vioapic.ready = true;
 }
 


### PR DESCRIPTION
v3:
revert "remove the constraint of 64 bits PCI BAR remapping".

v2:
This patch try to do unmap/map in vdev_pt_write_vbar directly and remove
the constraint of 64 bits PCI BAR remapping.

v1:
This patch try to do unmap/map in vdev_pt_remap_mem_vbar directly and remove
the constraint of 64 bits PCI BAR remapping.

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>