### PR TITLE
hv: Refine code for API reduction

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -170,7 +170,7 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
 			pci_vdev_write_bar(vdev, idx, val);
 			vdev_pt_allow_io_vbar(vdev, update_idx);
 		} else {
-			pci_vdev_write_cfg_u32(vdev, offset, val);
+			pci_vdev_write_cfg(vdev, offset, 4U, val);
 			vdev->vbars[update_idx].base = 0UL;
 		}
 		break;
@@ -188,7 +188,7 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
 			pci_vdev_write_bar(vdev, idx, val);
 			vdev_pt_map_mem_vbar(vdev, update_idx);
 		} else {
-			pci_vdev_write_cfg_u32(vdev, offset, val);
+			pci_vdev_write_cfg(vdev, offset, 4U, val);
 			vdev->vbars[update_idx].base = 0UL;
 		}
 		break;

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -61,13 +61,13 @@ void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 {
 	switch (bytes) {
 	case 1U:
-		pci_vdev_write_cfg_u8(vdev, offset, (uint8_t)val);
+		vdev->cfgdata.data_8[offset] = (uint8_t)val;
 		break;
 	case 2U:
-		pci_vdev_write_cfg_u16(vdev, offset, (uint16_t)val);
+		vdev->cfgdata.data_16[offset >> 1U] = (uint16_t)val;
 		break;
 	default:
-		pci_vdev_write_cfg_u32(vdev, offset, val);
+		vdev->cfgdata.data_32[offset >> 2U] = val;
 		break;
 	}
 }
@@ -157,7 +157,7 @@ void pci_vdev_write_bar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
 	bar = val & vbar->mask;
 	bar |= vbar->fixed;
 	offset = pci_bar_offset(idx);
-	pci_vdev_write_cfg_u32(vdev, offset, bar);
+	pci_vdev_write_cfg(vdev, offset, 4U, bar);
 
 	if (vbar->type == PCIBAR_MEM64HI) {
 		update_idx -= 1U;

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -47,46 +47,45 @@
 static void init_vhostbridge(struct pci_vdev *vdev)
 {
 	/* PCI config space */
-	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
-	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x5af0U);
+	pci_vdev_write_cfg(vdev, PCIR_VENDOR, 2U, 0x8086U);
+	pci_vdev_write_cfg(vdev, PCIR_DEVICE, 2U, 0x5af0U);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xbU);
+	pci_vdev_write_cfg(vdev, PCIR_REVID, 1U, 0xbU);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)PCIM_HDRTYPE_NORMAL
-			| PCIM_MFDEV);
-	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
-	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_HOST);
+	pci_vdev_write_cfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_NORMAL | PCIM_MFDEV));
+	pci_vdev_write_cfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
+	pci_vdev_write_cfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_HOST);
 
-	pci_vdev_write_cfg_u8(vdev, 0x34U, (uint8_t)0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0x3cU, (uint8_t)0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0x48U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0x4aU, (uint8_t)0xd1U);
-	pci_vdev_write_cfg_u8(vdev, 0x4bU, (uint8_t)0xfeU);
-	pci_vdev_write_cfg_u8(vdev, 0x50U, (uint8_t)0xc1U);
-	pci_vdev_write_cfg_u8(vdev, 0x51U, (uint8_t)0x2U);
-	pci_vdev_write_cfg_u8(vdev, 0x54U, (uint8_t)0x33U);
-	pci_vdev_write_cfg_u8(vdev, 0x58U, (uint8_t)0x7U);
-	pci_vdev_write_cfg_u8(vdev, 0x5aU, (uint8_t)0xf0U);
-	pci_vdev_write_cfg_u8(vdev, 0x5bU, (uint8_t)0x7fU);
-	pci_vdev_write_cfg_u8(vdev, 0x60U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0x63U, (uint8_t)0xe0U);
-	pci_vdev_write_cfg_u8(vdev, 0xabU, (uint8_t)0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xacU, (uint8_t)0x2U);
-	pci_vdev_write_cfg_u8(vdev, 0xb0U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xb3U, (uint8_t)0x7cU);
-	pci_vdev_write_cfg_u8(vdev, 0xb4U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xb6U, (uint8_t)0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xb7U, (uint8_t)0x7bU);
-	pci_vdev_write_cfg_u8(vdev, 0xb8U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xbbU, (uint8_t)0x7bU);
-	pci_vdev_write_cfg_u8(vdev, 0xbcU, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xbfU, (uint8_t)0x80U);
-	pci_vdev_write_cfg_u8(vdev, 0xe0U, (uint8_t)0x9U);
-	pci_vdev_write_cfg_u8(vdev, 0xe2U, (uint8_t)0xcU);
-	pci_vdev_write_cfg_u8(vdev, 0xe3U, (uint8_t)0x1U);
-	pci_vdev_write_cfg_u8(vdev, 0xf5U, (uint8_t)0xfU);
-	pci_vdev_write_cfg_u8(vdev, 0xf6U, (uint8_t)0x1cU);
-	pci_vdev_write_cfg_u8(vdev, 0xf7U, (uint8_t)0x1U);
+	pci_vdev_write_cfg(vdev, 0x34U, 1U, 0xe0U);
+	pci_vdev_write_cfg(vdev, 0x3cU, 1U, 0xe0U);
+	pci_vdev_write_cfg(vdev, 0x48U, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0x4aU, 1U, 0xd1U);
+	pci_vdev_write_cfg(vdev, 0x4bU, 1U, 0xfeU);
+	pci_vdev_write_cfg(vdev, 0x50U, 1U, 0xc1U);
+	pci_vdev_write_cfg(vdev, 0x51U, 1U, 0x2U);
+	pci_vdev_write_cfg(vdev, 0x54U, 1U, 0x33U);
+	pci_vdev_write_cfg(vdev, 0x58U, 1U, 0x7U);
+	pci_vdev_write_cfg(vdev, 0x5aU, 1U, 0xf0U);
+	pci_vdev_write_cfg(vdev, 0x5bU, 1U, 0x7fU);
+	pci_vdev_write_cfg(vdev, 0x60U, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0x63U, 1U, 0xe0U);
+	pci_vdev_write_cfg(vdev, 0xabU, 1U, 0x80U);
+	pci_vdev_write_cfg(vdev, 0xacU, 1U, 0x2U);
+	pci_vdev_write_cfg(vdev, 0xb0U, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0xb3U, 1U, 0x7cU);
+	pci_vdev_write_cfg(vdev, 0xb4U, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0xb6U, 1U, 0x80U);
+	pci_vdev_write_cfg(vdev, 0xb7U, 1U, 0x7bU);
+	pci_vdev_write_cfg(vdev, 0xb8U, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0xbbU, 1U, 0x7bU);
+	pci_vdev_write_cfg(vdev, 0xbcU, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0xbfU, 1U, 0x80U);
+	pci_vdev_write_cfg(vdev, 0xe0U, 1U, 0x9U);
+	pci_vdev_write_cfg(vdev, 0xe2U, 1U, 0xcU);
+	pci_vdev_write_cfg(vdev, 0xe3U, 1U, 0x1U);
+	pci_vdev_write_cfg(vdev, 0xf5U, 1U, 0xfU);
+	pci_vdev_write_cfg(vdev, 0xf6U, 1U, 0x1cU);
+	pci_vdev_write_cfg(vdev, 0xf7U, 1U, 0x1U);
 }
 
 static void deinit_vhostbridge(__unused struct pci_vdev *vdev)

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -710,8 +710,8 @@ int32_t vpci_assign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *pc
 
 			spinlock_obtain(&tgt_vm->vpci.lock);
 			vdev = vpci_init_vdev(vpci, vdev_in_sos->pci_dev_config, NULL);
