### PR TITLE
acrn-config: Refinemen vcpuaffinity and walk secondary PCI Bus

### DIFF
--- a/misc/acrn-config/board_config/board_c.py
+++ b/misc/acrn-config/board_config/board_c.py
@@ -63,7 +63,8 @@ def gen_dmar_structure(config):
         print("\t\t.segment       = DRHD{}_SEGMENT,".format(i_drhd_cnt), file=config)
         print("\t\t.flags         = DRHD{}_FLAGS,".format(i_drhd_cnt), file=config)
         print("\t\t.reg_base_addr = DRHD{}_REG_BASE,".format(i_drhd_cnt), file=config)
-        print("\t\t.ignore        = DRHD{}_IGNORE,".format(i_drhd_cnt), file=config)
+        if dev_cnt != 0:
+            print("\t\t.ignore        = DRHD{}_IGNORE,".format(i_drhd_cnt), file=config)
         print("\t\t.devices       = drhd{}_dev_scope".format(i_drhd_cnt), file=config)
         print("\t},", file=config)
 

--- a/misc/acrn-config/board_config/board_cfg_gen.py
+++ b/misc/acrn-config/board_config/board_cfg_gen.py
@@ -123,7 +123,7 @@ def main(args):
     gen_str = 'generated'
     # move changes to patch, and apply to the source code
     if enable_commit:
-        err_dic = board_cfg_lib.gen_patch(config_srcs, board)
+        err_dic = board_cfg_lib.gen_patch(config_srcs, "board " + board)
         config_str = 'Config patch'
         gen_str = 'committed'
 

--- a/misc/acrn-config/config_app/controller.py
+++ b/misc/acrn-config/config_app/controller.py
@@ -202,6 +202,19 @@ class XmlConfig:
             new_node = ElementTree.SubElement(dest_node, key, attrib={'desc': desc})
             new_node.text = value
 
