### PR TITLE
hv: patch set for vlapic reset and vcpu state transition

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -194,7 +194,7 @@ void vcpu_reset_eoi_exit_bitmaps(struct acrn_vcpu *vcpu)
 }
 
 /* As a vcpu reset internal API, DO NOT touch any vcpu state transition in this function. */
-static void vcpu_reset_internal(struct acrn_vcpu *vcpu, __unused enum reset_mode mode)
+static void vcpu_reset_internal(struct acrn_vcpu *vcpu, enum reset_mode mode)
 {
 	int32_t i;
 	struct acrn_vlapic *vlapic;
@@ -217,7 +217,7 @@ static void vcpu_reset_internal(struct acrn_vcpu *vcpu, __unused enum reset_mode
 	vcpu->thread_obj.notify_mode = SCHED_NOTIFY_IPI;
 
 	vlapic = vcpu_vlapic(vcpu);
-	vlapic_reset(vlapic, apicv_ops);
+	vlapic_reset(vlapic, apicv_ops, mode);
 
 	reset_vcpu_regs(vcpu);
 }

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -224,7 +224,7 @@ static inline uint32_t vlapic_find_isrv(const struct acrn_vlapic *vlapic)
 }
 
 static void
-vlapic_dfr_write_handler(struct acrn_vlapic *vlapic)
+vlapic_write_dfr(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic;
 
@@ -243,7 +243,7 @@ vlapic_dfr_write_handler(struct acrn_vlapic *vlapic)
 }
 
 static void
-vlapic_ldr_write_handler(struct acrn_vlapic *vlapic)
+vlapic_write_ldr(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic;
 
@@ -391,7 +391,7 @@ static uint32_t vlapic_get_ccr(const struct acrn_vlapic *vlapic)
 	return remain_count;
 }
 
-static void vlapic_dcr_write_handler(struct acrn_vlapic *vlapic)
+static void vlapic_write_dcr(struct acrn_vlapic *vlapic)
 {
 	uint32_t divisor_shift;
 	struct vlapic_timer *vtimer;
@@ -403,7 +403,7 @@ static void vlapic_dcr_write_handler(struct acrn_vlapic *vlapic)
 	vtimer->divisor_shift = divisor_shift;
 }
 
-static void vlapic_icrtmr_write_handler(struct acrn_vlapic *vlapic)
+static void vlapic_write_icrtmr(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic;
 	struct vlapic_timer *vtimer;
@@ -495,7 +495,7 @@ void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic, uint64_t val_arg)
 }
 
 static void
-vlapic_esr_write_handler(struct acrn_vlapic *vlapic)
+vlapic_write_esr(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic;
 
@@ -723,7 +723,7 @@ vlapic_get_lvt(const struct acrn_vlapic *vlapic, uint32_t offset)
 }
 
 static void
-vlapic_lvt_write_handler(struct acrn_vlapic *vlapic, uint32_t offset)
+vlapic_write_lvt(struct acrn_vlapic *vlapic, uint32_t offset)
 {
 	uint32_t *lvtptr, mask, val, idx;
 	struct lapic_regs *lapic;
@@ -798,25 +798,25 @@ vlapic_mask_lvts(struct acrn_vlapic *vlapic)
 	struct lapic_regs *lapic = &(vlapic->apic_page);
 
 	lapic->lvt_cmci.v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_CMCI_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_CMCI_LVT);
 
 	lapic->lvt[APIC_LVT_TIMER].v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_TIMER_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_TIMER_LVT);
 
 	lapic->lvt[APIC_LVT_THERMAL].v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_THERM_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_THERM_LVT);
 
 	lapic->lvt[APIC_LVT_PMC].v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_PERF_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_PERF_LVT);
 
 	lapic->lvt[APIC_LVT_LINT0].v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_LINT0_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_LINT0_LVT);
 
 	lapic->lvt[APIC_LVT_LINT1].v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_LINT1_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_LINT1_LVT);
 
 	lapic->lvt[APIC_LVT_ERROR].v |= APIC_LVT_M;
