### PR TITLE
acrn-config: add serial config in new $(board).config

### DIFF
--- a/misc/acrn-config/board_config/board_cfg_gen.py
+++ b/misc/acrn-config/board_config/board_cfg_gen.py
@@ -22,6 +22,16 @@ ACRN_DEFAULT_PLATFORM = ACRN_PATH + "hypervisor/include/arch/x86/default_acpi_in
 GEN_FILE = ["pci_devices.h", "board.c", "_acpi_info.h", "misc_cfg.h", "ve820.c", ".config"]
 
 
+def need_gen_new_board_config(board_name):
+
+    # 1. if it is old board, they are already have the $(board_name).config, return and no need to generate it.
+
+    if board_name in board_cfg_lib.BOARD_NAMES:
+        return False
+    else:
+        return True
+
+
 def main(args):
     """
     This is main function to start generate source code related with board
@@ -103,7 +113,7 @@ def main(args):
             return err_dic
 
     # generate new board_name.config
-    if board not in board_cfg_lib.BOARD_NAMES:
+    if need_gen_new_board_config(board):
         with open(config_board_kconfig, 'w+') as config:
             err_dic = new_board_kconfig.generate_file(config)
             if err_dic:

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -71,8 +71,8 @@ def get_scenario_name():
     Get scenario name from scenario.xml at fist line
     :param scenario_info: it is a file what contains board information for script to read from
     """
-    (err_dic, board) = common.get_xml_attrib(SCENARIO_INFO_FILE, "scenario")
-    return (err_dic, board)
+    (err_dic, scenario) = common.get_xml_attrib(SCENARIO_INFO_FILE, "scenario")
+    return (err_dic, scenario)
 
 
 def is_config_file_match():


### PR DESCRIPTION
Enhance the $(board).config for new board.
Serial config should be set in $(board).config for new board.

Tracked-On: #3854
Signed-off-by: Wei Liu <weix.w.liu@intel.com>