### PR TITLE
doc: fix docs with broken links

### DIFF
--- a/doc/developer-guides/c_coding_guidelines.rst
+++ b/doc/developer-guides/c_coding_guidelines.rst
@@ -3218,20 +3218,20 @@ function:
 6) A blank line shall separate different paragraphs. Inside each paragraph, a
    blank line is not required to separate each element.
 7) The brief description of the function shall be documented with the format
-   '@brief <brief description>'.
+   '\@brief <brief description>'.
 8) No specific format is required for the detailed description of the function.
 9) The description of the function parameter shall be documented with the format
-   '@param <parameter name> <parameter description>'.
-10) The pre-condition of the function shall be documented with the format '@pre
+   '\@param <parameter name> <parameter description>'.
+10) The pre-condition of the function shall be documented with the format '\@pre
     <pre-condition description>'.
 11) The post-condition of the function shall be documented with the format
-    '@post <post-condition description>'.
+    '\@post <post-condition description>'.
 12) The brief description of the function return value shall be documented with
-    the format '@return <brief description of return value>'.
-13) A void-returning function shall be documented with the format '@return
+    the format '\@return <brief description of return value>'.
+13) A void-returning function shall be documented with the format '\@return
     None'.
 14) The comments explaining the actual return values shall be documented with
-    the format '@retval <return value> <return value explanation>'.
+    the format '\@retval <return value> <return value explanation>'.
 15) If the description of one element needs to span multiple lines, each line
     shall be aligned to the start of the description in the first line for that
     element.

--- a/doc/developer-guides/contribute_guidelines.rst
+++ b/doc/developer-guides/contribute_guidelines.rst
@@ -106,7 +106,7 @@ configure, install, and use it as explained on the
 as introduced in the project ACRN `Getting Started Guide`_.
 
 .. _Getting Started Guide:
-   https://projectacrn.github.io/getting_started/
+   https://projectacrn.github.io/latest/try.html
 
 You should be familiar with common developer tools such as Git and
 platforms such as GitHub.

--- a/doc/developer-guides/hld/hld-security.rst
+++ b/doc/developer-guides/hld/hld-security.rst
@@ -282,7 +282,7 @@ following rules:
 Detailed configurations and policies are out of scope for this document.
 For good references on OS system security hardening and enhancement,
 see `AGL security
-<http://docs.automotivelinux.org/master/docs/architecture/en/dev/reference/security/part-2/0_Abstract.html>`_
+<https://docs.automotivelinux.org/docs/en/master/architecture/reference/security/part-2/0_Abstract.html>`_
 and `Android security <https://source.android.com/security/>`_
 
 Hypervisor Security Enhancement

--- a/doc/developer-guides/l1tf.rst
+++ b/doc/developer-guides/l1tf.rst
@@ -12,7 +12,7 @@ Refer to `Intel Analysis of L1TF`_ and `Linux L1TF document`_ for details.
    https://software.intel.com/security-software-guidance/insights/deep-dive-intel-analysis-l1-terminal-fault
 
 .. _Linux L1TF document:
-   https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/l1tf.rst
+   https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html
 
 L1 Terminal Fault is a speculative side channel which allows unprivileged
 speculative access to data which is available in the Level 1 Data Cache

--- a/doc/tutorials/acrn_ootb.rst
+++ b/doc/tutorials/acrn_ootb.rst
@@ -9,7 +9,7 @@ Set up a Build Environment
 **************************
 
 #. Follow the `Clear Linux OS installation guide
-   <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install-server>`_
+   <https://docs.01.org/clearlinux/latest/get-started/bare-metal-install-server.html>`_
    to install a native Clear Linux OS on a development machine.
 
 #. Log in to the Clear Linux OS and install these bundles::

--- a/doc/tutorials/agl-vms.rst
+++ b/doc/tutorials/agl-vms.rst
@@ -128,7 +128,7 @@ Service OS
 #. Download the compressed Clear Linux OS installer image from
    https://download.clearlinux.org/releases/31080/clear/clear-31080-live-server.img.xz
    and follow the `Clear Linux OS installation guide
-   <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install-server>`_
+   <https://docs.01.org/clearlinux/latest/get-started/bare-metal-install-server.html>`_
    as a starting point for installing the Clear Linux OS onto your platform.
    Follow the recommended options for choosing an Automatic installation
    type, and using the platform's storage as the target device for

--- a/doc/tutorials/increase-uos-disk-size.rst
+++ b/doc/tutorials/increase-uos-disk-size.rst
@@ -10,8 +10,9 @@ sufficient for some applications. This guide explains a simple few steps to
 increase the size of that virtual disk.
 
 This document is largely inspired from Clear Linux's `Increase virtual disk size
-of a Clear Linux* OS image <https://clearlinux.org/documentation/clear-linux/
-guides/maintenance/increase-virtual-disk-size>`_ tutorial. The process can be
+of a Clear Linux* OS image
+<https://docs.01.org/clearlinux/latest/guides/maintenance/increase-virtual-disk-size.html>`_
+tutorial. The process can be
 broken down into three steps:
 
 1. Increase the virtual disk (``uos.img``) size

--- a/doc/tutorials/kbl-nuc-sdc.rst
+++ b/doc/tutorials/kbl-nuc-sdc.rst
@@ -33,10 +33,10 @@ manually, as described below).
    instruction below to reference the appropriate version number of Clear
    Linux OS (we use version 32080 as an example).
 
