### PR TITLE
acrn-config: avoid conflict slot for launch config

### DIFF
--- a/misc/acrn-config/board_config/new_board_kconfig.py
+++ b/misc/acrn-config/board_config/new_board_kconfig.py
@@ -145,4 +145,9 @@ def generate_file(config):
     print("CONFIG_HV_RAM_START={}".format(hex(hv_start_addr)), file=config)
     print("CONFIG_HV_RAM_SIZE={}".format(hex(hv_ram_size)), file=config)
 
+    cpu_core_num = len(board_cfg_lib.get_processor_info())
+    if cpu_core_num == 2:
+        print("# KATA VM is not supported on dual-core systems", file=config)
+        print("CONFIG_MAX_KATA_VM_NUM=0", file=config)
+
     return err_dic

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -145,6 +145,7 @@ class PthruSelected():
 
         # check connections between several pass-through devices
         launch_cfg_lib.pt_devs_check_audio(self.bdf['audio'], self.bdf['audio_codec'])
+        launch_cfg_lib.bdf_duplicate_check(self.bdf)
 
 
 class VirtioDeviceSelect():


### PR DESCRIPTION

- avoid conflict slot for launch config
- Kata VM is not supported on dual-core systems

    Tracked-On: #4312
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
