### PR TITLE
vpci: revisit BAR restore

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -139,7 +139,7 @@ usage(int code)
 		"       %*s [-s pci] [-U uuid] [--vsbl vsbl_file_name] [--ovmf ovmf_file_path]\n"
 		"       %*s [--part_info part_info_name] [--enable_trusty] [--intr_monitor param_setting]\n"
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
-		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--ptdev_no_reset] [--debugexit] \n"
+		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--debugexit] \n"
 		"       %*s [--logger-setting param_setting] [--pm_notify_channel]\n"
 		"       %*s [--pm_by_vuart vuart_node] <vm>\n"
 		"       -A: create ACPI tables\n"
@@ -166,7 +166,6 @@ usage(int code)
 		"       --ovmf: ovmf file path\n"
 		"       --part_info: guest partition info file path\n"
 		"       --enable_trusty: enable trusty for guest\n"
-		"       --ptdev_no_reset: disable reset check for ptdev\n"
 		"       --debugexit: enable debug exit function\n"
 		"       --intr_monitor: enable interrupt storm monitor\n"
 		"            its params: threshold/s,probe-period(s),delay_time(ms),delay_duration(ms)\n"
@@ -722,7 +721,6 @@ enum {
 	CMD_OPT_TRUSTY_ENABLE,
 	CMD_OPT_VIRTIO_POLL_ENABLE,
 	CMD_OPT_MAC_SEED,
-	CMD_OPT_PTDEV_NO_RESET,
 	CMD_OPT_DEBUGEXIT,
 	CMD_OPT_VMCFG,
 	CMD_OPT_DUMP,
@@ -763,8 +761,6 @@ static struct option long_options[] = {
 					CMD_OPT_TRUSTY_ENABLE},
 	{"virtio_poll",		required_argument,	0, CMD_OPT_VIRTIO_POLL_ENABLE},
 	{"mac_seed",		required_argument,	0, CMD_OPT_MAC_SEED},
-	{"ptdev_no_reset",	no_argument,		0,
-		CMD_OPT_PTDEV_NO_RESET},
 	{"debugexit",		no_argument,		0, CMD_OPT_DEBUGEXIT},
 	{"intr_monitor",	required_argument,	0, CMD_OPT_INTR_MONITOR},
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
@@ -898,9 +894,6 @@ main(int argc, char *argv[])
 			strncpy(mac_seed_str, optarg, sizeof(mac_seed_str));
 			mac_seed_str[sizeof(mac_seed_str) - 1] = '\0';
 			mac_seed = mac_seed_str;
-			break;
-		case CMD_OPT_PTDEV_NO_RESET:
-			ptdev_no_reset(true);
 			break;
 		case CMD_OPT_DEBUGEXIT:
 			debugexit_enabled = true;

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -65,7 +65,6 @@ int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,
 void *paddr_guest2host(struct vmctx *ctx, uintptr_t gaddr, size_t len);
 int  virtio_uses_msix(void);
 size_t high_bios_size(void);
-void ptdev_no_reset(bool enable);
 void init_debugexit(void);
 void deinit_debugexit(void);
 #endif

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -338,22 +338,3 @@ void udelay(uint32_t us)
 	while (rdtsc() < dest_tsc) {
 	}
 }
-
-/*
- * @pre ms <= MAX_UINT32 / 1000U
- */
-void msleep(uint32_t ms)
-{
-	uint64_t dest_tsc, delta_tsc;
-
-	/* Calculate number of ticks to wait */
-	delta_tsc = us_to_ticks(ms * 1000U);
-	dest_tsc = rdtsc() + delta_tsc;
-
-	/* Loop until time expired */
-	while (rdtsc() < dest_tsc) {
-		if (need_reschedule(get_pcpu_id())) {
-			schedule();
-		}
-	}
-}

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -233,11 +233,6 @@ void init_vdev_pt(struct pci_vdev *vdev)
 	vdev->nr_bars = vdev->pdev->nr_bars;
 	pbdf.value = vdev->pdev->bdf.value;
 
-	vdev->has_flr = vdev->pdev->has_flr;
-	vdev->pcie_capoff = vdev->pdev->pcie_capoff;
-	vdev->has_af_flr = vdev->pdev->has_af_flr;
-	vdev->af_capoff = vdev->pdev->af_capoff;
-
 	for (idx = 0U; idx < vdev->nr_bars; idx++) {
 		vbar = &vdev->vbars[idx];
 		offset = pci_bar_offset(idx);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -342,6 +342,8 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 				((vdev->af_capoff + PCIR_AF_CTRL) == offset) && ((val & PCIM_AF_FLR) != 0U))) {
 			/* Assume that guest write FLR must be 4 bytes aligned */
 			pdev_do_flr(vdev->pdev->bdf, offset, bytes, val);
+	} else if (offset == PCIR_COMMAND) {
+		vdev_pt_write_command(vdev, (bytes > 2U) ? 2U : bytes, (uint16_t)val);
 	} else {
 		/* passthru to physical device */
 		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -337,11 +337,6 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		vmsi_write_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		vmsix_write_cfg(vdev, offset, bytes, val);
-	} else if ((vdev->has_flr && ((vdev->pcie_capoff + PCIR_PCIE_DEVCTRL) == offset) &&
-				((val & PCIM_PCIE_FLR) != 0U)) || (vdev->has_af_flr &&
-				((vdev->af_capoff + PCIR_AF_CTRL) == offset) && ((val & PCIM_AF_FLR) != 0U))) {
-			/* Assume that guest write FLR must be 4 bytes aligned */
-			pdev_do_flr(vdev->pdev->bdf, offset, bytes, val);
 	} else if (offset == PCIR_COMMAND) {
 		vdev_pt_write_command(vdev, (bytes > 2U) ? 2U : bytes, (uint16_t)val);
 	} else {

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -143,8 +143,6 @@ void deinit_vmsix(const struct pci_vdev *vdev);
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
-struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf);
-
 uint32_t pci_vdev_read_bar(const struct pci_vdev *vdev, uint32_t idx);
 void pci_vdev_write_bar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
 #endif /* VPCI_PRIV_H_ */

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -127,6 +127,7 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 
 void init_vdev_pt(struct pci_vdev *vdev);
 void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
