### PR TITLE
doc:debug feature is disabled by default

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -209,18 +209,20 @@ HYBRID:
    Standard VM.
 
 Assuming that you are at the top level of the acrn-hypervisor directory:
+  .. note::
+     Release version is built by default, 'RELEASE=0' is to build debug version.
 
 * Build ``INDUSTRY`` scenario on ``nuc7i7dnb``:
 
   .. code-block:: none
 
-     $ make all BOARD=nuc7i7dnb SCENARIO=industry
+     $ make all BOARD=nuc7i7dnb SCENARIO=industry RELEASE=0
 
 * Build ``SDC`` scenario on ``nuc6cayh``:
 
   .. code-block:: none
 
-     $ make all BOARD=nuc6cayh SCENARIO=sdc
+     $ make all BOARD=nuc6cayh SCENARIO=sdc RELEASE=0
 
 See the :ref:`hardware` document for information about the platform needs
 for each scenario.


### PR DESCRIPTION
Update guidance to build ACRN from source,
as debug feature is disabled by default in Makefile.

 'RELEASE' shall be 0 if debug feature is required.

Tracked-On: #4222
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>