### PR TITLE
show vcpu thread status in vcpu_list debug command

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -575,7 +575,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		vm->sw.io_shared_page = NULL;
 		if ((vm_config->load_order == POST_LAUNCHED_VM) && ((vm_config->guest_flags & GUEST_FLAG_IO_COMPLETION_POLLING) != 0U)) {
 			/* enable IO completion polling mode per its guest flags in vm_config. */
-			vm->sw.is_completion_polling = true;
+			vm->sw.is_polling_ioreq = true;
 		}
 		status = set_vcpuid_entries(vm);
 		if (status == 0) {

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -599,11 +599,13 @@ void switch_apicv_mode_x2apic(struct acrn_vcpu *vcpu)
 
 		value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS);
 		value32 &= ~VMX_PROCBASED_CTLS_TPR_SHADOW;
+		value32 &= ~VMX_PROCBASED_CTLS_HLT;
 		exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
 
 		exec_vmwrite32(VMX_TPR_THRESHOLD, 0U);
 
 		value32 = exec_vmread32(VMX_PROC_VM_EXEC_CONTROLS2);
+		value32 &= ~VMX_PROCBASED_CTLS2_PAUSE_LOOP;
 		value32 &= ~VMX_PROCBASED_CTLS2_VAPIC;
 		if (is_apicv_advanced_feature_supported()) {
 			value32 &= ~VMX_PROCBASED_CTLS2_VIRQ;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -552,7 +552,7 @@ int32_t hcall_notify_ioreq_finish(uint16_t vmid, uint16_t vcpu_id)
 				__func__, vcpu_id, target_vm->vm_id);
 		} else {
 			vcpu = vcpu_from_vid(target_vm, vcpu_id);
-			if (!vcpu->vm->sw.is_completion_polling) {
+			if (!vcpu->vm->sw.is_polling_ioreq) {
 				signal_event(&vcpu->events[VCPU_EVENT_IOREQ]);
 			}
 			ret = 0;

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -637,12 +637,12 @@ static int32_t shell_list_vcpu(__unused int32_t argc, __unused char **argv)
 	char temp_str[MAX_STR_SIZE];
 	struct acrn_vm *vm;
 	struct acrn_vcpu *vcpu;
-	char state[32];
+	char vcpu_state_str[32], thread_state_str[32];
 	uint16_t i;
 	uint16_t idx;
 
-	shell_puts("\r\nVM ID    PCPU ID    VCPU ID    VCPU ROLE    VCPU STATE"
-		"\r\n=====    =======    =======    =========    ==========\r\n");
+	shell_puts("\r\nVM ID    PCPU ID    VCPU ID    VCPU ROLE    VCPU STATE    THREAD STATE"
+		"\r\n=====    =======    =======    =========    ==========    ==========\r\n");
 
 	for (idx = 0U; idx < CONFIG_MAX_VM_NUM; idx++) {
 		vm = get_vm_from_vmid(idx);
@@ -652,31 +652,47 @@ static int32_t shell_list_vcpu(__unused int32_t argc, __unused char **argv)
 		foreach_vcpu(i, vm, vcpu) {
 			switch (vcpu->state) {
 			case VCPU_INIT:
-				(void)strncpy_s(state, 32U, "Init", 32U);
+				(void)strncpy_s(vcpu_state_str, 32U, "Init", 32U);
 				break;
 			case VCPU_PAUSED:
-				(void)strncpy_s(state, 32U, "Paused", 32U);
+				(void)strncpy_s(vcpu_state_str, 32U, "Paused", 32U);
 				break;
 			case VCPU_RUNNING:
-				(void)strncpy_s(state, 32U, "Running", 32U);
+				(void)strncpy_s(vcpu_state_str, 32U, "Running", 32U);
 				break;
 			case VCPU_ZOMBIE:
-				(void)strncpy_s(state, 32U, "Zombie", 32U);
+				(void)strncpy_s(vcpu_state_str, 32U, "Zombie", 32U);
 				break;
 			default:
-				(void)strncpy_s(state, 32U, "Unknown", 32U);
+				(void)strncpy_s(vcpu_state_str, 32U, "Unknown", 32U);
+				break;
+			}
+
+			switch (vcpu->thread_obj.status) {
+			case THREAD_STS_RUNNING:
+				(void)strncpy_s(thread_state_str, 32U, "RUNNING", 32U);
+				break;
+			case THREAD_STS_RUNNABLE:
+				(void)strncpy_s(thread_state_str, 32U, "RUNNABLE", 32U);
+				break;
+			case THREAD_STS_BLOCKED:
+				(void)strncpy_s(thread_state_str, 32U, "BLOCKED", 32U);
+				break;
+			default:
+				(void)strncpy_s(thread_state_str, 32U, "UNKNOWN", 32U);
+				break;
 			}
 			/* Create output string consisting of VM name
 			 * and VM id
 			 */
 			snprintf(temp_str, MAX_STR_SIZE,
-					"  %-9d %-10d %-7hu %-12s %-16s\r\n",
+					"  %-9d %-10d %-7hu %-12s %-16s %-16s\r\n",
 					vm->vm_id,
 					pcpuid_from_vcpu(vcpu),
 					vcpu->vcpu_id,
 					is_vcpu_bsp(vcpu) ?
 					"PRIMARY" : "SECONDARY",
-					state);
+					vcpu_state_str, thread_state_str);
 			/* Output information for this task */
 			shell_puts(temp_str);
 		}

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -97,7 +97,7 @@ int32_t acrn_insert_request(struct acrn_vcpu *vcpu, const struct io_request *io_
 		vhm_req->type = io_req->io_type;
 		(void)memcpy_s(&vhm_req->reqs, sizeof(union vhm_io_request),
 			&io_req->reqs, sizeof(union vhm_io_request));
-		if (vcpu->vm->sw.is_completion_polling) {
+		if (vcpu->vm->sw.is_polling_ioreq) {
 			vhm_req->completion_polling = 1U;
 			is_polling = true;
 		}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -67,7 +67,7 @@ struct vm_sw_info {
 	/* HVA to IO shared page */
 	void *io_shared_page;
 	/* If enable IO completion polling mode */
-	bool is_completion_polling;
+	bool is_polling_ioreq;
 };
 
 struct vm_pm_info {


### PR DESCRIPTION
    Due to vcpu and its thread are two different perspective modules, each
    of them has its own status. Dump both states for better understanding
    of system status.
