### PR TITLE
Enable OpRegion and graphics stolen memory for GVT-d

### DIFF
--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -56,10 +56,11 @@ static char bootargs[BOOT_ARG_LEN];
  * 2:       0x100000 -  lowmem      RAM             lowmem - 1MB
  * 3:         lowmem -  0x80000000  (reserved)      2GB - lowmem
  * 4:	  0x80000000 -  0x88000000  (reserved)	    128MB
- * 5:     0xDF000000 -  0xE0000000  (reserved)      16MB
- * 6:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
- * 7:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
- * 8:    0x140000000 -  highmem     RAM             highmem - 5GB
+ * 5:     0xDB000000 -  0xDF000000  (reserved)      64MB
+ * 6:     0xDF000000 -  0xE0000000  (reserved)      16MB
+ * 7:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
+ * 8:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
+ * 9:    0x140000000 -  highmem     RAM             highmem - 5GB
  */
 const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 	{	/* 0 to video memory */
@@ -90,6 +91,19 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		/* reserve for PRM resource */
 		.baseaddr = 0x80000000,
 		.length	  = 0x8000000,
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{
+		/* reserve for GVT-d graphics stolen memory.
+		 * The native BIOS allocates the stolen memory by itself,
+		 * and size can be configured by user itself through BIOS GUI.
+		 * For ACRN, we simply hard code to 64MB and static
+		 * reserved the memory region to avoid more efforts in OVMF,
+		 * and user *must* align the native BIOS setting to 64MB.
+		 */
+		.baseaddr = 0xDB000000,
+		.length	  = 0x4000000,
 		.type     = E820_TYPE_RESERVED
 	},
 

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -101,6 +101,9 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		 * For ACRN, we simply hard code to 64MB and static
 		 * reserved the memory region to avoid more efforts in OVMF,
 		 * and user *must* align the native BIOS setting to 64MB.
+		 *
+		 * GPU_GSM_GPA micro in passthrough.c should
++		 * align with this address here.
 		 */
 		.baseaddr = 0xDB000000,
 		.length	  = 0x4000000,

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -69,6 +69,10 @@
  */
 #define AUDIO_NHLT_HACK 1
 
+#define GPU_GSM_SIZE			0x4000000
+/* set gsm gpa=0xDB000000, which is reserved in e820 table */
+#define GPU_GSM_GPA  			0xDB000000
+
 extern uint64_t audio_nhlt_len;
 
 /* reference count for libpciaccess init/deinit */
@@ -80,6 +84,8 @@ struct mmio_map {
 	uint64_t hpa;
 	size_t size;
 };
+
+uint32_t gsm_start_hpa = 0;
 
 struct passthru_dev {
 	struct pci_vdev *dev;
@@ -861,6 +867,14 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	if (error < 0)
 		goto done;
 
+	if (ptdev->phys_bdf == PCI_BDF_GPU) {
+		/* get gsm hpa */
+		gsm_start_hpa = read_config(ptdev->phys_dev, PCIR_BDSM, 4);
+		gsm_start_hpa &= PCIM_BDSM_GSM_MASK;
+		/* initialize the EPT mapping for passthrough GPU gsm region */
+		vm_map_ptdev_mmio(ctx, 0, 2, 0, GPU_GSM_GPA, GPU_GSM_SIZE, gsm_start_hpa);
+	}
+
 	/* If ptdev support MSI/MSIX, stop here to skip virtual INTx setup.
 	 * Forge Guest to use MSI/MSIX in this case to mitigate IRQ sharing
 	 * issue
@@ -944,6 +958,10 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 				ptdev->sel.dev, ptdev->sel.func,
 				dev->bar[i].addr, ptdev->bar[i].size,
 				ptdev->bar[i].addr);
+	}
+
+	if (ptdev->phys_bdf == PCI_BDF_GPU) {
+		vm_unmap_ptdev_mmio(ctx, 0, 2, 0, GPU_GSM_GPA, GPU_GSM_SIZE, gsm_start_hpa);
 	}
 
 	pciaccess_cleanup();
@@ -1037,13 +1055,15 @@ passthru_cfgread(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 	/* Everything else just read from the device's config space */
 	*rv = read_config(ptdev->phys_dev, coff, bytes);
 
-	/*
-	 * return zero for graphics stolen memory since acrn does not have
-	 * support for RMRR
+	/* passthru_init has initialized the EPT mapping
+	 * for GPU gsm region.
+	 * So uos GPU can passthrough physical gsm now.
+	 * Here, only need return gsm gpa value for uos.
 	 */
 	if ((PCI_BDF(dev->bus, dev->slot, dev->func) == PCI_BDF_GPU)
-		&& (coff == PCIR_GMCH_CTL)) {
-		*rv &= ~PCIM_GMCH_CTL_GMS;
+		&& (coff == PCIR_BDSM)) {
+		*rv &= ~PCIM_BDSM_GSM_MASK;
+		*rv |= GPU_GSM_GPA;
 	}
 
 	return 0;

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,6 +1066,6 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
-#define PCIR_GMCH_CTL			0x50 /*GMCH grpahics control register */
-#define PCIM_GMCH_CTL_GMS		0xFF00 /*GMS - stolen memory bits 15:8 */
+#define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
+#define PCIM_BDSM_GSM_MASK  		0xFFF00000 /* bits 31:20 contains the base address of stolen memory */
 #endif

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1068,4 +1068,6 @@
 /* Graphics definitions */
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
 #define PCIM_BDSM_GSM_MASK  		0xFFF00000 /* bits 31:20 contains the base address of stolen memory */
+#define PCIR_ASLS_CTL			0xFC /* Opregion start addr register */
+#define PCIM_ASLS_OPREGION_MASK	0xFFFFF000 /* opregion need 4KB aligned */
 #endif

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        9
+#define NUM_E820_ENTRIES        10
 #define LOWRAM_E820_ENTRY       2
-#define HIGHRAM_E820_ENTRY      8
+#define HIGHRAM_E820_ENTRY      9
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {


### PR DESCRIPTION
Enable OpRegion and graphics stolen memory for GVT-d