### PR TITLE
Add one scheduler which support cpu sharing: sched_iorr

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -211,8 +211,12 @@ HW_C_SRCS += arch/x86/cat.c
 HW_C_SRCS += arch/x86/sgx.c
 HW_C_SRCS += common/softirq.c
 HW_C_SRCS += common/schedule.c
+ifeq ($(CONFIG_SCHED_NOOP),y)
 HW_C_SRCS += common/sched_noop.c
+endif
+ifeq ($(CONFIG_SCHED_IORR),y)
 HW_C_SRCS += common/sched_iorr.c
+endif
 HW_C_SRCS += hw/pci.c
 HW_C_SRCS += arch/x86/configs/vm_config.c
 HW_C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/board.c

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -212,6 +212,7 @@ HW_C_SRCS += arch/x86/sgx.c
 HW_C_SRCS += common/softirq.c
 HW_C_SRCS += common/schedule.c
 HW_C_SRCS += common/sched_noop.c
+HW_C_SRCS += common/sched_iorr.c
 HW_C_SRCS += hw/pci.c
 HW_C_SRCS += arch/x86/configs/vm_config.c
 HW_C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/board.c

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -37,6 +37,27 @@ config HYBRID
 
 endchoice
 
+choice
+	prompt "ACRN Scheduler"
+	default SCHED_NOOP
+	help
+	  Select the CPU scheduler to be used by the hypervisor
+
+config SCHED_NOOP
+	bool "NOOP scheduler"
+	help
+	  The NOOP (No-Operation) scheduler means there is a strict 1 to 1 mapping
+	  between vCPUs and pCPUs.
+
+config SCHED_IORR
+        bool "IORR scheduler"
+        help
+          IORR (IO sensitive Round Robin) scheduler supports multipule vCPUs running on
+	  on one pCPU, and they will be scheduled by a IO sensitive round robin policy.
+
+endchoice
+
+
 config BOARD
 	string "Target board"
 	help

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -8,6 +8,7 @@
 #include <per_cpu.h>
 #include <schedule.h>
 
+#define CONFIG_SLICE_MS 10UL
 struct sched_iorr_data {
 	/* keep list as the first item */
 	struct list_head list;
@@ -17,17 +18,48 @@ struct sched_iorr_data {
 	int64_t  left_cycles;
 };
 
-int sched_iorr_init(__unused struct sched_control *ctl)
-{
-	return 0;
-}
-
-void sched_iorr_deinit(__unused struct sched_control *ctl)
+static void sched_tick_handler(__unused void *param)
 {
 }
 
-void sched_iorr_init_data(__unused struct thread_object *obj)
+/*
+ * @pre ctl->pcpu_id == get_pcpu_id()
+ */
+int sched_iorr_init(struct sched_control *ctl)
 {
+	struct sched_iorr_control *iorr_ctl = &per_cpu(sched_iorr_ctl, ctl->pcpu_id);
+	uint64_t tick_period = CYCLES_PER_MS;
+	int ret = 0;
+
+	ASSERT(get_pcpu_id() == ctl->pcpu_id, "Init scheduler on wrong CPU!");
+
+	ctl->priv = iorr_ctl;
+	INIT_LIST_HEAD(&iorr_ctl->runqueue);
+
+	/* The tick_timer is periodically */
+	initialize_timer(&iorr_ctl->tick_timer, sched_tick_handler, ctl,
+			rdtsc() + tick_period, TICK_MODE_PERIODIC, tick_period);
+
+	if (add_timer(&iorr_ctl->tick_timer) < 0) {
+		pr_err("Failed to add schedule tick timer!");
+		ret = -1;
+	}
+	return ret;
+}
+
+void sched_iorr_deinit(struct sched_control *ctl)
+{
+	struct sched_iorr_control *iorr_ctl = (struct sched_iorr_control *)ctl->priv;
+	del_timer(&iorr_ctl->tick_timer);
+}
+
+void sched_iorr_init_data(struct thread_object *obj)
+{
+	struct sched_iorr_data *data;
+
+	data = (struct sched_iorr_data *)obj->data;
+	INIT_LIST_HEAD(&data->list);
+	data->left_cycles = data->slice_cycles = CONFIG_SLICE_MS * CYCLES_PER_MS;
 }
 
 static struct thread_object *sched_iorr_pick_next(__unused struct sched_control *ctl)

--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <list.h>
+#include <per_cpu.h>
+#include <schedule.h>
+
+struct sched_iorr_data {
+	/* keep list as the first item */
+	struct list_head list;
+
+	uint64_t slice_cycles;
+	uint64_t last_cycles;
+	int64_t  left_cycles;
+};
+
+int sched_iorr_init(__unused struct sched_control *ctl)
+{
+	return 0;
+}
+
+void sched_iorr_deinit(__unused struct sched_control *ctl)
+{
+}
+
+void sched_iorr_init_data(__unused struct thread_object *obj)
+{
+}
+
+static struct thread_object *sched_iorr_pick_next(__unused struct sched_control *ctl)
+{
+	return NULL;
+}
+
+static void sched_iorr_sleep(__unused struct thread_object *obj)
+{
+}
+
+static void sched_iorr_wake(__unused struct thread_object *obj)
+{
+}
+
+struct acrn_scheduler sched_iorr = {
+	.name		= "sched_iorr",
+	.init		= sched_iorr_init,
+	.init_data	= sched_iorr_init_data,
+	.pick_next	= sched_iorr_pick_next,
+	.sleep		= sched_iorr_sleep,
+	.wake		= sched_iorr_wake,
+	.deinit		= sched_iorr_deinit,
+};

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -73,7 +73,12 @@ void init_sched(uint16_t pcpu_id)
 	ctl->flags = 0UL;
 	ctl->curr_obj = NULL;
 	ctl->pcpu_id = pcpu_id;
+#ifdef CONFIG_SCHED_NOOP
 	ctl->scheduler = &sched_noop;
+#endif
+#ifdef CONFIG_SCHED_IORR
+	ctl->scheduler = &sched_iorr;
+#endif
 	if (ctl->scheduler->init != NULL) {
 		ctl->scheduler->init(ctl);
 	}

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -240,6 +240,11 @@ void kick_thread(const struct thread_object *obj)
 	release_schedule_lock(pcpu_id, rflag);
 }
 
