### PR TITLE
acrn-config: add mmcfg base address for board config

### DIFF
--- a/misc/acrn-config/board_config/acpi_platform_h.py
+++ b/misc/acrn-config/board_config/acpi_platform_h.py
@@ -168,6 +168,7 @@ def platform_info_parser(config, default_platform):
     write_direct_info_parser(config, "<WAKE_VECTOR_INFO>", "</WAKE_VECTOR_INFO>")
     write_direct_info_parser(config, "<RESET_REGISTER_INFO>", "</RESET_REGISTER_INFO>")
     drhd_info_parser(config)
+    write_direct_info_parser(config, "<MMCFG_BASE_INFO>", "</MMCFG_BASE_INFO>")
 
 
 def generate_file(config, default_platform):

--- a/misc/acrn-config/xmls/board-xmls/apl-mrb.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-mrb.xml
@@ -253,6 +253,11 @@
 	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P16 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:L2
 	clos max:4

--- a/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
@@ -227,6 +227,11 @@
 	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P4 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:L2
 	clos max:4

--- a/misc/acrn-config/xmls/board-xmls/apl-up2.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2.xml
@@ -227,6 +227,11 @@
 	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P4 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:L2
 	clos max:4

--- a/misc/acrn-config/xmls/board-xmls/nuc6cayh.xml
+++ b/misc/acrn-config/xmls/board-xmls/nuc6cayh.xml
@@ -183,6 +183,11 @@
 	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P8 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:L2
 	clos max:4

--- a/misc/acrn-config/xmls/board-xmls/nuc7i7dnb.xml
+++ b/misc/acrn-config/xmls/board-xmls/nuc7i7dnb.xml
@@ -181,6 +181,11 @@
 	{0x190UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000400UL, 0x000400UL},	/* P15 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:False
 	clos max:0

--- a/misc/acrn-config/xmls/board-xmls/whl-ipc-i5.xml
+++ b/misc/acrn-config/xmls/board-xmls/whl-ipc-i5.xml
@@ -173,6 +173,11 @@
 	{0x3E8UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000A00UL, 0x000A00UL},	/* P5 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:False
 	clos max:0

--- a/misc/acrn-config/xmls/board-xmls/whl-ipc-i7.xml
+++ b/misc/acrn-config/xmls/board-xmls/whl-ipc-i7.xml
@@ -177,6 +177,11 @@
 	{0x514UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000D00UL, 0x000D00UL},	/* P9 */
 	</PX_INFO>
 
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
+	</MMCFG_BASE_INFO>
+
 	<CLOS_INFO>
 	clos supported by cache:False
 	clos max:0


### PR DESCRIPTION

- add MMCFG_BASE_INFO item in board config
- get default pci mmcfg base address


   Tracked-On: #4173
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>

