### PR TITLE
acrn-config: set up whitelist for board containing hide pci device

### DIFF
--- a/misc/acrn-config/board_config/board_c.py
+++ b/misc/acrn-config/board_config/board_c.py
@@ -10,7 +10,8 @@ import board_cfg_lib
 INCLUDE_HEADER = """
 #include <board.h>
 #include <vtd.h>
-#include <msr.h>"""
+#include <msr.h>
+#include <pci.h>"""
 
 
 MSR_IA32_L2_MASK_BASE = 0x00000D10
@@ -155,6 +156,26 @@ def gen_px_cx(config):
     print("};", file=config)
 
 
+def gen_pci_hide(config):
+    """Generate hide pci information for this platform"""
+    if board_cfg_lib.BOARD_NAME in list(board_cfg_lib.KNOWN_HIDE_PDEVS_BOARD_DB.keys()) and board_cfg_lib.KNOWN_HIDE_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME] != 0:
+        hide_pdev_list = board_cfg_lib.KNOWN_HIDE_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME]
+        hide_pdev_num = len(hide_pdev_list)
+        print("const union pci_bdf plat_hide_pdevs[MAX_HIDE_PDEVS_NUM] = {", file=config)
+        for hide_pdev_i in range(hide_pdev_num):
+            bus = hex(int(hide_pdev_list[hide_pdev_i].split(':')[0], 16))
+            dev = hex(int(hide_pdev_list[hide_pdev_i].split(':')[1], 16))
+            fun = hex(int(hide_pdev_list[hide_pdev_i].split(':')[2], 16))
+            print("\t{", file=config)
+            print("\t\t.bits.b = {}U,".format(bus), file=config)
+            print("\t\t.bits.d = {}U,".format(dev), file=config)
+            print("\t\t.bits.f = {}U,".format(fun), file=config)
+            print("\t},", file=config)
+        print("};", file=config)
+    else:
+        print("const union pci_bdf plat_hide_pdevs[MAX_HIDE_PDEVS_NUM];", file=config)
+
+
 def generate_file(config):
     """
     Start to generate board.c
@@ -177,5 +198,8 @@ def generate_file(config):
 
     # start to parse PX/CX info
     gen_px_cx(config)
+
+    # gen hide pci info for platform
+    gen_pci_hide(config)
 
     return err_dic

--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -12,6 +12,7 @@ MISC_CFG_HEADER = """
 
 MISC_CFG_END = """#endif /* MISC_CFG_H */"""
 
+
 class Vuart:
 
     t_vm_id = {}
@@ -157,6 +158,15 @@ def generate_file(config):
     print("", file=config)
     if "SOS_VM" in vm_types:
         sos_bootarg_diff(sos_cmdlines, config)
+
+    # set macro for HIDE PTDEVS
+    print("", file=config)
+    if board_cfg_lib.BOARD_NAME in list(board_cfg_lib.KNOWN_HIDE_PDEVS_BOARD_DB):
+        print("#define MAX_HIDE_PDEVS_NUM	{}U".format(len(board_cfg_lib.KNOWN_HIDE_PDEVS_BOARD_DB[board_cfg_lib.BOARD_NAME])), file=config)
+    else:
+        print("#define MAX_HIDE_PDEVS_NUM	0U", file=config)
+    print("", file=config)
+
     print("{}".format(MISC_CFG_END), file=config)
 
     return err_dic

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -33,6 +33,11 @@ ERR_LIST = {}
 
 HEADER_LICENSE = common.open_license() + "\n"
 
+# The data base contains hide pci device
+KNOWN_HIDE_PDEVS_BOARD_DB = {
+    'apl-up2':['00:0d:0'],
+}
+
 
 def prepare(check_git):
     """ check environment """


### PR DESCRIPTION
Currently, config tool will maintain a whitelist for the board which
need to hide some pci devices. For the board out of whitelist, we set
MAX_HIDE_PDEVS_NUM to 0.

Tracked-On: #3475
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>