### PR TITLE
hv: support BVT scheduler

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -227,6 +227,9 @@ endif
 ifeq ($(CONFIG_SCHED_IORR),y)
 HW_C_SRCS += common/sched_iorr.c
 endif
+ifeq ($(CONFIG_SCHED_BVT),y)
+HW_C_SRCS += common/sched_bvt.c
+endif
 HW_C_SRCS += hw/pci.c
 HW_C_SRCS += arch/x86/configs/vm_config.c
 HW_C_SRCS += arch/x86/configs/$(CONFIG_BOARD)/board.c

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -55,6 +55,15 @@ config SCHED_IORR
           IORR (IO sensitive Round Robin) scheduler supports multipule vCPUs running on
 	  on one pCPU, and they will be scheduled by a IO sensitive round robin policy.
 
+config SCHED_BVT
+        bool "BVT scheduler"
+        help
+	  BVT (Borrowed Virtual time) is virtual time based scheduling algorithm, it
+	  dispatching the runnable thread with the earliest effective virtual time.
+	  TODO: BVT scheduler will be built on top of prioritized scheduling mechanism,
+	  i.e. higher priority threads get scheduled first, and same priority tasks are
+	  scheduled per BVT.
+
 endchoice
 
 

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <list.h>
+#include <per_cpu.h>
+#include <schedule.h>
+
+#define BVT_MCU_MS	1U
+/* context switch allowance */
+#define BVT_CSA_MCU 5U
+struct sched_bvt_data {
+	/* keep list as the first item */
+	struct list_head list;
+	/* minimum charging unit in cycles */
+	uint64_t mcu;
+	/* a thread receives a share of cpu in proportion to its weight */
+	uint16_t weight;
+	/* virtual time advance variable, proportional to 1 / weight */
+	uint64_t vt_ratio;
+	/* the count down number of mcu until reschedule should take place */
+	uint64_t run_countdown;
+	/* actual virtual time in units of mcu */
+	int64_t avt;
+	/* effective virtual time in units of mcu */
+	int64_t evt;
+
+	uint64_t start_tsc;
+};
+
+static int sched_bvt_init(__unused struct sched_control *ctl)
+{
+	return 0;
+}
+
+static void sched_bvt_deinit(__unused struct sched_control *ctl)
+{
+}
+
+static void sched_bvt_init_data(__unused struct thread_object *obj)
+{
+}
+
+static struct thread_object *sched_bvt_pick_next(__unused struct sched_control *ctl)
+{
+	return NULL;
+}
+
+static void sched_bvt_sleep(__unused struct thread_object *obj)
+{
+}
+
+static void sched_bvt_wake(__unused struct thread_object *obj)
+{
+}
+
+struct acrn_scheduler sched_bvt = {
+	.name		= "sched_bvt",
+	.init		= sched_bvt_init,
+	.init_data	= sched_bvt_init_data,
+	.pick_next	= sched_bvt_pick_next,
+	.sleep		= sched_bvt_sleep,
+	.wake		= sched_bvt_wake,
+	.deinit		= sched_bvt_deinit,
+};

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -30,6 +30,88 @@ struct sched_bvt_data {
 	uint64_t start_tsc;
 };
 
