### PR TITLE
doc: schedule_vcpu was removed

### DIFF
--- a/doc/developer-guides/hld/hv-cpu-virt.rst
+++ b/doc/developer-guides/hld/hv-cpu-virt.rst
@@ -216,8 +216,8 @@ Some example scenario flows are shown here:
 
    ACRN vCPU scheduling scenarios
 
--  **During starting a VM**: after create a vCPU, BSP calls *schedule_vcpu*
-   through *start_vm*, AP calls *schedule_vcpu* through vlapic
+-  **During starting a VM**: after create a vCPU, BSP calls *launch_vcpu*
+   through *start_vm*, AP calls *launch_vcpu* through vlapic
    INIT-SIPI emulation, finally this vCPU runs in a
    *vcpu_thread* loop.
 


### PR DESCRIPTION
schedule_vcpu should be replaced by launch_vcpu

Tracked-On: #3963
Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>