### PR TITLE
acrn-config: modify hpa start size value for logical_partition scenario

### DIFF
--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -20,7 +20,7 @@ GUEST_FLAG = ["0UL", "GUEST_FLAG_SECURE_WORLD_ENABLED", "GUEST_FLAG_LAPIC_PASSTH
               "GUEST_FLAG_HIDE_MTRR", "GUEST_FLAG_RT"]
 # Support 512M, 1G, 2G
 # pre launch less then 2G, sos vm less than 24G
-START_HPA_SIZE_LIST = ['0x20000000', '0x40000000', '0x80000000', 'CONFIG_SOS_RAM_SIZE', 'VM0_MEM_SIZE']
+START_HPA_SIZE_LIST = ['0x20000000', '0x40000000', '0x80000000', 'CONFIG_SOS_RAM_SIZE']
 
 
 MULTI_ITEM = ["guest_flag", "pcpu_id", "input", "block", "network"]

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -66,7 +66,7 @@
     </epc_section>
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -65,7 +65,7 @@
     </epc_section>
     <memory>
         <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -67,7 +67,7 @@
     </epc_section>
     <memory>
         <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -67,7 +67,7 @@
     </epc_section>
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -67,7 +67,7 @@
     </epc_section>
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -67,7 +67,7 @@
     </epc_section>
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -67,7 +67,7 @@
     </epc_section>
     <memory>
         <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM" readonly="true">VM0_MEM_SIZE</size>
+        <size desc="The memory size in Bytes for the VM">0x20000000</size>
         <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
         <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
     </memory>


### PR DESCRIPTION
Modify the hpa start size value for logical_partition scenario to avoid
build issue, and make the memory size of pre-launched VM configurable.

Tracked-On: #3854
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>