### PR TITLE
acrnboot: fix the parsing hv_cmdline to correctly handle the case of …

### DIFF
--- a/hypervisor/boot/cmdline.c
+++ b/hypervisor/boot/cmdline.c
@@ -17,7 +17,7 @@
 int32_t parse_hv_cmdline(void)
 {
 	const char *start;
-	const char *end;
+	const char *end = NULL;
 	struct multiboot_info *mbi = NULL;
 
 	if (boot_regs[0] != MULTIBOOT_INFO_MAGIC) {
@@ -35,20 +35,20 @@ int32_t parse_hv_cmdline(void)
 	start = (char *)hpa2hva_early((uint64_t)mbi->mi_cmdline);
 	dev_dbg(ACRN_DBG_PARSE, "hv cmdline: %s", start);
 
-	do {
-		while (*start == ' ')
+	while ((start != NULL) && ((*start) != '\0')) {
+		while ((*start) == ' ')
 			start++;
+		if ((*start) != '\0') {
+			end = start + 1;
+			while ((*end != ' ') && ((*end) != '\0'))
+				end++;
 
-		end = start + 1;
-		while ((*end != ' ') && ((*end) != '\0'))
-			end++;
-
-		if (!handle_dbg_cmd(start, (int32_t)(end - start))) {
-			/* if not handled by handle_dbg_cmd, it can be handled further */
+			if (!handle_dbg_cmd(start, (int32_t)(end - start))) {
+				/* if not handled by handle_dbg_cmd, it can be handled further */
+			}
+			start = end;
 		}
-		start = end + 1;
-
-	} while (((*end) != '\0') && ((*start) != '\0'));
+	}
 
 	return 0;
 }


### PR DESCRIPTION
…containing trailing whitespaces

    The pointer variable 'start' should be checked against NULL
    right after detected it is not pointer to a space character,
    otherwise the pointer variable 'end' must hold the wrong
    address right after NULL if the cmdline containing trailing
    whitespaces and deference the wrong address out of cmdline
    string.

Tracked-On: projectacrn#4250
Signed-off-by: Gary <gordon.king@intel.com>