### PR TITLE
hv: vmsi: refine function name 

### DIFF
--- a/doc/developer-guides/hld/hv-dev-passthrough.rst
+++ b/doc/developer-guides/hld/hv-dev-passthrough.rst
@@ -239,7 +239,7 @@ SOS:
 .. doxygenfunction:: ptirq_intx_pin_remap
    :project: Project ACRN
 
-.. doxygenfunction:: ptirq_msix_remap
+.. doxygenfunction:: ptirq_prepare_msix_remap
    :project: Project ACRN
 
 The following APIs are provided to manipulate the interrupt remapping

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -601,7 +601,7 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src)
  * entry_nr = 0 means first vector
  * user must provide bdf and entry_nr
  */
-int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t phys_bdf,
+int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t phys_bdf,
 				uint16_t entry_nr, struct ptirq_msi_info *info)
 {
 	struct ptirq_remapping_info *entry;
@@ -626,7 +626,7 @@ int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t phys_bd
 				pr_err("dev-assign: msi entry exist in others");
 			}
 		} else {
-			/* ptirq_msix_remap is called by SOS on demand, if
+			/* ptirq_prepare_msix_remap is called by SOS on demand, if
 			 * failed to find pre-hold mapping, return error to
 			 * the caller.
 			 */

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -111,7 +111,7 @@ static void vdev_pt_map_mem_vbar(struct pci_vdev *vdev, uint32_t idx)
 
 			addr_lo = round_page_down(addr_lo);
 			addr_hi = round_page_up(addr_hi);
-			register_mmio_emulation_handler(vm, vmsix_table_mmio_access_handler,
+			register_mmio_emulation_handler(vm, vmsix_handle_table_mmio_access,
 					addr_lo, addr_hi, vdev);
 			ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, addr_lo, addr_hi - addr_lo);
 			msix->mmio_gpa = vbar->base;

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -40,7 +40,7 @@
  * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  */
-static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
+static int32_t remap_vmsi(const struct pci_vdev *vdev, bool enable)
 {
 	struct ptirq_msi_info info;
 	union pci_bdf pbdf = vdev->pdev->bdf;
@@ -135,10 +135,10 @@ void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
 	if (((offset - vdev->msi.capoff) == PCIR_MSI_CTRL) &&
 		(((msgctrl ^ val) & PCIM_MSICTRL_MSI_ENABLE) != 0U)) {
 		enable = ((val & PCIM_MSICTRL_MSI_ENABLE) != 0U);
-		(void)vmsi_remap(vdev, enable);
+		(void)remap_vmsi(vdev, enable);
 	} else {
 		if (message_changed && ((msgctrl & PCIM_MSICTRL_MSI_ENABLE) != 0U)) {
-			(void)vmsi_remap(vdev, true);
+			(void)remap_vmsi(vdev, true);
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -75,7 +75,7 @@ static int32_t vmsi_remap(const struct pci_vdev *vdev, bool enable)
 		info.vmsi_data.full = 0U;
 	}
 
-	ret = ptirq_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info);
+	ret = ptirq_prepare_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info);
 	if (ret == 0) {
 		/* Update MSI Capability structure to physical device */
 		if ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) {

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -62,7 +62,7 @@ static int32_t vmsix_remap_entry(const struct pci_vdev *vdev, uint32_t index, bo
 	info.vmsi_addr.full = vdev->msix.table_entries[index].addr;
 	info.vmsi_data.full = (enable) ? vdev->msix.table_entries[index].data : 0U;
 
-	ret = ptirq_msix_remap(vdev->vpci->vm, vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
+	ret = ptirq_prepare_msix_remap(vdev->vpci->vm, vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
 	if (ret == 0) {
 		/* Write the table entry to the physical structure */
 		hva = hpa2hva(vdev->msix.mmio_hpa + vdev->msix.table_offset);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -134,7 +134,7 @@ void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
 void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
-int32_t vmsix_table_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
+int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_private_data);
 void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(const struct pci_vdev *vdev);

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -61,7 +61,7 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
  * @pre info != NULL
  *
  */
-int32_t ptirq_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_t phys_bdf,
+int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_t phys_bdf,
 				uint16_t entry_nr, struct ptirq_msi_info *info);
 
 


### PR DESCRIPTION
1. rename ptirq_msix_remap to ptirq_prepare_msix_remap
2. name vmsi with verb-object style

Tracked-On: #3475
Signed-off-by: Li Fei1 <fei1.li@intel.com>