### PR TITLE
hv: vpci: add _v prefix for some function name

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -167,10 +167,10 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
 	case PCIBAR_IO_SPACE:
 		vdev_pt_deny_io_vbar(vdev, update_idx);
 		if (val != ~0U) {
-			pci_vdev_write_bar(vdev, idx, val);
+			pci_vdev_write_vbar(vdev, idx, val);
 			vdev_pt_allow_io_vbar(vdev, update_idx);
 		} else {
-			pci_vdev_write_cfg(vdev, offset, 4U, val);
+			pci_vdev_write_vcfg(vdev, offset, 4U, val);
 			vdev->vbars[update_idx].base = 0UL;
 		}
 		break;
@@ -185,10 +185,10 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
 		}
 		vdev_pt_unmap_mem_vbar(vdev, update_idx);
 		if (val != ~0U) {
-			pci_vdev_write_bar(vdev, idx, val);
+			pci_vdev_write_vbar(vdev, idx, val);
 			vdev_pt_map_mem_vbar(vdev, update_idx);
 		} else {
-			pci_vdev_write_cfg(vdev, offset, 4U, val);
+			pci_vdev_write_vcfg(vdev, offset, 4U, val);
 			vdev->vbars[update_idx].base = 0UL;
 		}
 		break;
@@ -248,7 +248,7 @@ static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
 	pbdf.value = vdev->pdev->bdf.value;
 
 	for (offset = 0U; offset < PCI_CFG_HEADER_LENGTH; offset += 4U) {
-		pci_vdev_write_cfg(vdev, offset, 4U, pci_pdev_read_cfg(pbdf, offset, 4U));
+		pci_vdev_write_vcfg(vdev, offset, 4U, pci_pdev_read_cfg(pbdf, offset, 4U));
 	}
 
 	for (idx = 0U; idx < bar_cnt; idx++) {
@@ -316,8 +316,8 @@ static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
 				}
 				/* if it is parsing SRIOV VF BARs, no need to write vdev bars */
 				if (!is_sriov_bar) {
-					pci_vdev_write_bar(vdev, idx - 1U, lo);
-					pci_vdev_write_bar(vdev, idx, hi);
+					pci_vdev_write_vbar(vdev, idx - 1U, lo);
+					pci_vdev_write_vbar(vdev, idx, hi);
 				}
 			} else {
 				vbar->size = vbar->size & ~(vbar->size - 1UL);
@@ -326,7 +326,7 @@ static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
 				}
 				/* if it is parsing SRIOV VF BARs, no need to write vdev bar */
 				if (!is_sriov_bar) {
-					pci_vdev_write_bar(vdev, idx, lo);
+					pci_vdev_write_vbar(vdev, idx, lo);
 				}
 			}
 		}

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -47,45 +47,45 @@
 static void init_vhostbridge(struct pci_vdev *vdev)
 {
 	/* PCI config space */
-	pci_vdev_write_cfg(vdev, PCIR_VENDOR, 2U, 0x8086U);
-	pci_vdev_write_cfg(vdev, PCIR_DEVICE, 2U, 0x5af0U);
+	pci_vdev_write_vcfg(vdev, PCIR_VENDOR, 2U, 0x8086U);
+	pci_vdev_write_vcfg(vdev, PCIR_DEVICE, 2U, 0x5af0U);
 
-	pci_vdev_write_cfg(vdev, PCIR_REVID, 1U, 0xbU);
+	pci_vdev_write_vcfg(vdev, PCIR_REVID, 1U, 0xbU);
 
-	pci_vdev_write_cfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_NORMAL | PCIM_MFDEV));
-	pci_vdev_write_cfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
-	pci_vdev_write_cfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_HOST);
+	pci_vdev_write_vcfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_NORMAL | PCIM_MFDEV));
+	pci_vdev_write_vcfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
+	pci_vdev_write_vcfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_HOST);
 
