### PR TITLE
disable iommu snoop control and add dummy lpc when enable gvt-d

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -808,7 +808,11 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			keep_gsi = true;
 		else if (!strncmp(opt, "no_reset", 8))
 			need_reset = false;
-		else
+		else if (!strncmp(opt, "gpu", 3)) {
+			/* Create the dedicated "igd-lpc" on 00:1f.0 for IGD passthrough */
+			if (pci_parse_slot("31,igd-lpc") != 0)
+				warnx("faild to create igd-lpc");
+		} else
 			warnx("Invalid passthru options:%s", opt);
 	}
 

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -332,3 +332,10 @@ config MCE_ON_PSC_WORKAROUND_DISABLED
 	  conditionally applied to the models that may be affected by the issue. However,
 	  the software workaround has negative impact on performance. If all the guest OS
 	  kernels are trusted, this option may be set for performance.
+
+config IOMMU_ENFORCE_SNP
+	bool "IOMMU enforce snoop behavior of DMA operation"
+	default n
+	help
+	  GPU IOMMU doesn't support snoop control capability,
+	  To enable gvt-d,disable IOMMU snoop control by default.

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -113,6 +113,17 @@ static bool is_ctrl_setting_allowed(uint64_t msr_val, uint32_t ctrl)
 	return ((((uint32_t)(msr_val >> 32UL)) & ctrl) == ctrl);
 }
 
+bool is_apl_platform(void)
+{
+	bool ret = false;
+
+	if ((boot_cpu_data.family == 0x6U) && (boot_cpu_data.model == 0x92U)) {
+		ret = true;
+	}
+
+	return ret;
+}
+
 static void detect_ept_cap(void)
 {
 	uint64_t msr_val;

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1263,7 +1263,17 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 		domain->trans_table_ptr = translation_table;
 		domain->addr_width = addr_width;
 		domain->is_tt_ept = true;
+
+#ifdef CONFIG_IOMMU_ENFORCE_SNP
 		domain->iommu_snoop = true;
+#else
+		/* TODO: GPU IOMMU doesn't have snoop control capbility,
+		 * so set domain->iommu_snoop false to enable gvt-d by default.
+		 * If want to refine iommu snoop control policy,
+		 * need to change domain->iommu_snoop dynamically.
+		 */
+		domain->iommu_snoop = false;
+#endif
 
 		dev_dbg(DBG_LEVEL_IOMMU, "create domain [%d]: vm_id = %hu, ept@0x%x",
 			vmid_to_domainid(domain->vm_id), domain->vm_id, domain->trans_table_ptr);

--- a/hypervisor/include/arch/x86/cpu_caps.h
+++ b/hypervisor/include/arch/x86/cpu_caps.h
@@ -48,6 +48,7 @@ bool is_apicv_advanced_feature_supported(void);
 bool pcpu_has_cap(uint32_t bit);
 bool pcpu_has_vmx_ept_cap(uint32_t bit_mask);
 bool pcpu_has_vmx_vpid_cap(uint32_t bit_mask);
+bool is_apl_platform(void);
 void init_pcpu_capabilities(void);
 void init_pcpu_model_name(void);
 int32_t detect_hardware_support(void);


### PR DESCRIPTION
GPU IOMMU doesn’t support snoop control, to enable gvt-d, 
need to disable iommu snoop control for all VMs.

When enabling gvt-d, there is a restriction that 
Windows guest needs a lpc bridge device
located in 00:1f.0 PCI slot.
So add an extra lpc bridge.