### PR TITLE
doc: remove redundant copy of ovmf.fd firmware

### DIFF
--- a/doc/tutorials/running_deb_as_user_vm.rst
+++ b/doc/tutorials/running_deb_as_user_vm.rst
@@ -146,14 +146,13 @@ Re-use and modify the `launch_win.sh` script in order to launch the new Debian 1
 
       # scp ~/debian10/debian10.img user_name@ip_address:~/debian10.img
 
-#. Log in to the ACRN Service VM; generate the launch script and copy OVMF to the image directory:
+#. Log in to the ACRN Service VM, and create a launch script from the existing script:
 
    .. code-block:: none
 
       $ cd ~
       $ cp /usr/share/acrn/samples/nuc/launch_win.sh ./launch_debian.sh
       $ sed -i "s/win10-ltsc.img/debian10.img/" launch_debian.sh
-      $ cp /usr/share/acrn/bios/OVMF.fd ./
 
 #. Assign USB ports to the Debian VM in order to use the mouse and keyboard before the launch:
 

--- a/doc/tutorials/running_ubun_as_user_vm.rst
+++ b/doc/tutorials/running_ubun_as_user_vm.rst
@@ -136,14 +136,13 @@ Modify the `launch_win.sh` script in order to launch Ubuntu as the User VM.
 
       # scp ~/ubuntu_images/uos.img user_name@ip_address:~/uos.img
 
-#. Log in to the ACRN Service VM; generate the launch script and copy OVMF to the image directory:
+#. Log in to the ACRN Service VM, and create a launch script from the existing script:
 
    .. code-block:: none
 
       $ cd ~
       $ cp /usr/share/acrn/samples/nuc/launch_win.sh ./launch_ubuntu.sh
       $ sed -i "s/win10-ltsc.img/uos.img/" launch_ubuntu.sh
-      $ cp /usr/share/acrn/bios/OVMF.fd ./
 
 #. Assign USB ports to the Ubuntu VM in order to use the mouse and keyboard before the launch:
 

--- a/doc/tutorials/using_celadon_as_uos.rst
+++ b/doc/tutorials/using_celadon_as_uos.rst
@@ -84,7 +84,6 @@ Steps for Using Celadon as the User OS
 #. Prepare dependencies on your NUC::
 
    # mkdir ~/celadon && cd ~/celadon
-   # cp /usr/share/acrn/bios/OVMF.fd ./
    # cp /usr/share/acrn/samples/nuc/launch_win.sh ./launch_android.sh
    # sed -i "s/win10-ltsc/android/" launch_android.sh
    # scp <cel_apl_gptimage.img from your host> ./android.img


### PR DESCRIPTION
Remove redundant copy of ovmf.fd firmware as the lunach script now
instructs the DM to user the OVMF.fd firmware directly from the rootfs.

Tracked-On: #3972 
Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>