-	pci_vdev_write_cfg(vdev, 0x34U, 1U, 0xe0U);
-	pci_vdev_write_cfg(vdev, 0x3cU, 1U, 0xe0U);
-	pci_vdev_write_cfg(vdev, 0x48U, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0x4aU, 1U, 0xd1U);
-	pci_vdev_write_cfg(vdev, 0x4bU, 1U, 0xfeU);
-	pci_vdev_write_cfg(vdev, 0x50U, 1U, 0xc1U);
-	pci_vdev_write_cfg(vdev, 0x51U, 1U, 0x2U);
-	pci_vdev_write_cfg(vdev, 0x54U, 1U, 0x33U);
-	pci_vdev_write_cfg(vdev, 0x58U, 1U, 0x7U);
-	pci_vdev_write_cfg(vdev, 0x5aU, 1U, 0xf0U);
-	pci_vdev_write_cfg(vdev, 0x5bU, 1U, 0x7fU);
-	pci_vdev_write_cfg(vdev, 0x60U, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0x63U, 1U, 0xe0U);
-	pci_vdev_write_cfg(vdev, 0xabU, 1U, 0x80U);
-	pci_vdev_write_cfg(vdev, 0xacU, 1U, 0x2U);
-	pci_vdev_write_cfg(vdev, 0xb0U, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0xb3U, 1U, 0x7cU);
-	pci_vdev_write_cfg(vdev, 0xb4U, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0xb6U, 1U, 0x80U);
-	pci_vdev_write_cfg(vdev, 0xb7U, 1U, 0x7bU);
-	pci_vdev_write_cfg(vdev, 0xb8U, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0xbbU, 1U, 0x7bU);
-	pci_vdev_write_cfg(vdev, 0xbcU, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0xbfU, 1U, 0x80U);
-	pci_vdev_write_cfg(vdev, 0xe0U, 1U, 0x9U);
-	pci_vdev_write_cfg(vdev, 0xe2U, 1U, 0xcU);
-	pci_vdev_write_cfg(vdev, 0xe3U, 1U, 0x1U);
-	pci_vdev_write_cfg(vdev, 0xf5U, 1U, 0xfU);
-	pci_vdev_write_cfg(vdev, 0xf6U, 1U, 0x1cU);
-	pci_vdev_write_cfg(vdev, 0xf7U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0x34U, 1U, 0xe0U);
+	pci_vdev_write_vcfg(vdev, 0x3cU, 1U, 0xe0U);
+	pci_vdev_write_vcfg(vdev, 0x48U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0x4aU, 1U, 0xd1U);
+	pci_vdev_write_vcfg(vdev, 0x4bU, 1U, 0xfeU);
+	pci_vdev_write_vcfg(vdev, 0x50U, 1U, 0xc1U);
+	pci_vdev_write_vcfg(vdev, 0x51U, 1U, 0x2U);
+	pci_vdev_write_vcfg(vdev, 0x54U, 1U, 0x33U);
+	pci_vdev_write_vcfg(vdev, 0x58U, 1U, 0x7U);
+	pci_vdev_write_vcfg(vdev, 0x5aU, 1U, 0xf0U);
+	pci_vdev_write_vcfg(vdev, 0x5bU, 1U, 0x7fU);
+	pci_vdev_write_vcfg(vdev, 0x60U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0x63U, 1U, 0xe0U);
+	pci_vdev_write_vcfg(vdev, 0xabU, 1U, 0x80U);
+	pci_vdev_write_vcfg(vdev, 0xacU, 1U, 0x2U);
+	pci_vdev_write_vcfg(vdev, 0xb0U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0xb3U, 1U, 0x7cU);
+	pci_vdev_write_vcfg(vdev, 0xb4U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0xb6U, 1U, 0x80U);
+	pci_vdev_write_vcfg(vdev, 0xb7U, 1U, 0x7bU);
+	pci_vdev_write_vcfg(vdev, 0xb8U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0xbbU, 1U, 0x7bU);
+	pci_vdev_write_vcfg(vdev, 0xbcU, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0xbfU, 1U, 0x80U);
+	pci_vdev_write_vcfg(vdev, 0xe0U, 1U, 0x9U);
+	pci_vdev_write_vcfg(vdev, 0xe2U, 1U, 0xcU);
+	pci_vdev_write_vcfg(vdev, 0xe3U, 1U, 0x1U);
+	pci_vdev_write_vcfg(vdev, 0xf5U, 1U, 0xfU);
+	pci_vdev_write_vcfg(vdev, 0xf6U, 1U, 0x1cU);
+	pci_vdev_write_vcfg(vdev, 0xf7U, 1U, 0x1U);
 }
 
 static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
@@ -101,7 +101,7 @@ static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
 static int32_t read_vhostbridge_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
 {
-	*val = pci_vdev_read_cfg(vdev, offset, bytes);
+	*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 	return 0;
 }
 
@@ -115,7 +115,7 @@ static int32_t write_vhostbridge_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)
 {
 	if (!is_bar_offset(PCI_BAR_COUNT, offset)) {
-		pci_vdev_write_cfg(vdev, offset, bytes, val);
+		pci_vdev_write_vcfg(vdev, offset, bytes, val);
 	}
 	return 0;
 }

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -69,12 +69,12 @@ static void remap_vmsi(const struct pci_vdev *vdev)
 	uint32_t vmsi_msgdata, vmsi_addrlo, vmsi_addrhi = 0U;
 
 	/* Read the MSI capability structure from virtual device */
