### PR TITLE
hv: refine read/write configuration APIs for vmsi/vmsix

### DIFF
--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -98,7 +98,7 @@ static void remap_vmsi(const struct pci_vdev *vdev)
 /**
  * @pre vdev != NULL
  */
-void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+void read_vmsi_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* For PIO access, we emulate Capability Structures only */
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
@@ -109,7 +109,7 @@ void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
  *
  * @pre vdev != NULL
  */
-void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	uint32_t msgctrl;
 

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -113,7 +113,7 @@ static void remap_one_vmsix_entry(const struct pci_vdev *vdev, uint32_t index)
 /**
  * @pre vdev != NULL
  */
-void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
+void read_vmsix_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* For PIO access, we emulate Capability Structures only */
 	*val = pci_vdev_read_cfg(vdev, offset, bytes);
@@ -125,7 +125,7 @@ void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes
  * @pre vdev != NULL
  * @pre vdev->pdev != NULL
  */
-void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+void write_vmsix_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
 {
 	uint32_t old_msgctrl, msgctrl;
 

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -379,9 +379,9 @@ static int32_t vpci_write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 			vdev_pt_write_vbar(vdev, pci_bar_index(offset), val);
 		}
 	} else if (msicap_access(vdev, offset)) {
-		vmsi_write_cfg(vdev, offset, bytes, val);
+		write_vmsi_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		vmsix_write_cfg(vdev, offset, bytes, val);
+		write_vmsix_cfg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {
 		write_sriov_cap_reg(vdev, offset, bytes, val);
 	} else if (offset == PCIR_COMMAND) {
@@ -410,9 +410,9 @@ static int32_t vpci_read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset
 			*val = ~0U;
 		}
 	} else if (msicap_access(vdev, offset)) {
-		vmsi_read_cfg(vdev, offset, bytes, val);
+		read_vmsi_cfg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		vmsix_read_cfg(vdev, offset, bytes, val);
+		read_vmsix_cfg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {
 		read_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -146,14 +146,14 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
 void vdev_pt_write_command(const struct pci_vdev *vdev, uint32_t bytes, uint16_t new_cmd);
 
 void init_vmsi(struct pci_vdev *vdev);
-void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void read_vmsi_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_private_data);
-void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void read_vmsix_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void write_vmsix_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(const struct pci_vdev *vdev);
 
 void init_vsriov(struct pci_vdev *vdev);


### PR DESCRIPTION
change vmsi_read_cfg to read_vmsi_cfg, same applies to writing
change vmsix_read_cfg to read_vmsix_cfg, same applies to writing

Tracked-On: #4433

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>