-			pci_vdev_write_cfg_u8(vdev, PCIR_INTERRUPT_LINE, pcidev->intr_line);
-			pci_vdev_write_cfg_u8(vdev, PCIR_INTERRUPT_PIN, pcidev->intr_pin);
+			pci_vdev_write_cfg(vdev, PCIR_INTERRUPT_LINE, 1U, pcidev->intr_line);
+			pci_vdev_write_cfg(vdev, PCIR_INTERRUPT_PIN, 1U, pcidev->intr_pin);
 			for (idx = 0U; idx < vdev->nr_bars; idx++) {
 				pci_vdev_write_bar(vdev, idx, pcidev->bar[idx]);
 			}

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -58,18 +58,18 @@ static void init_vpci_bridge(struct pci_vdev *vdev)
 	/* read PCI config space to virtual space */
 	for (offset = 0x00U; offset < 0x100U; offset += 4U) {
 		val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, 4U);
-		pci_vdev_write_cfg_u32(vdev, offset, val);
+		pci_vdev_write_cfg(vdev, offset, 4U, val);
 	}
 
 	/* emulated for type info */
-	pci_vdev_write_cfg_u16(vdev, PCIR_VENDOR, (uint16_t)0x8086U);
-	pci_vdev_write_cfg_u16(vdev, PCIR_DEVICE, (uint16_t)0x9d12U);
+	pci_vdev_write_cfg(vdev, PCIR_VENDOR, 2U, 0x8086U);
+	pci_vdev_write_cfg(vdev, PCIR_DEVICE, 2U, 0x9d12U);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_REVID, (uint8_t)0xf1U);
+	pci_vdev_write_cfg(vdev, PCIR_REVID, 1U, 0xf1U);
 
-	pci_vdev_write_cfg_u8(vdev, PCIR_HDRTYPE, (uint8_t)(PCIM_HDRTYPE_BRIDGE | PCIM_MFDEV));
-	pci_vdev_write_cfg_u8(vdev, PCIR_CLASS, (uint8_t)PCIC_BRIDGE);
-	pci_vdev_write_cfg_u8(vdev, PCIR_SUBCLASS, (uint8_t)PCIS_BRIDGE_PCI);
+	pci_vdev_write_cfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_BRIDGE | PCIM_MFDEV));
+	pci_vdev_write_cfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
+	pci_vdev_write_cfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_PCI);
 }
 
 static void deinit_vpci_bridge(__unused struct pci_vdev *vdev)

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -40,30 +40,6 @@ static inline bool in_range(uint32_t value, uint32_t lower, uint32_t len)
 /**
  * @pre vdev != NULL
  */
-static inline void pci_vdev_write_cfg_u8(struct pci_vdev *vdev, uint32_t offset, uint8_t val)
-{
-	vdev->cfgdata.data_8[offset] = val;
-}
-
-/**
- * @pre vdev != NULL
- */
-static inline void pci_vdev_write_cfg_u16(struct pci_vdev *vdev, uint32_t offset, uint16_t val)
-{
-	vdev->cfgdata.data_16[offset >> 1U] = val;
-}
-
-/**
- * @pre vdev != NULL
- */
-static inline void pci_vdev_write_cfg_u32(struct pci_vdev *vdev, uint32_t offset, uint32_t val)
-{
-	vdev->cfgdata.data_32[offset >> 2U] = val;
-}
-
-/**
- * @pre vdev != NULL
- */
 static inline bool has_msix_cap(const struct pci_vdev *vdev)
 {
 	return (vdev->msix.capoff != 0U);


### PR DESCRIPTION
Removed the pci_vdev_write_cfg_u8/u16/u32 APIs and only used
pci_vdev_write_cfg as the API for writing vdev's cfgdata

Tracked-On: #4433

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>