### PR TITLE
HV: correct the formatting flag of hypcall_id

### DIFF
--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -227,7 +227,7 @@ int32_t vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 	uint64_t hypcall_id = vcpu_get_gpreg(vcpu, CPU_REG_R8);
 
 	if (!is_hypercall_from_ring0()) {
-		pr_err("hypercall is only allowed from RING-0!\n");
+		pr_err("hypercall 0x%llx is only allowed from RING-0!\n", hypcall_id);
 		vcpu_inject_gp(vcpu, 0U);
 		ret = -EACCES;
 	} else if (hypcall_id == HC_WORLD_SWITCH) {
@@ -243,7 +243,7 @@ int32_t vmcall_vmexit_handler(struct acrn_vcpu *vcpu)
 		/* Dispatch the hypercall handler */
 		ret = dispatch_sos_hypercall(vcpu);
 	} else  {
-		pr_err("hypercall %d is only allowed from SOS_VM!\n", hypcall_id);
+		pr_err("hypercall 0x%llx is only allowed from SOS_VM!\n", hypcall_id);
 		vcpu_inject_ud(vcpu);
 		ret = -ENODEV;
 	}


### PR DESCRIPTION
hypcall_id has a type of uint64_t and should use 'llx' as
formatting flag instead of '%d'. Otherwise, we will get a
confusing error log when not-allowed hypercall occurs.

Without this patch:
[96707209us][cpu=1][sev=3][seq=2386]:hypercall -2147483548 is only allowed from SOS_VM!

With this patch:
[84613395us][cpu=1][sev=3][seq=2136]:hypercall 0x80000064 is only allowed from SOS_VM!

So, we can figure out which not-allowed hypercall has been triggered more conveniently.

BTW, this patch adds hypcall_id which triggered from non-ring0 into error log.

Tracked-On: #4012
Signed-off-by: Kaige Fu <kaige.fu@intel.com>