-	vlapic_lvt_write_handler(vlapic, APIC_OFFSET_ERROR_LVT);
+	vlapic_write_lvt(vlapic, APIC_OFFSET_ERROR_LVT);
 }
 
 /*
@@ -1197,7 +1197,7 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 	return;
 }
 
-static void vlapic_icrlo_write_handler(struct acrn_vlapic *vlapic)
+static void vlapic_write_icrlo(struct acrn_vlapic *vlapic)
 {
 	uint16_t vcpu_id;
 	bool phys = false, is_broadcast = false;
@@ -1383,7 +1383,7 @@ static void vlapic_get_deliverable_intr(struct acrn_vlapic *vlapic, uint32_t vec
 }
 
 static void
-vlapic_svr_write_handler(struct acrn_vlapic *vlapic)
+vlapic_write_svr(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic;
 	uint32_t old, new, changed;
@@ -1569,22 +1569,22 @@ static int32_t vlapic_write(struct acrn_vlapic *vlapic, uint32_t offset, uint64_
 			break;
 		case APIC_OFFSET_LDR:
 			lapic->ldr.v = data32;
-			vlapic_ldr_write_handler(vlapic);
+			vlapic_write_ldr(vlapic);
 			break;
 		case APIC_OFFSET_DFR:
 			lapic->dfr.v = data32;
-			vlapic_dfr_write_handler(vlapic);
+			vlapic_write_dfr(vlapic);
 			break;
 		case APIC_OFFSET_SVR:
 			lapic->svr.v = data32;
-			vlapic_svr_write_handler(vlapic);
+			vlapic_write_svr(vlapic);
 			break;
 		case APIC_OFFSET_ICR_LOW:
 			if (is_x2apic_enabled(vlapic)) {
 				lapic->icr_hi.v = (uint32_t)(data >> 32U);
 			}
 			lapic->icr_lo.v = data32;
-			vlapic_icrlo_write_handler(vlapic);
+			vlapic_write_icrlo(vlapic);
 			break;
 		case APIC_OFFSET_ICR_HI:
 			lapic->icr_hi.v = data32;
@@ -1598,7 +1598,7 @@ static int32_t vlapic_write(struct acrn_vlapic *vlapic, uint32_t offset, uint64_
 		case APIC_OFFSET_ERROR_LVT:
 			regptr = vlapic_get_lvtptr(vlapic, offset);
 			*regptr = data32;
-			vlapic_lvt_write_handler(vlapic, offset);
+			vlapic_write_lvt(vlapic, offset);
 			break;
 		case APIC_OFFSET_TIMER_ICR:
 			/* if TSCDEADLINE mode ignore icr_timer */
@@ -1606,15 +1606,15 @@ static int32_t vlapic_write(struct acrn_vlapic *vlapic, uint32_t offset, uint64_
 				break;
 			}
 			lapic->icr_timer.v = data32;
-			vlapic_icrtmr_write_handler(vlapic);
+			vlapic_write_icrtmr(vlapic);
 			break;
 
 		case APIC_OFFSET_TIMER_DCR:
 			lapic->dcr_timer.v = data32;
-			vlapic_dcr_write_handler(vlapic);
+			vlapic_write_dcr(vlapic);
 			break;
 		case APIC_OFFSET_ESR:
-			vlapic_esr_write_handler(vlapic);
+			vlapic_write_esr(vlapic);
 			break;
 
 		case APIC_OFFSET_SELF_IPI:
@@ -1668,7 +1668,7 @@ vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops)
 
 	lapic->icr_timer.v = 0U;
 	lapic->dcr_timer.v = 0U;
-	vlapic_dcr_write_handler(vlapic);
+	vlapic_write_dcr(vlapic);
 	vlapic_reset_timer(vlapic);
 
 	vlapic->svr_last = lapic->svr.v;
@@ -1706,7 +1706,7 @@ void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs)
 		lapic->tmr[i].v = regs->tmr[i].v;
 	}
 	lapic->svr = regs->svr;
-	vlapic_svr_write_handler(vlapic);
+	vlapic_write_svr(vlapic);
 	lapic->lvt[APIC_LVT_TIMER].v = regs->lvt[APIC_LVT_TIMER].v;
 	lapic->lvt[APIC_LVT_LINT0].v = regs->lvt[APIC_LVT_LINT0].v;
 	lapic->lvt[APIC_LVT_LINT1].v = regs->lvt[APIC_LVT_LINT1].v;
@@ -1714,7 +1714,7 @@ void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs)
 	lapic->icr_timer = regs->icr_timer;
 	lapic->ccr_timer = regs->ccr_timer;
 	lapic->dcr_timer = regs->dcr_timer;
-	vlapic_dcr_write_handler(vlapic);
+	vlapic_write_dcr(vlapic);
 }
 
 uint64_t vlapic_get_apicbase(const struct acrn_vlapic *vlapic)
