### PR TITLE
doc: add site under construction page header

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -5,14 +5,14 @@
    max-width: none;
 }
 
-/* (temporarily) add an under development tagline to the bread crumb
+/* (temporarily) add an under development tagline to the bread crumb */
 .wy-breadcrumbs::after {
    content: " (Content reorganization in progress)";
    background-color: #FFFACD;
    color: red;
    font-weight: bold;
 }
-*/
+
 
 /* pygments tweak for white-on-black console */
 


### PR DESCRIPTION
While the site is being reorganized, let's put a header on each page
letting people know.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>