### PR TITLE
hv: CAT is supposed to be enabled in the system level

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -244,6 +244,14 @@ config HYPERV_ENABLED
 	  When set, the minimum set of TLFS functionality together with some
 	  performance enlightenments are enabled.
 
+config CAT_ENABLED
+	bool "Enable CAT (Cache Allocation Technology)"
+	default n
+	help
+	  When set in platforms that support CAT, hypervisor can allocate
+	  various amount of last-level-cache (LLC) resources to VMs to achieve
+	  different Class of Service (COS, or CLOS).
+
 config GPU_SBDF
 	hex "Segment, Bus, Device, and function of the GPU"
 	depends on ACPI_PARSE_ENABLED

--- a/hypervisor/arch/x86/cat.c
+++ b/hypervisor/arch/x86/cat.c
@@ -37,7 +37,7 @@ int32_t init_cat_cap_info(void)
 			cat_cap_info.res_id = CAT_RESID_L2;
 		}
 
-		cat_cap_info.support = true;
+		cat_cap_info.enabled = true;
 
 		/* CPUID.(EAX=0x10,ECX=ResID):EAX[4:0] reports the length of CBM supported
 		 * CPUID.(EAX=0x10,ECX=ResID):EBX[31:0] indicates the corresponding uints

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -184,13 +184,10 @@ bool sanitize_vm_config(void)
 			break;
 		}
 
-		if ((vm_config->guest_flags & GUEST_FLAG_CLOS_REQUIRED) != 0U) {
-			if (cat_cap_info.support && (vm_config->clos <= cat_cap_info.clos_max)) {
-					cat_cap_info.enabled = true;
-			} else {
-				pr_err("%s set wrong CLOS or CAT is not supported\n", __func__);
-				ret = false;
-			}
+		if (cat_cap_info.enabled && (vm_config->clos > cat_cap_info.clos_max)) {
+			pr_err("%s set CLOS(%d) more than system supports(%d)\n", __func__,
+					vm_config->clos, cat_cap_info.clos_max);
+			ret = false;
 		}
 
 		if (((vm_config->epc.size | vm_config->epc.base) & ~PAGE_MASK) != 0UL) {

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -149,10 +149,12 @@ void init_pcpu_pre(bool is_bsp)
 			panic("System IOAPIC info is incorrect!");
 		}
 
+#ifdef CONFIG_CAT_ENABLED
 		ret = init_cat_cap_info();
 		if (ret != 0) {
 			panic("Platform CAT info is incorrect!");
 		}
+#endif
 
 		/* NOTE: this must call after MMCONFIG is parsed in init_vboot and before APs are INIT. */
 		pci_switch_to_mmio_cfg_ops();

--- a/hypervisor/include/arch/x86/cat.h
+++ b/hypervisor/include/arch/x86/cat.h
@@ -9,8 +9,7 @@
 
 /* The intel Resource Director Tech(RDT) based Cache Allocation Tech support */
 struct cat_hw_info {
-	bool support;		/* If L2/L3 CAT supported */
-	bool enabled;		/* If any VM setup CLOS */
+	bool enabled;		/* If L2/L3 CAT enabled */
 	uint32_t bitmask;	/* Used by other entities */
 	uint16_t cbm_len;	/* Length of Cache mask in bits */
 	uint16_t clos_max;	/* Maximum CLOS supported, the number of cache masks */

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -127,7 +127,9 @@ struct acrn_vm_config {
 	uint16_t pci_dev_num;				/* indicate how many PCI devices in VM */
 	struct acrn_vm_pci_dev_config *pci_devs;	/* point to PCI devices BDF list */
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
-	uint16_t clos;					/* if guest_flags has GUEST_FLAG_CLOS_REQUIRED, then VM use this CLOS */
+	uint16_t clos;					/* Class of Service, effective only if CONFIG_CAT_ENABLED
+							 * is defined on CAT capable platforms
+							 */
 
 	struct vuart_config vuart[MAX_VUART_NUM_PER_VM];/* vuart configuration for VM */
 } __aligned(8);

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -50,9 +50,8 @@
 #define GUEST_FLAG_SECURE_WORLD_ENABLED		(1UL << 0U)	/* Whether secure world is enabled */
 #define GUEST_FLAG_LAPIC_PASSTHROUGH		(1UL << 1U)  	/* Whether LAPIC is passed through */
 #define GUEST_FLAG_IO_COMPLETION_POLLING	(1UL << 2U)  	/* Whether need hypervisor poll IO completion */
-#define GUEST_FLAG_CLOS_REQUIRED		(1UL << 3U)     /* Whether CLOS is required */
-#define GUEST_FLAG_HIDE_MTRR			(1UL << 4U)  	/* Whether hide MTRR from VM */
-#define GUEST_FLAG_RT				(1UL << 5U)     /* Whether the vm is RT-VM */
+#define GUEST_FLAG_HIDE_MTRR			(1UL << 3U)  	/* Whether hide MTRR from VM */
+#define GUEST_FLAG_RT				(1UL << 4U)     /* Whether the vm is RT-VM */
 
 /* TODO: We may need to get this addr from guest ACPI instead of hardcode here */
 #define VIRTUAL_PM1A_CNT_ADDR		0x404U


### PR DESCRIPTION
In platforms that support CAT, when it is enabled by ACRN, i.e.
IA32_resourceType_MASK_n registers are programmed with customized values,
it has impacts to the whole system.

The per guest flag GUEST_FLAG_CLOS_REQUIRED suggests that CAT may be
enabled in some guests, but not in others who don't have this flag,
which is conceptually incorrect.

This patch removes GUEST_FLAG_CLOS_REQUIRED, and adds a new Kconfig
entry CAT_ENABLED for CAT enabling. When it's enabled, platform_clos_array[]
defines a set of system-wide Class of Service (COS, or CLOS), and the
per guest vm_configs[].clos associates the guest with particular CLOS.

Tracked-On: #2462
Signed-off-by: Zide Chen <zide.chen@intel.com>