@@ -2512,19 +2512,19 @@ int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu)
 		/* Force APIC ID as read only */
 		break;
 	case APIC_OFFSET_LDR:
-		vlapic_ldr_write_handler(vlapic);
+		vlapic_write_ldr(vlapic);
 		break;
 	case APIC_OFFSET_DFR:
-		vlapic_dfr_write_handler(vlapic);
+		vlapic_write_dfr(vlapic);
 		break;
 	case APIC_OFFSET_SVR:
-		vlapic_svr_write_handler(vlapic);
+		vlapic_write_svr(vlapic);
 		break;
 	case APIC_OFFSET_ESR:
-		vlapic_esr_write_handler(vlapic);
+		vlapic_write_esr(vlapic);
 		break;
 	case APIC_OFFSET_ICR_LOW:
-		vlapic_icrlo_write_handler(vlapic);
+		vlapic_write_icrlo(vlapic);
 		break;
 	case APIC_OFFSET_CMCI_LVT:
 	case APIC_OFFSET_TIMER_LVT:
@@ -2533,13 +2533,13 @@ int32_t apic_write_vmexit_handler(struct acrn_vcpu *vcpu)
 	case APIC_OFFSET_LINT0_LVT:
 	case APIC_OFFSET_LINT1_LVT:
 	case APIC_OFFSET_ERROR_LVT:
-		vlapic_lvt_write_handler(vlapic, offset);
+		vlapic_write_lvt(vlapic, offset);
 		break;
 	case APIC_OFFSET_TIMER_ICR:
-		vlapic_icrtmr_write_handler(vlapic);
+		vlapic_write_icrtmr(vlapic);
 		break;
 	case APIC_OFFSET_TIMER_DCR:
-		vlapic_dcr_write_handler(vlapic);
+		vlapic_write_dcr(vlapic);
 		break;
 	case APIC_OFFSET_SELF_IPI:
 		if (is_x2apic_enabled(vlapic)) {

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1161,9 +1161,11 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 				"Sending INIT to %hu",
 				target_vcpu->vcpu_id);
 
-			/* put target vcpu to INIT state and wait for SIPI */
-			pause_vcpu(target_vcpu, VCPU_PAUSED);
-			reset_vcpu(target_vcpu, INIT_RESET);
+			if (target_vcpu->state != VCPU_INIT) {
+				/* put target vcpu to INIT state and wait for SIPI */
+				pause_vcpu(target_vcpu, VCPU_ZOMBIE);
+				reset_vcpu(target_vcpu, INIT_RESET);
+			}
 			/* new cpu model only need one SIPI to kick AP run,
 			 * the second SIPI will be ignored as it move out of
 			 * wait-for-SIPI state.

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1163,7 +1163,7 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 
 			/* put target vcpu to INIT state and wait for SIPI */
 			pause_vcpu(target_vcpu, VCPU_PAUSED);
-			reset_vcpu(target_vcpu);
+			reset_vcpu(target_vcpu, INIT_RESET);
 			/* new cpu model only need one SIPI to kick AP run,
 			 * the second SIPI will be ignored as it move out of
 			 * wait-for-SIPI state.
@@ -1686,8 +1686,6 @@ void
 vlapic_init(struct acrn_vlapic *vlapic)
 {
 	vlapic_init_timer(vlapic);
-
-	vlapic_reset(vlapic, apicv_ops);
 }
 
 void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs)

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1643,7 +1643,6 @@ static int32_t vlapic_write(struct acrn_vlapic *vlapic, uint32_t offset, uint64_
 void
 vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops)
 {
-	uint32_t i;
 	struct lapic_regs *lapic;
 
 	/*
@@ -1673,10 +1672,6 @@ vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops)
 	vlapic_reset_timer(vlapic);
 
 	vlapic->svr_last = lapic->svr.v;
-
-	for (i = 0U; i < (VLAPIC_MAXLVT_INDEX + 1U); i++) {
-		vlapic->lvt_last[i] = 0U;
-	}
 
 	vlapic->isrv = 0U;
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -650,7 +650,6 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 		}
 
 		foreach_vcpu(i, vm, vcpu) {
-			reset_vcpu(vcpu);
 			offline_vcpu(vcpu);
 
 			if (bitmap_test(pcpuid_from_vcpu(vcpu), &mask)) {
@@ -737,7 +736,7 @@ int32_t reset_vm(struct acrn_vm *vm)
 		}
 
 		foreach_vcpu(i, vm, vcpu) {
-			reset_vcpu(vcpu);
+			reset_vcpu(vcpu, COLD_RESET);
 
 			if (bitmap_test(pcpuid_from_vcpu(vcpu), &mask)) {
 				make_pcpu_offline(pcpuid_from_vcpu(vcpu));
@@ -824,7 +823,7 @@ void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 
 	vm->state = VM_STARTED;
 
-	reset_vcpu(bsp);
+	reset_vcpu(bsp, POWER_ON_RESET);
 
 	/* When SOS resume from S3, it will return to real mode
 	 * with entry set to wakeup_vec.

--- a/hypervisor/arch/x86/lapic.c
+++ b/hypervisor/arch/x86/lapic.c
@@ -76,17 +76,17 @@ void init_lapic(uint16_t pcpu_id)
 {
 	per_cpu(lapic_ldr, pcpu_id) = (uint32_t) msr_read(MSR_IA32_EXT_APIC_LDR);
 	/* Mask all LAPIC LVT entries before enabling the local APIC */
