### PR TITLE
hv: hotfix for xsave

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -532,6 +532,10 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu)
 		 */
 		flush_vpid_global();
 
+		/* Set XCR0 and XSS to default value */
+		write_xcr(0, XCR0_DEFAULT);
+		msr_write(MSR_IA32_XSS, XSS_DEFAULT);
+
 		/* Set vcpu launched */
 		vcpu->launched = true;
 

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -85,6 +85,8 @@
 #define CR4_SMAP                (1UL<<21U)
 #define CR4_PKE                 (1UL<<22U)	/* Protect-key-enable */
 
+/* XCR0_FPU */
+#define XCR0_FPU		(1UL<<0U)
 /* XCR0_SSE */
 #define XCR0_SSE		(1UL<<1U)
 /* XCR0_AVX */
@@ -100,6 +102,8 @@
  */
 #define	XCR0_RESERVED_BITS	((~((1UL << 10U) - 1UL)) | (1UL << 8U))
 
+#define XCR0_DEFAULT		(XCR0_FPU)
+#define XSS_DEFAULT		(0U)
 
 /*
  * Entries in the Interrupt Descriptor Table (IDT)


### PR DESCRIPTION
    In current code, XCR0 and XSS are not in default value during vcpu
    launch, it will result in a warning in Linux:

         WARNING: CPU: 0 PID: 0 at arch/x86/kernel/fpu/xstate.c:614
         fpu__init_system_xstate+0x43a/0x878

     For security reason, we set XCR0 and XSS with feature bitmap get from
     CPUID, and run XRSTORS in context switch in. This make sure the XSAVE
     area to be fully in initiate state.
     But, before enter guest for the first time, XCR0 and XSS should be set to
     default value, as the guest kernel assume it.