### PR TITLE
Python scripts discovering CPU IDs are off by 1

### DIFF
--- a/misc/acrn-config/target/misc.py
+++ b/misc/acrn-config/target/misc.py
@@ -201,7 +201,7 @@ def dump_cpu_core_info(config):
         print("\t{}".format(processor_id), end="", file=config)
 
         processor_id += 1
-        while (processor_id < int(line.split('-')[1].strip())):
+        while (processor_id <= int(line.split('-')[1].strip())):
             print(", {}".format(processor_id), end="", file=config)
             processor_id += 1
 


### PR DESCRIPTION
When generating the board configuration XML file, script ``misc.py`` reads file ``/sys/devices/system/cpu/possible`` on the target machine. There is a range ``N-M`` for CPU IDs that are available. The script identifies only CPU IDs ``N-(M-1)``.

Fix: change ``<`` to ``<=`` to include the final CPU ID.

Signed-off-by: Alexander Merritt <alex.merritt@intel.com>