### PR TITLE
hv: enable 32bit relocation which is needed for multiboot2

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -39,6 +39,7 @@ endchoice
 
 config MULTIBOOT2
 	bool "Multiboot2 support"
+	depends on RELOC
 	default n
 	help
 	  Support boot ACRN from multiboot2 protocol. Multiboot2 support is needed for

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -122,9 +122,18 @@ mb2_header_end:
 
     .global     cpu_primary_start_32
 cpu_primary_start_32:
+
+  /*
+   * Calculate the relocation delta between where we were compiled to run
+   * at and where we were actually loaded at.
+   */
+    call    0f
+0:  pop     %esi
+    sub     $0b, %esi
+
     /* save the MULTBOOT magic number & MBI */
-    movl    %eax, (boot_regs)
-    movl    %ebx, (boot_regs+4)
+    movl    %eax, boot_regs(%esi)
+    movl    %ebx, (boot_regs+4)(%esi)
 
     /* Disable interrupts */
     cli
@@ -156,8 +165,16 @@ cpu_primary_start_32:
     movl    $0x00000668, %eax
     mov     %eax, %cr4
 
+    /* fixup page table pointers with relocation delta */
+    addl    %esi, cpu_primary32_pdpt_addr(%esi)
+    addl    %esi, (cpu_primary32_pdpt_addr+8)(%esi)
+    addl    %esi, (cpu_primary32_pdpt_addr+16)(%esi)
+    addl    %esi, (cpu_primary32_pdpt_addr+24)(%esi)
+
     /* Set CR3 to PML4 table address */
     movl    $cpu_boot32_page_tables_start, %edi
+    addl    %esi, %edi
+    addl    %esi, (%edi)
     mov     %edi, %cr3
 
     /* Set LME bit in EFER */
@@ -178,11 +195,20 @@ cpu_primary_start_32:
 
     /* Load temportary GDT pointer value */
     mov     $cpu_primary32_gdt_ptr, %ebx
+    addl    %esi, %ebx
+    addl    %esi, 2(%ebx)
     lgdt    (%ebx)
 
     /* Perform a long jump based to start executing in 64-bit mode */
+    movl    $jmpbuf_32, %eax
+    addl    %esi, %eax
+    addl    %esi, (%eax)
+    ljmp    *(%eax)
+
+jmpbuf_32:
+    .long   primary_start_long_mode
     /* 0x0008 = HOST_GDT_RING0_CODE_SEL */
-    ljmp    $0x0008, $primary_start_long_mode
+    .word 0x0008
 
     .code64
     .org 0x200
@@ -212,17 +238,22 @@ primary_start_long_mode:
      */
     call relocate
 
+    call    0f
+0:  pop     %rsi
+    sub     $0b, %rsi    /* relocation delta */
+
     /* Load temportary GDT pointer value */
-    lea     cpu_primary32_gdt_ptr(%rip), %rbx
+    lea     cpu_primary64_gdt_ptr(%rip), %rbx
+    addq    %rsi, 2(%rbx)
     lgdt    (%ebx)
 
     /* Set the correct long jump address */
-    lea     jmpbuf(%rip), %rax
+    lea     jmpbuf_64(%rip), %rax
     lea     after(%rip), %rbx
     mov     %rbx, (%rax)
     rex.w ljmp  *(%rax)
 .data
-jmpbuf: .quad 0
+jmpbuf_64: .quad 0
 	/* 0x0008 = HOST_GDT_RING0_CODE_SEL */
         .word 0x0008
 .text
@@ -258,6 +289,10 @@ cpu_primary32_gdt_end:
 /* GDT pointer */
     .align  2
 cpu_primary32_gdt_ptr:
+    .short  (cpu_primary32_gdt_end - cpu_primary32_gdt) - 1
+    .quad   cpu_primary32_gdt
+
+cpu_primary64_gdt_ptr:
     .short  (cpu_primary32_gdt_end - cpu_primary32_gdt) - 1
     .quad   cpu_primary32_gdt
 

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -84,9 +84,6 @@ cpu_primary_start_32:
     movl    %eax, (boot_regs)
     movl    %ebx, (boot_regs+4)
 
-    /* Save boot context from 32bit mode */
-    call cpu_primary_save_32
-
     /* Disable interrupts */
     cli
 

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -115,8 +115,14 @@ relocatable_tag_end:
 mb2_header_end:
 #endif
 
+    /*
+     * The page tables are aligned to 4KB, which implicitly aligns this section at
+     * 4KB boundary. Put an extra .align here to explicitly state that regardless
+     * the actual length of the multiboot header section, this section will be linked
+     * at offset 0x1000 to the beginning of the target executable.
+     */
+    .align      0x1000
     .section    entry, "ax"
-
     .align      8
     .code32
 
@@ -210,8 +216,13 @@ jmpbuf_32:
     /* 0x0008 = HOST_GDT_RING0_CODE_SEL */
     .word 0x0008
 
