### PR TITLE
Makefile: disable fcf-protection for some build env

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -97,6 +97,13 @@ endif
 CFLAGS += -DSTACK_PROTECTOR
 endif
 
+# In case using Ubuntu 19.10 as build environment, its gcc has -fcf-protection enabled
+# by default. But this option is not compatible with -mindirect-branch:
+#   https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/1830961
+#
+# We disable the -fcf-protection in ACRN build.
+CFLAGS += -fcf-protection=none
+
 ASFLAGS += -m64 -nostdinc -nostdlib
 
 LDFLAGS += -Wl,--gc-sections -nostartfiles -nostdlib


### PR DESCRIPTION
In some build env (Ubuntu 19.10 as example), gcc enabled the option
-fcf-protection by default. But this option is not compatible with
-mindirect-branch. Which could trigger following build error:
  fail to build with gcc-9 [error: ‘-mindirect-branch’ and
  ‘-fcf-protection’ are not compatible]

-mindirect-branch is mandatory for retpoline mitigation and always
enabled for ACRN build. We disable -fcf-protection here for ACRN
build.

Tracked-On: #4358
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Wu Binbin <binbin.wu@intel.com>