### PR TITLE
vpci: minor refine of the coding style

### DIFF
--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -34,7 +34,7 @@
 #include <pci.h>
 
 
-struct pci_bar {
+struct pci_vbar {
 	enum pci_bar_type type;
 	uint64_t size;		/* BAR size */
 	uint64_t base;		/* BAR guest physical address */
@@ -94,7 +94,7 @@ struct pci_vdev {
 
 	/* The bar info of the virtual PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
-	struct pci_bar bar[PCI_BAR_COUNT];
+	struct pci_vbar vbars[PCI_BAR_COUNT];
 
 	struct pci_msi msi;
 	struct pci_msix msix;


### PR DESCRIPTION
1. minor fix of coding style about pci_read_cap
2. rename pci_bar to pci_vbar

Tracked-On: #3475
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>