### PR TITLE
PCI: Add PCIe ECAM access support

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/board.c
+++ b/hypervisor/arch/x86/configs/apl-mrb/board.c
@@ -6,6 +6,7 @@
 
 #include <board.h>
 #include <vtd.h>
+#include <pci.h>
 
 #ifndef CONFIG_ACPI_PARSE_ENABLED
 #error "DMAR info is not available, please set ACPI_PARSE_ENABLED to y in Kconfig. \
@@ -15,3 +16,4 @@
 struct dmar_info plat_dmar_info;
 struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 const struct cpu_state_table board_cpu_state_tbl;
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];

--- a/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
@@ -41,4 +41,6 @@
 				"cma=64M@0- "	\
 				"panic_print=0x1f"
 
+#define MAX_HIDDEN_PDEVS_NUM	0U
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/apl-up2/board.c
+++ b/hypervisor/arch/x86/configs/apl-up2/board.c
@@ -7,6 +7,7 @@
 #include <board.h>
 #include <msr.h>
 #include <vtd.h>
+#include <pci.h>
 
 #ifndef CONFIG_ACPI_PARSE_ENABLED
 #error "DMAR info is not available, please set ACPI_PARSE_ENABLED to y in Kconfig. \
@@ -35,3 +36,11 @@ struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM] = {
 };
 
 const struct cpu_state_table board_cpu_state_tbl;
+
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM] = {
+	{
+		.bits.b = 0x0,
+		.bits.d = 0xd,
+		.bits.f = 0x0,
+	},
+};

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -37,4 +37,6 @@
 				"i915.enable_guc=0x02 "	\
 				"cma=64M@0- "
 
+#define MAX_HIDDEN_PDEVS_NUM	1U
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/dnv-cb2/board.c
+++ b/hypervisor/arch/x86/configs/dnv-cb2/board.c
@@ -6,6 +6,7 @@
 
 #include <board.h>
 #include <vtd.h>
+#include <pci.h>
 
 #ifndef CONFIG_ACPI_PARSE_ENABLED
 #error "DMAR info is not available, please set ACPI_PARSE_ENABLED to y in Kconfig. \
@@ -15,3 +16,4 @@
 struct dmar_info plat_dmar_info;
 struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 const struct cpu_state_table board_cpu_state_tbl;
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];

--- a/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
@@ -26,4 +26,6 @@
 #define SOS_BOOTARGS_DIFF	""
 #endif
 
+#define MAX_HIDDEN_PDEVS_NUM	0U
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/generic/board.c
+++ b/hypervisor/arch/x86/configs/generic/board.c
@@ -6,6 +6,7 @@
 
 #include <board.h>
 #include <vtd.h>
+#include <pci.h>
 
 #ifndef CONFIG_ACPI_PARSE_ENABLED
 #error "DMAR info is not available, please set ACPI_PARSE_ENABLED to y in Kconfig. \
@@ -15,3 +16,4 @@
 struct dmar_info plat_dmar_info;
 struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 const struct cpu_state_table board_cpu_state_tbl;
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];

--- a/hypervisor/arch/x86/configs/generic/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/generic/misc_cfg.h
@@ -27,4 +27,6 @@
 #define SOS_BOOTARGS_DIFF	""
 #endif
 
+#define MAX_HIDDEN_PDEVS_NUM	0U
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/icl-rvp/board.c
+++ b/hypervisor/arch/x86/configs/icl-rvp/board.c
@@ -6,6 +6,7 @@
 
 #include <board.h>
 #include <vtd.h>
+#include <pci.h>
 
 #ifndef CONFIG_ACPI_PARSE_ENABLED
 #error "DMAR info is not available, please set ACPI_PARSE_ENABLED to y in Kconfig. \
@@ -15,3 +16,4 @@
 struct dmar_info plat_dmar_info;
 struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 const struct cpu_state_table board_cpu_state_tbl;
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];

