### PR TITLE
acrn-config: add Virtio input and xhci support

### DIFF
--- a/misc/acrn-config/config_app/views.py
+++ b/misc/acrn-config/config_app/views.py
@@ -290,11 +290,11 @@ def save_launch():
     # call validate function
     rename = False
     try:
-        (error_list, pthru_sel, dm_value) = validate_launch_setting(
+        (error_list, pthru_sel, virtio, dm_value) = validate_launch_setting(
             os.path.join(os.path.dirname(os.path.abspath(__file__)), 'res', xml_configs[0]+'.xml'),
             scenario_file_path,
             tmp_launch_file)
-        print(pthru_sel, dm_value)
+        print(pthru_sel, virtio, dm_value)
     except Exception as error:
         if os.path.isfile(tmp_launch_file):
             os.remove(tmp_launch_file)

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -406,24 +406,11 @@ def vboot_arg_set(dm, vmid, config):
         print("   $boot_image_option \\",file=config)
 
 
-def xhci_args_set(names, vmid, config):
-    board_name = names['board_name']
-    uos_type = names['uos_types'][vmid]
-
-    # Get locate of vmid
-    idx = 0
-    #if board_name not in ("whl-ipc-i5", "whl-ipc-i7"):
-    if uos_type in ("CLEARLINUX", "WINDOWS") and board_name in ("whl-ipc-i5", "whl-ipc-i7", "nuc7i7dnb"):
-        for num in names['uos_types'].keys():
-            idx += 1
-            if num == vmid:
-                break
-
-        # if the vmid is first vm
-        if idx == 1:
-            print("   -s {},xhci,1-2:2-2 \\".format(launch_cfg_lib.virtual_dev_slot("xhci")), file=config)
-        elif idx > 1:
-            print("   -s {},xhci,1-2:2-4 \\".format(launch_cfg_lib.virtual_dev_slot("xhci")), file=config)
+def xhci_args_set(dm, vmid, config):
+    # usb_xhci set, the value is string
+    if dm['xhci'][vmid]:
+        print("   -s {},xhci,{} \\".format(
+            launch_cfg_lib.virtual_dev_slot("xhci"), dm['xhci'][vmid]), file=config)
 
 
 def vritio_args_set(virt_io, vmid, config):
@@ -505,7 +492,7 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
         print("   --windows \\", file=config)
 
     # WA: XHCI args set
-    xhci_args_set(names, vmid, config)
+    xhci_args_set(dm, vmid, config)
 
     # VIRTIO args set
     vritio_args_set(virt_io, vmid, config)

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -438,6 +438,10 @@ def dm_arg_set(names, sel, dm, vmid, config):
     # uuid get
     scenario_uuid = launch_cfg_lib.get_scenario_uuid()
     sos_vmid = launch_cfg_lib.get_sos_vmid()
+    if not str(sos_vmid).isnumeric():
+        sos_vmid = 0
+        key = "launch config err:"
+        launch_cfg_lib.ERR_LIST[key] = "There is no SOS_VM in scenario config file!"
 
     # clearlinux/android/alios
     dm_str = 'acrn-dm -A -m $mem_size -s 0:0,hostbridge -U {}'.format(scenario_uuid[vmid + sos_vmid])

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -426,7 +426,16 @@ def xhci_args_set(names, vmid, config):
             print("   -s {},xhci,1-2:2-4 \\".format(launch_cfg_lib.virtual_dev_slot("xhci")), file=config)
 
 
-def dm_arg_set(names, sel, dm, vmid, config):
+def vritio_args_set(virt_io, vmid, config):
+
+    # virtio-input set, the value type is a list
+    for input_val in virt_io['input'][vmid]:
+        if input_val:
+            print("   -s {},virtio-input,{} \\".format(
+                launch_cfg_lib.virtual_dev_slot("virtio-input{}".format(input_val)), input_val), file=config)
+
+
+def dm_arg_set(names, sel, virt_io, dm, vmid, config):
 
     uos_type = names['uos_types'][vmid]
     board_name = names['board_name']
@@ -498,6 +507,9 @@ def dm_arg_set(names, sel, dm, vmid, config):
     # WA: XHCI args set
     xhci_args_set(names, vmid, config)
 
+    # VIRTIO args set
+    vritio_args_set(virt_io, vmid, config)
+
     # GVT args set
     gvt_arg_set(uos_type, config)
 
@@ -545,7 +557,7 @@ def dm_arg_set(names, sel, dm, vmid, config):
     print("}", file=config)
 
 
-def gen(names, pt_sel, dm, vmid, config):
+def gen(names, pt_sel, virt_io, dm, vmid, config):
 
     board_name = names['board_name']
     uos_type = names['uos_types'][vmid]
@@ -566,7 +578,7 @@ def gen(names, pt_sel, dm, vmid, config):
     log_level_set(uos_type, config)
 
     # gen acrn-dm args
-    dm_arg_set(names, pt_sel, dm, vmid, config)
+    dm_arg_set(names, pt_sel, virt_io, dm, vmid, config)
 
     # gen launch end
     launch_end(names, dm, vmid, config)

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -23,6 +23,7 @@ class AcrnDmArgs:
         self.args["vbootloader"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vbootloader")
         self.args["console_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "console_type")
         self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
+        self.args["xhci"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "usb_xhci")
 
     def check_item(self):
         rootfs = launch_cfg_lib.get_rootdev_info(self.board_info)

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -142,3 +142,13 @@ class PthruSelected():
         launch_cfg_lib.pt_devs_check(self.bdf["audio_codec"], self.vpid["audio_codec"], "audio_codec")
         launch_cfg_lib.pt_devs_check(self.bdf["wifi"], self.vpid["wifi"], "wifi")
         launch_cfg_lib.pt_devs_check(self.bdf["bluetooth"], self.vpid["bluetooth"], "bluetooth")
+
+
+class VirtioDeviceSelect():
+
+    dev = {}
+    def __init__(self, launch_info):
+        self.launch_info = launch_info
+
+    def get_virtio(self):
+        self.dev["input"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "input")

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -14,14 +14,14 @@ class AcrnDmArgs:
         self.launch_info = launch_info
 
     def get_args(self):
-        self.args["uos_type"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "uos_type")
-        self.args["rtos_type"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "rtos_type")
-        self.args["mem_size"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "mem_size")
-        self.args["gvt_args"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "gvt_args")
-        self.args["rootfs_dev"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "rootfs_dev")
-        self.args["rootfs_img"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "rootfs_img")
-        self.args["vbootloader"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "vbootloader")
-        self.args["console_type"] = launch_cfg_lib.get_sub_tree_tag(self.launch_info, "console_type")
+        self.args["uos_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "uos_type")
+        self.args["rtos_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "rtos_type")
+        self.args["mem_size"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "mem_size")
+        self.args["gvt_args"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "gvt_args")
+        self.args["rootfs_dev"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "rootfs_dev")
+        self.args["rootfs_img"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "rootfs_img")
+        self.args["vbootloader"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vbootloader")
+        self.args["console_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "console_type")
         self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
 
     def check_item(self):

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -155,16 +155,6 @@ def get_tree_tag(config_file, tag_str):
     return common.get_tree_tag_val(config_file, tag_str)
 
 
-def get_sub_tree_tag(config_file, tag_str):
-    """
-     This is get tag value by tag_str from config file
-     :param config_file: it is a file what contains information for script to read from
-     :param tag_str: it is key of pattern to config file item
-     :return: value of tag_str item
-     """
-    return common.get_branch_tag_val(config_file, tag_str)
-
-
 def get_sub_leaf_tag(config_file, branch_tag, tag_str):
     """
      This is get tag value by tag_str from config file

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -23,7 +23,7 @@ GUEST_FLAG = ["0UL", "GUEST_FLAG_SECURE_WORLD_ENABLED", "GUEST_FLAG_LAPIC_PASSTH
 START_HPA_SIZE_LIST = ['0x20000000', '0x40000000', '0x80000000', 'CONFIG_SOS_RAM_SIZE', 'VM0_MEM_SIZE']
 
 
-MULTI_ITEM = ["guest_flag", "pcpu_id"]
+MULTI_ITEM = ["guest_flag", "pcpu_id", "input"]
 
 
 class MultiItem():
@@ -31,6 +31,7 @@ class MultiItem():
     def __init__(self):
         self.guest_flag = []
         self.pcpu_id = []
+        self.vir_input = []
         self.vir_console = []
         self.vir_net = []
 
@@ -38,7 +39,7 @@ class TmpItem():
 
     def __init__(self):
         self.tag = {}
-        self.multi = MultiItem
+        self.multi = MultiItem()
 
 def open_license():
     """ Get the license """
@@ -410,6 +411,10 @@ def get_leaf_value(tmp, tag_str, leaf):
     if leaf.tag == "pcpu_id" and tag_str == "pcpu_id":
         tmp.multi.pcpu_id.append(leaf.text)
 
+    # get virtio-input for vm
+    if leaf.tag == "input" and tag_str == "input":
+        tmp.multi.vir_input.append(leaf.text)
+
 
 def get_sub_value(tmp, tag_str, vm_id):
 
@@ -421,6 +426,10 @@ def get_sub_value(tmp, tag_str, vm_id):
     # append cpus for vm
     if tmp.multi.pcpu_id and tag_str == "pcpu_id":
         tmp.tag[vm_id] = tmp.multi.pcpu_id
+
+    # append input for vm
+    if tmp.multi.vir_input and tag_str == "input":
+        tmp.tag[vm_id] = tmp.multi.vir_input
 
 
 def get_leaf_tag_map(config_file, branch_tag, tag_str):

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -150,13 +150,6 @@ def get_param(args):
     return (err_dic, board_info_file, scenario_info_file, launch_info_file, int(vm_th), enable_commit)
 
 
-def get_scenario_uuid():
-    # {id_num:uuid} (id_num:0~max)
-    scenario_uuid_dic = {}
-    scenario_uuid_dic = common.get_branch_tag_map(SCENARIO_INFO_FILE, 'uuid')
-    return scenario_uuid_dic
-
-
 def get_post_num_list():
     """
     Get board name from launch.xml at fist line
@@ -314,35 +307,40 @@ def is_config_file_match():
     return (err_dic, match)
 
 
+def get_leaf_tag_map(info_file, prime_item, item=''):
+    """
+    :param info_file: some configurations in the info file
+    :param prime_item: the prime item in xml file
+    :param item: the item in xml file
+    :return: dictionary which item value could be indexed by vmid
+    """
+    vmid_item_dic = common.get_leaf_tag_map(info_file, prime_item, item)
+    return vmid_item_dic
+
+
+def get_scenario_uuid():
+    # {id_num:uuid} (id_num:0~max)
+    scenario_uuid_dic = {}
+    scenario_uuid_dic = get_leaf_tag_map(SCENARIO_INFO_FILE, 'uuid')
+    return scenario_uuid_dic
+
+
 def get_sos_vmid():
 
-    load_list = common.get_branch_tag_val(SCENARIO_INFO_FILE, "load_order")
+    load_dic = get_leaf_tag_map(SCENARIO_INFO_FILE, "load_order")
 
-    sos_id = 0
-    for load_order in load_list:
+    sos_id = ''
+    for idx,load_order in load_dic.items():
         if load_order == "SOS_VM":
+            sos_id = idx
             break
-
-        sos_id += 1
 
     return sos_id
 
 
-def get_sub_tree_tag(config_file, tag_str):
-    """
-     This is get tag value by tag_str from config file
-     :param config_file: it is a file what contains information for script to read from
-     :param tag_str: it is key of pattern to config file item
-     :return: value of tag_str item
-     """
-    arg = common.get_spec_branch_tag_val(config_file, tag_str)
-
-    return arg
-
-
 def get_bdf_from_tag(config_file, branch_tag, tag_str):
     bdf_list = {}
-    bdf_list = common.get_spec_leaf_tag_val(config_file, branch_tag, tag_str)
+    bdf_list = get_leaf_tag_map(config_file, branch_tag, tag_str)
 
     # split b:d:f from pci description
     for idx, bdf_v in bdf_list.items():
@@ -393,7 +391,7 @@ def get_uos_type():
     """
     Get uos name from launch.xml at fist line
     """
-    uos_types = get_sub_tree_tag(LAUNCH_INFO_FILE, "uos_type")
+    uos_types = get_leaf_tag_map(LAUNCH_INFO_FILE, "uos_type")
 
     return uos_types
 

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -224,7 +224,7 @@ def get_vm_num(config_file):
     return common.get_vm_count(config_file)
 
 
-def get_sub_leaf_tag(config_file, branch_tag, tag_str):
+def get_sub_leaf_tag(config_file, branch_tag, tag_str=''):
     """
       This is get tag value by tag_str from config file
       :param config_file: it is a file what contains information for script to read from
@@ -370,7 +370,7 @@ def uuid_format_check(uuid_dic, item):
             ERR_LIST[key] = "VM uuid format unknown"
 
 
-def get_leaf_tag_map(info_file, prime_item, item):
+def get_leaf_tag_map(info_file, prime_item, item=''):
     """
     :param info_file: some configurations in the info file
     :param prime_item: the prime item in xml file
@@ -396,9 +396,10 @@ def cpus_per_vm_check(id_cpus_per_vm_dic, item):
             ERR_LIST[key] = "VM have no assignment cpus"
 
 
-def mem_start_hpa_check(id_start_hpa_dic, item):
+def mem_start_hpa_check(id_start_hpa_dic, prime_item, item):
     """
     Check host physical address
+    :param prime_item: the prime item in xml file
     :param item: vm start_hpa item in xml
     :return: None
     """
@@ -418,9 +419,10 @@ def mem_start_hpa_check(id_start_hpa_dic, item):
                 ERR_LIST[key] = "Address should be Hex format"
 
 
-def mem_size_check(id_hpa_size_dic, item):
+def mem_size_check(id_hpa_size_dic, prime_item, item):
     """
     Check host physical size
+    :param prime_item: the prime item in xml file
     :param item: vm size item in xml
     :return: None
     """
@@ -444,9 +446,10 @@ def mem_size_check(id_hpa_size_dic, item):
                 ERR_LIST[key] = "Mem size should less than 2GB"
 
 
-def os_kern_name_check(id_kern_name_dic, item):
+def os_kern_name_check(id_kern_name_dic, prime_item, item):
     """
     Check os kernel name
+    :param prime_item: the prime item in xml file
     :param item: vm os config name item in xml
     :return: None
     """
@@ -457,9 +460,10 @@ def os_kern_name_check(id_kern_name_dic, item):
             ERR_LIST[key] = "VM os config kernel name length should be in range [1,32] bytes"
 
 
-def os_kern_type_check(id_kern_type_dic, item):
+def os_kern_type_check(id_kern_type_dic, prime_item, item):
     """
     Check os kernel type
+    :param prime_item: the prime item in xml file
     :param item: vm os config type item in xml
     :return: None
     """
@@ -476,9 +480,10 @@ def os_kern_type_check(id_kern_type_dic, item):
             ERR_LIST[key] = "VM os config kernel type unknown"
 
 
-def os_kern_mod_check(id_kern_mod_dic, item):
+def os_kern_mod_check(id_kern_mod_dic, prime_item, item):
     """
     Check os kernel mod
+    :param prime_item: the prime item in xml file
     :param item: vm os config mod item in xml
     :return: None
     """
@@ -489,9 +494,10 @@ def os_kern_mod_check(id_kern_mod_dic, item):
             ERR_LIST[key] = "VM os config kernel mod tag should be in range [1,32] bytes"
 
 
-def os_kern_args_check(id_kern_args_dic, item):
+def os_kern_args_check(id_kern_args_dic, prime_item, item):
     """
     Check os kernel args
+    :param prime_item: the prime item in xml file
     :param item: vm os config args item in xml
     :return: None
     """
@@ -504,9 +510,10 @@ def os_kern_args_check(id_kern_args_dic, item):
             ERR_LIST[key] = "VM os config kernel service os should be SOS_VM_BOOTARGS"
 
 
-def os_kern_console_check(id_kern_console_dic, item):
+def os_kern_console_check(id_kern_console_dic, prime_item, item):
     """
     Check os kernel console
+    :param prime_item: the prime item in xml file
     :param item: vm os config console item in xml
     :return: None
     """
@@ -517,9 +524,10 @@ def os_kern_console_check(id_kern_console_dic, item):
             ERR_LIST[key] = "VM os config kernel console should be ttyS[0..3]"
 
 
-def os_kern_load_addr_check(id_kern_load_addr_dic, item):
+def os_kern_load_addr_check(id_kern_load_addr_dic, prime_item, item):
     """
     Check os kernel load address
+    :param prime_item: the prime item in xml file
     :param item: vm os config load address item in xml
     :return: None
     """
@@ -536,9 +544,10 @@ def os_kern_load_addr_check(id_kern_load_addr_dic, item):
             ERR_LIST[key] = "VM os config kernel load address should Hex format"
 
 
-def os_kern_entry_addr_check(id_kern_entry_addr_dic, item):
+def os_kern_entry_addr_check(id_kern_entry_addr_dic, prime_item, item):
     """
     Check os kernel entry address
+    :param prime_item: the prime item in xml file
     :param item: vm os config entry address item in xml
     :return: None
     """
@@ -555,9 +564,10 @@ def os_kern_entry_addr_check(id_kern_entry_addr_dic, item):
             ERR_LIST[key] = "VM os config kernel entry address should Hex format"
 
 
-def os_kern_root_dev_check(id_kern_rootdev_dic, item):
+def os_kern_root_dev_check(id_kern_rootdev_dic, prime_item, item):
     """
     Check os kernel rootfs partitions
+    :param prime_item: the prime item in xml file
     :param item: vm os config rootdev item in xml
     :return: None
     """
@@ -566,16 +576,6 @@ def os_kern_root_dev_check(id_kern_rootdev_dic, item):
         if not kern_rootdev:
             key = "vm:id={},{},{}".format(id_key, prime_item, item)
             ERR_LIST[key] = "VM os config kernel root device should not empty"
-
-
-def get_branch_tag_map(info_file, item):
-    """
-    :param info_file: some configurations in the info file
-    :param item: the item in xml file
-    :return: dictionary which item value could be indexed by vmid
-    """
-    vmid_item_dic = common.get_branch_tag_map(info_file, item)
-    return vmid_item_dic
 
 
 def pci_dev_num_check(id_dev_num_dic, item):

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -108,14 +108,14 @@ class CfgOsKern:
         Check all items in this class
         :return: None
         """
-        scenario_cfg_lib.os_kern_name_check(self.kern_name, "name")
-        scenario_cfg_lib.os_kern_type_check(self.kern_type, "kern_type")
-        scenario_cfg_lib.os_kern_mod_check(self.kern_mod, "kern_mod")
-        scenario_cfg_lib.os_kern_args_check(self.kern_args, "kern_args")
-        scenario_cfg_lib.os_kern_console_check(self.kern_console, "console")
-        scenario_cfg_lib.os_kern_load_addr_check(self.kern_load_addr, "kern_load_addr")
-        scenario_cfg_lib.os_kern_entry_addr_check(self.kern_entry_addr, "kern_entry_addr")
-        scenario_cfg_lib.os_kern_root_dev_check(self.kern_root_dev, "rootdev")
+        scenario_cfg_lib.os_kern_name_check(self.kern_name, "os_config", "name")
+        scenario_cfg_lib.os_kern_type_check(self.kern_type, "os_config", "kern_type")
+        scenario_cfg_lib.os_kern_mod_check(self.kern_mod, "os_config", "kern_mod")
+        scenario_cfg_lib.os_kern_args_check(self.kern_args, "os_config", "kern_args")
+        scenario_cfg_lib.os_kern_console_check(self.kern_console, "os_config", "console")
+        scenario_cfg_lib.os_kern_load_addr_check(self.kern_load_addr, "os_config", "kern_load_addr")
+        scenario_cfg_lib.os_kern_entry_addr_check(self.kern_entry_addr, "os_config", "kern_entry_addr")
+        scenario_cfg_lib.os_kern_root_dev_check(self.kern_root_dev, "os_config", "rootdev")
 
 
 class VuartTarget:
@@ -195,8 +195,8 @@ class MemInfo:
         Check all items in this class
         :return: None
         """
-        scenario_cfg_lib.mem_start_hpa_check(self.mem_start_hpa, "start_hpa")
-        scenario_cfg_lib.mem_size_check(self.mem_size, "size")
+        scenario_cfg_lib.mem_start_hpa_check(self.mem_start_hpa, "memory", "start_hpa")
+        scenario_cfg_lib.mem_size_check(self.mem_size, "memory", "size")
 
 
 class CfgPci:
@@ -212,14 +212,14 @@ class CfgPci:
         Get pci device number items
         :return: None
         """
-        self.pci_dev_num = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "pci_dev_num")
+        self.pci_dev_num = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "pci_dev_num")
 
     def get_pci_devs(self):
         """
         Get pci devices items
         :return: None
         """
-        self.pci_devs = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "pci_devs")
+        self.pci_devs = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "pci_devs")
 
     def get_info(self):
         """
@@ -274,14 +274,14 @@ class VmInfo:
         Get all items which belong to this class
         :return: None
         """
-        self.name = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "name")
-        self.load_order = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "load_order")
-        self.uuid = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "uuid")
+        self.name = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "name")
+        self.load_order = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "load_order")
+        self.uuid = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "uuid")
         self.guest_flag_idx = scenario_cfg_lib.get_sub_leaf_tag(
             self.scenario_info, "guest_flags", "guest_flag")
         self.cpus_per_vm = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "vcpu_affinity", "pcpu_id")
-        self.clos_set = scenario_cfg_lib.get_branch_tag_map(self.scenario_info, "clos")
+        self.clos_set = scenario_cfg_lib.get_leaf_tag_map(self.scenario_info, "clos")
         self.epc_section.get_info()
         self.mem_info.get_info()
         self.os_cfg.get_info()

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -150,8 +150,8 @@ def is_need_epc(epc_section, i, config):
         return
     else:
         print("\t\t.epc= {", file=config)
-        print('\t\t\t.base = "{0}",'.format(epc_section.base), file=config)
-        print('\t\t\t.size = {0},'.format(epc_section.size), file=config)
+        print('\t\t\t.base = {0},'.format(epc_section.base[i]), file=config)
+        print('\t\t\t.size = {0},'.format(epc_section.size[i]), file=config)
         print("\t\t},", file=config)
 
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -26,5 +26,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -26,5 +26,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -26,5 +26,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -26,5 +26,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -26,5 +26,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -26,5 +26,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -10,6 +10,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -26,5 +26,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability"></rtos_type>
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc=""></vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc=""></rootfs_dev>
 	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -10,6 +10,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -26,5 +26,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability"></rtos_type>
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc=""></vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc=""></rootfs_dev>
 	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -26,6 +26,9 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
     <uos id="2">
 	<uos_type desc="UOS type"></uos_type>
@@ -54,5 +57,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -10,6 +10,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -41,6 +42,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability"></rtos_type>
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc=""></vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc=""></rootfs_dev>
 	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>
@@ -36,7 +36,7 @@
 	<rtos_type desc="UOS Realtime capability"></rtos_type>
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc=""></vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc=""></rootfs_dev>
 	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -10,6 +10,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -26,5 +26,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability"></rtos_type>
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc=""></vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc=""></rootfs_dev>
 	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -23,5 +23,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
 	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
@@ -35,7 +35,7 @@
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc="" readonly="true">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -24,6 +24,9 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 
     <uos id="2">
@@ -50,5 +53,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -38,6 +39,7 @@
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -27,5 +27,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -23,5 +23,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
 	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
@@ -35,7 +35,7 @@
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc="" readonly="true">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -24,6 +24,9 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 
     <uos id="2">
@@ -50,5 +53,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -38,6 +39,7 @@
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -27,5 +27,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -23,5 +23,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
 	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
@@ -35,7 +35,7 @@
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc="" readonly="true">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -24,6 +24,9 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 
     <uos id="2">
@@ -50,5 +53,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -38,6 +39,7 @@
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -27,5 +27,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -23,5 +23,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
 	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -4,7 +4,7 @@
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
-	<vbootloader desc="virtual bootloader method">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
@@ -35,7 +35,7 @@
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
-	<vbootloader desc="" readonly="true">ovmf</vbootloader>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -24,6 +24,9 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 
     <uos id="2">
@@ -50,5 +53,9 @@
 		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
 	</passthrough_devices>
+
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -38,6 +39,7 @@
 	<rootfs_dev configurable="0" desc=""></rootfs_dev>
 	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -11,6 +11,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -27,5 +27,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -8,6 +8,7 @@
 	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
 	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -24,5 +24,8 @@
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
+	<virtio_devices>
+		<input desc="virtio input device"></input>
+	</virtio_devices>
     </uos>
 </acrn-config>


### PR DESCRIPTION

- correct epc_section base/size value
- add usb xhci mediator support for
- add 'usb_xhci' info to launch xmls
- add virtio-input support for launch
- add 'virtio-input' info in launch xmls
- refinement for library config

    Tracked-On: #4164
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
