### PR TITLE
doc: add copyright/license header to doc scripts

### DIFF
--- a/doc/scripts/filter-doc-log.sh
+++ b/doc/scripts/filter-doc-log.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (C) 2019 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # run the filter-known-issues.py script to remove "expected" warning
 # messages from the output of the document build process and write

--- a/doc/scripts/pullsource.sh
+++ b/doc/scripts/pullsource.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (C) 2019 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
 
 q="--quiet"
 


### PR DESCRIPTION
Signed-off-by: David B. Kinder <david.b.kinder@intel.com>