### PR TITLE
hv: add Kconfig parameter to define the Service VM EFI bootloader

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -303,3 +303,11 @@ config MAX_KATA_VM_NUM
 	int "Maximum number of Kata Containers in SOS"
 	range 0 1
 	default 0
+
+config UEFI_OS_LOADER_NAME
+	string "UEFI OS loader name"
+	default "\\EFI\\org.clearlinux\\bootloaderx64.efi"
+	help
+	  Name of the UEFI bootloader that starts the Service VM. This is
+	  typically the systemd-boot or Grub bootloader but could be any other
+	  UEFI executable.

--- a/misc/efi-stub/boot.c
+++ b/misc/efi-stub/boot.c
@@ -394,7 +394,6 @@ fail:
 
 }
 
-#define DEFAULT_UEFI_OS_LOADER_NAME L"\\EFI\\org.clearlinux\\bootloaderx64.efi"
 /**
  * efi_main - The entry point for the OS loader image.
  * @image: firmware-allocated handle that identifies the image
@@ -460,7 +459,7 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 		 * bootloader name to be used. Fall back to the default bootloader
 		 * as specified in config.h
 		 */
-		bootloader_name = DEFAULT_UEFI_OS_LOADER_NAME;
+		bootloader_name = ch8_2_ch16(CONFIG_UEFI_OS_LOADER_NAME, strlen(CONFIG_UEFI_OS_LOADER_NAME));
 	}
 
 	section = ".hv";

--- a/misc/efi-stub/stdlib.h
+++ b/misc/efi-stub/stdlib.h
@@ -108,4 +108,19 @@ static inline char *ch16_2_ch8(CHAR16 *str16, UINTN len)
 	return str8;
 }
 
+static inline CHAR16 *ch8_2_ch16(char *str8, UINTN len)
+{
+	UINTN i;
+	CHAR16 *str16;
+
+	str16 = AllocatePool((len + 1) * sizeof(CHAR16));
+
+	for (i = 0; i < len; i++)
+		str16[i] = str8[i];
+
+	str16[len] = 0;
+
+	return str16;
+}
+
 #endif /* __STDLIB_H__ */


### PR DESCRIPTION
Add a Kconfig parameter called UEFI_OS_LOADER_NAME to hold the Service VM EFI
bootloader to be run by the ACRN hypervisor. A new string manipulation function
to convert from (char *) to (CHAR16 *) has been added to facilitate the
implementation.

The default value is set to systemd-boot (bootloaderx64.efi)

Tracked-On: #2793
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>