### PR TITLE
doc: More re-org updates; What is ACRN and Advanced Guides pages

### DIFF
--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -13,6 +13,7 @@ Tools
 
    tutorials/acrn_configuration_tool
    reference/kconfig/index
+   user-guides/acrn-shell
    user-guides/acrn-dm-parameters
    misc/tools/acrn-crashlog/README
    misc/tools/**
@@ -90,5 +91,4 @@ Additional Tutorials
    tutorials/building_acrn_in_docker
    tutorials/acrn_ootb
    tutorials/run_kata_containers
-   user-guides/acrn-shell
    user-guides/kernel-parameters

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -23,6 +23,13 @@ partitioning hypervisors. The ACRN hypervisor architecture partitions
 the system into different functional domains, with carefully selected
 user VM sharing optimizations for IoT and embedded devices.
 
+ACRN Open Source Roadmap 2020
+*****************************
+
+Stay informed on what's ahead for ACRN in 2020 by visting the `ACRN 2020 Roadmap <https://projectacrn.org/wp-content/uploads/sites/59/2020/03/ACRN-Roadmap-External-2020.pdf>`_.
+
+For up-to-date happenings, visit the `ACRN blog <https://projectacrn.org/blog/>`_.
+
 ACRN High-Level Architecture
 ****************************
 


### PR DESCRIPTION
Add ACRN Open Source Roadmap 2020 link to Intro/What is ACRN page
Add ACRN blog link to ACRN Intro page (under Roadmap)
Move ACRN Shell Commands to 'Tools' under Advanced Guides page

Signed-off-by: Deb Taylor <deb.taylor@intel.com>