### PR TITLE
hv: vpci:  add lock to protect PCI or MSI-X BAR concurrent access

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -484,6 +484,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		prepare_epc_vm_memmap(vm);
 
 		spinlock_init(&vm->vm_lock);
+		spinlock_init(&vm->emul_mmio_lock);
 
 		vm->arch_vm.vlapic_state = VM_VLAPIC_XAPIC;
 		vm->intr_inject_delay_delta = 0UL;

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -74,14 +74,14 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
  * @pre vpci != NULL
  * @pre vpci->pci_vdev_cnt <= CONFIG_MAX_PCI_DEV_NUM
  */
-struct pci_vdev *pci_find_vdev(const struct acrn_vpci *vpci, union pci_bdf vbdf)
+struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf)
 {
 	struct pci_vdev *vdev, *tmp;
 	uint32_t i;
 
 	vdev = NULL;
 	for (i = 0U; i < vpci->pci_vdev_cnt; i++) {
-		tmp = (struct pci_vdev *)&(vpci->pci_vdevs[i]);
+		tmp = &(vpci->pci_vdevs[i]);
 
 		if (bdf_is_equal(tmp->bdf, vbdf)) {
 			vdev = tmp;

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -143,6 +143,6 @@ void deinit_vmsix(const struct pci_vdev *vdev);
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
-struct pci_vdev *pci_find_vdev(const struct acrn_vpci *vpci, union pci_bdf vbdf);
+struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf);
 
 #endif /* VPCI_PRIV_H_ */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -123,8 +123,9 @@ struct acrn_vm {
 	struct acrn_vuart vuart[MAX_VUART_NUM_PER_VM];		/* Virtual UART */
 	enum vpic_wire_mode wire_mode;
 	struct iommu_domain *iommu;	/* iommu domain of this VM */
-	spinlock_t vm_lock;	/* Spin-lock used to protect VM modifications */
+	spinlock_t vm_lock;	/* Spin-lock used to protect vlapic_state modifications for a VM */
 
+	spinlock_t emul_mmio_lock;	/* Used to protect emulation mmio_node concurrent access for a VM */
 	uint16_t max_emul_mmio_regions;	/* max index of the emulated mmio_region */
 	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -30,6 +30,7 @@
 #ifndef VPCI_H_
 #define VPCI_H_
 
+#include <spinlock.h>
 #include <pci.h>
 
 
@@ -112,6 +113,7 @@ union pci_cfg_addr_reg {
 };
 
 struct acrn_vpci {
+	spinlock_t lock;
 	struct acrn_vm *vm;
 	union pci_cfg_addr_reg addr;
 	uint32_t pci_vdev_cnt;
@@ -120,8 +122,8 @@ struct acrn_vpci {
 
 extern const struct pci_vdev_ops vhostbridge_ops;
 void vpci_init(struct acrn_vm *vm);
-void vpci_cleanup(const struct acrn_vm *vm);
+void vpci_cleanup(struct acrn_vm *vm);
 void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
-void vpci_reset_ptdev_intr_info(const struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
+void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 
 #endif /* VPCI_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -101,15 +101,19 @@ struct pci_vdev {
 	struct pci_vdev *new_owner;
 };
 
-struct pci_addr_info {
-	union pci_bdf cached_bdf;
-	uint32_t cached_reg;
-	bool cached_enable;
+union pci_cfg_addr_reg {
+	uint32_t value;
+	struct {
+		uint32_t reg_num : 8;	/* BITs 0-7, Register Number (BITs 0-1, always reserve to 0) */
+		uint32_t bdf : 16;	/* BITs 8-23, BDF Number */
+		uint32_t resv : 7;	/* BITs 24-30, Reserved */
+		uint32_t enable : 1;	/* BITs 31, Enable bit */
+	} bits;
 };
 
 struct acrn_vpci {
 	struct acrn_vm *vm;
-	struct pci_addr_info addr_info;
+	union pci_cfg_addr_reg addr;
 	uint32_t pci_vdev_cnt;
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };


### PR DESCRIPTION
1)  define PCI CONFIG_ADDRESS Register as its physical layout
2) add a global PCI lock for each VM
3)  add a lock to protect mmio_node access

Tracked-On: #3475
Signed-off-by: Li, Fei1 <fei1.li@intel.com>