### PR TITLE
acrn-config: Support whiskylake i5 and whiskylake i7 board

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -211,12 +211,11 @@ def boot_image_type(args, vmid, config):
     print("", file=config)
 
 
-def interrupt_storm(names, vmid, config):
-    uos_type = names['uos_types'][vmid]
-
-    if uos_type not in ("CLEARLINUX", "ANDROID", "ALIOS") or is_nuc_whl_clr(names, vmid):
+def interrupt_storm(pt_sel, config):
+    if not pt_sel:
         return
 
+    # TODO: --intr_monitor should be configurable by user
     print("#interrupt storm monitor for pass-through devices, params order:", file=config)
     print("#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)", file=config)
     print('intr_storm_monitor="--intr_monitor 10000,10,1,100"', file=config)
@@ -517,9 +516,11 @@ def dm_arg_set(names, sel, dm, vmid, config):
             print("   -i /run/acrn/ioc_$vm_name,0x20 \\", file=config)
             print("   -l com2,/run/acrn/ioc_$vm_name \\", file=config)
 
+        if sel:
+            print("   $intr_storm_monitor \\", file=config)
+
         if not is_nuc_whl_clr(names, vmid):
             print("   -s {},wdt-i6300esb \\".format(launch_cfg_lib.virtual_dev_slot("wdt-i6300esb")), file=config)
-            print("   $intr_storm_monitor \\", file=config)
             print("   -s {},xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \\".format(launch_cfg_lib.virtual_dev_slot("xhci")), file=config)
 
     if uos_type != "PREEMPT-RT LINUX":
@@ -553,7 +554,7 @@ def gen(names, pt_sel, dm, vmid, config):
     wa_usage(uos_type, config)
     delay_use_usb_storage(uos_type, config)
     mem_size_set(names, dm, vmid, config)
-    interrupt_storm(names, vmid, config)
+    interrupt_storm(pt_sel, config)
     log_level_set(uos_type, config)
 
     # gen acrn-dm args

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -251,29 +251,10 @@ def wa_usage(uos_type, config):
         print("echo on > /sys/devices/pci0000:00/0000:00:15.0/power/control", file=config)
         print("", file=config)
 
-def mem_size_set(names, args, vmid, config):
-
-    uos_type = names['uos_types'][vmid]
+def mem_size_set(args, vmid, config):
     mem_size = args['mem_size'][vmid]
 
-    if uos_type not in ("CLEARLINUX", "ANDROID", "ALIOS") or is_nuc_whl_clr(names, vmid):
-        print("mem_size={}M".format(mem_size), file=config)
-        return
-
-    print("#for memsize setting, total 8GB(>7.5GB) uos->6GB, 4GB(>3.5GB) uos->2GB", file=config)
-    print("memsize=`cat /proc/meminfo|head -n 1|awk '{print $2}'`", file=config)
-    print("if [ $memsize -gt 7500000 ];then", file=config)
-    print("    mem_size=6G", file=config)
-    print("elif [ $memsize -gt 3500000 ];then", file=config)
-    print("    mem_size=2G", file=config)
-    print("else", file=config)
-    print("    mem_size=1750M", file=config)
-    print("fi", file=config)
-    print("", file=config)
-    print('if [ "$setup_mem" != "" ];then', file=config)
-    print("    mem_size=$setup_mem", file=config)
-    print("fi", file=config)
-    print("", file=config)
+    print("mem_size={}M".format(mem_size), file=config)
 
 
 def uos_launch(names, args, vmid, config):
@@ -322,14 +303,10 @@ def launch_end(names, args, vmid, config):
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_whl_clr(names, vmid):
         print("debug=0", file=config)
         print("", file=config)
-        print('while getopts "M:hdC" opt', file=config)
+        print('while getopts "hdC" opt', file=config)
         print("do", file=config)
         print("	case $opt in", file=config)
 
-        if not mem_size:
-            print("		M) setup_mem=$OPTARG", file=config)
-        else:
-            print("		M) setup_mem={}M".format(mem_size), file=config)
         print("			;;", file=config)
         print("		d) debug=1", file=config)
         print("			;;", file=config)
@@ -553,7 +530,7 @@ def gen(names, pt_sel, dm, vmid, config):
     pt.gen_pt(names, pt_sel, vmid, config)
     wa_usage(uos_type, config)
     delay_use_usb_storage(uos_type, config)
-    mem_size_set(names, dm, vmid, config)
+    mem_size_set(dm, vmid, config)
     interrupt_storm(pt_sel, config)
     log_level_set(uos_type, config)
 

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -7,12 +7,20 @@ import launch_cfg_lib
 import pt
 
 
-def is_nuc_clr(names, vmid):
+def is_nuc_whl_clr(names, vmid):
     uos_type = names['uos_types'][vmid]
     board_name = names['board_name']
 
-    if uos_type == "CLEARLINUX" and 'nuc' in board_name:
+    if uos_type == "CLEARLINUX" and board_name not in ("apl-mrb", "apl-up2"):
         return True
+
+    return False
+
+
+def is_mount_needed(names, vmid):
+    uos_type = names['uos_types'][vmid]
+    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_whl_clr(names, vmid):
+         return True
 
     return False
 
@@ -118,7 +126,7 @@ def run_container(board_name, uos_type, config):
     if 'nuc' in board_name:
         board_name = 'nuc'
 
-    if board_name == "apl-up2" or uos_type != "CLEARLINUX":
+    if board_name not in ("apl-mrb", "nuc") or uos_type != "CLEARLINUX":
         return
 
     print("function run_container()", file=config)
@@ -206,7 +214,7 @@ def boot_image_type(args, vmid, config):
 def interrupt_storm(names, vmid, config):
     uos_type = names['uos_types'][vmid]
 
