### PR TITLE
keep DM consistent with GVT-g when deal with pci bars

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -128,6 +128,7 @@ vm_create(const char *name, uint64_t req_buf, int *vcpu_num)
 	/* Pass uuid as parameter of create vm*/
 	uuid_copy(create_vm.uuid, vm_uuid);
 
+	ctx->enable_gvt = false;
 	ctx->fd = devfd;
 	ctx->lowmem_limit = 2 * GB;
 	ctx->highmem_gpa_base = PCI_EMUL_MEMLIMIT64;

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -558,7 +558,7 @@ modify_bar_registration(struct pci_vdev *dev, int idx, int registration)
 	return error;
 }
 
-static void
+void
 unregister_bar(struct pci_vdev *dev, int idx)
 {
 	modify_bar_registration(dev, idx, 0);
@@ -614,6 +614,9 @@ update_bar_address(struct vmctx *ctx, struct pci_vdev *dev, uint64_t addr,
 
 	if (decode)
 		unregister_bar(dev, idx);
+
+	if(type != PCIBAR_IO && ctx->enable_gvt)
+		ctx->update_gvt_bar(ctx);
 
 	switch (type) {
 	case PCIBAR_IO:

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -507,20 +507,6 @@ modify_bar_registration(struct pci_vdev *dev, int idx, int registration)
 	struct inout_port iop;
 	struct mem_range mr;
 
-	if (is_pci_gvt(dev)) {
-		/* GVT device is the only one who traps the pci bar access and
-		 * intercepts the corresponding contents in kernel. It needs
-		 * register pci resource only, but no need to register the
-		 * region.
-		 *
-		 * FIXME: This is a short term solution. This patch will be
-		 * obsoleted with the migration of using OVMF to do bar
-		 * addressing and generate ACPI PCI resource from using
-		 * acrn-dm.
-		 */
-		pr_notice("modify_bar_registration: bypass for pci-gvt\n");
-		return 0;
-	}
 	switch (dev->bar[idx].type) {
 	case PCIBAR_IO:
 		bzero(&iop, sizeof(struct inout_port));

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -91,6 +91,57 @@ gvt_init_config(struct pci_gvt *gvt)
 	uint8_t cap_ptr = 0;
 	uint8_t aperture_size_reg;
 	uint16_t aperture_size = 256;
+	char res_name[PATH_MAX];
+	char resource[512];
+	int res_fd;
+	uint64_t bar0_start_addr;
+	uint64_t bar0_end_addr;
+	uint64_t bar2_start_addr;
+	uint64_t bar2_end_addr;
+	char *next;
+	struct vmctx *ctx;
+
+	snprintf(res_name, sizeof(res_name),
+		"/sys/bus/pci/devices/%04x:%02x:%02x.%x/resource",
+		gvt->addr.domain, gvt->addr.bus, gvt->addr.slot,
+		gvt->addr.function);
+	res_fd = open(res_name, O_RDONLY);
+	if (res_fd == -1) {
+		perror("gvt:open host pci resource failed\n");
+		return -1;
+	}
+
+	ret = pread(res_fd, resource, 512, 0);
+
+	close(res_fd);
+
+	if (ret < 512) {
+		perror("failed to read host device resource space\n");
+		return -1;
+	}
+
+	next = resource;
+
+    	bar0_start_addr = strtoull(next, &next, 16);
+    	bar0_end_addr = strtoull(next, &next, 16);
+
+    	/* bar0 and bar2 have some distance, need pass the distance */
+    	next = next + 80;
+
+    	bar2_start_addr = strtoull(next, &next, 16);
+    	bar2_end_addr = strtoull(next, &next, 16);
+
+	ctx = gvt->gvt_pi->vmctx;
+
+	if(bar0_start_addr < ctx->lowmem_limit 
+		|| bar2_start_addr < ctx->lowmem_limit
+		|| bar0_end_addr > PCI_EMUL_ECFG_BASE
+		|| bar2_end_addr > PCI_EMUL_ECFG_BASE){
+		perror("gvt pci bases are out of range\n");
+		return -1;
+	}
+
+	ctx->enable_gvt = true;
 
 	snprintf(name, sizeof(name),
 		"/sys/bus/pci/devices/%04x:%02x:%02x.%x/config",
@@ -292,6 +343,7 @@ pci_gvt_init(struct vmctx *ctx, struct pci_vdev *pi, char *opts)
 	if(!ret)
 		return ret;
 fail:
+	ctx->enable_gvt = false;
 	perror("GVT: init failed\n");
 	free(gvt);
 	return -1;

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -331,6 +331,7 @@ void	pciaccess_cleanup(void);
 int	parse_bdf(char *s, int *bus, int *dev, int *func, int base);
 struct pci_vdev *pci_get_vdev_info(int slot);
 int register_bar(struct pci_vdev *dev, int idx);
+void unregister_bar(struct pci_vdev *dev, int idx);
 
 /**
  * @brief Set virtual PCI device's configuration space in 1 byte width

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -330,7 +330,7 @@ int	pciaccess_init(void);
 void	pciaccess_cleanup(void);
 int	parse_bdf(char *s, int *bus, int *dev, int *func, int base);
 struct pci_vdev *pci_get_vdev_info(int slot);
-
+int register_bar(struct pci_vdev *dev, int idx);
 
 /**
  * @brief Set virtual PCI device's configuration space in 1 byte width

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -73,6 +73,8 @@ struct vmctx {
 
 	/* ensure other pci devices bar space not conflict with gvt */
 	void (*adjust_bar_region)(struct vmctx *ctx, uint64_t *base, uint64_t size);
+
+	void (*update_gvt_bar)(struct vmctx *ctx);
 };
 
 #define	PROT_RW		(PROT_READ | PROT_WRITE)

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -67,6 +67,9 @@ struct vmctx {
 
 	/* BSP state. guest loader needs to fill it */
 	struct acrn_set_vcpu_regs bsp_regs;
+
+	/* if this vm enable gvt */
+	bool enable_gvt;
 };
 
 #define	PROT_RW		(PROT_READ | PROT_WRITE)

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -70,6 +70,9 @@ struct vmctx {
 
 	/* if this vm enable gvt */
 	bool enable_gvt;
+
+	/* ensure other pci devices bar space not conflict with gvt */
+	void (*adjust_bar_region)(struct vmctx *ctx, uint64_t *base, uint64_t size);
 };
 
 #define	PROT_RW		(PROT_READ | PROT_WRITE)


### PR DESCRIPTION
In previous design:
1. GVT-g sets vgpu bars' value from physical gpu bars.
2. ACRN-DM sets pci bars according to its policy.

These two paths don't communicate with each other, but
they deal with the same thing:pci bars.
So there's a risk that ACRN-DM bars region overlap with GVT-g.

In the following four patches, we will keep DM consistent with 
GVT-g when deal with pci bars.

In the following description, 
patch 1 refers dm:gvt:get physical gpu bars' value in ACRN-DM
patch 2 refers dm:gvt:reserve gvt bar0 and bar2 regions
patch 3 refers dm:gvt:update gvt bars before other pci devices write bar address
patch 4 refers dm:gvt:Enable gvt bar registration

In our design:
1. When ACRN-DM init pci-gvt, it will read physical gpu bars, 
and set these values for pci-gvt, 
patch 1 will complete this work.
2. When ACRN-DM allocates pci bars for other pci devices,
it will reserve pci-gvt bar regions,
patch 2 will complete this work.
3. uos kernel may update gvt bars' value,
but ACRN-DM doesn't know this update.
So ACRN-DM needs to get gvt latest bars' info when update
pci bars values for other pci devices.
patch 3 will complete this work.
4. patch4 will enable gvt bar registration