### PR TITLE
dm:replace perror with pr_err

### DIFF
--- a/devicemodel/core/mevent.c
+++ b/devicemodel/core/mevent.c
@@ -411,7 +411,7 @@ mevent_dispatch(void)
 	 */
 	ret = pipe2(mevent_pipefd, O_NONBLOCK);
 	if (ret < 0) {
-		perror("pipe");
+		pr_err("pipe");
 		exit(0);
 	}
 
@@ -433,7 +433,7 @@ mevent_dispatch(void)
 		ret = epoll_wait(epoll_fd, eventlist, MEVENT_MAX, -1);
 
 		if (ret == -1 && errno != EINTR)
-			perror("Error return from epoll_wait");
+			pr_err("Error return from epoll_wait");
 
 		/*
 		 * Handle reported events

--- a/devicemodel/core/timer.c
+++ b/devicemodel/core/timer.c
@@ -12,6 +12,7 @@
 #include "vmmapi.h"
 #include "mevent.h"
 #include "timer.h"
+#include "log.h"
 
 /* We can use timerfd and epoll mechanism to emulate kinds of timers like
  * PIT/RTC/WDT/PMTIMER/... in device model under Linux.
@@ -45,7 +46,7 @@ timer_handler(int fd __attribute__((unused)),
 
 	if (size < 0) {
 		if (errno != EAGAIN) {
-			perror("acrn_timer read timerfd error");
+			pr_err("acrn_timer read timerfd error");
 		}
 		return;
 	}
@@ -73,18 +74,18 @@ acrn_timer_init(struct acrn_timer *timer, void (*cb)(void *, uint64_t),
 		timer->fd = timerfd_create(timer->clockid,
 					TFD_NONBLOCK | TFD_CLOEXEC);
 	} else {
-		perror("acrn_timer clockid is not supported.\n");
+		pr_err("acrn_timer clockid is not supported.\n");
 	}
 
 	if (timer->fd <= 0) {
-		perror("acrn_timer create failed.\n");
+		pr_err("acrn_timer create failed.\n");
 		return -1;
 	}
 
 	timer->mevp = mevent_add(timer->fd, EVF_READ, timer_handler, timer, NULL, NULL);
 	if (timer->mevp == NULL) {
 		close(timer->fd);
-		perror("acrn_timer mevent add failed.\n");
+		pr_err("acrn_timer mevent add failed.\n");
 		return -1;
 	}
 

--- a/devicemodel/hw/block_if.c
+++ b/devicemodel/hw/block_if.c
@@ -696,7 +696,7 @@ blockif_open(const char *optstr, const char *ident)
 
 	bc = calloc(1, sizeof(struct blockif_ctxt));
 	if (bc == NULL) {
-		perror("calloc");
+		pr_err("calloc");
 		goto err;
 	}
 
@@ -750,7 +750,7 @@ blockif_open(const char *optstr, const char *ident)
 	for (i = 0; i < BLOCKIF_NUMTHR; i++) {
 		if (snprintf(tname, sizeof(tname), "blk-%s-%d",
 					ident, i) >= sizeof(tname)) {
-			perror("blk thread name too long");
+			pr_err("blk thread name too long");
 		}
 		pthread_create(&bc->btid[i], NULL, blockif_thr, bc);
 		pthread_setname_np(bc->btid[i], tname);

--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -133,7 +133,7 @@ int create_mmio_rsvd_rgn(uint64_t start,
 	int i;
 
 	if(bar_type == PCIBAR_IO){
-		perror("fail to create PCIBAR_IO bar_type\n");
+		pr_err("fail to create PCIBAR_IO bar_type\n");
 		return -1;
 	}
 
@@ -154,7 +154,7 @@ int create_mmio_rsvd_rgn(uint64_t start,
 		}
 	}
 
-	perror("reserved_bar_regions is overflow\n");
+	pr_err("reserved_bar_regions is overflow\n");
 	return -1;
 }
 

--- a/devicemodel/hw/pci/gvt.c
+++ b/devicemodel/hw/pci/gvt.c
@@ -106,7 +106,7 @@ update_gvt_bar(struct vmctx *ctx)
 
 	bar_fd = open(bar_path, O_RDONLY);
 	if(bar_fd == -1){
-		perror("failed to open sys bar info\n");
+		pr_err("failed to open sys bar info\n");
 		return;
 	}
 
@@ -115,7 +115,7 @@ update_gvt_bar(struct vmctx *ctx)
 	close(bar_fd);
 
 	if (ret < 76) {
-		perror("failed to read sys bar info\n");
+		pr_err("failed to read sys bar info\n");
 		return;
 	}
 
@@ -174,7 +174,7 @@ gvt_init_config(struct pci_gvt *gvt)
 		gvt->addr.function);
 	res_fd = open(res_name, O_RDONLY);
 	if (res_fd == -1) {
-		perror("gvt:open host pci resource failed\n");
+		pr_err("gvt:open host pci resource failed\n");
 		return -1;
 	}
 
@@ -183,7 +183,7 @@ gvt_init_config(struct pci_gvt *gvt)
 	close(res_fd);
 
 	if (ret < 512) {
-		perror("failed to read host device resource space\n");
+		pr_err("failed to read host device resource space\n");
 		return -1;
 	}
 
@@ -201,7 +201,7 @@ gvt_init_config(struct pci_gvt *gvt)
 		|| bar2_start_addr < ctx->lowmem_limit
 		|| bar0_end_addr > PCI_EMUL_ECFG_BASE
 		|| bar2_end_addr > PCI_EMUL_ECFG_BASE){
-		perror("gvt pci bases are out of range\n");
+		pr_err("gvt pci bases are out of range\n");
 		return -1;
 	}
 
@@ -225,7 +225,7 @@ gvt_init_config(struct pci_gvt *gvt)
 		gvt->addr.function);
 	gvt->host_config_fd = open(name, O_RDONLY);
 	if (gvt->host_config_fd == -1) {
-		perror("gvt:open host pci config failed\n");
+		pr_err("gvt:open host pci config failed\n");
 		return -1;
 	}
 
@@ -234,7 +234,7 @@ gvt_init_config(struct pci_gvt *gvt)
 	close(gvt->host_config_fd);
 
 	if (ret <= PCI_REGMAX) {
-		perror("failed to read host device config space\n");
+		pr_err("failed to read host device config space\n");
 		return -1;
 	}
 
@@ -368,7 +368,7 @@ pci_gvt_init(struct vmctx *ctx, struct pci_vdev *pi, char *opts)
 
 	gvt = calloc(1, sizeof(struct pci_gvt));
 	if (!gvt) {
-		perror("gvt:calloc gvt failed\n");
+		pr_err("gvt:calloc gvt failed\n");
 		return -1;
 	}
 
@@ -396,7 +396,7 @@ pci_gvt_init(struct vmctx *ctx, struct pci_vdev *pi, char *opts)
 fail:
 	gvt_dev = NULL;
 	ctx->gvt_enabled = false;
-	perror("GVT: init failed\n");
+	pr_err("GVT: init failed\n");
 	free(gvt);
 	return -1;
 }

--- a/devicemodel/hw/pci/virtio/virtio_block.c
+++ b/devicemodel/hw/pci/virtio/virtio_block.c
@@ -471,7 +471,7 @@ virtio_blk_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	} else {
 		bctxt = blockif_open(opts, bident);
 		if (bctxt == NULL) {
-			perror("Could not open backing file");
+			pr_err("Could not open backing file");
 			return -1;
 		}
 	}

--- a/devicemodel/hw/pci/wdt_i6300esb.c
+++ b/devicemodel/hw/pci/wdt_i6300esb.c
@@ -187,7 +187,7 @@ start_wdt_timer(void)
 	timer_val.it_value.tv_sec = seconds;
 
 	if (acrn_timer_settime(&wdt_state.timer, &timer_val) == -1) {
-		perror("WDT timerfd_settime failed.\n");
+		pr_err("WDT timerfd_settime failed.\n");
 		wdt_state.wdt_armed = false;
 		return;
 	}
@@ -331,7 +331,7 @@ pci_wdt_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
 	/*the wdt just has one inistance */
 	if (wdt_state.reboot_enabled && wdt_state.timer1_val) {
-		perror("wdt can't be initialized twice, please check!");
+		pr_err("wdt can't be initialized twice, please check!");
 		return -1;
 	}
 

