### PR TITLE
hv: use BOOT_CPU_ID instead of hardcoded value

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -104,7 +104,7 @@ void init_pcpu_pre(bool is_bsp)
 	int32_t ret;
 
 	if (is_bsp) {
-		pcpu_id = BOOT_CPU_ID;
+		pcpu_id = BSP_CPU_ID;
 		start_tsc = rdtsc();
 
 		/* Get CPU capabilities thru CPUID, including the physical address bit
@@ -187,7 +187,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 
 	init_pcpu_xsave();
 
-	if (pcpu_id == BOOT_CPU_ID) {
+	if (pcpu_id == BSP_CPU_ID) {
 		/* Print Hypervisor Banner */
 		print_hv_banner();
 
@@ -205,7 +205,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 
 		pr_acrnlog("Detect processor: %s", (get_pcpu_info())->model_name);
 
-		pr_dbg("Core %hu is up", BOOT_CPU_ID);
+		pr_dbg("Core %hu is up", BSP_CPU_ID);
 
 		if (!sanitize_vm_config()) {
 			panic("VM Configuration Error!");
@@ -218,7 +218,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 		}
 
 		/* Initialize interrupts */
-		init_interrupt(BOOT_CPU_ID);
+		init_interrupt(BSP_CPU_ID);
 
 		timer_init();
 		setup_notification();
@@ -242,7 +242,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 			panic("Failed to start all secondary cores!");
 		}
 
