### PR TITLE
acrn-config: add virtio-console and poweroff channel to support

### DIFF
--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -14,17 +14,11 @@ MISC_CFG_END = """#endif /* MISC_CFG_H */"""
 
 class Vuart:
 
-    t_vm_id = []
-    t_vuart_id = []
-    v_type = []
-    v_base = []
-    v_irq = []
-
-    def style_check_1(self):
-        self.v_irq = []
-
-    def style_check_2(self):
-        self.v_irq = []
+    t_vm_id = {}
+    t_vuart_id = {}
+    v_type = {}
+    v_base = {}
+    v_irq = {}
 
 
 def sos_bootarg_diff(sos_cmdlines, config):
@@ -158,7 +152,6 @@ def generate_file(config):
         if vuart1_setting[i_type]['base'] != "INVALID_COM_BASE":
             print("#define SOS_COM2_BASE\t\t{}U".format(vuart1_port_base), file=config)
             print("#define SOS_COM2_IRQ\t\t{}U".format(vuart1_irq), file=config)
-
 
     # sos boot command line
     print("", file=config)

--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -92,10 +92,10 @@ def generate_file(config):
 
     if vuart0_dic:
         # parse to get poart/base of vuart0/vuart1
-        vuart0_port_base = board_cfg_lib.TTY_CONSOLE[list(vuart0_dic.keys())[0]]
+        vuart0_port_base = board_cfg_lib.LEGACY_TTYS[list(vuart0_dic.keys())[0]]
         vuart0_irq = vuart0_dic[list(vuart0_dic.keys())[0]]
 
-    vuart1_port_base = board_cfg_lib.TTY_CONSOLE[list(vuart1_dic.keys())[0]]
+    vuart1_port_base = board_cfg_lib.LEGACY_TTYS[list(vuart1_dic.keys())[0]]
     vuart1_irq = vuart1_dic[list(vuart1_dic.keys())[0]]
 
     # parse the setting ttys vuatx dic: {vmid:base/irq}

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -501,15 +501,6 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
         if uos_type in ("ANDROID", "ALIOS"):
             print("   -s {},virtio-rpmb \\".format(launch_cfg_lib.virtual_dev_slot("virtio-rpmb")), file=config)
-        if board_name == "apl-up2":
-            print("   --pm_notify_channel power_button \\", file=config)
-        if board_name == "apl-mrb":
-            print("   --pm_notify_channel ioc \\", file=config)
-
-    if is_nuc_whl_clr(names, vmid):
-        print("   --pm_notify_channel uart \\", file=config)
-        print('   --pm_by_vuart pty,/run/acrn/life_mngr_$vm_name  \\', file=config)
-        print('   -l com2,/run/acrn/life_mngr_$vm_name \\', file=config)
 
     # mac_seed
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
@@ -521,7 +512,6 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
         print("   --lapic_pt \\", file=config)
         print("   --rtvm \\", file=config)
         print("   --virtio_poll 1000000 \\", file=config)
-        print("   --pm_notify_channel uart --pm_by_vuart tty,/dev/ttyS1 \\", file=config)
 
     # vxworks
     if uos_type == "VXWORKS":
@@ -538,7 +528,12 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
         print("{} \\".format(dm_str), file=config)
         print("   --windows \\", file=config)
 
-    # WA: XHCI args set
+    # pm_channel set
+    if dm['pm_channel'][vmid] and dm['pm_channel'][vmid] != None:
+        pm_key = dm['pm_channel'][vmid]
+        print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
+
+    # XHCI args set
     xhci_args_set(dm, vmid, config)
 
     # VIRTIO args set

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -465,6 +465,12 @@ def virtio_args_set(dm, virt_io, vmid, config):
                 net_name = net.split(',')[0]
             print("   -s {},virtio-net,{} \\".format(launch_cfg_lib.virtual_dev_slot("virtio-net{}".format(net)), net_name), file=config)
 
+    # virtio-console set, the value type is a string
+    if virt_io['console'][vmid]:
+        print("   -s {},virtio-console,{} \\".format(
+            launch_cfg_lib.virtual_dev_slot("virtio-console"),
+                virt_io['console'][vmid]), file=config)
+
 
 def dm_arg_set(names, sel, virt_io, dm, vmid, config):
 
@@ -545,15 +551,9 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     vboot_arg_set(dm, vmid, config)
 
     # redirect console