+    def clone_curr_elem(self, elem, *args):
+        """
+        clone elements for current path.
+        :param elem: the element to clone.
+        :param args: the path of the element.
+        :return: None.
+        """
+        if self._curr_xml_tree is None:
+            return
+
+        dest_node = self._get_dest_node(*args)
+        dest_node.append(elem)
+
     def delete_curr_key(self, *args):
         """
         delete the element by its path.

--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -323,6 +323,17 @@ $().ready(function(){
         config_item.remove();
     });
 
+    $('#remove_vm_kata').on('click', function() {
+        if(confirm("Do you want to remove the VM?")) {
+            save_scenario("remove_vm_kata");
+        }
+    });
+
+    $('#add_vm_kata').on('click', function() {
+        if(confirm("Do you want to add the Kata VM based on generic config?")) {
+            save_scenario("add_vm_kata");
+        }
+    });
 })
 
 
@@ -362,7 +373,8 @@ function save_scenario(generator=null){
 
     scenario_config = {
 		old_scenario_name: $("#old_scenario_name").text(),
-		new_scenario_name: $("#new_scenario_name").val()
+		new_scenario_name: $("#new_scenario_name").val(),
+		generator: generator
 	}
 
     $("input").each(function(){
@@ -425,7 +437,7 @@ function save_scenario(generator=null){
                     validate_message = 'Scenario setting existed, saved successfully with a new name: '
                         +file_name+'\ninto acrn-hypervisor/misc/acrn-config/xmls/config-xmls/'+board_info+'/user_defined/.';
                 }
-                if(generator != null) {
+                if(generator=="generate_board_src" || generator=="generate_scenario_src") {
                     commit_confirm_message = validate_message+'\n\nGenerate source codes from scenario setting.'
                         +'\n\nDo you want to commit changes to local tree?'
                     commit_confirm = 'no'

--- a/misc/acrn-config/config_app/templates/scenario.html
+++ b/misc/acrn-config/config_app/templates/scenario.html
@@ -87,14 +87,24 @@
 
     {% if board_info != None and root != None and scenario_item_values %}
     <table class="table table-hover" id="tab">
+        {% set vm_kata = [] %}
         {% for vm in root.getchildren() %}
+            {% if 'desc' in vm.attrib and vm.attrib['desc'] == 'specific for Kata'  %}
+                {% do vm_kata.append(1) %}
+            {% endif %}
             {% if 'configurable' not in vm.attrib or vm.attrib['configurable'] != '0'%}
             <tr>
                 <td>
                     <div class="form-group">
                         <label class="col-sm-1 control-label">VM: </label>
                         <label class="col-sm-1 control-label" id="vm">{{vm.attrib['id']}}</label>
+
                     </div>
+                    {% if 'desc' in vm.attrib or vm.attrib['desc'] == 'specific for Kata'  %}
+                    <div class="form-group">
+                        <button type="button" class="btn" id="remove_vm_kata">Remove Kata VM</button>
+                    </div>
+                    {% endif %}
                 </td>
                 <td>
                 {% for elem in vm.getchildren() %}
@@ -321,6 +331,11 @@
             </tr>
             {% endif %}
         {% endfor %}
+        {% if not vm_kata and ('scenario' in root.attrib and root.attrib['scenario'] == 'sdc') %}
+        <tr><td>
+            <button type="button" class="btn" id="add_vm_kata">Add Kata VM</button>
+        </td></tr>
+        {% endif %}
     </table>
     {% else %}
     <text class="form-control" id="err_msg">No setting available. Select one board info and make sure the scenario xml

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -22,6 +22,7 @@ class AcrnDmArgs:
         self.args["rootfs_img"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "rootfs_img")
         self.args["vbootloader"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "vbootloader")
         self.args["console_type"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "console_type")
+        self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
 
     def check_item(self):
         rootfs = launch_cfg_lib.get_rootdev_info(self.board_info)

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -550,7 +550,7 @@ def add_to_patch(srcs_list, commit_name):
         return err_dic
 
     # commit this changes
-    git_commit = 'git commit -sm "acrn-config: config board patch for {}"'.format(commit_name)
+    git_commit = 'git commit -sm "acrn-config: config patch for {}"'.format(commit_name)
 
     try:
         ret = subprocess.call(git_commit, shell=True, stdout=subprocess.PIPE,

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -368,6 +368,17 @@ def get_vpid_from_bdf(bdf_vpid_map, bdf_list):
     return vpid_list
 
 
+def get_leaf_tag_map(info_file, prime_item, item):
+    """
+    :param info_file: some configurations in the info file
+    :param prime_item: the prime item in xml file
+    :param item: the item in xml file
+    :return: dictionary which item value could be indexed by vmid
+    """
+    vmid_item_dic = common.get_leaf_tag_map(info_file, prime_item, item)
+    return vmid_item_dic
+
+
 def gen_patch(srcs_list, launch_name):
     """
     Generate patch and apply to local source code

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -10,7 +10,6 @@ HEADER_LICENSE = common.open_license()
 BOARD_INFO_FILE = "board_info.txt"
 SCENARIO_INFO_FILE = ""
 
-VM_COUNT = 0
 LOAD_ORDER_TYPE = ['PRE_LAUNCHED_VM', 'SOS_VM', 'POST_LAUNCHED_VM']
 START_HPA_LIST = ['0', '0x100000000', '0x120000000']
 
@@ -34,6 +33,16 @@ PCI_DEVS_LIST = ['sos_pci_devs', 'vm0_pci_devs', 'vm1_pci_devs']
 COMMUNICATE_VM_ID = []
 
 ERR_LIST = {}
+
+VM_COUNT = 0
+DEFAULT_VM_COUNT = {
+    'sdc':2,
+    'sdc2':4,
+    'industry':3,
+    'hybrid':3,
+    'logical_partition':2,
+}
+KATA_VM_COUNT = 0
 
 def prepare(check_git):
     """ Check environment """

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -117,6 +117,13 @@ def main(args):
         scenario_cfg_lib.print_red("Validate the scenario item failue", err=True)
         return err_dic
 
+    # get kata vm count
+    if scenario != "logical_partition":
+        scenario_cfg_lib.KATA_VM_COUNT = scenario_cfg_lib.VM_COUNT - scenario_cfg_lib.DEFAULT_VM_COUNT[scenario]
+        if scenario_cfg_lib.KATA_VM_COUNT > 1:
+            err_dic['scenario config: kata vm count err'] = "Only one kata vm is supported!"
+            return err_dic
+
     # generate vm_configuration.h
     with open(vm_config_h, 'w') as config:
         vm_configurations_h.generate_file(scenario, vm_info, config)

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -136,7 +136,7 @@ def main(args):
     gen_str = 'generated'
     # move changes to patch, and apply to the source code
     if enable_commit:
