### PR TITLE
The second SRIOV patch-set

### DIFF
--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -54,13 +54,21 @@ static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
 
 
 /*
- * @pre: pdev != NULL
+ * @brief Initialize a acrn_vm_pci_dev_config structure
+ *
+ * Initialize a acrn_vm_pci_dev_config structure with a specified the pdev structure.
+ * A acrn_vm_pci_dev_config is used to store a PCI device configuration for a VM. The
+ * caller of the function init_one_dev_config should guarantee execution atomically.
+ *
+ * @pre pdev != NULL
+ *
+ * @return If there's a successfully initialized acrn_vm_pci_dev_config return it, otherwise return NULL;
  */
-void init_one_dev_config(struct pci_pdev *pdev)
+struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev)
 {
 	uint16_t vmid;
 	struct acrn_vm_config *vm_config;
-	struct acrn_vm_pci_dev_config *dev_config;
+	struct acrn_vm_pci_dev_config *dev_config = NULL;
 
 	if (!is_allocated_to_prelaunched_vm(pdev)) {
 		for (vmid = 0U; vmid < CONFIG_MAX_VM_NUM; vmid++) {
@@ -77,4 +85,5 @@ void init_one_dev_config(struct pci_pdev *pdev)
 			vm_config->pci_dev_num++;
 		}
 	}
+	return dev_config;
 }

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -220,12 +220,11 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
  * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  */
-void init_vdev_pt(struct pci_vdev *vdev)
+static void init_bars(struct pci_vdev *vdev)
 {
 	enum pci_bar_type type;
 	uint32_t idx;
 	struct pci_vbar *vbar;
-	uint16_t pci_command;
 	uint32_t size32, offset, lo, hi = 0U;
 	union pci_bdf pbdf;
 	uint64_t mask;
@@ -293,7 +292,34 @@ void init_vdev_pt(struct pci_vdev *vdev)
 			}
 		}
 	}
+}
 
+/*
+ * @brief Initialize a specified passthrough vdev structure.
+ *
+ * The function init_vdev_pt is used to initialize a vdev structure. If a vdev structure supports
+ * SRIOV capability that the vdev represents a SRIOV physical function(PF) virtual device, then
+ * function init_vdev_pt can initialize PF vdev SRIOV capability if parameter is_pf_vdev is true.
+ *
+ * @param vdev        pointer to vdev data structure
+ * @param is_pf_vdev  indicate the first parameter vdev is the data structure of a PF, which contains
+ *                    the SR-IOV capability
+ *
+ * @pre vdev != NULL
+ * @pre vdev->vpci != NULL
+ * @pre vdev->vpci->vm != NULL
+ * @pre vdev->pdev != NULL
+ *
+ * @return None
+ */
+void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
+{
+	uint16_t pci_command;
+
+	/* SRIOV capability initialization implementaion in next patch */
+	(void) is_pf_vdev;
+
+	init_bars(vdev);
 	if (is_prelaunched_vm(vdev->vpci->vm)) {
 		pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U);
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -351,13 +351,17 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 {
 	uint16_t pci_command;
 
-	init_bars(vdev, is_pf_vdev);
-	if (is_prelaunched_vm(vdev->vpci->vm) && (!is_pf_vdev)) {
-		pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U);
+	if (vdev->phyfun != NULL) {
+		init_sriov_vf_vdev(vdev);
+	} else {
+		init_bars(vdev, is_pf_vdev);
+		if (is_prelaunched_vm(vdev->vpci->vm) && (!is_pf_vdev)) {
+			pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U);
 
-		/* Disable INTX */
-		pci_command |= 0x400U;
-		pci_pdev_write_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U, pci_command);
+			/* Disable INTX */
+			pci_command |= 0x400U;
+			pci_pdev_write_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U, pci_command);
+		}
 	}
 }
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -358,7 +358,7 @@ static void vpci_init_pt_dev(struct pci_vdev *vdev)
 	init_vmsi(vdev);
 	init_vmsix(vdev);
 	init_vsriov(vdev);
