### PR TITLE
hv: trap RDPMC instruction execution from any guest

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -283,6 +283,11 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	 */
 	value32 &= ~VMX_PROCBASED_CTLS_INVLPG;
 
+	/*
+	 * Enable VM_EXIT for rdpmc execution.
+	 */
+	value32 |= VMX_PROCBASED_CTLS_RDPMC;
+
 	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
 	pr_dbg("VMX_PROC_VM_EXEC_CONTROLS: 0x%x ", value32);
 


### PR DESCRIPTION
PMU is hidden from any guest, UD is expected when guest
try to execute 'rdpmc' instruction.

this patch sets 'RDPMC exiting' in Processorbased
VM-execution control.

Tracked-On: #3453
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>