### PR TITLE
dm: remove vdev_update_bar_map callback for PCIe device

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -689,7 +689,6 @@ update_bar_address(struct vmctx *ctx, struct pci_vdev *dev, uint64_t addr,
 	int idx, int type, bool ignore_reg_unreg)
 {
 	bool decode = false;
-	uint64_t orig_addr = dev->bar[idx].addr;
 
 	if (!ignore_reg_unreg) {
 		if (dev->bar[idx].type == PCIBAR_IO)
@@ -734,10 +733,6 @@ update_bar_address(struct vmctx *ctx, struct pci_vdev *dev, uint64_t addr,
 
 	if (decode)
 		register_bar(dev, idx);
-
-	/* update bar mapping */
-	if (dev->dev_ops->vdev_update_bar_map && decode)
-		dev->dev_ops->vdev_update_bar_map(ctx, dev, idx, orig_addr);
 }
 
 static struct mmio_rsvd_rgn *

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -561,39 +561,6 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	vm_deassign_pcidev(ctx, &pcidev);
 }
 
-static void
-passthru_update_bar_map(struct vmctx *ctx, struct pci_vdev *dev,
-	int idx, uint64_t orig_addr)
-{
-	struct passthru_dev *ptdev;
-
-	if (!dev->arg) {
-		warnx("%s: passthru_dev is NULL", __func__);
-		return;
-	}
-
-	ptdev = (struct passthru_dev *)dev->arg;
-
-	if (ptdev->bar[idx].size == 0 ||
-		idx == ptdev_msix_table_bar(ptdev) ||
-		ptdev->bar[idx].type == PCIBAR_IO)
-		return;
-
-	if (dev->bar[idx].addr + dev->bar[idx].size > PCI_EMUL_MEMLIMIT64 ||
-		orig_addr + dev->bar[idx].size > PCI_EMUL_MEMLIMIT64)
-		return;
-
-	vm_unmap_ptdev_mmio(ctx, ptdev->sel.bus,
-			ptdev->sel.dev, ptdev->sel.func,
-			orig_addr, ptdev->bar[idx].size,
-			ptdev->bar[idx].addr);
-
-	vm_map_ptdev_mmio(ctx, ptdev->sel.bus,
-			ptdev->sel.dev, ptdev->sel.func,
-			dev->bar[idx].addr, ptdev->bar[idx].size,
-			ptdev->bar[idx].addr);
-}
-
 /* bind pin info for pass-through device */
 static void
 passthru_bind_irq(struct vmctx *ctx, struct pci_vdev *dev)
@@ -1333,7 +1300,6 @@ struct pci_vdev_ops passthru = {
 	.vdev_barwrite		= passthru_write,
 	.vdev_barread		= passthru_read,
 	.vdev_phys_access	= passthru_bind_irq,
-	.vdev_update_bar_map	= passthru_update_bar_map,
 	.vdev_write_dsdt	= passthru_write_dsdt,
 };
 DEFINE_PCI_DEVTYPE(passthru);

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -71,11 +71,6 @@ struct pci_vdev_ops {
 	/* ops related to physical resources */
 	void	(*vdev_phys_access)(struct vmctx *ctx, struct pci_vdev *dev);
 
-	/* update BAR map callback */
-	void	(*vdev_update_bar_map)(struct vmctx *ctx,
-				struct pci_vdev *dev, int idx,
-				uint64_t orig_addr);
-
 	/* config space read/write callbacks */
 	int	(*vdev_cfgwrite)(struct vmctx *ctx, int vcpu,
 			       struct pci_vdev *pi, int offset,


### PR DESCRIPTION
Since this callback is only useful for pass through PCIe device and now pass through
PCIe device emulation has splited from DM to HV. we could remove this callback now.

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>