-	init_vdev_pt(vdev);
+	init_vdev_pt(vdev, false);
 
 	assign_vdev_pt_iommu_domain(vdev);
 }

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -160,6 +160,7 @@ void init_vsriov(struct pci_vdev *vdev);
 void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 uint32_t sriov_bar_offset(const struct pci_vdev *vdev, uint32_t bar_idx);
+void init_sriov_vf_vdev(struct pci_vdev *vdev);
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -141,7 +141,7 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 	return (has_msi_cap(vdev) && in_range(offset, vdev->msi.capoff, vdev->msi.caplen));
 }
 
-void init_vdev_pt(struct pci_vdev *vdev);
+void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev);
 void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
 void vdev_pt_write_command(const struct pci_vdev *vdev, uint32_t bytes, uint16_t new_cmd);
 

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -159,6 +159,7 @@ void deinit_vmsix(const struct pci_vdev *vdev);
 void init_vsriov(struct pci_vdev *vdev);
 void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+uint32_t sriov_bar_offset(const struct pci_vdev *vdev, uint32_t bar_idx);
 
 uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
 void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -74,8 +74,7 @@ static bool is_vf_enabled(const struct pci_vdev *pf_vdev)
  */
 static void init_sriov_vf_bar(struct pci_vdev *pf_vdev)
 {
-	/* Implementation in next patch */
-	(void)pf_vdev;
+	init_vdev_pt(pf_vdev, true);
 }
 
 /**
@@ -233,4 +232,13 @@ void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
 	} else {
 		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 	}
+}
+
+
+/**
+ * @pre vdev != NULL
+ */
+uint32_t sriov_bar_offset(const struct pci_vdev *vdev, uint32_t bar_idx)
+{
+	return (vdev->sriov.capoff + PCIR_SRIOV_VF_BAR_OFF + (bar_idx << 2U));
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -49,8 +49,6 @@ static uint32_t num_pci_pdev;
 static struct pci_pdev pci_pdev_array[CONFIG_MAX_PCI_DEV_NUM];
 static uint64_t pci_mmcfg_base = DEFAULT_PCI_MMCFG_BASE;
 
-static void init_pdev(uint16_t pbdf, uint32_t drhd_index);
-
 #ifdef CONFIG_ACPI_PARSE_ENABLED
 void set_mmcfg_base(uint64_t mmcfg_base)
 {
@@ -607,11 +605,22 @@ static void pci_read_cap(struct pci_pdev *pdev)
 	}
 }
 
-static void init_pdev(uint16_t pbdf, uint32_t drhd_index)
+/*
+ * @brief Initialize a pdev data structure.
+ *
+ * Initialize a pdev data structure with a physical device BDF(pbdf) and DRHD index(drhd_index).
+ * The caller of the function init_pdev should guarantee execution atomically.
+ *
+ * @param pbdf        Physical device BDF
+ * @param drhd_index  DRHD index
+ *
+ * @return If there's a successfully initialized pdev return it, otherwise return NULL;
+ */
+struct pci_pdev *init_pdev(uint16_t pbdf, uint32_t drhd_index)
 {
 	uint8_t hdr_type;
 	union pci_bdf bdf;
-	struct pci_pdev *pdev;
+	struct pci_pdev *pdev = NULL;
 
 	if (num_pci_pdev < CONFIG_MAX_PCI_DEV_NUM) {
 		bdf.value = pbdf;
@@ -640,4 +649,6 @@ static void init_pdev(uint16_t pbdf, uint32_t drhd_index)
 	} else {
 		pr_err("%s, failed to alloc pci_pdev!\n", __func__);
 	}
+
+	return pdev;
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -252,7 +252,7 @@ static bool is_hv_owned_pdev(union pci_bdf pbdf)
 static void pci_init_pdev(union pci_bdf pbdf, uint32_t drhd_index)
 {
 	if (!is_hv_owned_pdev(pbdf)) {
-		init_pdev(pbdf.value, drhd_index);
+		(void)init_pdev(pbdf.value, drhd_index);
 	}
 }
 
@@ -469,7 +469,7 @@ static void init_all_dev_config(void)
 				total += cnt;
 			}
 		}
