### PR TITLE
Gp2.0 Patches back-porting

### DIFF
--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -244,6 +244,7 @@ acrn_load_elf(struct vmctx *ctx, char *elf_file_name, unsigned long *entry,
 	}
 
 	*entry = elf_ehdr->e_entry;
+	fclose(fp);
 	free(elf_buf);
 
 	return ret;

--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -2383,8 +2383,8 @@ pci_ahci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts, int atapi)
 			sizeof(ahci_dev->port[p].ident),
 			"ACRN--%02X%02X-%02X%02X-%02X%02X", digest[0],
 			digest[1], digest[2], digest[3], digest[4], digest[5]);
-		if (rc > sizeof(ahci_dev->port[p].ident))
-			WPRINTF("%s: digest is longer than ident\n", __func__);
+		if (rc >= sizeof(ahci_dev->port[p].ident) || rc < 0)
+			WPRINTF("%s: digest number is invalid!\n", __func__);
 
 		/*
 		 * Allocate blockif request structures and add them

--- a/devicemodel/hw/pci/gsi_sharing.c
+++ b/devicemodel/hw/pci/gsi_sharing.c
@@ -13,6 +13,7 @@
 #include <pciaccess.h>
 
 #include "pci_core.h"
+#include "mevent.h"
 
 #define MAX_DEV_PER_GSI 4
 
@@ -117,7 +118,7 @@ create_gsi_sharing_groups(void)
 	uint8_t gsi;
 	char *dev_name;
 	int i, error, msi_support;
-	struct gsi_sharing_group *group = NULL;
+	struct gsi_sharing_group *group = NULL, *temp = NULL;
 
 	error = pciaccess_init();
 	if (error < 0)
@@ -144,7 +145,7 @@ create_gsi_sharing_groups(void)
 	 * clean up gsg_head - the list for gsi_sharing_group
 	 * delete the element without gsi sharing condition (shared_dev_num < 2)
 	 */
