### PR TITLE
vpci: refine vmsi/vmsi-x remap

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -637,48 +637,43 @@ int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf, uint16_t
 
 	if (entry != NULL) {
 		ret = 0;
-		if (is_entry_active(entry) && (info->vmsi_data.full == 0U)) {
-			/* handle destroy case */
-			info->pmsi_data.full = 0U;
-		} else {
-			/* build physical config MSI, update to info->pmsi_xxx */
-			if (is_lapic_pt_configured(vm)) {
-				enum vm_vlapic_state vlapic_state = check_vm_vlapic_state(vm);
-				if (vlapic_state == VM_VLAPIC_X2APIC) {
-					/*
-					 * All the vCPUs are in x2APIC mode and LAPIC is Pass-through
-					 * Use guest vector to program the interrupt source
-					 */
-					ptirq_build_physical_msi(vm, info, entry, (uint32_t)info->vmsi_data.bits.vector);
-				} else if (vlapic_state == VM_VLAPIC_XAPIC) {
-					/*
-					 * All the vCPUs are in xAPIC mode and LAPIC is emulated
-					 * Use host vector to program the interrupt source
-					 */
-					ptirq_build_physical_msi(vm, info, entry, irq_to_vector(entry->allocated_pirq));
-				} else if (vlapic_state == VM_VLAPIC_TRANSITION) {
-					/*
-					 * vCPUs are in middle of transition, so do not program interrupt source
-					 * TODO: Devices programmed during transistion do not work after transition
-					 * as device is not programmed with interrupt info. Need to implement a
-					 * method to get interrupts working after transition.
-					 */
-					ret = -EFAULT;
-				} else {
-					/* Do nothing for VM_VLAPIC_DISABLED */
-					ret = -EFAULT;
-				}
-			} else {
+		/* build physical config MSI, update to info->pmsi_xxx */
+		if (is_lapic_pt_configured(vm)) {
+			enum vm_vlapic_state vlapic_state = check_vm_vlapic_state(vm);
+			if (vlapic_state == VM_VLAPIC_X2APIC) {
+				/*
+				 * All the vCPUs are in x2APIC mode and LAPIC is Pass-through
+				 * Use guest vector to program the interrupt source
+				 */
+				ptirq_build_physical_msi(vm, info, entry, (uint32_t)info->vmsi_data.bits.vector);
+			} else if (vlapic_state == VM_VLAPIC_XAPIC) {
+				/*
+				 * All the vCPUs are in xAPIC mode and LAPIC is emulated
+				 * Use host vector to program the interrupt source
+				 */
 				ptirq_build_physical_msi(vm, info, entry, irq_to_vector(entry->allocated_pirq));
+			} else if (vlapic_state == VM_VLAPIC_TRANSITION) {
+				/*
+				 * vCPUs are in middle of transition, so do not program interrupt source
+				 * TODO: Devices programmed during transistion do not work after transition
+				 * as device is not programmed with interrupt info. Need to implement a
+				 * method to get interrupts working after transition.
+				 */
+				ret = -EFAULT;
+			} else {
+				/* Do nothing for VM_VLAPIC_DISABLED */
+				ret = -EFAULT;
 			}
+		} else {
+			ptirq_build_physical_msi(vm, info, entry, irq_to_vector(entry->allocated_pirq));
+		}
 
-			if (ret == 0) {
-				entry->msi = *info;
-				vbdf.value = virt_bdf;
-				dev_dbg(ACRN_DBG_IRQ, "PCI %x:%x.%x MSI VR[%d] 0x%x->0x%x assigned to vm%d",
-					vbdf.bits.b, vbdf.bits.d, vbdf.bits.f, entry_nr, info->vmsi_data.bits.vector,
-					irq_to_vector(entry->allocated_pirq), entry->vm->vm_id);
-			}
+		if (ret == 0) {
+			entry->msi = *info;
+			vbdf.value = virt_bdf;
+			dev_dbg(ACRN_DBG_IRQ, "PCI %x:%x.%x MSI VR[%d] 0x%x->0x%x assigned to vm%d",
+				vbdf.bits.b, vbdf.bits.d, vbdf.bits.f, entry_nr, info->vmsi_data.bits.vector,
+				irq_to_vector(entry->allocated_pirq), entry->vm->vm_id);
 		}
 	}
 

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -36,68 +36,63 @@
 
 /**
  * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+static inline void enable_disable_msi(const struct pci_vdev *vdev, bool enable)
+{
+	union pci_bdf pbdf = vdev->pdev->bdf;
+	uint32_t capoff = vdev->msi.capoff;
+	uint32_t msgctrl = pci_pdev_read_cfg(pbdf, capoff + PCIR_MSI_CTRL, 2U);
+
+	if (enable) {
+		msgctrl |= PCIM_MSICTRL_MSI_ENABLE;
+	} else {
+		msgctrl &= ~PCIM_MSICTRL_MSI_ENABLE;
+	}
+	pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_CTRL, 2U, msgctrl);
+}
+/**
+ * @brief Remap vMSI virtual address and data to MSI physical address and data
+ * This function is called when physical MSI is disabled.
+ *
+ * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  */
-static int32_t remap_vmsi(const struct pci_vdev *vdev, bool enable)
+static void remap_vmsi(const struct pci_vdev *vdev)
 {
-	struct ptirq_msi_info info;
+	struct ptirq_msi_info info = {};
 	union pci_bdf pbdf = vdev->pdev->bdf;
 	struct acrn_vm *vm = vdev->vpci->vm;
 	uint32_t capoff = vdev->msi.capoff;
-	uint32_t msgctrl, msgdata;
-	uint32_t addrlo, addrhi;
-	int32_t ret;
-
-	/* Disable MSI during configuration */
-	msgctrl = pci_vdev_read_cfg(vdev, capoff + PCIR_MSI_CTRL, 2U);
-	if ((msgctrl & PCIM_MSICTRL_MSI_ENABLE) == PCIM_MSICTRL_MSI_ENABLE) {
-		pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_CTRL, 2U, msgctrl & ~PCIM_MSICTRL_MSI_ENABLE);
-	}
+	uint32_t vmsi_msgdata, vmsi_addrlo, vmsi_addrhi = 0U;
 
 	/* Read the MSI capability structure from virtual device */
-	addrlo = pci_vdev_read_cfg_u32(vdev, capoff + PCIR_MSI_ADDR);
-	if ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) {
-		msgdata = pci_vdev_read_cfg_u16(vdev, capoff + PCIR_MSI_DATA_64BIT);
-		addrhi = pci_vdev_read_cfg_u32(vdev, capoff + PCIR_MSI_ADDR_HIGH);
+	vmsi_addrlo = pci_vdev_read_cfg_u32(vdev, capoff + PCIR_MSI_ADDR);
+	if (vdev->msi.is_64bit) {
+		vmsi_addrhi = pci_vdev_read_cfg_u32(vdev, capoff + PCIR_MSI_ADDR_HIGH);
+		vmsi_msgdata = pci_vdev_read_cfg_u16(vdev, capoff + PCIR_MSI_DATA_64BIT);
 	} else {
-		msgdata = pci_vdev_read_cfg_u16(vdev, capoff + PCIR_MSI_DATA);
-		addrhi = 0U;
+		vmsi_msgdata = pci_vdev_read_cfg_u16(vdev, capoff + PCIR_MSI_DATA);
 	}
+	info.vmsi_addr.full = (uint64_t)vmsi_addrlo | ((uint64_t)vmsi_addrhi << 32U);
+	info.vmsi_data.full = vmsi_msgdata;
 
-	info.vmsi_addr.full = (uint64_t)addrlo | ((uint64_t)addrhi << 32U);
-
-	/* MSI is being enabled or disabled */
-	if (enable) {
-		info.vmsi_data.full = msgdata;
-	} else {
-		info.vmsi_data.full = 0U;
-	}
-
-	ret = ptirq_prepare_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info);
-	if (ret == 0) {
-		/* Update MSI Capability structure to physical device */
-		if ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) {
+	if (ptirq_prepare_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info) == 0) {
+		pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR, 0x4U, (uint32_t)info.pmsi_addr.full);
+		if (vdev->msi.is_64bit) {
+			pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR_HIGH, 0x4U,
+					(uint32_t)(info.pmsi_addr.full >> 32U));
 			pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_DATA_64BIT, 0x2U, (uint16_t)info.pmsi_data.full);
 		} else {
 			pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_DATA, 0x2U, (uint16_t)info.pmsi_data.full);
 		}
 
