### PR TITLE
hv: vpci: pass through stolen memory and opregion memory for GVT-D

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -464,8 +464,12 @@ static int32_t write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	} else if (sriovcap_access(vdev, offset)) {
 		write_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {
-		/* passthru to physical device */
-		pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+		/* For GVT-D, prevent stolen memory and opregion memory write */
+		if (!(is_postlaunched_vm(vdev->vpci->vm) && is_gvtd(vdev->pdev->bdf) &&
+			((offset == PCIR_BDSM) || (offset == PCIR_ASLS_CTL)))) {
+			/* passthru to physical device */
+			pci_pdev_write_cfg(vdev->pdev->bdf, offset, bytes, val);
+		}
 	}
 
 	return 0;
@@ -483,8 +487,14 @@ static int32_t read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	} else if (sriovcap_access(vdev, offset)) {
 		read_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {
-		/* passthru to physical device */
-		*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
+		/* For GVT-D, just return GPA for stolen memory and opregion memory read. */
+		if (is_postlaunched_vm(vdev->vpci->vm) && is_gvtd(vdev->pdev->bdf) &&
+				((offset == PCIR_BDSM) || (offset == PCIR_ASLS_CTL))) {
+			*val = pci_vdev_read_vcfg(vdev, offset, bytes);
+		} else {
+			/* passthru to physical device */
+			*val = pci_pdev_read_cfg(vdev->pdev->bdf, offset, bytes);
+		}
 	}
 
 	return 0;
@@ -716,6 +726,12 @@ int32_t vpci_assign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *pc
 				pci_vdev_write_vbar(vdev, idx, pcidev->bar[idx]);
 			}
 
+			if (is_gvtd(bdf)) {
+				/* rsvd2[0U] for stolen memory GPA; rsvd2[1U] for opregion memory GPA */
+				pci_vdev_write_vcfg(vdev, PCIR_BDSM, 4U, pcidev->rsvd2[0U]);
+				pci_vdev_write_vcfg(vdev, PCIR_ASLS_CTL, 4U, pcidev->rsvd2[1U]);
+			}
+
 			vdev->bdf.value = pcidev->virt_bdf;
 			spinlock_release(&tgt_vm->vpci.lock);
 			vdev_in_sos->new_owner = vdev;
@@ -764,7 +780,6 @@ int32_t vpci_deassign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *
 			deinit_vmsi(vdev);
 
 			deinit_vmsix(vdev);
-
 		}
 		spinlock_release(&tgt_vm->vpci.lock);
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -185,6 +185,10 @@
 #define HOST_BRIDGE_BDF		0U
 #define PCI_STD_NUM_BARS        6U
 
+/* Graphics definitions */
+#define PCIR_BDSM             0x5CU /* BDSM graphics base data of stolen memory register */
+#define PCIR_ASLS_CTL         0xFCU /* Opregion start addr register */
+
 union pci_bdf {
 	uint16_t value;
 	struct {
@@ -249,6 +253,11 @@ struct pci_cfg_ops {
 	uint32_t (*pci_read_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 	void (*pci_write_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 };
+
+static inline bool is_gvtd(union pci_bdf bdf)
+{
+	return (bdf.value == CONFIG_GPU_SBDF);
+}
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {


### PR DESCRIPTION
In order to add GVT-D support, we need pass through stolen memory and opregion memroy
to the post-launched VM. To implement this, we first reserve the GPA for stolen memory
and opregion memory through post-launched VM e820 table. Then we would build EPT mapping
between the GPA and the stolen memory and opregion memory real HPA. The last, we need to
return the GPA to post-launched VM if it wants to read the stolen memory and opregion
memory address and prevent post-launched VM to write the stolen memory and opregion memory
address register for now.
We do the GPA reserve and GPA to HPA EPT mapping in ACRN-DM and the stolen memory and
opregion memory CFG space register access emulation in ACRN-HV.

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>