### PR TITLE
HV: remove MAX_VCPUS_PER_VM in Kconfig

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -76,14 +76,6 @@ config RELEASE
 	  console and hypervisor shell are available only in non-release
 	  (i.e. debug) builds. Assertions are not effective in release builds.
 
-config MAX_VCPUS_PER_VM
-	int "Maximum number of VCPUs per VM"
-	range 1 48
-	default 8
-	help
-	  The maximum number of virtual CPUs the hypervisor can support in a
-	  single VM.
-
 config MAX_EMULATED_MMIO_REGIONS
 	int "Maximum number of emulated MMIO regions"
 	range 0 128

--- a/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
@@ -7,7 +7,7 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define CONFIG_MAX_PCPU_NUM	4U
+#define MAX_PCPU_NUM	4U
 #define MAX_PLATFORM_CLOS_NUM	0U
 
 #define ROOTFS_0		"root=/dev/sda3 "

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -7,7 +7,7 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define CONFIG_MAX_PCPU_NUM	4U
+#define MAX_PCPU_NUM	4U
 #define MAX_PLATFORM_CLOS_NUM	4U
 
 #define ROOTFS_0		"root=/dev/sda3 "

--- a/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
@@ -7,7 +7,7 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define CONFIG_MAX_PCPU_NUM	8U
+#define MAX_PCPU_NUM	8U
 #define MAX_PLATFORM_CLOS_NUM	0U
 
 #define ROOTFS_0		"root=/dev/sda3 "

--- a/hypervisor/arch/x86/configs/generic/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/generic/misc_cfg.h
@@ -7,7 +7,7 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define CONFIG_MAX_PCPU_NUM	4U
+#define MAX_PCPU_NUM	4U
 #define MAX_PLATFORM_CLOS_NUM	0U
 
 #define ROOTFS_0		"root=/dev/sda3 "

--- a/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
@@ -7,7 +7,7 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define CONFIG_MAX_PCPU_NUM	4U
+#define MAX_PCPU_NUM	4U
 #define MAX_PLATFORM_CLOS_NUM	0U
 
 #define ROOTFS_0		"root=/dev/sda3 "

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
@@ -7,7 +7,7 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define CONFIG_MAX_PCPU_NUM	4U
+#define MAX_PCPU_NUM	4U
 #define MAX_PLATFORM_CLOS_NUM	0U
 
 #define ROOTFS_0		"root=/dev/sda3 "

