### PR TITLE
Some bugfixs and preparation patches for sched_iorr

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -768,7 +768,7 @@ static void context_switch_in(struct thread_object *next)
 	struct acrn_vcpu *vcpu = list_entry(next, struct acrn_vcpu, thread_obj);
 	struct ext_context *ectx = &(vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx);
 
-	switch_vmcs(vcpu);
+	load_vmcs(vcpu);
 
 	msr_write(MSR_IA32_STAR, ectx->ia32_star);
 	msr_write(MSR_IA32_LSTAR, ectx->ia32_lstar);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -702,7 +702,9 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state)
 	vcpu->prev_state = vcpu->state;
 	vcpu->state = new_state;
 
-	sleep_thread(&vcpu->thread_obj);
+	if (vcpu->prev_state == VCPU_RUNNING) {
+		sleep_thread(&vcpu->thread_obj);
+	}
 	if (pcpu_id != get_pcpu_id()) {
 		while (vcpu->running) {
 			asm_pause();

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -540,7 +540,7 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 /**
  * @pre vcpu != NULL
  */
-void switch_vmcs(const struct acrn_vcpu *vcpu)
+void load_vmcs(const struct acrn_vcpu *vcpu)
 {
 	uint64_t vmcs_pa;
 	void **vmcs_ptr = &get_cpu_var(vmcs_run);

--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -40,6 +40,7 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	bool do_mem_log;
 	bool do_npk_log;
 	char *buffer;
+	struct thread_object *current;
 
 	do_console_log = (((logmsg_ctl.flags & LOG_FLAG_STDOUT) != 0U) && (severity <= console_loglevel));
 	do_mem_log = (((logmsg_ctl.flags & LOG_FLAG_MEMORY) != 0U) && (severity <= mem_loglevel));
@@ -58,11 +59,12 @@ void do_logmsg(uint32_t severity, const char *fmt, ...)
 	/* Get CPU ID */
 	pcpu_id = get_pcpu_id();
 	buffer = per_cpu(logbuf, pcpu_id);
+	current = sched_get_current(pcpu_id);
 
 	(void)memset(buffer, 0U, LOG_MESSAGE_MAX_SIZE);
 	/* Put time-stamp, CPU ID and severity into buffer */
-	snprintf(buffer, LOG_MESSAGE_MAX_SIZE, "[%luus][cpu=%hu][sev=%u][seq=%u]:",
-			timestamp, pcpu_id, severity, atomic_inc_return(&logmsg_ctl.seq));
+	snprintf(buffer, LOG_MESSAGE_MAX_SIZE, "[%luus][cpu=%hu][%s][sev=%u][seq=%u]:",
+			timestamp, pcpu_id, current->name, severity, atomic_inc_return(&logmsg_ctl.seq));
 
 	/* Put message into remaining portion of local buffer */
 	va_start(args, fmt);

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -126,18 +126,15 @@ int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_
 
 		/* Polling completion of the request in polling mode */
 		if (is_polling) {
-			/*
-			 * Now, we only have one case that will schedule out this vcpu
-			 * from IO completion polling status, it's pause_vcpu to VCPU_ZOMBIE.
-			 * In this case, we cannot come back to polling status again. Currently,
-			 * it's OK as we needn't handle IO completion in zombie status.
-			 */
-			while (!need_reschedule(pcpuid_from_vcpu(vcpu))) {
+			while (true) {
 				if (has_complete_ioreq(vcpu)) {
 					/* we have completed ioreq pending */
 					break;
 				}
 				asm_pause();
+				if (need_reschedule(pcpuid_from_vcpu(vcpu))) {
+					schedule();
+				}
 			}
 		} else if (need_reschedule(pcpuid_from_vcpu(vcpu))) {
 			schedule();

--- a/hypervisor/include/arch/x86/guest/vmcs.h
+++ b/hypervisor/include/arch/x86/guest/vmcs.h
@@ -41,7 +41,7 @@ static inline uint64_t apic_access_offset(uint64_t qual)
 	return (qual & APIC_ACCESS_OFFSET);
 }
 void init_vmcs(struct acrn_vcpu *vcpu);
-void switch_vmcs(const struct acrn_vcpu *vcpu);
+void load_vmcs(const struct acrn_vcpu *vcpu);
 
 void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu);
 #endif /* ASSEMBLER */


### PR DESCRIPTION
This patchset will add one scheduler named sched_iorr which support cpu sharing.
sched_iorr is short for IO sensitive Round-robin scheduler. It aims to schedule
threads with round-robin as basic policy, and be enhanced with some faireness
configuration such as preemption occurs on running out of timeslice, IO request
pending thread will be scheduled in high priority.

The patchset also add PAUSE-loop, HLT emulation support. HLT emulation is a simple
version for improving cpu sharing performance for now, which will be improved later.

There are also some bugfixs in the first few patches of the patchset.

Conghui Chen (1):
  hv: bugfix for debug commands with smp_call (in this PR)

Shuo A Liu (12):
  hv: print current sched_object in acrn logmsg (in this PR)
  hv: io: do schedule if we need in IO completion polling mode (in this PR)
  hv: do not sleep a non-RUNNING vcpu (in this PR)
  hv: sched_iorr: Add IO sensitive Round-robin scheduler
  hv: sched_iorr: add init functions of sched_iorr
  hv: sched_iorr: add tick handler and runqueue operations
  hv: sched_iorr: add some interfaces implementation of sched_iorr
  hv: sched: add yield support
  hv: sched: PAUSE-loop exiting support in hypervisor
  hv: sched: simple HLT emulation in hypervisor
  hv: sched: suspend/resume scheduling in suspend-to-ram path
  hv: sched: use hypervisor configuration to choose scheduler

 hypervisor/Makefile                   |   5 +
 hypervisor/arch/x86/Kconfig           |  21 ++++
 hypervisor/arch/x86/guest/vcpu.c      |   4 +-
 hypervisor/arch/x86/guest/vmcs.c      |   9 +-
 hypervisor/arch/x86/guest/vmexit.c    |  19 +++-
 hypervisor/arch/x86/pm.c              |   2 +
 hypervisor/common/sched_iorr.c        | 179 ++++++++++++++++++++++++++++++++++
 hypervisor/common/schedule.c          |  28 ++++++
 hypervisor/debug/logmsg.c             |   6 +-
 hypervisor/debug/shell.c              |  32 +++---
 hypervisor/dm/io_req.c                |  11 +--
 hypervisor/include/arch/x86/per_cpu.h |   1 +
 hypervisor/include/common/schedule.h  |  11 +++
 13 files changed, 302 insertions(+), 26 deletions(-)
 create mode 100644 hypervisor/common/sched_iorr.c