### PR TITLE
Doc: Changed lines in RN 1.0 and 0.1 to correct ref issue.

### DIFF
--- a/doc/release_notes/release_notes_0.1.rst
+++ b/doc/release_notes/release_notes_0.1.rst
@@ -63,8 +63,8 @@ Developers can configure hypervisor via Kconfig parameters. (See
 New ACRN tools
 ==============
 
-We've added a collection of support tools including acrnctl, acrntrace, acrnlog,
-acrn-crashlog, acrnprobe. (See :ref:`tools` documentation for details.)
+We've added a collection of support tools including acrnctl, acrntrace,
+acrnlog, acrn-crashlog, acrnprobe.
 
 Known Issues
 ************

--- a/doc/release_notes/release_notes_1.0.rst
+++ b/doc/release_notes/release_notes_1.0.rst
@@ -195,7 +195,7 @@ modified to map native GPIO to UOS. (See :ref:`virtio-hld` for more information.
 New ACRN tools
 ==============
 We've added a collection of support tools including ``acrnctl``, ``acrntrace``, ``acrnlog``,
-``acrn-crashlog``, ``acrnprobe``. (See :ref:`tools` for details.)
+``acrn-crashlog``, ``acrnprobe``. (See the `Tools` section under **User Guides** for details.)
 
 Document updates
 ================


### PR DESCRIPTION
We moved the Tools page in v1.6 (future) and this was causing RN 0.1 and 1.0 to throw errors because they referenced the Tools page. I updated the language on these pages.

Signed-off-by: Deb Taylor <deb.taylor@intel.com>