-	msr_write(MSR_IA32_EXT_APIC_LVT_CMCI, LAPIC_LVT_MASK);
-	msr_write(MSR_IA32_EXT_APIC_LVT_TIMER, LAPIC_LVT_MASK);
-	msr_write(MSR_IA32_EXT_APIC_LVT_THERMAL, LAPIC_LVT_MASK);
-	msr_write(MSR_IA32_EXT_APIC_LVT_PMI, LAPIC_LVT_MASK);
-	msr_write(MSR_IA32_EXT_APIC_LVT_LINT0, LAPIC_LVT_MASK);
-	msr_write(MSR_IA32_EXT_APIC_LVT_LINT1, LAPIC_LVT_MASK);
-	msr_write(MSR_IA32_EXT_APIC_LVT_ERROR, LAPIC_LVT_MASK);
+	msr_write(MSR_IA32_EXT_APIC_LVT_CMCI, APIC_LVT_M);
+	msr_write(MSR_IA32_EXT_APIC_LVT_TIMER, APIC_LVT_M);
+	msr_write(MSR_IA32_EXT_APIC_LVT_THERMAL, APIC_LVT_M);
+	msr_write(MSR_IA32_EXT_APIC_LVT_PMI, APIC_LVT_M);
+	msr_write(MSR_IA32_EXT_APIC_LVT_LINT0, APIC_LVT_M);
+	msr_write(MSR_IA32_EXT_APIC_LVT_LINT1, APIC_LVT_M);
+	msr_write(MSR_IA32_EXT_APIC_LVT_ERROR, APIC_LVT_M);
 
 	/* Enable Local APIC */
 	/* TODO: add spurious-interrupt handler */
-	msr_write(MSR_IA32_EXT_APIC_SIVR, LAPIC_SVR_APIC_ENABLE_MASK | LAPIC_SVR_VECTOR);
+	msr_write(MSR_IA32_EXT_APIC_SIVR, APIC_SVR_ENABLE | APIC_SVR_VECTOR);
 
 	/* Ensure there are no ISR bits set. */
 	clear_lapic_isr();
@@ -146,7 +146,7 @@ void suspend_lapic(void)
 
 	/* disable APIC with software flag */
 	val = msr_read(MSR_IA32_EXT_APIC_SIVR);
-	val = (~(uint64_t)LAPIC_SVR_APIC_ENABLE_MASK) & val;
+	val = (~(uint64_t)APIC_SVR_ENABLE) & val;
 	msr_write(MSR_IA32_EXT_APIC_SIVR, val);
 }
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -552,11 +552,8 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 				__func__, vcpu_id, target_vm->vm_id);
 		} else {
 			vcpu = vcpu_from_vid(target_vm, vcpu_id);
-			if (vcpu->state == VCPU_PAUSED) {
-				if (!vcpu->vm->sw.is_completion_polling) {
-					resume_vcpu(vcpu);
-				}
-				ret = 0;
+			if (!vcpu->vm->sw.is_completion_polling) {
+				ret = resume_vcpu(vcpu);
 			}
 		}
 	}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -64,7 +64,6 @@ int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid)
 				break;
 			}
 			pause_vcpu(vcpu, VCPU_ZOMBIE);