-	LIST_FOREACH(group, &gsg_head, gsg_list) {
+	list_foreach_safe(group, &gsg_head, gsg_list, temp) {
 		if (group->shared_dev_num < 2) {
 			LIST_REMOVE(group, gsg_list);
 			free(group);
@@ -181,7 +182,7 @@ update_pt_info(uint16_t phys_bdf)
 int
 check_gsi_sharing_violation(void)
 {
-	struct gsi_sharing_group *group;
+	struct gsi_sharing_group *group, *temp;
 	int i, error, violation;
 
 	error = 0;
@@ -226,7 +227,7 @@ check_gsi_sharing_violation(void)
 	}
 
 	/* destroy the gsg_head after all the checks have been done */
-	LIST_FOREACH(group, &gsg_head, gsg_list) {
+	list_foreach_safe(group, &gsg_head, gsg_list, temp) {
 		LIST_REMOVE(group, gsg_list);
 		free(group);
 	}

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -234,7 +234,6 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		else
 			break;
 	}
-	closedir(dir);
 
 	if (!dent) {
 		WPRINTF(("Cannot find NPK device\n"));
@@ -246,9 +245,11 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			dent->d_name);
 	if (rc > PATH_MAX)
 		WPRINTF(("NPK device name too long\n"));
+
+	closedir(dir);
 	fd = open(name, O_RDONLY);
 	if (fd == -1) {
-		WPRINTF(("Cannot open host NPK config\n"));
+		WPRINTF(("Cannot open host NPK config:%s\n", name));
 		return error;
 	}
 

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -243,8 +243,8 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	/* read the host NPK configuration space */
 	rc = snprintf(name, PATH_MAX, "%s/%s/config", NPK_DRV_SYSFS_PATH,
 			dent->d_name);
-	if (rc > PATH_MAX)
-		WPRINTF(("NPK device name too long\n"));
+	if (rc >= PATH_MAX || rc < 0)
+		WPRINTF(("NPK device name is invalid!\n"));
 
 	closedir(dir);
 	fd = open(name, O_RDONLY);

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -417,12 +417,12 @@ virtio_blk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	MD5_Init(&mdctx);
 	MD5_Update(&mdctx, opts, strnlen(opts, VIRTIO_BLK_MAX_OPTS_LEN));
 	MD5_Final(digest, &mdctx);
-	if (snprintf(blk->ident, sizeof(blk->ident),
+	rc = snprintf(blk->ident, sizeof(blk->ident),
 		"ACRN--%02X%02X-%02X%02X-%02X%02X", digest[0],
-		digest[1], digest[2], digest[3], digest[4],
-		digest[5]) >= sizeof(blk->ident)) {
-		WPRINTF(("virtio_blk: block ident too long\n"));
-	}
+		digest[1], digest[2], digest[3], digest[4], digest[5]);
+
+	if (rc >= sizeof(blk->ident) || rc < 0)
+		WPRINTF(("virtio_blk: block ident is invalid!\n"));
 
 	/* setup virtio block config space */
 	blk->cfg.capacity = size / DEV_BSIZE; /* 512-byte units */

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -942,7 +942,7 @@ static void
 vmei_virtual_fw_reset(struct virtio_mei *vmei)
 {
 	DPRINTF("Firmware reset\n");
-	struct vmei_me_client *e;
+	struct vmei_me_client *e, *temp;
 
 	vmei_set_status(vmei, VMEI_STS_RESET);
 	vmei->config->hw_ready = 0;
@@ -953,7 +953,7 @@ vmei_virtual_fw_reset(struct virtio_mei *vmei)
 
 	/* disconnect all */
 	pthread_mutex_lock(&vmei->list_mutex);
-	LIST_FOREACH(e, &vmei->active_clients, list) {
+	list_foreach_safe(e, &vmei->active_clients, list, temp) {
 		vmei_me_client_destroy_host_clients(e);
 	}
 	pthread_mutex_unlock(&vmei->list_mutex);

--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -329,12 +329,10 @@ static void crb_reg_write(struct tpm_crb_vdev *tpm_vdev, uint64_t addr, int size
 
 			if (pthread_cond_signal(&tpm_vdev->request_cond)) {
 				DPRINTF("ERROR: Failed to wait condition\n");
-				break;
 			}
 
 			if (pthread_mutex_unlock(&tpm_vdev->request_mutex)) {
 				DPRINTF("ERROR: Failed to release mutex lock\n");
-				break;
 			}
 		}
 		break;

--- a/hypervisor/arch/x86/guest/guest.c
+++ b/hypervisor/arch/x86/guest/guest.c
@@ -9,6 +9,7 @@
 #include <multiboot.h>
 #include <reloc.h>
 #include <e820.h>
+#include <trampoline.h>
 
 #define ACRN_DBG_GUEST	6U
 
@@ -507,5 +508,14 @@ int32_t prepare_vm0_memmap(struct acrn_vm *vm)
 	 */
 	hv_hpa = get_hv_image_base();
 	ept_mr_del(vm, pml4_page, hv_hpa, CONFIG_HV_RAM_SIZE);
+
+	/* unmap AP trampoline code for security reason.
+	 * 'allocate_pages()' in efi boot mode or
+	 * 'e820_alloc_low_memory()' in direct boot
+	 * mode will ensure the base address of tramploline
+	 * code be page-aligned.
+	 */
+	ept_mr_del(vm, pml4_page, trampoline_start16_paddr, CONFIG_LOW_RAM_SIZE);
+
 	return 0;
 }

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -91,10 +91,18 @@ static void modify_or_del_pte(const uint64_t *pde, uint64_t vaddr_start, uint64_
 		uint64_t *pte = pt_page + index;
 
 		if (mem_ops->pgentry_present(*pte) == 0UL) {
-			panic("invalid op, pte not present");
+			/*
+			 * Entry is not present, print warning message but avoid complains for
+			 * low memory (< 1M bytes), Service VM may update attributes for this region
+			 * when updating MTRR setting.
+			 */
+			if (vaddr >= MEM_1M) {
+				pr_warn("%s, vaddr: 0x%lx pte is not present.\n", __func__, vaddr);
+			}
+		} else {
+			local_modify_or_del_pte(pte, prot_set, prot_clr, type);
 		}
 
-		local_modify_or_del_pte(pte, prot_set, prot_clr, type);
 		vaddr += PTE_SIZE;
 		if (vaddr >= vaddr_end) {
 			break;
@@ -122,21 +130,23 @@ static void modify_or_del_pde(const uint64_t *pdpte, uint64_t vaddr_start, uint6
 		uint64_t vaddr_next = (vaddr & PDE_MASK) + PDE_SIZE;
 
 		if (mem_ops->pgentry_present(*pde) == 0UL) {
-			panic("invalid op, pde not present");
-		}
-		if (pde_large(*pde) != 0UL) {
-			if (vaddr_next > vaddr_end || !mem_aligned_check(vaddr, PDE_SIZE)) {
-				split_large_page(pde, IA32E_PD, vaddr, mem_ops);
-			} else {
-				local_modify_or_del_pte(pde, prot_set, prot_clr, type);
-				if (vaddr_next < vaddr_end) {
-					vaddr = vaddr_next;
-					continue;
+			pr_warn("%s, addr: 0x%lx pde is not present.\n", __func__, vaddr);
+		} else {
+			if (pde_large(*pde) != 0UL) {
+				if (vaddr_next > vaddr_end || !mem_aligned_check(vaddr, PDE_SIZE)) {
+					split_large_page(pde, IA32E_PD, vaddr, mem_ops);
+				} else {
+					local_modify_or_del_pte(pde, prot_set, prot_clr, type);
+					if (vaddr_next < vaddr_end) {
+						vaddr = vaddr_next;
+						continue;
+					}
+					break;	/* done */
 				}
-				break;	/* done */
 			}
+			modify_or_del_pte(pde, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
 		}
-		modify_or_del_pte(pde, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
+
 		if (vaddr_next >= vaddr_end) {
 			break;	/* done */
 		}
@@ -164,22 +174,24 @@ static void modify_or_del_pdpte(const uint64_t *pml4e, uint64_t vaddr_start, uin
 		uint64_t vaddr_next = (vaddr & PDPTE_MASK) + PDPTE_SIZE;
 
 		if (mem_ops->pgentry_present(*pdpte) == 0UL) {
-			panic("invalid op, pdpte not present");
-		}
-		if (pdpte_large(*pdpte) != 0UL) {
-			if (vaddr_next > vaddr_end ||
+			pr_warn("%s, addr: 0x%lx pdpte is not present.\n", __func__, vaddr);
+		} else {
+			if (pdpte_large(*pdpte) != 0UL) {
+				if (vaddr_next > vaddr_end ||
 					!mem_aligned_check(vaddr, PDPTE_SIZE)) {
-				split_large_page(pdpte, IA32E_PDPT, vaddr, mem_ops);
-			} else {
-				local_modify_or_del_pte(pdpte, prot_set, prot_clr, type);
-				if (vaddr_next < vaddr_end) {
-					vaddr = vaddr_next;
-					continue;
+					split_large_page(pdpte, IA32E_PDPT, vaddr, mem_ops);
+				} else {
+					local_modify_or_del_pte(pdpte, prot_set, prot_clr, type);
+					if (vaddr_next < vaddr_end) {
+						vaddr = vaddr_next;
+						continue;
+					}
+					break;	/* done */
 				}
-				break;	/* done */
 			}
+			modify_or_del_pde(pdpte, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
 		}
-		modify_or_del_pde(pdpte, vaddr, vaddr_end, prot_set, prot_clr, mem_ops, type);
+
 		if (vaddr_next >= vaddr_end) {
 			break;	/* done */
 		}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1110,7 +1110,7 @@ int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param)
 	}
 
 	if ((param > NR_MAX_VECTOR) || (param < VECTOR_DYNAMIC_START)) {
-		pr_err("%s: Invalid passed vector\n");
+		pr_err("%s: Invalid passed vector\n", __func__);
 		return -EINVAL;
 	}
 

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -313,19 +313,28 @@ int32_t strcmp(const char *s1_arg, const char *s2_arg)
 	return *s1 - *s2;
 }
 
+/**
+ * *pre n_arg > 0
+ */
 int32_t strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg)
 {
 	const char *s1 = s1_arg;
 	const char *s2 = s2_arg;
 	size_t n = n_arg;
-	while (((n - 1) != 0U) && ((*s1) != '\0') && ((*s2) != '\0')
-		&& ((*s1) == (*s2))) {
-		s1++;
-		s2++;
-		n--;
+	int32_t ret = 0;
+
+	if (n > 0U) {
+		while (((n - 1) != 0U) && ((*s1) != '\0') && ((*s2) != '\0')
+			&& ((*s1) == (*s2))) {
+			s1++;
+			s2++;
+			n--;
+		}
+
+		ret = (int32_t)(*s1 - *s2);
 	}
 
-	return *s1 - *s2;
+	return ret;
 }
 
 /*

--- a/tools/acrn-crashlog/usercrash/server.c
+++ b/tools/acrn-crashlog/usercrash/server.c
@@ -358,11 +358,6 @@ static void crash_completed_cb(evutil_socket_t sockfd, short ev, void *arg)
 		goto out;
 	}
 
-	if (crash->crash_path) {
-		LOGI("usercrash log written to: %s, ", crash->crash_path);
-		LOGI("crash process name is: %s\n", crash->name);
-	}
-
 out:
 	free_crash(crash);
 	/* If there's something queued up, let them proceed */

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -94,6 +94,7 @@ static inline int _get_vmname_pid(const char *src, char *p_vmname,
 		int max_len_vmname, int *pid)
 {
 	char *p = NULL;
+	long val64;
 
 	p = strchr(src, '.');
 	/* p - src: length of the substring "vmname" in the sting "src" */
@@ -108,10 +109,12 @@ static inline int _get_vmname_pid(const char *src, char *p_vmname,
 	else
 		p = p + strlen(".monitor.");
 
-	*pid = strtol(p, NULL, 10);
-	if ((errno == ERANGE && (*pid == LONG_MAX || *pid == LONG_MIN))
-			|| (errno != 0 && *pid == 0))
+	val64 = strtol(p, NULL, 10);
+	if ((errno == ERANGE && (val64 == LONG_MAX || val64 == LONG_MIN))
+			|| (errno != 0 && val64 == 0))
 		return -1;
+
+	*pid = (int)val64;
 
 	p = strchr(p, '.');
 	if (!p || strncmp(".socket", p, strlen(".socket")))


### PR DESCRIPTION
This PR back ports recent fix on ACRN baseline onto GP2.0 /apl_sdc_stable branch

Patches List:
1 | Improper Usage Of MACRO   LIST_FOREACH() |  
2 | Descriptor of Directory Stream   Is Referenced After Release |  
3 | DM: FILE Pointer Is Not Closed   After Operations in acrn_load_elf |  
4 | DM: 'tpm_vdev->request_mutex'   is potentially not unlocked in 'crb_reg_write()' |  
6 | DM: The return value of snprintf   is improperly checked |  
7 | the return value of   "strtol" is not validated properly |  
8 | Invalid pointer validation in   "crash_completed_cb()" |  
9 | AP Trampoline Code in Hypervisor   Is Potentially Accessible to Service VM |  
10 | Hypervisor crash when run   syz_ic_set_callback_vector. |  
11 | Buffer overflow will happen in   'strncmp' when 'n_arg' is 0 |  

