### PR TITLE
acrn: rename param in uart16550_init

### DIFF
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -193,13 +193,13 @@ static void uart16550_set_baud_rate(uint32_t baud_rate)
 	uart16550_write_reg(uart, temp_reg, UART16550_LCR);
 }
 
-void uart16550_init(bool eraly_boot)
+void uart16550_init(bool early_boot)
 {
 	if (!uart.enabled) {
 		return;
 	}
 
-	if (!eraly_boot && !uart.serial_port_mapped) {
+	if (!early_boot && !uart.serial_port_mapped) {
 		uart.mmio_base_vaddr = hpa2hva(hva2hpa_early(uart.mmio_base_vaddr));
 		hv_access_memory_region_update((uint64_t)uart.mmio_base_vaddr, PDE_SIZE);
 		return;


### PR DESCRIPTION
Tracked-On: #4390 

Signed-off-by: Alexander Merritt <alex.merritt@intel.com>

See prior commit which added this typo

`eraly_boot -> early_boot`

```
commit cc47dbe7698b1991bc5844a609fb5f00608af0f8
Author: Li, Fei1 <fei1.li@intel.com>
Date:   Wed Jul 24 17:50:27 2019 +0800

    hv: uart: enable early boot uart

    Enable uart as early as possible to make things easier for debugging.
    After this we could use printf to output information to the uart. As for
    pr_xxx APIs, they start to work when init_logmsg is called.

    Tracked-On: #2987
    Signed-off-by: Li, Fei1 <fei1.li@intel.com>

diff --git a/hypervisor/debug/uart16550.c b/hypervisor/debug/uart16550.c
index 11bd859a..98837a6b 100644
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -131,12 +131,17 @@ static void uart16550_set_baud_rate(uint32_t baud_rate)
        uart16550_write_reg(uart, temp_reg, UART16550_LCR);
 }

-void uart16550_init(void)
+void uart16550_init(bool eraly_boot)
 {
        if (!uart.enabled) {
                return;
        }

+       if (!eraly_boot && !uart.serial_port_mapped) {
+               hv_access_memory_region_update((uint64_t)uart.mmio_base_vaddr, PDE_SIZE);
+               return;
+       }
+
        /* if configure serial PCI BDF, get its base MMIO address */
        if (!uart.serial_port_mapped) {
                serial_pci_bdf.value = get_pci_bdf_value(pci_bdf_info);
```