### PR TITLE
Makefile: Fix build issue if the ld is updated to 2.34

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -108,6 +108,7 @@ ASFLAGS += -m64 -nostdinc -nostdlib
 
 LDFLAGS += -Wl,--gc-sections -nostartfiles -nostdlib
 LDFLAGS += -Wl,-n,-z,max-page-size=0x1000
+LDFLAGS += -Wl,--no-dynamic-linker
 
 ifeq (y, $(CONFIG_RELOC))
 # on X86_64, when build with "-pie", GCC fails on linking R_X86_64_32


### PR DESCRIPTION
We hit build issue if the ld version is 2.34:
 error: PHDR segment not covered by LOAD segment

One issue was created to binutils bugzilla system:
 https://sourceware.org/bugzilla/show_bug.cgi?id=25585
From the ld guys comment, this is not an issue of 2.34. It's an
issue fixing of the old ld. He suggested to add option
   --no-dynamic-linker
to ld if we don't depend on dynamically linker to loader our binary.

Tracked-On: #4415
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>