--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -53,7 +53,7 @@ static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 			.lint = 0x1U,
 		},
 		.lapic_array = {
-			[0U ... (CONFIG_MAX_PCPU_NUM - 1U)] = {
+			[0U ... (MAX_PCPU_NUM - 1U)] = {
 				.header.type = ACPI_MADT_TYPE_LOCAL_APIC,
 				.header.length = sizeof(struct acpi_madt_local_apic),
 				.lapic_flags = 0x1U, /* Processor Enabled=1, Runtime Online Capable=0 */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -32,7 +32,7 @@
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
 
-struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM] __aligned(PAGE_SIZE);
+struct per_cpu_region per_cpu_data[MAX_PCPU_NUM] __aligned(PAGE_SIZE);
 static uint16_t phys_cpu_num = 0U;
 static uint64_t pcpu_sync = 0UL;
 static uint64_t startup_paddr = 0UL;
@@ -47,18 +47,18 @@ static uint16_t get_pcpu_id_from_lapic_id(uint32_t lapic_id);
 static uint64_t start_tsc __attribute__((__section__(".bss_noinit")));
 
 /**
- * @pre phys_cpu_num <= CONFIG_MAX_PCPU_NUM
+ * @pre phys_cpu_num <= MAX_PCPU_NUM
  */
 static bool init_percpu_lapic_id(void)
 {
 	uint16_t i;
-	uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM];
+	uint32_t lapic_id_array[MAX_PCPU_NUM];
 	bool success = false;
 
 	/* Save all lapic_id detected via parse_mdt in lapic_id_array */
 	phys_cpu_num = parse_madt(lapic_id_array);
 
-	if ((phys_cpu_num != 0U) && (phys_cpu_num <= CONFIG_MAX_PCPU_NUM)) {
+	if ((phys_cpu_num != 0U) && (phys_cpu_num <= MAX_PCPU_NUM)) {
 		for (i = 0U; i < phys_cpu_num; i++) {
 			per_cpu(lapic_id, i) = lapic_id_array[i];
 		}
@@ -82,7 +82,7 @@ static void pcpu_set_current_state(uint16_t pcpu_id, enum pcpu_boot_state state)
 }
 
 /*
- * @post return <= CONFIG_MAX_PCPU_NUM
+ * @post return <= MAX_PCPU_NUM
  */
 uint16_t get_pcpu_nums(void)
 {
@@ -174,7 +174,7 @@ void init_pcpu_pre(bool is_bsp)
 		early_init_lapic();
 
 		pcpu_id = get_pcpu_id_from_lapic_id(get_cur_lapic_id());
-		if (pcpu_id >= CONFIG_MAX_PCPU_NUM) {
+		if (pcpu_id >= MAX_PCPU_NUM) {
 			panic("Invalid pCPU ID!");
 		}
 	}

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -67,7 +67,7 @@ static uint32_t calculate_logical_dest_mask(uint64_t pdmask)
 	uint16_t pcpu_id;
 
 	pcpu_id = ffs64(pcpu_mask);
-	while (pcpu_id < CONFIG_MAX_PCPU_NUM) {
+	while (pcpu_id < MAX_PCPU_NUM) {
 		bitmap_clear_nolock(pcpu_id, &pcpu_mask);
 		dest_mask |= per_cpu(lapic_ldr, pcpu_id);
 		pcpu_id = ffs64(pcpu_mask);

--- a/hypervisor/arch/x86/guest/hyperv.c
+++ b/hypervisor/arch/x86/guest/hyperv.c
@@ -262,7 +262,7 @@ hyperv_init_vcpuid_entry(uint32_t leaf, uint32_t subleaf, uint32_t flags,
 		entry->edx = 0U;
 		break;
 	case 0x40000005U: /* HV Maximum Supported Virtual & logical Processors */
-		entry->eax = CONFIG_MAX_VCPUS_PER_VM;
+		entry->eax = MAX_VCPUS_PER_VM;
 		entry->ebx = 0U;
 		entry->ecx = 0U;
 		entry->edx = 0U;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -412,7 +412,7 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 	 * vm->hw.created_vcpus++;
 	 */
 	vcpu_id = vm->hw.created_vcpus;
-	if (vcpu_id < CONFIG_MAX_VCPUS_PER_VM) {
+	if (vcpu_id < MAX_VCPUS_PER_VM) {
 		/* Allocate memory for VCPU */
 		vcpu = &(vm->hw.vcpu_array[vcpu_id]);
 		(void)memset((void *)vcpu, 0U, sizeof(struct acrn_vcpu));
@@ -443,7 +443,7 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 		 *
 		 * This assignment guarantees a unique non-zero per vcpu vpid in runtime.
 		 */
-		vcpu->arch.vpid = 1U + (vm->vm_id * CONFIG_MAX_VCPUS_PER_VM) + vcpu->vcpu_id;
+		vcpu->arch.vpid = 1U + (vm->vm_id * MAX_VCPUS_PER_VM) + vcpu->vcpu_id;
 
 		/* Initialize exception field in VCPU context */
 		vcpu->arch.exception_info.exception = VECTOR_INVALID;

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1685,7 +1685,7 @@ vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops)
 
 /**
  * @pre vlapic->vm != NULL
- * @pre vlapic->vcpu->vcpu_id < CONFIG_MAX_VCPUS_PER_VM
+ * @pre vlapic->vcpu->vcpu_id < MAX_VCPUS_PER_VM
  */
 void
 vlapic_init(struct acrn_vlapic *vlapic)

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -240,7 +240,7 @@ void send_dest_ipi_mask(uint32_t dest_mask, uint32_t vector)
 
 	pcpu_id = ffs64(mask);
 
-	while (pcpu_id < CONFIG_MAX_PCPU_NUM) {
+	while (pcpu_id < MAX_PCPU_NUM) {
 		bitmap32_clear_nolock(pcpu_id, &mask);
 		if (is_pcpu_active(pcpu_id)) {
 			icr.value_32.hi_32 = per_cpu(lapic_id, pcpu_id);
@@ -270,7 +270,7 @@ void send_single_ipi(uint16_t pcpu_id, uint32_t vector)
 }
 
 /**
- * @pre pcpu_id < CONFIG_MAX_PCPU_NUM
+ * @pre pcpu_id < MAX_PCPU_NUM
  *
  * @return None
  */

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -44,7 +44,7 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 	/* wait for previous smp call complete, which may run on other cpus */
 	while (atomic_cmpxchg64(&smp_call_mask, 0UL, mask & INVALID_BIT_INDEX) != 0UL);
 	pcpu_id = ffs64(mask);
-	while (pcpu_id < CONFIG_MAX_PCPU_NUM) {
+	while (pcpu_id < MAX_PCPU_NUM) {
 		bitmap_clear_nolock(pcpu_id, &mask);
 		if (is_pcpu_active(pcpu_id)) {
 			smp_call = &per_cpu(smp_call_info, pcpu_id);

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -159,7 +159,7 @@ void *get_acpi_tbl(const char *signature)
  * of Type 0
  */
 static uint16_t
-local_parse_madt(struct acpi_table_madt *madt, uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM])
+local_parse_madt(struct acpi_table_madt *madt, uint32_t lapic_id_array[MAX_PCPU_NUM])
 {
 	uint16_t pcpu_num = 0U;
 	struct acpi_madt_local_apic *processor;
@@ -181,7 +181,7 @@ local_parse_madt(struct acpi_table_madt *madt, uint32_t lapic_id_array[CONFIG_MA
 		if (entry->type == ACPI_MADT_TYPE_LOCAL_APIC) {
 			processor = (struct acpi_madt_local_apic *)iterator;
 			if ((processor->lapic_flags & ACPI_MADT_ENABLED) != 0U) {
-				if (pcpu_num < CONFIG_MAX_PCPU_NUM) {
+				if (pcpu_num < MAX_PCPU_NUM) {
 					lapic_id_array[pcpu_num] = processor->id;
 				}
 				pcpu_num++;
@@ -227,7 +227,7 @@ ioapic_parse_madt(void *madt, struct ioapic_info *ioapic_id_array)
 }
 
 /* The lapic_id info gotten from madt will be returned in lapic_id_array */
-uint16_t parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM])
+uint16_t parse_madt(uint32_t lapic_id_array[MAX_PCPU_NUM])
 {
 	uint16_t ret = 0U;
 	struct acpi_table_rsdp *rsdp = NULL;

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -202,7 +202,7 @@ struct acpi_dmar_device_scope {
 void *get_acpi_tbl(const char *signature);
 
 struct ioapic_info;
-uint16_t parse_madt(uint32_t lapic_id_array[CONFIG_MAX_PCPU_NUM]);
+uint16_t parse_madt(uint32_t lapic_id_array[MAX_PCPU_NUM]);
 uint16_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array);
 
 #ifdef CONFIG_ACPI_PARSE_ENABLED

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -120,7 +120,7 @@ int32_t hcall_get_platform_info(struct acrn_vm *vm, uint64_t param)
 	struct hc_platform_info platform_info;
 
 	platform_info.cpu_num = get_pcpu_nums();
-	platform_info.max_vcpus_per_vm = CONFIG_MAX_VCPUS_PER_VM;
+	platform_info.max_vcpus_per_vm = MAX_VCPUS_PER_VM;
 	platform_info.max_kata_containers = CONFIG_MAX_KATA_VM_NUM;
 	if (copy_to_gpa(vm, &platform_info, param, sizeof(platform_info)) != 0) {
 		pr_err("%s: Unable copy param to vm\n", __func__);
@@ -317,7 +317,7 @@ int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 			(target_vm->state != VM_STARTED)) {
 		if (copy_from_gpa(vm, &vcpu_regs, param, sizeof(vcpu_regs)) != 0) {
 			pr_err("%s: Unable copy param to vm\n", __func__);
-		} else if (vcpu_regs.vcpu_id >= CONFIG_MAX_VCPUS_PER_VM) {
+		} else if (vcpu_regs.vcpu_id >= MAX_VCPUS_PER_VM) {
 			pr_err("%s: invalid vcpu_id for set_vcpu_regs\n", __func__);
 		} else {
 			vcpu = vcpu_from_vid(target_vm, vcpu_regs.vcpu_id);
@@ -548,7 +548,7 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 		dev_dbg(ACRN_DBG_HYCALL, "[%d] NOTIFY_FINISH for vcpu %d",
 			vmid, vcpu_id);
 
-		if (vcpu_id >= CONFIG_MAX_VCPUS_PER_VM) {
+		if (vcpu_id >= MAX_VCPUS_PER_VM) {
 			pr_err("%s, failed to get VCPU %d context from VM %d\n",
 				__func__, vcpu_id, target_vm->vm_id);
 		} else {

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -812,7 +812,7 @@ static void profiling_stop_pmu(void)
 int32_t profiling_msr_ops_all_cpus(struct acrn_vm *vm, uint64_t addr)
 {
 	uint16_t i;
-	struct profiling_msr_ops_list msr_list[CONFIG_MAX_PCPU_NUM];
+	struct profiling_msr_ops_list msr_list[MAX_PCPU_NUM];
 	uint16_t pcpu_nums = get_pcpu_nums();
 
 	dev_dbg(ACRN_DBG_PROFILING, "%s: entering", __func__);
@@ -1256,7 +1256,7 @@ int32_t profiling_get_pcpu_id(struct acrn_vm *vm, uint64_t addr)
 int32_t profiling_get_status_info(struct acrn_vm *vm, uint64_t gpa)
 {
 	uint16_t i;
-	struct profiling_status pstats[CONFIG_MAX_PCPU_NUM];
+	struct profiling_status pstats[MAX_PCPU_NUM];
 	uint16_t pcpu_nums = get_pcpu_nums();
 
 	dev_dbg(ACRN_DBG_PROFILING, "%s: entering", __func__);

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -26,7 +26,7 @@
 #define MAX_STR_SIZE		256U
 #define SHELL_PROMPT_STR	"ACRN:\\>"
 
-#define SHELL_LOG_BUF_SIZE		(PAGE_SIZE * CONFIG_MAX_PCPU_NUM / 2U)
+#define SHELL_LOG_BUF_SIZE		(PAGE_SIZE * MAX_PCPU_NUM / 2U)
 static char shell_log_buf[SHELL_LOG_BUF_SIZE];
 
 /* Input Line Other - Switch to the "other" input line (there are only two

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -658,7 +658,7 @@ static inline void clac(void)
 }
 
 /*
- * @post return <= CONFIG_MAX_PCPU_NUM
+ * @post return <= MAX_PCPU_NUM
  */
 uint16_t get_pcpu_nums(void);
 bool is_pcpu_active(uint16_t pcpu_id);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -191,7 +191,7 @@ void vlapic_create(struct acrn_vcpu *vcpu);
 void vlapic_free(struct acrn_vcpu *vcpu);
 /**
  * @pre vlapic->vm != NULL
- * @pre vlapic->vcpu->vcpu_id < CONFIG_MAX_VCPUS_PER_VM
+ * @pre vlapic->vcpu->vcpu_id < MAX_VCPUS_PER_VM
  */
 void vlapic_init(struct acrn_vlapic *vlapic);
 void vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -32,7 +32,7 @@
 
 struct vm_hw_info {
 	/* vcpu array of this VM */
-	struct acrn_vcpu vcpu_array[CONFIG_MAX_VCPUS_PER_VM];
+	struct acrn_vcpu vcpu_array[MAX_VCPUS_PER_VM];
 	uint16_t created_vcpus;	/* Number of created vcpus */
 } __aligned(PAGE_SIZE);
 
@@ -167,7 +167,7 @@ static inline uint64_t vm_active_cpus(const struct acrn_vm *vm)
 }
 
 /*
- * @pre vcpu_id < CONFIG_MAX_VCPUS_PER_VM
+ * @pre vcpu_id < MAX_VCPUS_PER_VM
  * @pre &(vm->hw.vcpu_array[vcpu_id])->state != VCPU_OFFLINE
  */
 static inline struct acrn_vcpu *vcpu_from_vid(struct acrn_vm *vm, uint16_t vcpu_id)

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -60,7 +60,7 @@ struct per_cpu_region {
 	uint64_t tsc_suspend;
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
-extern struct per_cpu_region per_cpu_data[CONFIG_MAX_PCPU_NUM];
+extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];
 /*
  * get percpu data for pcpu_id.
  */

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -15,6 +15,7 @@
 #include <sgx.h>
 
 #define AFFINITY_CPU(n)		(1U << (n))
+#define MAX_VCPUS_PER_VM	MAX_PCPU_NUM
 #define MAX_VUART_NUM_PER_VM	2U
 #define MAX_VM_OS_NAME_LEN	32U
 #define MAX_MOD_TAG_LEN		32U
@@ -99,7 +100,7 @@ struct acrn_vm_config {
 	const uint8_t uuid[16];				/* UUID of the VM */
 	uint16_t vcpu_num;				/* Number of vCPUs for the VM */
 
-	uint64_t vcpu_affinity[CONFIG_MAX_VCPUS_PER_VM];/* bitmaps for vCPUs' affinity */
+	uint64_t vcpu_affinity[MAX_VCPUS_PER_VM];/* bitmaps for vCPUs' affinity */
 	uint64_t guest_flags;				/* VM flags that we want to configure for guest
 							 * Now we have two flags:
 							 *	GUEST_FLAG_SECURE_WORLD_ENABLED

--- a/hypervisor/include/debug/profiling_internal.h
+++ b/hypervisor/include/debug/profiling_internal.h
@@ -10,6 +10,7 @@
 #ifdef PROFILING_ON
 
 #include <vcpu.h>
+#include <vm_config.h>
 #include <vm_configurations.h>
 
 #define MAX_MSR_LIST_NUM		15U
@@ -114,7 +115,7 @@ struct profiling_vm_info {
 	uint8_t uuid[16];
 	char vm_name[16];
 	uint16_t num_vcpus;
-	struct profiling_vcpu_pcpu_map cpu_map[CONFIG_MAX_VCPUS_PER_VM];
+	struct profiling_vcpu_pcpu_map cpu_map[MAX_VCPUS_PER_VM];
 };
 
 struct profiling_vm_info_list {

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -54,7 +54,7 @@ struct acpi_table_info {
 	struct {
 		struct acpi_table_madt madt;
 		struct acpi_madt_local_apic_nmi lapic_nmi;
-		struct acpi_madt_local_apic lapic_array[CONFIG_MAX_PCPU_NUM];
+		struct acpi_madt_local_apic lapic_array[MAX_PCPU_NUM];
 	} __packed;
 };
 

--- a/hypervisor/pre_build/static_checks.c
+++ b/hypervisor/pre_build/static_checks.c
@@ -16,7 +16,7 @@
 typedef int32_t CAT_(CTA_DummyType,__LINE__)[(expr) ? 1 : -1]
 
 /* This is to make sure the 16 bits vpid won't overflow */
-#if ((CONFIG_MAX_VM_NUM * CONFIG_MAX_VCPUS_PER_VM) > 0xffffU)
+#if ((CONFIG_MAX_VM_NUM * MAX_VCPUS_PER_VM) > 0xffffU)
 #error "VM number or VCPU number are too big"
 #endif
 

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -46,7 +46,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		.uuid = {0xd2U, 0x79U, 0x54U, 0x38U, 0x25U, 0xd6U, 0x11U, 0xe8U,	\
 			 0x86U, 0x4eU, 0xcbU, 0x7aU, 0x18U, 0xb3U, 0x46U, 0x43U},
 			/* d2795438-25d6-11e8-864e-cb7a18b34643 */
-		.vcpu_num = CONFIG_MAX_PCPU_NUM - CONFIG_MAX_KATA_VM_NUM - 1U,
+		.vcpu_num = MAX_PCPU_NUM - CONFIG_MAX_KATA_VM_NUM - 1U,
 		.vcpu_affinity = VM1_CONFIG_VCPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -121,7 +121,7 @@ def generate_file(config):
     print("{}".format(MISC_CFG_HEADER), file=config)
 
     # define CONFIG_MAX_PCPCU_NUM
-    print("#define CONFIG_MAX_PCPU_NUM\t{}U".format(max_cpu_num), file=config)
+    print("#define MAX_PCPU_NUM\t{}U".format(max_cpu_num), file=config)
 
     # set macro of max clos number
     (cache_support, clos_max) = board_cfg_lib.clos_info_parser(board_cfg_lib.BOARD_INFO_FILE)


### PR DESCRIPTION
In current architecutre, the maximum vCPUs number per VM could not
    exceed the pCPUs number. Given the MAX_PCPU_NUM macro is provided
    in board configurations, so remove the MAX_VCPUS_PER_VM from Kconfig
    and add a macro of MAX_VCPUS_PER_VM to reference MAX_PCPU_NUM directly.
    
Tracked-On: #4230

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
