### PR TITLE
Mmu: remove unconfigure high memory from EFI memory map

### DIFF
--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -112,6 +112,7 @@ uint64_t e820_alloc_low_memory(uint32_t size_arg)
 void init_e820(void)
 {
 	uint32_t i;
+	uint64_t top_addr_space = CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE;
 
 	if (boot_regs[0] == MULTIBOOT_INFO_MAGIC) {
 		/*
@@ -137,6 +138,14 @@ void init_e820(void)
 				mbi->mi_mmap_length, mbi->mi_mmap_addr, hv_e820_entries_nr);
 
 			for (i = 0U; i < hv_e820_entries_nr; i++) {
+				if (mmap[i].baseaddr >= top_addr_space) {
+					mmap[i].length = 0UL;
+				} else {
+					if ((mmap[i].baseaddr + mmap[i].length) > top_addr_space) {
+						mmap[i].length = top_addr_space - mmap[i].baseaddr;
+					}
+				}
+
 				hv_e820[i].baseaddr = mmap[i].baseaddr;
 				hv_e820[i].length = mmap[i].length;
 				hv_e820[i].type = mmap[i].type;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -220,12 +220,12 @@ void init_paging(void)
 	const struct e820_entry *entry;
 	uint32_t entries_count = get_e820_entries_count();
 	const struct e820_entry *p_e820 = get_e820_entry();
-	const struct e820_mem_params *p_e820_mem_info = get_e820_mem_info();
+	const struct mem_range *p_mem_range_info = get_mem_range_info();
 
 	pr_dbg("HV MMU Initialization");
 
 	/* align to 2MB */
-	high64_max_ram = round_pde_up(p_e820_mem_info->mem_top);
+	high64_max_ram = round_pde_up(p_mem_range_info->mem_top);
 	if ((high64_max_ram > (CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)) ||
 			(high64_max_ram < (1UL << 32U))) {
 		printf("ERROR!!! high64_max_ram: 0x%llx, top address space: 0x%llx\n",

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -28,7 +28,7 @@ struct e820_entry {
 	uint32_t type;
 } __packed;
 
-struct e820_mem_params {
+struct mem_range {
 	uint64_t mem_bottom;
 	uint64_t mem_top;
 	uint64_t total_mem_size;
@@ -47,6 +47,6 @@ uint32_t get_e820_entries_count(void);
 const struct e820_entry *get_e820_entry(void);
 
 /* get the e820 total memory info */
-const struct e820_mem_params *get_e820_mem_info(void);
+const struct mem_range *get_mem_range_info(void);
 
 #endif


### PR DESCRIPTION
Now the default board memory size is 16 GB. However, ACRN support more and more boards
which may have memory size large than 16 GB. This patch try to remove un-configure
high memory form EFI memory map.

Tracked-On: #4007
Signed-off-by: Li Fei1 <fei1.li@intel.com>