### PR TITLE
Mitigation Machine Check Error on Page Size Change (for release_1.0)

### DIFF
--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -79,7 +79,7 @@ static void create_secure_world_ept(struct acrn_vm *vm, uint64_t gpa_orig,
 	pml4_base = vm->arch_vm.ept_mem_ops.info->ept.sworld_pgtable_base;
 	(void)memset(pml4_base, 0U, PAGE_SIZE);
 	vm->arch_vm.sworld_eptp = pml4_base;
-	sanitize_pte((uint64_t *)vm->arch_vm.sworld_eptp);
+	sanitize_pte((uint64_t *)vm->arch_vm.sworld_eptp, &vm->arch_vm.ept_mem_ops);
 
 	/* The trusty memory is remapped to guest physical address
 	 * of gpa_rebased to gpa_rebased + size
@@ -88,7 +88,7 @@ static void create_secure_world_ept(struct acrn_vm *vm, uint64_t gpa_orig,
 									TRUSTY_PML4_PAGE_NUM(TRUSTY_EPT_REBASE_GPA);
 	(void)memset(sub_table_addr, 0U, PAGE_SIZE);
 	sworld_pml4e = hva2hpa(sub_table_addr) | table_present;
-	set_pgentry((uint64_t *)pml4_base, sworld_pml4e);
+	set_pgentry((uint64_t *)pml4_base, sworld_pml4e, &vm->arch_vm.ept_mem_ops);
 
 	nworld_pml4e = get_pgentry((uint64_t *)vm->arch_vm.nworld_eptp);
 
@@ -102,7 +102,7 @@ static void create_secure_world_ept(struct acrn_vm *vm, uint64_t gpa_orig,
 		pdpte = get_pgentry(src_pdpte_p);
 		if ((pdpte & table_present) != 0UL) {
 			pdpte &= ~EPT_EXE;
-			set_pgentry(dest_pdpte_p, pdpte);
+			set_pgentry(dest_pdpte_p, pdpte, &vm->arch_vm.ept_mem_ops);
 		}
 		src_pdpte_p++;
 		dest_pdpte_p++;
@@ -133,7 +133,7 @@ void destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem)
 
 		ept_mr_del(vm, vm->arch_vm.sworld_eptp, gpa_uos, size);
 		/* sanitize trusty ept page-structures */
-		sanitize_pte((uint64_t *)vm->arch_vm.sworld_eptp);
+		sanitize_pte((uint64_t *)vm->arch_vm.sworld_eptp, &vm->arch_vm.ept_mem_ops);
 		vm->arch_vm.sworld_eptp = NULL;
 
 		/* Restore memory to guest normal world */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -333,7 +333,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 
 	init_ept_mem_ops(vm);
 	vm->arch_vm.nworld_eptp = vm->arch_vm.ept_mem_ops.get_pml4_page(vm->arch_vm.ept_mem_ops.info);
-	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp);
+	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp, &vm->arch_vm.ept_mem_ops);
 
 	/* Register default handlers for PIO & MMIO if it is SOS VM or Pre-launched VM */
 	if ((vm_config->type == SOS_VM) || (vm_config->type == PRE_LAUNCHED_VM)) {

--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -14,6 +14,7 @@
 #include <vmexit.h>
 #include <vmx.h>
 #include <ept.h>
+#include <pgtable.h>
 #include <trace.h>
 #include <logmsg.h>
 
@@ -105,68 +106,81 @@ int32_t ept_violation_vmexit_handler(struct acrn_vcpu *vcpu)
 
 	/* Handle page fault from guest */
 	exit_qual = vcpu->arch.exit_qualification;
-
-	io_req->type = REQ_MMIO;
-
-	/* Specify if read or write operation */
-	if ((exit_qual & 0x2UL) != 0UL) {
-		/* Write operation */
-		mmio_req->direction = REQUEST_WRITE;
-		mmio_req->value = 0UL;
-
-		/* XXX: write access while EPT perm RX -> WP */
-		if ((exit_qual & 0x38UL) == 0x28UL) {
-			io_req->type = REQ_WP;
-		}
-	} else {
-		/* Read operation */
-		mmio_req->direction = REQUEST_READ;
-
-		/* TODO: Need to determine how sign extension is determined for
-		 * reads
-		 */
-	}
-
 	/* Get the guest physical address */
 	gpa = exec_vmread64(VMX_GUEST_PHYSICAL_ADDR_FULL);
 
 	TRACE_2L(TRACE_VMEXIT_EPT_VIOLATION, exit_qual, gpa);
 
-	/* Adjust IPA appropriately and OR page offset to get full IPA of abort
-	 */
-	mmio_req->address = gpa;
+	/*caused by instruction fetch */
+	if ((exit_qual & 0x4UL) != 0UL) {
+		if (vcpu->arch.cur_context == NORMAL_WORLD) {
+			ept_mr_modify(vcpu->vm, (uint64_t *)vcpu->vm->arch_vm.nworld_eptp,
+				gpa & PAGE_MASK, PAGE_SIZE, EPT_EXE, 0UL);
+		} else {
+			ept_mr_modify(vcpu->vm, (uint64_t *)vcpu->vm->arch_vm.sworld_eptp,
+				gpa & PAGE_MASK, PAGE_SIZE, EPT_EXE, 0UL);
+		}
+		vcpu_retain_rip(vcpu);
+		status = 0;
+	} else {
 
-	ret = decode_instruction(vcpu);
-	if (ret > 0) {
-		mmio_req->size = (uint64_t)ret;
-		/*
-		 * For MMIO write, ask DM to run MMIO emulation after
-		 * instruction emulation. For MMIO read, ask DM to run MMIO
-		 * emulation at first.
+		io_req->type = REQ_MMIO;
+
+		/* Specify if read or write operation */
+		if ((exit_qual & 0x2UL) != 0UL) {
+			/* Write operation */
+			mmio_req->direction = REQUEST_WRITE;
+			mmio_req->value = 0UL;
+
+			/* XXX: write access while EPT perm RX -> WP */
+			if ((exit_qual & 0x38UL) == 0x28UL) {
+				io_req->type = REQ_WP;
+			}
+		} else {
+			/* Read operation */
+			mmio_req->direction = REQUEST_READ;
+
+			/* TODO: Need to determine how sign extension is determined for
+			 * reads
+			 */
+		}
+
+		/* Adjust IPA appropriately and OR page offset to get full IPA of abort
 		 */
+		mmio_req->address = gpa;
 
-		/* Determine value being written. */
-		if (mmio_req->direction == REQUEST_WRITE) {
-			status = emulate_instruction(vcpu);
-			if (status != 0) {
-				ret = -EFAULT;
+		ret = decode_instruction(vcpu);
+		if (ret > 0) {
+			mmio_req->size = (uint64_t)ret;
+			/*
+			 * For MMIO write, ask DM to run MMIO emulation after
+			 * instruction emulation. For MMIO read, ask DM to run MMIO
+			 * emulation at first.
+			 */
+
+			/* Determine value being written. */
+			if (mmio_req->direction == REQUEST_WRITE) {
+				status = emulate_instruction(vcpu);
+				if (status != 0) {
+					ret = -EFAULT;
+				}
+			}
+
+			if (ret > 0) {
+				status = emulate_io(vcpu, io_req);
+			}
+		} else {
+			if (ret == -EFAULT) {
+				pr_info("page fault happen during decode_instruction");
+				status = 0;
 			}
 		}
-
-		if (ret > 0) {
-			status = emulate_io(vcpu, io_req);
-		}
-	} else {
-		if (ret == -EFAULT) {
-			pr_info("page fault happen during decode_instruction");
-			status = 0;
+		if (ret <= 0) {
+			pr_acrnlog("Guest Linear Address: 0x%016llx", exec_vmread(VMX_GUEST_LINEAR_ADDR));
+			pr_acrnlog("Guest Physical Address address: 0x%016llx", gpa);
 		}
 	}
 
-	if (ret <= 0) {
-		pr_acrnlog("Guest Linear Address: 0x%016llx", exec_vmread(VMX_GUEST_LINEAR_ADDR));
-		pr_acrnlog("Guest Physical Address address: 0x%016llx", gpa);
-	}
 	return status;
 }
 

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -175,16 +175,16 @@ static inline uint64_t get_sanitized_page(void)
 	return hva2hpa(sanitized_page);
 }
 
-void sanitize_pte_entry(uint64_t *ptep)
+void sanitize_pte_entry(uint64_t *ptep, const struct memory_ops *mem_ops)
 {
-	set_pgentry(ptep, get_sanitized_page());
+	set_pgentry(ptep, get_sanitized_page(), mem_ops);
 }
 
-void sanitize_pte(uint64_t *pt_page)
+void sanitize_pte(uint64_t *pt_page, const struct memory_ops *mem_ops)
 {
 	uint64_t i;
 	for (i = 0UL; i < PTRS_PER_PTE; i++) {
-		sanitize_pte_entry(pt_page + i);
+		sanitize_pte_entry(pt_page + i, mem_ops);
 	}
 }
 
@@ -327,5 +327,5 @@ void init_paging(void)
 	enable_paging();
 
 	/* set ptep in sanitized_page point to itself */
-	sanitize_pte((uint64_t *)sanitized_page);
+	sanitize_pte((uint64_t *)sanitized_page, &ppt_mem_ops);
 }

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -37,6 +37,7 @@ static void split_large_page(uint64_t *pte, enum _page_table_level level,
 		paddrinc = PTE_SIZE;
 		ref_prot = (*pte) & ~PDE_PFN_MASK;
 		ref_prot &= ~PAGE_PSE;
+		mem_ops->recover_exe_right(&ref_prot);
 		pbase = (uint64_t *)mem_ops->get_pt_page(mem_ops->info, vaddr);
 		break;
 	}
@@ -294,6 +295,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 			if (mem_aligned_check(paddr, PDE_SIZE) &&
 				mem_aligned_check(vaddr, PDE_SIZE) &&
 				(vaddr_next <= vaddr_end)) {
+				mem_ops->tweak_exe_right(&prot);
 				set_pgentry(pde, paddr | (prot | PAGE_PSE), mem_ops);
 				if (vaddr_next < vaddr_end) {
 					paddr += (vaddr_next - vaddr);
@@ -336,6 +338,7 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 			if (mem_aligned_check(paddr, PDPTE_SIZE) &&
 				mem_aligned_check(vaddr, PDPTE_SIZE) &&
 				(vaddr_next <= vaddr_end)) {
+				mem_ops->tweak_exe_right(&prot);
 				set_pgentry(pdpte, paddr | (prot | PAGE_PSE), mem_ops);
 				if (vaddr_next < vaddr_end) {
 					paddr += (vaddr_next - vaddr);

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -45,37 +45,37 @@ static void split_large_page(uint64_t *pte, enum _page_table_level level,
 
 	paddr = ref_paddr;
 	for (i = 0UL; i < PTRS_PER_PTE; i++) {
-		set_pgentry(pbase + i, paddr | ref_prot);
+		set_pgentry(pbase + i, paddr | ref_prot, mem_ops);
 		paddr += paddrinc;
 	}
 
 	ref_prot = mem_ops->get_default_access_right();
-	set_pgentry(pte, hva2hpa((void *)pbase) | ref_prot);
+	set_pgentry(pte, hva2hpa((void *)pbase) | ref_prot, mem_ops);
 
 	/* TODO: flush the TLB */
 }
 
 static inline void local_modify_or_del_pte(uint64_t *pte,
-		uint64_t prot_set, uint64_t prot_clr, uint32_t type)
+		uint64_t prot_set, uint64_t prot_clr, uint32_t type, const struct memory_ops *mem_ops)
 {
 	if (type == MR_MODIFY) {
 		uint64_t new_pte = *pte;
 		new_pte &= ~prot_clr;
 		new_pte |= prot_set;
-		set_pgentry(pte, new_pte);
+		set_pgentry(pte, new_pte, mem_ops);
 	} else {
-		sanitize_pte_entry(pte);
+		sanitize_pte_entry(pte, mem_ops);
 	}
 }
 
 /*
  * pgentry may means pml4e/pdpte/pde
  */
-static inline void construct_pgentry(uint64_t *pde, void *pd_page, uint64_t prot)
+static inline void construct_pgentry(uint64_t *pde, void *pd_page, uint64_t prot, const struct memory_ops *mem_ops)
 {
-	sanitize_pte((uint64_t *)pd_page);
+	sanitize_pte((uint64_t *)pd_page, mem_ops);
 
-	set_pgentry(pde, hva2hpa(pd_page) | prot);
+	set_pgentry(pde, hva2hpa(pd_page) | prot, mem_ops);
 }
 
 /*
@@ -106,7 +106,7 @@ static void modify_or_del_pte(const uint64_t *pde, uint64_t vaddr_start, uint64_
 				pr_warn("%s, vaddr: 0x%lx pte is not present.\n", __func__, vaddr);
 			}
 		} else {
-			local_modify_or_del_pte(pte, prot_set, prot_clr, type);
+			local_modify_or_del_pte(pte, prot_set, prot_clr, type, mem_ops);
 		}
 
 		vaddr += PTE_SIZE;
@@ -142,7 +142,7 @@ static void modify_or_del_pde(const uint64_t *pdpte, uint64_t vaddr_start, uint6
 				if ((vaddr_next > vaddr_end) || (!mem_aligned_check(vaddr, PDE_SIZE))) {
 					split_large_page(pde, IA32E_PD, vaddr, mem_ops);
 				} else {
-					local_modify_or_del_pte(pde, prot_set, prot_clr, type);
+					local_modify_or_del_pte(pde, prot_set, prot_clr, type, mem_ops);
 					if (vaddr_next < vaddr_end) {
 						vaddr = vaddr_next;
 						continue;
@@ -187,7 +187,7 @@ static void modify_or_del_pdpte(const uint64_t *pml4e, uint64_t vaddr_start, uin
 						(!mem_aligned_check(vaddr, PDPTE_SIZE))) {
 					split_large_page(pdpte, IA32E_PDPT, vaddr, mem_ops);
 				} else {
-					local_modify_or_del_pte(pdpte, prot_set, prot_clr, type);
+					local_modify_or_del_pte(pdpte, prot_set, prot_clr, type, mem_ops);
 					if (vaddr_next < vaddr_end) {
 						vaddr = vaddr_next;
 						continue;
@@ -261,7 +261,7 @@ static void add_pte(const uint64_t *pde, uint64_t paddr_start, uint64_t vaddr_st
 		if (mem_ops->pgentry_present(*pte) != 0UL) {
 			ASSERT(false, "invalid op, pte present");
 		} else {
-			set_pgentry(pte, paddr | prot);
+			set_pgentry(pte, paddr | prot, mem_ops);
 			paddr += PTE_SIZE;
 			vaddr += PTE_SIZE;
 
@@ -294,7 +294,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 			if (mem_aligned_check(paddr, PDE_SIZE) &&
 				mem_aligned_check(vaddr, PDE_SIZE) &&
 				(vaddr_next <= vaddr_end)) {
-				set_pgentry(pde, paddr | (prot | PAGE_PSE));
+				set_pgentry(pde, paddr | (prot | PAGE_PSE), mem_ops);
 				if (vaddr_next < vaddr_end) {
 					paddr += (vaddr_next - vaddr);
 					vaddr = vaddr_next;
@@ -303,7 +303,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 				break;	/* done */
 			} else {
 				void *pt_page = mem_ops->get_pt_page(mem_ops->info, vaddr);
-				construct_pgentry(pde, pt_page, mem_ops->get_default_access_right());
+				construct_pgentry(pde, pt_page, mem_ops->get_default_access_right(), mem_ops);
 			}
 		}
 		add_pte(pde, paddr, vaddr, vaddr_end, prot, mem_ops);
@@ -336,7 +336,7 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 			if (mem_aligned_check(paddr, PDPTE_SIZE) &&
 				mem_aligned_check(vaddr, PDPTE_SIZE) &&
 				(vaddr_next <= vaddr_end)) {
-				set_pgentry(pdpte, paddr | (prot | PAGE_PSE));
+				set_pgentry(pdpte, paddr | (prot | PAGE_PSE), mem_ops);
 				if (vaddr_next < vaddr_end) {
 					paddr += (vaddr_next - vaddr);
 					vaddr = vaddr_next;
@@ -345,7 +345,7 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 				break;	/* done */
 			} else {
 				void *pd_page = mem_ops->get_pd_page(mem_ops->info, vaddr);
-				construct_pgentry(pdpte, pd_page, mem_ops->get_default_access_right());
+				construct_pgentry(pdpte, pd_page, mem_ops->get_default_access_right(), mem_ops);
 			}
 		}
 		add_pde(pdpte, paddr, vaddr, vaddr_end, prot, mem_ops);
@@ -381,7 +381,7 @@ void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base, uint
 		pml4e = pml4e_offset(pml4_page, vaddr);
 		if (mem_ops->pgentry_present(*pml4e) == 0UL) {
 			void *pdpt_page = mem_ops->get_pdpt_page(mem_ops->info, vaddr);
-			construct_pgentry(pml4e, pdpt_page, mem_ops->get_default_access_right());
+			construct_pgentry(pml4e, pdpt_page, mem_ops->get_default_access_right(), mem_ops);
 		}
 		add_pdpte(pml4e, paddr, vaddr, vaddr_end, prot, mem_ops);
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1289,9 +1289,6 @@ int32_t move_pt_device(const struct iommu_domain *from_domain, struct iommu_doma
 
 void enable_iommu(void)
 {
-	if (!iommu_page_walk_coherent) {
-		cache_flush_invalidate_all();
-	}
 	do_action_for_iommus(dmar_enable);
 }
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -284,16 +284,18 @@ static inline void dmar_wait_completion(const struct dmar_drhd_rt *dmar_unit, ui
 	}
 }
 
-/* flush cache when root table, context table updated */
-static void iommu_flush_cache(const struct dmar_drhd_rt *dmar_unit,
-			      void *p, uint32_t size)
+/* Flush CPU cache when root table, context table or second-level translation teable updated
+ * In the context of ACRN, GPA to HPA mapping relationship is not changed after VM created,
+ * skip flushing iotlb to avoid performance penalty.
+ */
+void iommu_flush_cache(const void *p, uint32_t size)
 {
 	uint32_t i;
 
 	/* if vtd support page-walk coherency, no need to flush cacheline */
-	if (iommu_ecap_c(dmar_unit->ecap) == 0U) {
+	if (!iommu_page_walk_coherent) {
 		for (i = 0U; i < size; i += CACHE_LINE_SIZE) {
-			clflush((char *)p + i);
+			clflush((const char *)p + i);
 		}
 	}
 }
@@ -1077,7 +1079,7 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 
 			root_entry->hi_64 = 0UL;
 			root_entry->lo_64 = lo_64;
-			iommu_flush_cache(dmar_unit, root_entry, sizeof(struct dmar_entry));
+			iommu_flush_cache(root_entry, sizeof(struct dmar_entry));
 		} else {
 			context_table_addr = dmar_get_bitslice(root_entry->lo_64,
 					ROOT_ENTRY_LOWER_CTP_MASK, ROOT_ENTRY_LOWER_CTP_POS);
@@ -1132,7 +1134,7 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 
 				context_entry->hi_64 = hi_64;
 				context_entry->lo_64 = lo_64;
-				iommu_flush_cache(dmar_unit, context_entry, sizeof(struct dmar_entry));
+				iommu_flush_cache(context_entry, sizeof(struct dmar_entry));
 			}
 		}
 	}
@@ -1181,7 +1183,7 @@ static int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t s
 				/* clear the present bit first */
 				context_entry->lo_64 = 0UL;
 				context_entry->hi_64 = 0UL;
-				iommu_flush_cache(dmar_unit, context_entry, sizeof(struct dmar_entry));
+				iommu_flush_cache(context_entry, sizeof(struct dmar_entry));
 
 				sid.bits.b = bus;
 				sid.bits.d = pci_slot(devfun);
@@ -1370,7 +1372,7 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
 		ir_entry->entry.hi_64 = irte.entry.hi_64;
 		ir_entry->entry.lo_64 = irte.entry.lo_64;
 
-		iommu_flush_cache(dmar_unit, ir_entry, sizeof(union dmar_ir_entry));
+		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);
 	}
 	return ret;
