### PR TITLE
acrn-config: add virtio-blk and virtio-net to support

### DIFF
--- a/misc/acrn-config/config_app/controller.py
+++ b/misc/acrn-config/config_app/controller.py
@@ -163,11 +163,17 @@ class XmlConfig:
         tag = args[-1]
         args = args[:-1]
         dest_node = self._get_dest_node(*args)
+        new_node_desc = None
         for node in dest_node.getchildren():
-            dest_node.remove(node)
+            if node.tag == tag:
+                if 'desc' in node.attrib:
+                    new_node_desc = node.attrib['desc']
+                dest_node.remove(node)
         for value in values:
             new_node = ElementTree.SubElement(dest_node, tag)
             new_node.text = value
+            if new_node_desc is not None:
+                new_node.attrib['desc'] = new_node_desc
 
     def set_curr_attr(self, attr_name, attr_value, *args):
         """

--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -510,7 +510,14 @@ function save_launch(generator=null) {
     $("input").each(function(){
         var id = $(this).attr('id');
     	var value = $(this).val();
-    	if(id!='new_launch_name' && id!='board_info_file'
+
+        if(id.indexOf('virtio_devices,network')>=0 || id.indexOf('virtio_devices,block')>=0) {
+            if(id in launch_config) {
+                launch_config[id].push(value);
+            } else {
+                launch_config[id] = [value];
+            }
+        } else if(id!='new_launch_name' && id!='board_info_file'
     	    && id!='board_info_upload' && id!='scenario_name'
     	    && id!="launch_file") {
             launch_config[id] = value;

--- a/misc/acrn-config/config_app/templates/launch.html
+++ b/misc/acrn-config/config_app/templates/launch.html
@@ -157,6 +157,7 @@
                 {% elif elem.getchildren() != [] %}
                     {% if 'multiselect' not in elem.attrib or elem.attrib['multiselect'] != 'true' %}
                     {% set first_child = [] %}
+                    {% set first_multi_child = {'block': 0, 'network': 0} %}
                         {% for sub_elem in elem.getchildren() %}
                             {% set sub_elem_text = '' if sub_elem.text == None else sub_elem.text %}
                             {% if 'configurable' not in sub_elem.attrib or sub_elem.attrib['configurable'] != '0' %}
@@ -178,7 +179,7 @@
                                         {{sub_elem.tag}}</label>
 
                                     {% if ','.join(['uos', elem.tag, sub_elem.tag]) not in launch_item_values %}
-                                    <div class="col-sm-6">
+                                    <div class="col-sm-5">
                                         {% if 'readonly' in sub_elem.attrib and sub_elem.attrib['readonly'] == 'true' %}
                                         <input type="text" class="form-control" readonly
                                                id="{{'uos:id='+vm.attrib['id']+','+elem.tag+','+sub_elem.tag}}"
@@ -189,6 +190,19 @@
                                                value="{{sub_elem_text}}">
                                         {% endif %}
                                     </div>
+
+                                    {% if elem.tag in ['virtio_devices'] and sub_elem.tag in ['block', 'network'] %}
+                                        <div class="col-sm-1">
+                                            <button type="button" class="btn" id="add_virtio_{{sub_elem.tag}}_{{first_multi_child[sub_elem.tag]}}">+</button>
+                                            {% if first_multi_child[sub_elem.tag] == 0 %}
+                                            <button type="button" disabled class="btn" id="remove_virtio_{{sub_elem.tag}}_{{first_multi_child[sub_elem.tag]}}">-</button>
+                                            {% else %}
+                                            <button type="button" class="btn" id="remove_virtio_{{sub_elem.tag}}_{{first_multi_child[sub_elem.tag]}}">-</button>
+                                            {% endif %}
+                                        </div>
+                                        {% do first_multi_child.update({sub_elem.tag: first_multi_child[sub_elem.tag]+1}) %}
+                                    {% endif%}
+
                                     {% else %}
                                     <div class="dropdown col-sm-6">
                                         {% if 'readonly' in sub_elem.attrib and sub_elem.attrib['readonly'] == 'true' %}

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -17,10 +17,18 @@ def is_nuc_whl_clr(names, vmid):
     return False
 
 
-def is_mount_needed(names, vmid):
-    uos_type = names['uos_types'][vmid]
-    if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS") and not is_nuc_whl_clr(names, vmid):
-         return True
+def is_mount_needed(virt_io, vmid):
+    rootfs_img = ''
+    blk_dev_list = launch_cfg_lib.get_rootdev_info(launch_cfg_lib.BOARD_INFO_FILE)
+    if virt_io['block'][vmid]:
+        if ':' in virt_io['block'][vmid]:
+            blk_dev = virt_io['block'][vmid].split(':')[0]
+            rootfs_img = virt_io['block'][vmid].split(':')[1]
+        else:
+            blk_dev = virt_io['block'][vmid]
+
+        if blk_dev in blk_dev_list and rootfs_img:
+            return True
 
     return False
 
@@ -264,7 +272,7 @@ def mem_size_set(args, vmid, config):
     print("mem_size={}M".format(mem_size), file=config)
 
 
-def uos_launch(names, args, vmid, config):
+def uos_launch(names, args, virt_io, vmid, config):
 
     gvt_args = args['gvt_args'][vmid]
     uos_type = names['uos_types'][vmid]
@@ -294,14 +302,14 @@ def uos_launch(names, args, vmid, config):
         if uos_type in ("CLEARLINUX", "WINDOWS"):
             print('launch_{} 1 "{}"'.format(launch_uos, gvt_args), file=config)
 
-    if is_mount_needed(names, vmid):
+    if is_mount_needed(virt_io, vmid):
         print("", file=config)
         print('launch_{} {} "{}" "{}" $debug'.format(launch_uos, vmid, gvt_args, vmid), file=config)
         print("", file=config)
         print("umount /data", file=config)
 
 
-def launch_end(names, args, vmid, config):
+def launch_end(names, args, virt_io, vmid, config):
 
     board_name = names['board_name']
     uos_type = names['uos_types'][vmid]
@@ -327,8 +335,8 @@ def launch_end(names, args, vmid, config):
         print("done", file=config)
         print("", file=config)
 
-    if is_mount_needed(names, vmid):
-        root_fs = args['rootfs_dev'][vmid]
+    if is_mount_needed(virt_io, vmid):
+        root_fs = virt_io['block'][vmid].split(':')[0]
 
         print('if [ ! -b "{}" ]; then'.format(root_fs), file=config)
         print('  echo "no {} data partition, exit"'.format(root_fs), file=config)
@@ -341,7 +349,7 @@ def launch_end(names, args, vmid, config):
 
     off_line_cpus(args, vmid, uos_type, config)
 
-    uos_launch(names, args, vmid, config)
+    uos_launch(names, args, virt_io, vmid, config)
 
 
 def set_dm_pt(names, sel, vmid, config):
@@ -413,7 +421,7 @@ def xhci_args_set(dm, vmid, config):
             launch_cfg_lib.virtual_dev_slot("xhci"), dm['xhci'][vmid]), file=config)
 
 
-def vritio_args_set(virt_io, vmid, config):
+def virtio_args_set(dm, virt_io, vmid, config):
 
     # virtio-input set, the value type is a list
     for input_val in virt_io['input'][vmid]:
@@ -421,15 +429,18 @@ def vritio_args_set(virt_io, vmid, config):
             print("   -s {},virtio-input,{} \\".format(
                 launch_cfg_lib.virtual_dev_slot("virtio-input{}".format(input_val)), input_val), file=config)
 
+    # virtio-blk set, the value type is a list
+    for blk in virt_io['block'][vmid]:
+        if blk:
+            print("   -s {},virtio-blk,{} \\".format(launch_cfg_lib.virtual_dev_slot("virtio-blk{}".format(blk)), blk.strip(':')), file=config)
+
 
 def dm_arg_set(names, sel, virt_io, dm, vmid, config):
 
     uos_type = names['uos_types'][vmid]
     board_name = names['board_name']
 
-    # vboot loader for vsbl
     boot_image_type(dm, vmid, config)
-    root_img = dm['rootfs_img'][vmid]
 
     # uuid get
     scenario_uuid = launch_cfg_lib.get_scenario_uuid()
@@ -495,7 +506,7 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     xhci_args_set(dm, vmid, config)
 
     # VIRTIO args set
-    vritio_args_set(virt_io, vmid, config)
+    virtio_args_set(dm, virt_io, vmid, config)
 
     # GVT args set
     gvt_arg_set(uos_type, config)
@@ -529,12 +540,6 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
 
         if not is_nuc_whl_clr(names, vmid):
             print("   -s {},wdt-i6300esb \\".format(launch_cfg_lib.virtual_dev_slot("wdt-i6300esb")), file=config)
-            #print("   -s {},xhci,1-1:1-2:1-3:2-1:2-2:2-3:cap=apl \\".format(launch_cfg_lib.virtual_dev_slot("xhci")), file=config)
-
-    if dm['vbootloader'][vmid] and dm['vbootloader'][vmid] == "vsbl":
-        print("   -s {},virtio-blk$boot_dev_flag,/data/{} \\".format(launch_cfg_lib.virtual_dev_slot("virtio-blk"), root_img), file=config)
-    elif dm['vbootloader'][vmid] and dm['vbootloader'][vmid] == "ovmf":
-        print("   -s {},virtio-blk,{} \\".format(launch_cfg_lib.virtual_dev_slot("virtio-blk"), root_img), file=config)
 
     if uos_type in ("ANDROID", "ALIOS"):
         print("   --enable_trusty \\", file=config)
@@ -568,4 +573,4 @@ def gen(names, pt_sel, virt_io, dm, vmid, config):
     dm_arg_set(names, pt_sel, virt_io, dm, vmid, config)
 
     # gen launch end
-    launch_end(names, dm, vmid, config)
+    launch_end(names, dm, virt_io, vmid, config)

--- a/misc/acrn-config/launch_config/launch_cfg_gen.py
+++ b/misc/acrn-config/launch_config/launch_cfg_gen.py
@@ -43,7 +43,6 @@ def get_launch_item_values(board_info):
     # acrn dm available optargs
     launch_item_values['uos,uos_type'] = launch_cfg_lib.UOS_TYPES
     launch_item_values["uos,rtos_type"] = launch_cfg_lib.RTOS_TYPE
-    launch_item_values["uos,rootfs_dev"] = launch_cfg_lib.get_rootdev_info(board_info)
 
     launch_item_values["uos,vbootloader"] = launch_cfg_lib.BOOT_TYPE
     launch_item_values['uos,console_type'] = launch_cfg_lib.REDIRECT_CONSOLE

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -18,8 +18,6 @@ class AcrnDmArgs:
         self.args["rtos_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "rtos_type")
         self.args["mem_size"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "mem_size")
         self.args["gvt_args"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "gvt_args")
-        self.args["rootfs_dev"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "rootfs_dev")
-        self.args["rootfs_img"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "rootfs_img")
         self.args["vbootloader"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vbootloader")
         self.args["console_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "console_type")
         self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
@@ -33,7 +31,6 @@ class AcrnDmArgs:
         launch_cfg_lib.args_aval_check(self.args["gvt_args"], "gvt_args", launch_cfg_lib.GVT_ARGS)
         launch_cfg_lib.args_aval_check(self.args["vbootloader"], "vbootloader", launch_cfg_lib.BOOT_TYPE)
         launch_cfg_lib.args_aval_check(self.args["console_type"], "console_type", launch_cfg_lib.REDIRECT_CONSOLE)
-        launch_cfg_lib.args_aval_check(self.args["rootfs_dev"], "rootfs_dev", rootfs)
 
 
 class AvailablePthru():
@@ -153,3 +150,4 @@ class VirtioDeviceSelect():
 
     def get_virtio(self):
         self.dev["input"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "input")
+        self.dev["block"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "block")

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -151,3 +151,4 @@ class VirtioDeviceSelect():
     def get_virtio(self):
         self.dev["input"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "input")
         self.dev["block"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "block")
+        self.dev["network"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "network")

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -23,7 +23,7 @@ GUEST_FLAG = ["0UL", "GUEST_FLAG_SECURE_WORLD_ENABLED", "GUEST_FLAG_LAPIC_PASSTH
 START_HPA_SIZE_LIST = ['0x20000000', '0x40000000', '0x80000000', 'CONFIG_SOS_RAM_SIZE', 'VM0_MEM_SIZE']
 
 
-MULTI_ITEM = ["guest_flag", "pcpu_id", "input", "block"]
+MULTI_ITEM = ["guest_flag", "pcpu_id", "input", "block", "network"]
 
 
 class MultiItem():
@@ -34,7 +34,7 @@ class MultiItem():
         self.vir_input = []
         self.vir_block = []
         self.vir_console = []
-        self.vir_net = []
+        self.vir_network = []
 
 class TmpItem():
 
@@ -420,6 +420,10 @@ def get_leaf_value(tmp, tag_str, leaf):
     if leaf.tag == "block" and tag_str == "block":
         tmp.multi.vir_block.append(leaf.text)
 
+    # get virtio-net for vm
+    if leaf.tag == "network" and tag_str == "network":
+        tmp.multi.vir_network.append(leaf.text)
+
 
 def get_sub_value(tmp, tag_str, vm_id):
 
@@ -439,6 +443,10 @@ def get_sub_value(tmp, tag_str, vm_id):
     # append virtio block for vm
     if tmp.multi.vir_block and tag_str == "block":
         tmp.tag[vm_id] = tmp.multi.vir_block
+
+    # append virtio network for vm
+    if tmp.multi.vir_network and tag_str == "network":
+        tmp.tag[vm_id] = tmp.multi.vir_network
 
 
 def get_leaf_tag_map(config_file, branch_tag, tag_str):

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -23,7 +23,7 @@ GUEST_FLAG = ["0UL", "GUEST_FLAG_SECURE_WORLD_ENABLED", "GUEST_FLAG_LAPIC_PASSTH
 START_HPA_SIZE_LIST = ['0x20000000', '0x40000000', '0x80000000', 'CONFIG_SOS_RAM_SIZE', 'VM0_MEM_SIZE']
 
 
-MULTI_ITEM = ["guest_flag", "pcpu_id", "input"]
+MULTI_ITEM = ["guest_flag", "pcpu_id", "input", "block"]
 
 
 class MultiItem():
@@ -32,6 +32,7 @@ class MultiItem():
         self.guest_flag = []
         self.pcpu_id = []
         self.vir_input = []
+        self.vir_block = []
         self.vir_console = []
         self.vir_net = []
 
@@ -415,6 +416,10 @@ def get_leaf_value(tmp, tag_str, leaf):
     if leaf.tag == "input" and tag_str == "input":
         tmp.multi.vir_input.append(leaf.text)
 
+    # get virtio-blk for vm
+    if leaf.tag == "block" and tag_str == "block":
+        tmp.multi.vir_block.append(leaf.text)
+
 
 def get_sub_value(tmp, tag_str, vm_id):
 
@@ -427,9 +432,13 @@ def get_sub_value(tmp, tag_str, vm_id):
     if tmp.multi.pcpu_id and tag_str == "pcpu_id":
         tmp.tag[vm_id] = tmp.multi.pcpu_id
 
-    # append input for vm
+    # append virtio input for vm
     if tmp.multi.vir_input and tag_str == "input":
         tmp.tag[vm_id] = tmp.multi.vir_input
+
+    # append virtio block for vm
+    if tmp.multi.vir_block and tag_str == "block":
+        tmp.tag[vm_id] = tmp.multi.vir_block
 
 
 def get_leaf_tag_map(config_file, branch_tag, tag_str):

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -461,7 +461,7 @@ def args_aval_check(arg_list, item, avl_list):
     """
     # args should be set into launch xml from webUI
     i_cnt = 1