-    if dm['console_type'][vmid] == "com1(ttyS0)":
+    if dm['vuart0'][vmid] == "Enable":
         print("   -s 1:0,lpc \\", file=config)
         print("   -l com1,stdio \\", file=config)
-        print("   -s {},{} \\".format(launch_cfg_lib.virtual_dev_slot("com1(ttyS0)"),
-            launch_cfg_lib.RE_CONSOLE_MAP['com1(ttyS0)']), file=config)
-    else:
-        print("   -s {},{} \\".format(
-            launch_cfg_lib.virtual_dev_slot("virtio-console(hvc0)"),
-                launch_cfg_lib.RE_CONSOLE_MAP['virtio-console(hvc0)']), file=config)
 
     if uos_type in ("CLEARLINUX", "ANDROID", "ALIOS"):
         print("   -s {},virtio-hyper_dmabuf \\".format(launch_cfg_lib.virtual_dev_slot("virtio-hyper_dmabuf")), file=config)

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -531,6 +531,12 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     # pm_channel set
     if dm['pm_channel'][vmid] and dm['pm_channel'][vmid] != None:
         pm_key = dm['pm_channel'][vmid]
+        if pm_key == "vuart1(tty)":
+            vuart_base = launch_cfg_lib.get_vuart1_from_scenario(sos_vmid + vmid)
+            if vuart_base == "INVALID_COM_BASE":
+                err_key = "uos:id={}:poweroff_channel".format(vmid)
+                launch_cfg_lib.ERR_LIST[err_key] = "vuart1 of VM{} in scenario file should select 'SOS_COM2_BASE'".format(sos_vmid + vmid)
+                return
         print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
 
     # XHCI args set

--- a/misc/acrn-config/launch_config/launch_cfg_gen.py
+++ b/misc/acrn-config/launch_config/launch_cfg_gen.py
@@ -45,7 +45,7 @@ def get_launch_item_values(board_info):
     launch_item_values["uos,rtos_type"] = launch_cfg_lib.RTOS_TYPE
 
     launch_item_values["uos,vbootloader"] = launch_cfg_lib.BOOT_TYPE
-    launch_item_values['uos,console_type'] = launch_cfg_lib.REDIRECT_CONSOLE
+    launch_item_values['uos,vuart0'] = launch_cfg_lib.DM_VUART0
     launch_item_values['uos,gvt_args'] = launch_cfg_lib.GVT_ARGS
 
     return launch_item_values

--- a/misc/acrn-config/launch_config/launch_cfg_gen.py
+++ b/misc/acrn-config/launch_config/launch_cfg_gen.py
@@ -46,6 +46,7 @@ def get_launch_item_values(board_info):
 
     launch_item_values["uos,vbootloader"] = launch_cfg_lib.BOOT_TYPE
     launch_item_values['uos,vuart0'] = launch_cfg_lib.DM_VUART0
