### PR TITLE
acrn-config: fix missing passthru parameter for launch config

### DIFF
--- a/misc/acrn-config/launch_config/launch_cfg_gen.py
+++ b/misc/acrn-config/launch_config/launch_cfg_gen.py
@@ -89,7 +89,7 @@ def ui_entry_api(board_info, scenario_info, launch_info, enable_commit=False):
 
     err_dic = {}
     git_env_check = False
-    arg_list = ['board_cfg_gen.py', '--board', board_info, '--scenario', scenario_info, '--launch', launch_info, '--uosid', '0']
+    arg_list = ['launch_cfg_gen.py', '--board', board_info, '--scenario', scenario_info, '--launch', launch_info, '--uosid', '0']
 
     if enable_commit:
         arg_list.append('--enable_commit')

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -578,11 +578,12 @@ def get_slot(bdf_list, dev):
             slot_fun = str(bus) + ":" +  str(slot) + ":" + str(fun)
             if bus != 0:
                 slot_fun = virtual_dev_slot(dev)
+                PT_SLOT[dev] = slot_fun
+            else:
+                # add already used slot for pass-throught devices to avoid conflict with virtio devices
+                PT_SLOT[dev] = slot
 
             slot_list[p_id] = slot_fun
-
-            # add already used slot for pass-throught devices to avoid conflict with virtio devices
-            PT_SLOT[dev] = slot
 
     return slot_list
 


### PR DESCRIPTION
If the bus number is not 0, then malloc a virtual slot for the device,
meanwhile, it should be added to PT_SLOT for the next query, otherwise
the passthru parameter would be lost in the launch script.

Tracked-On: #4494
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>