### PR TITLE
doc: fix a missing argument in the function description

### DIFF
--- a/doc/developer-guides/hld/hv-dev-passthrough.rst
+++ b/doc/developer-guides/hld/hv-dev-passthrough.rst
@@ -141,7 +141,7 @@ interrupt to virtual interrupt or vice versa. The term VT-d interrupt-remapping
 remaps the interrupt index in the VT-d interrupt-remapping table to the physical
 interrupt vector after checking the external interrupt request is valid. Translation
 physical vector to virtual vector is still needed to be done by hypervisor, which is
-also described in the below section :ref:`_interrupt-remapping`.
+also described in the below section :ref:`interrupt-remapping`.
 
 MMIO Remapping
 **************

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -210,7 +210,7 @@ struct ptirq_remapping_info *ptirq_dequeue_softirq(uint16_t pcpu_id);
  * Appropriate number should be configured on different platforms.
  *
  * @param[in]    vm acrn_vm that the entry allocated for.
- * @param[in]    interrupt type: PTDEV_INTR_MSI or PTDEV_INTR_INTX
+ * @param[in]    intr_type interrupt type: PTDEV_INTR_MSI or PTDEV_INTR_INTX
  *
  * @retval NULL when \p the number of entries allocated is CONFIG_MAX_PT_IRQ_ENTRIES
  * @retval !NULL when \p the number of entries allocated is less than CONFIG_MAX_PT_IRQ_ENTRIES


### PR DESCRIPTION
One argument is missing for the function ptirq_alloc_entry.
This patch fixes the doc generation error.

Tracked-On: #3882
Signed-off-by: Binbin Wu <binbin.wu@intel.com>