-			reset_vcpu(vcpu);
 			offline_vcpu(vcpu);
 		}
 	}

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -131,12 +131,11 @@
 		if (vcpu->state != VCPU_OFFLINE)
 
 enum vcpu_state {
+	VCPU_OFFLINE = 0U,
 	VCPU_INIT,
 	VCPU_RUNNING,
 	VCPU_PAUSED,
 	VCPU_ZOMBIE,
-	VCPU_OFFLINE,
-	VCPU_UNKNOWN_STATE,
 };
 
 enum vm_cpu_mode {
@@ -626,9 +625,9 @@ void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  *
- * @return None
+ * @return 0 on success, -1 on failure.
  */
-void resume_vcpu(struct acrn_vcpu *vcpu);
+int32_t resume_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief set the vcpu to running state, then it will be scheculed.

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -146,6 +146,7 @@ enum vm_cpu_mode {
 	CPU_MODE_64BIT,			/* IA-32E mode (CS.L = 1) */
 };
 
+enum reset_mode;
 
 /* 2 worlds: 0 for Normal World, 1 for Secure World */
 #define NR_WORLD	2
@@ -600,10 +601,11 @@ void offline_vcpu(struct acrn_vcpu *vcpu);
  * Reset all fields in a vCPU instance, the vCPU state is reset to VCPU_INIT.
  *
  * @param[inout] vcpu pointer to vcpu data structure
+ * @param[in] mode the reset mode
  *
  * @return None
  */
-void reset_vcpu(struct acrn_vcpu *vcpu);
+void reset_vcpu(struct acrn_vcpu *vcpu, enum reset_mode mode);
 
 /**
  * @brief pause the vcpu and set new state

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -106,6 +106,7 @@ struct acrn_apicv_ops {
 	bool (*x2apic_write_msr_may_valid)(uint32_t offset);
 };
 
+enum reset_mode;
 extern const struct acrn_apicv_ops *apicv_ops;
 void vlapic_set_apicv_ops(void);
 
@@ -194,7 +195,7 @@ void vlapic_free(struct acrn_vcpu *vcpu);
  * @pre vlapic->vcpu->vcpu_id < MAX_VCPUS_PER_VM
  */
 void vlapic_init(struct acrn_vlapic *vlapic);
-void vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops);
+void vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops, enum reset_mode mode);
 void vlapic_restore(struct acrn_vlapic *vlapic, const struct lapic_regs *regs);
 uint64_t vlapic_apicv_get_apic_access_addr(void);
 uint64_t vlapic_apicv_get_apic_page_addr(struct acrn_vlapic *vlapic);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -30,6 +30,14 @@
 #include <hyperv.h>
 #endif
 
+enum reset_mode {
+	POWER_ON_RESET,		/* reset by hardware Power-on */
+	COLD_RESET,		/* hardware cold reset */
+	WARM_RESET,		/* behavior slightly differ from cold reset, that some MSRs might be retained. */
+	INIT_RESET,		/* reset by INIT */
+	SOFTWARE_RESET,		/* reset by software disable<->enable */
+};
+
 struct vm_hw_info {
 	/* vcpu array of this VM */
 	struct acrn_vcpu vcpu_array[MAX_VCPUS_PER_VM];

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -36,18 +36,6 @@
 #define INTR_LAPIC_ICR_ALL_INC_SELF         0x2U
 #define INTR_LAPIC_ICR_ALL_EX_SELF            0x3U
 
-/* LAPIC register bit and bitmask definitions */
-#define LAPIC_SVR_VECTOR                        0x000000FFU
-#define LAPIC_SVR_APIC_ENABLE_MASK                   0x00000100U
-
-#define LAPIC_LVT_MASK                          0x00010000U
-#define LAPIC_DELIVERY_MODE_EXTINT_MASK         0x00000700U
-
-/* LAPIC Timer bit and bitmask definitions */
-#define LAPIC_TMR_ONESHOT                       ((uint32_t) 0x0U << 17U)
-#define LAPIC_TMR_PERIODIC                      ((uint32_t) 0x1U << 17U)
-#define LAPIC_TMR_TSC_DEADLINE                  ((uint32_t) 0x2U << 17U)
-
 enum intr_cpu_startup_shorthand {
 	INTR_CPU_STARTUP_USE_DEST,
 	INTR_CPU_STARTUP_ALL_EX_SELF,


### PR DESCRIPTION
- correct apic lvt reset value
- clean up redundant macro in lapic.h
- rename function of vlapic_xxx_write_handler
- refine reset_vcpu api
- ensure valid vcpu state transition
- restore lapic state and apic id upon INIT

Tracked-On: #4267

Signed-off-by: Victor Sun <victor.sun@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>

