### PR TITLE
hv: refine confusing e820 table logging layout

### DIFF
--- a/hypervisor/arch/x86/e820.c
+++ b/hypervisor/arch/x86/e820.c
@@ -136,8 +136,8 @@ void init_e820(void)
 		hv_e820[i].length = mmap[i].length;
 		hv_e820[i].type = mmap[i].type;
 
-		dev_dbg(DBG_LEVEL_E820, "mmap table: %d type: 0x%x\n", i, mmap[i].type);
-		dev_dbg(DBG_LEVEL_E820, "Base: 0x%016lx length: 0x%016lx",
+		dev_dbg(DBG_LEVEL_E820, "mmap table: %d type: 0x%x", i, mmap[i].type);
+		dev_dbg(DBG_LEVEL_E820, "Base: 0x%016lx length: 0x%016lx\n",
 			mmap[i].baseaddr, mmap[i].length);
 	}
 


### PR DESCRIPTION
It puts the new line in the wrong place, and the logs are confusing.
For example, for these entries:

mmap[0] - type: 1, base: 0x00000, length: 0x9800
mmap[1] - type: 2, base: 0x98000, length: 0x8000
mmap[2] - type: 3, base: 0xc0000, length: 0x4000

Currently it prints them in this way:

    mmap table: 0 type: 0x1

    Base: 0x0000000000000000 length: 0x0000000000098000
    mmap table: 1 type: 0x2

    Base: 0x0000000000098000 length: 0x0000000000008000
    mmap table: 2 type: 0x3

    Base: 0x00000000000c0000 length: 0x0000000000040000

With this fix, it looks like the following, and now it's of same style
with how prepare_sos_vm_memmap() logs ve820 tables.

    mmap table: 0 type: 0x1
    Base: 0x0000000000000000 length: 0x0000000000098000

    mmap table: 1 type: 0x2
    Base: 0x0000000000098000 length: 0x0000000000008000

    mmap table: 2 type: 0x3
    Base: 0x00000000000c0000 length: 0x0000000000040000

Tracked-On: #1842
Signed-off-by: Zide Chen <zide.chen@intel.com>