-		if (enable) {
-			pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR, 0x4U, (uint32_t)info.pmsi_addr.full);
-			if ((msgctrl & PCIM_MSICTRL_64BIT) != 0U) {
-				pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR_HIGH, 0x4U,
-					(uint32_t)(info.pmsi_addr.full >> 32U));
-			}
-
-			/* If MSI Enable is being set, make sure INTxDIS bit is set */
-			enable_disable_pci_intx(pbdf, false);
-			pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_CTRL, 2U, msgctrl | PCIM_MSICTRL_MSI_ENABLE);
-		}
+		/* If MSI Enable is being set, make sure INTxDIS bit is set */
+		enable_disable_pci_intx(pbdf, false);
+		enable_disable_msi(vdev, true);
 	}
-
-	return ret;
 }
 
 /**
@@ -116,30 +111,14 @@ void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
  */
 void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	bool message_changed = false;
-	bool enable;
 	uint32_t msgctrl;
 
-	/* Save msgctrl for comparison */
-	msgctrl = pci_vdev_read_cfg(vdev, vdev->msi.capoff + PCIR_MSI_CTRL, 2U);
-
-	/* Either Message Data or message Addr is being changed */
-	if (((offset - vdev->msi.capoff) >= PCIR_MSI_ADDR) && (val != pci_vdev_read_cfg(vdev, offset, bytes))) {
-		message_changed = true;
-	}
-
-	/* Write to vdev */
+	enable_disable_msi(vdev, false);
 	pci_vdev_write_cfg(vdev, offset, bytes, val);
 
