### PR TITLE
hv: add static check for CONFIG_HV_RAM_START and CONFIG_HV_RAM_SIZE

### DIFF
--- a/hypervisor/pre_build/static_checks.c
+++ b/hypervisor/pre_build/static_checks.c
@@ -8,6 +8,7 @@
 #include <boot_context.h>
 #include <acrn_common.h>
 #include <vcpu.h>
+#include <mmu.h>
 #include <trusty.h>
 
 #define CAT__(A,B) A ## B
@@ -18,6 +19,14 @@ typedef int32_t CAT_(CTA_DummyType,__LINE__)[(expr) ? 1 : -1]
 /* This is to make sure the 16 bits vpid won't overflow */
 #if ((CONFIG_MAX_VM_NUM * MAX_VCPUS_PER_VM) > 0xffffU)
 #error "VM number or VCPU number are too big"
+#endif
+
+#if ((CONFIG_HV_RAM_START & (MEM_2M - 1UL)) != 0UL)
+#error "CONFIG_HV_RAM_START must be aligned to 2MB"
+#endif
+
+#if ((CONFIG_HV_RAM_SIZE & (MEM_2M - 1UL)) != 0UL)
+#error "CONFIG_HV_RAM_SIZE must be integral multiple of 2MB"
 #endif
 
 /* Build time sanity checks to make sure hard-coded offset


### PR DESCRIPTION
Hypervisor uses 2MB large page, and if either CONFIG_HV_RAM_START or
CONFIG_HV_RAM_SIZE is not aligned to 2MB, ACRN won't boot. Add static check
to avoid unexpected boot failures.

If CONFIG_RELOC is enabled, CONFIG_HV_RAM_START is not directly referred
by the code, but it causes problems because ld_text_end could be relocated
to an address that is not 2MB aligned which fails mmu_modify_or_del().

Tracked-On: #4441
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>
Signed-off-by: Zide Chen <zide.chen@intel.com>