### PR TITLE
acrn-config: include msr.h in board.c

### DIFF
--- a/misc/acrn-config/board_config/board_c.py
+++ b/misc/acrn-config/board_config/board_c.py
@@ -9,7 +9,8 @@ import board_cfg_lib
 
 INCLUDE_HEADER = """
 #include <board.h>
-#include <vtd.h>"""
+#include <vtd.h>
+#include <msr.h>"""
 
 
 MSR_IA32_L2_MASK_BASE = 0x00000D10


### PR DESCRIPTION
without the msr.h file the build will be failed when CAT is enabled.

Tracked-On: #4066
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>