### PR TITLE
hv: enable early pr_xxx() logs

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -22,7 +22,6 @@
 #include <vmx.h>
 #include <msr.h>
 #include <ptdev.h>
-#include <ld_sym.h>
 #include <logmsg.h>
 #include <cat.h>
 #include <vboot.h>
@@ -107,16 +106,6 @@ void init_pcpu_pre(bool is_bsp)
 	if (is_bsp) {
 		pcpu_id = BOOT_CPU_ID;
 		start_tsc = rdtsc();
-
-		/* Clear BSS */
-		(void)memset(&ld_bss_start, 0U, (size_t)(&ld_bss_end - &ld_bss_start));
-
-		(void)parse_hv_cmdline();
-		/*
-		 * Enable UART as early as possible.
-		 * Then we could use printf for debugging on early boot stage.
-		 */
-		uart16550_init(true);
 
 		/* Get CPU capabilities thru CPUID, including the physical address bit
 		 * limit which is required for initializing paging.

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -318,7 +318,13 @@ uint64_t us_to_ticks(uint32_t us)
 
 uint64_t ticks_to_us(uint64_t ticks)
 {
-	return (ticks * 1000UL) / (uint64_t)tsc_khz;
+	uint64_t us = 0UL;
+
+	if (tsc_khz != 0U ) {
+		us = (ticks * 1000UL) / (uint64_t)tsc_khz;
+	}
+
+	return us;
 }
 
 uint64_t ticks_to_ms(uint64_t ticks)


### PR DESCRIPTION
Currently panic() and pr_xxx() statements before init_primary_pcpu_post()
won't be printed, which is inconvenient and misleading for debugging.

This patch makes pr_xxx() APIs working before init_pcpu_pre():

- clear .bss in init.c, which makes sense to clear .bss at the very beginning
  of initialization code. Also this makes it possible to call init_logmsg()
  before init_pcpu_pre().

- move parse_hv_cmdline() and uart16550_init(true) to init.c.

- refine ticks_to_us() to handle the case that it's called before
  calibrate_tsc(). As a side effect, it prints "0us" in early pr_xxx() calls.

- call init_debug_pre() in init_primary_pcpu() and after this point,
  both printf() and pr_xxx() APIs are available.

However, this patch doesn't address the issue that pr_xxx() could be called
on PCPUs that set_current_pcpu_id() hasn't been called, which implies that
the PCPU ID shown in early logs may not be accurate.

Tracked-On: #2987
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>