### PR TITLE
Fix gaps in ACRN support for server platforms

### DIFF
--- a/doc/reference/hardware.rst
+++ b/doc/reference/hardware.rst
@@ -23,6 +23,10 @@ Minimum Requirements for Processor
 **********************************
 1 GB Large pages
 
+Known Limitations
+*****************
+Platforms with multiple PCI segments
+
 Verified Platforms According to ACRN Usage
 ******************************************
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -224,12 +224,12 @@ void init_pcpu_post(uint16_t pcpu_id)
 		timer_init();
 		setup_notification();
 		setup_posted_intr_notification();
-		init_pci_pdev_list();
 
 		if (init_iommu() != 0) {
 			panic("failed to initialize iommu!");
 		}
 
+		init_pci_pdev_list(); /* init_iommu must come before this */
 		ptdev_init();
 
 		if (init_sgx() != 0) {

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -205,7 +205,7 @@ static inline uint16_t vmid_to_domainid(uint16_t vm_id)
 }
 
 static int32_t dmar_register_hrhd(struct dmar_drhd_rt *dmar_unit);
-static struct dmar_drhd_rt *device_to_dmaru(uint16_t segment, uint8_t bus, uint8_t devfun);
+static struct dmar_drhd_rt *device_to_dmaru(uint8_t bus, uint8_t devfun);
 static int32_t register_hrhd_units(void)
 {
 	struct dmar_drhd_rt *drhd_rt;
@@ -553,17 +553,13 @@ static struct dmar_drhd_rt *ioapic_to_dmaru(uint16_t ioapic_id, union pci_bdf *s
 	return dmar_unit;
 }
 
-static struct dmar_drhd_rt *device_to_dmaru(uint16_t segment, uint8_t bus, uint8_t devfun)
+static struct dmar_drhd_rt *device_to_dmaru(uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_unit = NULL;
 	uint32_t i, j;
 
 	for (j = 0U; j < platform_dmar_info->drhd_count; j++) {
 		dmar_unit = &dmar_drhd_units[j];
-
-		if (dmar_unit->drhd->segment != segment) {
-			continue;
-		}
 
 		for (i = 0U; i < dmar_unit->drhd->dev_cnt; i++) {
 			if ((dmar_unit->drhd->devices[i].bus == bus) &&
@@ -572,7 +568,6 @@ static struct dmar_drhd_rt *device_to_dmaru(uint16_t segment, uint8_t bus, uint8
 			}
 		}
 
-		/* found exact one or the one which has the same segment number with INCLUDE_PCI_ALL set */
 		if ((i != dmar_unit->drhd->dev_cnt) || ((dmar_unit->drhd->flags & DRHD_FLAG_INCLUDE_PCI_ALL_MASK) != 0U)) {
 			break;
 		}
@@ -1049,7 +1044,7 @@ static void dmar_resume(struct dmar_drhd_rt *dmar_unit)
 	dmar_enable_intr_remapping(dmar_unit);
 }
 
-static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun)
+static int32_t add_iommu_device(struct iommu_domain *domain, uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_entry *root_table;
@@ -1066,7 +1061,7 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 	sid.fields.bus = bus;
 	sid.fields.devfun = devfun;
 
-	dmar_unit = device_to_dmaru(segment, bus, devfun);
+	dmar_unit = device_to_dmaru(bus, devfun);
 	if (dmar_unit == NULL) {
 		pr_err("no dmar unit found for device: %x:%x.%x", bus, sid.bits.d, sid.bits.f);
 		ret = -EINVAL;
@@ -1164,7 +1159,7 @@ static int32_t add_iommu_device(struct iommu_domain *domain, uint16_t segment, u
 	return ret;
 }
 
-static int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t segment, uint8_t bus, uint8_t devfun)
+static int32_t remove_iommu_device(const struct iommu_domain *domain, uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_entry *root_table;
@@ -1176,7 +1171,7 @@ static int32_t remove_iommu_device(const struct iommu_domain *domain, uint16_t s
 	union pci_bdf sid;
 	int32_t ret = 0;
 
-	dmar_unit = device_to_dmaru(segment, bus, devfun);
+	dmar_unit = device_to_dmaru(bus, devfun);
 
 	sid.fields.bus = bus;
 	sid.fields.devfun = devfun;
@@ -1302,11 +1297,11 @@ int32_t move_pt_device(const struct iommu_domain *from_domain, struct iommu_doma
 
 	if (bus_local < CONFIG_IOMMU_BUS_NUM) {
 		if (from_domain != NULL) {
-			status = remove_iommu_device(from_domain, 0U, bus, devfun);
+			status = remove_iommu_device(from_domain, bus, devfun);
 		}
 
 		if ((status == 0) && (to_domain != NULL)) {
-			status = add_iommu_device(to_domain, 0U, bus, devfun);
+			status = add_iommu_device(to_domain, bus, devfun);
 		}
 	} else {
 		status = -EINVAL;
@@ -1373,7 +1368,7 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
 	int32_t ret = 0;
 
 	if (intr_src.is_msi) {
-		dmar_unit = device_to_dmaru(0U, (uint8_t)intr_src.src.msi.bits.b, intr_src.src.msi.fields.devfun);
+		dmar_unit = device_to_dmaru((uint8_t)intr_src.src.msi.bits.b, intr_src.src.msi.fields.devfun);
 		sid.value = intr_src.src.msi.value;
 		trigger_mode = 0x0UL;
 	} else {
@@ -1417,7 +1412,7 @@ void dmar_free_irte(struct intr_source intr_src, uint16_t index)
 	union pci_bdf sid;
 
 	if (intr_src.is_msi) {
-		dmar_unit = device_to_dmaru(0U, (uint8_t)intr_src.src.msi.bits.b, intr_src.src.msi.fields.devfun);
+		dmar_unit = device_to_dmaru((uint8_t)intr_src.src.msi.bits.b, intr_src.src.msi.fields.devfun);
 	} else {
 		dmar_unit = ioapic_to_dmaru(intr_src.src.ioapic_id, &sid);
 	}

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -45,6 +45,29 @@ static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
 
 static void init_pdev(uint16_t pbdf);
 
+/* @brief: Find the DRHD index corresponding to a PCI device
+ * Runs through the pci_pdev_array and returns the value in drhd_idx
+ * member from pdev strucutre that matches matches B:D.F
+ *
+ * @pbdf[in]	B:D.F of a PCI device
+ *
+ * @return if there is a matching pbdf in pci_pdev_array, pdev->drhd_idx, else INVALID_DRHD_INDEX
+ */
+
+uint32_t pci_lookup_drhd_for_pbdf(uint16_t pbdf)
+{
+	uint32_t drhd_index = INVALID_DRHD_INDEX;
+	uint32_t index;
+
+	for (index = 0U; index < num_pci_pdev; index++) {
+		if (pci_pdev_array[index].bdf.value == pbdf) {
+			drhd_index = pci_pdev_array[index].drhd_index;
+			break;
+		}
+	}
+
+	return drhd_index;
+}
 
 static uint32_t pci_pdev_calc_address(union pci_bdf bdf, uint32_t offset)
 {

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -38,16 +38,19 @@
 #include <uart16550.h>
 #include <logmsg.h>
 #include <pci_dev.h>
+#include <vtd.h>
+#include <bits.h>
+#include <board.h>
 
 static spinlock_t pci_device_lock;
 static uint32_t num_pci_pdev;
 static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
 
-static void init_pdev(uint16_t pbdf);
+static void init_pdev(uint16_t pbdf, uint32_t drhd_index);
 
 /* @brief: Find the DRHD index corresponding to a PCI device
  * Runs through the pci_pdev_array and returns the value in drhd_idx
- * member from pdev strucutre that matches matches B:D.F
+ * member from pdev structure that matches matches B:D.F
  *
  * @pbdf[in]	B:D.F of a PCI device
  *
@@ -151,65 +154,221 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable)
 	}
 }
 
-#define BUS_SCAN_SKIP		0U
-#define BUS_SCAN_PENDING	1U
-#define BUS_SCAN_COMPLETE	2U
-void init_pci_pdev_list(void)
+static bool is_hidden_pdev(union pci_bdf pbdf)
 {
+	bool hidden = false;
+	/* if it is debug uart, hide it*/
+	if (is_pci_dbg_uart(pbdf)) {
+		pr_info("hide pci uart dev: (%x:%x:%x)", pbdf.bits.b, pbdf.bits.d, pbdf.bits.f);
+		hidden = true;
+	}
+
+	return hidden;
+}
+
+static void pci_init_pdev(union pci_bdf pbdf, uint32_t drhd_index)
+{
+	if (!is_hidden_pdev(pbdf)) {
+		init_pdev(pbdf.value, drhd_index);
+	}
+}
+
+/*
+ * quantity of uint64_t to encode a bitmap of all bus values
+ * TODO: PCI_BUSMAX is a good candidate to move to
+ * generated platform files.
+ */
+#define BUSES_BITMAP_LEN        ((PCI_BUSMAX + 1U) >> 6U)
+
+/*
+ * must be >= total Endpoints in all DRDH devscope
+ * TODO: BDF_SET_LEN is a good candidate to move to
+ * generated platform files.
+ */
+#define BDF_SET_LEN			32U
+
+struct pci_bdf_to_iommu {
+	union pci_bdf dev_scope_bdf;
+	uint32_t dev_scope_drhd_index;
+};
+
+struct pci_bdf_set {
+	uint32_t pci_bdf_map_count;
+	struct pci_bdf_to_iommu bdf_map[BDF_SET_LEN];
+};
+
+struct pci_bus_set {
+	uint8_t bus_under_scan;
+	uint32_t bus_drhd_index;
+};
+
+static uint32_t pci_check_override_drhd_index(union pci_bdf pbdf,
+						const struct pci_bdf_set *const bdfs_from_drhds,
+						uint32_t current_drhd_index)
+{
+	uint16_t bdfi;
+	uint32_t bdf_drhd_index = current_drhd_index;
+
+	for (bdfi = 0U; bdfi < bdfs_from_drhds->pci_bdf_map_count; bdfi++) {
+		if (bdfs_from_drhds->bdf_map[bdfi].dev_scope_bdf.value == pbdf.value) {
+			/*
+			 * Override current_drhd_index
+			 */
+				bdf_drhd_index =
+					bdfs_from_drhds->bdf_map[bdfi].dev_scope_drhd_index;
+			}
+	}
+
+	return bdf_drhd_index;
+}
+
+/* Scan part of PCI hierarchy, starting with the given bus. */
+static void init_pci_hierarchy(uint8_t bus, uint64_t buses_visited[BUSES_BITMAP_LEN],
+				const struct pci_bdf_set *const bdfs_from_drhds, uint32_t drhd_index)
+{
+	bool is_mfdev;
+	uint32_t vendor;
+	uint8_t hdr_type, dev, func;
 	union pci_bdf pbdf;
-	uint8_t hdr_type, secondary_bus, dev, func;
-	uint32_t bus, val;
-	uint8_t bus_to_scan[PCI_BUSMAX + 1] = { BUS_SCAN_SKIP };
+	uint8_t current_bus_index;
+	uint32_t current_drhd_index, bdf_drhd_index;
 
-	/* start from bus 0 */
-	bus_to_scan[0U] = BUS_SCAN_PENDING;
+	struct pci_bus_set bus_map[PCI_BUSMAX + 1U]; /* FIFO queue of buses to walk */
+	uint32_t s = 0U, e = 0U; /* start and end index into queue */
 
-	for (bus = 0U; bus <= PCI_BUSMAX; bus++) {
-		if (bus_to_scan[bus] != BUS_SCAN_PENDING) {
-			continue;
-		}
+	bus_map[e].bus_under_scan = bus;
+	bus_map[e].bus_drhd_index = drhd_index;
+	e = e + 1U;
+	while (s < e) {
+		current_bus_index = bus_map[s].bus_under_scan;
+		current_drhd_index = bus_map[s].bus_drhd_index;
+		s = s + 1U;
 
-		bus_to_scan[bus] = BUS_SCAN_COMPLETE;
-		pbdf.bits.b = (uint8_t)bus;
+		bitmap_set_nolock(current_bus_index,
+					&buses_visited[current_bus_index >> 6U]);
 
+		pbdf.bits.b = current_bus_index;
 		for (dev = 0U; dev <= PCI_SLOTMAX; dev++) {
 			pbdf.bits.d = dev;
+			is_mfdev = false;
 
 			for (func = 0U; func <= PCI_FUNCMAX; func++) {
+
 				pbdf.bits.f = func;
-				val = pci_pdev_read_cfg(pbdf, PCIR_VENDOR, 4U);
 
-				if ((val == 0xFFFFFFFFU) || (val == 0U) || (val == 0xFFFF0000U) || (val == 0xFFFFU)) {
-					/* If function 0 is not implemented, skip to next device */
-					if (func == 0U) {
-						break;
-					}
+				vendor = read_pci_pdev_cfg_vendor(pbdf);
+				hdr_type = read_pci_pdev_cfg_headertype(pbdf);
 
-					/* continue scan next function */
+				if (func == 0U) {
+					is_mfdev = is_pci_cfg_multifunction(hdr_type);
+				}
+
+				/* Do not probe beyond function 0 if not a multi-function device
+				 * TODO unless device supports ARI or SR-IOV
+				 * (PCIe spec r5.0 §7.5.1.1.9)
+				 */
+				if (((func == 0U) && !is_pci_vendor_valid(vendor)) ||
+						((func > 0U) && (!is_mfdev))) {
+					break;
+				}
+
+				if (!is_pci_vendor_valid(vendor)) {
 					continue;
 				}
 
-				/* if it is debug uart, hide it from SOS */
-				if (is_pci_dbg_uart(pbdf)) {
-					pr_info("hide pci uart dev: (%x:%x:%x)", pbdf.bits.b, pbdf.bits.d, pbdf.bits.f);
-					continue;
-				}
+				bdf_drhd_index = pci_check_override_drhd_index(pbdf, bdfs_from_drhds,
+									current_drhd_index);
+				pci_init_pdev(pbdf, bdf_drhd_index);
 
-				init_pdev(pbdf.value);
-
-				hdr_type = (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_HDRTYPE, 1U);
-				if ((hdr_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE) {
-
-					/* Secondary bus to be scanned */
-					secondary_bus = (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_SECBUS_1, 1U);
-					if (bus_to_scan[secondary_bus] != BUS_SCAN_SKIP) {
-						pr_err("%s, bus %d may be downstream of different PCI bridges",
-							__func__, secondary_bus);
-					} else {
-						bus_to_scan[secondary_bus] = BUS_SCAN_PENDING;
-					}
+				if (is_pci_cfg_bridge(hdr_type)) {
+					bus_map[e].bus_under_scan = read_pci_pdev_cfg_secbus(pbdf);
+					bus_map[e].bus_drhd_index = bdf_drhd_index;
+					e = e + 1U;
 				}
 			}
+		}
+	}
+}
+
+/*
+ * @brief: Setup bdfs_from_drhds data structure as the DMAR tables are walked searching
+ * for PCI device scopes. bdfs_from_drhds is used later in init_pci_hierarchy
+ * to map the right DRHD unit to the PCI device
+ */
+static void pci_add_bdf_from_drhd(union pci_bdf bdf, struct pci_bdf_set *const bdfs_from_drhds,
+					uint32_t drhd_index)
+{
+	if (bdfs_from_drhds->pci_bdf_map_count < BDF_SET_LEN) {
+		bdfs_from_drhds->bdf_map[bdfs_from_drhds->pci_bdf_map_count].dev_scope_bdf = bdf;
+		bdfs_from_drhds->bdf_map[bdfs_from_drhds->pci_bdf_map_count].dev_scope_drhd_index = drhd_index;
+		bdfs_from_drhds->pci_bdf_map_count++;
+	} else {
+		ASSERT(bdfs_from_drhds->pci_bdf_map_count < BDF_SET_LEN,
+				"Compare value in BDF_SET_LEN against those in ACPI DMAR tables");
+	}
+}
+
+
+/*
+ * @brief: Setup bdfs_from_drhds data structure as the DMAR tables are walked searching
+ * for PCI device scopes. bdfs_from_drhds is used later in init_pci_hierarchy
+ * to map the right DRHD unit to the PCI device.
+ * TODO: bdfs_from_drhds is a good candidate to be part of generated platform
+ * info.
+ */
+static void pci_parse_iommu_devscopes(struct pci_bdf_set *const bdfs_from_drhds,
+						uint32_t *drhd_idx_pci_all)
+{
+	union pci_bdf bdf;
+	uint32_t drhd_index, devscope_index;
+
+	for (drhd_index = 0U; drhd_index < plat_dmar_info.drhd_count; drhd_index++) {
+		for (devscope_index = 0U; devscope_index < plat_dmar_info.drhd_units[drhd_index].dev_cnt;
+						devscope_index++) {
+			bdf.fields.bus = plat_dmar_info.drhd_units[drhd_index].devices[devscope_index].bus;
+			bdf.fields.devfun = plat_dmar_info.drhd_units[drhd_index].devices[devscope_index].devfun;
+
+			if ((plat_dmar_info.drhd_units[drhd_index].devices[devscope_index].type ==
+						ACPI_DMAR_SCOPE_TYPE_ENDPOINT) ||
+				(plat_dmar_info.drhd_units[drhd_index].devices[devscope_index].type ==
+						ACPI_DMAR_SCOPE_TYPE_BRIDGE)) {
+				pci_add_bdf_from_drhd(bdf, bdfs_from_drhds, drhd_index);
+			} else {
+				/*
+				 * Do nothing for IOAPIC, ACPI namespace and
+				 * MSI Capable HPET device scope
+				 */
+			}
+		}
+	}
+
+	if ((plat_dmar_info.drhd_units[plat_dmar_info.drhd_count - 1U].flags & DRHD_FLAG_INCLUDE_PCI_ALL_MASK)
+			== DRHD_FLAG_INCLUDE_PCI_ALL_MASK) {
+		*drhd_idx_pci_all = plat_dmar_info.drhd_count - 1U;
+	}
+}
+
+/*
+ * @brief Walks the PCI heirarchy and initializes array of pci_pdev structs
+ * Uses DRHD info from ACPI DMAR tables to cover the endpoints and
+ * bridges along with their hierarchy captured in the device scope entries
+ * Walks through rest of the devices starting at bus 0 and thru PCI_BUSMAX
+ */
+void init_pci_pdev_list(void)
+{
+	uint64_t buses_visited[BUSES_BITMAP_LEN] = {0UL};
+	struct pci_bdf_set bdfs_from_drhds;
+	uint32_t drhd_idx_pci_all = INVALID_DRHD_INDEX;
+	uint16_t bus;
+	bool was_visited = false;
+
+	pci_parse_iommu_devscopes(&bdfs_from_drhds, &drhd_idx_pci_all);
+
+	/* TODO: iterate over list of PCI Host Bridges found in ACPI namespace */
+	for (bus = 0U; bus <= PCI_BUSMAX; bus++) {
+		was_visited = bitmap_test((bus & 0x3FU), &buses_visited[bus >> 6U]);
+		if (!was_visited) {
+			init_pci_hierarchy((uint8_t)bus, buses_visited, &bdfs_from_drhds, drhd_idx_pci_all);
 		}
 	}
 }
@@ -283,7 +442,7 @@ static void pci_read_cap(struct pci_pdev *pdev)
 	}
 }
 
-static void init_pdev(uint16_t pbdf)
+static void init_pdev(uint16_t pbdf, uint32_t drhd_index)
 {
 	uint8_t hdr_type;
 	union pci_bdf bdf;
@@ -302,6 +461,8 @@ static void init_pdev(uint16_t pbdf)
 			if ((pci_pdev_read_cfg(bdf, PCIR_STATUS, 2U) & PCIM_STATUS_CAPPRESENT) != 0U) {
 				pci_read_cap(pdev);
 			}
+
+			pdev->drhd_index = drhd_index;
 
 			fill_pci_dev_config(pdev);
 

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -10,6 +10,8 @@
 #include <pci.h>
 #include <platform_acpi_info.h>
 
+#define INVALID_DRHD_INDEX 0xFFFFFFFFU
+
 /*
  * Intel IOMMU register specification per version 1.0 public spec.
  */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -236,5 +236,36 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
 void init_pci_pdev_list(void);
 
+static inline bool is_pci_vendor_valid(uint32_t vendor_id)
+{
+	return !((vendor_id == 0xFFFFFFFFU) || (vendor_id == 0U) ||
+		 (vendor_id == 0xFFFF0000U) || (vendor_id == 0xFFFFU));
+}
+
+static inline uint32_t read_pci_pdev_cfg_vendor(union pci_bdf pbdf)
+{
+	return pci_pdev_read_cfg(pbdf, PCIR_VENDOR, 2U);
+}
+
+static inline uint8_t read_pci_pdev_cfg_headertype(union pci_bdf pbdf)
+{
+	return (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_HDRTYPE, 1U);
+}
+
+static inline uint8_t read_pci_pdev_cfg_secbus(union pci_bdf pbdf)
+{
+	return (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_SECBUS_1, 1U);
+}
+
+static inline bool is_pci_cfg_multifunction(uint8_t header_type)
+{
+	return ((header_type & PCIM_MFDEV) == PCIM_MFDEV);
+}
+
+static inline bool is_pci_cfg_bridge(uint8_t header_type)
+{
+	return ((header_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE);
+}
+
 
 #endif /* PCI_H_ */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -237,6 +237,12 @@ uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
+/*
+ * @brief Walks the PCI heirarchy and initializes array of pci_pdev structs
+ * Uses DRHD info from ACPI DMAR tables to cover the endpoints and
+ * bridges along with their hierarchy captured in the device scope entries
+ * Walks through rest of the devices starting at bus 0 and thru PCI_BUSMAX
+ */
 void init_pci_pdev_list(void);
 
 /* @brief: Find the DRHD index corresponding to a PCI device

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -165,6 +165,9 @@ struct pci_msix_cap {
 };
 
 struct pci_pdev {
+	/* IOMMU responsible for DMA and Interrupt Remapping for this device */
+	uint32_t drhd_index;
+
 	/* The bar info of the physical PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
 
@@ -235,6 +238,16 @@ void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
 void init_pci_pdev_list(void);
+
+/* @brief: Find the DRHD index corresponding to a PCI device
+ * Runs through the pci_pdev_array and returns the value in drhd_idx
+ * member from pdev strucutre that matches matches B:D.F
+ *
+ * @pbdf[in]	B:D.F of a PCI device
+ *
+ * @return if there is a matching pbdf in pci_pdev_array, pdev->drhd_idx, else -1U
+ */
+uint32_t pci_lookup_drhd_for_pbdf(uint16_t pbdf);
 
 static inline bool is_pci_vendor_valid(uint32_t vendor_id)
 {


### PR DESCRIPTION
These patches introduce changes to:
1. Correctly handle IOMMU-to-device association when DMAR DRHD entries
contain Bridge type device scope
2. Handle multi-function devices more gracefully

Tracked-On: #4134
Signed-off-by: Alexander Merritt <alex.merritt@intel.com>
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>