### PR TITLE
HV: Kconfig: set kata num to 1 and add some memory range check 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ hypervisor:
 	else \
 		$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD_FILE=$(BOARD_FILE) SCENARIO_FILE=$(SCENARIO_FILE) defconfig; \
 		echo "CONFIG_$(shell echo $(SCENARIO) | tr a-z A-Z)=y" >> $(HV_OUT)/.config;	\
+		if [ "$(SCENARIO)" != "sdc" ]; then \
+			echo "CONFIG_MAX_KATA_VM_NUM=0" >> $(HV_OUT)/.config; \
+		fi; \
 		if [ "$(CONFIG_XML_ENABLED)" = "true" ]; then \
 			echo "CONFIG_ENFORCE_VALIDATED_ACPI_INFO=y" >> $(HV_OUT)/.config;	\
 		fi; \

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -178,6 +178,7 @@ config NPK_LOGLEVEL_DEFAULT
 
 config LOW_RAM_SIZE
 	hex "Size of the low RAM region"
+	range 0 0x10000
 	default 0x00010000
 	help
 	  A 32-bit integer indicating the size of RAM region below address
@@ -199,6 +200,7 @@ config HV_RAM_START
 
 config HV_RAM_SIZE
 	hex "Size of the RAM region used by the hypervisor"
+	range 0x1000000 0x10000000
 	default 0x0b800000
 	help
 	  A 64-bit integer indicating the size of RAM used by the hypervisor.
@@ -207,6 +209,7 @@ config HV_RAM_SIZE
 
 config PLATFORM_RAM_SIZE
 	hex "Size of the physical platform RAM"
+	range 0x100000000 0x4000000000
 	default 0x400000000
 	help
 	  A 64-bit integer indicating the size of the physical platform RAM
@@ -214,6 +217,7 @@ config PLATFORM_RAM_SIZE
 
 config SOS_RAM_SIZE
 	hex "Size of the Service OS (SOS) RAM"
+	range 0x100000000 0x4000000000
 	default 0x400000000
 	help
 	  A 64-bit integer indicating the size of the Service OS RAM (MMIO not
@@ -221,6 +225,7 @@ config SOS_RAM_SIZE
 
  config UOS_RAM_SIZE
 	hex "Size of the User OS (UOS) RAM"
+	range 0 0x2000000000
 	default 0x200000000
 	help
 	  A 64-bit integer indicating the size of the User OS RAM (MMIO not

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -308,7 +308,8 @@ config L1D_FLUSH_VMENTRY_ENABLED
 config MAX_KATA_VM_NUM
 	int "Maximum number of Kata Containers in SOS"
 	range 0 1
-	default 0
+	default 1 if SDC
+	default 0 if !SDC
 
 config UEFI_OS_LOADER_NAME
 	string "UEFI OS loader name"


### PR DESCRIPTION
- Set default CONFIG_KATA_VM_NUM to 1 in SDC scenario so that user could
    have a try on Kata container without rebuilding hypervisor.

- When user use make menuconfig to configure memory related kconfig items,
    we need add range check to avoid compile error or other potential issues.
    
Tracked-On: #4229

Signed-off-by: Victor Sun <victor.sun@intel.com>
