### PR TITLE
acrn-config: fix a few formatting issues

### DIFF
--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -661,9 +661,9 @@ def cpus_assignment(cpus_per_vm, index):
                 cpu_str = "{{AFFINITY_CPU({0}U)".format(cpus_per_vm[index][0])
         else:
             if i == len(cpus_per_vm[index]) - 1:
-                cpu_str = cpu_str + " , AFFINITY_CPU({0}U)}}".format(cpus_per_vm[index][i])
+                cpu_str = cpu_str + ", AFFINITY_CPU({0}U)}}".format(cpus_per_vm[index][i])
             else:
-                cpu_str = cpu_str + " , AFFINITY_CPU({0}U)".format(cpus_per_vm[index][i])
+                cpu_str = cpu_str + ", AFFINITY_CPU({0}U)".format(cpus_per_vm[index][i])
 
     vm_cpu_bmp['cpu_map'] = cpu_str
     vm_cpu_bmp['cpu_num'] = len(cpus_per_vm[index])

--- a/misc/acrn-config/scenario_config/pci_dev_c.py
+++ b/misc/acrn-config/scenario_config/pci_dev_c.py
@@ -14,6 +14,7 @@ def generate_file(config):
     :return: None
     """
     print("{}".format(scenario_cfg_lib.HEADER_LICENSE), file=config)
+    print("", file=config)
     print("#include <vm_config.h>", file=config)
     print("#include <pci_devices.h>", file=config)
     print("#include <vpci.h>", file=config)
@@ -25,6 +26,7 @@ def generate_file(config):
           file=config)
     print(" */", file=config)
     for i in range(scenario_cfg_lib.VM_COUNT):
+        print("", file=config)
         print("struct acrn_vm_pci_dev_config " +
               "vm{}_pci_devs[VM{}_CONFIG_PCI_DEV_NUM] = {{".format(i, i), file=config)
         print("\t{", file=config)
@@ -47,4 +49,3 @@ def generate_file(config):
         if i != 0:
             print("#endif", file=config)
         print("};", file=config)
-        print("", file=config)

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -41,7 +41,7 @@ def uuid_output(uuid, uuid_string, config):
     print("\t\t\t 0x{0}U, 0x{1}U, 0x{2}U, 0x{3}U, 0x{4}U, 0x{5}U, 0x{6}U, 0x{7}U}},".
           format(uuid[16:18], uuid[18:20], uuid[20:22], uuid[22:24],
                  uuid[24:26], uuid[26:28], uuid[28:30], uuid[30:32]), file=config)
-    print("\t\t\t/* {0} */".format(uuid_string), file=config)
+    print("\t\t/* {0} */".format(uuid_string), file=config)
 
 
 def vuart0_output(i, vm_type, vm_info, config):

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -32,7 +32,7 @@ def cpu_affinity_output(vm_info, i, config):
         return
 
     cpu_bits = vm_info.get_cpu_bitmap(i)
-    print("#define VM{0}_CONFIG_VCPU_AFFINITY\t{1}".format(
+    print("#define VM{0}_CONFIG_VCPU_AFFINITY\t\t{1}".format(
         i, cpu_bits['cpu_map']), file=config)
 
 
@@ -132,7 +132,7 @@ def logic_max_vm_num(config):
     :return: None
     """
     print("", file=config)
-    print("#define CONFIG_MAX_VM_NUM\t{0}U".format(scenario_cfg_lib.VM_COUNT), file=config)
+    print("#define CONFIG_MAX_VM_NUM\t\t{0}U".format(scenario_cfg_lib.VM_COUNT), file=config)
     print("", file=config)
     print("/* The VM CONFIGs like:", file=config)
     print(" *\tVMX_CONFIG_VCPU_AFFINITY", file=config)


### PR DESCRIPTION
scenario_cfg_lib.py:
  - removed extra white space before ','

pci_dev_c.py:
  - follow style in other files, added two empty lines
  - removed extra line at the end of the .c file

vm_configurations_c.py
  - alignment

vm_configurations_h.py
  - alignment

Tracked-On: #3602
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>