### PR TITLE
vpci: trap PCI AF FLR or PCIe FLR and restore BARs information

### DIFF
--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -338,3 +338,22 @@ void udelay(uint32_t us)
 	while (rdtsc() < dest_tsc) {
 	}
 }
+
+/*
+ * @pre ms <= MAX_UINT32 / 1000U
+ */
+void msleep(uint32_t ms)
+{
+	uint64_t dest_tsc, delta_tsc;
+
+	/* Calculate number of ticks to wait */
+	delta_tsc = us_to_ticks(ms * 1000U);
+	dest_tsc = rdtsc() + delta_tsc;
+
+	/* Loop until time expired */
+	while (rdtsc() < dest_tsc) {
+		if (need_reschedule(get_pcpu_id())) {
+			schedule();
+		}
+	}
+}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -235,6 +235,8 @@ void init_vdev_pt(struct pci_vdev *vdev)
 
 	vdev->has_flr = vdev->pdev->has_flr;
 	vdev->pcie_capoff = vdev->pdev->pcie_capoff;
+	vdev->has_af_flr = vdev->pdev->has_af_flr;
+	vdev->af_capoff = vdev->pdev->af_capoff;
 
 	for (idx = 0U; idx < vdev->nr_bars; idx++) {
 		vbar = &vdev->bar[idx];

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -233,6 +233,9 @@ void init_vdev_pt(struct pci_vdev *vdev)
 	vdev->nr_bars = vdev->pdev->nr_bars;
 	pbdf.value = vdev->pdev->bdf.value;
 
+	vdev->has_flr = vdev->pdev->has_flr;
+	vdev->pcie_capoff = vdev->pdev->pcie_capoff;
+
 	for (idx = 0U; idx < vdev->nr_bars; idx++) {
 		vbar = &vdev->bar[idx];
 		offset = pci_bar_offset(idx);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -337,8 +337,9 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		vmsi_write_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		vmsix_write_cfg(vdev, offset, bytes, val);
-	} else if (vdev->has_flr && ((vdev->pcie_capoff + PCIR_PCIE_DEVCTRL) == offset) &&
-				((val & PCIM_PCIE_FLR) != 0U)) {
+	} else if ((vdev->has_flr && ((vdev->pcie_capoff + PCIR_PCIE_DEVCTRL) == offset) &&
+				((val & PCIM_PCIE_FLR) != 0U)) || (vdev->has_af_flr &&
+				((vdev->af_capoff + PCIR_AF_CTRL) == offset) && ((val & PCIM_AF_FLR) != 0U))) {
 			/* Assume that guest write FLR must be 4 bytes aligned */
 			pdev_do_flr(vdev->pdev->bdf, offset, bytes, val);
 	} else {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -337,6 +337,10 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		vmsi_write_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		vmsix_write_cfg(vdev, offset, bytes, val);
+	} else if (vdev->has_flr && ((vdev->pcie_capoff + PCIR_PCIE_DEVCTRL) == offset) &&
+				((val & PCIM_PCIE_FLR) != 0U)) {
+			/* Assume that guest write FLR must be 4 bytes aligned */
+			pdev_do_flr(vdev->pdev->bdf, offset, bytes, val);
 	} else {
 		/* passthru to physical device */
 		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -50,6 +50,7 @@ struct hv_timer {
 #define CYCLES_PER_MS	us_to_ticks(1000U)
 
 void udelay(uint32_t us);
+void msleep(uint32_t ms);
 
 /**
  * @brief convert us to ticks.

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -99,6 +99,9 @@ struct pci_vdev {
 	struct pci_msi msi;
 	struct pci_msix msix;
 
+	bool has_flr;
+	uint32_t pcie_capoff;
+
 	/* Pointer to corresponding PCI device's vm_config */
 	struct acrn_vm_pci_dev_config *pci_dev_config;
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -102,6 +102,9 @@ struct pci_vdev {
 	bool has_flr;
 	uint32_t pcie_capoff;
 
+	bool has_af_flr;
+	uint32_t af_capoff;
+
 	/* Pointer to corresponding PCI device's vm_config */
 	struct acrn_vm_pci_dev_config *pci_dev_config;
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -138,6 +138,12 @@
 #define PCIM_PCIE_FLRCAP      (0x1U << 28U)
 #define PCIM_PCIE_FLR         (0x1U << 15U)
 
+/* Conventional PCI Advanced Features Capability */
+#define PCIY_AF               0x13U
+#define PCIM_AF_FLR_CAP       (0x1U << 25U)
+#define PCIR_AF_CTRL          0x4U
+#define PCIM_AF_FLR           0x1U
+
 #define HOST_BRIDGE_BDF		0U
 #define PCI_STD_NUM_BARS        6U
 
@@ -189,6 +195,10 @@ struct pci_pdev {
 	/* Function Level Reset Capability */
 	bool has_flr;
 	uint32_t pcie_capoff;
+
+	/* Conventional PCI Advanced Features FLR Capability */
+	bool has_af_flr;
+	uint32_t af_capoff;
 };
 
 static inline uint32_t pci_bar_offset(uint32_t idx)

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -131,7 +131,15 @@
 #define MSIX_CAPLEN           12U
 #define MSIX_TABLE_ENTRY_SIZE 16U
 
+/* PCI Express Capability */
+#define PCIY_PCIE             0x10U
+#define PCIR_PCIE_DEVCAP      0x04U
+#define PCIR_PCIE_DEVCTRL     0x08U
+#define PCIM_PCIE_FLRCAP      (0x1U << 28U)
+#define PCIM_PCIE_FLR         (0x1U << 15U)
+
 #define HOST_BRIDGE_BDF		0U
+#define PCI_STD_NUM_BARS        6U
 
 union pci_bdf {
 	uint16_t value;
@@ -177,6 +185,10 @@ struct pci_pdev {
 	uint32_t msi_capoff;
 
 	struct pci_msix_cap msix;
+
+	/* Function Level Reset Capability */
+	bool has_flr;
+	uint32_t pcie_capoff;
 };
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
@@ -291,5 +303,6 @@ static inline bool is_pci_cfg_bridge(uint8_t header_type)
 	return ((header_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE);
 }
 
+void pdev_do_flr(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 
 #endif /* PCI_H_ */


### PR DESCRIPTION
v3:
Update commit comments
refine usleep to msleep
rename vdev_pt_do_flr to pdev_do_flr

v2:
replace udelay instead of usleep
warp a function to do the save, reset and restore.
update some comment.

v1:
This patch tries to trap PCI AF FLR or PCIe FLR. Then restore BARs information to physical CFG space.

Tracked-On: #3465
Signed-off-by: Li Fei1 fei1.li@intel.com