### PR TITLE
Makefile: add gcc flags to prevent some optimization

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -19,6 +19,7 @@ CFLAGS += -Wall -ffunction-sections
 CFLAGS += -Werror
 CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+CFLAGS += -fno-delete-null-pointer-checks -fwrapv
 CFLAGS += -fpie
 CFLAGS += -Wno-stringop-truncation -Wno-address-of-packed-member
 

--- a/misc/acrn-manager/Makefile
+++ b/misc/acrn-manager/Makefile
@@ -11,6 +11,7 @@ MANAGER_CFLAGS += -Wall -ffunction-sections
 MANAGER_CFLAGS += -Werror
 MANAGER_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 MANAGER_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+MANAGER_CFLAGS += -fno-delete-null-pointer-checks -fwrapv
 MANAGER_CFLAGS += -fpie -fpic
 #FIXME: remove me. work-around for system() calls, which will be removed
 MANAGER_CFLAGS += -Wno-format-truncation -Wno-unused-result

--- a/misc/efi-stub/Makefile
+++ b/misc/efi-stub/Makefile
@@ -74,6 +74,7 @@ CFLAGS=-I. -I.. -I$(INCDIR)/efi -I$(INCDIR)/efi/$(ARCH) \
 
 CFLAGS += -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 
+CFLAGS += -fno-delete-null-pointer-checks -fwrapv
 ifeq ($(ARCH),ia32)
 	ifeq ($(HOST),x86_64)
 		CFLAGS += -m32

--- a/misc/life_mngr/Makefile
+++ b/misc/life_mngr/Makefile
@@ -10,6 +10,7 @@ LIFEMNGR_CFLAGS += -Wall -ffunction-sections
 LIFEMNGR_CFLAGS += -Werror
 LIFEMNGR_CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 LIFEMNGR_CFLAGS += -Wformat -Wformat-security -fno-strict-aliasing
+LIFEMNGR_CFLAGS += -fno-delete-null-pointer-checks -fwrapv
 LIFEMNGR_CFLAGS += -fpie -fpic
 LIFEMNGR_CFLAGS += $(CFLAGS)
 


### PR DESCRIPTION
Add the below flags, they are needed in -O2:

-fno-delete-null-pointer-checks:
    tells the compiler NOT to assume that null pointer deference does
    not exist.

-fwrapv:
    tells the compiler that signed overflow always wraps.

Tracked-On: #4194
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Yonghua Huang <yonghua.huang@intel.com>