### PR TITLE
hv: refine retpoline speculation barriers

### DIFF
--- a/hypervisor/arch/x86/lib/retpoline-thunk.S
+++ b/hypervisor/arch/x86/lib/retpoline-thunk.S
@@ -12,6 +12,7 @@ __x86_indirect_thunk_\reg:
     call 22f
 11:
     pause
+    lfence
     jmp 11b
 22:
     mov %\reg, (%rsp)


### PR DESCRIPTION
  Per Section 4.4 Speculation Barriers, in
  "Retpoline: A Branch Target Inject Mitigation" white paper,
  "LFENCE instruction limits the speculative execution that
  a processor implementation can perform around the LFENCE,
  possibly impacting processor performance,but also creating
  a tool with which to mitigate speculative-execution
  side-channel attacks."

Tracked-On: #4424
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>