-        err_dic = scenario_cfg_lib.gen_patch(config_srcs, scenario)
+        err_dic = scenario_cfg_lib.gen_patch(config_srcs, "scenario " + scenario)
         config_str = 'Config patch'
         gen_str = 'committed'
 

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -219,7 +219,6 @@ def gen_sdc_source(vm_info, config):
     """
     uuid_0 = uuid2str(vm_info.uuid[0])
     uuid_1 = uuid2str(vm_info.uuid[1])
-    uuid_2 = uuid2str(vm_info.uuid[2])
 
     (err_dic, sos_guest_flags) = get_guest_flag(vm_info.guest_flag_idx[0])
     if err_dic:
@@ -264,31 +263,38 @@ def gen_sdc_source(vm_info, config):
     # UUID
     uuid_output(uuid_1, vm_info.uuid[1], config)
     is_need_epc(vm_info.epc_section, 1, config)
-    print("\t\t.vcpu_num = CONFIG_MAX_PCPU_NUM - CONFIG_MAX_KATA_VM_NUM - 1U,", file=config)
-    print("\t\t.vcpu_affinity = VM{}_CONFIG_VCPU_AFFINITY,".format(1), file=config)
+
+    vm1_id = 1
+    vm1_cpu_num = len(vm_info.cpus_per_vm[vm1_id])
+    print("\t\t.vcpu_num = {}U,".format(vm1_cpu_num), file=config)
+    print("\t\t.vcpu_affinity = VM{}_CONFIG_VCPU_AFFINITY,".format(vm1_id), file=config)
     # VUART
     err_dic = vuart_output(1, vm_info, config)
     if err_dic:
         return err_dic
-    # VM2
-    print("#if CONFIG_MAX_KATA_VM_NUM > 0", file=config)
-    print("\t{", file=config)
-    print("\t\t.load_order = POST_LAUNCHED_VM,", file=config)
-    uuid_output(uuid_2, vm_info.uuid[2], config)
-    vcpu_affinity_output(vm_info, 2, config)
-    is_need_epc(vm_info.epc_section, 2, config)
-    print("\t\t.vuart[0] = {", file=config)
-    print("\t\t\t.type = VUART_LEGACY_PIO,", file=config)
-    print("\t\t\t.addr.port_base = INVALID_COM_BASE,", file=config)
-    print("\t\t},", file=config)
-    print("\t\t.vuart[1] = {", file=config)
-    print("\t\t\t.type = VUART_LEGACY_PIO,", file=config)
-    print("\t\t\t.addr.port_base = INVALID_COM_BASE,", file=config)
-    print("\t\t}", file=config)
-    print("\t},", file=config)
-    print("#endif", file=config)
-    print("};", file=config)
 
+    # VM2
+    if scenario_cfg_lib.KATA_VM_COUNT == 1:
+        # Setup Kata vm configurations if more than 3 VMs in SDC config file
+        uuid_2 = uuid2str(vm_info.uuid[2])
+        print("#if CONFIG_MAX_KATA_VM_NUM > 0", file=config)
+        print("\t{", file=config)
+        print("\t\t.load_order = POST_LAUNCHED_VM,", file=config)
+        uuid_output(uuid_2, vm_info.uuid[2], config)
+        vcpu_affinity_output(vm_info, 2, config)
+        is_need_epc(vm_info.epc_section, 2, config)
+        print("\t\t.vuart[0] = {", file=config)
+        print("\t\t\t.type = VUART_LEGACY_PIO,", file=config)
+        print("\t\t\t.addr.port_base = INVALID_COM_BASE,", file=config)
+        print("\t\t},", file=config)
+        print("\t\t.vuart[1] = {", file=config)
+        print("\t\t\t.type = VUART_LEGACY_PIO,", file=config)
+        print("\t\t\t.addr.port_base = INVALID_COM_BASE,", file=config)
+        print("\t\t}", file=config)
+        print("\t},", file=config)
+        print("#endif", file=config)
+
+    print("};", file=config)
     return err_dic
 
 

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -44,8 +44,8 @@ def gen_sdc_header(vm_info, config):
     """
     gen_common_header(config)
     print("#include <misc_cfg.h>\n", file=config)
