### PR TITLE
acrn-config: some cleanup for logical partition mode Linux bootargs

### DIFF
--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -204,9 +204,9 @@ Enable partition mode in ACRN hypervisor
      #define VM0_CONFIG_MEM_SIZE		0x20000000UL
 
      #define VM0_CONFIG_OS_NAME			"ClearLinux 26600"
-     #define VM0_CONFIG_OS_BOOTARGS		"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
+     #define VM0_CONFIG_OS_BOOTARGS		"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
-						consoleblank=0 tsc=reliable xapic_phys"
+						consoleblank=0 tsc=reliable"
 
      #define	VM1_CONFIGURED
 
@@ -218,9 +218,9 @@ Enable partition mode in ACRN hypervisor
      #define VM1_CONFIG_MEM_SIZE		0x20000000UL
 
      #define VM1_CONFIG_OS_NAME			"ClearLinux 26600"
-     #define VM1_CONFIG_OS_BOOTARGS		"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
+     #define VM1_CONFIG_OS_BOOTARGS		"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
-						consoleblank=0 tsc=reliable xapic_phys"
+						consoleblank=0 tsc=reliable"
 
      #define VM0_CONFIG_PCI_PTDEV_NUM		2U
      #define VM1_CONFIG_PCI_PTDEV_NUM		3U
@@ -295,9 +295,9 @@ Enable partition mode in ACRN hypervisor
      #define VM0_CONFIG_MEM_SIZE		0x20000000UL
 
      #define VM0_CONFIG_OS_NAME			"ClearLinux 26600"
-     #define VM0_CONFIG_OS_BOOTARGS		"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet console=hvc0 \
+     #define VM0_CONFIG_OS_BOOTARGS		"root=/dev/sda3 rw rootwait noxsave maxcpus=2 nohpet \
 						console=ttyS2 no_timer_check ignore_loglevel log_buf_len=16M \
-						consoleblank=0 tsc=reliable xapic_phys"
+						consoleblank=0 tsc=reliable"
 
    .. note::
 

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -31,9 +31,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.bootargs = VM0_CONFIG_OS_BOOTARG_CONSOLE	\
 				VM0_CONFIG_OS_BOOTARG_MAXCPUS		\
 				VM0_CONFIG_OS_BOOTARG_ROOT		\
-				"rw rootwait noxsave nohpet console=hvc0 \
+				"rw rootwait noxsave nohpet \
 				no_timer_check ignore_loglevel log_buf_len=16M \
-				consoleblank=0 tsc=reliable xapic_phys"
+				consoleblank=0 tsc=reliable"
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
@@ -71,9 +71,9 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.bootargs = VM1_CONFIG_OS_BOOTARG_CONSOLE	\
 				VM1_CONFIG_OS_BOOTARG_MAXCPUS		\
 				VM1_CONFIG_OS_BOOTARG_ROOT		\
-				"rw rootwait noxsave nohpet console=hvc0 \
+				"rw rootwait noxsave nohpet \
 				no_timer_check ignore_loglevel log_buf_len=16M \
-				consoleblank=0 tsc=reliable xapic_phys"
+				consoleblank=0 tsc=reliable"
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -29,7 +29,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -78,8 +78,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -29,7 +29,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -77,8 +77,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -30,7 +30,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -79,8 +79,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
@@ -30,7 +30,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -79,8 +79,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -30,7 +30,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -79,8 +79,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -30,7 +30,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -79,8 +79,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -30,7 +30,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -79,8 +79,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -30,7 +30,7 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -79,8 +79,8 @@
         <console configurable="0" desc="ttyS console for Linux kernel">/dev/ttyS0</console>
         <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable xapic_phys
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">


### PR DESCRIPTION
- commit 69152647 ("hv: Use virtual APIC IDs for Pre-launched VMs")
  enables virtual APIC IDs for pre-launched VMs thus xapic_phys is no
  longer needed to force guest xAPIC to work in physical destination mode.

- HVC is not available in logical partition mode and "console=hvc0" should
  be removed from guest Linux bootargs.

Tracked-On: #3854
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>