### PR TITLE
hv: add sanity check for vuart configuration

### DIFF
--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -580,17 +580,16 @@ static struct acrn_vuart *find_active_target_vuart(const struct vuart_config *vu
 
 	target_vmid = vu_config->t_vuart.vm_id;
 	target_vuid = vu_config->t_vuart.vuart_id;
-	if (target_vmid < CONFIG_MAX_VM_NUM) {
+
+	if ((target_vmid < CONFIG_MAX_VM_NUM) && (target_vuid < MAX_VUART_NUM_PER_VM)) {
 		target_vm = get_vm_from_vmid(target_vmid);
-	}
-
-	if (target_vuid < MAX_VUART_NUM_PER_VM) {
 		target_vu = &target_vm->vuart[target_vuid];
+
+		if ((target_vu != NULL) && (target_vu->active)) {
+			ret_vu = target_vu;
+		}
 	}
 
-	if ((target_vu != NULL) && (target_vu->active)) {
-		ret_vu = target_vu;
-	}
 	return ret_vu;
 }
 


### PR DESCRIPTION
- target vm_id of vuart can't be un-defined VM, nor the VM itself.
- fix potential NULL pointer dereference in find_active_target_vuart()

Tracked-On: #3854
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>