### PR TITLE
acrn-config: Add non-contiguous HPA to currently supported hardware.

### DIFF
--- a/misc/acrn-config/board_config/ve820_c.py
+++ b/misc/acrn-config/board_config/ve820_c.py
@@ -45,8 +45,12 @@ def ve820_per_launch(config, hpa_size, hpa2_size):
             low_mem_hpa_len.append(511 * 1024 * 1024)
             high_mem_hpa_len.append(int(hpa_size[i], 16) - 512 * 1024 * 1024)
 
-         #HPA2 is always allocated in >4G space.
-        high_mem_hpa2_len.append(int(hpa2_size[i], 16))
+        if len(hpa2_size) == 0:
+            high_mem_hpa2_len.append(0)
+        else:
+            high_mem_hpa2_len.append(int(hpa2_size[i], 16))
+
+        #HPA2 is always allocated in >4G space.
         if (high_mem_hpa_len[i] != 0) and (high_mem_hpa2_len[i] != 0):
             high_mem_hpa2_addr.append(FOUR_GBYTE + high_mem_hpa_len[i])
         else:

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -17,6 +17,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -18,6 +18,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -65,6 +67,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -18,6 +18,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -64,6 +66,8 @@
     <memory>
         <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -17,6 +17,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -19,6 +19,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -66,6 +68,8 @@
     <memory>
         <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -17,6 +17,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -19,6 +19,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -66,6 +68,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -17,6 +17,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -19,6 +19,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -66,6 +68,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -17,6 +17,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -19,6 +19,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -66,6 +68,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -17,6 +17,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -19,6 +19,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
         <size desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
@@ -66,6 +68,8 @@
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
         <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>
     <os_config>
         <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>


### PR DESCRIPTION
For currently supported hardware such as KNL NUC, the scenario xml file is not generated and the newly added non-contiguous variables will not be present. This can lead to build issues. This patch adds the second non-contiguous HPA variable to all supported hardware for both logical_partition and hybrid modes. It also adds checks to ensure that HPA2 is valid before using it while creating the guest VM ve820.

Tracked-On: #4242
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>