### PR TITLE
HV: patch set to enable multiboot2

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -107,6 +107,9 @@ CFLAGS += -fcf-protection=none
 endif
 
 ASFLAGS += -m64 -nostdinc -nostdlib
+ifeq (y, $(CONFIG_MULTIBOOT2))
+ASFLAGS += -DCONFIG_MULTIBOOT2
+endif
 
 LDFLAGS += -Wl,--gc-sections -nostartfiles -nostdlib
 LDFLAGS += -Wl,-n,-z,max-page-size=0x1000

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -193,6 +193,7 @@ endif
 BOOT_S_SRCS += arch/x86/boot/cpu_primary.S
 BOOT_S_SRCS += arch/x86/boot/cpu_save_boot_ctx.S
 BOOT_S_SRCS += arch/x86/boot/trampoline.S
+BOOT_C_SRCS += boot/multiboot.c
 BOOT_C_SRCS += boot/reloc.c
 
 # hardware management component

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -197,6 +197,9 @@ BOOT_S_SRCS += arch/x86/boot/cpu_primary.S
 BOOT_S_SRCS += arch/x86/boot/cpu_save_boot_ctx.S
 BOOT_S_SRCS += arch/x86/boot/trampoline.S
 BOOT_C_SRCS += boot/multiboot.c
+ifeq ($(CONFIG_MULTIBOOT2),y)
+BOOT_C_SRCS += boot/multiboot2.c
+endif
 BOOT_C_SRCS += boot/reloc.c
 
 # hardware management component

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -37,6 +37,14 @@ config HYBRID
 
 endchoice
 
+config MULTIBOOT2
+	bool "Multiboot2 support"
+	default n
+	help
+	  Support boot ACRN from multiboot2 protocol. Multiboot2 support is needed for
+	  some EFI platforms to get correct ACPI RSDP, it also could provide host efi
+	  information for hypervisor.
+
 choice
 	prompt "ACRN Scheduler"
 	default SCHED_NOOP

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -63,6 +63,8 @@ info_req_tag_start:
     .long   MULTIBOOT2_TAG_TYPE_MMAP
     .long   MULTIBOOT2_TAG_TYPE_MODULE
     .long   MULTIBOOT2_TAG_TYPE_ACPI_NEW
+    .long   MULTIBOOT2_TAG_TYPE_EFI64
+    .long   MULTIBOOT2_TAG_TYPE_EFI_MMAP
 info_req_tag_end:
 
     .align     MULTIBOOT2_TAG_ALIGN
@@ -246,3 +248,9 @@ cpu_primary32_pdt_addr:
     .quad  address + 0x83
     address = address + 0x200000
     .endr
+
+#ifdef CONFIG_MULTIBOOT2
+    .global efiloader_sig
+efiloader_sig:
+    .asciz    "EL64"
+#endif

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -22,6 +22,10 @@
  */
 
 #include <multiboot.h>
+#ifdef CONFIG_MULTIBOOT2
+#include <multiboot2.h>
+#endif
+
 /* MULTIBOOT HEADER */
 #define MULTIBOOT_HEADER_FLAGS	MULTIBOOT_HEADER_NEED_MEMINFO
 
@@ -38,6 +42,33 @@
     /* header checksum = -(magic + flags) */
     .long   -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS)
 
+#ifdef CONFIG_MULTIBOOT2
+    .align     MULTIBOOT2_HEADER_ALIGN
+mb2_header_start:
+    /* Magic number indicating a Multiboot2 header. */
+    .long   MULTIBOOT2_HEADER_MAGIC
+    /* Architecture: i386. */
+    .long   MULTIBOOT2_ARCHITECTURE_I386
+    /* Multiboot2 header length. */
+    .long   mb2_header_end - mb2_header_start
+    /* Multiboot2 header checksum. */
+    .long   -(MULTIBOOT2_HEADER_MAGIC + MULTIBOOT2_ARCHITECTURE_I386 + (mb2_header_end - mb2_header_start))
+
+    /* please be aware that each tag should be 8 bytes aligned */
+    .align     MULTIBOOT2_TAG_ALIGN
+info_req_tag_start:
+    .short  MULTIBOOT2_HEADER_TAG_INFORMATION_REQUEST
+    .short  0
+    .long   info_req_tag_end - info_req_tag_start
+    .long   MULTIBOOT2_TAG_TYPE_MMAP
+info_req_tag_end:
+
+    .align     MULTIBOOT2_TAG_ALIGN
+    .short  MULTIBOOT2_HEADER_TAG_END
+    .short  0
+    .long   8
+mb2_header_end:
+#endif
     .section    entry, "ax"
 
     .align      8

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -21,9 +21,9 @@
  * the macros involved are changed.
  */
 