-    skip_check_list = ['gvt_args', 'rootfs_dev']
+    skip_check_list = ['gvt_args']
     if item in skip_check_list:
         return
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk1p3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">android/android.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:android/android.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">AaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:android/android.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">AliaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:alios/alios.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk1p3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">alios/alios.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:alios/alios.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:clearlinux/clearlinux.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk1p3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">clearlinux/clearlinux.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:clearlinux/clearlinux.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk0p1</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">clearlinux/clearlinux.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:clearlinux/clearlinux.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:clearlinux/clearlinux.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">AaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:android/android.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk0p1</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">android/android.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:android/android.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/mmcblk0p1</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">clearlinux/clearlinux.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:clearlinux/clearlinux.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:clearlinux/clearlinux.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc=""></rootfs_dev>
-	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
@@ -29,6 +27,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -8,7 +8,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -26,6 +26,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc=""></rootfs_dev>
-	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
@@ -29,6 +27,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -8,7 +8,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -26,6 +26,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc=""></rootfs_dev>
-	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
@@ -29,6 +27,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
     <uos id="2">
@@ -37,8 +36,6 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc=""></rootfs_dev>
-	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
@@ -61,6 +58,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -8,7 +8,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -40,7 +40,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -26,6 +26,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
@@ -57,6 +58,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc=""></rootfs_dev>
-	<rootfs_img desc=""></rootfs_img>
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
@@ -29,6 +27,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -8,7 +8,7 @@
 	<console_type desc="UOS console type"></console_type>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -26,6 +26,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
