### PR TITLE
For GVT-D 1.5-release Validation Only

### DIFF
--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -56,10 +56,11 @@ static char bootargs[BOOT_ARG_LEN];
  * 2:       0x100000 -  lowmem      RAM             lowmem - 1MB
  * 3:         lowmem -  0x80000000  (reserved)      2GB - lowmem
  * 4:	  0x80000000 -  0x88000000  (reserved)	    128MB
- * 5:     0xDF000000 -  0xE0000000  (reserved)      16MB
- * 6:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
- * 7:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
- * 8:    0x140000000 -  highmem     RAM             highmem - 5GB
+ * 5:     0xDB000000 -  0xDF000000  (reserved)      64MB
+ * 6:     0xDF000000 -  0xE0000000  (reserved)      16MB
+ * 7:     0xE0000000 -  0x100000000 MCFG, MMIO      512MB
+ * 8:    0x100000000 -  0x140000000 64-bit PCI hole 1GB
+ * 9:    0x140000000 -  highmem     RAM             highmem - 5GB
  */
 const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 	{	/* 0 to video memory */
@@ -90,6 +91,19 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		/* reserve for PRM resource */
 		.baseaddr = 0x80000000,
 		.length	  = 0x8000000,
+		.type     = E820_TYPE_RESERVED
+	},
+
+	{
+		/* reserve for GVT-d graphics stolen memory.
+		 * The native BIOS allocates the stolen memory by itself,
+		 * and size can be configured by user itself through BIOS GUI.
+		 * For ACRN, we simply hard code to 64MB and static
+		 * reserved the memory region to avoid more efforts in OVMF,
+		 * and user *must* align the native BIOS setting to 64MB.
+		 */
+		.baseaddr = 0xDB000000,
+		.length	  = 0x4000000,
 		.type     = E820_TYPE_RESERVED
 	},
 

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -101,6 +101,9 @@ const struct e820_entry e820_default_entries[NUM_E820_ENTRIES] = {
 		 * For ACRN, we simply hard code to 64MB and static
 		 * reserved the memory region to avoid more efforts in OVMF,
 		 * and user *must* align the native BIOS setting to 64MB.
+		 *
+		 * GPU_GSM_GPA micro in passthrough.c should
++		 * align with this address here.
 		 */
 		.baseaddr = 0xDB000000,
 		.length	  = 0x4000000,

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -537,6 +537,7 @@ cfginitbar(struct vmctx *ctx, struct passthru_dev *ptdev)
 	struct pci_bar_io bar;
 	enum pcibar_type bartype;
 	uint64_t base, size;
+	uint32_t vbar_lo32;
 
 	dev = ptdev->dev;
 
@@ -599,6 +600,24 @@ cfginitbar(struct vmctx *ctx, struct passthru_dev *ptdev)
 		error = pci_emul_alloc_pbar(dev, i, base, bartype, size);
 		if (error)
 			return -1;
+
+		/*
+		 * For pass-thru devices,
+		 * set the bar prefetchable property the same as physical bar.
+		 *
+		 * the pci bar prefetchable property has set by pci_emul_alloc_pbar,
+		 * here, override the prefetchable property according to the physical bar.
+		 */
+		if (bartype == PCIBAR_MEM32 ||  bartype == PCIBAR_MEM64) {
+			vbar_lo32 = pci_get_cfgdata32(dev, PCIR_BAR(i));
+
+			if (bar.base & PCIM_BAR_MEM_PREFETCH)
+				vbar_lo32 |= PCIM_BAR_MEM_PREFETCH;
+			else
+				vbar_lo32 &= ~PCIM_BAR_MEM_PREFETCH;
+
+			pci_set_cfgdata32(dev, PCIR_BAR(i), vbar_lo32);
+	}
 
 		/* The MSI-X table needs special handling */
 		if (i == ptdev_msix_table_bar(ptdev)) {

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -73,6 +73,14 @@
 /* set gsm gpa=0xDB000000, which is reserved in e820 table */
 #define GPU_GSM_GPA  			0xDB000000
 
+#define GPU_OPREGION_SIZE		0x3000
+/* set opregion gpa=0xDFFFD000, which is reserved in e820 table.
+ * [0xDFFFD000, 0XE0000000] 12K opregion has reserved for GVT-g,
+ * because GVT-d is not compatible with GVT-g,
+ * so here can use [0xDFFFD000, 0XE0000000] region.
+ */
+#define GPU_OPREGION_GPA  		0xDFFFD000
+
 extern uint64_t audio_nhlt_len;
 
 /* reference count for libpciaccess init/deinit */
@@ -91,6 +99,7 @@ struct mmio_map {
 };
 
 uint32_t gsm_start_hpa = 0;
+uint32_t opregion_start_hpa = 0;
 
 struct passthru_dev {
 	struct pci_vdev *dev;
@@ -887,6 +896,12 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		gsm_start_hpa &= PCIM_BDSM_GSM_MASK;
 		/* initialize the EPT mapping for passthrough GPU gsm region */
 		vm_map_ptdev_mmio(ctx, 0, 2, 0, GPU_GSM_GPA, GPU_GSM_SIZE, gsm_start_hpa);
+
+		/* get opregion hpa */
+		opregion_start_hpa = read_config(ptdev->phys_dev, PCIR_ASLS_CTL, 4);
+		opregion_start_hpa &= PCIM_ASLS_OPREGION_MASK;
+		/* initialize the EPT mapping for passthrough GPU opregion */
+		vm_map_ptdev_mmio(ctx, 0, 2, 0, GPU_OPREGION_GPA, GPU_OPREGION_SIZE, opregion_start_hpa);
 	}
 
 	/* If ptdev support MSI/MSIX, stop here to skip virtual INTx setup.
@@ -976,6 +991,7 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 
 	if (ptdev->phys_bdf == PCI_BDF_GPU) {
 		vm_unmap_ptdev_mmio(ctx, 0, 2, 0, GPU_GSM_GPA, GPU_GSM_SIZE, gsm_start_hpa);
+		vm_unmap_ptdev_mmio(ctx, 0, 2, 0, GPU_OPREGION_GPA, GPU_OPREGION_SIZE, opregion_start_hpa);
 	}
 
 	pciaccess_cleanup();
@@ -1078,6 +1094,18 @@ passthru_cfgread(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 		&& (coff == PCIR_BDSM)) {
 		*rv &= ~PCIM_BDSM_GSM_MASK;
 		*rv |= GPU_GSM_GPA;
+	}
+
+	/* passthru_init has initialized the EPT mapping
+	 * for GPU opregion.
+	 * So uos GPU can passthrough physical opregion now.
+	 * Here, only need return opregion gpa value for uos.
+	 */
+	if ((PCI_BDF(dev->bus, dev->slot, dev->func) == PCI_BDF_GPU)
+		&& (coff == PCIR_ASLS_CTL)) {
+		/* reserve opregion start addr offset to 4KB page */
+		*rv &= ~PCIM_ASLS_OPREGION_MASK;
+		*rv |= GPU_OPREGION_GPA;
 	}
 
 	return 0;

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -69,6 +69,10 @@
  */
 #define AUDIO_NHLT_HACK 1
 
+#define GPU_GSM_SIZE			0x4000000
+/* set gsm gpa=0xDB000000, which is reserved in e820 table */
+#define GPU_GSM_GPA  			0xDB000000
+
 extern uint64_t audio_nhlt_len;
 
 /* reference count for libpciaccess init/deinit */
@@ -85,6 +89,8 @@ struct mmio_map {
 	uint64_t hpa;
 	size_t size;
 };
+
+uint32_t gsm_start_hpa = 0;
 
 struct passthru_dev {
 	struct pci_vdev *dev;
@@ -875,6 +881,14 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	if (error < 0)
 		goto done;
 
+	if (ptdev->phys_bdf == PCI_BDF_GPU) {
+		/* get gsm hpa */
+		gsm_start_hpa = read_config(ptdev->phys_dev, PCIR_BDSM, 4);
+		gsm_start_hpa &= PCIM_BDSM_GSM_MASK;
+		/* initialize the EPT mapping for passthrough GPU gsm region */
+		vm_map_ptdev_mmio(ctx, 0, 2, 0, GPU_GSM_GPA, GPU_GSM_SIZE, gsm_start_hpa);
+	}
+
 	/* If ptdev support MSI/MSIX, stop here to skip virtual INTx setup.
 	 * Forge Guest to use MSI/MSIX in this case to mitigate IRQ sharing
 	 * issue
@@ -958,6 +972,10 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 				ptdev->sel.dev, ptdev->sel.func,
 				dev->bar[i].addr, ptdev->bar[i].size,
 				ptdev->bar[i].addr);
+	}
+
+	if (ptdev->phys_bdf == PCI_BDF_GPU) {
+		vm_unmap_ptdev_mmio(ctx, 0, 2, 0, GPU_GSM_GPA, GPU_GSM_SIZE, gsm_start_hpa);
 	}
 
 	pciaccess_cleanup();
@@ -1051,13 +1069,15 @@ passthru_cfgread(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 	/* Everything else just read from the device's config space */
 	*rv = read_config(ptdev->phys_dev, coff, bytes);
 
-	/*
-	 * return zero for graphics stolen memory since acrn does not have
-	 * support for RMRR
+	/* passthru_init has initialized the EPT mapping
+	 * for GPU gsm region.
+	 * So uos GPU can passthrough physical gsm now.
+	 * Here, only need return gsm gpa value for uos.
 	 */
 	if ((PCI_BDF(dev->bus, dev->slot, dev->func) == PCI_BDF_GPU)
-		&& (coff == PCIR_GMCH_CTL)) {
-		*rv &= ~PCIM_GMCH_CTL_GMS;
+		&& (coff == PCIR_BDSM)) {
+		*rv &= ~PCIM_BDSM_GSM_MASK;
+		*rv |= GPU_GSM_GPA;
 	}
 
 	return 0;

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,6 +1066,6 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
-#define PCIR_GMCH_CTL			0x50 /*GMCH grpahics control register */
-#define PCIM_GMCH_CTL_GMS		0xFF00 /*GMS - stolen memory bits 15:8 */
+#define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
+#define PCIM_BDSM_GSM_MASK  		0xFFF00000 /* bits 31:20 contains the base address of stolen memory */
 #endif

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1068,4 +1068,6 @@
 /* Graphics definitions */
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
 #define PCIM_BDSM_GSM_MASK  		0xFFF00000 /* bits 31:20 contains the base address of stolen memory */
+#define PCIR_ASLS_CTL			0xFC /* Opregion start addr register */
+#define PCIM_ASLS_OPREGION_MASK	0xFFFFF000 /* opregion need 4KB aligned */
 #endif

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        9
+#define NUM_E820_ENTRIES        10
 #define LOWRAM_E820_ENTRY       2
-#define HIGHRAM_E820_ENTRY      8
+#define HIGHRAM_E820_ENTRY      9
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {

--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -204,12 +204,14 @@ handle_one_drhd(struct acpi_dmar_hardware_unit *acpi_drhd,
 
 		consumed = handle_dmar_devscope(dev_scope, cp, remaining);
 
+		/*
 		if (((drhd->segment << 16U) |
 		     (dev_scope->bus << 8U) |
 		     dev_scope->devfun) == CONFIG_GPU_SBDF) {
 			ASSERT(dev_count == 1, "no dedicated iommu for gpu");
 			drhd->ignore = true;
 		}
+		*/
 
 		if (consumed <= 0)
 			break;

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -184,7 +184,7 @@ bool iommu_snoop_supported(const struct iommu_domain *iommu)
 	bool ret;
 
 	if ((iommu == NULL) || (iommu->iommu_snoop)) {
-		ret =  true;
+		ret =  false;
 	} else {
 		ret = false;
 	}
@@ -1263,7 +1263,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 		domain->trans_table_ptr = translation_table;
 		domain->addr_width = addr_width;
 		domain->is_tt_ept = true;
-		domain->iommu_snoop = true;
+		domain->iommu_snoop = false;
 
 		dev_dbg(ACRN_DBG_IOMMU, "create domain [%d]: vm_id = %hu, ept@0x%x",
 			vmid_to_domainid(domain->vm_id), domain->vm_id, domain->trans_table_ptr);


### PR DESCRIPTION

1. 2 hypervisor patches to clean  IOMMU snoop control bit, this is global and has side effect. These patches need to be revised.
2. 5 dm patches are cherry-picked from\ master branch.   
   2 for set bar lowbits from HW ; 
   3 for reserve memory space for stolen memory and opregion in dm. 


Junming Liu (7):
  dm:keep pci bar property unchanged when updating pci bar address
  dm:derive the prefetch property of PCI bar for pass-through device
  dm:reserve 64M hole for graphics stolen memory in e820 table
  dm:passthrough graphics stolen memory to uos gpu
  dm:passthrough opregion to uos gpu
  Always disable the iommu_snoop when enabling the IOMMU for GPU
  hv: More changes to enable GPU passthru

 devicemodel/core/sw_load_common.c   | 25 ++++++++--
 devicemodel/hw/pci/core.c           | 13 +++--
 devicemodel/hw/pci/passthrough.c    | 77 +++++++++++++++++++++++++++--
 devicemodel/include/pcireg.h        |  6 ++-
 devicemodel/include/sw_load.h       |  4 +-
 hypervisor/acpi_parser/dmar_parse.c |  2 +
 hypervisor/arch/x86/vtd.c           |  4 +-
 7 files changed, 113 insertions(+), 18 deletions(-)
