### PR TITLE
devicemodel: refactor CMD_OPT_LAPIC_PT case branch

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -907,6 +907,8 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_LAPIC_PT:
 			lapic_pt = true;
+			is_rtvm = true;
+			break;
 		case CMD_OPT_RTVM:
 			is_rtvm = true;
 			break;


### PR DESCRIPTION
    This patch refactors the CMD_OPT_LAPIC_PT case branch
    to explicity add the dependency of option RTVM at the
    same branch, it is decoupled from the next case branch
    to comply with strict code standard and improve the
    code readability.

Tracked-On: #4283
Signed-off-by: Gary <gordon.king@intel.com>