### PR TITLE
doc: fix wrong Docker container image in tutorial

### DIFF
--- a/doc/tutorials/building_acrn_in_docker.rst
+++ b/doc/tutorials/building_acrn_in_docker.rst
@@ -140,7 +140,7 @@ Build the ACRN User VM PREEMPT_RT Kernel in Docker
 
       $ cp x86-64_defconfig .config
       $ docker run -u`id -u`:`id -g` --rm  -v $PWD:/workspace \
-        acrn/clearlinux-acrn-builder:latest \
+        clearlinux-acrn-builder:latest \
         bash -c "make clean && make olddefconfig && make && make modules_install INSTALL_MOD_PATH=out/"
 
    For the Docker image downloaded from Docker Hub, use this command to build ACRN:


### PR DESCRIPTION
Fix the name of the Docker Container image that is used to build the kernel
for an RTVM (Preempt-RT kernel) when that image was built by the user
him/herself.

Tracked-On: #4322
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>