### PR TITLE
Delete pass-through audio to WaaG in default

### DIFF
--- a/devicemodel/samples/nuc/launch_win.sh
+++ b/devicemodel/samples/nuc/launch_win.sh
@@ -14,10 +14,6 @@ if [[ "$result" != "" ]]; then
   exit
 fi
 
-#add audio passthrough device
-echo "8086:9d71" > /sys/bus/pci/drivers/pci-stub/new_id
-echo "0000:00:1f.3" > /sys/bus/pci/drivers/pci-stub/bind
-
 #for memsize setting
 mem_size=4096M
 
@@ -25,7 +21,6 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
   -s 2,pci-gvt -G "$2" \
   -s 3,virtio-blk,./win10-ltsc.img \
   -s 4,virtio-net,tap0 \
-  -s 5,passthru,00/1f/3 \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
   --windows \
   $vm_name


### PR DESCRIPTION
 Delete pass-through audio to WaaG in default because WHL cannot support audio reset.

Tracked-On: #4397
Signed-off-by: fangfang.shen <fangfang.shen@intel.com>