### PR TITLE
HV: parse default pci mmcfg base

### DIFF
--- a/hypervisor/arch/x86/configs/nuc7i7dnb/platform_acpi_info.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/platform_acpi_info.h
@@ -39,6 +39,9 @@
 #define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
 #define RESET_REGISTER_VALUE    0x6U
 
+/* PCI mmcfg base of MCFG */
+#define DEFAULT_PCI_MMCFG_BASE	0xE0000000UL
+
 /* DRHD of DMAR */
 
 #define DRHD_COUNT              2U

--- a/hypervisor/arch/x86/configs/platform_acpi_info.h
+++ b/hypervisor/arch/x86/configs/platform_acpi_info.h
@@ -24,6 +24,9 @@
 #define RESET_REGISTER_VALUE	0UL
 #define RESET_REGISTER_SPACE_ID 0UL
 
+/* PCI mmcfg base of MCFG, pre-assumption is platform only has one PCI segment group */
+#define DEFAULT_PCI_MMCFG_BASE	0UL
+
 /* DRHD of DMAR */
 #define DRHD_COUNT		8U
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -144,6 +144,12 @@ void init_pcpu_pre(bool is_bsp)
 		early_init_lapic();
 
 		init_vboot();
+#ifdef CONFIG_ACPI_PARSE_ENABLED
+		ret = acpi_fixup();
+		if (ret != 0) {
+			panic("failed to parse/fix up ACPI table!");
+		}
+#endif
 
 		if (!init_percpu_lapic_id()) {
 			panic("failed to init_percpu_lapic_id!");

--- a/hypervisor/boot/guest/vboot_wrapper.c
+++ b/hypervisor/boot/guest/vboot_wrapper.c
@@ -68,9 +68,6 @@ void init_vboot(void)
 	 * initialized before calling other vboot_ops interface.
 	 */
 	vboot_ops->init();
-#ifdef CONFIG_ACPI_PARSE_ENABLED
-	acpi_fixup();
-#endif
 }
 
 /* @pre: vboot_ops != NULL */

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -36,13 +36,19 @@
 #define OFFSET_WAKE_VECTOR_32    12U
 #define OFFSET_WAKE_VECTOR_64    24U
 
+/* MCFG field offsets */
+#define OFFSET_MCFG_LENGTH       4U
+#define OFFSET_MCFG_ENTRY0       44U
+#define OFFSET_MCFG_ENTRY0_BASE  44U
+#define OFFSET_MCFG_ENTRY1       60U
+
 #define ACPI_SIG_FADT            "FACP" /* Fixed ACPI Description Table */
 #define ACPI_SIG_FACS             0x53434146U /* "FACS" */
 #define ACPI_SIG_RSDP            "RSD PTR " /* Root System Description Ptr */
 #define ACPI_SIG_XSDT            "XSDT"      /* Extended  System Description Table */
 #define ACPI_SIG_MADT            "APIC" /* Multiple APIC Description Table */
 #define ACPI_SIG_DMAR            "DMAR"
-
+#define ACPI_SIG_MCFG            "MCFG" /* Memory Mapped Configuration table */
 
 struct packed_gas {
 	uint8_t 	space_id;
@@ -200,7 +206,7 @@ uint16_t parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM]);
 uint16_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array);
 
 #ifdef CONFIG_ACPI_PARSE_ENABLED
-void acpi_fixup(void);
+int32_t acpi_fixup(void);
 #endif
 
 #endif /* !ACPI_H */

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -41,12 +41,26 @@
 #include <vtd.h>
 #include <bits.h>
 #include <board.h>
+#include <platform_acpi_info.h>
 
 static spinlock_t pci_device_lock;
 static uint32_t num_pci_pdev;
 static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
+static uint64_t pci_mmcfg_base = DEFAULT_PCI_MMCFG_BASE;
 
 static void init_pdev(uint16_t pbdf, uint32_t drhd_index);
+
+#ifdef CONFIG_ACPI_PARSE_ENABLED
+void set_mmcfg_base(uint64_t mmcfg_base)
+{
+	pci_mmcfg_base = mmcfg_base;
+}
+#endif
+
+uint64_t get_mmcfg_base(void)
+{
+	return pci_mmcfg_base;
+}
 
 /* @brief: Find the DRHD index corresponding to a PCI device
  * Runs through the pci_pdev_array and returns the value in drhd_idx

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -233,6 +233,11 @@ static inline bool bdf_is_equal(union pci_bdf a, union pci_bdf b)
 	return (a.value == b.value);
 }
 
+#ifdef CONFIG_ACPI_PARSE_ENABLED
+void set_mmcfg_base(uint64_t mmcfg_base);
+#endif
+uint64_t get_mmcfg_base(void);
+
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);


### PR DESCRIPTION
The default PCI mmcfg base is stored in ACPI MCFG table, when
CONFIG_ACPI_PARSE_ENABLED is set, acpi_fixup() function will
parse and fix up the platform mmcfg base in ACRN boot stage;
when it is not set, platform mmcfg base will be initialized to
DEFAULT_PCI_MMCFG_BASE which generated by acrn-config tool;

Please note we will not support platform which has multiple PCI
segment groups.

Tracked-On: #4157

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>