### PR TITLE
dm: don't deassign pass through PCIe device in DM

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -686,7 +686,8 @@ vm_loop(struct vmctx *ctx)
 			break;
 		}
 
-		if (VM_SUSPEND_SYSTEM_RESET == vm_get_suspend_mode()) {
+		/* RTVM can't be reset */
+		if ((VM_SUSPEND_SYSTEM_RESET == vm_get_suspend_mode()) && (!is_rtvm)) {
 			vm_system_reset(ctx);
 		}
 

--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -45,6 +45,7 @@
 #include "pciio.h"
 #include "pci_core.h"
 #include "acpi.h"
+#include "dm.h"
 
 
 /* Some audio drivers get topology data from ACPI NHLT table.
@@ -558,7 +559,13 @@ passthru_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	pcidev.phys_bdf = ptdev->phys_bdf;
 	pciaccess_cleanup();
 	free(ptdev);
-	vm_deassign_pcidev(ctx, &pcidev);
+
+	if (!is_rtvm) {
+		/* Let the HV to deassign the pt device for RTVM, In this case, the RTVM
+		 * could still be alive if DM died.
+		 */
+		vm_deassign_pcidev(ctx, &pcidev);
+	}
 }
 
 /* bind pin info for pass-through device */


### PR DESCRIPTION
Let the ACRN HV to do this in shutdown sequence. In this case, the RTVM could be
still alive if something wrong happened to cause the DM died.

Tracked-On: #4428
Signed-off-by: Li Fei1 <fei1.li@intel.com>