-	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 
@@ -36,8 +35,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc=""></rootfs_dev>
-	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -58,6 +55,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -37,7 +37,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
@@ -54,6 +55,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">home/clear/uos/uos.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
-	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 
@@ -36,8 +35,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc=""></rootfs_dev>
-	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -58,6 +55,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -37,7 +37,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
@@ -54,6 +55,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">home/clear/uos/uos.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
-	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 
@@ -36,8 +35,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc=""></rootfs_dev>
-	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -58,6 +55,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -37,7 +37,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
@@ -54,6 +55,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">home/clear/uos/uos.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc="rootfs partition devices"></rootfs_dev>
-	<rootfs_img configurable="0" desc="rootfs image"></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./VxWorks.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./win10-ltsc.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
     </uos>
 
@@ -36,8 +35,6 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev configurable="0" desc=""></rootfs_dev>
-	<rootfs_img configurable="0" desc=""></rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -58,6 +55,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -37,7 +37,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
 	</virtio_devices>
@@ -54,6 +55,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">home/clear/uos/uos.img</rootfs_img>
 	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
@@ -30,6 +28,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -9,7 +9,7 @@
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -27,6 +27,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
 	</virtio_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -5,8 +5,6 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<rootfs_dev desc="rootfs partition devices" readonly="true">/dev/sda3</rootfs_dev>
-	<rootfs_img desc="rootfs image" readonly="true">./zephyr.img</rootfs_img>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
 
@@ -27,6 +25,7 @@
 
 	<virtio_devices>
 		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<console_type desc="UOS console type">com1(ttyS0)</console_type>
-	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2:4"></usb_xhci>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -24,6 +24,7 @@
 	</passthrough_devices>
 
 	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
 	</virtio_devices>


### PR DESCRIPTION
- update UI to support virtio devices
- modify the description of usb xhci
- add virtio-net mediator support for launch config
- add 'virtio-network' info in launch xmls
- add virtio-block support for launch config
- add rootfs_dev/rootfs_img with virtio-blk item

    Tracked-On: #4185
    Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
