### PR TITLE
doc: update project's target max LOC

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -36,7 +36,8 @@ the ACRN hypervisor for the following reasons:
 
 - **Keep small footprint.** Implementing dynamic parsing introduces
   hundreds or thousands of lines of code. Avoiding dynamic parsing
-  helps keep the hypervisor's Lines of Code (LOC) in a desirable range (around 30K).
+  helps keep the hypervisor's Lines of Code (LOC) in a desirable range (less
+  than 40K).
 
 - **Improve boot up time.** Dynamic parsing at runtime increases the boot
   up time. Using a build-time configuration and not dynamic parsing


### PR DESCRIPTION
Project ACRN is targetting to keep the hypervisor's total number of lines of
code (LOC) below 40K. Update the "Build ACRN from Source" document to accurately
reflect that.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>