### PR TITLE
hv: fix pcpu_id mask issue in smp_call_function()

### DIFF
--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -43,7 +43,7 @@ void smp_call_function(uint64_t mask, smp_call_func_t func, void *data)
 	struct smp_call_info_data *smp_call;
 
 	/* wait for previous smp call complete, which may run on other cpus */
-	while (atomic_cmpxchg64(&smp_call_mask, 0UL, mask & INVALID_BIT_INDEX) != 0UL);
+	while (atomic_cmpxchg64(&smp_call_mask, 0UL, mask) != 0UL);
 	pcpu_id = ffs64(mask);
 	while (pcpu_id < MAX_PCPU_NUM) {
 		bitmap_clear_nolock(pcpu_id, &mask);


### PR DESCRIPTION
INVALID_BIT_INDEX has 16 bits only, which removes all pcpu_id that
is >= 16 from the destination mask.

Tracked-On: #4354
Signed-off-by: Zide Chen <zide.chen@intel.com>