+void vdev_pt_write_command(const struct pci_vdev *vdev, uint32_t bytes, uint16_t new_cmd);
 
 void init_vmsi(struct pci_vdev *vdev);
 void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -481,6 +481,9 @@ static void pci_read_cap(struct pci_pdev *pdev)
 			for (idx = 0U; idx < len; idx++) {
 				pdev->msix.cap[idx] = (uint8_t)pci_pdev_read_cfg(pdev->bdf, (uint32_t)pos + idx, 1U);
 			}
+		} else if (cap == PCIY_PMC) {
+			val = pci_pdev_read_cfg(pdev->bdf, pos + PCIR_PMCSR, 4U);
+			pdev->has_pm_reset = ((val & PCIM_PMCSR_NO_SOFT_RST) == 0U);
 		} else if (cap == PCIY_PCIE) {
 			pcie_devcap = pci_pdev_read_cfg(pdev->bdf, pos + PCIR_PCIE_DEVCAP, 4U);
 			pdev->has_flr = ((pcie_devcap & PCIM_PCIE_FLRCAP) != 0U);

--- a/hypervisor/include/arch/x86/timer.h
+++ b/hypervisor/include/arch/x86/timer.h
@@ -50,7 +50,6 @@ struct hv_timer {
 #define CYCLES_PER_MS	us_to_ticks(1000U)
 
 void udelay(uint32_t us);
-void msleep(uint32_t ms);
 
 /**
  * @brief convert us to ticks.

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -130,6 +130,7 @@ struct acrn_vpci {
 extern const struct pci_vdev_ops vhostbridge_ops;
 void vpci_init(struct acrn_vm *vm);
 void vpci_cleanup(struct acrn_vm *vm);
+struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf);
 void vpci_set_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 void vpci_reset_ptdev_intr_info(struct acrn_vm *target_vm, uint16_t vbdf, uint16_t pbdf);
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -99,12 +99,6 @@ struct pci_vdev {
 	struct pci_msi msi;
 	struct pci_msix msix;
 
-	bool has_flr;
-	uint32_t pcie_capoff;
-
-	bool has_af_flr;
-	uint32_t af_capoff;
-
 	/* Pointer to corresponding PCI device's vm_config */
 	struct acrn_vm_pci_dev_config *pci_dev_config;
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -131,6 +131,12 @@
 #define MSIX_CAPLEN           12U
 #define MSIX_TABLE_ENTRY_SIZE 16U
 
+/* PCI Power Management Capability */
+#define PCIY_PMC              0x01U
+/* Power Management Control/Status Register */
+#define PCIR_PMCSR            0x04U
+#define PCIM_PMCSR_NO_SOFT_RST (0x1U << 3U)
+
 /* PCI Express Capability */
 #define PCIY_PCIE             0x10U
 #define PCIR_PCIE_DEVCAP      0x04U
@@ -195,6 +201,7 @@ struct pci_pdev {
 
 	struct pci_msix_cap msix;
 
+	bool has_pm_reset;
 	bool has_flr;
 	bool has_af_flr;
 };

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -179,11 +179,14 @@ struct pci_msix_cap {
 };
 
 struct pci_pdev {
+	uint8_t hdr_type;
+
 	/* IOMMU responsible for DMA and Interrupt Remapping for this device */
 	uint32_t drhd_index;
 
 	/* The bar info of the physical PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
+	uint32_t bars[PCI_STD_NUM_BARS];
 
 	/* The bus/device/function triple of the physical PCI device. */
 	union pci_bdf bdf;
@@ -314,5 +317,7 @@ static inline bool is_pci_cfg_bridge(uint8_t header_type)
 }
 
 void pdev_do_flr(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
+bool pdev_need_bar_restore(const struct pci_pdev *pdev);
+void pdev_restore_bar(const struct pci_pdev *pdev);
 
 #endif /* PCI_H_ */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -195,13 +195,8 @@ struct pci_pdev {
 
 	struct pci_msix_cap msix;
 
-	/* Function Level Reset Capability */
 	bool has_flr;
-	uint32_t pcie_capoff;
-
-	/* Conventional PCI Advanced Features FLR Capability */
 	bool has_af_flr;
-	uint32_t af_capoff;
 };
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
@@ -316,7 +311,6 @@ static inline bool is_pci_cfg_bridge(uint8_t header_type)
 	return ((header_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE);
 }
 
-void pdev_do_flr(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 bool pdev_need_bar_restore(const struct pci_pdev *pdev);
 void pdev_restore_bar(const struct pci_pdev *pdev);
 


### PR DESCRIPTION
v4:
Since there're some PT devices don't support FLR or PM reset (like Audio, USB). So now only print error message for this case.

v3:
refine BAR restore logic

v2:
revisit BAR restore by doing this when writing Command Register if reset was detected.

v1:
1. restore PCI BARs CFG when setting power state from D3HOT to D0
2. add assumption for passthrough PCI device for each PT device should support FLR or PM reset
3. do reset for passthrough PCI device by default

Tracked-On: #3465
Signed-off-by: Li Fei1 <fei1.li@intel.com>