-    print("#define CONFIG_MAX_VM_NUM\t\t({0}U + CONFIG_MAX_KATA_VM_NUM)".format(
-        scenario_cfg_lib.VM_COUNT - 1), file=config)
+
+    print("#define CONFIG_MAX_VM_NUM\t\t(2U + CONFIG_MAX_KATA_VM_NUM)", file=config)
     print("", file=config)
     print("/* Bits mask of guest flags that can be programmed by device model." +
           " Other bits are set by hypervisor only */", file=config)
@@ -66,17 +66,23 @@ def gen_sdc_header(vm_info, config):
     print('\t\t\t\t\t"i915.domain_plane_owners=0x011111110000 " \\', file=config)
     print('\t\t\t\t\t"i915.enable_gvt=1 "\t\\', file=config)
     print("\t\t\t\t\tSOS_BOOTARGS_DIFF", file=config)
-
     print("", file=config)
-    print("#if CONFIG_MAX_KATA_VM_NUM > 0", file=config)
+
     # POST LAUNCHED VM
-    print("  #define VM1_CONFIG_VCPU_AFFINITY\t{AFFINITY_CPU(1U), AFFINITY_CPU(2U)}", file=config)
-    # KATA VM
-    cpu_affinity_output(vm_info, 2, config)
-    print("#else", file=config)
-    for i in range(scenario_cfg_lib.VM_COUNT - 1):
-        cpu_affinity_output(vm_info, i, config)
-    print("#endif", file=config)
+    if scenario_cfg_lib.KATA_VM_COUNT == 1:
+        print("#if CONFIG_MAX_KATA_VM_NUM > 0", file=config)
+        # Set VM1 vcpu
+        cpu_affinity_output(vm_info, 1, config)
+        # KATA VM
+        cpu_affinity_output(vm_info, 2, config)
+        #else:
+        print("#else", file=config)
+        # Only two VMs in SDC config, setup vcpu affinity for VM1
+        cpu_affinity_output(vm_info, 1, config)
+        print("#endif", file=config)
+    else:
+        cpu_affinity_output(vm_info, 1, config)
+
     print("", file=config)
     print("{0}".format(VM_END_DEFINE), file=config)
 

--- a/misc/acrn-config/target/dmar.py
+++ b/misc/acrn-config/target/dmar.py
@@ -51,23 +51,6 @@ class DmarHeader(ctypes.Structure):
         self._pack_ = 0
 
 
-class DmarSubtblHeader(ctypes.Structure):
-    """DMAR Sub Table Header"""
-    _pack_ = 1
-    _fields_ = [
-        ('type', ctypes.c_uint16),
-        ('length', ctypes.c_uint16),
-    ]
-
-    def style_check_1(self):
-        """Style check if have public method"""
-        self._pack_ = 0
-
-    def style_check_2(self):
-        """Style check if have public method"""
-        self._pack_ = 0
-
-
 class DmarDevScope(ctypes.Structure):
     """DMAR Device Scope"""
     _pack_ = 1
@@ -92,7 +75,8 @@ class DmarHwUnit(ctypes.Structure):
     """DMAR Hardware Unit"""
     _pack_ = 1
     _fields_ = [
-        ('sub_header', DmarSubtblHeader),
+        ('type', ctypes.c_uint16),
+        ('length', ctypes.c_uint16),
         ('flags', ctypes.c_uint8),
         ('reserved', ctypes.c_uint8),
         ('segment', ctypes.c_uint16),
@@ -124,14 +108,6 @@ class DevScopePath(ctypes.Structure):
         """Style check if have public method"""
         self._pack_ = 0
 
-
-def map_file(sysnode):
-    """Map sys node to memory address"""
-    data = open(sysnode, 'rb').read()
-    buf = ctypes.create_string_buffer(data, len(data))
-    addr = ctypes.addressof(buf)
-
-    return addr
 
 class DmarHwList:
     """DMAR HW List"""
@@ -171,7 +147,7 @@ class DmarDevList:
 class DmarTbl:
     """DMAR TBL"""
     def __init__(self):
-        self.sub_tbl_offset = 0
+        self.drhd_offset = 0
         self.dmar_drhd = 0
         self.dmar_dev_scope = 0
         self.dev_scope_offset = 0
@@ -208,21 +184,21 @@ class PathDevFun:
         self.path = 0
 
 
-def walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, n_cnt, drhd_cnt):
+def walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, drhd_cnt):
     """Walk Pci bus
     :param tmp_pdf: it is a class what contains path,device,function in dmar device scope region
     :param dmar_tbl: it is a class to describe dmar which contains Device Scope and DRHD
     :param dmar_hw_list: it is a class to describe hardware scope in DMAR table
-    :param n_cnt: the number of device in device scope
     :param drhd_cnt: it is a counter to calculate the DRHD in DMAR table
     """
