### PR TITLE
vPCI: throw the qurik part of pass through pci device to DM and keep HV clean

### DIFF
--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -154,8 +154,9 @@ struct vm_memmap {
  *
  */
 struct acrn_assign_pcidev {
-	/** reversed for externed compatibility */
-	uint32_t rsvd1;
+#define QUIRK_PTDEV	(1 << 0)	/* We will only handle general part in HV, others in DM */
+	/** the type of the the pass-through PCI device */
+	uint32_t type;
 
 	/** virtual BDF# of the pass-through PCI device */
 	uint16_t virt_bdf;

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -23,6 +23,14 @@ struct acrn_vm_config *get_vm_config(uint16_t vm_id)
 	return &vm_configs[vm_id];
 }
 
+/*
+ * @pre vm_id < CONFIG_MAX_VM_NUM
+ */
+uint8_t get_vm_severity(uint16_t vm_id)
+{
+	return vm_configs[vm_id].severity;
+}
+
 static inline bool uuid_is_equal(const uint8_t *uuid1, const uint8_t *uuid2)
 {
 	uint64_t uuid1_h = *(const uint64_t *)uuid1;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -119,7 +119,6 @@ static struct acrn_vm *get_highest_severity_vm(void)
 {
 	uint16_t vm_id, highest_vm_id = 0U;
 	struct acrn_vm *vm = NULL;
-	struct acrn_vm_config *vm_config;
 
 	for (vm_id = 1U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
 		vm = get_vm_from_vmid(vm_id);
@@ -129,8 +128,7 @@ static struct acrn_vm *get_highest_severity_vm(void)
 			continue;
 		}
 
-		vm_config = get_vm_config(vm_id);
-		if (vm_config->severity > get_vm_config(highest_vm_id)->severity) {
+		if (get_vm_severity(vm_id) > get_vm_severity(highest_vm_id)) {
 			highest_vm_id = vm_id;
 		}
 	}

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -353,8 +353,16 @@ static struct pci_vdev *find_available_vdev(struct acrn_vpci *vpci, union pci_bd
 	struct pci_vdev *vdev = pci_find_vdev(vpci, bdf);
 
 	if ((vdev != NULL) && (vdev->vpci != vpci)) {
-		/* If the device is assigned to other guest, we could not access it */
-		vdev = NULL;
+		/* In the case a device is assigned to a UOS and is not in a zombie state */
+		if ((vdev->new_owner != NULL) && (vdev->new_owner->vpci != NULL)) {
+			/* the SOS is able to access, if and only if the SOS has higher severity than the UOS. */
+			if (get_vm_severity(vpci->vm->vm_id) <
+					get_vm_severity(vdev->new_owner->vpci->vm->vm_id)) {
+				vdev = NULL;
+			}
+		} else {
+			vdev = NULL;
+		}
 	}
 
 	return vdev;

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -32,6 +32,11 @@
 
 #include <pci.h>
 
+static inline bool is_quirk_ptdev(const struct pci_vdev *vdev)
+{
+	return ((vdev->flags & QUIRK_PTDEV) != 0U);
+}
+
 static inline bool in_range(uint32_t value, uint32_t lower, uint32_t len)
 {
 	return ((value >= lower) && (value < (lower + len)));

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -137,6 +137,7 @@ struct acrn_vm_config {
 } __aligned(8);
 
 struct acrn_vm_config *get_vm_config(uint16_t vm_id);
+uint8_t get_vm_severity(uint16_t vm_id);
 bool vm_has_matched_uuid(uint16_t vmid, const uint8_t *uuid);
 bool sanitize_vm_config(void);
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -104,6 +104,8 @@ struct pci_vdev {
 
 	union pci_cfgdata cfgdata;
 
+	uint32_t flags;
+
 	/* The bar info of the virtual PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
 	struct pci_vbar vbars[PCI_BAR_COUNT];

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -186,10 +186,6 @@
 #define HOST_BRIDGE_BDF		0U
 #define PCI_STD_NUM_BARS        6U
 
-/* Graphics definitions */
-#define PCIR_BDSM             0x5CU /* BDSM graphics base data of stolen memory register */
-#define PCIR_ASLS_CTL         0xFCU /* Opregion start addr register */
-
 union pci_bdf {
 	uint16_t value;
 	struct {
@@ -254,11 +250,6 @@ struct pci_cfg_ops {
 	uint32_t (*pci_read_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 	void (*pci_write_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 };
-
-static inline bool is_gvtd(union pci_bdf bdf)
-{
-	return (bdf.value == CONFIG_GPU_SBDF);
-}
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -272,8 +272,9 @@ struct hc_ptdev_irq {
  * the parameter for HC_ASSIGN_PCIDEV or HC_DEASSIGN_PCIDEV hypercall
  */
 struct acrn_assign_pcidev {
-	/** reversed for externed compatibility */
-	uint32_t rsvd1;
+#define QUIRK_PTDEV    (1U << 0)    /* We will only handle general part in HV, others in DM */
+	/** the type of the the pass-through PCI device */
+	uint32_t type;
 
 	/** virtual BDF# of the pass-through PCI device */
 	uint16_t virt_bdf;


### PR DESCRIPTION
v4:
deliver IO request to DM for QUIRK PTDev when writing PCI CFG address register

v3:
refine some comments and a minor refine about acrn_assign_pcidev type MACRO definition.

v2:
1. refine the description: use term "severity" instead of "priority"
2. add get_vm_severity function to get a VM's severity
3. a minor bug fix about "the return value of read/write_pt_dev_cfg is not used"

v1:
throw the qurik part of pass through pci device to DM and keep HV clean

Tracked-On: #4371
Signed-off-by: Li Fei1 <fei1.li@intel.com>