+/*
+ * @pre obj != NULL
+ * @pre obj->data != NULL
+ */
+static bool is_inqueue(struct thread_object *obj)
+{
+	struct sched_bvt_data *data = (struct sched_bvt_data *)obj->data;
+	return !list_empty(&data->list);
+}
+
+/*
+ * @pre obj != NULL
+ * @pre obj->data != NULL
+ * @pre obj->sched_ctl != NULL
+ * @pre obj->sched_ctl->priv != NULL
+ */
+static void runqueue_add(struct thread_object *obj)
+{
+	struct sched_bvt_control *bvt_ctl =
+		(struct sched_bvt_control *)obj->sched_ctl->priv;
+	struct sched_bvt_data *data = (struct sched_bvt_data *)obj->data;
+	struct list_head *pos;
+	struct thread_object *iter_obj;
+	struct sched_bvt_data *iter_data;
+
+	/*
+	 * the earliest evt has highest priority,
+	 * the runqueue is ordered by priority.
+	 */
+
+	if (list_empty(&bvt_ctl->runqueue)) {
+		list_add(&data->list, &bvt_ctl->runqueue);
+	} else {
+		list_for_each(pos, &bvt_ctl->runqueue) {
+			iter_obj = list_entry(pos, struct thread_object, data);
+			iter_data = (struct sched_bvt_data *)iter_obj->data;
+			if (iter_data->evt > data->evt) {
+				list_add_node(&data->list, pos->prev, pos);
+				break;
+			}
+		}
+		if (!is_inqueue(obj)) {
+			list_add_tail(&data->list, &bvt_ctl->runqueue);
+		}
+	}
+}
+
+/*
+ * @pre obj != NULL
+ * @pre obj->data != NULL
+ */
+static void runqueue_remove(struct thread_object *obj)
+{
+	struct sched_bvt_data *data = (struct sched_bvt_data *)obj->data;
+
+	list_del_init(&data->list);
+}
+
+/*
+ * @brief Get the SVT (scheduler virtual time) which indicates the
+ * minimum AVT of any runnable threads.
+ * @pre obj != NULL
+ * @pre obj->data != NULL
+ * @pre obj->sched_ctl != NULL
+ * @pre obj->sched_ctl->priv != NULL
+ */
+
+static int64_t get_svt(struct thread_object *obj)
+{
+	struct sched_bvt_control *bvt_ctl = (struct sched_bvt_control *)obj->sched_ctl->priv;
+	struct sched_bvt_data *obj_data;
+	struct thread_object *tmp_obj;
+	int64_t svt = 0;
+
+	if (!list_empty(&bvt_ctl->runqueue)) {
+		tmp_obj = get_first_item(&bvt_ctl->runqueue, struct thread_object, data);
+		obj_data = (struct sched_bvt_data *)tmp_obj->data;
+		svt = obj_data->avt;
+	}
+	return svt;
+}
+
 static void sched_tick_handler(__unused void *param)
 {
 }
@@ -83,12 +165,26 @@ static struct thread_object *sched_bvt_pick_next(__unused struct sched_control *
 	return NULL;
 }
 
-static void sched_bvt_sleep(__unused struct thread_object *obj)
+static void sched_bvt_sleep(struct thread_object *obj)
 {
+	runqueue_remove(obj);
 }
 
-static void sched_bvt_wake(__unused struct thread_object *obj)
+static void sched_bvt_wake(struct thread_object *obj)
 {
+	struct sched_bvt_data *data;
+	int64_t svt, threshold;
+
+	data = (struct sched_bvt_data *)obj->data;
+	svt = get_svt(obj);
+	threshold = svt - BVT_CSA_MCU;
+	/* adjusting AVT for a thread after a long sleep */
+	data->avt = (data->avt > threshold) ? data->avt : svt;
+	/* TODO: evt = avt - (warp ? warpback : 0U) */
+	data->evt = data->avt;
+	/* add to runqueue in order */
+	runqueue_add(obj);
+
 }
 
 struct acrn_scheduler sched_bvt = {

--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -79,6 +79,9 @@ void init_sched(uint16_t pcpu_id)
 #ifdef CONFIG_SCHED_IORR
 	ctl->scheduler = &sched_iorr;
 #endif
+#ifdef CONFIG_SCHED_BVT
+	ctl->scheduler = &sched_bvt;
+#endif
 	if (ctl->scheduler->init != NULL) {
 		ctl->scheduler->init(ctl);
 	}

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -39,6 +39,7 @@ struct per_cpu_region {
 	struct sched_control sched_ctl;
 	struct sched_noop_control sched_noop_ctl;
 	struct sched_iorr_control sched_iorr_ctl;
+	struct sched_bvt_control sched_bvt_ctl;
 	struct thread_object idle;
 	struct host_gdt gdt;
 	struct tss_64 tss;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -90,6 +90,12 @@ struct sched_iorr_control {
 	struct hv_timer tick_timer;
 };
 
+extern struct acrn_scheduler sched_bvt;
+struct sched_bvt_control {
+	struct list_head runqueue;
+	struct hv_timer tick_timer;
+};
+
 bool is_idle_thread(const struct thread_object *obj);
 uint16_t sched_get_pcpuid(const struct thread_object *obj);
 struct thread_object *sched_get_current(uint16_t pcpu_id);


### PR DESCRIPTION
As the current IORR scheduler has below defects:
1) unfair
2) cannot prevent I/O attack: Use I/O to maliciously preempt pCPU resources
BVT is introduced. It can provide fair share of pCPU resource to vCPU,
and prevent I/O attack. BVT also has competitive I/O performance as IORR.