### PR TITLE
ACRN V1.0 stable patches back- porting

### DIFF
--- a/devicemodel/core/sw_load_elf.c
+++ b/devicemodel/core/sw_load_elf.c
@@ -244,6 +244,7 @@ acrn_load_elf(struct vmctx *ctx, char *elf_file_name, unsigned long *entry,
 	}
 
 	*entry = elf_ehdr->e_entry;
+	fclose(fp);
 	free(elf_buf);
 
 	return ret;

--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -2383,8 +2383,8 @@ pci_ahci_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts, int atapi)
 			sizeof(ahci_dev->port[p].ident),
 			"ACRN--%02X%02X-%02X%02X-%02X%02X", digest[0],
 			digest[1], digest[2], digest[3], digest[4], digest[5]);
-		if (rc > sizeof(ahci_dev->port[p].ident))
-			WPRINTF("%s: digest is longer than ident\n", __func__);
+		if (rc >= sizeof(ahci_dev->port[p].ident) || rc < 0)
+			WPRINTF("%s: digest number is invalid!\n", __func__);
 
 		/*
 		 * Allocate blockif request structures and add them

--- a/devicemodel/hw/pci/gsi_sharing.c
+++ b/devicemodel/hw/pci/gsi_sharing.c
@@ -13,6 +13,7 @@
 #include <pciaccess.h>
 
 #include "pci_core.h"
+#include "mevent.h"
 
 #define MAX_DEV_PER_GSI 4
 
@@ -117,7 +118,7 @@ create_gsi_sharing_groups(void)
 	uint8_t gsi;
 	char *dev_name;
 	int i, error, msi_support;
-	struct gsi_sharing_group *group = NULL;
+	struct gsi_sharing_group *group = NULL, *temp = NULL;
 
 	error = pciaccess_init();
 	if (error < 0)
@@ -144,7 +145,7 @@ create_gsi_sharing_groups(void)
 	 * clean up gsg_head - the list for gsi_sharing_group
 	 * delete the element without gsi sharing condition (shared_dev_num < 2)
 	 */
