### PR TITLE
Revert "Makefile: add default defconfig for new board"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,6 @@ define install_acrn_debug
 endef
 
 hypervisor:
-	$(MAKE) -C $(T)/hypervisor cfg_src
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)	\
 				BOARD_FILE=$(BOARD_FILE) SCENARIO_FILE=$(SCENARIO_FILE) clean
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) RELEASE=$(RELEASE)	\

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -43,8 +43,6 @@ ARCH_ASFLAGS :=
 ARCH_ARFLAGS :=
 ARCH_LDFLAGS :=
 
-DEFCONFIG_FILE := $(CURDIR)/arch/x86/configs/$(BOARD).config
-
 ifneq ($(BOARD_FILE)$(SCENARIO_FILE),)
 override BOARD := $(shell echo `sed -n '/<acrn-config/p' $(BOARD_FILE) | sed -r 's/.*board="(.*)".*/\1/g'`)
 SCENARIO_IN_XML := $(shell sed -n '/<acrn-config/p' $(SCENARIO_FILE) | sed -r 's/.*scenario="(.*)".*/\1/g')
@@ -390,7 +388,7 @@ ifneq ($(BOARD_FILE)$(SCENARIO_FILE),)
 	@if [ "$(BOARD)" != "$(CONFIG_BOARD)" ]; then \
 		echo "Board in xml file <$(BOARD)> does not match Kconfig <$(CONFIG_BOARD)>!"; exit 1; \
 	fi
-	@if [ "$(SCENARIO_IN_XML)" != "$(SCENARIO_NAME)" ] && [ -f $(DEFCONFIG_FILE) ]; then \
+	@if [ "$(SCENARIO_IN_XML)" != "$(SCENARIO_NAME)" ]; then \
 		echo "Scenario in xml file <$(SCENARIO_IN_XML)> does not match Kconfig <$(SCENARIO_NAME)>!"; exit 1; \
 	fi
 	@python3 ../misc/acrn-config/board_config/board_cfg_gen.py --board $(BOARD_FILE) --scenario $(SCENARIO_FILE) > $(HV_OBJDIR)/.cfg_src_result


### PR DESCRIPTION
This reverts commit 9ddf27669bc2a7dab643b138fe55572fcb2cba6c.
Souce code should be generate out firstly to solve the dependency for
make all acrn-hypervisor code. 9ddf27669bc commit does not work in some
scenario, so revert it.

Tracked-On: #3779
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>