### PR TITLE
hv: Variable/macro renaming for handling PT dev interrupts using IOAPIC/PIC

### DIFF
--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1073,7 +1073,7 @@ static void get_entry_info(const struct ptirq_remapping_info *entry, char *type,
 			uint32_t phys_irq = entry->allocated_pirq;
 			union ioapic_rte rte;
 
-			if (entry->virt_sid.intx_id.src == PTDEV_VPIN_IOAPIC) {
+			if (entry->virt_sid.intx_id.ctlr == INTX_CTLR_IOAPIC) {
 				(void)strncpy_s(type, 16U, "IOAPIC", 16U);
 			} else {
 				(void)strncpy_s(type, 16U, "PIC", 16U);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -333,7 +333,7 @@ static void vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr, 
 			if ((new.bits.intr_mask == IOAPIC_RTE_MASK_CLR) || (last.bits.intr_mask  == IOAPIC_RTE_MASK_CLR)) {
 				/* VM enable intr */
 				/* NOTE: only support max 256 pin */
-				(void)ptirq_intx_pin_remap(vioapic->vm, pin, PTDEV_VPIN_IOAPIC);
+				(void)ptirq_intx_pin_remap(vioapic->vm, pin, INTX_CTLR_IOAPIC);
 			}
 
 			/*
@@ -420,7 +420,7 @@ vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
 			continue;
 		}
 
-		ptirq_intx_ack(vm, pin, PTDEV_VPIN_IOAPIC);
+		ptirq_intx_ack(vm, pin, INTX_CTLR_IOAPIC);
 	}
 
 	/*

--- a/hypervisor/dm/vpic.c
+++ b/hypervisor/dm/vpic.c
@@ -342,7 +342,7 @@ static int32_t vpic_ocw1(const struct acrn_vpic *vpic, struct i8259_reg_state *i
 
 			virt_pin = (master_pic(vpic, i8259)) ?
 					pin : (pin + 8U);
-			(void)ptirq_intx_pin_remap(vpic->vm, virt_pin, PTDEV_VPIN_PIC);
+			(void)ptirq_intx_pin_remap(vpic->vm, virt_pin, INTX_CTLR_PIC);
 		}
 		pin = (pin + 1U) & 0x7U;
 	}
@@ -379,7 +379,7 @@ static int32_t vpic_ocw2(const struct acrn_vpic *vpic, struct i8259_reg_state *i
 		/* if level ack PTDEV */
 		if ((i8259->elc & (1U << (isr_bit & 0x7U))) != 0U) {
 			ptirq_intx_ack(vpic->vm, (master_pic(vpic, i8259) ? isr_bit : isr_bit + 8U),
-					PTDEV_VPIN_PIC);
+					INTX_CTLR_PIC);
 		}
 	} else if (((val & OCW2_SL) != 0U) && i8259->rotate) {
 		/* specific priority */

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -30,14 +30,14 @@
  *
  * @param[in] vm pointer to acrn_vm
  * @param[in] virt_pin virtual pin number associated with the passthrough device
- * @param[in] vpin_src ioapic or pic
+ * @param[in] vpin_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
  *
  * @return None
  *
  * @pre vm != NULL
  *
  */
-void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
+void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, enum intx_ctlr vpin_ctlr);
 
 /**
  * @brief MSI/MSI-x remapping for passthrough device.
@@ -73,7 +73,7 @@ int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_
  *
  * @param[in] vm pointer to acrn_vm
  * @param[in] virt_pin virtual pin number associated with the passthrough device
- * @param[in] vpin_src ioapic or pic
+ * @param[in] vpin_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
  *
  * @return
  *    - 0: on success
@@ -84,7 +84,7 @@ int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_
  * @pre vm != NULL
  *
  */
-int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, uint32_t vpin_src);
+int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, enum intx_ctlr vpin_ctlr);
 
 /**
  * @brief Add an interrupt remapping entry for INTx as pre-hold mapping.

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -10,19 +10,22 @@
 #include <spinlock.h>
 #include <timer.h>
 
+
+enum intx_ctlr {
+	INTX_CTLR_IOAPIC	= 0U,
+	INTX_CTLR_PIC
+};
+
 #define PTDEV_INTR_MSI		(1U << 0U)
 #define PTDEV_INTR_INTX		(1U << 1U)
 
 #define INVALID_PTDEV_ENTRY_ID 0xffffU
 
-#define PTDEV_VPIN_IOAPIC	0x0U
-#define	PTDEV_VPIN_PIC		0x1U
-
 #define DEFINE_MSI_SID(name, a, b)	\
 union source_id (name) = {.msi_id = {.bdf = (a), .entry_nr = (b)} }
 
-#define DEFINE_IOAPIC_SID(name, a, b)	\
-union source_id (name) = {.intx_id = {.pin = (a), .src = (b)} }
+#define DEFINE_INTX_SID(name, a, b)	\
+union source_id (name) = {.intx_id = {.pin = (a), .ctlr = (b)} }
 
 union irte_index {
 	uint16_t index;
@@ -32,6 +35,7 @@ union irte_index {
 	} bits __packed;
 };
 
+
 union source_id {
 	uint64_t value;
 	struct {
@@ -39,9 +43,13 @@ union source_id {
 		uint16_t entry_nr;
 		uint32_t reserved;
 	} msi_id;
+	/*
+	 * ctlr indicates if the source of interrupt is IO-APIC or PIC
+	 * pin indicates the pin number of interrupt controller determined by ctlr
+	 */
 	struct {
+		enum intx_ctlr ctlr;
 		uint32_t pin;
-		uint32_t src;
 	} intx_id;
 };
 


### PR DESCRIPTION

1. Renames DEFINE_IOAPIC_SID with DEFINE_INTX_SID as the virtual interrupt controller can
   be IOAPIC or PIC
2. Rename the src member of source_id.intx_id to ctlr to indicate interrupt
   controller
2. Changes the type of src member of source_id.intx_id from uint32_t to
   enum with INTX_CTLR_IOAPIC and INTX_CTLR_PIC

Tracked-On: #4447
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>