### PR TITLE
acrn-config: add support  to parse 'cpu_sharing' from launch config

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -382,7 +382,8 @@ def launch_end(names, args, virt_io, vmid, config):
             print("", file=config)
             i += 1
 
-    off_line_cpus(args, vmid, uos_type, config)
+    if args['cpu_sharing'][vmid] == "Disabled":
+        off_line_cpus(args, vmid, uos_type, config)
 
     uos_launch(names, args, virt_io, vmid, config)
 

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -483,10 +483,7 @@ def virtio_args_set(dm, virt_io, vmid, config):
     # virtio-net set, the value type is a list
     for net in virt_io['network'][vmid]:
         if net:
-            net_name = net
-            if ',' in net:
-                net_name = net.split(',')[0]
-            print("   -s {},virtio-net,tap_{} \\".format(launch_cfg_lib.virtual_dev_slot("virtio-net{}".format(net)), net_name), file=config)
+            print("   -s {},virtio-net,tap_{} \\".format(launch_cfg_lib.virtual_dev_slot("virtio-net{}".format(net)), net), file=config)
 
     # virtio-console set, the value type is a string
     if virt_io['console'][vmid]:

--- a/misc/acrn-config/launch_config/launch_cfg_gen.py
+++ b/misc/acrn-config/launch_config/launch_cfg_gen.py
@@ -46,6 +46,7 @@ def get_launch_item_values(board_info):
 
     launch_item_values["uos,vbootloader"] = launch_cfg_lib.BOOT_TYPE
     launch_item_values['uos,vuart0'] = launch_cfg_lib.DM_VUART0
+    launch_item_values['uos,cpu_sharing'] = launch_cfg_lib.CPU_SHARING
     launch_item_values['uos,poweroff_channel'] = launch_cfg_lib.PM_CHANNEL
 
     return launch_item_values

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -20,6 +20,7 @@ class AcrnDmArgs:
         self.args["gvt_args"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "gvt_args")
         self.args["vbootloader"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vbootloader")
         self.args["vuart0"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "vuart0")
+        self.args["cpu_sharing"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "cpu_sharing")
         self.args["pm_channel"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "poweroff_channel")
         self.args["off_pcpus"] = launch_cfg_lib.get_leaf_tag_map(self.scenario_info, "vcpu_affinity", "pcpu_id")
         self.args["xhci"] = launch_cfg_lib.get_leaf_tag_map(self.launch_info, "usb_xhci")
@@ -31,6 +32,7 @@ class AcrnDmArgs:
         launch_cfg_lib.mem_size_check(self.args["mem_size"], "mem_size")
         launch_cfg_lib.args_aval_check(self.args["vbootloader"], "vbootloader", launch_cfg_lib.BOOT_TYPE)
         launch_cfg_lib.args_aval_check(self.args["vuart0"], "vuart0", launch_cfg_lib.DM_VUART0)
+        launch_cfg_lib.cpu_sharing_check(self.args["cpu_sharing"], "cpu_sharing")
 
 
 class AvailablePthru():

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -16,6 +16,7 @@ ERR_LIST = {}
 BOOT_TYPE = ['no', 'vsbl', 'ovmf']
 RTOS_TYPE = ['no', 'Soft RT', 'Hard RT']
 DM_VUART0 = ['Disable', 'Enable']
+CPU_SHARING = ['Disabled', 'Enabled']
 UOS_TYPES = ['CLEARLINUX', 'ANDROID', 'ALIOS', 'PREEMPT-RT LINUX', 'VXWORKS', 'WINDOWS', 'ZEPHYR', 'GENERIC LINUX']
 
 PT_SUB_PCI = {}
@@ -643,3 +644,42 @@ def check_block_mount(virtio_blk_dic):
                 mount_flags.append(False)
 
         MOUNT_FLAG_DIC[vmid] = mount_flags
+
+
+def cpu_sharing_check(cpu_sharing, item):
+    """
+    Check cpu sharing status with cpu affinity setting
+    :param cpu_share_status:
+    :param item:
+    :return: None
+    """
+    use_cpus = []
+    use_same_cpu = False
+    vm_cpu_share = []
+    vm_cpu_share_consistent = True
+
+    cpu_affinity = get_leaf_tag_map(SCENARIO_INFO_FILE, "vcpu_affinity", "pcpu_id")
+    for vm_i in cpu_affinity.keys():
+        for cpu in cpu_affinity[vm_i]:
+            if cpu in use_cpus:
+                use_same_cpu = True
+            else:
+                use_cpus.append(cpu)
+
+    for vm_i in cpu_sharing.keys():
+        cpu_share = cpu_sharing[vm_i]
+        stat_len = len(vm_cpu_share)
+        if stat_len != 0 and cpu_share not in vm_cpu_share:
+            vm_cpu_share_consistent = False
+        else:
+            vm_cpu_share.append(cpu_share)
+
+        if not vm_cpu_share_consistent:
+            key = "uos:id={},{}".format(vm_i, item)
+            ERR_LIST[key] = "CPU sharing for all VMs should be consistent to 'Disabled' or 'Enabled'"
+            return
+
+        if cpu_sharing[vm_i] == "Disabled" and use_same_cpu:
+            key = "uos:id={},{}".format(vm_i, item)
+            ERR_LIST[key] = "The same pcpu was configurated in scenario config, and not allow to set the cpu_sharing to 'Disabled'!"
+            return

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
@@ -38,6 +39,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
@@ -39,6 +40,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
@@ -39,6 +40,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/tgl-rvp/industry_launch_1uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/tgl-rvp/industry_launch_1uos.xml
@@ -6,6 +6,7 @@
         <mem_size desc="UOS memory size in MByte">2000</mem_size>
         <gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
         <vbootloader desc="">ovmf</vbootloader>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
         <rootfs_dev desc="">/dev/nvme0n1p3</rootfs_dev>
         <rootfs_img desc="">/root/uos/uos.img</rootfs_img>
         <console_type desc="UOS console type">com1(ttyS0)</console_type>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
@@ -39,6 +40,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -6,6 +6,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 
@@ -39,6 +40,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -6,6 +6,7 @@
 	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 


### PR DESCRIPTION

- remove uncessary split for 'virtio-net'
- add 'cpu_sharing' support for launch config
- add 'cpu_sharing' info in launch xmls

    Tracked-On: #4298
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
