### PR TITLE
acrn-config: Fix vbar address generated by the offline tool

### DIFF
--- a/misc/acrn-config/board_config/pci_devices_h.py
+++ b/misc/acrn-config/board_config/pci_devices_h.py
@@ -41,6 +41,9 @@ def parser_pci():
     for line in pci_lines:
         # get pci bar information into pci_bar_dic
         if "Region" in line and "Memory at" in line:
+            #ignore memory region from SR-IOV capabilities
+            if "size=" not in line:
+                 continue
             bar_num = line.split()[1].strip(':')
             bar_addr = get_value_after_str(line, "at")
             if int(bar_addr, 16) > 0xffffffff:


### PR DESCRIPTION
Devices that support SR-IOV can expose their capabilities in
lspci -vv command as below. The offline tool, instead of picking
up the bios exposed memory region(bc000000) for the devices ends
picking up the SR-IOV memory region(00000000c0000000) and generates
VBAR address (in pci_devices.h). This is incorrect. This patch
fixes the offline tool to take the right memory region as the
VBAR address.

Sample lspic -vv log:
67:00.0 Ethernet controller: Intel Corporation Ethernet Connection
 X722 for 10GbE backplane (rev 09)
Subsystem: Intel Corporation Device 0000
Control: I/O- Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr+
Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort-
Latency: 0
Interrupt: pin A routed to IRQ 61
Region 0: Memory at bc000000 (64-bit, prefetchable) [size=16M]
Region 3: Memory at c1000000 (64-bit, prefetchable) [size=32K]
Capabilities: [160 v1] Single Root I/O Virtualization (SR-IOV)
IOVCap: Migration-, Interrupt Message Number: 000
IOVCtl: Enable- Migration- Interrupt- MSE- ARIHierarchy+
IOVSta: Migration-
Initial VFs: 32, Total VFs: 32, Number of VFs: 0, Function Dependency Link: 00
VF offset: 16, stride: 1, Device ID: 37cd
Supported Page Size: 00000553, System Page Size: 00000001
Region 0: Memory at 00000000c0000000 (64-bit, prefetchable)
Region 3: Memory at 00000000c1020000 (64-bit, prefetchable)
VF Migration: offset: 00000000, BIR: 0

Tracked-On: #4443
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>