### PR TITLE
doc: add new dependency to Clear Linux ACRN builder container

### DIFF
--- a/doc/getting-started/Dockerfile
+++ b/doc/getting-started/Dockerfile
@@ -19,6 +19,7 @@ RUN swupd update -b && \
 			devpkg-libusb \
 			devpkg-libpciaccess \
 			devpkg-gnu-efi \
+			devpkg-numactl \
 			bc \
 			lz4 \
 			diffutils \


### PR DESCRIPTION
Since commit 9e9e1f61, a new build dependency on the NUMA library has been
introduced. We therefore need to add the `devpkg-numactl` bundle to our
Dockerfile used to build the Clear Linux "ACRN builder" container image.

Tracked-On: #4175
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>