### PR TITLE
hv: vpci: add a global CFG header configuration access handler

### DIFF
--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -104,6 +104,14 @@ static inline bool vbar_access(const struct pci_vdev *vdev, uint32_t offset)
 /**
  * @pre vdev != NULL
  */
+static inline bool cfg_header_access(uint32_t offset)
+{
+	return (offset < PCI_CFG_HEADER_LENGTH);
+}
+
+/**
+ * @pre vdev != NULL
+ */
 static inline bool has_msi_cap(const struct pci_vdev *vdev)
 {
 	return (vdev->msi.capoff != 0U);
@@ -119,7 +127,6 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 
 void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev);
 void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
-void vdev_pt_write_command(const struct pci_vdev *vdev, uint32_t bytes, uint16_t new_cmd);
 
 void init_vmsi(struct pci_vdev *vdev);
 void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -43,6 +43,8 @@
  * PCIZ_xxx: extended capability identification number
  */
 
+#define PCI_CFG_HEADER_LENGTH 0x40U
+
 /* some PCI bus constants */
 #define PCI_BUSMAX            0xFFU
 #define PCI_SLOTMAX           0x1FU


### PR DESCRIPTION
v5:
refine comments and fix MISRA-C violation.

v4:
Add cfg_header_read_cfg and cfg_header_write_cfg to handle the 1st 64B
CFG Space header PCI configuration space.
Only Command and Status Registers are pass through;
Only Command and Status Registers and Base Address Registers are writable.
In order to implement this, we add two type bit mask for per 4B register:
pass through mask and read-only mask. When pass through bit mask is set, this
means this bit of this 4B register is pass through, otherwise, it is virtualized;
When read-only mask is set, this means this bit of this 4B register is read-only,
otherwise, it's writable. We should write it to physical CFG space or virtual
CFG space base on whether the pass through bit mask is set or not.

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>