-    if uos_type not in ("CLEARLINUX", "ANDROID", "ALIOS") or is_nuc_clr(names, vmid):
+    if uos_type not in ("CLEARLINUX", "ANDROID", "ALIOS") or is_nuc_whl_clr(names, vmid):
         return
 
     print("#interrupt storm monitor for pass-through devices, params order:", file=config)
@@ -249,7 +257,7 @@ def mem_size_set(names, args, vmid, config):
     uos_type = names['uos_types'][vmid]
     mem_size = args['mem_size'][vmid]
 
-    if uos_type not in ("CLEARLINUX", "ANDROID", "ALIOS") or is_nuc_clr(names, vmid):
+    if uos_type not in ("CLEARLINUX", "ANDROID", "ALIOS") or is_nuc_whl_clr(names, vmid):
         print("mem_size={}M".format(mem_size), file=config)
         return
 
@@ -274,8 +282,11 @@ def uos_launch(names, args, vmid, config):
     gvt_args = args['gvt_args'][vmid]
     uos_type = names['uos_types'][vmid]
     launch_uos = launch_cfg_lib.undline_name(uos_type).lower()
+    board_name = names['board_name']
+    if 'nuc' in board_name:
+        board_name = 'nuc'
 
-    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_clr(names, vmid):
+    if uos_type == "CLEARLINUX" and board_name in ("apl-mrb", "nuc"):
         print('if [ "$1" = "-C" ];then', file=config)
         print('    if [ $(hostname) = "runc" ]; then', file=config)
         print('            echo "Already in container exit!"', file=config)
@@ -296,7 +307,7 @@ def uos_launch(names, args, vmid, config):
         if uos_type in ("CLEARLINUX", "WINDOWS"):
             print('launch_{} 1 "{}"'.format(launch_uos, gvt_args), file=config)
 
-    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_clr(names, vmid):
+    if is_mount_needed(names, vmid):
         print("", file=config)
         print('launch_{} {} "{}" "{}" $debug'.format(launch_uos, vmid, gvt_args, vmid), file=config)
         print("", file=config)
@@ -309,7 +320,7 @@ def launch_end(names, args, vmid, config):
     uos_type = names['uos_types'][vmid]
     mem_size = args["mem_size"][vmid]
 
-    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_clr(names, vmid):
+    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_whl_clr(names, vmid):
         print("debug=0", file=config)
         print("", file=config)
         print('while getopts "M:hdC" opt', file=config)
@@ -335,7 +346,7 @@ def launch_end(names, args, vmid, config):
         print("done", file=config)
         print("", file=config)
 
-    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_clr(names, vmid):
+    if is_mount_needed(names, vmid):
         root_fs = args['rootfs_dev'][vmid]
 
         print('if [ ! -b "{}" ]; then'.format(root_fs), file=config)
@@ -435,7 +446,7 @@ def dm_arg_set(names, sel, dm, vmid, config):
         else:
             print('{} $npk_virt \\'.format(dm_str), file=config)
 
-    if board_name == "apl-up2" or is_nuc_clr(names, vmid):
+    if board_name == "apl-up2" or is_nuc_whl_clr(names, vmid):
         print("   $logger_setting \\", file=config)
 
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
@@ -446,7 +457,7 @@ def dm_arg_set(names, sel, dm, vmid, config):
         if board_name == "apl-mrb":
             print("   --pm_notify_channel ioc \\", file=config)
 
-    if is_nuc_clr(names, vmid):
+    if is_nuc_whl_clr(names, vmid):
         print("   --pm_notify_channel uart \\", file=config)
         print('   --pm_by_vuart pty,/run/acrn/life_mngr_$vm_name  \\', file=config)
         print('   -l com2,/run/acrn/life_mngr_$vm_name \\', file=config)
@@ -506,7 +517,7 @@ def dm_arg_set(names, sel, dm, vmid, config):
             print("   -i /run/acrn/ioc_$vm_name,0x20 \\", file=config)
             print("   -l com2,/run/acrn/ioc_$vm_name \\", file=config)
 
-        if not is_nuc_clr(names, vmid):
+        if not is_nuc_whl_clr(names, vmid):
             print("   -s {},wdt-i6300esb \\".format(launch_cfg_lib.virtual_dev_slot("wdt-i6300esb")), file=config)
             print("   $intr_storm_monitor \\", file=config)
             print("   -s {},xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \\".format(launch_cfg_lib.virtual_dev_slot("xhci")), file=config)

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -376,7 +376,6 @@ def get_board_private_vuart(branch_tag, tag_console):
 
     # VUART1
     if len(vuart1_valid_console) == 4:
-        ttys_n = get_sub_leaf_tag(SCENARIO_INFO_FILE, branch_tag, "vuart1_console")
         vuart1_console_dic[ttys_n] = alloc_irq()
     else:
         vuart1_console_dic[vuart1_valid_console[0]] = alloc_irq()

