### PR TITLE
Introduce SR-IOV feature for ACRN

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -293,6 +293,7 @@ VP_DM_C_SRCS += dm/vpci/vhostbridge.c
 VP_DM_C_SRCS += dm/vpci/pci_pt.c
 VP_DM_C_SRCS += dm/vpci/vmsi.c
 VP_DM_C_SRCS += dm/vpci/vmsix.c
+VP_DM_C_SRCS += dm/vpci/vsriov.c
 VP_DM_C_SRCS += arch/x86/guest/vlapic.c
 VP_DM_C_SRCS += arch/x86/guest/pm.c
 VP_DM_C_SRCS += arch/x86/guest/assign.c

--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -56,7 +56,7 @@ static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
 /*
  * @pre: pdev != NULL
  */
-void fill_pci_dev_config(struct pci_pdev *pdev)
+void init_one_dev_config(struct pci_pdev *pdev)
 {
 	uint16_t vmid;
 	struct acrn_vm_config *vm_config;

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -357,6 +357,7 @@ static void vpci_init_pt_dev(struct pci_vdev *vdev)
 	 */
 	init_vmsi(vdev);
 	init_vmsix(vdev);
+	init_vsriov(vdev);
 	init_vdev_pt(vdev);
 
 	assign_vdev_pt_iommu_domain(vdev);
@@ -381,6 +382,8 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 		vmsi_write_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		vmsix_write_cfg(vdev, offset, bytes, val);
+	} else if (sriovcap_access(vdev, offset)) {
+		write_sriov_cap_reg(vdev, offset, bytes, val);
 	} else if (offset == PCIR_COMMAND) {
 		vdev_pt_write_command(vdev, (bytes > 2U) ? 2U : bytes, (uint16_t)val);
 	} else {
@@ -410,6 +413,8 @@ static int32_t vpci_read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset
 		vmsi_read_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		vmsix_read_cfg(vdev, offset, bytes, val);
+	} else if (sriovcap_access(vdev, offset)) {
+		read_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {
 		if (is_postlaunched_vm(vdev->vpci->vm) &&
 				in_range(offset, PCIR_INTERRUPT_LINE, 4U)) {

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -101,6 +101,22 @@ static inline bool msixcap_access(const struct pci_vdev *vdev, uint32_t offset)
 	return (has_msix_cap(vdev) && in_range(offset, vdev->msix.capoff, vdev->msix.caplen));
 }
 
+/*
+ * @pre vdev != NULL
+ */
+static inline bool has_sriov_cap(const struct pci_vdev *vdev)
+{
+	return (vdev->sriov.capoff != 0U);
+}
+
+/*
+ * @pre vdev != NULL
+ */
+static inline bool sriovcap_access(const struct pci_vdev *vdev, uint32_t offset)
+{
+	return (has_sriov_cap(vdev) && in_range(offset, vdev->sriov.capoff, vdev->sriov.caplen));
+}
+
 /**
  * @pre vdev != NULL
  */
@@ -139,6 +155,10 @@ int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_
 void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(const struct pci_vdev *vdev);
+
+void init_vsriov(struct pci_vdev *vdev);
+void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -27,8 +27,143 @@
  * $FreeBSD$
  */
 
+#include <vm.h>
 #include <ptdev.h>
 #include <vpci.h>
+#include <logmsg.h>
+
+#include "vpci_priv.h"
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static inline uint8_t get_vf_devfun(const struct pci_vdev *pf_vdev, uint16_t fst_off, uint16_t stride, uint16_t id)
+{
+	return ((uint8_t)((pf_vdev->bdf.fields.devfun + fst_off + (stride * id)) & 0xFFU));
+}
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static inline uint8_t get_vf_bus(const struct pci_vdev *pf_vdev, uint16_t fst_off, uint16_t stride, uint16_t id)
+{
+	return ((uint8_t)(pf_vdev->bdf.fields.bus + ((pf_vdev->bdf.fields.devfun + fst_off + (stride * id)) >> 8U)));
+}
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static inline uint16_t read_sriov_reg(const struct pci_vdev *pf_vdev, uint16_t reg)
+{
+	return ((uint16_t)(pci_pdev_read_cfg(pf_vdev->bdf, pf_vdev->sriov.capoff + reg, 2U)));
+}
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static bool is_vf_enabled(const struct pci_vdev *pf_vdev)
+{
+	uint16_t control;
+
+	control = read_sriov_reg(pf_vdev, PCIR_SRIOV_CONTROL);
+	return ((control & PCIM_SRIOV_VF_ENABLE) != 0U);
+}
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static void init_sriov_vf_bar(struct pci_vdev *pf_vdev)
+{
+	/* Implementation in next patch */
+	(void)pf_vdev;
+}
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static void create_vf(struct pci_vdev *pf_vdev, union pci_bdf vf_bdf)
+{
+	/* Implementation in next patch */
+	(void)pf_vdev;
+	(void)vf_bdf;
+}
+
+/**
+ * @pre pf_vdev != NULL
+ * @pre is_vf_enabled(pf_dev) == true
+ * @Application constraints: PCIR_SRIOV_NUMVFS register value cannot be 0 if VF_ENABLE is set.
+ */
+static void enable_vf(struct pci_vdev *pf_vdev)
+{
+	union pci_bdf vf_bdf;
+	uint16_t idx;
+	uint16_t sub_vid = 0U;
+
+	/* Confirm that the physical VF_ENABLE register has been set successfully */
+	ASSERT(is_vf_enabled(pf_vdev), "VF_ENABLE was not set successfully on the hardware");
+
+	/*
+         * All VFs bars information are located at PF VF_BAR fields of SRIOV capability.
+	 * Initialize the PF's VF_BAR registers before initialize each VF device bar.
+	 */
+	init_sriov_vf_bar(pf_vdev);
+
+	/*
+	 * Per PCIE base spec 9.3.3.3.1, VF Enable bit from cleared to set, the
+	 * system is not perrmitted to issue requests to the VFs until one of
+	 * the following is true:
+	 * 1. at least 100ms has passed.
+	 * 2. An FRS message has been received from the PF with a reason code
+	 *    of VF Enabled.
+	 * 3. At least VF Enable Time has passed since VF Enable was Set.
+	 *    VF Enable Time is either the Reset Time value in the Readiness Time
+	 *    Reporting capability associated with the VF or a value determined
+	 *    by system software/firmware.
+	 *
+	 * Curerntly, we use the first way to wait for VF physical devices to be ready.
+	 */
+	udelay (100U * 1000U);
+
+	/*
+	 * Due to VF's DEVICE ID and VENDOR ID are 0xFFFF, so check if VF physical
+	 * device has been created by the value of SUBSYSTEM VENDOR ID.
+	 * To check if all enabled VFs are ready, just check the first VF already exists,
+	 * do not need to check all.
+	 */
+	sub_vid = (uint16_t) pci_pdev_read_cfg(vf_bdf, PCIV_SUB_VENDOR_ID, 2U);
+	if ((sub_vid != 0xFFFFU) && (sub_vid != 0U)) {
+		uint16_t num_vfs, stride, fst_off;
+
+		num_vfs = read_sriov_reg(pf_vdev, PCIR_SRIOV_NUMVFS);
+		fst_off = read_sriov_reg(pf_vdev, PCIR_SRIOV_FST_VF_OFF);
+		stride = read_sriov_reg(pf_vdev, PCIR_SRIOV_VF_STRIDE);
+		for (idx = 0U; idx < num_vfs; idx++) {
+			vf_bdf.fields.bus = get_vf_bus(pf_vdev, fst_off, stride, idx);
+			vf_bdf.fields.devfun = get_vf_devfun(pf_vdev, fst_off, stride, idx);
+
+			/* if one VF has never been created then create new pdev/vdev for this VF */
+			if (pci_find_vdev(&pf_vdev->vpci->vm->vpci, vf_bdf) == NULL) {
+				create_vf(pf_vdev, vf_bdf);
+			}
+		}
+	} else {
+		/*
+		 * If the VF physical device was not created successfully, the pdev/vdev
+		 * will also not be created so that SOS can aware of VF creation failure,
+		 */
+		pr_err("PF %x:%x.%x can't create VFs after 100 ms",
+			pf_vdev->bdf.bits.b, pf_vdev->bdf.bits.d, pf_vdev->bdf.bits.f);
+	}
+}
+
+/**
+ * @pre pf_vdev != NULL
+ */
+static void disable_vf(struct pci_vdev *pf_vdev)
+{
+	/* Implementation in next patch */
+	(void)pf_vdev;
+}
 
 /**
  * @pre vdev != NULL
@@ -58,7 +193,44 @@ void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t b
  */
 void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	/* Needs to intercept VF_ENABLE and add it in next patch. */
-	pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 
+	uint32_t reg;
+
+	reg = offset - vdev->sriov.capoff;
+	if (reg == PCIR_SRIOV_CONTROL) {
+		bool enable;
+
+		enable = (((val & PCIM_SRIOV_VF_ENABLE) != 0U) ? true : false);
+		if (enable != is_vf_enabled(vdev)) {
+			if (enable) {
+				/*
+				 * set VF_ENABLE to PF physical device before enable_vf
+				 * since need to ask hardware to create VF physical
+				 * devices firstly
+				 */
+				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+				enable_vf(vdev);
+			} else {
+				disable_vf(vdev);
+				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+			}
+		} else {
+			pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+		}
+	} else if (reg == PCIR_SRIOV_NUMVFS) {
+		uint16_t total;
+
+		total = read_sriov_reg(vdev, PCIR_SRIOV_TOTAL_VFS);
+		/*
+		 * sanity check for NumVFs register based on PCE Express Base 4.0 9.3.3.7 chapter
+		 * The results are undefined if NumVFs is set to a value greater than TotalVFs
+		 * NumVFs may only be written while VF Enable is Clear
+		 * If NumVFs is written when VF Enable is Set, the results are undefined
+		 */
+		if ((((uint16_t)(val & 0xFFU)) <= total) && (!is_vf_enabled(vdev))) {
+			pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+		}
+	} else {
+		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+	}
 }

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011 NetApp, Inc.
+ * Copyright (c) 2018 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NETAPP, INC ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL NETAPP, INC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#include <ptdev.h>
+#include <vpci.h>
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+void init_vsriov(struct pci_vdev *vdev)
+{
+	struct pci_pdev *pdev = vdev->pdev;
+
+	vdev->sriov.capoff = pdev->sriov.capoff;
+	vdev->sriov.caplen = pdev->sriov.caplen;
+}
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+{
+	/* no need to do emulation, passthrough to physical device directly */
+	*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
+}
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+{
+	/* Needs to intercept VF_ENABLE and add it in next patch. */
+	pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+
+}

--- a/hypervisor/include/arch/x86/pci_dev.h
+++ b/hypervisor/include/arch/x86/pci_dev.h
@@ -14,6 +14,6 @@
 extern struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 struct pci_pdev;
-void fill_pci_dev_config(struct pci_pdev *pdev);
+void init_one_dev_config(struct pci_pdev *pdev);
 
 #endif /* PCI_DEV_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -69,6 +69,12 @@ struct pci_msix {
 	uint32_t  table_count;
 };
 
