### PR TITLE
Makefile: fix build issue on old gcc

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -102,7 +102,9 @@ endif
 #   https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/1830961
 #
 # We disable the -fcf-protection in ACRN build.
+ifeq (true, $(shell [ $(GCC_MAJOR) -gt 8 ] && echo true))
 CFLAGS += -fcf-protection=none
+endif
 
 ASFLAGS += -m64 -nostdinc -nostdlib
 


### PR DESCRIPTION
The previous fcf-protection fix broke the old gcc (older than
gcc 8 which is common on Ubuntu 18.04 and older distributions).

We only add fcf-protection=none for gcc8 and newer.

Tracked-On: #4358
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>