### PR TITLE
Doc: add space at the end of efibootmgr bootloader

### DIFF
--- a/doc/getting-started/rt_industry.rst
+++ b/doc/getting-started/rt_industry.rst
@@ -157,7 +157,7 @@ Use the pre-installed industry ACRN hypervisor
    .. note:: Ensure that ACRN is first in the boot order, or you may use ``efibootmgr -o 1`` command to move it
       to the first position. If you need to enable the serial port, run the following command before rebooting:
 
-      ``efibootmgr -c -l '\EFI\acrn\acrn.efi' -d /dev/sda -p 1 -L ACRN -u "uart=port@0x3f8"``
+      ``efibootmgr -c -l '\EFI\acrn\acrn.efi' -d /dev/sda -p 1 -L ACRN -u "uart=port@0x3f8 "``
 
 #. Reboot KBL NUC.
 
@@ -198,13 +198,17 @@ Use the ACRN industry out-of-the-box image
 
    ::
 
-      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN" -u "uart=disabled"
+      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN" -u "uart=disabled "
 
    Or use the following command to enable the serial port:
 
    ::
 
-      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN" -u "uart=port@0x3f8"
+      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 -L "ACRN" -u "uart=port@0x3f8 "
+
+   .. note:: This is a workaround for the issue in efi-stub;
+      Add an extra space to the EFI option to make sure space could be used to detect the end of bootloader name string.
+      The extra space can be removed after the issue in efi-stub is fixed later.
 
 #. Reboot the test machine. After the Clear Linux OS boots,
    log in as “root” for the first time.

--- a/doc/tutorials/using_ubuntu_as_sos.rst
+++ b/doc/tutorials/using_ubuntu_as_sos.rst
@@ -113,10 +113,15 @@ the source code, build it, and install it on your device.
 
          # For SATA
          sudo efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/sda -p 1 \
-                -L "ACRN Hypervisor" -u "bootloader=\EFI\ubuntu\grubx64.efi"
+                -L "ACRN Hypervisor" -u "bootloader=\EFI\ubuntu\grubx64.efi "
          # For NVMe
          sudo efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/nvme0n1 -p 1 \
-                -L "ACRN Hypervisor" -u "bootloader=\EFI\ubuntu\grubx64.efi"
+                -L "ACRN Hypervisor" -u "bootloader=\EFI\ubuntu\grubx64.efi "
+
+      .. Note::
+         This is a workaround for the issue in efi-stub;
+         Add an extra space to the EFI option to make sure space could be used to detect the end of bootloader name string.
+         This extra space can be removed after issue in efi-stub fixed later.
 
    #. Verify that "ACRN Hypervisor" is added and that it will boot first:
 


### PR DESCRIPTION
For some corner case; the bootloader will load fail if no space
at the end of efibootmgr bootloader; so add it for workaround.

Signed-off-by: fuzhongl <fuzhong.liu@intel.com>
Reviewed-by: Yin Fengwei <fengwei.yin@intel.com>