+/* SRIOV capability structure */
+struct pci_cap_sriov {
+	uint32_t  capoff;
+	uint32_t  caplen;
+};
+
 union pci_cfgdata {
 	uint8_t data_8[PCIE_CONFIG_SPACE_SIZE];
 	uint16_t data_16[PCIE_CONFIG_SPACE_SIZE >> 1U];
@@ -98,6 +104,7 @@ struct pci_vdev {
 
 	struct pci_msi msi;
 	struct pci_msix msix;
+	struct pci_cap_sriov sriov;
 
 	/* Pointer to corresponding PCI device's vm_config */
 	struct acrn_vm_pci_dev_config *pci_dev_config;

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -114,6 +114,7 @@
 
 /* SRIOV Definitions */
 #define PCI_SRIOV_CAP_LEN	0x40U
+#define PCIR_SRIOV_TOTAL_VFS	0xEU
 
 /* PCI Message Signalled Interrupts (MSI) */
 #define PCIR_MSI_CTRL         0x02U

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -86,6 +86,7 @@
 #define PCIM_BAR_MEM_1MB      0x02U
 #define PCIM_BAR_MEM_64       0x04U
 #define PCIM_BAR_MEM_BASE     0xFFFFFFF0U
+#define PCIV_SUB_VENDOR_ID    0x2CU
 #define PCIR_CAP_PTR          0x34U
 #define PCIR_CAP_PTR_CARDBUS  0x14U
 #define PCI_BASE_ADDRESS_MEM_MASK (~0x0fUL)
@@ -114,7 +115,12 @@
 
 /* SRIOV Definitions */
 #define PCI_SRIOV_CAP_LEN	0x40U
+#define PCIR_SRIOV_CONTROL	0x8U
 #define PCIR_SRIOV_TOTAL_VFS	0xEU
+#define PCIR_SRIOV_NUMVFS	0x10U
+#define PCIR_SRIOV_FST_VF_OFF	0x14U
+#define PCIR_SRIOV_VF_STRIDE	0x16U
+#define PCIM_SRIOV_VF_ENABLE	0x1U
 
 /* PCI Message Signalled Interrupts (MSI) */
 #define PCIR_MSI_CTRL         0x02U

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -106,6 +106,15 @@
 #define PCIY_MSI              0x05U
 #define PCIY_MSIX             0x11U
 
+/* PCIe Extended Capability*/
+#define PCI_ECAP_BASE_PTR	0x100U
+#define PCI_ECAP_ID(hdr)	((uint32_t)((hdr) & 0xFFFFU))
+#define PCI_ECAP_NEXT(hdr)	((uint32_t)(((hdr) >> 20U) & 0xFFCU))
+#define PCIZ_SRIOV		0x10U
+
+/* SRIOV Definitions */
+#define PCI_SRIOV_CAP_LEN	0x40U
+
 /* PCI Message Signalled Interrupts (MSI) */
 #define PCIR_MSI_CTRL         0x02U
 #define PCIM_MSICTRL_64BIT    0x80U
@@ -189,6 +198,11 @@ struct pci_msix_cap {
 	uint8_t   cap[MSIX_CAPLEN];
 };
 
+struct pci_sriov_cap {
+	uint32_t  capoff;
+	uint32_t  caplen;
+};
+
 struct pci_pdev {
 	uint8_t hdr_type;
 
@@ -205,6 +219,7 @@ struct pci_pdev {
 	uint32_t msi_capoff;
 
 	struct pci_msix_cap msix;
+	struct pci_sriov_cap sriov;
 
 	bool has_pm_reset;
 	bool has_flr;


### PR DESCRIPTION
This patch-set implements SRIOV-capable device discovery and add SRIOV capability interception entries.

SR-IOV(single root input/output virtualization) can isolate PCIe devices and
make the devices to have good performance, close to bare-metal. The SR-IOV
consists of two basic units, one is called PF(Physical Function) that supports
SRIOV PCIe extended capability and manages entire physical device, another is
called VF (Virtual Function) and is a "lightweight" PCIe function which is meant
to be given to a VM as a pass-through device. For more details, please refer to
PCI Express Base Specification Revision 4.0 Chapter 9. 

Tracked-On: #4433