### PR TITLE
acrn-config: add missed include in pci_dev.c for logical partition

### DIFF
--- a/misc/acrn-config/scenario_config/pci_dev_c.py
+++ b/misc/acrn-config/scenario_config/pci_dev_c.py
@@ -18,6 +18,8 @@ def generate_file(config):
     print("#include <vm_config.h>", file=config)
     print("#include <pci_devices.h>", file=config)
     print("#include <vpci.h>", file=config)
+    print("#include <mmu.h>", file=config)
+    print("#include <page.h>", file=config)
     print("", file=config)
     print("/* The vbar_base info of pt devices is included in device MACROs which defined in",
           file=config)


### PR DESCRIPTION
commit a68f655a118f707501cd0ed241f2e71554d31af3 added two extra header
include in pci_dev.c for logical_partition scenario but acrn-config did
not handle that.
This patch fix the issue.

Tracked-On: #4492
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>