--- a/devicemodel/log/disk_logger.c
+++ b/devicemodel/log/disk_logger.c
@@ -174,7 +174,7 @@ static void write_to_disk(const char *fmt, va_list args)
 
 	write_cnt = write(disk_fd, buffer, strnlen(buffer, DISK_LOG_MAX_LEN));
 	if (write_cnt < 0) {
-		perror(DISK_PREFIX"write disk failed");
+		pr_err(DISK_PREFIX"write disk failed");
 		close(disk_fd);
 		disk_fd = -1;
 		return;

--- a/devicemodel/log/kmsg_logger.c
+++ b/devicemodel/log/kmsg_logger.c
@@ -51,7 +51,7 @@ static int init_kmsg_logger(bool enable, uint8_t log_level)
 	kmsg_fd = open(KMSG_DEV_NODE, O_RDWR | O_APPEND | O_NONBLOCK);
 	if (kmsg_fd < 0) {
 		kmsg_enabled = false;
-		perror(KMSG_PREFIX"open kmsg dev failed");
+		pr_err(KMSG_PREFIX"open kmsg dev failed");
 	}
 
 	return kmsg_fd;
@@ -85,7 +85,7 @@ static void write_to_kmsg(const char *fmt, va_list args)
 
 	write_cnt = write(kmsg_fd, kmsg_buf, strnlen(kmsg_buf, KMSG_MAX_LEN));
 	if (write_cnt < 0) {
-		perror(KMSG_PREFIX"write kmsg failed");
+		pr_err(KMSG_PREFIX"write kmsg failed");
 		close(kmsg_fd);
 		kmsg_fd = -1;
 	}


### PR DESCRIPTION
use acrn-dm logger function instread of perror,
this helps the stability testing log capture.

Tracked-On: #4098
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>