-	vmsi_addrlo = pci_vdev_read_cfg(vdev, (capoff + PCIR_MSI_ADDR), 4U);
+	vmsi_addrlo = pci_vdev_read_vcfg(vdev, (capoff + PCIR_MSI_ADDR), 4U);
 	if (vdev->msi.is_64bit) {
-		vmsi_addrhi = pci_vdev_read_cfg(vdev, (capoff + PCIR_MSI_ADDR_HIGH), 4U);
-		vmsi_msgdata = pci_vdev_read_cfg(vdev, (capoff + PCIR_MSI_DATA_64BIT), 2U);
+		vmsi_addrhi = pci_vdev_read_vcfg(vdev, (capoff + PCIR_MSI_ADDR_HIGH), 4U);
+		vmsi_msgdata = pci_vdev_read_vcfg(vdev, (capoff + PCIR_MSI_DATA_64BIT), 2U);
 	} else {
-		vmsi_msgdata = pci_vdev_read_cfg(vdev, (capoff + PCIR_MSI_DATA), 2U);
+		vmsi_msgdata = pci_vdev_read_vcfg(vdev, (capoff + PCIR_MSI_DATA), 2U);
 	}
 	info.vmsi_addr.full = (uint64_t)vmsi_addrlo | ((uint64_t)vmsi_addrhi << 32U);
 	info.vmsi_data.full = vmsi_msgdata;
@@ -101,7 +101,7 @@ static void remap_vmsi(const struct pci_vdev *vdev)
 void vmsi_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* For PIO access, we emulate Capability Structures only */
-	*val = pci_vdev_read_cfg(vdev, offset, bytes);
+	*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 }
 
 /**
@@ -114,9 +114,9 @@ void vmsi_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
 	uint32_t msgctrl;
 
 	enable_disable_msi(vdev, false);
-	pci_vdev_write_cfg(vdev, offset, bytes, val);
+	pci_vdev_write_vcfg(vdev, offset, bytes, val);
 
-	msgctrl = pci_vdev_read_cfg(vdev, vdev->msi.capoff + PCIR_MSI_CTRL, 2U);
+	msgctrl = pci_vdev_read_vcfg(vdev, vdev->msi.capoff + PCIR_MSI_CTRL, 2U);
 	if ((msgctrl & PCIM_MSICTRL_MSI_ENABLE) != 0U) {
 		remap_vmsi(vdev);
 	}
@@ -152,7 +152,7 @@ void init_vmsi(struct pci_vdev *vdev)
 
 		val &= ~((uint32_t)PCIM_MSICTRL_MMC_MASK << 16U);
 		val &= ~((uint32_t)PCIM_MSICTRL_MME_MASK << 16U);
-		pci_vdev_write_cfg(vdev, vdev->msi.capoff, 4U, val);
+		pci_vdev_write_vcfg(vdev, vdev->msi.capoff, 4U, val);
 	}
 }
 

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -116,7 +116,7 @@ static void remap_one_vmsix_entry(const struct pci_vdev *vdev, uint32_t index)
 void vmsix_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val)
 {
 	/* For PIO access, we emulate Capability Structures only */
-	*val = pci_vdev_read_cfg(vdev, offset, bytes);
+	*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 }
 
 /**
@@ -129,10 +129,10 @@ void vmsix_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uin
 {
 	uint32_t old_msgctrl, msgctrl;
 
-	old_msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
+	old_msgctrl = pci_vdev_read_vcfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
 	/* Write to vdev */