--- a/misc/acrn-config/xmls/board-xmls/whl-ipc-i5.xml
+++ b/misc/acrn-config/xmls/board-xmls/whl-ipc-i5.xml
@@ -1,0 +1,248 @@
+<acrn-config board="whl-ipc-i5">
+	<BIOS_INFO>
+	BIOS Information
+	Vendor: American Megatrends Inc.
+	Version: WL10R104
+	Release Date: 09/12/2019
+	BIOS Revision: 5.13
+	</BIOS_INFO>
+
+	<BASE_BOARD_INFO>
+	Base Board Information
+	Manufacturer: Maxtang
+	Product Name: WL10
+	Version: V1.0
+	</BASE_BOARD_INFO>
+
+	<PCI_DEVICE>
+	00:00.0 Host bridge: Intel Corporation Device 3e34 (rev 0b)
+	00:02.0 VGA compatible controller: Intel Corporation Device 3ea0
+	Region 0: Memory at a0000000 (64-bit, non-prefetchable) [size=16M]
+	Region 2: Memory at 90000000 (64-bit, prefetchable) [size=256M]
+	00:12.0 Signal processing controller: Intel Corporation Device 9df9 (rev 30)
+	Region 0: Memory at a141e000 (64-bit, non-prefetchable) [size=4K]
+	00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)
+	Region 0: Memory at a1400000 (64-bit, non-prefetchable) [size=64K]
+	00:14.2 RAM memory: Intel Corporation Device 9def (rev 30)
+	Region 0: Memory at a1416000 (64-bit, non-prefetchable) [disabled] [size=8K]
+	Region 2: Memory at a141d000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:16.0 Communication controller: Intel Corporation Device 9de0 (rev 30)
+	Region 0: Memory at a141c000 (64-bit, non-prefetchable) [size=4K]
+	00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)
+	Region 0: Memory at a1414000 (32-bit, non-prefetchable) [size=8K]
+	Region 1: Memory at a141b000 (32-bit, non-prefetchable) [size=256]
+	Region 5: Memory at a141a000 (32-bit, non-prefetchable) [size=2K]
+	00:1a.0 SD Host controller: Intel Corporation Device 9dc4 (rev 30)
+	Region 0: Memory at a1419000 (64-bit, non-prefetchable) [size=4K]
+	00:1c.0 PCI bridge: Intel Corporation Device 9db8 (rev f0)
+	00:1c.4 PCI bridge: Intel Corporation Device 9dbc (rev f0)
+	00:1d.0 PCI bridge: Intel Corporation Device 9db0 (rev f0)
+	00:1d.1 PCI bridge: Intel Corporation Device 9db1 (rev f0)
+	00:1f.0 ISA bridge: Intel Corporation Device 9d84 (rev 30)
+	00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)
+	Region 0: Memory at a1410000 (64-bit, non-prefetchable) [size=16K]
+	Region 4: Memory at a1000000 (64-bit, non-prefetchable) [size=1M]
+	00:1f.4 SMBus: Intel Corporation Device 9da3 (rev 30)
+	Region 0: Memory at a1418000 (64-bit, non-prefetchable) [size=256]
+	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 9da4 (rev 30)
+	Region 0: Memory at fe010000 (32-bit, non-prefetchable) [size=4K]
+	02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)
+	Region 0: Memory at a1300000 (64-bit, non-prefetchable) [size=16K]
+	03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
+	Region 0: Memory at a1200000 (32-bit, non-prefetchable) [size=128K]
+	Region 3: Memory at a1220000 (32-bit, non-prefetchable) [size=16K]
+	04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
+	Region 0: Memory at a1100000 (32-bit, non-prefetchable) [size=128K]
+	Region 3: Memory at a1120000 (32-bit, non-prefetchable) [size=16K]
+	</PCI_DEVICE>
+
+	<PCI_VID_PID>
+	00:00.0 0600: 8086:3e34 (rev 0b)
+	00:02.0 0300: 8086:3ea0
+	00:12.0 1180: 8086:9df9 (rev 30)
+	00:14.0 0c03: 8086:9ded (rev 30)
+	00:14.2 0500: 8086:9def (rev 30)
+	00:16.0 0780: 8086:9de0 (rev 30)
+	00:17.0 0106: 8086:9dd3 (rev 30)
+	00:1a.0 0805: 8086:9dc4 (rev 30)
+	00:1c.0 0604: 8086:9db8 (rev f0)
+	00:1c.4 0604: 8086:9dbc (rev f0)
+	00:1d.0 0604: 8086:9db0 (rev f0)
+	00:1d.1 0604: 8086:9db1 (rev f0)
+	00:1f.0 0601: 8086:9d84 (rev 30)
+	00:1f.3 0403: 8086:9dc8 (rev 30)
+	00:1f.4 0c05: 8086:9da3 (rev 30)
+	00:1f.5 0c80: 8086:9da4 (rev 30)
+	02:00.0 0108: 126f:2263 (rev 03)
+	03:00.0 0200: 8086:157b (rev 03)
+	04:00.0 0200: 8086:157b (rev 03)
+	</PCI_VID_PID>
+
+	<WAKE_VECTOR_INFO>
+	#define WAKE_VECTOR_32          0x8C8AA08CUL
+	#define WAKE_VECTOR_64          0x8C8AA098UL
+	</WAKE_VECTOR_INFO>
+
+	<RESET_REGISTER_INFO>
+	#define RESET_REGISTER_ADDRESS  0xCF9UL
+	#define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
+	#define RESET_REGISTER_VALUE    0x6U
+	</RESET_REGISTER_INFO>
+
+	<PM_INFO>
+	#define PM1A_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_EVT_BIT_WIDTH      0x20U
+	#define PM1A_EVT_BIT_OFFSET     0x0U
+	#define PM1A_EVT_ADDRESS        0x1800UL
+	#define PM1A_EVT_ACCESS_SIZE    0x2U
+	#define PM1B_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_EVT_BIT_WIDTH      0x0U
+	#define PM1B_EVT_BIT_OFFSET     0x0U
+	#define PM1B_EVT_ADDRESS        0x0UL
+	#define PM1B_EVT_ACCESS_SIZE    0x2U
+	#define PM1A_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_CNT_BIT_WIDTH      0x10U
+	#define PM1A_CNT_BIT_OFFSET     0x0U
+	#define PM1A_CNT_ADDRESS        0x1804UL
+	#define PM1A_CNT_ACCESS_SIZE    0x2U
+	#define PM1B_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_CNT_BIT_WIDTH      0x0U
+	#define PM1B_CNT_BIT_OFFSET     0x0U
+	#define PM1B_CNT_ADDRESS        0x0UL
+	#define PM1B_CNT_ACCESS_SIZE    0x2U
+	</PM_INFO>
+
+	<S3_INFO>
+	/* S3 is not supported by BIOS */
+	#define S3_PKG_VAL_PM1A         0x0U
+	#define S3_PKG_VAL_PM1B         0x0U
+	#define S3_PKG_RESERVED         0x0U
+	</S3_INFO>
+
+	<S5_INFO>
+	#define S5_PKG_VAL_PM1A         0x7U
+	#define S5_PKG_VAL_PM1B         0U
+	#define S5_PKG_RESERVED         0x0U
+	</S5_INFO>
+
+	<DRHD_INFO>
+	#define DRHD_COUNT              2U
+	#define DRHD0_DEV_CNT           1U
+	#define DRHD0_SEGMENT           0U
+	#define DRHD0_FLAGS             0U
+	#define DRHD0_REG_BASE          0xFED90000UL
+	#define DRHD0_IGNORE            true
+	#define DRHD0_DEVSCOPE0_BUS     0x0U
+	#define DRHD0_DEVSCOPE0_PATH    0x10U
+	#define DRHD0_DEVSCOPE1_BUS     0x0U
+	#define DRHD0_DEVSCOPE1_PATH    0x0U
+	#define DRHD0_DEVSCOPE2_BUS     0x0U
+	#define DRHD0_DEVSCOPE2_PATH    0x0U
+	#define DRHD0_DEVSCOPE3_BUS     0x0U
+	#define DRHD0_DEVSCOPE3_PATH    0x0U
+	#define DRHD1_DEV_CNT           2U
+	#define DRHD1_SEGMENT           0U
+	#define DRHD1_FLAGS             1U
+	#define DRHD1_REG_BASE          0xFED91000UL
+	#define DRHD1_IGNORE            false
+	#define DRHD1_DEVSCOPE0_BUS     0x0U
+	#define DRHD1_DEVSCOPE0_PATH    0xf7U
+	#define DRHD1_DEVSCOPE1_BUS     0x0U
+	#define DRHD1_DEVSCOPE1_PATH    0xf6U
+	#define DRHD1_DEVSCOPE2_BUS     0x0U
+	#define DRHD1_DEVSCOPE2_PATH    0x0U
+	#define DRHD1_DEVSCOPE3_BUS     0x0U
+	#define DRHD1_DEVSCOPE3_PATH    0x0U
+	#define DRHD1_IOAPIC_ID         2U
+	#define DRHD2_DEV_CNT           0U
+	#define DRHD2_SEGMENT           0U
+	#define DRHD2_FLAGS             0U
+	#define DRHD2_REG_BASE          0x00UL
+	#define DRHD2_IGNORE            false
+	#define DRHD2_DEVSCOPE0_BUS     0x0U
+	#define DRHD2_DEVSCOPE0_PATH    0x0U
+	#define DRHD2_DEVSCOPE1_BUS     0x0U
+	#define DRHD2_DEVSCOPE1_PATH    0x0U
+	#define DRHD2_DEVSCOPE2_BUS     0x0U
+	#define DRHD2_DEVSCOPE2_PATH    0x0U
+	#define DRHD2_DEVSCOPE3_BUS     0x0U
+	#define DRHD2_DEVSCOPE3_PATH    0x0U
+	#define DRHD3_DEV_CNT           0U
+	#define DRHD3_SEGMENT           0U
+	#define DRHD3_FLAGS             0U
+	#define DRHD3_REG_BASE          0x00UL
+	#define DRHD3_IGNORE            false
+	#define DRHD3_DEVSCOPE0_BUS     0x0U
+	#define DRHD3_DEVSCOPE0_PATH    0x0U
+	#define DRHD3_DEVSCOPE1_BUS     0x0U
+	#define DRHD3_DEVSCOPE1_PATH    0x0U
+	#define DRHD3_DEVSCOPE2_BUS     0x0U
+	#define DRHD3_DEVSCOPE2_PATH    0x0U
+	#define DRHD3_DEVSCOPE3_BUS     0x0U
+	#define DRHD3_DEVSCOPE3_PATH    0x0U
+	</DRHD_INFO>
+
+	<CPU_BRAND>
+	"Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz"
+	</CPU_BRAND>
+
+	<CX_INFO>
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x00UL}, 0x01U, 0x01U, 0x00U},	/* C1 */
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x33UL}, 0x02U, 0x97U, 0x00U},	/* C2 */
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x60UL}, 0x03U, 0x40AU, 0x00U},	/* C3 */
+	</CX_INFO>
+
+	<PX_INFO>
+	{0xBB9UL, 0x00UL, 0x0AUL, 0x0AUL, 0x002700UL, 0x002700UL},	/* P0 */
+	{0xBB8UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001E00UL, 0x001E00UL},	/* P1 */
+	{0x708UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001200UL, 0x001200UL},	/* P2 */
+	{0x640UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001000UL, 0x001000UL},	/* P3 */
+	{0x5DCUL, 0x00UL, 0x0AUL, 0x0AUL, 0x000F00UL, 0x000F00UL},	/* P4 */
+	{0x3E8UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000A00UL, 0x000A00UL},	/* P5 */
+	</PX_INFO>
+
+	<CLOS_INFO>
+	clos supported by cache:False
+	clos max:0
+	</CLOS_INFO>
+
+	<SYSTEM_RAM_INFO>
+	00001000-0005efff : System RAM
+	00060000-0009ffff : System RAM
+	00100000-1fdfffff : System RAM
+	20000000-3fffffff : System RAM
+	40400000-8276e017 : System RAM
+	8276e018-8277e657 : System RAM
+	8277e658-8277f017 : System RAM
+	8277f018-8278f057 : System RAM
+	8278f058-85b3dfff : System RAM
+	85b40000-8bfbafff : System RAM
+	8ceff000-8cefffff : System RAM
+	100000000-26dffffff : System RAM
+	</SYSTEM_RAM_INFO>
+
+	<BLOCK_DEVICE_INFO>
+	/dev/nvme0n1p3: TYPE="ext4"
+	/dev/sda3: TYPE="ext4"
+	</BLOCK_DEVICE_INFO>
+
+	<TTYS_INFO>
+	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
+	seri:/dev/ttyS1 type:portio base:0x2F8 irq:3
+	seri:/dev/ttyS2 type:portio base:0x3E8 irq:7
+	seri:/dev/ttyS3 type:portio base:0x2E8 irq:7
+	</TTYS_INFO>
+
+	<AVAILABLE_IRQ_INFO>
+	5, 6, 10, 11, 12, 13, 14, 15
+	</AVAILABLE_IRQ_INFO>
+
+	<TOTAL_MEM_INFO>
+	8044092 kB
+	</TOTAL_MEM_INFO>
+
+	<CPU_PROCESSOR_INFO>
+	0, 1, 2, 3
+	</CPU_PROCESSOR_INFO>
+
+</acrn-config>