-    .code64
+    /*
+     * Offset from the beginning of the entry section.
+     * This is to make sure that cpu_primary_start_64 is linked to a known address
+     * so that efi-stub knows where to pass control to hypervisor.
+     */
     .org 0x200
+    .code64
     .global     cpu_primary_start_64
 cpu_primary_start_64:
     /* save the MULTBOOT magic number & MBI */
@@ -252,11 +263,10 @@ primary_start_long_mode:
     lea     after(%rip), %rbx
     mov     %rbx, (%rax)
     rex.w ljmp  *(%rax)
-.data
 jmpbuf_64: .quad 0
 	/* 0x0008 = HOST_GDT_RING0_CODE_SEL */
         .word 0x0008
-.text
+
 after:
     /* 0x10 = HOST_GDT_RING0_DATA_SEL*/
     movl    $0x10,%eax

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -56,16 +56,57 @@ mb2_header_start:
 
     /* please be aware that each tag should be 8 bytes aligned */
     .align     MULTIBOOT2_TAG_ALIGN
+    /*
+     * Request infomation from boot loader, which is supposed to provide th relevant information
+     * specified in the following tags to the image through the MBI if it is available
+     */
 info_req_tag_start:
     .short  MULTIBOOT2_HEADER_TAG_INFORMATION_REQUEST
     .short  0
     .long   info_req_tag_end - info_req_tag_start
-    .long   MULTIBOOT2_TAG_TYPE_MMAP
-    .long   MULTIBOOT2_TAG_TYPE_MODULE
-    .long   MULTIBOOT2_TAG_TYPE_ACPI_NEW
-    .long   MULTIBOOT2_TAG_TYPE_EFI64
-    .long   MULTIBOOT2_TAG_TYPE_EFI_MMAP
+    .long   MULTIBOOT2_TAG_TYPE_MMAP        /* memory map */
+    .long   MULTIBOOT2_TAG_TYPE_MODULE      /* boot modules infomation */
+    .long   MULTIBOOT2_TAG_TYPE_ACPI_NEW    /* a copy of RSDP as defined per ACPI 2.0 or later specification */
+    .long   MULTIBOOT2_TAG_TYPE_EFI64       /* EFI system table, to be passed to guest Linux  */
+    .long   MULTIBOOT2_TAG_TYPE_EFI_MMAP    /* EFI memory map, to be passed to guest Linux */
 info_req_tag_end:
+
+    .align  MULTIBOOT2_TAG_ALIGN
+address_tag_start:
+    .short  MULTIBOOT2_HEADER_TAG_ADDRESS
+    .short  0
+    .long   address_tag_end - address_tag_start
+    .long   mb2_header_start  /* address corresponding to the beginning of the Multiboot2 header */
+    .long   -1  /* load_addr: the file to be loaded from its beginning */
+    /*
+     * load_end_addr: this includes .bss so that boot loader could reserve the
+     * memory that .bss occupies to avoid placing boot modules or other data in that area.
+     *
+     * However, the boot loader is supposed not to actually load the .bss section because
+     * it's beyond the scope of acrn.bin
+     */
+    .long   _ld_ram_end
+    .long   0   /* bss_end_addr, don't ask boot loader to clear .bss */
+address_tag_end:
+
+    .align  MULTIBOOT2_TAG_ALIGN
+entry_address_tag_start:
+    .short  MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS
+    .short  0
+    .long   entry_address_tag_end - entry_address_tag_start
+    .long   cpu_primary_start_32  /* The address to which the boot loader should jump to start hypervisor */
+entry_address_tag_end:
+
+    .align  MULTIBOOT2_TAG_ALIGN
+relocatable_tag_start:
+    .short  MULTIBOOT2_HEADER_TAG_RELOCATABLE
+    .short  0
+    .long   relocatable_tag_end - relocatable_tag_start
+    .long   0x10000000   /* min_addr. TODO: change it to 2MB after fixing the load_addr issue */
+    .long   0x80000000   /* max_addr */
+    .long   0x200000     /* image alignment */
+    .long   1            /* preference: lowest possible address */
+relocatable_tag_end:
 
     .align     MULTIBOOT2_TAG_ALIGN
     .short  MULTIBOOT2_HEADER_TAG_END
@@ -73,6 +114,7 @@ info_req_tag_end:
     .long   8
 mb2_header_end:
 #endif
+
     .section    entry, "ax"
 
     .align      8

--- a/hypervisor/arch/x86/boot/cpu_save_boot_ctx.S
+++ b/hypervisor/arch/x86/boot/cpu_save_boot_ctx.S
@@ -8,43 +8,6 @@
 
     .section    entry, "ax"
     .align      8