-		ASSERT(get_pcpu_id() == BOOT_CPU_ID, "");
+		ASSERT(get_pcpu_id() == BSP_CPU_ID, "");
 	} else {
 		pr_dbg("Core %hu is up", pcpu_id);
 
@@ -483,7 +483,7 @@ static void init_pcpu_xsave(void)
 	val64 |= CR4_OSXSAVE;
 	CPU_CR_WRITE(cr4, val64);
 
-	if (get_pcpu_id() == BOOT_CPU_ID) {
+	if (get_pcpu_id() == BSP_CPU_ID) {
 		cpuid(CPUID_FEATURES, &unused, &unused, &ecx, &unused);
 
 		/* if set, update it */

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -126,7 +126,7 @@ static bool vcpu_do_pending_extint(const struct acrn_vcpu *vcpu)
 
 	/* check if there is valid interrupt from vPIC, if yes just inject it */
 	/* PIC only connect with primary CPU */
-	primary = vcpu_from_vid(vm, BOOT_CPU_ID);
+	primary = vcpu_from_vid(vm, BSP_CPU_ID);
 	if (vcpu == primary) {
 
 		vpic_pending_intr(vm_pic(vcpu->vm), &vector);

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1652,7 +1652,7 @@ vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops, enum 
 
 	vlapic->msr_apicbase = DEFAULT_APIC_BASE;
 
-	if (vlapic->vcpu->vcpu_id == BOOT_CPU_ID) {
+	if (vlapic->vcpu->vcpu_id == BSP_CPU_ID) {
 		vlapic->msr_apicbase |= APICBASE_BSP;
 	}
 	if (mode == INIT_RESET) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -199,7 +199,7 @@ static inline uint16_t get_vm_bsp_pcpu_id(const struct acrn_vm_config *vm_config
 {
 	uint16_t cpu_id = INVALID_CPU_ID;
 
-	cpu_id = ffs64(vm_config->vcpu_affinity[0]);
+	cpu_id = ffs64(vm_config->vcpu_affinity[BSP_CPU_ID]);
 
 	return (cpu_id < get_pcpu_nums()) ? cpu_id : INVALID_CPU_ID;
 }
@@ -730,7 +730,7 @@ void start_vm(struct acrn_vm *vm)
 	vm->state = VM_STARTED;
 
 	/* Only start BSP (vid = 0) and let BSP start other APs */
-	bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
+	bsp = vcpu_from_vid(vm, BSP_CPU_ID);
 	vcpu_make_request(bsp, ACRN_REQUEST_INIT_VMCS);
 	launch_vcpu(bsp);
 }
@@ -824,7 +824,7 @@ void pause_vm(struct acrn_vm *vm)
  */
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec)
 {
-	struct acrn_vcpu *bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
+	struct acrn_vcpu *bsp = vcpu_from_vid(vm, BSP_CPU_ID);
 
 	vm->state = VM_STARTED;
 

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -98,7 +98,7 @@ static bool handle_common_reset_reg_write(struct acrn_vm *vm, bool reset)
 			 *    or pre-launched VM reset,
 			 * ACRN doesn't support re-launch, just shutdown the guest.
 			 */
-			const struct acrn_vcpu *bsp = vcpu_from_vid(vm, BOOT_CPU_ID);
+			const struct acrn_vcpu *bsp = vcpu_from_vid(vm, BSP_CPU_ID);
 
 			pause_vm(vm);
 			per_cpu(shutdown_vm_id, pcpuid_from_vcpu(bsp)) = vm->vm_id;

--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -22,13 +22,13 @@ void arch_fire_vhm_interrupt(void)
 {
 	/*
 	 * use vLAPIC to inject vector to SOS vcpu 0 if vlapic is enabled
-	 * otherwise, send IPI hardcoded to BOOT_CPU_ID
+	 * otherwise, send IPI hardcoded to BSP_CPU_ID
 	 */
 	struct acrn_vm *sos_vm;
 	struct acrn_vcpu *vcpu;
 
 	sos_vm = get_sos_vm();
-	vcpu = vcpu_from_vid(sos_vm, BOOT_CPU_ID);
+	vcpu = vcpu_from_vid(sos_vm, BSP_CPU_ID);
 
 	vlapic_set_intr(vcpu, get_vhm_notification_vector(), LAPIC_TRIG_EDGE);
 }

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -48,7 +48,7 @@ static void init_debug_pre(void)
 /*TODO: move into debug module */
 static void init_debug_post(uint16_t pcpu_id)
 {
-	if (pcpu_id == BOOT_CPU_ID) {
+	if (pcpu_id == BSP_CPU_ID) {
 		/* Initialize the shell */
 		shell_init();
 		console_setup_timer();
@@ -69,11 +69,11 @@ static void init_primary_pcpu_post(void)
 {
 	init_seed();
 
-	init_pcpu_post(BOOT_CPU_ID);
+	init_pcpu_post(BSP_CPU_ID);
 
-	init_debug_post(BOOT_CPU_ID);
+	init_debug_post(BSP_CPU_ID);
 
-	init_guest_mode(BOOT_CPU_ID);
+	init_guest_mode(BSP_CPU_ID);
 
 	run_idle_thread();
 }

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -451,7 +451,7 @@ static void disable_pic_irqs(void)
 
 void init_default_irqs(uint16_t cpu_id)
 {
-	if (cpu_id == BOOT_CPU_ID) {
+	if (cpu_id == BSP_CPU_ID) {
 		init_irq_descs();
 
 		/* we use ioapic only, disable legacy PIC */
@@ -488,7 +488,7 @@ void init_interrupt(uint16_t pcpu_id)
 {
 	struct host_idt_descriptor *idtd = &HOST_IDTR;
 
-	if (pcpu_id == BOOT_CPU_ID) {
+	if (pcpu_id == BSP_CPU_ID) {
 		fixup_idt(idtd);
 	}
 	set_idt(idtd);

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -197,7 +197,7 @@ void timer_init(void)
 
 	init_percpu_timer(pcpu_id);
 
-	if (pcpu_id == BOOT_CPU_ID) {
+	if (pcpu_id == BSP_CPU_ID) {
 		register_softirq(SOFTIRQ_TIMER, timer_softirq);
 
 		retval = request_irq(TIMER_IRQ, (irq_action_t)tsc_deadline_handler, NULL, IRQF_NONE);

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -269,8 +269,8 @@ static int32_t init_general_vm_boot_info(struct acrn_vm *vm)
 
 static void depri_boot_spurious_handler(uint32_t vector)
 {
-	if (get_pcpu_id() == BOOT_CPU_ID) {
-		struct acrn_vcpu *vcpu = vcpu_from_vid(get_sos_vm(), BOOT_CPU_ID);
+	if (get_pcpu_id() == BSP_CPU_ID) {
+		struct acrn_vcpu *vcpu = vcpu_from_vid(get_sos_vm(), BSP_CPU_ID);
 
 		if (vcpu != NULL) {
 			vlapic_set_intr(vcpu, vector, LAPIC_TRIG_EDGE);
@@ -284,7 +284,7 @@ static int32_t depri_boot_sw_loader(struct acrn_vm *vm)
 {
 	int32_t ret = 0;
 	/* get primary vcpu */
-	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
+	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BSP_CPU_ID);
 	struct acrn_vcpu_regs *vcpu_regs = &boot_context;
 	const struct depri_boot_context *depri_boot_ctx = get_depri_boot_ctx();
 	const struct lapic_regs *depri_boot_lapic_regs = get_depri_boot_lapic_regs();

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -59,7 +59,7 @@ int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid)
 	foreach_vcpu(i, vm, vcpu) {
 		if (vlapic_get_apicid(vcpu_vlapic(vcpu)) == lapicid) {
 			/* should not offline BSP */
-			if (vcpu->vcpu_id == BOOT_CPU_ID) {
+			if (vcpu->vcpu_id == BSP_CPU_ID) {
 				ret = -1;
 				break;
 			}

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -176,7 +176,7 @@ void ptirq_deactivate_entry(struct ptirq_remapping_info *entry)
 
 void ptdev_init(void)
 {
-	if (get_pcpu_id() == BOOT_CPU_ID) {
+	if (get_pcpu_id() == BSP_CPU_ID) {
 		spinlock_init(&ptdev_lock);
 		register_softirq(SOFTIRQ_PTDEV, ptirq_softirq);
 	}

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -180,7 +180,7 @@ int32_t direct_boot_sw_loader(struct acrn_vm *vm)
 	struct sw_module_info *bootargs_info = &(vm->sw.bootargs_info);
 	struct sw_module_info *ramdisk_info = &(vm->sw.ramdisk_info);
 	/* get primary vcpu */
-	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
+	struct acrn_vcpu *vcpu = vcpu_from_vid(vm, BSP_CPU_ID);
 
 	pr_dbg("Loading guest to run-time location");
 

--- a/hypervisor/debug/profiling.c
+++ b/hypervisor/debug/profiling.c
@@ -1412,7 +1412,7 @@ void profiling_setup(void)
 	dev_dbg(DBG_LEVEL_PROFILING, "%s: entering", __func__);
 	cpu = get_pcpu_id();
 	/* support PMI notification, SOS_VM will register all CPU */
-	if ((cpu == BOOT_CPU_ID) && (profiling_pmi_irq == IRQ_INVALID)) {
+	if ((cpu == BSP_CPU_ID) && (profiling_pmi_irq == IRQ_INVALID)) {
 		pr_info("%s: calling request_irq", __func__);
 		retval = request_irq(PMI_IRQ,
 			profiling_pmi_handler, NULL, IRQF_NONE);

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -937,7 +937,7 @@ static int32_t shell_dump_guest_mem(int32_t argc, char **argv)
 		length = (uint64_t)strtol_deci(argv[3]);
 
 		vm = get_vm_from_vmid(vm_id);
-		vcpu = vcpu_from_vid(vm, BOOT_CPU_ID);
+		vcpu = vcpu_from_vid(vm, BSP_CPU_ID);
 
 		dump.vcpu = vcpu;
 		dump.gva = gva;

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -202,7 +202,7 @@ static void vpic_notify_intr(struct acrn_vpic *vpic)
 		 */
 		i8259->intr_raised = true;
 		if (vpic->vm->wire_mode == VPIC_WIRE_INTR) {
-			struct acrn_vcpu *bsp = vcpu_from_vid(vpic->vm, BOOT_CPU_ID);
+			struct acrn_vcpu *bsp = vcpu_from_vid(vpic->vm, BSP_CPU_ID);
 			vcpu_inject_extint(bsp);
 		} else {
 			/*

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -145,8 +145,6 @@
 #define CPU_MHZ_TO_HZ           1000000
 #define CPU_MHZ_TO_KHZ          1000
 
-/* Boot CPU ID */
-#define BOOT_CPU_ID             0U
 
 /* Number of GPRs saved / restored for guest in VCPU structure */
 #define NUM_GPRS                            16U
@@ -275,6 +273,9 @@ extern uint64_t               secondary_cpu_stack[1];
  *   + offset_of_member_per_cpu_region
  * to locate the per cpu data.
  */
+
+/* Boot CPU ID */
+#define BSP_CPU_ID             0U
 
 /**
  *The invalid cpu_id (INVALID_CPU_ID) is error

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -283,7 +283,7 @@ struct guest_mem_dump {
 
 static inline bool is_vcpu_bsp(const struct acrn_vcpu *vcpu)
 {
-	return (vcpu->vcpu_id == BOOT_CPU_ID);
+	return (vcpu->vcpu_id == BSP_CPU_ID);
 }
 
 static inline enum vm_cpu_mode get_vcpu_mode(const struct acrn_vcpu *vcpu)


### PR DESCRIPTION
  Repace hardcoded value with BOOT_CPU_ID when
  ID of BSP is referenced.

Tracked-On: #851
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>