--- a/hypervisor/arch/x86/configs/nuc6cayh/board.c
+++ b/hypervisor/arch/x86/configs/nuc6cayh/board.c
@@ -6,6 +6,7 @@
 
 #include <board.h>
 #include <vtd.h>
+#include <pci.h>
 
 #ifndef CONFIG_ACPI_PARSE_ENABLED
 #error "DMAR info is not available, please set ACPI_PARSE_ENABLED to y in Kconfig. \
@@ -15,3 +16,4 @@
 struct dmar_info plat_dmar_info;
 struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 const struct cpu_state_table board_cpu_state_tbl;
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];

--- a/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
@@ -26,4 +26,6 @@
 #define SOS_BOOTARGS_DIFF	""
 #endif
 
+#define MAX_HIDDEN_PDEVS_NUM	0U
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/board.c
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/board.c
@@ -6,6 +6,7 @@
 
 #include <board.h>
 #include <vtd.h>
+#include <pci.h>
 
 static struct dmar_dev_scope drhd0_dev_scope[DRHD0_DEV_CNT] = {
 	{
@@ -57,3 +58,4 @@ struct dmar_info plat_dmar_info = {
 
 struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 const struct cpu_state_table board_cpu_state_tbl;
+const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
@@ -27,4 +27,6 @@
 #define SOS_BOOTARGS_DIFF	""
 #endif
 
+#define MAX_HIDDEN_PDEVS_NUM	0U
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -237,6 +237,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 			panic("failed to initialize iommu!");
 		}
 
+		hv_access_memory_region_update(get_mmcfg_base(), PCI_MMCONFIG_SIZE);
 		init_pci_pdev_list(); /* init_iommu must come before this */
 		ptdev_init();
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -165,6 +165,8 @@ void init_pcpu_pre(bool is_bsp)
 			panic("Platform CAT info is incorrect!");
 		}
 
+		/* NOTE: this must call after MMCONFIG is parsed in init_vboot and before APs are INIT. */
+		pci_switch_to_mmio_cfg_ops();
 	} else {
 		/* Switch this CPU to use the same page tables set-up by the
 		 * primary/boot CPU

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -431,6 +431,9 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	 * code be page-aligned.
 	 */
 	ept_del_mr(vm, pml4_page, get_ap_trampoline_buf(), CONFIG_LOW_RAM_SIZE);
+
+	/* unmap PCIe MMCONFIG region since it's owned by hypervisor */
+	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, get_mmcfg_base(), PCI_MMCONFIG_SIZE);
 }
 
 /* Add EPT mapping of EPC reource for the VM */

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -45,6 +45,68 @@ static char pci_bdf_info[MAX_BDF_LEN + 1U];
 typedef uint32_t uart_reg_t;
 static union pci_bdf serial_pci_bdf;
 
