### PR TITLE
hv: ept: apply MCE on page size change mitigation conditionally

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -21,10 +21,10 @@ config LOGICAL_PARTITION
 	help
 	  This scenario will run two pre-launched VMs.
 
-config INDUSTRY 
+config INDUSTRY
 	bool "Industry VMs"
 	help
-	  This scenario is a typical scenario for industry usage with 4 VMs: 
+	  This scenario is a typical scenario for industry usage with 4 VMs:
 	  one pre-launched SOS VM, one post-launched Standard VM for HMI, one or two
 	  post-launched  RT VM for real-time control.
 
@@ -304,3 +304,12 @@ config UEFI_OS_LOADER_NAME
 	  Name of the UEFI bootloader that starts the Service VM. This is
 	  typically the systemd-boot or Grub bootloader but could be any other
 	  UEFI executable.
+
+config MCE_ON_PSC_WORKAROUND_DISABLED
+	bool "Force to disable software workaround for Machine Check Error on Page Size Change"
+	default n
+	help
+	  By default, software workaround for Machine Check Error on Page Size Change is
+	  conditionally applied to the models that may be affected by the issue. However,
+	  the software workaround has negative impact on performance. If all the guest OS
+	  kernels are trusted, this option may be set for performance.

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -296,7 +296,8 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 			pr_fatal("%s, pde 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			if (mem_ops->pgentry_present(*pde) == 0UL) {
-				if (mem_aligned_check(paddr, PDE_SIZE) &&
+				if (mem_ops->large_page_enabled &&
+					mem_aligned_check(paddr, PDE_SIZE) &&
 					mem_aligned_check(vaddr, PDE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {
 					mem_ops->tweak_exe_right(&prot);
@@ -343,7 +344,8 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 			pr_fatal("%s, pdpte 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			if (mem_ops->pgentry_present(*pdpte) == 0UL) {
-				if (mem_aligned_check(paddr, PDPTE_SIZE) &&
+				if (mem_ops->large_page_enabled &&
+					mem_aligned_check(paddr, PDPTE_SIZE) &&
 					mem_aligned_check(vaddr, PDPTE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {
 					mem_ops->tweak_exe_right(&prot);

--- a/hypervisor/arch/x86/security.c
+++ b/hypervisor/arch/x86/security.c
@@ -185,6 +185,12 @@ void set_fs_base(void)
 }
 #endif
 
+#ifdef CONFIG_MCE_ON_PSC_WORKAROUND_DISABLED
+bool is_ept_force_4k_ipage(void)
+{
+	return false;
+}
+#else
 bool is_ept_force_4k_ipage(void)
 {
 	bool force_4k_ipage = true;
@@ -229,3 +235,4 @@ bool is_ept_force_4k_ipage(void)
 
 	return force_4k_ipage;
 }
+#endif

--- a/hypervisor/include/arch/x86/msr.h
+++ b/hypervisor/include/arch/x86/msr.h
@@ -630,12 +630,13 @@ void update_msr_bitmap_x2apic_passthru(struct acrn_vcpu *vcpu);
 #define PRED_SET_IBPB				(1U << 0U)
 
 /* IA32 ARCH Capabilities bit */
-#define IA32_ARCH_CAP_RDCL_NO			(1U << 0U)
-#define IA32_ARCH_CAP_IBRS_ALL			(1U << 1U)
-#define IA32_ARCH_CAP_RSBA			(1U << 2U)
-#define IA32_ARCH_CAP_SKIP_L1DFL_VMENTRY	(1U << 3U)
-#define IA32_ARCH_CAP_SSB_NO			(1U << 4U)
-#define IA32_ARCH_CAP_MDS_NO			(1U << 5U)
+#define IA32_ARCH_CAP_RDCL_NO			(1UL << 0U)
+#define IA32_ARCH_CAP_IBRS_ALL			(1UL << 1U)
+#define IA32_ARCH_CAP_RSBA			(1UL << 2U)
+#define IA32_ARCH_CAP_SKIP_L1DFL_VMENTRY	(1UL << 3U)
+#define IA32_ARCH_CAP_SSB_NO			(1UL << 4U)
+#define IA32_ARCH_CAP_MDS_NO			(1UL << 5U)
+#define IA32_ARCH_CAP_IF_PSCHANGE_MC_NO		(1UL << 6U)
 
 /* Flush L1 D-cache */
 #define IA32_L1D_FLUSH				(1UL << 0U)

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -64,6 +64,7 @@ union pgtable_pages_info {
 
 struct memory_ops {
 	union pgtable_pages_info *info;
+	bool large_page_enabled;
 	uint64_t (*get_default_access_right)(void);
 	uint64_t (*pgentry_present)(uint64_t pte);
 	struct page *(*get_pml4_page)(const union pgtable_pages_info *info);

--- a/hypervisor/include/arch/x86/security.h
+++ b/hypervisor/include/arch/x86/security.h
@@ -21,6 +21,7 @@ int32_t get_ibrs_type(void);
 void cpu_l1d_flush(void);
 bool check_cpu_security_cap(void);
 void cpu_internal_buffers_clear(void);
+bool is_ept_force_4k_ipage(void);
 
 #ifdef STACK_PROTECTOR
 struct stack_canary {


### PR DESCRIPTION
In order to mitigate the issue Machine Check Error on Page Size Change, hypervisor force to break large pages (2MB/1GB) to 4KB pages in EPT on instruction fetch in VM.
However, the mitigate has performance penalty. So only apply the mitigation conditionally.
- Turn off the mitigation for the processor models that are known immune to the issue.
- Add an option to force to disable the mitigation when all VMs are trusted.
- Build 4KB page mapping in EPT for RTVM

Tracked-On: #4101
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>