-	/* Do remap if MSI Enable bit is being changed */
-	if (((offset - vdev->msi.capoff) == PCIR_MSI_CTRL) &&
-		(((msgctrl ^ val) & PCIM_MSICTRL_MSI_ENABLE) != 0U)) {
-		enable = ((val & PCIM_MSICTRL_MSI_ENABLE) != 0U);
-		(void)remap_vmsi(vdev, enable);
-	} else {
-		if (message_changed && ((msgctrl & PCIM_MSICTRL_MSI_ENABLE) != 0U)) {
-			(void)remap_vmsi(vdev, true);
-		}
+	msgctrl = pci_vdev_read_cfg(vdev, vdev->msi.capoff + PCIR_MSI_CTRL, 2U);
+	if ((msgctrl & PCIM_MSICTRL_MSI_ENABLE) != 0U) {
+		remap_vmsi(vdev);
 	}
 }
 
@@ -169,6 +148,7 @@ void init_vmsi(struct pci_vdev *vdev)
 	if (has_msi_cap(vdev)) {
 		val = pci_pdev_read_cfg(pdev->bdf, vdev->msi.capoff, 4U);
 		vdev->msi.caplen = ((val & (PCIM_MSICTRL_64BIT << 16U)) != 0U) ? 14U : 10U;
+		vdev->msi.is_64bit = ((val & (PCIM_MSICTRL_64BIT << 16U)) != 0U);
 
 		val &= ~((uint32_t)PCIM_MSICTRL_MMC_MASK << 16U);
 		val &= ~((uint32_t)PCIM_MSICTRL_MME_MASK << 16U);

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -48,119 +48,66 @@ static inline bool msixtable_access(const struct pci_vdev *vdev, uint32_t offset
 
 /**
  * @pre vdev != NULL
+ */
+static inline struct msix_table_entry *get_msix_table_entry(const struct pci_vdev *vdev, uint32_t index)
+{
+	void *hva = hpa2hva(vdev->msix.mmio_hpa + vdev->msix.table_offset);
+	return ((struct msix_table_entry *)hva + index);
+}
+
+/**
+ * @pre vdev != NULL
+ */
+static void mask_one_msix_vector(const struct pci_vdev *vdev, uint32_t index)
+{
+	uint32_t vector_control;
+	struct msix_table_entry *pentry = get_msix_table_entry(vdev, index);
+
+	stac();
+	vector_control = pentry->vector_control | PCIM_MSIX_VCTRL_MASK;
+	mmio_write32(vector_control, (void *)&(pentry->vector_control));
+	clac();
+}
+
+/**
+ * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  */
-static int32_t remap_vmsix_entry(const struct pci_vdev *vdev, uint32_t index, bool enable)
+static void remap_one_vmsix_entry(const struct pci_vdev *vdev, uint32_t index)
 {
+	const struct msix_table_entry *ventry;
 	struct msix_table_entry *pentry;
-	struct ptirq_msi_info info;
-	void *hva;
+	struct ptirq_msi_info info = {};
 	int32_t ret;
 
-	info.vmsi_addr.full = vdev->msix.table_entries[index].addr;
-	info.vmsi_data.full = (enable) ? vdev->msix.table_entries[index].data : 0U;
+	mask_one_msix_vector(vdev, index);
+	ventry = &vdev->msix.table_entries[index];
+	if ((ventry->vector_control & PCIM_MSIX_VCTRL_MASK) == 0U) {
+		info.vmsi_addr.full = vdev->msix.table_entries[index].addr;
+		info.vmsi_data.full = vdev->msix.table_entries[index].data;
 
-	ret = ptirq_prepare_msix_remap(vdev->vpci->vm, vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
-	if (ret == 0) {
-		/* Write the table entry to the physical structure */
-		hva = hpa2hva(vdev->msix.mmio_hpa + vdev->msix.table_offset);
-		pentry = (struct msix_table_entry *)hva + index;
+		ret = ptirq_prepare_msix_remap(vdev->vpci->vm, vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
+		if (ret == 0) {
+			/* Write the table entry to the physical structure */
+			pentry = get_msix_table_entry(vdev, index);
 
-		/*
-		 * PCI 3.0 Spec allows writing to Message Address and Message Upper Address
-		 * fields with a single QWORD write, but some hardware can accept 32 bits
-		 * write only
-		 */
-		stac();
-		mmio_write32((uint32_t)(info.pmsi_addr.full), (void *)&(pentry->addr));
-		mmio_write32((uint32_t)(info.pmsi_addr.full >> 32U), (void *)((char *)&(pentry->addr) + 4U));
+			/*
+			 * PCI 3.0 Spec allows writing to Message Address and Message Upper Address
+			 * fields with a single QWORD write, but some hardware can accept 32 bits
+			 * write only
+			 */
+			stac();
+			mmio_write32((uint32_t)(info.pmsi_addr.full), (void *)&(pentry->addr));
+			mmio_write32((uint32_t)(info.pmsi_addr.full >> 32U), (void *)((char *)&(pentry->addr) + 4U));
 
-		mmio_write32(info.pmsi_data.full, (void *)&(pentry->data));
-		mmio_write32(vdev->msix.table_entries[index].vector_control, (void *)&(pentry->vector_control));
-		clac();
-	}
-
-	return ret;
-}
-
-/**
- * @pre vdev != NULL
- * @pre vdev->pdev != NULL
- */
-static inline void enable_disable_msix(const struct pci_vdev *vdev, bool enable)
-{
-	uint32_t msgctrl;
-
-	msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
-	if (enable) {
-		msgctrl |= PCIM_MSIXCTRL_MSIX_ENABLE;
-	} else {
-		msgctrl &= ~PCIM_MSIXCTRL_MSIX_ENABLE;
-	}
-	pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
-}
-
-/**
- * Do MSI-X remap for all MSI-X table entries in the target device
- * @pre vdev != NULL
- * @pre vdev->pdev != NULL
- */
-static int32_t remap_vmsix(const struct pci_vdev *vdev, bool enable)
-{
-	uint32_t index;
-	int32_t ret = 0;
-
-	/* disable MSI-X during configuration */
-	enable_disable_msix(vdev, false);
-
-	for (index = 0U; index < vdev->msix.table_count; index++) {
-		ret = remap_vmsix_entry(vdev, index, enable);
-		if (ret != 0) {
-			break;
+			mmio_write32(info.pmsi_data.full, (void *)&(pentry->data));
+			mmio_write32(vdev->msix.table_entries[index].vector_control, (void *)&(pentry->vector_control));
+			clac();
 		}
 	}
 
-	/* If MSI Enable is being set, make sure INTxDIS bit is set */
-	if (ret == 0) {
-		if (enable) {
-			enable_disable_pci_intx(vdev->pdev->bdf, false);
-		}
-		enable_disable_msix(vdev, enable);
-	}
-
-	return ret;
-}
-
-/**
- * Do MSI-X remap for one MSI-X table entry only
- * @pre vdev != NULL
- * @pre vdev->pdev != NULL
- */
-static int32_t remap_one_vmsx_entry(const struct pci_vdev *vdev, uint32_t index, bool enable)
-{
-	uint32_t msgctrl;
-	int32_t ret;
-
-	/* disable MSI-X during configuration */
-	enable_disable_msix(vdev, false);
-
-	ret = remap_vmsix_entry(vdev, index, enable);
-	if (ret == 0) {
-		/* If MSI Enable is being set, make sure INTxDIS bit is set */
-		if (enable) {
-			enable_disable_pci_intx(vdev->pdev->bdf, false);
-		}
-
-		/* Restore MSI-X Enable bit */
-		msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
-		if ((msgctrl & PCIM_MSIXCTRL_MSIX_ENABLE) == PCIM_MSIXCTRL_MSIX_ENABLE) {
-			pci_pdev_write_cfg(vdev->pdev->bdf, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U, msgctrl);
-		}
-	}
-
-	return ret;
 }
 
 /**
@@ -180,26 +127,19 @@ void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes
  */
 void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	uint32_t msgctrl;
+	uint32_t old_msgctrl, msgctrl;
 
-	msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
-
+	old_msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
 	/* Write to vdev */
 	pci_vdev_write_cfg(vdev, offset, bytes, val);
+	msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
 
-	/* Writing Message Control field? */
-	if ((offset - vdev->msix.capoff) == PCIR_MSIX_CTRL) {
-		if (((msgctrl ^ val) & PCIM_MSIXCTRL_MSIX_ENABLE) != 0U) {
-			if ((val & PCIM_MSIXCTRL_MSIX_ENABLE) != 0U) {
-				(void)remap_vmsix(vdev, true);
-			} else {
-				(void)remap_vmsix(vdev, false);
-			}
+	if (((old_msgctrl ^ msgctrl) & (PCIM_MSIXCTRL_MSIX_ENABLE | PCIM_MSIXCTRL_FUNCTION_MASK)) != 0U) {
+		/* If MSI Enable is being set, make sure INTxDIS bit is set */
+		if ((msgctrl & PCIM_MSIXCTRL_MSIX_ENABLE) != 0U) {
+			enable_disable_pci_intx(vdev->pdev->bdf, false);
 		}
-
-		if (((msgctrl ^ val) & PCIM_MSIXCTRL_FUNCTION_MASK) != 0U) {
-			pci_pdev_write_cfg(vdev->pdev->bdf, offset, 2U, val);
-		}
+		pci_pdev_write_cfg(vdev->pdev->bdf, offset, 2U, msgctrl);
 	}
 }
 
@@ -207,12 +147,10 @@ void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uin
  * @pre vdev != NULL
  * @pre mmio != NULL
  */
-static void rw_vmsix_table(const struct pci_vdev *vdev, struct mmio_request *mmio, uint32_t offset)
+static void rw_vmsix_table(struct pci_vdev *vdev, struct mmio_request *mmio, uint32_t offset)
 {
-	const struct msix_table_entry *entry;
-	uint32_t vector_control, entry_offset, table_offset, index;
-	bool message_changed = false;
-	bool unmasked;
+	struct msix_table_entry *entry;
+	uint32_t entry_offset, table_offset, index;
 
 	/* Find out which entry it's accessing */
 	table_offset = offset - vdev->msix.table_offset;
@@ -228,43 +166,10 @@ static void rw_vmsix_table(const struct pci_vdev *vdev, struct mmio_request *mmi
 		} else {
 			/* Only DWORD and QWORD are permitted */
 			if ((mmio->size == 4U) || (mmio->size == 8U)) {
-				/* Save for comparison */
-				vector_control = entry->vector_control;
-
-				/*
-				 * Writing different value to Message Data/Addr?
-				 * PCI Spec: Software is permitted to fill in MSI-X Table entry DWORD fields
-				 * individually with DWORD writes, or software in certain cases is permitted
-				 * to fill in appropriate pairs of DWORDs with a single QWORD write
-				 */
-				if (entry_offset < offsetof(struct msix_table_entry, data)) {
-					uint64_t qword_mask = ~0UL;
-
-					if (mmio->size == 4U) {
-						qword_mask = (entry_offset == 0U) ?
-								0x00000000FFFFFFFFUL : 0xFFFFFFFF00000000UL;
-					}
-					message_changed = ((entry->addr & qword_mask) != (mmio->value & qword_mask));
-				} else {
-					if (entry_offset == offsetof(struct msix_table_entry, data)) {
-						message_changed = (entry->data != (uint32_t)mmio->value);
-					}
-				}
-
 				/* Write to pci_vdev */
 				(void)memcpy_s((void *)entry + entry_offset, (size_t)mmio->size,
 						&mmio->value, (size_t)mmio->size);
-
-				/* If MSI-X hasn't been enabled, do nothing */
-				if ((pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U)
-						& PCIM_MSIXCTRL_MSIX_ENABLE) == PCIM_MSIXCTRL_MSIX_ENABLE) {
-
-					if ((((entry->vector_control ^ vector_control) & PCIM_MSIX_VCTRL_MASK) != 0U)
-							|| message_changed) {
-						unmasked = ((entry->vector_control & PCIM_MSIX_VCTRL_MASK) == 0U);
-						(void)remap_one_vmsx_entry(vdev, index, unmasked);
-					}
-				}
+				remap_one_vmsix_entry(vdev, index);
 			} else {
 				pr_err("%s, Only DWORD and QWORD are permitted", __func__);
 			}

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -51,6 +51,7 @@ struct msix_table_entry {
 
 /* MSI capability structure */
 struct pci_msi {
+	bool      is_64bit;
 	uint32_t  capoff;
 	uint32_t  caplen;
 };


### PR DESCRIPTION
1. Do vMSI-X remap only when Mask Bit in Vector Control Register for MSI-X Table Entry is unmask
2. fix the Message Control Register check logic when doing vmsi/vmsi-x remap
3. fix the HV doesn't really disable MSI/MSI-X when guest wants to.

Tracked-On: #3475
Signed-off-by: Li Fei1 <fei1.li@intel.com>