### PR TITLE
Makefile: fix make failure for logical_partition or hybrid scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ include $(T)/hypervisor/scripts/makefile/cfg_update.mk
 
 ifeq ($(DEFAULT_MENU_CONFIG_FILE), $(wildcard $(DEFAULT_MENU_CONFIG_FILE)))
   BOARD_IN_MENUCONFIG := $(shell grep CONFIG_BOARD= $(DEFAULT_MENU_CONFIG_FILE) | awk -F '"' '{print $$2}')
-  SCENARIO_IN_MENUCONFIG := $(shell grep -E "SDC=y|SDC2=y|INDUSTRY=y|LOGICAL_PARTITION=y" \
-           $(DEFAULT_MENU_CONFIG_FILE) | awk -F "_|=" '{print $$2}' | tr A-Z a-z)
+  SCENARIO_IN_MENUCONFIG := $(shell grep -E "SDC=y|SDC2=y|INDUSTRY=y|LOGICAL_PARTITION=y|HYBRID=y" \
+           $(DEFAULT_MENU_CONFIG_FILE) | awk -F "=" '{print $$1}' | cut -d '_' -f 2- | tr A-Z a-z)
 
   RELEASE := $(shell grep CONFIG_RELEASE=y $(DEFAULT_MENU_CONFIG_FILE))
   ifneq ($(RELEASE),)


### PR DESCRIPTION
If "make menuconfig" chooses hybrid or logical_partition scenario,
currently the build fails with "SCENARIO <$(SCENARIO)> is not supported.".

- CONFIG_LOGICAL_PARTITION: "awk -F "_|=" '{print $$2}'" yields the second
  field (LOGICAL) only. The new "cut -d '_' -f 2-" keeps all fields after
  "CONFIG_".

- Add the missing HYBRID scenario.

Tracked-On: #4067
Signed-off-by: Zide Chen <zide.chen@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>