-	pci_vdev_write_cfg(vdev, offset, bytes, val);
-	msgctrl = pci_vdev_read_cfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
+	pci_vdev_write_vcfg(vdev, offset, bytes, val);
+	msgctrl = pci_vdev_read_vcfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
 
 	if (((old_msgctrl ^ msgctrl) & (PCIM_MSIXCTRL_MSIX_ENABLE | PCIM_MSIXCTRL_FUNCTION_MASK)) != 0U) {
 		/* If MSI Enable is being set, make sure INTxDIS bit is set */

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -406,7 +406,7 @@ static void read_cfg_header(const struct pci_vdev *vdev,
 	if (vbar_access(vdev, offset)) {
 		/* bar access must be 4 bytes and offset must also be 4 bytes aligned */
 		if ((bytes == 4U) && ((offset & 0x3U) == 0U)) {
-			*val = pci_vdev_read_bar(vdev, pci_bar_index(offset));
+			*val = pci_vdev_read_vbar(vdev, pci_bar_index(offset));
 		} else {
 			*val = ~0U;
 		}
@@ -414,7 +414,7 @@ static void read_cfg_header(const struct pci_vdev *vdev,
 		if (bitmap32_test(((uint16_t)offset) >> 2U, &cfg_hdr_perm.pt_mask)) {
 			*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
 		} else {
-			*val = pci_vdev_read_cfg(vdev, offset, bytes);
+			*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 		}
 	}
 }
@@ -446,7 +446,7 @@ static void write_cfg_header(struct pci_vdev *vdev,
 			if (bitmap32_test(((uint16_t)offset) >> 2U, &cfg_hdr_perm.pt_mask)) {
 				pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
 			} else {
-				pci_vdev_write_cfg(vdev, offset, bytes, val);
+				pci_vdev_write_vcfg(vdev, offset, bytes, val);
 			}
 		}
 	}
@@ -710,10 +710,10 @@ int32_t vpci_assign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *pc
 
 			spinlock_obtain(&tgt_vm->vpci.lock);
 			vdev = vpci_init_vdev(vpci, vdev_in_sos->pci_dev_config, NULL);
-			pci_vdev_write_cfg(vdev, PCIR_INTERRUPT_LINE, 1U, pcidev->intr_line);
-			pci_vdev_write_cfg(vdev, PCIR_INTERRUPT_PIN, 1U, pcidev->intr_pin);
+			pci_vdev_write_vcfg(vdev, PCIR_INTERRUPT_LINE, 1U, pcidev->intr_line);
+			pci_vdev_write_vcfg(vdev, PCIR_INTERRUPT_PIN, 1U, pcidev->intr_pin);
 			for (idx = 0U; idx < vdev->nr_bars; idx++) {
-				pci_vdev_write_bar(vdev, idx, pcidev->bar[idx]);
+				pci_vdev_write_vbar(vdev, idx, pcidev->bar[idx]);
 			}
 
 			vdev->bdf.value = pcidev->virt_bdf;

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -58,18 +58,18 @@ static void init_vpci_bridge(struct pci_vdev *vdev)
 	/* read PCI config space to virtual space */
 	for (offset = 0x00U; offset < 0x100U; offset += 4U) {
 		val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, 4U);
-		pci_vdev_write_cfg(vdev, offset, 4U, val);
+		pci_vdev_write_vcfg(vdev, offset, 4U, val);
 	}
 
 	/* emulated for type info */
-	pci_vdev_write_cfg(vdev, PCIR_VENDOR, 2U, 0x8086U);
-	pci_vdev_write_cfg(vdev, PCIR_DEVICE, 2U, 0x9d12U);
+	pci_vdev_write_vcfg(vdev, PCIR_VENDOR, 2U, 0x8086U);
+	pci_vdev_write_vcfg(vdev, PCIR_DEVICE, 2U, 0x9d12U);
 
-	pci_vdev_write_cfg(vdev, PCIR_REVID, 1U, 0xf1U);
+	pci_vdev_write_vcfg(vdev, PCIR_REVID, 1U, 0xf1U);
 
-	pci_vdev_write_cfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_BRIDGE | PCIM_MFDEV));
-	pci_vdev_write_cfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
-	pci_vdev_write_cfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_PCI);
+	pci_vdev_write_vcfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_BRIDGE | PCIM_MFDEV));
+	pci_vdev_write_vcfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
+	pci_vdev_write_vcfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_PCI);
 }
 
 static void deinit_vpci_bridge(__unused struct pci_vdev *vdev)
@@ -80,7 +80,7 @@ static int32_t read_vpci_bridge_cfg(const struct pci_vdev *vdev, uint32_t offset
 	uint32_t bytes, uint32_t *val)
 {
 	if ((offset + bytes) <= 0x100U) {
-		*val = pci_vdev_read_cfg(vdev, offset, bytes);
+		*val = pci_vdev_read_vcfg(vdev, offset, bytes);
 	} else {
 		/* just passthru read to physical device when read PCIE sapce > 0x100 */
 		*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -121,9 +121,9 @@ void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
 uint32_t sriov_bar_offset(const struct pci_vdev *vdev, uint32_t bar_idx);
 void init_sriov_vf_vdev(struct pci_vdev *vdev);
 
-uint32_t pci_vdev_read_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
-void pci_vdev_write_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+uint32_t pci_vdev_read_vcfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes);
+void pci_vdev_write_vcfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 
-uint32_t pci_vdev_read_bar(const struct pci_vdev *vdev, uint32_t idx);
-void pci_vdev_write_bar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
+uint32_t pci_vdev_read_vbar(const struct pci_vdev *vdev, uint32_t idx);
+void pci_vdev_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
 #endif /* VPCI_PRIV_H_ */


### PR DESCRIPTION
Add _v prefix for some function name to indicate this function wants to operate
on virtual CFG space or virtual BAR register.

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>