### PR TITLE
acrn-config: modify board config for whl-ipc-i5/whl-ipc-i7

### DIFF
--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -375,9 +375,14 @@ def get_board_private_vuart(branch_tag, tag_console):
             vuart0_console_dic[ttys_n] = NATIVE_CONSOLE_DIC[ttys_n]
 
     # VUART1
-    if len(vuart1_valid_console) == 4:
-        vuart1_console_dic[ttys_n] = alloc_irq()
+    if len(NATIVE_CONSOLE_DIC) >= 2:
+        # There are more than 1 serial port in native, we need to use native ttyS1 info for vuart1 which include
+        # base ioport and irq number.
+        if 'ttyS1' in NATIVE_CONSOLE_DIC.keys():
+            vuart1_console_dic['ttyS1'] = NATIVE_CONSOLE_DIC['ttyS1']
     else:
+        # There is only one native serial port. We hardcode base ioport for vuart1 and allocate a irq which is
+        # free in native env and use it for vuart1 irq number
         vuart1_console_dic[vuart1_valid_console[0]] = alloc_irq()
 
     return (err_dic, vuart0_console_dic, vuart1_console_dic)


### PR DESCRIPTION
    acrn-config: chose ttyS1 for vuart1

    For vuart1, if it's mapped to a real native serial port, we must
    re-use the native serial port io base and irq number. If no native
    serial port is mapped to vuart1, non-exist io base and irq should
    be used.

    Please note: UOS launch script may need be updated according to
    which serial port index is used by vuart1.

    Now, we are using ttyS1 of SOS for vuart1 in our release. User may
    need to remap vuart to different ttySx by following above rule if
    ttyS1 in user platform is used by other devices like Bluetooth/Wifi.

    Tracked-On: #4016
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-On: Victor Sun <victor.sun@intel.com>
