### PR TITLE
PCID Virtualization Support

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -116,8 +116,8 @@ static void init_vcpuid_entry(uint32_t leaf, uint32_t subleaf,
 	case 0x07U:
 		if (subleaf == 0U) {
 			cpuid_subleaf(leaf, subleaf, &entry->eax, &entry->ebx, &entry->ecx, &entry->edx);
-			/* mask invpcid */
-			entry->ebx &= ~(CPUID_EBX_INVPCID | CPUID_EBX_PQM | CPUID_EBX_PQE);
+
+			entry->ebx &= ~(CPUID_EBX_PQM | CPUID_EBX_PQE);
 
 			/* mask SGX and SGX_LC */
 			entry->ebx &= ~CPUID_EBX_SGX;
@@ -421,9 +421,6 @@ static void guest_cpuid_01h(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx
 
 	/* mask SDBG for silicon debug */
 	*ecx &= ~CPUID_ECX_SDBG;
-
-	/* mask pcid */
-	*ecx &= ~CPUID_ECX_PCID;
 
 	/*mask vmx to guest os */
 	*ecx &= ~CPUID_ECX_VMX;

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -292,18 +292,12 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	pr_dbg("VMX_PROC_VM_EXEC_CONTROLS: 0x%x ", value32);
 
 	/* Set up secondary processor based VM execution controls - pg 2901
-	 * 24.6.2. Set up for: * Enable EPT * Enable RDTSCP * Unrestricted
-	 * guest (optional)
+	 * 24.6.2. Set up for: * Enable EPT * Eable VPID * Enable RDTSCP *
+	 * Enable Unrestricted guest (optional)
 	 */
 	value32 = check_vmx_ctrl(MSR_IA32_VMX_PROCBASED_CTLS2,
-			VMX_PROCBASED_CTLS2_VAPIC | VMX_PROCBASED_CTLS2_EPT |
+			VMX_PROCBASED_CTLS2_VAPIC | VMX_PROCBASED_CTLS2_EPT |VMX_PROCBASED_CTLS2_VPID |
 			VMX_PROCBASED_CTLS2_RDTSCP | VMX_PROCBASED_CTLS2_UNRESTRICT);
-
-	if (vcpu->arch.vpid != 0U) {
-		value32 |= VMX_PROCBASED_CTLS2_VPID;
-	} else {
-		value32 &= ~VMX_PROCBASED_CTLS2_VPID;
-	}
 
 	if (is_apicv_advanced_feature_supported()) {
 		value32 |= VMX_PROCBASED_CTLS2_VIRQ;

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -299,6 +299,15 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 			VMX_PROCBASED_CTLS2_VAPIC | VMX_PROCBASED_CTLS2_EPT |VMX_PROCBASED_CTLS2_VPID |
 			VMX_PROCBASED_CTLS2_RDTSCP | VMX_PROCBASED_CTLS2_UNRESTRICT);
 
+	/* SDM Vol3, 25.3,  setting "enable INVPCID" VM-execution to 1 with "INVLPG exiting" disabled,
+	 * passes-through INVPCID instruction to guest if the instruction is supported.
+	 */
+	if (pcpu_has_cap(X86_FEATURE_INVPCID)) {
+		value32 |= VMX_PROCBASED_CTLS2_INVPCID;
+	} else {
+		value32 &= ~VMX_PROCBASED_CTLS2_INVPCID;
+	}
+
 	if (is_apicv_advanced_feature_supported()) {
 		value32 |= VMX_PROCBASED_CTLS2_VIRQ;
 		value32 |= VMX_PROCBASED_CTLS2_VAPIC_REGS;


### PR DESCRIPTION
Guest OS kernels, like Linux kernel, enabled Kernal Page Table Isolation (KPTI) as the mitigation of Meltdown.
Enabling KPTI without the support of PCID will cause significant performance loss when user/kernel space switch is frequent.
This patch series passes-through PCID capabilities to guest VM.

Note: On the hardware platforms that are not affected by Miltdown, Linux doesn't enabled KPTI unless it is forced by kernel parameter "pti=on".

Tracked-On: #4296
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>