@@ -1401,7 +1403,7 @@ void dmar_free_irte(struct intr_source intr_src, uint16_t index)
 		ir_entry = ir_table + index;
 		ir_entry->bits.present = 0x0UL;
 
-		iommu_flush_cache(dmar_unit, ir_entry, sizeof(union dmar_ir_entry));
+		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);
 	}
 }

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -102,8 +102,8 @@ enum _page_table_level {
 #define PAGE_SIZE_2M	MEM_2M
 #define PAGE_SIZE_1G	MEM_1G
 
-void sanitize_pte_entry(uint64_t *ptep);
-void sanitize_pte(uint64_t *pt_page);
+void sanitize_pte_entry(uint64_t *ptep, const struct memory_ops *mem_ops);
+void sanitize_pte(uint64_t *pt_page, const struct memory_ops *mem_ops);
 /**
  * @brief MMU paging enable
  *
@@ -171,7 +171,7 @@ static inline void cache_flush_invalidate_all(void)
 	asm volatile ("   wbinvd\n" : : : "memory");
 }
 
-static inline void clflush(volatile void *p)
+static inline void clflush(const volatile void *p)
 {
 	asm volatile ("clflush (%0)" :: "r"(p));
 }

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -71,6 +71,7 @@ struct memory_ops {
 	struct page *(*get_pd_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	struct page *(*get_pt_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	void *(*get_sworld_memory_base)(const union pgtable_pages_info *info);
+	void (*clflush_pagewalk)(const void *p);
 };
 
 extern const struct memory_ops ppt_mem_ops;

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -72,6 +72,8 @@ struct memory_ops {
 	struct page *(*get_pt_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	void *(*get_sworld_memory_base)(const union pgtable_pages_info *info);
 	void (*clflush_pagewalk)(const void *p);
+	void (*tweak_exe_right)(uint64_t *entry);
+	void (*recover_exe_right)(uint64_t *entry);
 };
 
 extern const struct memory_ops ppt_mem_ops;

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -168,9 +168,10 @@ static inline uint64_t get_pgentry(const uint64_t *pte)
 /*
  * pgentry may means pml4e/pdpte/pde/pte
  */
-static inline void set_pgentry(uint64_t *ptep, uint64_t pte)
+static inline void set_pgentry(uint64_t *ptep, uint64_t pte, const struct memory_ops *mem_ops)
 {
 	*ptep = pte;
+	mem_ops->clflush_pagewalk(ptep);
 }
 
 static inline uint64_t pde_large(uint64_t pde)

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -542,7 +542,7 @@ struct iommu_domain;
  * @brief Assign a device specified by bus & devfun to a iommu domain.
  *
  * Remove the device from the from_domain (if non-NULL), and add it to the to_domain (if non-NULL).
- * API silently fails to add/remove devices to/from domains that are under "Ignored" DMAR units. 
+ * API silently fails to add/remove devices to/from domains that are under "Ignored" DMAR units.
  *
  * @param[in]    from_domain iommu domain from which the device is removed from
  * @param[in]    to_domain iommu domain to which the device is assgined to
@@ -666,6 +666,18 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
  *
  */
 void dmar_free_irte(struct intr_source intr_src, uint16_t index);
+
+/**
+ * @brief Flash cacheline(s) for a specific address with specific size.
+ *
+ * Flash cacheline(s) for a specific address with specific size,
+ * if all IOMMUs active support page-walk coherency, cacheline(s) are not fluashed.
+ *
+ * @param[in] p the address of the buffer, whose cache need to be invalidated
+ * @param[in] size the size of the buffer
+ *
+ */
+void iommu_flush_cache(const void *p, uint32_t size);
 /**
   * @}
   */


### PR DESCRIPTION
Issue description:
-----------------
Machine Check Error on Page Size Change
Instruction fetch may cause machine check error if page size
and memory type was changed without invalidation on some
processors[1][2]. Malicious guest kernel could trigger this issue.

This issue applies to both primary page table and extended page
tables (EPT), however the primary page table is controlled by
hypervisor only. This patch mitigates the situation in EPT.

Mitigation details:
------------------
Implement non-execute huge pages in EPT.
This patch series clears the execute permission (bit 2) in the
EPT entries for large pages. When EPT violation is triggered by
guest instruction fetch, hypervisor converts the large page to
smaller 4 KB pages and restore the execute permission, and then
re-execute the guest instruction.

The current patch turns on the mitigation by default.
The follow-up patches will conditionally turn on/off the feature
per processor model.

[1] Refer to erratum KBL002 in "7th Generation Intel Processor
Family and 8th Generation Intel Processor Family for U Quad Core
Platforms Specification Update"
https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/7th-gen-core-family-spec-update.pdf
[2] Refer to erratum SKL002 in "6th Generation Intel Processor
Family Specification Update"
https://www.intel.com/content/www/us/en/products/docs/processors/core/desktop-6th-gen-core-family-spec-update.html

Tracked-On: projectacrn#4120
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>