### PR TITLE
trace leaf and subleaf of cpuid

### DIFF
--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -274,14 +274,13 @@ int32_t cpuid_vmexit_handler(struct acrn_vcpu *vcpu)
 	rbx = vcpu_get_gpreg(vcpu, CPU_REG_RBX);
 	rcx = vcpu_get_gpreg(vcpu, CPU_REG_RCX);
 	rdx = vcpu_get_gpreg(vcpu, CPU_REG_RDX);
+	TRACE_2L(TRACE_VMEXIT_CPUID, rax, rcx);
 	guest_cpuid(vcpu, (uint32_t *)&rax, (uint32_t *)&rbx,
 		(uint32_t *)&rcx, (uint32_t *)&rdx);
 	vcpu_set_gpreg(vcpu, CPU_REG_RAX, rax);
 	vcpu_set_gpreg(vcpu, CPU_REG_RBX, rbx);
 	vcpu_set_gpreg(vcpu, CPU_REG_RCX, rcx);
 	vcpu_set_gpreg(vcpu, CPU_REG_RDX, rdx);
-
-	TRACE_2L(TRACE_VMEXIT_CPUID, (uint64_t)vcpu->vcpu_id, 0UL);
 
 	return 0;
 }

--- a/misc/tools/acrntrace/scripts/formats
+++ b/misc/tools/acrntrace/scripts/formats
@@ -5,7 +5,7 @@
 0x00000011 CPU%(cpu)d 0x%(event)016x %(tsc)d vmenter
 0x00010001 CPU%(cpu)d 0x%(event)016x %(tsc)d external intr [vector = 0x%(1)08x]
 0x00010002 CPU%(cpu)d 0x%(event)016x %(tsc)d intr window
-0x00010004 CPU%(cpu)d 0x%(event)016x %(tsc)d cpuid [vcpuid = %(1)d]
+0x00010004 CPU%(cpu)d 0x%(event)016x %(tsc)d cpuid [leaf = 0x%(1)08x, subleaf = 0x%(2)08x]
 0x00010012 CPU%(cpu)d 0x%(event)016x %(tsc)d hypercall [vmid = %(1)d, hypercall id = 0x%(2)08x]
 0x0001001C CPU%(cpu)d 0x%(event)016x %(tsc)d cr access [access type = 0x%(1)08x, cr num = %(2)d]
 0x0001001F CPU%(cpu)d 0x%(event)016x %(tsc)d read msr [msr = 0x%(1)08x, val = 0x%(2)016x]


### PR DESCRIPTION
We care more about leaf and subleaf of cpuid than vcpu_id.
So, this patch changes the cpuid trace-entry to trace the leaf
and subleaf of this cpuid vmexit.