### PR TITLE
HV: Fix poweroff issue of hard RTVM

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -758,8 +758,7 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id)
 		vcpu->thread_obj.sched_ctl = &per_cpu(sched_ctl, pcpu_id);
 		vcpu->thread_obj.thread_entry = vcpu_thread;
 		vcpu->thread_obj.pcpu_id = pcpu_id;
-		vcpu->thread_obj.notify_mode = is_lapic_pt_enabled(vcpu) ?
-			SCHED_NOTIFY_INIT : SCHED_NOTIFY_IPI;
+		vcpu->thread_obj.notify_mode = SCHED_NOTIFY_IPI;
 		vcpu->thread_obj.host_sp = build_stack_frame(vcpu);
 		vcpu->thread_obj.switch_out = context_switch_out;
 		vcpu->thread_obj.switch_in = context_switch_in;

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -599,6 +599,12 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 		exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS2, value32);
 
 		update_msr_bitmap_x2apic_passthru(vcpu);
+
+		/*
+		 * After passthroughing lapic to guest, we should use INIT signal to
+		 * notify vcpu thread instead of IPI
+		 */
+		vcpu->thread_obj.notify_mode = SCHED_NOTIFY_INIT;
 	} else {
 		value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS2);
 		value32 &= ~VMX_PROCBASED_CTLS2_VAPIC;


### PR DESCRIPTION
We should use INIT signal to notify the vcpu threads when
powering off the hard RTVM. To achive this, we should set
the vcpu->thread_obj.notify_mode as SCHED_NOTIFY_INIT.

Patch (27163df9 hv: sched: add sleep/wake for thread object)
tries to set the notify_mode according `is_lapic_pt_enabled(vcpu)`
in function prepare_vcpu. But at this point, the is_lapic_pt_enabled(vcpu)
will always return false. Consequently, it will set notify_mode
as SCHED_NOTIFY_IPI. Then leads to the failure of powering off
hard RTVM.

This patch fixes it by:
  - Initialize the notify_mode as SCHED_NOTIFY_IPI in prepare_vcpu.
  - Set the notify_mode as SCHED_NOTIFY_INIT after passthroughing lapic to guest.

Tracked-On: #3974
Signed-off-by: Kaige Fu <kaige.fu@intel.com>