### PR TITLE
keep DM consistent with GVT-g when deal with pci bars

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -128,6 +128,7 @@ vm_create(const char *name, uint64_t req_buf, int *vcpu_num)
 	/* Pass uuid as parameter of create vm*/
 	uuid_copy(create_vm.uuid, vm_uuid);
 
+	ctx->gvt_enabled = false;
 	ctx->fd = devfd;
 	ctx->lowmem_limit = 2 * GB;
 	ctx->highmem_gpa_base = PCI_EMUL_MEMLIMIT64;

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -602,20 +602,6 @@ modify_bar_registration(struct pci_vdev *dev, int idx, int registration)
 	struct inout_port iop;
 	struct mem_range mr;
 
-	if (is_pci_gvt(dev)) {
-		/* GVT device is the only one who traps the pci bar access and
-		 * intercepts the corresponding contents in kernel. It needs
-		 * register pci resource only, but no need to register the
-		 * region.
-		 *
-		 * FIXME: This is a short term solution. This patch will be
-		 * obsoleted with the migration of using OVMF to do bar
-		 * addressing and generate ACPI PCI resource from using
-		 * acrn-dm.
-		 */
-		pr_notice("modify_bar_registration: bypass for pci-gvt\n");
-		return 0;
-	}
 	switch (dev->bar[idx].type) {
 	case PCIBAR_IO:
 		bzero(&iop, sizeof(struct inout_port));

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -45,6 +45,11 @@
 #define	PCI_EMUL_MEMBASE64	0x100000000UL	/* 4GB */
 #define	PCI_EMUL_MEMLIMIT64	0x140000000UL	/* 5GB */
 
+/* Currently,only gvt need reserved bar regions,
+ * so just hardcode REGION_NUMS=5 here
+ */
+#define REGION_NUMS 5
+
 struct vmctx;
 struct pci_vdev;
 struct memory_region;
@@ -242,6 +247,20 @@ struct pciecap {
 	uint16_t	slot_status2;
 } __attribute__((packed));
 static_assert(sizeof(struct pciecap) == 60, "compile-time assertion failed");
+
+struct mmio_rsvd_rgn {
+	uint64_t start;
+	uint64_t end;
+	int idx;
+	int bar_type;
+	/* if vdev=NULL, it also indicates this mmio_rsvd_rgn is not used */
+	struct pci_vdev *vdev;
+};
+
+extern struct mmio_rsvd_rgn reserved_bar_regions[REGION_NUMS];
+int create_mmio_rsvd_rgn(uint64_t start,
+                uint64_t end, int idx, int bar_type, struct pci_vdev *vdev);
+void destory_mmio_rsvd_rgns(struct pci_vdev *vdev);
 
 typedef void (*pci_lintr_cb)(int b, int s, int pin, int pirq_pin,
 			     int ioapic_irq, void *arg);

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -277,6 +277,7 @@ int	pci_emul_alloc_bar(struct pci_vdev *pdi, int idx,
 int	pci_emul_alloc_pbar(struct pci_vdev *pdi, int idx,
 			    uint64_t hostbase, enum pcibar_type type,
 			    uint64_t size);
+void	pci_emul_free_bar(struct pci_vdev *pdi, int idx);
 void	pci_emul_free_bars(struct pci_vdev *pdi);
 int	pci_emul_add_capability(struct pci_vdev *dev, u_char *capdata,
 				int caplen);

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -70,6 +70,8 @@ struct vmctx {
 
 	/* if gvt-g is enabled for current VM */
 	bool gvt_enabled;
+
+	void (*update_gvt_bar)(struct vmctx *ctx);
 };
 
 #define	PROT_RW		(PROT_READ | PROT_WRITE)

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -67,6 +67,9 @@ struct vmctx {
 
 	/* BSP state. guest loader needs to fill it */
 	struct acrn_set_vcpu_regs bsp_regs;
+
+	/* if gvt-g is enabled for current VM */
+	bool gvt_enabled;
 };
 
 #define	PROT_RW		(PROT_READ | PROT_WRITE)


### PR DESCRIPTION
In previous design:
1. GVT-g sets vgpu bars' value from physical gpu bars.
2. ACRN-DM sets pci bars according to its policy.

These two paths don't communicate with each other, but
they deal with the same thing:pci bars.
So there's a risk that ACRN-DM bars region overlap with GVT-g.
In the following four patches, we will keep DM consistent with 
GVT-g when deal with pci bars.

In the following description, 
patch 1 refers dm:gvt:reserve gvt bar regions in ACRN-DM
patch 2 refers dm:gvt:adjust pci bar region with reserved bar regions
patch 3 refers dm:gvt:update gvt bars before other pci devices write bar address
patch 4 refers dm:gvt:Enable gvt bar registration

In our design:
1. When ACRN-DM init gvt, it will read physical gpu bars, 
and reserve these bar regions.
patch 1 will complete this work.
2. patch 2 will adjust pci bar region with reserved bar regions.
3. uos kernel may update gvt bars' value,
but ACRN-DM doesn't know this update.
So ACRN-DM needs to get gvt latest bars' info when update
pci bars values for other pci devices.
patch 3 will complete this work.
4. patch4 will enable gvt bar registration