### PR TITLE
hv: mmu: minor fix about add_pte

### DIFF
--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -264,12 +264,12 @@ static void add_pte(const uint64_t *pde, uint64_t paddr_start, uint64_t vaddr_st
 			pr_fatal("%s, pte 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			set_pgentry(pte, paddr | prot, mem_ops);
-			paddr += PTE_SIZE;
-			vaddr += PTE_SIZE;
+		}
+		paddr += PTE_SIZE;
+		vaddr += PTE_SIZE;
 
-			if (vaddr >= vaddr_end) {
-				break;	/* done */
-			}
+		if (vaddr >= vaddr_end) {
+			break;	/* done */
 		}
 	}
 }


### PR DESCRIPTION
In Commit 127c73c3, we remove the strict check for adding page table mapping. However,
we just replace the ASSERT of pr_fatal in add_pte. This is not enough. We still add
the virtual address by 4K if the page table mapping is exist and check the virtual
address is over the virtual address region for this mapping. Otherwise, The complain
will continue for 512 times at most.

Now On APL UP2, the SOS will re-program the PCI BAR for some Intel Corporation Sunrise Point-LP PCI Express Root Port. There're too many compalin like "add_pte, pte 0xXXXXXXXX is already present!"

Tracked-On: #3475
Signed-off-by: Li Fei1 <fei1.li@intel.com>