+
+static uint32_t pci_direct_calc_address(union pci_bdf bdf, uint32_t offset)
+{
+	uint32_t addr = (uint32_t)bdf.value;
+
+	addr <<= 8U;
+	addr |= (offset | PCI_CFG_ENABLE);
+	return addr;
+}
+
+static uint32_t pci_direct_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes)
+{
+	uint32_t addr;
+	uint32_t val;
+
+	addr = pci_direct_calc_address(bdf, offset);
+
+	/* Write address to ADDRESS register */
+	pio_write32(addr, (uint16_t)PCI_CONFIG_ADDR);
+
+	/* Read result from DATA register */
+	switch (bytes) {
+	case 1U:
+		val = (uint32_t)pio_read8((uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
+		break;
+	case 2U:
+		val = (uint32_t)pio_read16((uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
+		break;
+	default:
+		val = pio_read32((uint16_t)PCI_CONFIG_DATA);
+		break;
+	}
+
+	return val;
+}
+
+static void pci_direct_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val)
+{
+	uint32_t addr = pci_direct_calc_address(bdf, offset);
+
+	/* Write address to ADDRESS register */
+	pio_write32(addr, (uint16_t)PCI_CONFIG_ADDR);
+
+	/* Write value to DATA register */
+	switch (bytes) {
+	case 1U:
+		pio_write8((uint8_t)val, (uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
+		break;
+	case 2U:
+		pio_write16((uint16_t)val, (uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
+		break;
+	default:
+		pio_write32(val, (uint16_t)PCI_CONFIG_DATA);
+		break;
+	}
+}
+
+struct pci_cfg_ops pci_direct_cfg_ops = {
+	.pci_read_cfg = pci_direct_read_cfg,
+	.pci_write_cfg = pci_direct_write_cfg,
+};
+
 /* PCI BDF must follow format: bus:dev.func, for example 0:18.2 */
 static uint16_t get_pci_bdf_value(char *bdf)
 {

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -202,7 +202,7 @@ void enable_disable_pci_intx(union pci_bdf bdf, bool enable)
 	}
 }
 
-static bool is_hidden_pdev(union pci_bdf pbdf)
+static bool is_hv_owned_pdev(union pci_bdf pbdf)
 {
 	bool hidden = false;
 	/* if it is debug uart, hide it*/
@@ -216,7 +216,7 @@ static bool is_hidden_pdev(union pci_bdf pbdf)
 
 static void pci_init_pdev(union pci_bdf pbdf, uint32_t drhd_index)
 {
-	if (!is_hidden_pdev(pbdf)) {
+	if (!is_hv_owned_pdev(pbdf)) {
 		init_pdev(pbdf.value, drhd_index);
 	}
 }

--- a/hypervisor/include/arch/x86/board.h
+++ b/hypervisor/include/arch/x86/board.h
@@ -9,6 +9,7 @@
 #include <types.h>
 #include <misc_cfg.h>
 #include <host_pm.h>
+#include <pci.h>
 
 /* forward declarations */
 struct acrn_vm;
@@ -21,6 +22,7 @@ struct platform_clos_info {
 extern struct dmar_info plat_dmar_info;
 extern struct platform_clos_info platform_clos_array[MAX_PLATFORM_CLOS_NUM];
 extern const struct cpu_state_table board_cpu_state_tbl;
+extern const union pci_bdf plat_hidden_pdevs[MAX_HIDDEN_PDEVS_NUM];
 
 /* board specific functions */
 void create_prelaunched_vm_e820(struct acrn_vm *vm);

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -7,6 +7,8 @@
 #ifndef UART16550_H
 #define UART16550_H
 
+#include <pci.h>
+
 /* Register / bit definitions for 16c550 uart */
 /*receive buffer register            | base+00h, dlab=0b r*/
 #define UART16550_RBR           0x00U
@@ -126,6 +128,8 @@
 
 /* UART oscillator clock */
 #define UART_CLOCK_RATE	1843200U	/* 1.8432 MHz */
+
+extern struct pci_cfg_ops pci_direct_cfg_ops;
 
 void uart16550_init(bool early_boot);
 char uart16550_getc(void);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -70,9 +70,9 @@ struct pci_msix {
 };
 
 union pci_cfgdata {
-	uint8_t data_8[PCI_REGMAX + 1U];
-	uint16_t data_16[(PCI_REGMAX + 1U) >> 1U];
-	uint32_t data_32[(PCI_REGMAX + 1U) >> 2U];
+	uint8_t data_8[PCIE_CONFIG_SPACE_SIZE];
+	uint16_t data_16[PCIE_CONFIG_SPACE_SIZE >> 1U];
+	uint32_t data_32[PCIE_CONFIG_SPACE_SIZE >> 2U];
 };
 
 struct pci_vdev;
@@ -123,6 +123,7 @@ struct acrn_vpci {
 	spinlock_t lock;
 	struct acrn_vm *vm;
 	union pci_cfg_addr_reg addr;
+	uint64_t pci_mmcfg_base;
 	uint32_t pci_vdev_cnt;
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -320,5 +320,4 @@ static inline bool is_pci_cfg_bridge(uint8_t header_type)
 
 bool pdev_need_bar_restore(const struct pci_pdev *pdev);
 void pdev_restore_bar(const struct pci_pdev *pdev);
-
 #endif /* PCI_H_ */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -206,6 +206,11 @@ struct pci_pdev {
 	bool has_af_flr;
 };
 
+struct pci_cfg_ops {
+	uint32_t (*pci_read_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
+	void (*pci_write_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
+};
+
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {
 	return PCIR_BARS + (idx << 2U);
@@ -320,4 +325,5 @@ static inline bool is_pci_cfg_bridge(uint8_t header_type)
 
 bool pdev_need_bar_restore(const struct pci_pdev *pdev);
 void pdev_restore_bar(const struct pci_pdev *pdev);
+void pci_switch_to_mmio_cfg_ops(void);
 #endif /* PCI_H_ */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -48,8 +48,11 @@
 #define PCI_SLOTMAX           0x1FU
 #define PCI_FUNCMAX           0x7U
 #define PCI_BAR_COUNT         0x6U
-#define PCI_REGMAX            0xFFU
 #define PCI_REGMASK           0xFCU
+
+#define PCI_CONFIG_SPACE_SIZE 0x100U
+#define PCIE_CONFIG_SPACE_SIZE 0x1000U
+#define PCI_MMCONFIG_SIZE     0x10000000U
 
 /* I/O ports */
 #define PCI_CONFIG_ADDR       0xCF8U
@@ -323,6 +326,7 @@ static inline bool is_pci_cfg_bridge(uint8_t header_type)
 	return ((header_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE);
 }
 
+bool is_plat_hidden_pdev(union pci_bdf bdf);
 bool pdev_need_bar_restore(const struct pci_pdev *pdev);
 void pdev_restore_bar(const struct pci_pdev *pdev);
 void pci_switch_to_mmio_cfg_ops(void);

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -5,5 +5,7 @@
  */
 
 #include <types.h>
+#include <pci.h>
 
 void uart16550_init(__unused bool early_boot) {}
+struct pci_cfg_ops pci_direct_cfg_ops;

--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -12,6 +12,7 @@ MISC_CFG_HEADER = """
 
 MISC_CFG_END = """#endif /* MISC_CFG_H */"""
 
+
 class Vuart:
 
     t_vm_id = {}
@@ -157,6 +158,15 @@ def generate_file(config):
     print("", file=config)
     if "SOS_VM" in vm_types:
         sos_bootarg_diff(sos_cmdlines, config)
+
+    # set macro for HIDDEN PTDEVS
+    print("", file=config)
+    if board_cfg_lib.BOARD_NAME in list(board_cfg_lib.KNOWN_HIDDEN_PDEVS_BOARD_DB):
+        print("#define MAX_HIDDEN_PDEVS_NUM	{}U".format(len(board_cfg_lib.KNOWN_HIDDEN_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME])), file=config)
+    else:
+        print("#define MAX_HIDDEN_PDEVS_NUM	0U", file=config)
+    print("", file=config)
+
     print("{}".format(MISC_CFG_END), file=config)
 
     return err_dic

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -33,6 +33,11 @@ ERR_LIST = {}
 
 HEADER_LICENSE = common.open_license() + "\n"
 
+# The data base contains hide pci device
+KNOWN_HIDDEN_PDEVS_BOARD_DB = {
+    'apl-up2':['00:0d:0'],
+}
+
 
 def prepare(check_git):
     """ check environment """


### PR DESCRIPTION
v6:
expose BIOS hided PCI devices to SOS more generically.

v5:
expose P2SB to SOS

v4:
Add PCI-compatible Configuration Mechanism (IO port) access back for early debug.

v3:
update PCIe MMCONFIG region to be owned by hypervisor.

v2:
Remove PCIe ECAM access emulation for pre-launched VM since it doesn't mean to support PCIe ECAM access.


v1:
Now ACRN HV only trap PCI mmconfig access for pre-launched VM and SOS and emulate
the front 256 bytes configuration space access add pass through the PCI external
configuration space access.

Tracked-On: #3475
Signed-off-by: Li Fei1 <fei1.li@intel.com>
