### PR TITLE
hv: Fix the definition of struct representing interrupt hw frame

### DIFF
--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -264,7 +264,7 @@ void dump_intr_excp_frame(const struct intr_excp_ctx *ctx)
 	pr_acrnlog("=     RDX=0x%016llX  RDI=0x%016llX  RSI=0x%016llX\n",
 			ctx->gp_regs.rdx, ctx->gp_regs.rdi, ctx->gp_regs.rsi);
 	pr_acrnlog("=     RSP=0x%016llX  RBP=0x%016llX  RBX=0x%016llX\n",
-			ctx->gp_regs.rsp, ctx->gp_regs.rbp, ctx->gp_regs.rbx);
+			ctx->rsp, ctx->gp_regs.rbp, ctx->gp_regs.rbx);
 	pr_acrnlog("=      R8=0x%016llX   R9=0x%016llX  R10=0x%016llX\n",
 			ctx->gp_regs.r8, ctx->gp_regs.r9, ctx->gp_regs.r10);
 	pr_acrnlog("=     R11=0x%016llX  R12=0x%016llX  R13=0x%016llX\n",

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -76,6 +76,7 @@ struct intr_excp_ctx {
 	uint64_t rip;
 	uint64_t cs;
 	uint64_t rflags;
+	uint64_t rsp;
 	uint64_t ss;
 };
 


### PR DESCRIPTION
In 64-bit mode, processor pushes SS and RSP onto stack unconditionally.
Also when dumping the exception info, it makes more sense to dump
the RSP at the point of interrupt, rather than the RSP after pushing
context (including GPRs)

Tracked-On: #4102
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>