### PR TITLE
HV: init local variable before it is used.

### DIFF
--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -440,7 +440,7 @@ static void pci_parse_iommu_devscopes(struct pci_bdf_set *const bdfs_from_drhds,
 void init_pci_pdev_list(void)
 {
 	uint64_t buses_visited[BUSES_BITMAP_LEN] = {0UL};
-	struct pci_bdf_set bdfs_from_drhds;
+	struct pci_bdf_set bdfs_from_drhds = {.pci_bdf_map_count = 0U};
 	uint32_t drhd_idx_pci_all = INVALID_DRHD_INDEX;
 	uint16_t bus;
 	bool was_visited = false;


### PR DESCRIPTION
it is better to init bdfs_from_drhds.pci_bdf_map_count
before it is passed to other function to do:
    bdfs_from_drhds->pci_bdf_map_count++

Tracked-On: #3875
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Fei Li <fei1.li@intel.com>