### PR TITLE
hv:panic if there is no memory map in multiboot info

### DIFF
--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -154,6 +154,8 @@ void init_e820(void)
 				dev_dbg(ACRN_DBG_E820, "Base: 0x%016lx length: 0x%016lx",
 					mmap[i].baseaddr, mmap[i].length);
 			}
+		} else {
+			panic("no memory map found from multiboot info");
 		}
 
 		obtain_mem_range_info();


### PR DESCRIPTION
add panic if there is no memory map info during booting.

Tracked-On: #1842
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>