### PR TITLE
Makefile: Build Release version by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 	FIRMWARE ?= uefi
 endif
 
-RELEASE ?= 0
+RELEASE ?= 1
 SCENARIO ?= sdc
 
 O ?= build


### PR DESCRIPTION
 Update build option for 'acrn-hypervisor', build release
 version by default.

Tracked-On: #4222
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>