--- a/misc/acrn-config/xmls/board-xmls/whl-ipc-i7.xml
+++ b/misc/acrn-config/xmls/board-xmls/whl-ipc-i7.xml
@@ -1,0 +1,251 @@
+<acrn-config board="whl-ipc-i7">
+	<BIOS_INFO>
+	BIOS Information
+	Vendor: American Megatrends Inc.
+	Version: WL10R104
+	Release Date: 09/12/2019
+	BIOS Revision: 5.13
+	</BIOS_INFO>
+
+	<BASE_BOARD_INFO>
+	Base Board Information
+	Manufacturer: Maxtang
+	Product Name: WL10
+	Version: V1.0
+	</BASE_BOARD_INFO>
+
+	<PCI_DEVICE>
+	00:00.0 Host bridge: Intel Corporation Device 3e34 (rev 0b)
+	00:02.0 VGA compatible controller: Intel Corporation Device 3ea0
+	Region 0: Memory at a0000000 (64-bit, non-prefetchable) [size=16M]
+	Region 2: Memory at 90000000 (64-bit, prefetchable) [size=256M]
+	00:12.0 Signal processing controller: Intel Corporation Device 9df9 (rev 30)
+	Region 0: Memory at a141e000 (64-bit, non-prefetchable) [size=4K]
+	00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)
+	Region 0: Memory at a1400000 (64-bit, non-prefetchable) [size=64K]
+	00:14.2 RAM memory: Intel Corporation Device 9def (rev 30)
+	Region 0: Memory at a1416000 (64-bit, non-prefetchable) [disabled] [size=8K]
+	Region 2: Memory at a141d000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:16.0 Communication controller: Intel Corporation Device 9de0 (rev 30)
+	Region 0: Memory at a141c000 (64-bit, non-prefetchable) [size=4K]
+	00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)
+	Region 0: Memory at a1414000 (32-bit, non-prefetchable) [size=8K]
+	Region 1: Memory at a141b000 (32-bit, non-prefetchable) [size=256]
+	Region 5: Memory at a141a000 (32-bit, non-prefetchable) [size=2K]
+	00:1a.0 SD Host controller: Intel Corporation Device 9dc4 (rev 30)
+	Region 0: Memory at a1419000 (64-bit, non-prefetchable) [size=4K]
+	00:1c.0 PCI bridge: Intel Corporation Device 9db8 (rev f0)
+	00:1c.4 PCI bridge: Intel Corporation Device 9dbc (rev f0)
+	00:1d.0 PCI bridge: Intel Corporation Device 9db0 (rev f0)
+	00:1d.1 PCI bridge: Intel Corporation Device 9db1 (rev f0)
+	00:1f.0 ISA bridge: Intel Corporation Device 9d84 (rev 30)
+	00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)
+	Region 0: Memory at a1410000 (64-bit, non-prefetchable) [size=16K]
+	Region 4: Memory at a1000000 (64-bit, non-prefetchable) [size=1M]
+	00:1f.4 SMBus: Intel Corporation Device 9da3 (rev 30)
+	Region 0: Memory at a1418000 (64-bit, non-prefetchable) [size=256]
+	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 9da4 (rev 30)
+	Region 0: Memory at fe010000 (32-bit, non-prefetchable) [size=4K]
+	02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)
+	Region 0: Memory at a1300000 (64-bit, non-prefetchable) [size=16K]
+	03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
+	Region 0: Memory at a1200000 (32-bit, non-prefetchable) [size=128K]
+	Region 3: Memory at a1220000 (32-bit, non-prefetchable) [size=16K]
+	04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
+	Region 0: Memory at a1100000 (32-bit, non-prefetchable) [size=128K]
+	Region 3: Memory at a1120000 (32-bit, non-prefetchable) [size=16K]
+	</PCI_DEVICE>
+
+	<PCI_VID_PID>
+	00:00.0 0600: 8086:3e34 (rev 0b)
+	00:02.0 0300: 8086:3ea0
+	00:12.0 1180: 8086:9df9 (rev 30)
+	00:14.0 0c03: 8086:9ded (rev 30)
+	00:14.2 0500: 8086:9def (rev 30)
+	00:16.0 0780: 8086:9de0 (rev 30)
+	00:17.0 0106: 8086:9dd3 (rev 30)
+	00:1a.0 0805: 8086:9dc4 (rev 30)
+	00:1c.0 0604: 8086:9db8 (rev f0)
+	00:1c.4 0604: 8086:9dbc (rev f0)
+	00:1d.0 0604: 8086:9db0 (rev f0)
+	00:1d.1 0604: 8086:9db1 (rev f0)
+	00:1f.0 0601: 8086:9d84 (rev 30)
+	00:1f.3 0403: 8086:9dc8 (rev 30)
+	00:1f.4 0c05: 8086:9da3 (rev 30)
+	00:1f.5 0c80: 8086:9da4 (rev 30)
+	02:00.0 0108: 126f:2263 (rev 03)
+	03:00.0 0200: 8086:157b (rev 03)
+	04:00.0 0200: 8086:157b (rev 03)
+	</PCI_VID_PID>
+
+	<WAKE_VECTOR_INFO>
+	#define WAKE_VECTOR_32          0x8C8AA08CUL
+	#define WAKE_VECTOR_64          0x8C8AA098UL
+	</WAKE_VECTOR_INFO>
+
+	<RESET_REGISTER_INFO>
+	#define RESET_REGISTER_ADDRESS  0xCF9UL
+	#define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
+	#define RESET_REGISTER_VALUE    0x6U
+	</RESET_REGISTER_INFO>
+
+	<PM_INFO>
+	#define PM1A_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_EVT_BIT_WIDTH      0x20U
+	#define PM1A_EVT_BIT_OFFSET     0x0U
+	#define PM1A_EVT_ADDRESS        0x1800UL
+	#define PM1A_EVT_ACCESS_SIZE    0x2U
+	#define PM1B_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_EVT_BIT_WIDTH      0x0U
+	#define PM1B_EVT_BIT_OFFSET     0x0U
+	#define PM1B_EVT_ADDRESS        0x0UL
+	#define PM1B_EVT_ACCESS_SIZE    0x2U
+	#define PM1A_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_CNT_BIT_WIDTH      0x10U
+	#define PM1A_CNT_BIT_OFFSET     0x0U
+	#define PM1A_CNT_ADDRESS        0x1804UL
+	#define PM1A_CNT_ACCESS_SIZE    0x2U
+	#define PM1B_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_CNT_BIT_WIDTH      0x0U
+	#define PM1B_CNT_BIT_OFFSET     0x0U
+	#define PM1B_CNT_ADDRESS        0x0UL
+	#define PM1B_CNT_ACCESS_SIZE    0x2U
+	</PM_INFO>
+
+	<S3_INFO>
+	/* S3 is not supported by BIOS */
+	#define S3_PKG_VAL_PM1A         0x0U
+	#define S3_PKG_VAL_PM1B         0x0U
+	#define S3_PKG_RESERVED         0x0U
+	</S3_INFO>
+
+	<S5_INFO>
+	#define S5_PKG_VAL_PM1A         0x7U
+	#define S5_PKG_VAL_PM1B         0U
+	#define S5_PKG_RESERVED         0x0U
+	</S5_INFO>
+
+	<DRHD_INFO>
+	#define DRHD_COUNT              2U
+	#define DRHD0_DEV_CNT           1U
+	#define DRHD0_SEGMENT           0U
+	#define DRHD0_FLAGS             0U
+	#define DRHD0_REG_BASE          0xFED90000UL
+	#define DRHD0_IGNORE            true
+	#define DRHD0_DEVSCOPE0_BUS     0x0U
+	#define DRHD0_DEVSCOPE0_PATH    0x10U
+	#define DRHD0_DEVSCOPE1_BUS     0x0U
+	#define DRHD0_DEVSCOPE1_PATH    0x0U
+	#define DRHD0_DEVSCOPE2_BUS     0x0U
+	#define DRHD0_DEVSCOPE2_PATH    0x0U
+	#define DRHD0_DEVSCOPE3_BUS     0x0U
+	#define DRHD0_DEVSCOPE3_PATH    0x0U
+	#define DRHD1_DEV_CNT           2U
+	#define DRHD1_SEGMENT           0U
+	#define DRHD1_FLAGS             1U
+	#define DRHD1_REG_BASE          0xFED91000UL
+	#define DRHD1_IGNORE            false
+	#define DRHD1_DEVSCOPE0_BUS     0x0U
+	#define DRHD1_DEVSCOPE0_PATH    0xf7U
+	#define DRHD1_DEVSCOPE1_BUS     0x0U
+	#define DRHD1_DEVSCOPE1_PATH    0xf6U
+	#define DRHD1_DEVSCOPE2_BUS     0x0U
+	#define DRHD1_DEVSCOPE2_PATH    0x0U
+	#define DRHD1_DEVSCOPE3_BUS     0x0U
+	#define DRHD1_DEVSCOPE3_PATH    0x0U
+	#define DRHD1_IOAPIC_ID         2U
+	#define DRHD2_DEV_CNT           0U
+	#define DRHD2_SEGMENT           0U
+	#define DRHD2_FLAGS             0U
+	#define DRHD2_REG_BASE          0x00UL
+	#define DRHD2_IGNORE            false
+	#define DRHD2_DEVSCOPE0_BUS     0x0U
+	#define DRHD2_DEVSCOPE0_PATH    0x0U
+	#define DRHD2_DEVSCOPE1_BUS     0x0U
+	#define DRHD2_DEVSCOPE1_PATH    0x0U
+	#define DRHD2_DEVSCOPE2_BUS     0x0U
+	#define DRHD2_DEVSCOPE2_PATH    0x0U
+	#define DRHD2_DEVSCOPE3_BUS     0x0U
+	#define DRHD2_DEVSCOPE3_PATH    0x0U
+	#define DRHD3_DEV_CNT           0U
+	#define DRHD3_SEGMENT           0U
+	#define DRHD3_FLAGS             0U
+	#define DRHD3_REG_BASE          0x00UL
+	#define DRHD3_IGNORE            false
+	#define DRHD3_DEVSCOPE0_BUS     0x0U
+	#define DRHD3_DEVSCOPE0_PATH    0x0U
+	#define DRHD3_DEVSCOPE1_BUS     0x0U
+	#define DRHD3_DEVSCOPE1_PATH    0x0U
+	#define DRHD3_DEVSCOPE2_BUS     0x0U
+	#define DRHD3_DEVSCOPE2_PATH    0x0U
+	#define DRHD3_DEVSCOPE3_BUS     0x0U
+	#define DRHD3_DEVSCOPE3_PATH    0x0U
+	</DRHD_INFO>
+
+	<CPU_BRAND>
+	"Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz"
+	</CPU_BRAND>
+
+	<CX_INFO>
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x00UL}, 0x01U, 0x01U, 0x00U},	/* C1 */
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x33UL}, 0x02U, 0x97U, 0x00U},	/* C2 */
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x60UL}, 0x03U, 0x40AU, 0x00U},	/* C3 */
+	</CX_INFO>
+
+	<PX_INFO>
+	{0x835UL, 0x00UL, 0x0AUL, 0x0AUL, 0x002E00UL, 0x002E00UL},	/* P0 */
+	{0x834UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001500UL, 0x001500UL},	/* P1 */
+	{0x7D0UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001400UL, 0x001400UL},	/* P2 */
+	{0x76CUL, 0x00UL, 0x0AUL, 0x0AUL, 0x001300UL, 0x001300UL},	/* P3 */
+	{0x708UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001200UL, 0x001200UL},	/* P4 */
+	{0x6A4UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001100UL, 0x001100UL},	/* P5 */
+	{0x640UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001000UL, 0x001000UL},	/* P6 */
+	{0x5DCUL, 0x00UL, 0x0AUL, 0x0AUL, 0x000F00UL, 0x000F00UL},	/* P7 */
+	{0x578UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000E00UL, 0x000E00UL},	/* P8 */
+	{0x514UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000D00UL, 0x000D00UL},	/* P9 */
+	</PX_INFO>
+
+	<CLOS_INFO>
+	clos supported by cache:False
+	clos max:0
+	</CLOS_INFO>
+
+	<SYSTEM_RAM_INFO>
+	00001000-0005efff : System RAM
+	00060000-0009ffff : System RAM
+	00100000-3fffffff : System RAM
+	40400000-826f5017 : System RAM
+	826f5018-82705657 : System RAM
+	82705658-82706017 : System RAM
+	82706018-82716057 : System RAM
+	82716058-85b5dfff : System RAM
+	85b60000-8bfbbfff : System RAM
+	8ceff000-8cefffff : System RAM
+	100000000-26dffffff : System RAM
+	</SYSTEM_RAM_INFO>
+
+	<BLOCK_DEVICE_INFO>
+	/dev/nvme0n1p3: TYPE="ext4"
+	/dev/sda3: TYPE="ext4"
+	</BLOCK_DEVICE_INFO>
+
+	<TTYS_INFO>
+	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
+	seri:/dev/ttyS1 type:portio base:0x2F8 irq:3
+	seri:/dev/ttyS2 type:portio base:0x3E8 irq:7
+	seri:/dev/ttyS3 type:portio base:0x2E8 irq:7
+	</TTYS_INFO>
+
+	<AVAILABLE_IRQ_INFO>
+	6, 10, 11, 13, 14, 15
+	</AVAILABLE_IRQ_INFO>
+
+	<TOTAL_MEM_INFO>
+	8105908 kB
+	</TOTAL_MEM_INFO>
+
+	<CPU_PROCESSOR_INFO>
+	0, 1, 2, 3
+	</CPU_PROCESSOR_INFO>
+
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -1,0 +1,113 @@
+<acrn-config board="whl-ipc-i5" scenario="hybrid">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+    <uuid configurable="0" desc="vm uuid">fc836901-8685-4bc0-8b71-6e31dc36fa47</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <bootargs desc="Specify kernel boot arguments"></bootargs>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="2">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -1,0 +1,99 @@
+<acrn-config board="whl-ipc-i5" scenario="industry">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="2">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">495ae2e5-2603-4d64-af76-d4bc5a8ec0e5</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -1,0 +1,27 @@
+<acrn-config board="whl-ipc-i5" scenario="industry" uos_launcher="1">
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
+	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -1,0 +1,28 @@
+<acrn-config board="whl-ipc-i5" scenario="industry" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">VXWORKS</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -1,0 +1,28 @@
+<acrn-config board="whl-ipc-i5" scenario="industry" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
+	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -1,0 +1,54 @@
+<acrn-config board="whl-ipc-i5" scenario="industry" uos_launcher="2">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
+	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="" readonly="true">ovmf</vbootloader>
+	<rootfs_dev configurable="0" desc=""></rootfs_dev>
+	<rootfs_img configurable="0" desc=""></rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -1,0 +1,95 @@
+<acrn-config board="whl-ipc-i5" scenario="logical_partition">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+    <uuid configurable="0" desc="vm uuid">26c5e0d8-8f8a-47d8-8109-f201ebd61a5e</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag></guest_flag>
+        <guest_flag></guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>0</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        </bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">vm0_pci_devs</pci_devs>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
+    <uuid configurable="0" desc="vm uuid">dd87ce08-66f9-473d-bc58-7605837f935e</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_RT</guest_flag>
+        <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable xapic_phys
+        </bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">vm1_pci_devs</pci_devs>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -1,0 +1,97 @@
+<acrn-config board="whl-ipc-i5" scenario="sdc">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="2" configurable="0" desc="specific for Kata">
+    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_BASE</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_BASE</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc2.xml
@@ -1,0 +1,125 @@
+<acrn-config board="whl-ipc-i5" scenario="sdc2">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="2">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">495ae2e5-2603-4d64-af76-d4bc5a8ec0e5</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="3">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">38158821-5208-4005-b72a-8a609e4190d0</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -1,0 +1,31 @@
+<acrn-config board="whl-ipc-i5" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">CLEARLINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">home/clear/uos/uos.img</rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<poweroff_channel desc="the method of power off uos" readonly="true">
+	--pm_notify_channel power_button \
+	</poweroff_channel>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -1,0 +1,28 @@
+<acrn-config board="whl-ipc-i5" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">ZEPHYR</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">128</mem_size>
+	<gvt_args desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
+	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -1,0 +1,113 @@
+<acrn-config board="whl-ipc-i7" scenario="hybrid">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+    <uuid configurable="0" desc="vm uuid">fc836901-8685-4bc0-8b71-6e31dc36fa47</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <bootargs desc="Specify kernel boot arguments"></bootargs>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number"></pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list"></pci_devs>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="2">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -1,0 +1,99 @@
+<acrn-config board="whl-ipc-i7" scenario="industry">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="2">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">495ae2e5-2603-4d64-af76-d4bc5a8ec0e5</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -1,0 +1,27 @@
+<acrn-config board="whl-ipc-i7" scenario="industry" uos_launcher="1">
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
+	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -1,0 +1,28 @@
+<acrn-config board="whl-ipc-i7" scenario="industry" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">VXWORKS</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -1,0 +1,28 @@
+<acrn-config board="whl-ipc-i7" scenario="industry" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
+	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -1,0 +1,54 @@
+<acrn-config board="whl-ipc-i7" scenario="industry" uos_launcher="2">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
+	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="" readonly="true">ovmf</vbootloader>
+	<rootfs_dev configurable="0" desc=""></rootfs_dev>
+	<rootfs_img configurable="0" desc=""></rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -1,0 +1,95 @@
+<acrn-config board="whl-ipc-i7" scenario="logical_partition">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+    <uuid configurable="0" desc="vm uuid">26c5e0d8-8f8a-47d8-8109-f201ebd61a5e</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag></guest_flag>
+        <guest_flag></guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>0</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        </bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">vm0_pci_devs</pci_devs>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">PRE_LAUNCHED_VM</load_order>
+    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
+    <uuid configurable="0" desc="vm uuid">dd87ce08-66f9-473d-bc58-7605837f935e</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_RT</guest_flag>
+        <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <memory>
+        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
+        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable xapic_phys
+        </bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">vm1_pci_devs</pci_devs>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -1,0 +1,97 @@
+<acrn-config board="whl-ipc-i7" scenario="sdc">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+        <pcpu_id>2</pcpu_id>
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="2" configurable="0" desc="specific for Kata">
+    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_BASE</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_BASE</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc2.xml
@@ -1,0 +1,125 @@
+<acrn-config board="whl-ipc-i7" scenario="sdc2">
+  <vm id="0">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">SOS_VM</load_order>
+    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+    <uuid configurable="0" desc="vm uuid">dbbbd434-7a57-4216-a12c-2201f1ab0240</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>GUEST_FLAG_HIGHEST_SEVERITY</guest_flag>
+    </guest_flags>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <memory>
+        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+    </memory>
+    <os_config>
+        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+    </os_config>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+    <pci_dev_num configurable="0" desc="pci devices number">SOS_EMULATED_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs configurable="0" desc="pci devices list">sos_pci_devs</pci_devs>
+    <board_private>
+        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <console desc="ttyS console for Linux kernel">/dev/ttyS0</console>
+        <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        </bootargs>
+    </board_private>
+  </vm>
+  <vm id="1">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">d2795438-25d6-11e8-864e-cb7a18b34643</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>1</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="2">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">495ae2e5-2603-4d64-af76-d4bc5a8ec0e5</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>2</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+  <vm id="3">
+    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM." readonly="true">POST_LAUNCHED_VM</load_order>
+    <uuid configurable="0" desc="vm uuid">38158821-5208-4005-b72a-8a609e4190d0</uuid>
+    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <guest_flag>0</guest_flag>
+    </guest_flags>
+    <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+        <pcpu_id>3</pcpu_id>
+    </vcpu_affinity>
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
+    <epc_section desc="epc section">
+        <base desc="SGX EPC section base, must be page aligned">0</base>
+        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    </epc_section>
+    <vuart id="0">
+        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+    </vuart>
+    <vuart id="1">
+        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+    </vuart>
+  </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -1,0 +1,31 @@
+<acrn-config board="whl-ipc-i7" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">CLEARLINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">home/clear/uos/uos.img</rootfs_img>
+	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<poweroff_channel desc="the method of power off uos" readonly="true">
+	--pm_notify_channel power_button \
+	</poweroff_channel>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -1,0 +1,28 @@
+<acrn-config board="whl-ipc-i7" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">ZEPHYR</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">128</mem_size>
+	<gvt_args desc="GVT argument for the vm"></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
+	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
+	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+    </uos>
+</acrn-config>


### PR DESCRIPTION
- refine mem_size_set function
- refine interrupt_storm function
- add support to generate launch script
- remove runC script from unnecessary launch script
- add config files for whl-ipc-i7 board
- add config files for whl-ipc-i5 board
- remove parser for console

    Tracked-On: #3854
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