+    # path offset is in end of device spcope
+    dmar_tbl.path_offset = dmar_tbl.dev_scope_offset + ctypes.sizeof(DmarDevScope)
+    n_cnt = (dmar_tbl.dmar_dev_scope.scope_length - ctypes.sizeof(DmarDevScope)) // 2
     while n_cnt:
         scope_path = DevScopePath.from_address(dmar_tbl.path_offset)
         tmp_pdf.device = scope_path.device
         tmp_pdf.function = scope_path.function
         tmp_pdf.path = (((tmp_pdf.device & 0x1F) << 3) | ((tmp_pdf.function & 0x7)))
-        dmar_tbl.path_offset += ctypes.sizeof(DevScopePath)
-        n_cnt -= 1
 
         if ((dmar_tbl.dmar_drhd.segment << 16) | (
                 dmar_tbl.dmar_dev_scope.bus << 8) | tmp_pdf.path) == CONFIG_GPU_SBDF:
@@ -230,7 +206,8 @@ def walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, n_cnt, drhd_cnt):
         else:
             dmar_hw_list.hw_ignore[drhd_cnt] = 'false'
 
-    return (tmp_pdf, dmar_tbl, dmar_hw_list)
+        dmar_tbl.path_offset += ctypes.sizeof(DevScopePath)
+        n_cnt -= 1
 
 
 def walk_dev_scope(dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt):