-		init_one_dev_config(pdev);
+		(void)init_one_dev_config(pdev);
 	}
 }
 

--- a/hypervisor/include/arch/x86/pci_dev.h
+++ b/hypervisor/include/arch/x86/pci_dev.h
@@ -14,6 +14,6 @@
 extern struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 struct pci_pdev;
-void init_one_dev_config(struct pci_pdev *pdev);
+struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev);
 
 #endif /* PCI_DEV_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -112,6 +112,9 @@ struct pci_vdev {
 	struct pci_msix msix;
 	struct pci_cap_sriov sriov;
 
+	/* Pointer to the SRIOV VF associated PF's vdev */
+	struct pci_vdev *phyfun;
+
 	/* Pointer to corresponding PCI device's vm_config */
 	struct acrn_vm_pci_dev_config *pci_dev_config;
 
@@ -149,5 +152,6 @@ struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf);
 struct acrn_assign_pcidev;
 int32_t vpci_assign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *pcidev);
 int32_t vpci_deassign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *pcidev);
+struct pci_vdev *vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_config *dev_config, struct pci_vdev *parent_pf_vdev);
 
 #endif /* VPCI_H_ */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -73,6 +73,12 @@ struct pci_msix {
 struct pci_cap_sriov {
 	uint32_t  capoff;
 	uint32_t  caplen;
+
+	/*
+	 * If the vdev is a SRIOV PF vdev, the vbars is used to store
+	 * the bar information that is using to initialize SRIOV VF vdev bar.
+	 */
+	struct pci_vbar vbars[PCI_BAR_COUNT];
 };
 
 union pci_cfgdata {

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -120,6 +120,7 @@
 #define PCIR_SRIOV_NUMVFS	0x10U
 #define PCIR_SRIOV_FST_VF_OFF	0x14U
 #define PCIR_SRIOV_VF_STRIDE	0x16U
+#define PCIR_SRIOV_VF_BAR_OFF	0x24U
 #define PCIM_SRIOV_VF_ENABLE	0x1U
 
 /* PCI Message Signalled Interrupts (MSI) */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -301,6 +301,7 @@ void set_mmcfg_base(uint64_t mmcfg_base);
 #endif
 uint64_t get_mmcfg_base(void);
 
+struct pci_pdev *init_pdev(uint16_t pbdf, uint32_t drhd_index);
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);


### PR DESCRIPTION
Refine the HV APIs about  adding pdev/pci_dev_config/vdev data structures, and implement VF device creation.

Yuan Liu (6):
  hv: refine init_vdev_pt function
  hv: implement SRIOV VF_BAR initialization
  hv: refine init_pdev function
  hv: refine init_one_dev_config
  hv: refine vpci_init_vdev function
  hv: initialize SRIOV VF device

 hypervisor/arch/x86/configs/pci_dev.c | 15 +++++--
 hypervisor/dm/vpci/pci_pt.c           | 85 ++++++++++++++++++++++++++++-------
 hypervisor/dm/vpci/vpci.c             | 22 +++++++--
 hypervisor/dm/vpci/vpci_priv.h        |  5 ++-
 hypervisor/dm/vpci/vsriov.c           | 60 ++++++++++++++++++++++---
 hypervisor/hw/pci.c                   | 19 ++++++--
 hypervisor/include/arch/x86/pci_dev.h |  2 +-
 hypervisor/include/dm/vpci.h          | 10 +++++
 hypervisor/include/hw/pci.h           |  2 +
 9 files changed, 185 insertions(+), 35 deletions(-)

Tracked-On: #4433

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>