+#include <multiboot.h>
 /* MULTIBOOT HEADER */
-#define MULTIBOOT_HEADER_MAGIC 0x1badb002
-#define MULTIBOOT_HEADER_FLAGS 0x00000002 /*flags bit 1 : enable mem_*, mmap_**/
+#define MULTIBOOT_HEADER_FLAGS	MULTIBOOT_HEADER_NEED_MEMINFO
 
     .extern cpu_primary_save32
     .extern cpu_primary_save64

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -61,6 +61,8 @@ info_req_tag_start:
     .short  0
     .long   info_req_tag_end - info_req_tag_start
     .long   MULTIBOOT2_TAG_TYPE_MMAP
+    .long   MULTIBOOT2_TAG_TYPE_MODULE
+    .long   MULTIBOOT2_TAG_TYPE_ACPI_NEW
 info_req_tag_end:
 
     .align     MULTIBOOT2_TAG_ALIGN

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -116,6 +116,10 @@ void init_pcpu_pre(bool is_bsp)
 			panic("hardware not support!");
 		}
 
+		if (sanitize_multiboot_info() != 0) {
+			panic("Multiboot info error!");
+		}
+
 		init_pcpu_model_name();
 
 		load_pcpu_state_data();

--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -9,7 +9,7 @@
 #include <page.h>
 #include <e820.h>
 #include <mmu.h>
-#include <multiboot.h>
+#include <boot.h>
 #include <logmsg.h>
 
 /*

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -14,7 +14,7 @@
 #include <logmsg.h>
 #include <seed.h>
 #include <ld_sym.h>
-#include <vboot.h>
+#include <boot.h>
 
 /* Push sp magic to top of stack for call trace */
 #define SWITCH_TO(rsp, to)                                              \

--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -8,14 +8,11 @@
 #include <init.h>
 #include <console.h>
 #include <per_cpu.h>
-#include <profiling.h>
-#include <vtd.h>
 #include <shell.h>
 #include <vmx.h>
 #include <vm.h>
 #include <logmsg.h>
 #include <seed.h>
-#include <uart16550.h>
 #include <ld_sym.h>
 #include <vboot.h>
 