@@ -240,8 +217,8 @@ def walk_dev_scope(dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt):
     :param dmar_hw_list: it is a class to describe DRHD in DMAR table
     :param drhd_cnt: it is a counter to calculate the DRHD in DMAR table
     """
-    dmar_tbl.dev_scope_offset = dmar_tbl.sub_tbl_offset + ctypes.sizeof(DmarHwUnit)
-    scope_end = dmar_tbl.dev_scope_offset + dmar_tbl.dmar_drhd.sub_header.length
+    dmar_tbl.dev_scope_offset = dmar_tbl.drhd_offset + ctypes.sizeof(DmarHwUnit)
+    scope_end = dmar_tbl.dev_scope_offset + dmar_tbl.dmar_drhd.length
     dmar_tbl.dev_scope_cnt = 0
 
     while dmar_tbl.dev_scope_offset < scope_end:
@@ -258,19 +235,13 @@ def walk_dev_scope(dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt):
             dmar_dev_list.dev_scope_type_list.append(dmar_tbl.dmar_dev_scope.entry_type)
             dmar_dev_list.dev_scope_id_list.append(dmar_tbl.dmar_dev_scope.enumeration_id)
 
-            # path offset is in end of device spcope
-            dmar_tbl.path_offset = dmar_tbl.dev_scope_offset + ctypes.sizeof(DmarDevScope)
             # walk the pci bus with path deep, and find the {Device,Function}
             tmp_pdf = PathDevFun()
-            n_cnt = (dmar_tbl.dmar_dev_scope.scope_length - ctypes.sizeof(DmarDevScope)) // 2
-            (tmp_pdf, dmar_tbl, dmar_hw_list) = walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list,
-                                                             n_cnt, drhd_cnt)
+            walk_pci_bus(tmp_pdf, dmar_tbl, dmar_hw_list, drhd_cnt)
             dmar_dev_list.dev_bus_list.append(dmar_tbl.dmar_dev_scope.bus)
             dmar_dev_list.dev_path_list.append(tmp_pdf.path)
 
         dmar_tbl.dev_scope_offset += dmar_tbl.dmar_dev_scope.scope_length
-
-    return (dmar_tbl, dmar_dev_list, dmar_hw_list)
 
 
 def walk_dmar_table(dmar_tbl, dmar_hw_list, dmar_dev_list, sysnode):
@@ -289,33 +260,31 @@ def walk_dmar_table(dmar_tbl, dmar_hw_list, dmar_dev_list, sysnode):
 
     # cytpes.c_int16.from_address(addr) reade int16 from ad1
     # in end of tbl header is remapping structure(DRHD/sub tbl)
-    dmar_tbl.sub_tbl_offset = addr + ctypes.sizeof(DmarHeader)
+    dmar_tbl.drhd_offset = addr + ctypes.sizeof(DmarHeader)
     drhd_cnt = 0
     while True:
-        sub_dmar = DmarSubtblHeader.from_address(dmar_tbl.sub_tbl_offset)
-        sub_dmar_type = sub_dmar.type
-        sub_dmar_len = sub_dmar.length
+        # get one DRHD type in sub table
+        dmar_tbl.dmar_drhd = DmarHwUnit.from_address(dmar_tbl.drhd_offset)
+        dmar_type = dmar_tbl.dmar_drhd.type
+        dmar_len = dmar_tbl.dmar_drhd.length
 
-        if dmar_tbl.sub_tbl_offset - addr >= dmar_tbl_header.length:
+        if dmar_tbl.drhd_offset - addr >= dmar_tbl_header.length:
             break
 
-        if sub_dmar_type != ACPI_DMAR_TYPE['ACPI_DMAR_TYPE_HARDWARE_UNIT']:
-            dmar_tbl.sub_tbl_offset += sub_dmar.length
+        if dmar_type != ACPI_DMAR_TYPE['ACPI_DMAR_TYPE_HARDWARE_UNIT']:
+            dmar_tbl.drhd_offset += dmar_len
             continue
 
-        # get one DRHD type in sub table
-        dmar_tbl.dmar_drhd = DmarHwUnit.from_address(dmar_tbl.sub_tbl_offset)
         dmar_hw_list.hw_segment_list.append(dmar_tbl.dmar_drhd.segment)
         dmar_hw_list.hw_flags_list.append(dmar_tbl.dmar_drhd.flags)
         dmar_hw_list.hw_address_list.append(dmar_tbl.dmar_drhd.address)
 
         # in end of DRHD/sub tbl header is dev scope, then enumerate the device scope
-        (dmar_tbl, dmar_dev_list, dmar_hw_list) = walk_dev_scope(
-            dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt)
-
+        walk_dev_scope(dmar_tbl, dmar_dev_list, dmar_hw_list, drhd_cnt)
         dmar_dev_list.dev_scope_cnt_list.append(dmar_tbl.dev_scope_cnt)
+
         drhd_cnt += 1
-        dmar_tbl.sub_tbl_offset += sub_dmar_len
+        dmar_tbl.drhd_offset += dmar_len
 
     return (dmar_tbl, dmar_hw_list, dmar_dev_list, drhd_cnt)
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -71,8 +71,8 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -71,8 +71,8 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
@@ -48,8 +48,6 @@
     </guest_flags>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
-        <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">
@@ -69,12 +67,12 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
-        <pcpu_id>3</pcpu_id>
+        <pcpu_id>1</pcpu_id>
     </vcpu_affinity>
     <epc_section desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -70,8 +70,8 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -70,8 +70,8 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -70,8 +70,8 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -70,8 +70,8 @@
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
   </vm>
-  <vm id="2" configurable="0" desc="specific for Kata">
-    <load_order configurable="0" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
+  <vm id="2" configurable="1" desc="specific for Kata">
+    <load_order readonly="true" desc="Specify the VM by its load order: PRE_LAUNCHED_VM, SOS_VM or POST_LAUNCHED_VM.">POST_LAUNCHED_VM</load_order>
     <uuid configurable="0" desc="vm uuid">a7ada506-1ab0-4b6b-a0da-e513ca9b8c2f</uuid>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">


### PR DESCRIPTION
- skip the DRHDn_IGNORE when no device scope
- walk secondary PCI Bus for target board
- refinement for DmarDevScope struct
- modify SDC config xml to support kata vm config in webUI
- add UI to add or remove Kata VM for sdc scenario
- launch refinement on vcpu affinity and uos image
- refine vcpu affinity/number for SDC scenario
- print warning if MMIO BAR size above 4G
- modify the git commit message for gen_patch

    Tracked-On: #4143
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
