### PR TITLE
acrn-config: UI supports to edit mulitple virtio input devices

### DIFF
--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -511,7 +511,8 @@ function save_launch(generator=null) {
         var id = $(this).attr('id');
     	var value = $(this).val();
 
-        if(id.indexOf('virtio_devices,network')>=0 || id.indexOf('virtio_devices,block')>=0) {
+        if(id.indexOf('virtio_devices,network')>=0 || id.indexOf('virtio_devices,block')>=0
+            || id.indexOf('virtio_devices,input')>=0) {
             if(id in launch_config) {
                 launch_config[id].push(value);
             } else {

--- a/misc/acrn-config/config_app/templates/launch.html
+++ b/misc/acrn-config/config_app/templates/launch.html
@@ -157,7 +157,7 @@
                 {% elif elem.getchildren() != [] %}
                     {% if 'multiselect' not in elem.attrib or elem.attrib['multiselect'] != 'true' %}
                     {% set first_child = [] %}
-                    {% set first_multi_child = {'block': 0, 'network': 0} %}
+                    {% set first_multi_child = {'block': 0, 'network': 0, 'input': 0} %}
                         {% for sub_elem in elem.getchildren() %}
                             {% set sub_elem_text = '' if sub_elem.text == None else sub_elem.text %}
                             {% if 'configurable' not in sub_elem.attrib or sub_elem.attrib['configurable'] != '0' %}
@@ -191,7 +191,7 @@
                                         {% endif %}
                                     </div>
 
-                                    {% if elem.tag in ['virtio_devices'] and sub_elem.tag in ['block', 'network'] %}
+                                    {% if elem.tag in ['virtio_devices'] and sub_elem.tag in ['block', 'network', 'input'] %}
                                         <div class="col-sm-1">
                                             <button type="button" class="btn" id="add_virtio_{{sub_elem.tag}}_{{first_multi_child[sub_elem.tag]}}">+</button>
                                             {% if first_multi_child[sub_elem.tag] == 0 %}


### PR DESCRIPTION
This is to make acrn config UI supports to edit more than one virtio
input devices in multi-lines

Tracked-On: #4163
Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>