-#. Download the compressed Clear Linux OS installer image from
-   https://download.clearlinux.org/releases/31470/clear/clear-31470-live-server.iso.xz
+#. Download the Clear Linux OS installer image from
+   https://download.clearlinux.org/releases/31470/clear/clear-31470-live-server.iso
    and follow the `Clear Linux OS Installation Guide
-   <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install-server>`_
+   <https://docs.01.org/clearlinux/latest/get-started/bare-metal-install-server.html>`_
    as a starting point for installing the Clear Linux OS onto your platform.
    Follow the recommended options for choosing an :kbd:`Advanced options`
    installation type, and using the platform's storage as the target device

--- a/doc/tutorials/realtime_performance_tuning.rst
+++ b/doc/tutorials/realtime_performance_tuning.rst
@@ -175,7 +175,8 @@ The Top-down Micro-Architecture Analysis Method (TMAM), based on Top-Down
 Characterization methodology, aims to provide an insight into whether you
 have made wise choices with your algorithms and data structures. See the
 Intel |reg| 64 and IA-32 `Architectures Optimization Reference Manual <http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-optimization-manual.pdf>`_,
-Appendix B.1 for more details on TMAM. Refer to this `technical paper <https://fd.io/wp-content/uploads/sites/34/2018/01/performance_analysis_sw_data_planes_dec21_2017.pdf>`_
+Appendix B.1 for more details on TMAM. Refer to this `technical paper
+<https://fd.io/docs/whitepapers/performance_analysis_sw_data_planes_dec21_2017.pdf>`_
 which adopts TMAM for systematic performance benchmarking and analysis
 of compute-native Network Function data planes that are executed on
 Commercial-Off-The-Shelf (COTS) servers using available open-source

--- a/doc/tutorials/trustyACRN.rst
+++ b/doc/tutorials/trustyACRN.rst
@@ -393,7 +393,7 @@ should obey these following rules (and more):
 Detailed configurations and policies are out of scope in this article.
 Good references for OS system security hardening and enhancement
 include: `AGL security
-<http://docs.automotivelinux.org/master/docs/architecture/en/dev/reference/security/part-2/0_Abstract.html>`_
+<https://docs.automotivelinux.org/docs/en/master/architecture/reference/security/part-2/0_Abstract.html>`_
 and `Android security
 <https://source.android.com/security/>`_
 

--- a/doc/tutorials/using_partition_mode_on_nuc.rst
+++ b/doc/tutorials/using_partition_mode_on_nuc.rst
@@ -33,7 +33,7 @@ Prerequisites
   are started by the ACRN hypervisor.  Each VM has its own root
   filesystem. Set up each VM by following the `Install Clear Linux
   OS on bare metal with live server
-  <https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install-server>`_
+  <https://docs.01.org/clearlinux/latest/get-started/bare-metal-install-server.html>`_
   and install Clear Linux OS (version: 29970) first on a SATA disk and then again
   on a storage device with a USB interface. The two pre-launched
   VMs will mount the root file systems via the SATA controller and

--- a/doc/tutorials/using_partition_mode_on_up2.rst
+++ b/doc/tutorials/using_partition_mode_on_up2.rst
@@ -22,7 +22,7 @@ Prerequisites
 In this tutorial two Linux privileged VMs are started by the ACRN hypervisor.
 To set up the Linux root filesystems for each VM, follow the Clear Linux OS
 `bare metal installation guide
-<https://clearlinux.org/documentation/clear-linux/get-started/bare-metal-install#bare-metal-install-server>`_
+<https://docs.01.org/clearlinux/latest/get-started/bare-metal-install-server.html>`_
 to install Clear Linux OS on a **SATA disk** and a **USB flash disk** prior the setup,
 as the two privileged VMs will mount the root filesystems via the SATA controller
 and the USB controller respectively.

--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -138,7 +138,8 @@ Install the Service VM kernel
 Download the latest Service VM kernel.
 
 1. The latest Service VM kernel from the latest Clear Linux OS release is
-   located here: https://download.clearlinux.org/releases/current/clear/x86_64/os/Packages.  Look for the following ``.rpm`` file:
+   located here:
+   https://download.clearlinux.org/releases/current/clear/x86_64/os/Packages/.  Look for the following ``.rpm`` file:
    ``linux-iot-lts2018-sos-<kernel-version>-<build-version>.x86_64.rpm``.
 
    While we recommend using the current (latest) Clear Linux OS release, you

--- a/misc/acrn-manager/README.rst
+++ b/misc/acrn-manager/README.rst
@@ -57,7 +57,7 @@ container::
    # acrnctl add launch_uos.sh -C
 
 .. note:: You can download an `example launch_uos.sh script
-   <https://raw.githubusercontent.com/projectacrn/acrnhypervisor/master/devicemodel/samples/nuc/launch_uos.sh>`_
+   <https://raw.githubusercontent.com/projectacrn/acrn-hypervisor/master/devicemodel/samples/nuc/launch_uos.sh>`_
    that supports the ``-C``  (``run_container`` function) option. You may refer to :ref:`acrn-dm_qos`
    for more details about this option.
 


### PR DESCRIPTION
Fix links in documentation that have moved (e.g.,
clearlinux.org/documentation moved to docs.01.org/clearlinux/latest).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>