### PR TITLE
acrn-config: remove pcpu3 from vm1 in SDC scenario

### DIFF
--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -52,7 +52,6 @@
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -52,7 +52,6 @@
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -51,7 +51,6 @@
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -51,7 +51,6 @@
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -51,7 +51,6 @@
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -51,7 +51,6 @@
     <vcpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
     </vcpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">0</clos>
     <epc_section desc="epc section">


### PR DESCRIPTION
Currently kata vm is supported in SDC scenario by default, both vm1
and kata vm would share pcpu id 3 for vcpu affinity even when cpu
sharing is not enabled.
Remove pcpu id 3 from vm1 in SDC scenario config xmls.

Tracked-On: #4286
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>