### PR TITLE
hv: pci: rename CFG read/write function for PCI-compatible Configurat…

### DIFF
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -46,67 +46,6 @@ typedef uint32_t uart_reg_t;
 static union pci_bdf serial_pci_bdf;
 
 
-static uint32_t pci_direct_calc_address(union pci_bdf bdf, uint32_t offset)
-{
-	uint32_t addr = (uint32_t)bdf.value;
-
-	addr <<= 8U;
-	addr |= (offset | PCI_CFG_ENABLE);
-	return addr;
-}
-
-static uint32_t pci_direct_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes)
-{
-	uint32_t addr;
-	uint32_t val;
-
-	addr = pci_direct_calc_address(bdf, offset);
-
-	/* Write address to ADDRESS register */
-	pio_write32(addr, (uint16_t)PCI_CONFIG_ADDR);
-
-	/* Read result from DATA register */
-	switch (bytes) {
-	case 1U:
-		val = (uint32_t)pio_read8((uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
-		break;
-	case 2U:
-		val = (uint32_t)pio_read16((uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
-		break;
-	default:
-		val = pio_read32((uint16_t)PCI_CONFIG_DATA);
-		break;
-	}
-
-	return val;
-}
-
-static void pci_direct_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val)
-{
-	uint32_t addr = pci_direct_calc_address(bdf, offset);
-
-	/* Write address to ADDRESS register */
-	pio_write32(addr, (uint16_t)PCI_CONFIG_ADDR);
-
-	/* Write value to DATA register */
-	switch (bytes) {
-	case 1U:
-		pio_write8((uint8_t)val, (uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 3U));
-		break;
-	case 2U:
-		pio_write16((uint16_t)val, (uint16_t)PCI_CONFIG_DATA + ((uint16_t)offset & 2U));
-		break;
-	default:
-		pio_write32(val, (uint16_t)PCI_CONFIG_DATA);
-		break;
-	}
-}
-
-struct pci_cfg_ops pci_direct_cfg_ops = {
-	.pci_read_cfg = pci_direct_read_cfg,
-	.pci_write_cfg = pci_direct_write_cfg,
-};
-
 /* PCI BDF must follow format: bus:dev.func, for example 0:18.2 */
 static uint16_t get_pci_bdf_value(char *bdf)
 {

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -7,8 +7,6 @@
 #ifndef UART16550_H
 #define UART16550_H
 
-#include <pci.h>
-
 /* Register / bit definitions for 16c550 uart */
 /*receive buffer register            | base+00h, dlab=0b r*/
 #define UART16550_RBR           0x00U
@@ -128,8 +126,6 @@
 
 /* UART oscillator clock */
 #define UART_CLOCK_RATE	1843200U	/* 1.8432 MHz */
-
-extern struct pci_cfg_ops pci_direct_cfg_ops;
 
 void uart16550_init(bool early_boot);
 char uart16550_getc(void);

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -8,4 +8,3 @@
 #include <pci.h>
 
 void uart16550_init(__unused bool early_boot) {}
-struct pci_cfg_ops pci_direct_cfg_ops;


### PR DESCRIPTION
…ion Mechanism

Move CFG read/write function for PCI-compatible Configuration Mechanism from
debug/uartuart16550.c to hw/pci.c and rename CFG read/write function for
PCI-compatible Configuration Mechanism to pci_pio_read/write_cfg to align with
CFG read/write function pci_mmcfg_read/write_cfg for PCI Express Enhanced
Configuration Access Mechanism.

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>