### PR TITLE
hv: unmap SR-IOV VF MMIO when the VF physical device is disabled

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -377,6 +377,7 @@ static void vpci_init_pt_dev(struct pci_vdev *vdev)
 
 static void vpci_deinit_pt_dev(struct pci_vdev *vdev)
 {
+	deinit_vdev_pt(vdev);
 	remove_vdev_pt_iommu_domain(vdev);
 	deinit_vmsix(vdev);
 	deinit_vmsi(vdev);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -102,6 +102,7 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 }
 
 void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev);
+void deinit_vdev_pt(struct pci_vdev *vdev);
 void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
 void vdev_pt_map_msix(struct pci_vdev *vdev, bool hold_lock);
 

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -239,8 +239,6 @@ static void disable_vfs(struct pci_vdev *pf_vdev)
 	 * resources
 	 *
 	 * If the VF drivers are still running in SOS or UOS, the MMIO access will return 0xFF.
-	 *
-	 * TODO For security reasons, we need to enforce a return of 0xFF to avoid information leakage.
 	 */
 	num_vfs = read_sriov_reg(pf_vdev, PCIR_SRIOV_NUMVFS);
 	first = read_sriov_reg(pf_vdev, PCIR_SRIOV_FST_VF_OFF);


### PR DESCRIPTION
To avoid information leakage, we need to ensure that the device is
inaccessble when it does not exist.

For SR-IOV disabled VF device, we have the following operations.
    1. The configuration space accessing will get 0xFFFFFFFF as a
       return value after set the device state to zombie.
    2. The BAR MMIO EPT mapping are removed, the accesssing causes
       EPT violation.
    3. The device will be detached from IOMMU.
    4. The IRQ pin and vector are released.

Tracked-On: #4433

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>