### PR TITLE
Ramdisk acrn config

### DIFF
--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -76,6 +76,7 @@ class CfgOsKern:
     kern_entry_addr = {}
     kern_root_dev = {}
     kern_args_append = {}
+    ramdisk_mod = {}
 
     def __init__(self, scenario_file):
         self.scenario_info = scenario_file
@@ -100,6 +101,8 @@ class CfgOsKern:
             self.scenario_info, "os_config", "kern_entry_addr")
         self.kern_root_dev = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "os_config", "rootfs")
+        self.ramdisk_mod = scenario_cfg_lib.get_leaf_tag_map(
+            self.scenario_info, "os_config", "ramdisk_mod")
         self.kern_args_append = scenario_cfg_lib.get_leaf_tag_map(
             self.scenario_info, "boot_private", "bootargs")
 

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -252,6 +252,9 @@ def gen_sdc_source(vm_info, config):
     print('\t\t\t.kernel_mod_tag = "{0}",'.format(
         vm_info.os_cfg.kern_mod[0]), file=config)
     print('\t\t\t.bootargs = {0},'.format(vm_info.os_cfg.kern_args[0]), file=config)
+    if (vm_info.os_cfg.ramdisk_mod[0].strip()):
+        print('\t\t\t.ramdisk_mod_tag = "{0}",'.format(
+            vm_info.os_cfg.ramdisk_mod[0]), file=config)
     print("\t\t},", file=config)
     # VUART
     err_dic = vuart_output(0, vm_info, config)
@@ -343,6 +346,9 @@ def gen_sdc2_source(vm_info, config):
     print('\t\t\t.kernel_mod_tag = "{0}",'.format(
         vm_info.os_cfg.kern_mod[0]), file=config)
     print('\t\t\t.bootargs = {0},'.format(vm_info.os_cfg.kern_args[0]), file=config)
+    if (vm_info.os_cfg.ramdisk_mod[0].strip()):
+        print('\t\t\t.ramdisk_mod_tag = "{0}",'.format(
+            vm_info.os_cfg.ramdisk_mod[0]), file=config)
     print("\t\t},", file=config)
     # VUART
     err_dic = vuart_output(0, vm_info, config)
@@ -465,6 +471,9 @@ def gen_logical_partition_source(vm_info, config):
             vm_info.os_cfg.kern_type[i]), file=config)
         print('\t\t\t.kernel_mod_tag = "{0}",'.format(
             vm_info.os_cfg.kern_mod[i]), file=config)
+        if (vm_info.os_cfg.ramdisk_mod[i].strip()):
+            print('\t\t\t.ramdisk_mod_tag = "{0}",'.format(
+                vm_info.os_cfg.ramdisk_mod[i]), file=config)
         print("\t\t\t.bootargs = VM{0}_CONFIG_OS_BOOTARG_CONSOLE\t\\".format(i), file=config)
         print("\t\t\t\tVM{0}_CONFIG_OS_BOOTARG_MAXCPUS\t\t\\".format(i), file=config)
         print("\t\t\t\tVM{0}_CONFIG_OS_BOOTARG_ROOT\t\t\\".format(i), file=config)
@@ -526,8 +535,11 @@ def gen_industry_source(vm_info, config):
                 vm_info.os_cfg.kern_type[i]), file=config)
             print('\t\t\t.kernel_mod_tag = "{0}",'.format(
                 vm_info.os_cfg.kern_mod[i]), file=config)
+            if (vm_info.os_cfg.ramdisk_mod[i].strip()):
+                print('\t\t\t.ramdisk_mod_tag = "{0}",'.format(
+                    vm_info.os_cfg.ramdisk_mod[i]), file=config)
             print("\t\t\t.bootargs = {0}".format(
-                vm_info.os_cfg.kern_args[i]), file=config)
+               vm_info.os_cfg.kern_args[i]), file=config)
             print("\t\t},", file=config)
 
         if i == 2:
@@ -599,6 +611,9 @@ def gen_hybrid_source(vm_info, config):
                 vm_info.os_cfg.kern_type[i]), file=config)
             print('\t\t\t.kernel_mod_tag = "{0}",'.format(
                 vm_info.os_cfg.kern_mod[i]), file=config)
+            if (vm_info.os_cfg.ramdisk_mod[i].strip()):
+                print('\t\t\t.ramdisk_mod_tag = "{0}",'.format(
+                vm_info.os_cfg.ramdisk_mod[i]), file=config)
 
             if i < post_vm_i:
                 if not vm_info.os_cfg.kern_args[i] or not vm_info.os_cfg.kern_args[i].strip():

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -23,6 +23,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -69,6 +70,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -23,6 +23,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -68,6 +69,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -24,6 +24,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -70,6 +71,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/generic/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
@@ -24,6 +24,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -70,6 +71,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -24,6 +24,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -70,6 +71,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -24,6 +24,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -70,6 +71,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -24,6 +24,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -70,6 +71,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -22,6 +22,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
@@ -57,6 +58,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -24,6 +24,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
@@ -70,6 +71,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc2.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc2.xml
@@ -15,6 +15,7 @@
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <vuart id="0">


### PR DESCRIPTION
Pre-launched or SOS VMs could use ramdisks to boot. This
patch adds acrn-config tool support to parse such use-case
scenario xmls.

    Tracked-On: #4197
    Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
