### PR TITLE
hv: pci: add some pre-assumption for PCIe ECAM

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -160,7 +160,10 @@ void init_pcpu_pre(bool is_bsp)
 		}
 #endif
 
-		/* NOTE: this must call after MMCONFIG is parsed in init_vboot and before APs are INIT. */
+		/* NOTE: this must call after MMCONFIG is parsed in init_vboot and before APs are INIT.
+		 * We only support platform with MMIO based CFG space access.
+		 * IO port access only support in debug version.
+		 */
 		pci_switch_to_mmio_cfg_ops();
 	} else {
 		/* Switch this CPU to use the same page tables set-up by the

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -129,18 +129,34 @@ void pci_switch_to_mmio_cfg_ops(void)
 
 /*
  * @pre bytes == 1U || bytes == 2U || bytes == 4U
+ * @pre must not be called before pci_switch_to_mmio_cfg_ops in release version.
  */
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes)
 {
-	return acrn_pci_cfg_ops->pci_read_cfg(bdf, offset, bytes);
+	uint32_t val = ~0U;
+
+	/* The pci_read_cfg would not be empty unless be called before
+	 * pci_switch_to_mmio_cfg_ops in release version.
+	 */
+	if (acrn_pci_cfg_ops->pci_read_cfg != NULL) {
+		val = acrn_pci_cfg_ops->pci_read_cfg(bdf, offset, bytes);
+	}
+
+	return val;
 }
 
 /*
  * @pre bytes == 1U || bytes == 2U || bytes == 4U
+ * @pre must not be called before pci_switch_to_mmio_cfg_ops in release version.
  */
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val)
 {
-	acrn_pci_cfg_ops->pci_write_cfg(bdf, offset, bytes, val);
+	/* The pci_write_cfg would not be empty unless be called before
+	 * pci_switch_to_mmio_cfg_ops in release version.
+	 */
+	if (acrn_pci_cfg_ops->pci_write_cfg != NULL) {
+		acrn_pci_cfg_ops->pci_write_cfg(bdf, offset, bytes, val);
+	}
 }
 
 bool pdev_need_bar_restore(const struct pci_pdev *pdev)


### PR DESCRIPTION
Add some pre-assumption for PCIe ECAM:
1) ACRN only support platforms with PCIe ECAM to access PCIe device CFG space;
2) Must not use ECAM to access PCIe device CFG space before
pci_switch_to_mmio_cfg_ops was called. (In release version, ACRN didn't support
IO port Mechanism. ECAM is the only way to access the PCIe device CFG space).

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>