### PR TITLE
hv: add printf "not support the value of vuart index parameter" in fu…

### DIFF
--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -534,7 +534,7 @@ static bool vuart_register_io_handler(struct acrn_vm *vm, uint16_t port_base, ui
 		pio_idx = UART_PIO_IDX1;
 		break;
 	default:
-		printf("Not support vuart index %d, will not register \n");
+		printf("Not support vuart index %d, will not register \n", vuart_idx);
 		ret = false;
 	}
 	if (ret != 0U) {


### PR DESCRIPTION
…nction vuart_register_io_handler

call vuart_register_io_handler function,when the parameter vuart_idx is greater than or equal to 2,
print the vuart index value which will not register the vuart.

Tracked-On: #4072

Signed-off-by: Jidong Xia <xiajidong@cmss.chinamobile.com>