### PR TITLE
Doc: Add libnuma dependency for acrntrace

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -90,7 +90,8 @@ Install the necessary tools for the following systems:
           libblkid-dev \
           e2fslibs-dev \
           pkg-config \
-          zlib1g-dev
+          zlib1g-dev \
+          libnuma-dev
      $ sudo pip3 install kconfiglib
 
   .. note::
@@ -129,7 +130,8 @@ Install the necessary tools for the following systems:
           python3 \
           python3-pip \
           libblkid-devel \
-          e2fsprogs-devel
+          e2fsprogs-devel \
+          numactl-devel
      $ sudo pip3 install kconfiglib
 
 
@@ -151,7 +153,8 @@ Install the necessary tools for the following systems:
              python34 \
              python34-pip \
              libblkid-devel \
-             e2fsprogs-devel
+             e2fsprogs-devel \
+             libnuma-devel
      $ sudo pip3 install kconfiglib
 
   .. note::


### PR DESCRIPTION
"9e9e1f61 acrntrace: Add opt to specify the cpus where we should capture the data"
uses APIs of libnuma. So this patch adds dependency of libnuma in building-from-source.rst.

libnuma functions have been included in os-core-dev bundle of clearlinux.

Tracked-On: #4175
Signed-off-by: Kaige Fu <kaige.fu@intel.com>