### PR TITLE
acrn-config: Refinement for board config

### DIFF
--- a/misc/acrn-config/board_config/acpi_platform_h.py
+++ b/misc/acrn-config/board_config/acpi_platform_h.py
@@ -90,6 +90,12 @@ def multi_info_parser(config, default_platform, msg_s, msg_e):
     pm_ac_sz = OverridAccessSize()
     multi_lines = board_cfg_lib.get_info(board_cfg_lib.BOARD_INFO_FILE, msg_s, msg_e)
 
+    # S3/S5 not supported by BIOS
+    sx_name = msg_s.split('_')[0].strip('<')
+    if not multi_lines and sx_name in ("S3", "S5"):
+        print("/* {} is not supported by BIOS */".format(sx_name), file=config)
+        return
+
     for s_line in multi_lines:
         # parse the commend line
         if '/*' in s_line:

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -336,6 +336,9 @@ def parser_vuart_console():
     else:
         ttys = get_sub_leaf_tag(SCENARIO_INFO_FILE, "os_config", "console")
 
+    if not ttys or ttys[0] == None:
+        return (err_dic, ttys_n)
+
     if ttys and 'BDF' in ttys[0] or '/dev' in ttys[0]:
         ttys_n = ttys[0].split('/')[2]
     else:
@@ -359,20 +362,24 @@ def get_board_private_vuart(branch_tag, tag_console):
     if err_dic:
         return err_dic
 
-    if not ttys_n or ttys_n not in list(TTY_CONSOLE.keys()):
-        err_dic["board config: ttyS not available"] = "console should be set in scenario.xml of board_private section"
-        return (err_dic, vuart0_console_dic, vuart1_console_dic)
+    if ttys_n:
 
-    (vuart0_valid_console, vuart1_valid_console, show_vuart1) = console_to_show(BOARD_INFO_FILE)
+        if ttys_n not in list(TTY_CONSOLE.keys()):
+            err_dic["board config: ttyS not available"] = "console should be set in scenario.xml of board_private section"
+            return (err_dic, vuart0_console_dic, vuart1_console_dic)
 
-    # VUART0
-    if ttys_n not in list(NATIVE_CONSOLE_DIC.keys()):
-        vuart0_console_dic[ttys_n] = alloc_irq()
-    else:
-        if int(NATIVE_CONSOLE_DIC[ttys_n]) >= 16:
+        (vuart0_valid_console, vuart1_valid_console, show_vuart1) = console_to_show(BOARD_INFO_FILE)
+
+        # VUART0
+        if ttys_n not in list(NATIVE_CONSOLE_DIC.keys()):
             vuart0_console_dic[ttys_n] = alloc_irq()
         else:
-            vuart0_console_dic[ttys_n] = NATIVE_CONSOLE_DIC[ttys_n]
+            if int(NATIVE_CONSOLE_DIC[ttys_n]) >= 16:
+                vuart0_console_dic[ttys_n] = alloc_irq()
+            else:
+                vuart0_console_dic[ttys_n] = NATIVE_CONSOLE_DIC[ttys_n]
+    else:
+        vuart1_valid_console = ['ttyS1']
 
     # VUART1
     if len(NATIVE_CONSOLE_DIC) >= 2 and 'ttyS1' in NATIVE_CONSOLE_DIC.keys():

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -718,14 +718,14 @@ def avl_vuart_ui_select(scenario_info):
         vm_type = get_order_type_by_vmid(vm_i)
 
         if vm_type == "SOS_VM":
-            key = "vm={}:vuart=0,base".format(vm_i)
+            key = "vm={},vuart=0,base".format(vm_i)
             tmp_vuart[key] = ['SOS_COM1_BASE', 'INVALID_COM_BASE']
-            key = "vm={}:vuart=1,base".format(vm_i)
+            key = "vm={},vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['SOS_COM2_BASE', 'INVALID_COM_BASE']
         else:
-            key = "vm={}:vuart=0,base".format(vm_i)
+            key = "vm={},vuart=0,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM1_BASE']
-            key = "vm={}:vuart=1,base".format(vm_i)
+            key = "vm={},vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM2_BASE']
 
     #print(tmp_vuart)


### PR DESCRIPTION
- enhance the board config that has no serial port
- set S3/S5 to default value while BIOS not support them
- modify the key of vuart base

    Tracked-On: #4128
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