+    launch_item_values['uos,poweroff_channel'] = launch_cfg_lib.PM_CHANNEL
     launch_item_values['uos,gvt_args'] = launch_cfg_lib.GVT_ARGS
 
     return launch_item_values

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -20,6 +20,7 @@ class AcrnDmArgs:
         self.args["gvt_args"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "gvt_args")
         self.args["vbootloader"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vbootloader")
         self.args["vuart0"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vuart0")
+        self.args["pm_channel"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "poweroff_channel")
         self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
         self.args["xhci"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "usb_xhci")
 

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -19,7 +19,7 @@ class AcrnDmArgs:
         self.args["mem_size"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "mem_size")
         self.args["gvt_args"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "gvt_args")
         self.args["vbootloader"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vbootloader")
-        self.args["console_type"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "console_type")
+        self.args["vuart0"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vuart0")
         self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
         self.args["xhci"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "usb_xhci")
 
@@ -30,7 +30,7 @@ class AcrnDmArgs:
         launch_cfg_lib.mem_size_check(self.args["mem_size"], "mem_size")
         launch_cfg_lib.args_aval_check(self.args["gvt_args"], "gvt_args", launch_cfg_lib.GVT_ARGS)
         launch_cfg_lib.args_aval_check(self.args["vbootloader"], "vbootloader", launch_cfg_lib.BOOT_TYPE)
-        launch_cfg_lib.args_aval_check(self.args["console_type"], "console_type", launch_cfg_lib.REDIRECT_CONSOLE)
+        launch_cfg_lib.args_aval_check(self.args["vuart0"], "vuart0", launch_cfg_lib.DM_VUART0)
 
 
 class AvailablePthru():
@@ -152,3 +152,4 @@ class VirtioDeviceSelect():
         self.dev["input"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "input")
         self.dev["block"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "block")
         self.dev["network"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "network")
+        self.dev["console"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "virtio_devices", "console")

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -384,29 +384,6 @@ def get_board_private_vuart(branch_tag, tag_console):
     return (err_dic, vuart0_console_dic, vuart1_console_dic)
 
 
-def get_vuart_id(tmp_vuart, leaf_tag, leaf_text):
-    """
-    Get all vuart id member of class
-    :param leaf_tag: key pattern of item tag
-    :param tmp_vuart: a dictionary to store member:value
-    :param leaf_text: key pattern of item tag's value
-    :return: a dictionary to which stored member:value
-    """
-    if leaf_tag == "type":
-        tmp_vuart['type'] = leaf_text
-    if leaf_tag == "base":
-        tmp_vuart['base'] = leaf_text
-    if leaf_tag == "irq":
-        tmp_vuart['irq'] = leaf_text
-
-    if leaf_tag == "target_vm_id":
-        tmp_vuart['target_vm_id'] = leaf_text
-    if leaf_tag == "target_uart_id":
-        tmp_vuart['target_uart_id'] = leaf_text
-
-    return tmp_vuart
-
-
 def get_vuart_info_id(config_file, idx):
     """
     Get vuart information by vuart id indexx
@@ -414,24 +391,7 @@ def get_vuart_info_id(config_file, idx):
     :param idx: vuart index in range: [0,1]
     :return: dictionary which stored the vuart-id
     """
-    tmp_tag = []
-    vm_id = 0
-    root = common.get_config_root(config_file)
-    for item in root:
-        for sub in item:
-            tmp_vuart = {}
-            for leaf in sub:
-                if sub.tag == "vuart" and int(sub.attrib['id']) == idx:
-                    tmp_vuart = get_vuart_id(tmp_vuart, leaf.tag, leaf.text)
-
-            # append vuart for each vm
-            if tmp_vuart and sub.tag == "vuart":
-                #tmp_vuart[vm_id] = tmp_vuart
-                tmp_tag.append(tmp_vuart)
-
-        if item.tag == "vm":
-            vm_id += 1
-
+    tmp_tag = common.get_vuart_info_id(config_file, idx)
     return tmp_tag
 
 

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -18,7 +18,7 @@ BASE_BOARD = ['Base Board Information', 'Manufacturer:', 'Product Name:', 'Versi
 BOARD_NAMES = ['apl-mrb', 'apl-nuc', 'apl-up2', 'dnv-cb2', 'nuc6cayh',
                'nuc7i7dnb', 'kbl-nuc-i7', 'icl-rvp']
 
-TTY_CONSOLE = {
+LEGACY_TTYS = {
     'ttyS0':'0x3F8',
     'ttyS1':'0x2F8',
     'ttyS2':'0x3E8',
@@ -353,10 +353,6 @@ def get_board_private_vuart(branch_tag, tag_console):
         return err_dic
 
     if ttys_n:
-
-        if ttys_n not in list(TTY_CONSOLE.keys()):
-            err_dic["board config: ttyS not available"] = "console should be set in scenario.xml of board_private section"
-            return (err_dic, vuart0_console_dic, vuart1_console_dic)
 
         (vuart0_valid_console, vuart1_valid_console, show_vuart1) = console_to_show(BOARD_INFO_FILE)
 

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -627,3 +627,53 @@ def undline_name(name):
         name_str = "_".join(name_str.split()).upper()
 
     return name_str
+
+
+def get_vuart_id(tmp_vuart, leaf_tag, leaf_text):
+    """
+    Get all vuart id member of class
+    :param tmp_vuart: a dictionary to store member:value
+    :param leaf_tag: key pattern of item tag
+    :param leaf_text: key pattern of item tag's value
+    :return: a dictionary to which stored member:value
+    """
+    if leaf_tag == "type":
+        tmp_vuart['type'] = leaf_text
+    if leaf_tag == "base":
+        tmp_vuart['base'] = leaf_text
+    if leaf_tag == "irq":
+        tmp_vuart['irq'] = leaf_text
+
+    if leaf_tag == "target_vm_id":
+        tmp_vuart['target_vm_id'] = leaf_text
+    if leaf_tag == "target_uart_id":
+        tmp_vuart['target_uart_id'] = leaf_text
+
+    return tmp_vuart
+
+
+def get_vuart_info_id(config_file, idx):
+    """
+    Get vuart information by vuart id indexx
+    :param config_file: it is a file what contains information for script to read from
+    :param idx: vuart index in range: [0,1]
+    :return: dictionary which stored the vuart-id
+    """
+    tmp_tag = {}
+    vm_id = 0
+    root = get_config_root(config_file)
+    for item in root:
+        for sub in item:
+            tmp_vuart = {}
+            for leaf in sub:
+                if sub.tag == "vuart" and int(sub.attrib['id']) == idx:
+                    tmp_vuart = get_vuart_id(tmp_vuart, leaf.tag, leaf.text)
+
+            # append vuart for each vm
+            if tmp_vuart and sub.tag == "vuart":
+                tmp_tag[vm_id] = tmp_vuart
+
+        if item.tag == "vm":
+            vm_id += 1
+
+    return tmp_tag

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -48,6 +48,14 @@ PT_SLOT = {
 
 
 POST_UUID_DIC = {}
+PM_CHANNEL = ['', 'IOC', 'PowerButton', 'vuart1(pty)', 'vuart1(tty)']
+PM_CHANNEL_DIC = {
+    None:'',
+    'IOC':'--pm_notify_channel ioc',
+    'PowerButton':'--pm_notify_channel power_button',
+    'vuart1(pty)':'--pm_notify_channel uart \\\n\t--pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n\t-l com2,/run/acrn/life_mngr_$vm_name',
+    'vuart1(tty)':'--pm_notify_channel uart --pm_by_vuart tty,/dev/ttyS1',
+}
 
 
 def prepare(check_git):

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -15,14 +15,9 @@ LAUNCH_INFO_FILE = ""
 ERR_LIST = {}
 BOOT_TYPE = ['no', 'vsbl', 'ovmf']
 RTOS_TYPE = ['no', 'Soft RT', 'Hard RT']
-REDIRECT_CONSOLE = ['com1(ttyS0)', 'virtio-console(hvc0)']
+DM_VUART0 = ['Disable', 'Enable']
 UOS_TYPES = ['CLEARLINUX', 'ANDROID', 'ALIOS', 'PREEMPT-RT LINUX', 'VXWORKS', 'WINDOWS', 'ZEPHYR', 'GENERIC LINUX']
 GVT_ARGS = ['64 448 8']
-
-RE_CONSOLE_MAP = {
-        "com1(ttyS0)":"virtio-console,@pty:pty_port",
-        "virtio-console(hvc0)":"virtio-console,@stdio:stdio_port"
-}
 
 PT_SUB_PCI = {}
 PT_SUB_PCI['usb_xdci'] = ['USB controller']

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -53,7 +53,7 @@ PM_CHANNEL_DIC = {
     None:'',
     'IOC':'--pm_notify_channel ioc',
     'PowerButton':'--pm_notify_channel power_button',
-    'vuart1(pty)':'--pm_notify_channel uart \\\n\t--pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n\t-l com2,/run/acrn/life_mngr_$vm_name',
+    'vuart1(pty)':'--pm_notify_channel uart \\\n   --pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
     'vuart1(tty)':'--pm_notify_channel uart --pm_by_vuart tty,/dev/ttyS1',
 }
 
@@ -596,3 +596,9 @@ def undline_name(name):
     :return: name_str which contain'_'
     """
     return common.undline_name(name)
+
+
+def get_vuart1_from_scenario(vmid):
+    """Get the vmid's  vuart1 base"""
+    vuart1 = common.get_vuart_info_id(SCENARIO_INFO_FILE, 1)
+    return vuart1[vmid]['base']

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -44,6 +44,13 @@ DEFAULT_VM_COUNT = {
 }
 KATA_VM_COUNT = 0
 
+LEGACY_TTYS = {
+    'ttyS0':'0x3F8',
+    'ttyS1':'0x2F8',
+    'ttyS2':'0x3E8',
+    'ttyS3':'0x2E8',
+}
+
 def prepare(check_git):
     """ Check environment """
     return common.check_env(check_git)
@@ -178,8 +185,11 @@ def get_ttys_info(board_info):
         if not ttys_line:
             break
 
-        #ttys_dev = " ".join(ttys_line.strip().split()[:-2])
         ttys_dev = ttys_line.split()[0].split(':')[1]
+        ttysn = ttys_dev.split('/')[-1]
+        # currently SOS console can only support legacy serial port
+        if ttysn not in list(LEGACY_TTYS.keys()):
+            continue
         ttys_list.append(ttys_dev)
 
     return ttys_list

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -670,29 +670,6 @@ def gen_patch(srcs_list, scenario_name):
     return err_dic
 
 
-def get_vuart_id(tmp_vuart, leaf_tag, leaf_text):
-    """
-    Get all vuart id member of class
-    :param tmp_vuart: a dictionary to store member:value
-    :param leaf_tag: key pattern of item tag
-    :param leaf_text: key pattern of item tag's value
-    :return: a dictionary to which stored member:value
-    """
-    if leaf_tag == "type":
-        tmp_vuart['type'] = leaf_text
-    if leaf_tag == "base":
-        tmp_vuart['base'] = leaf_text
-    if leaf_tag == "irq":
-        tmp_vuart['irq'] = leaf_text
-
-    if leaf_tag == "target_vm_id":
-        tmp_vuart['target_vm_id'] = leaf_text
-    if leaf_tag == "target_uart_id":
-        tmp_vuart['target_uart_id'] = leaf_text
-
-    return tmp_vuart
-
-
 def get_vuart_info_id(config_file, idx):
     """
     Get vuart information by vuart id indexx
@@ -700,23 +677,7 @@ def get_vuart_info_id(config_file, idx):
     :param idx: vuart index in range: [0,1]
     :return: dictionary which stored the vuart-id
     """
-    tmp_tag = {}
-    vm_id = 0
-    root = common.get_config_root(config_file)
-    for item in root:
-        for sub in item:
-            tmp_vuart = {}
-            for leaf in sub:
-                if sub.tag == "vuart" and int(sub.attrib['id']) == idx:
-                    tmp_vuart = get_vuart_id(tmp_vuart, leaf.tag, leaf.text)
-
-            # append vuart for each vm
-            if tmp_vuart and sub.tag == "vuart":
-                tmp_tag[vm_id] = tmp_vuart
-
-        if item.tag == "vm":
-            vm_id += 1
-
+    tmp_tag = common.get_vuart_info_id(config_file, idx)
     return tmp_tag
 
 
@@ -737,7 +698,6 @@ def avl_vuart_ui_select(scenario_info):
             key = "vm={},vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM2_BASE']
 
-    #print(tmp_vuart)
     return tmp_vuart
 
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel ioc \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">AaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:android/android.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel ioc \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">AliaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:alios/alios.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel ioc \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk1p3:clearlinux/clearlinux.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel ioc \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:clearlinux/clearlinux.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">AaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:android/android.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/dev/mmcblk0p1:clearlinux/clearlinux.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type"></console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
@@ -29,6 +29,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -6,8 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type"></console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
@@ -29,6 +29,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -6,8 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type"></console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
@@ -29,6 +29,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
     <uos id="2">
@@ -37,7 +38,7 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type"></console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
@@ -61,6 +62,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -6,8 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
-	<poweroff_channel desc="the method of power off uos">
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -39,8 +38,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte"></mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type"></console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">
 	</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
@@ -29,6 +29,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -6,8 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -38,6 +39,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 
@@ -36,7 +37,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -58,6 +59,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -38,6 +39,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 
@@ -36,7 +37,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -58,6 +59,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -38,6 +39,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 
@@ -36,7 +37,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -58,6 +59,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -38,6 +39,7 @@
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
 	</virtio_devices>
     </uos>
 
@@ -36,7 +37,7 @@
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
 	<gvt_args configurable="0" desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -58,6 +59,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -6,9 +6,7 @@
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos" readonly="true">
-	--pm_notify_channel power_button \
-	</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
 	<gvt_args desc="GVT argument for the vm">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">virtio-console(hvc0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos" readonly="true">
 	--pm_notify_channel power_button \
 	</poweroff_channel>
@@ -30,6 +30,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -5,7 +5,7 @@
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
-	<console_type desc="UOS console type">com1(ttyS0)</console_type>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>
@@ -27,6 +27,7 @@
 		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
 		<input desc="virtio input device"></input>
 		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
 	</virtio_devices>
     </uos>
 </acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT argument for the vm"></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
 	<passthrough_devices>


### PR DESCRIPTION

- hide non-legacy serial port as SOS console
- unify get_vuart_info_id api in config tool
- add 'poweroff_channel' support for launch config
- modify 'poweroff_channel' info in launch xmls
- add 'virtio-console' info in launch xmls
- add 'virtio-console' mediator support for launch config
    
    Tracked-On: #4212
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