-	LIST_FOREACH(group, &gsg_head, gsg_list) {
+	list_foreach_safe(group, &gsg_head, gsg_list, temp) {
 		if (group->shared_dev_num < 2) {
 			LIST_REMOVE(group, gsg_list);
 			free(group);
@@ -181,7 +182,7 @@ update_pt_info(uint16_t phys_bdf)
 int
 check_gsi_sharing_violation(void)
 {
-	struct gsi_sharing_group *group;
+	struct gsi_sharing_group *group, *temp;
 	int i, error, violation;
 
 	error = 0;
@@ -226,7 +227,7 @@ check_gsi_sharing_violation(void)
 	}
 
 	/* destroy the gsg_head after all the checks have been done */
-	LIST_FOREACH(group, &gsg_head, gsg_list) {
+	list_foreach_safe(group, &gsg_head, gsg_list, temp) {
 		LIST_REMOVE(group, gsg_list);
 		free(group);
 	}

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -234,7 +234,6 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		else
 			break;
 	}
-	closedir(dir);
 
 	if (!dent) {
 		WPRINTF(("Cannot find NPK device\n"));
@@ -246,9 +245,11 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			dent->d_name);
 	if (rc > PATH_MAX)
 		WPRINTF(("NPK device name too long\n"));
+
+	closedir(dir);
 	fd = open(name, O_RDONLY);
 	if (fd == -1) {
-		WPRINTF(("Cannot open host NPK config\n"));
+		WPRINTF(("Cannot open host NPK config:%s\n", name));
 		return error;
 	}
 

--- a/devicemodel/hw/pci/npk.c
+++ b/devicemodel/hw/pci/npk.c
@@ -243,8 +243,8 @@ static int pci_npk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	/* read the host NPK configuration space */
 	rc = snprintf(name, PATH_MAX, "%s/%s/config", NPK_DRV_SYSFS_PATH,
 			dent->d_name);
-	if (rc > PATH_MAX)
-		WPRINTF(("NPK device name too long\n"));
+	if (rc >= PATH_MAX || rc < 0)
+		WPRINTF(("NPK device name is invalid!\n"));
 
 	closedir(dir);
 	fd = open(name, O_RDONLY);

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -427,12 +427,12 @@ virtio_blk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	MD5_Init(&mdctx);
 	MD5_Update(&mdctx, opts, strnlen(opts, VIRTIO_BLK_MAX_OPTS_LEN));
 	MD5_Final(digest, &mdctx);
-	if (snprintf(blk->ident, sizeof(blk->ident),
+	rc = snprintf(blk->ident, sizeof(blk->ident),
 		"ACRN--%02X%02X-%02X%02X-%02X%02X", digest[0],
-		digest[1], digest[2], digest[3], digest[4],
-		digest[5]) >= sizeof(blk->ident)) {
-		WPRINTF(("virtio_blk: block ident too long\n"));
-	}
+		digest[1], digest[2], digest[3], digest[4], digest[5]);
+
+	if (rc >= sizeof(blk->ident) || rc < 0)
+		WPRINTF(("virtio_blk: block ident is invalid!\n"));
 
 	/* setup virtio block config space */
 	blk->cfg.capacity = size / DEV_BSIZE; /* 512-byte units */

--- a/devicemodel/hw/pci/virtio/virtio_mei.c
+++ b/devicemodel/hw/pci/virtio/virtio_mei.c
@@ -937,7 +937,7 @@ static void
 vmei_virtual_fw_reset(struct virtio_mei *vmei)
 {
 	DPRINTF("Firmware reset\n");
-	struct vmei_me_client *e;
+	struct vmei_me_client *e, *temp;
 
 	vmei_set_status(vmei, VMEI_STS_RESET);
 	vmei->config->hw_ready = 0;
@@ -948,7 +948,7 @@ vmei_virtual_fw_reset(struct virtio_mei *vmei)
 
 	/* disconnect all */
 	pthread_mutex_lock(&vmei->list_mutex);
-	LIST_FOREACH(e, &vmei->active_clients, list) {
+	list_foreach_safe(e, &vmei->active_clients, list, temp) {
 		vmei_me_client_destroy_host_clients(e);
 	}
 	pthread_mutex_unlock(&vmei->list_mutex);

--- a/devicemodel/hw/platform/tpm/tpm_crb.c
+++ b/devicemodel/hw/platform/tpm/tpm_crb.c
@@ -334,12 +334,10 @@ static void crb_reg_write(struct tpm_crb_vdev *tpm_vdev, uint64_t addr, int size
 
 			if (pthread_cond_signal(&tpm_vdev->request_cond)) {
 				DPRINTF("ERROR: Failed to wait condition\n");
-				break;
 			}
 
 			if (pthread_mutex_unlock(&tpm_vdev->request_mutex)) {
 				DPRINTF("ERROR: Failed to release mutex lock\n");
-				break;
 			}
 		}
 		break;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -25,6 +25,7 @@
 #include <cat.h>
 #include <firmware.h>
 #include <board.h>
+#include <trampoline.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -304,6 +305,14 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	 */
 	hv_hpa = hva2hpa((void *)(get_hv_image_base()));
 	ept_mr_del(vm, pml4_page, hv_hpa, CONFIG_HV_RAM_SIZE);
+
+	/* unmap AP trampoline code for security reason.
+	 * 'allocate_pages()' in efi boot mode or
+	 * 'e820_alloc_low_memory()' in direct boot
+	 * mode will ensure the base address of tramploline
+	 * code be page-aligned.
+	 */
+	ept_mr_del(vm, pml4_page, get_trampoline_start16_paddr(), CONFIG_LOW_RAM_SIZE);
 }
 
 /**

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1234,7 +1234,7 @@ int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param)
 		pr_err("%s: Targeting to service vm", __func__);
 	        ret = -EPERM;
 	} else if ((param > NR_MAX_VECTOR) || (param < VECTOR_DYNAMIC_START)) {
-		pr_err("%s: Invalid passed vector\n");
+		pr_err("%s: Invalid passed vector\n", __func__);
 		ret = -EINVAL;
 	} else {
 		set_vhm_notification_vector((uint32_t)param);

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -232,19 +232,26 @@ int32_t strcmp(const char *s1_arg, const char *s2_arg)
 	return *str1 - *str2;
 }
 
+/**
+ * @pre n_arg > 0
+ */
 int32_t strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg)
 {
 	const char *str1 = s1_arg;
 	const char *str2 = s2_arg;
 	size_t n = n_arg;
+	int32_t ret = 0;
 
-	while (((n - 1) != 0U) && ((*str1) != '\0') && ((*str2) != '\0') && ((*str1) == (*str2))) {
-		str1++;
-		str2++;
-		n--;
+	if (n > 0U) {
+		while (((n - 1) != 0U) && ((*str1) != '\0') && ((*str2) != '\0') && ((*str1) == (*str2))) {
+			str1++;
+			str2++;
+			n--;
+		}
+		ret = (int32_t) (*str1 - *str2);
 	}
 
-	return *str1 - *str2;
+	return ret;
 }
 
 /*

--- a/tools/acrn-crashlog/usercrash/server.c
+++ b/tools/acrn-crashlog/usercrash/server.c
@@ -358,11 +358,6 @@ static void crash_completed_cb(evutil_socket_t sockfd, short ev, void *arg)
 		goto out;
 	}
 
-	if (crash->crash_path) {
-		LOGI("usercrash log written to: %s, ", crash->crash_path);
-		LOGI("crash process name is: %s\n", crash->name);
-	}
-
 out:
 	free_crash(crash);
 	/* If there's something queued up, let them proceed */

--- a/tools/acrn-manager/acrn_vm_ops.c
+++ b/tools/acrn-manager/acrn_vm_ops.c
@@ -74,6 +74,7 @@ static inline int _get_vmname_pid(const char *src, char *p_vmname,
 		int max_len_vmname, int *pid)
 {
 	char *p = NULL;
+	long val64;
 
 	p = strchr(src, '.');
 	/* p - src: length of the substring "vmname" in the sting "src" */
@@ -88,10 +89,12 @@ static inline int _get_vmname_pid(const char *src, char *p_vmname,
 	else
 		p = p + strlen(".monitor.");
 
-	*pid = strtol(p, NULL, 10);
-	if ((errno == ERANGE && (*pid == LONG_MAX || *pid == LONG_MIN))
-			|| (errno != 0 && *pid == 0))
+	val64 = strtol(p, NULL, 10);
+	if ((errno == ERANGE && (val64 == LONG_MAX || val64 == LONG_MIN))
+			|| (errno != 0 && val64 == 0))
 		return -1;
+
+	*pid = (int)val64;
 
 	p = strchr(p, '.');
 	if (!p || strncmp(".socket", p, strlen(".socket")))


### PR DESCRIPTION
This PR back ports recent fix on ACRN baseline onto ACRN 1.0 stable branch

Patches List:
1 | Improper Usage Of MACRO LIST_FOREACH() |  
2 | Descriptor of Directory Stream Is Referenced After Release |  
3 | DM: FILE Pointer Is Not Closed After Operations in acrn_load_elf |  
4 | DM: 'tpm_vdev->request_mutex' is potentially not unlocked in 'crb_reg_write()' |  
6 | DM: The return value of snprintf is improperly checked |  
7 | the return value of "strtol" is not validated properly |  
8 | Invalid pointer validation in "crash_completed_cb()" |  
9 | AP Trampoline Code in Hypervisor Is Potentially Accessible to Service VM |  
10 | Hypervisor crash when run syz_ic_set_callback_vector. |  
11 | Buffer overflow will happen in 'strncmp' when 'n_arg' is 0 |  