-    .code32
-
-    .global     cpu_primary_save_32
-cpu_primary_save_32:
-    /* save context from 32bit mode */
-    lea     boot_context, %eax
-    sgdt    BOOT_CTX_GDT_OFFSET(%eax)
-    sidt    BOOT_CTX_IDT_OFFSET(%eax)
-    str     BOOT_CTX_TR_SEL_OFFSET(%eax)
-    sldt    BOOT_CTX_LDT_SEL_OFFSET(%eax)
-    movl    %cr0, %ecx
-    movl    %ecx, BOOT_CTX_CR0_OFFSET(%eax)
-    movl    %cr3, %ecx
-    movl    %ecx, BOOT_CTX_CR3_OFFSET(%eax)
-    movl    %cr4, %ecx
-    movl    %ecx, BOOT_CTX_CR4_OFFSET(%eax)
-    mov     %cs, %cx
-    mov     %cx,  BOOT_CTX_CS_SEL_OFFSET(%eax)
-    lar     %ecx, %ecx
-    /* CS AR start from bit 8 */
-    shr     $8, %ecx
-    /* Clear Limit field, bit 8-11 */
-    andl    $0x0000f0ff, %ecx
-    mov     %ecx, BOOT_CTX_CS_AR_OFFSET(%eax)
-
-    /* Save CS limit field */
-    mov     %cs, %cx
-    xor     %edx, %edx
-    lsl     %ecx, %edx
-    mov     %edx, BOOT_CTX_CS_LIMIT_OFFSET(%eax)
-
-    mov     %es,  BOOT_CTX_ES_SEL_OFFSET(%eax)
-    mov     %ss,  BOOT_CTX_SS_SEL_OFFSET(%eax)
-    mov     %ds,  BOOT_CTX_DS_SEL_OFFSET(%eax)
-    mov     %fs,  BOOT_CTX_FS_SEL_OFFSET(%eax)
-    mov     %gs,  BOOT_CTX_GS_SEL_OFFSET(%eax)
-    ret
 
     .code64
     .global     cpu_primary_save_64

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -53,7 +53,16 @@ static inline bool boot_from_multiboot1(void)
 #ifdef CONFIG_MULTIBOOT2
 static inline bool boot_from_multiboot2(void)
 {
-	return ((boot_regs[0] == MULTIBOOT2_INFO_MAGIC) && (boot_regs[1] != 0U));
+	/*
+	 * Multiboot spec states that the Multiboot information structure may be placed
+	 * anywhere in memory by the boot loader.
+	 *
+	 * Seems both SBL and GRUB won't place multiboot1 MBI structure at 0 address,
+	 * but GRUB could place Multiboot2 MBI structure at 0 address until commit
+	 * 0f3f5b7c13fa9b67 ("multiboot2: Set min address for mbi allocation to 0x1000")
+	 * which dates on Dec 26 2019.
+	 */
+	return (boot_regs[0] == MULTIBOOT2_INFO_MAGIC);
 }
 
 int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info);

--- a/hypervisor/boot/include/reloc.h
+++ b/hypervisor/boot/include/reloc.h
@@ -13,7 +13,4 @@ extern uint64_t get_hv_image_base(void);
 /* external symbols that are helpful for relocation */
 extern uint8_t		_DYNAMIC[1];
 
-extern uint8_t		cpu_primary_start_32;
-extern uint8_t		cpu_primary_start_64;
-
 #endif /* RELOCATE_H */

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -20,6 +20,7 @@ SECTIONS
     .entry :
     {
         KEEP(*(entry)) ;
+	ld_entry_end = . ;
 
     } > ram
 

--- a/hypervisor/include/arch/x86/boot/ld_sym.h
+++ b/hypervisor/include/arch/x86/boot/ld_sym.h
@@ -10,6 +10,7 @@
 extern uint8_t		ld_text_end;
 extern uint8_t		ld_bss_start;
 extern uint8_t		ld_bss_end;
+extern uint8_t		ld_entry_end;
 extern const uint8_t	ld_trampoline_load;
 extern uint8_t		ld_trampoline_start;
 extern uint8_t		ld_trampoline_end;

--- a/misc/efi-stub/boot.c
+++ b/misc/efi-stub/boot.c
@@ -94,14 +94,10 @@ static inline void hv_jump(EFI_PHYSICAL_ADDRESS hv_start,
 
 	efi_ctx->vcpu_regs.rip = (uint64_t)&guest_entry;
 
-	/* The 64-bit entry of acrn hypervisor is 0x200 from the start
-	 * address of hv image. But due to there is multiboot header,
-	 * so it has to be added with 0x10.
-	 *
-	 * FIXME: The hardcode value 0x210 should be worked out
-	 * from the link address of cpu_primary_start_64 in acrn.out
+	/* The 64-bit entry of acrn hypervisor is 0x1200 from the start
+	 * address of hv image.
 	 */
-	hf = (hv_func)(hv_start + 0x210);
+	hf = (hv_func)(hv_start + 0x1200);
 
 	asm volatile ("cli");
 


### PR DESCRIPTION
- add multiboot2 tags to enable boot loader to relocate hypervisor image
- manually fixup relocation delta in code32
- change some existing fixup in code64 so it won't double fixup.
- update the 64-bit entry address to efi-stub