@@ -32,12 +29,6 @@
 /*TODO: move into debug module */
 static void init_debug_pre(void)
 {
-	/*
-	 * Enable UART as early as possible.
-	 * Then we could use printf for debugging on early boot stage.
-	 */
-	uart16550_init(true);
-
 	/* Initialize console */
 	console_init();
 
@@ -88,7 +79,7 @@ void init_primary_pcpu(void)
 	/* Clear BSS */
 	(void)memset(&ld_bss_start, 0U, (size_t)(&ld_bss_end - &ld_bss_start));
 
-	(void)parse_hv_cmdline();
+	parse_hv_cmdline();
 
 	init_debug_pre();
 

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -11,7 +11,7 @@
 #include <sprintf.h>
 #include <ept.h>
 #include <logmsg.h>
-#include <multiboot.h>
+#include <boot.h>
 #include <crypto_api.h>
 #include <seed.h>
 #include "seed_abl.h"

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -41,17 +41,12 @@ static uint32_t parse_seed_arg(void)
 {
 	char *cmd_src = NULL;
 	char *arg, *arg_end;
-	struct multiboot_info *mbi = NULL;
+	struct acrn_multiboot_info *mbi = get_multiboot_info();
 	uint32_t i = SEED_ARG_NUM - 1U;
 	uint32_t len;
 
-	if (boot_regs[0U] == MULTIBOOT_INFO_MAGIC) {
-		mbi = (struct multiboot_info *)hpa2hva((uint64_t)boot_regs[1U]);
-		if (mbi != NULL) {
-			if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) {
-				cmd_src = (char *)hpa2hva((uint64_t)mbi->mi_cmdline);
-			}
-		}
+	if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) {
+		cmd_src = mbi->mi_cmdline;
 	}
 
 	if (cmd_src != NULL) {

--- a/hypervisor/boot/cmdline.c
+++ b/hypervisor/boot/cmdline.c
@@ -16,7 +16,7 @@ void parse_hv_cmdline(void)
 	const char *start = NULL;
 	const char *end = NULL;
 
-	if ((boot_regs[0] == MULTIBOOT_INFO_MAGIC) && (boot_regs[1] != 0U)) {
+	if (boot_from_multiboot1()) {
 		struct multiboot_info *mbi = (struct multiboot_info *)(hpa2hva_early((uint64_t)boot_regs[1]));
 
 		if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) {

--- a/hypervisor/boot/cmdline.c
+++ b/hypervisor/boot/cmdline.c
@@ -6,11 +6,10 @@
 
 #include <types.h>
 #include <errno.h>
-#include <multiboot.h>
+#include <boot.h>
 #include <pgtable.h>
 #include <dbg_cmd.h>
 #include <logmsg.h>
-#include <vboot.h>
 
 void parse_hv_cmdline(void)
 {

--- a/hypervisor/boot/guest/deprivilege_boot.c
+++ b/hypervisor/boot/guest/deprivilege_boot.c
@@ -24,11 +24,10 @@ static struct lapic_regs depri_boot_lapic_regs;
 static void init_depri_boot(void)
 {
 	static bool depri_initialized = false;
-	struct multiboot_info *mbi = NULL;
+	struct acrn_multiboot_info *mbi = get_multiboot_info();
 
 	if (!depri_initialized) {
-		mbi = (struct multiboot_info *) hpa2hva(((uint64_t)(uint32_t)boot_regs[1]));
-		if ((mbi == NULL) || ((mbi->mi_flags & MULTIBOOT_INFO_HAS_DRIVES) == 0U)) {
+		if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_DRIVES) == 0U) {
 			pr_err("no multiboot drivers for depri_boot found");
 		} else {
 			(void)memcpy_s(&depri_boot_ctx, sizeof(struct depri_boot_context),

--- a/hypervisor/boot/guest/deprivilege_boot.c
+++ b/hypervisor/boot/guest/deprivilege_boot.c
@@ -15,7 +15,7 @@
 #include <lapic.h>
 #include <per_cpu.h>
 #include <guest/vm.h>
-#include <multiboot.h>
+#include <boot.h>
 #include <deprivilege_boot.h>
 
 static struct depri_boot_context depri_boot_ctx;

--- a/hypervisor/boot/guest/direct_boot.c
+++ b/hypervisor/boot/guest/direct_boot.c
@@ -9,6 +9,7 @@
 #include <types.h>
 #include <e820.h>
 #include <cpu.h>
+#include <boot.h>
 #include <direct_boot.h>
 
 /* AP trampoline code buffer base address. */
@@ -27,7 +28,13 @@ static uint64_t get_direct_boot_ap_trampoline(void)
 
 static void* get_direct_boot_rsdp(void)
 {
+#ifdef CONFIG_MULTIBOOT2
+	struct acrn_multiboot_info *mbi = get_multiboot_info();
+
+	return mbi->mi_acpi_rsdp;
+#else
 	return NULL;
+#endif
 }
 
 static void init_direct_boot_irq(void)

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -10,7 +10,7 @@
 #include <per_cpu.h>
 #include <irq.h>
 #include <boot_context.h>
-#include <multiboot.h>
+#include <boot.h>
 #include <pgtable.h>
 #include <zeropage.h>
 #include <seed.h>

--- a/hypervisor/boot/guest/vboot_wrapper.c
+++ b/hypervisor/boot/guest/vboot_wrapper.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <multiboot.h>
 #include <vm.h>
 #include <types.h>
 #include <pgtable.h>
 #include <acpi.h>
+#include <boot.h>
 #include <vboot.h>
 #include <direct_boot.h>
 #include <deprivilege_boot.h>

--- a/hypervisor/boot/guest/vboot_wrapper.c
+++ b/hypervisor/boot/guest/vboot_wrapper.c
@@ -31,8 +31,7 @@ static enum vboot_mode sos_boot_mode;
  */
 void init_vboot(void)
 {
-
-	struct multiboot_info *mbi;
+	struct acrn_multiboot_info *mbi = get_multiboot_info();
 	uint32_t i;
 
 	const struct vboot_bootloader_map vboot_bootloader_maps[BOOTLOADER_NUM] = {
@@ -43,23 +42,18 @@ void init_vboot(void)
 		{"PXELINUX", DIRECT_BOOT_MODE},
 	};
 
-	mbi = (struct multiboot_info *)hpa2hva((uint64_t)boot_regs[1]);
-	if (mbi == NULL) {
-		panic("No multiboot info");
-	} else {
-		for (i = 0U; i < BOOTLOADER_NUM; i++) {
-			if (strncmp(hpa2hva(mbi->mi_loader_name), vboot_bootloader_maps[i].bootloader_name,
-				strnlen_s(vboot_bootloader_maps[i].bootloader_name, BOOTLOADER_NAME_SIZE)) == 0) {
-				/* Only support two vboot mode */
-				if (vboot_bootloader_maps[i].mode == DEPRI_BOOT_MODE) {
-					vboot_ops = get_deprivilege_boot_ops();
-					sos_boot_mode = DEPRI_BOOT_MODE;
-				} else {
-					vboot_ops = get_direct_boot_ops();
-					sos_boot_mode = DIRECT_BOOT_MODE;
-				}
-				break;
+	for (i = 0U; i < BOOTLOADER_NUM; i++) {
+		if (strncmp(mbi->mi_loader_name, vboot_bootloader_maps[i].bootloader_name,
+			strnlen_s(vboot_bootloader_maps[i].bootloader_name, BOOTLOADER_NAME_SIZE)) == 0) {
+			/* Only support two vboot mode */
+			if (vboot_bootloader_maps[i].mode == DEPRI_BOOT_MODE) {
+				vboot_ops = get_deprivilege_boot_ops();
+				sos_boot_mode = DEPRI_BOOT_MODE;
+			} else {
+				vboot_ops = get_direct_boot_ops();
+				sos_boot_mode = DIRECT_BOOT_MODE;
 			}
+			break;
 		}
 	}
 

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -8,6 +8,9 @@
 #define BOOT_H_
 
 #include <multiboot.h>
+#ifdef CONFIG_MULTIBOOT2
+#include <multiboot2.h>
+#endif
 #include <e820.h>
 
 #define MAX_BOOTARGS_SIZE		2048U
@@ -36,6 +39,15 @@ static inline bool boot_from_multiboot1(void)
 {
 	return ((boot_regs[0] == MULTIBOOT_INFO_MAGIC) && (boot_regs[1] != 0U));
 }
+
+#ifdef CONFIG_MULTIBOOT2
+static inline bool boot_from_multiboot2(void)
+{
+	return ((boot_regs[0] == MULTIBOOT2_INFO_MAGIC) && (boot_regs[1] != 0U));
+}
+
+int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info);
+#endif
 
 struct acrn_multiboot_info *get_multiboot_info(void);
 int32_t sanitize_multiboot_info(void);

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef BOOT_H_
+#define BOOT_H_
+
+#include <multiboot.h>
+
+#define MAX_BOOTARGS_SIZE		2048U
+
+/* boot_regs store the multiboot info magic and address */
+extern uint32_t boot_regs[2];
+
+#endif /* BOOT_H_ */

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -12,9 +12,14 @@
 #include <multiboot2.h>
 #endif
 #include <e820.h>
+#include <zeropage.h>
 
 #define MAX_BOOTARGS_SIZE		2048U
 #define MAX_MODULE_COUNT		4U
+
+/* extended flags for acrn multiboot info from multiboot2  */
+#define	MULTIBOOT_INFO_HAS_EFI_MMAP	0x00010000U
+#define	MULTIBOOT_INFO_HAS_EFI64	0x00020000U
 
 struct acrn_multiboot_info {
 	uint32_t		mi_flags;	/* the flags is back-compatible with multiboot1 */
@@ -32,10 +37,13 @@ struct acrn_multiboot_info {
 	struct multiboot_mmap	mi_mmap_entry[E820_MAX_ENTRIES];
 
 	void			*mi_acpi_rsdp;
+	struct efi_info		mi_efi_info;
 };
 
 /* boot_regs store the multiboot info magic and address */
 extern uint32_t boot_regs[2];
+
+extern char *efiloader_sig;
 
 static inline bool boot_from_multiboot1(void)
 {

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -30,6 +30,8 @@ struct acrn_multiboot_info {
 
 	uint32_t		mi_mmap_entries;
 	struct multiboot_mmap	mi_mmap_entry[E820_MAX_ENTRIES];
+
+	void			*mi_acpi_rsdp;
 };
 
 /* boot_regs store the multiboot info magic and address */

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -8,10 +8,37 @@
 #define BOOT_H_
 
 #include <multiboot.h>
+#include <e820.h>
 
 #define MAX_BOOTARGS_SIZE		2048U
+#define MAX_MODULE_COUNT		4U
+
+struct acrn_multiboot_info {
+	uint32_t		mi_flags;	/* the flags is back-compatible with multiboot1 */
+
+	char			*mi_cmdline;
+	char			*mi_loader_name;
+
+	uint32_t		mi_mods_count;
+	struct multiboot_module	mi_mods[MAX_MODULE_COUNT];
+
+	uint32_t 		mi_drives_length;
+	uint32_t		mi_drives_addr;
+
+	uint32_t		mi_mmap_entries;
+	struct multiboot_mmap	mi_mmap_entry[E820_MAX_ENTRIES];
+};
 
 /* boot_regs store the multiboot info magic and address */
 extern uint32_t boot_regs[2];
+
+static inline bool boot_from_multiboot1(void)
+{
+	return ((boot_regs[0] == MULTIBOOT_INFO_MAGIC) && (boot_regs[1] != 0U));
+}
+
+struct acrn_multiboot_info *get_multiboot_info(void);
+int32_t sanitize_multiboot_info(void);
+void parse_hv_cmdline(void);
 
 #endif /* BOOT_H_ */

--- a/hypervisor/boot/include/guest/vboot.h
+++ b/hypervisor/boot/include/guest/vboot.h
@@ -26,6 +26,5 @@ uint64_t get_ap_trampoline_buf(void);
 void *get_rsdp_ptr(void);
 
 enum vboot_mode get_sos_boot_mode(void);
-void parse_hv_cmdline(void);
 
 #endif /* end of include guard: VBOOT_H */

--- a/hypervisor/boot/include/guest/vboot.h
+++ b/hypervisor/boot/include/guest/vboot.h
@@ -26,6 +26,6 @@ uint64_t get_ap_trampoline_buf(void);
 void *get_rsdp_ptr(void);
 
 enum vboot_mode get_sos_boot_mode(void);
-int32_t parse_hv_cmdline(void);
+void parse_hv_cmdline(void);
 
 #endif /* end of include guard: VBOOT_H */

--- a/hypervisor/boot/include/multiboot.h
+++ b/hypervisor/boot/include/multiboot.h
@@ -7,16 +7,20 @@
 #ifndef MULTIBOOT_H
 #define MULTIBOOT_H
 
-#include <types.h>
+#define	MULTIBOOT_HEADER_MAGIC		0x1BADB002
 #define	MULTIBOOT_INFO_MAGIC		0x2BADB002U
+
+/* MULTIBOOT HEADER FLAGS */
+#define	MULTIBOOT_HEADER_NEED_MEMINFO	0x00000002
+
+/* MULTIBOOT INFO FLAGS */
 #define	MULTIBOOT_INFO_HAS_CMDLINE	0x00000004U
 #define	MULTIBOOT_INFO_HAS_MODS		0x00000008U
 #define	MULTIBOOT_INFO_HAS_MMAP		0x00000040U
 #define	MULTIBOOT_INFO_HAS_DRIVES	0x00000080U
 #define	MULTIBOOT_INFO_HAS_LOADER_NAME	0x00000200U
 
-/* maximum lengt of the guest OS' command line parameter string */
-#define MAX_BOOTARGS_SIZE		2048U
+#ifndef ASSEMBLER
 
 struct multiboot_info {
 	uint32_t               mi_flags;
@@ -83,6 +87,6 @@ struct multiboot_module {
 	uint32_t	mm_reserved;
 };
 
-/* boot_regs store the multiboot header address */
-extern uint32_t boot_regs[2];
-#endif
+#endif	/* ASSEMBLER */
+
+#endif	/* MULTIBOOT_H */

--- a/hypervisor/boot/include/multiboot2.h
+++ b/hypervisor/boot/include/multiboot2.h
@@ -126,6 +126,22 @@ struct multiboot2_tag_new_acpi
 	uint8_t rsdp[0];
 };
 
+struct multiboot2_tag_efi64
+{
+	uint32_t type;
+	uint32_t size;
+	uint64_t pointer;
+};
+
+struct multiboot2_tag_efi_mmap
+{
+	uint32_t type;
+	uint32_t size;
+	uint32_t descr_size;
+	uint32_t descr_vers;
+	uint8_t efi_mmap[0];
+};
+
 #endif /* ASSEMBLER */
 
 #endif /*  MULTIBOOT2_H */

--- a/hypervisor/boot/include/multiboot2.h
+++ b/hypervisor/boot/include/multiboot2.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*   multiboot2.h - Multiboot 2 header file. */
+/*   Copyright (C) 1999,2003,2007,2008,2009,2010  Free Software Foundation, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL ANY
+ *  DEVELOPER OR DISTRIBUTOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ *  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MULTIBOOT2_H
+#define MULTIBOOT2_H
+
+#define MULTIBOOT2_HEADER_ALIGN				8
+
+#define MULTIBOOT2_HEADER_MAGIC				0xe85250d6U
+
+/*  This should be in %eax. */
+#define MULTIBOOT2_INFO_MAGIC				0x36d76289U
+
+/*  Alignment of the multiboot info structure. */
+#define MULTIBOOT2_INFO_ALIGN				0x00000008U
+
+/*  Flags set in the 'flags' member of the multiboot header. */
+
+#define MULTIBOOT2_TAG_ALIGN				8U
+#define MULTIBOOT2_TAG_TYPE_END				0U
+#define MULTIBOOT2_TAG_TYPE_CMDLINE			1U
+#define MULTIBOOT2_TAG_TYPE_BOOT_LOADER_NAME		2U
+#define MULTIBOOT2_TAG_TYPE_MODULE			3U
+#define MULTIBOOT2_TAG_TYPE_BASIC_MEMINFO		4U
+#define MULTIBOOT2_TAG_TYPE_BOOTDEV			5U
+#define MULTIBOOT2_TAG_TYPE_MMAP			6U
+#define MULTIBOOT2_TAG_TYPE_VBE				7U
+#define MULTIBOOT2_TAG_TYPE_FRAMEBUFFER			8U
+#define MULTIBOOT2_TAG_TYPE_ELF_SECTIONS		9U
+#define MULTIBOOT2_TAG_TYPE_APM				10U
+#define MULTIBOOT2_TAG_TYPE_EFI32			11U
+#define MULTIBOOT2_TAG_TYPE_EFI64			12U
+#define MULTIBOOT2_TAG_TYPE_SMBIOS			13U
+#define MULTIBOOT2_TAG_TYPE_ACPI_OLD			14U
+#define MULTIBOOT2_TAG_TYPE_ACPI_NEW			15U
+#define MULTIBOOT2_TAG_TYPE_NETWORK			16U
+#define MULTIBOOT2_TAG_TYPE_EFI_MMAP			17U
+#define MULTIBOOT2_TAG_TYPE_EFI_BS			18U
+#define MULTIBOOT2_TAG_TYPE_EFI32_IH			19U
+#define MULTIBOOT2_TAG_TYPE_EFI64_IH			20U
+#define MULTIBOOT2_TAG_TYPE_LOAD_BASE_ADDR		21U
+
+#define MULTIBOOT2_HEADER_TAG_END			0
+#define MULTIBOOT2_HEADER_TAG_INFORMATION_REQUEST	1
+#define MULTIBOOT2_HEADER_TAG_ADDRESS			2
+#define MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS		3
+#define MULTIBOOT2_HEADER_TAG_CONSOLE_FLAGS		4
+#define MULTIBOOT2_HEADER_TAG_FRAMEBUFFER		5
+#define MULTIBOOT2_HEADER_TAG_MODULE_ALIGN		6
+#define MULTIBOOT2_HEADER_TAG_EFI_BS			7
+#define MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI32	8
+#define MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI64	9
+#define MULTIBOOT2_HEADER_TAG_RELOCATABLE		10
+
+#define MULTIBOOT2_ARCHITECTURE_I386			0
+#define MULTIBOOT2_ARCHITECTURE_MIPS32			4
+
+#ifndef ASSEMBLER
+struct multiboot2_mmap_entry
+{
+	uint64_t addr;
+	uint64_t len;
+	uint32_t type;
+	uint32_t zero;
+};
+
+struct multiboot2_tag
+{
+	uint32_t type;
+	uint32_t size;
+};
+
+struct multiboot2_tag_string
+{
+	uint32_t type;
+	uint32_t size;
+	char string[0];
+};
+
+struct multiboot2_tag_module
+{
+	uint32_t type;
+	uint32_t size;
+	uint32_t mod_start;
+	uint32_t mod_end;
+	char cmdline[0];
+};
+
+struct multiboot2_tag_mmap
+{
+	uint32_t type;
+	uint32_t size;
+	uint32_t entry_size;
+	uint32_t entry_version;
+	struct multiboot2_mmap_entry entries[0];
+};
+
+struct multiboot2_tag_new_acpi
+{
+	uint32_t type;
+	uint32_t size;
+	uint8_t rsdp[0];
+};
+
+#endif /* ASSEMBLER */
+
+#endif /*  MULTIBOOT2_H */

--- a/hypervisor/boot/multiboot.c
+++ b/hypervisor/boot/multiboot.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <errno.h>
+#include <pgtable.h>
+#include <boot.h>
+#include <rtl.h>
+#include <logmsg.h>
+
+static struct acrn_multiboot_info acrn_mbi = { 0U };
+
+int32_t sanitize_multiboot_info(void)
+{
+	int32_t ret = 0;
+
+	if (boot_from_multiboot1()) {
+		struct multiboot_info *mbi = (struct multiboot_info *)(hpa2hva_early((uint64_t)boot_regs[1]));
+
+		pr_info("Multiboot1 detected.");
+		acrn_mbi.mi_flags = mbi->mi_flags;
+		acrn_mbi.mi_drives_addr = mbi->mi_drives_addr;
+		acrn_mbi.mi_drives_length = mbi->mi_drives_length;
+		acrn_mbi.mi_cmdline = (char *)hpa2hva_early((uint64_t)mbi->mi_cmdline);
+		acrn_mbi.mi_loader_name = (char *)hpa2hva_early((uint64_t)mbi->mi_loader_name);
+
+		acrn_mbi.mi_mmap_entries = mbi->mi_mmap_length / sizeof(struct multiboot_mmap);
+		if ((acrn_mbi.mi_mmap_entries != 0U) && (mbi->mi_mmap_addr != 0U)) {
+			if (acrn_mbi.mi_mmap_entries > E820_MAX_ENTRIES) {
+				pr_err("Too many E820 entries %d\n", acrn_mbi.mi_mmap_entries);
+				acrn_mbi.mi_mmap_entries = E820_MAX_ENTRIES;
+			}
+			(void)memcpy_s((void *)(&acrn_mbi.mi_mmap_entry[0]),
+				(acrn_mbi.mi_mmap_entries * sizeof(struct multiboot_mmap)),
+				(const void *)hpa2hva_early((uint64_t)mbi->mi_mmap_addr),
+				(acrn_mbi.mi_mmap_entries * sizeof(struct multiboot_mmap)));
+		} else {
+			acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MMAP;
+		}
+
+		acrn_mbi.mi_mods_count = mbi->mi_mods_count;
+		if ((mbi->mi_mods_count != 0U) && (mbi->mi_mods_addr != 0U)) {
+			if (mbi->mi_mods_count > MAX_MODULE_COUNT) {
+				pr_err("Too many multiboot modules %d\n", mbi->mi_mods_count);
+				acrn_mbi.mi_mods_count = MAX_MODULE_COUNT;
+			}
+			(void)memcpy_s((void *)(&acrn_mbi.mi_mods[0]),
+				(acrn_mbi.mi_mods_count * sizeof(struct multiboot_module)),
+				(const void *)hpa2hva_early((uint64_t)mbi->mi_mods_addr),
+				(acrn_mbi.mi_mods_count * sizeof(struct multiboot_module)));
+		} else {
+			acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MODS;
+		}
+
+	} else {
+		pr_err("no multiboot info found!");
+		ret = -ENODEV;
+	}
+
+	if ((acrn_mbi.mi_flags & MULTIBOOT_INFO_HAS_MMAP) == 0U) {
+		pr_err("no multiboot memory map info found!");
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+/*
+ * @post retval != NULL
+ * @post retval->mi_flags & MULTIBOOT_INFO_HAS_MMAP != 0U
+ * @post (retval->mi_mmap_entries > 0U) && (retval->mi_mmap_entries <= E820_MAX_ENTRIES)
+ */
+struct acrn_multiboot_info *get_multiboot_info(void)
+{
+	return &acrn_mbi;
+}

--- a/hypervisor/boot/multiboot.c
+++ b/hypervisor/boot/multiboot.c
@@ -54,7 +54,10 @@ int32_t sanitize_multiboot_info(void)
 		} else {
 			acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MODS;
 		}
-
+#ifdef CONFIG_MULTIBOOT2
+	} else if (boot_from_multiboot2()) {
+		ret = multiboot2_to_acrn_mbi(&acrn_mbi, hpa2hva_early((uint64_t)boot_regs[1]));
+#endif
 	} else {
 		pr_err("no multiboot info found!");
 		ret = -ENODEV;

--- a/hypervisor/boot/multiboot2.c
+++ b/hypervisor/boot/multiboot2.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <errno.h>
+#include <boot.h>
+#include <pgtable.h>
+#include <util.h>
+#include <logmsg.h>
+
+/**
+ * @pre mbi != NULL && mb2_tag_mmap != NULL
+ */
+static void mb2_mmap_to_mbi(struct acrn_multiboot_info *mbi, struct multiboot2_tag_mmap *mb2_tag_mmap)
+{
+	uint32_t i;
+
+	/* multiboot2 mmap tag header occupied 16 bytes */
+	mbi->mi_mmap_entries = (mb2_tag_mmap->size - 16U) / sizeof(struct multiboot2_mmap_entry);
+	if (mbi->mi_mmap_entries > E820_MAX_ENTRIES) {
+		pr_err("Too many E820 entries %d\n", mbi->mi_mmap_entries);
+		mbi->mi_mmap_entries = E820_MAX_ENTRIES;
+	}
+	for (i = 0U; i < mbi->mi_mmap_entries; i++) {
+		mbi->mi_mmap_entry[i].baseaddr = mb2_tag_mmap->entries[i].addr;
+		mbi->mi_mmap_entry[i].length = mb2_tag_mmap->entries[i].len;
+		mbi->mi_mmap_entry[i].type = mb2_tag_mmap->entries[i].type;
+	}
+	mbi->mi_flags |= MULTIBOOT_INFO_HAS_MMAP;
+}
+
+/**
+ * @pre mbi != NULL && mb2_info != NULL
+ */
+int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info)
+{
+	int32_t ret = 0;
+	struct multiboot2_tag *mb2_tag, *mb2_tag_end;
+	uint32_t mb2_info_size = *(uint32_t *)mb2_info;
+
+	/* The start part of multiboot2 info: total mbi size (4 bytes), reserved (4 bytes) */
+	mb2_tag = (struct multiboot2_tag *)((uint8_t *)mb2_info + 8U);
+	mb2_tag_end = (struct multiboot2_tag *)((uint8_t *)mb2_info + mb2_info_size);
+
+	while ((mb2_tag->type != MULTIBOOT2_TAG_TYPE_END) && (mb2_tag < mb2_tag_end)) {
+		if (mb2_tag->size == 0U) {
+			pr_err("the multiboot2 tag size should not be 0!");
+			ret = -EINVAL;
+			break;
+		}
+
+		switch (mb2_tag->type) {
+		case MULTIBOOT2_TAG_TYPE_MMAP:
+			mb2_mmap_to_mbi(mbi, (struct multiboot2_tag_mmap *)mb2_tag);
+			break;
+		default:
+			if (mb2_tag->type <= MULTIBOOT2_TAG_TYPE_LOAD_BASE_ADDR) {
+				pr_warn("unhandled multiboot2 tag type: %d", mb2_tag->type);
+			} else {
+				pr_err("unknown multiboot2 tag type: %d", mb2_tag->type);
+				ret = -EINVAL;
+			}
+			break;
+		}
+		if (ret != 0) {
+			pr_err("multiboot2 info format error!");
+			break;
+		}
+		/*
+		 * tag->size is not including padding whearas each tag
+		 * start at 8-bytes aligned address.
+		 */
+		mb2_tag = (struct multiboot2_tag *)((uint8_t *)mb2_tag
+				+ ((mb2_tag->size + (MULTIBOOT2_INFO_ALIGN - 1U)) & ~(MULTIBOOT2_INFO_ALIGN - 1U)));
+	}
+	return ret;
+}

--- a/hypervisor/debug/console.c
+++ b/hypervisor/debug/console.c
@@ -24,6 +24,11 @@ uint16_t console_vmid = ACRN_INVALID_VMID;
 
 void console_init(void)
 {
+	/*
+	 * Enable UART as early as possible.
+	 * Then we could use printf for debugging on early boot stage.
+	 */
+	uart16550_init(true);
 }
 
 void console_putc(const char *ch)

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -9,7 +9,7 @@
 
 #include <types.h>
 #include <pci.h>
-#include <multiboot.h>
+#include <boot.h>
 #include <acrn_common.h>
 #include <vm_configurations.h>
 #include <sgx.h>

--- a/hypervisor/include/arch/x86/zeropage.h
+++ b/hypervisor/include/arch/x86/zeropage.h
@@ -8,8 +8,23 @@
 #define ZEROPAGE_H
 #include <e820.h>
 
+struct efi_info {
+	uint32_t efi_loader_signature;	/* 0x1d0 */
+	uint32_t efi_systab;		/* 0x1c4 */
+	uint32_t efi_memdesc_size;	/* 0x1c8 */
+	uint32_t efi_memdesc_version;	/* 0x1cc */
+	uint32_t efi_memmap;		/* 0x1d0 */
+	uint32_t efi_memmap_size;	/* 0x1d4 */
+	uint32_t efi_systab_hi;		/* 0x1d8 */
+	uint32_t efi_memmap_hi;		/* 0x1dc */
+} __packed;
+
 struct zero_page {
-	uint8_t pad1[0x1e8];	/* 0x000 */
+	uint8_t pad0[0x1c0];	/* 0x000 */
+
+	struct efi_info boot_efi_info;
+
+	uint8_t pad1[0x8];	/* 0x1e0 */
 	uint8_t e820_nentries;	/* 0x1e8 */
 	uint8_t pad2[0x8];	/* 0x1e9 */
 


### PR DESCRIPTION
Currently ACRN hypervisor can only boot from multiboot1 protocol, which
introduced a possible risk that when boot from a EFI platform, hypervisor
might have problem to parse host ACPI RSDP pointer, because RSDP might
exist in efi system table only, which is not visible for multiboot1.

The patch set enables multiboot2 support for ACRN. When CONFIG_MULTIBOOT2
is enabled, both multiboot1 and multiboot2 header magic would be existed in
hv image, and ACRN will be loaded accordingly per bootloader scenario.
When CONFIG_MULTIBOOT2 is disabled, only multiboot1 magic is existed and
ACRN can only boot from multiboot1 protocol.

Another benefit for multiboot2 enabling is it could pass host efi information,
make guest possible to boot with efi environment.

Bootloader scenario and multiboot usage:

	1. When boot from acrn.efi application, it uses multiboot1;
	2. When boot from grub multiboot command, it uses multiboot1;
	3. When boot from grub multiboot2 command, it uses multiboot2;

Tracked-On: #4419

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>