+void yield_current(void)
+{
+	make_reschedule_request(get_pcpu_id(), DEL_MODE_IPI);
+}
+
 void run_thread(struct thread_object *obj)
 {
 	uint64_t rflag;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -38,6 +38,7 @@ struct per_cpu_region {
 	struct per_cpu_timers cpu_timers;
 	struct sched_control sched_ctl;
 	struct sched_noop_control sched_noop_ctl;
+	struct sched_iorr_control sched_iorr_ctl;
 	struct thread_object idle;
 	struct host_gdt gdt;
 	struct tss_64 tss;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -7,6 +7,8 @@
 #ifndef SCHEDULE_H
 #define SCHEDULE_H
 #include <spinlock.h>
+#include <list.h>
+#include <timer.h>
 
 #define	NEED_RESCHEDULE		(1U)
 
@@ -77,9 +79,15 @@ struct acrn_scheduler {
 	void	(*deinit)(struct sched_control *ctl);
 };
 extern struct acrn_scheduler sched_noop;
+extern struct acrn_scheduler sched_iorr;
 
 struct sched_noop_control {
 	struct thread_object *noop_thread_obj;
+};
+
+struct sched_iorr_control {
+	struct list_head runqueue;
+	struct hv_timer tick_timer;
 };
 
 bool is_idle_thread(const struct thread_object *obj);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -109,6 +109,7 @@ void run_thread(struct thread_object *obj);
 void sleep_thread(struct thread_object *obj);
 void wake_thread(struct thread_object *obj);
 void kick_thread(const struct thread_object *obj);
+void yield_current(void);
 void schedule(void);
 
 void arch_switch_to(void *prev_sp, void *next_sp);


### PR DESCRIPTION
This patchset will add one scheduler named sched_iorr which support cpu sharing.
sched_iorr is short for IO sensitive Round-robin scheduler. It aims to schedule threads with round-robin as basic policy, and be enhanced with some faireness configuration such as preemption occurs on running out of timeslice, IO request pending thread will be scheduled in high priority.

The patchset also add PAUSE-loop, HLT emulation support. HLT emulation is a simple version for improving cpu sharing performance for now, which will be improved later.

v2: Add @pre and assert for sched_iorr_init

Shuo A Liu (9):
  hv: sched_iorr: Add IO sensitive Round-robin scheduler
  hv: sched_iorr: add init functions of sched_iorr
  hv: sched_iorr: add tick handler and runqueue operations
  hv: sched_iorr: add some interfaces implementation of sched_iorr
  hv: sched: add yield support
  hv: sched: PAUSE-loop exiting support in hypervisor (not in this PR, pending)
  hv: sched: simple HLT emulation in hypervisor (not in this PR, pending)
  hv: sched: suspend/resume scheduling in suspend-to-ram path (drop)
  hv: sched: use hypervisor configuration to choose scheduler

 hypervisor/Makefile                   |   5 +
 hypervisor/arch/x86/Kconfig           |  21 ++++
 hypervisor/arch/x86/guest/vmcs.c      |   9 +-
 hypervisor/arch/x86/guest/vmexit.c    |  19 +++-
 hypervisor/arch/x86/pm.c              |   2 +
 hypervisor/common/sched_iorr.c        | 179 ++++++++++++++++++++++++++++++++++
 hypervisor/common/schedule.c          |  28 ++++++
 hypervisor/include/arch/x86/per_cpu.h |   1 +
 hypervisor/include/common/schedule.h  |  11 +++
 9 files changed, 271 insertions(+), 4 deletions(-)  create mode 100644 hypervisor/common/sched_iorr.c
