### PR TITLE
Support for platforms with multiple IO-APICs

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -292,7 +292,7 @@ config RELOC
 
 config MAX_IOAPIC_NUM
 	int "Maximum number of IO-APICs"
-	range 1 8
+	range 1 10
 	default 1
 
 config MAX_IOAPIC_LINES

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -350,51 +350,47 @@ static struct ptirq_remapping_info *add_intx_remapping(struct acrn_vm *vm, uint3
 	DEFINE_INTX_SID(virt_sid, virt_pin, vpin_ctlr);
 	uint32_t phys_irq = ioapic_pin_to_irq(phys_pin);
 
-	if (((vpin_ctlr == INTX_CTLR_IOAPIC) && (virt_pin >= vioapic_pincount(vm))) || ((vpin_ctlr == INTX_CTLR_PIC) && (virt_pin >= vpic_pincount()))) {
-		pr_err("ptirq_add_intx_remapping fails!\n");
-	} else if (!ioapic_irq_is_gsi(phys_irq)) {
-		pr_err("%s, invalid phys_pin: %d <-> irq: 0x%x is not a GSI\n", __func__, phys_pin, phys_irq);
-	} else {
-		entry = ptirq_lookup_entry_by_sid(PTDEV_INTR_INTX, &phys_sid, NULL);
-		if (entry == NULL) {
-			if (ptirq_lookup_entry_by_sid(PTDEV_INTR_INTX, &virt_sid, vm) == NULL) {
-				entry = ptirq_alloc_entry(vm, PTDEV_INTR_INTX);
-				if (entry != NULL) {
-					entry->phys_sid.value = phys_sid.value;
-					entry->virt_sid.value = virt_sid.value;
-					entry->release_cb = ptirq_free_irte;
-
-					/* activate entry */
-					if (ptirq_activate_entry(entry, phys_irq) < 0) {
-						ptirq_release_entry(entry);
-						entry = NULL;
-					}
-				}
-			} else {
-				pr_err("INTX re-add vpin %d", virt_pin);
-			}
-		} else if (entry->vm != vm) {
-			if (is_sos_vm(entry->vm)) {
-				entry->vm = vm;
+	entry = ptirq_lookup_entry_by_sid(PTDEV_INTR_INTX, &phys_sid, NULL);
+	if (entry == NULL) {
+		if (ptirq_lookup_entry_by_sid(PTDEV_INTR_INTX, &virt_sid, vm) == NULL) {
+			entry = ptirq_alloc_entry(vm, PTDEV_INTR_INTX);
+			if (entry != NULL) {
+				entry->phys_sid.value = phys_sid.value;
 				entry->virt_sid.value = virt_sid.value;
-				entry->polarity = 0U;
-			} else {
-				pr_err("INTX pin%d already in vm%d with vpin%d, not able to add into vm%d with vpin%d",
-					phys_pin, entry->vm->vm_id, entry->virt_sid.intx_id.pin, vm->vm_id, virt_pin);
-				entry = NULL;
+				entry->release_cb = ptirq_free_irte;
+
+				/* activate entry */
+				if (ptirq_activate_entry(entry, phys_irq) < 0) {
+					ptirq_release_entry(entry);
+					entry = NULL;
+				}
 			}
 		} else {
-			/* The mapping has already been added to the VM. No action
-			 * required. */
+			pr_err("INTX re-add vpin %d", virt_pin);
 		}
+	} else if (entry->vm != vm) {
+		if (is_sos_vm(entry->vm)) {
+			entry->vm = vm;
+			entry->virt_sid.value = virt_sid.value;
+			entry->polarity = 0U;
+		} else {
+			pr_err("INTX pin%d already in vm%d with vpin%d, not able to add into vm%d with vpin%d",
+					phys_pin, entry->vm->vm_id, entry->virt_sid.intx_id.pin, vm->vm_id, virt_pin);
+			entry = NULL;
+		}
+	} else {
+		/* The mapping has already been added to the VM. No action
+		 * required. */
+	}
 
-		/*
-		 * ptirq entry is either created or transferred from SOS VM to Post-launched VM
-		 */
-		if (entry != NULL) {
-			dev_dbg(DBG_LEVEL_IRQ, "VM%d INTX add pin mapping vpin%d:ppin%d",
-				entry->vm->vm_id, virt_pin, phys_pin);
-		}
+
+	/*
+	 * ptirq entry is either created or transferred from SOS VM to Post-launched VM
+	 */
+
+	if (entry != NULL) {
+		dev_dbg(DBG_LEVEL_IRQ, "VM%d INTX add pin mapping vpin%d:ppin%d",
+			entry->vm->vm_id, virt_pin, phys_pin);
 	}
 
 	return entry;
@@ -408,31 +404,27 @@ static void remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_pin, e
 	struct intr_source intr_src;
 	DEFINE_INTX_SID(virt_sid, virt_pin, vpin_ctlr);
 
-	if (((vpin_ctlr == INTX_CTLR_IOAPIC) && (virt_pin >= vioapic_pincount(vm))) || ((vpin_ctlr == INTX_CTLR_PIC) && (virt_pin >= vpic_pincount()))) {
-		pr_err("virtual irq pin is invalid!\n");
-	} else {
-		entry = ptirq_lookup_entry_by_sid(PTDEV_INTR_INTX, &virt_sid, vm);
-		if (entry != NULL) {
-			if (is_entry_active(entry)) {
-				phys_irq = entry->allocated_pirq;
-				/* disable interrupt */
-				ioapic_gsi_mask_irq(phys_irq);
+	entry = ptirq_lookup_entry_by_sid(PTDEV_INTR_INTX, &virt_sid, vm);
+	if (entry != NULL) {
+		if (is_entry_active(entry)) {
+			phys_irq = entry->allocated_pirq;
+			/* disable interrupt */
+			ioapic_gsi_mask_irq(phys_irq);
 
-				ptirq_deactivate_entry(entry);
-				intr_src.is_msi = false;
-				intr_src.src.ioapic_id = ioapic_irq_to_ioapic_id(phys_irq);
+			ptirq_deactivate_entry(entry);
+			intr_src.is_msi = false;
+			intr_src.src.ioapic_id = ioapic_irq_to_ioapic_id(phys_irq);
 
-				dmar_free_irte(intr_src, (uint16_t)phys_irq);
-				dev_dbg(DBG_LEVEL_IRQ,
-					"deactive %s intx entry:ppin=%d, pirq=%d ",
-					(vpin_ctlr == INTX_CTLR_PIC) ? "vPIC" : "vIOAPIC",
-					entry->phys_sid.intx_id.pin, phys_irq);
-				dev_dbg(DBG_LEVEL_IRQ, "from vm%d vpin=%d\n",
-					entry->vm->vm_id, virt_pin);
-			}
-
-			ptirq_release_entry(entry);
+			dmar_free_irte(intr_src, (uint16_t)phys_irq);
+			dev_dbg(DBG_LEVEL_IRQ,
+				"deactive %s intx entry:ppin=%d, pirq=%d ",
+				(vpin_ctlr == INTX_CTLR_PIC) ? "vPIC" : "vIOAPIC",
+				entry->phys_sid.intx_id.pin, phys_irq);
+			dev_dbg(DBG_LEVEL_IRQ, "from vm%d vpin=%d\n",
+				entry->vm->vm_id, virt_pin);
 		}
+
+		ptirq_release_entry(entry);
 	}
 }
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -659,7 +659,7 @@ int32_t reset_vm(struct acrn_vm *vm)
 		}
 
 		reset_vm_ioreqs(vm);
-		vioapic_reset(vm);
+		reset_vioapics(vm);
 		destroy_secure_world(vm, false);
 		vm->sworld_control.flag.active = 0UL;
 		vm->state = VM_CREATED;

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -301,18 +301,12 @@ bool ioapic_is_pin_valid(uint32_t pin)
 	return (pin != INVALID_INTERRUPT_PIN);
 }
 
-uint32_t ioapic_pin_to_irq(uint32_t pin)
+/*
+ *@pre ioapic_irq_is_gsi(gsi) == true
+ */
+uint32_t ioapic_gsi_to_irq(uint32_t gsi)
 {
-	uint32_t i;
-	uint32_t irq = IRQ_INVALID;
-
-	for (i = 0U; i < ioapic_nr_gsi; i++) {
-		if (gsi_table_data[i].pin == pin) {
-			irq = i;
-			break;
-		}
-	}
-	return irq;
+	return gsi;
 }
 
 static void

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -73,6 +73,17 @@ uint32_t get_pic_pin_from_ioapic_pin(uint32_t pin_index)
 	return pin_id;
 }
 
+uint8_t get_platform_ioapic_info (struct ioapic_info **plat_ioapic_info)
+{
+	*plat_ioapic_info = ioapic_array;
+	return ioapic_num;
+}
+
+uint8_t get_gsi_to_ioapic_index(uint32_t gsi)
+{
+	return gsi_table_data[gsi].ioapic_info.index;
+}
+
 /*
  * @pre gsi < NR_MAX_GSI
  */

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -82,7 +82,7 @@ static void free_irq_num(uint32_t irq)
 	uint64_t rflags;
 
 	if (irq < NR_IRQS) {
-		if (!ioapic_irq_is_gsi(irq)) {
+		if (!is_ioapic_irq(irq)) {
 			spinlock_irqsave_obtain(&irq_alloc_spinlock, &rflags);
 			(void)bitmap_test_and_clear_nolock((uint16_t)(irq & 0x3FU),
 						     irq_alloc_bitmap + (irq >> 6U));
@@ -301,7 +301,7 @@ static inline bool irq_need_mask(const struct irq_desc *desc)
 {
 	/* level triggered gsi should be masked */
 	return (((desc->flags & IRQF_LEVEL) != 0U)
-		&& ioapic_irq_is_gsi(desc->irq));
+		&& is_ioapic_irq(desc->irq));
 }
 
 static inline bool irq_need_unmask(const struct irq_desc *desc)
@@ -309,7 +309,7 @@ static inline bool irq_need_unmask(const struct irq_desc *desc)
 	/* level triggered gsi for non-ptdev should be unmasked */
 	return (((desc->flags & IRQF_LEVEL) != 0U)
 		&& ((desc->flags & IRQF_PT) == 0U)
-		&& ioapic_irq_is_gsi(desc->irq));
+		&& is_ioapic_irq(desc->irq));
 }
 
 static inline void handle_irq(const struct irq_desc *desc)

--- a/hypervisor/boot/acpi_base.c
+++ b/hypervisor/boot/acpi_base.c
@@ -209,14 +209,14 @@ local_parse_madt(struct acpi_table_madt *madt, uint32_t lapic_id_array[MAX_PCPU_
 	return pcpu_num;
 }
 
-static uint16_t
+static uint8_t
 ioapic_parse_madt(void *madt, struct ioapic_info *ioapic_id_array)
 {
 	struct acpi_madt_ioapic *ioapic;
 	struct acpi_table_madt *madt_ptr;
 	void *first, *end, *iterator;
 	struct acpi_subtable_header *entry;
-	uint16_t ioapic_idx = 0U;
+	uint8_t ioapic_idx = 0U;
 
 	madt_ptr = (struct acpi_table_madt *)madt;
 
@@ -261,9 +261,9 @@ uint16_t parse_madt(uint32_t lapic_id_array[MAX_PCPU_NUM])
 	return ret;
 }
 
-uint16_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array)
+uint8_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array)
 {
-	uint16_t ret = 0U;
+	uint8_t ret = 0U;
 	struct acpi_table_rsdp *rsdp = NULL;
 
 	rsdp = get_rsdp();

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -203,7 +203,7 @@ void *get_acpi_tbl(const char *signature);
 
 struct ioapic_info;
 uint16_t parse_madt(uint32_t lapic_id_array[MAX_PCPU_NUM]);
-uint16_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array);
+uint8_t parse_madt_ioapic(struct ioapic_info *ioapic_id_array);
 
 #ifdef CONFIG_ACPI_PARSE_ENABLED
 int32_t acpi_fixup(void);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -18,6 +18,7 @@
 #include <hypercall.h>
 #include <errno.h>
 #include <logmsg.h>
+#include <ioapic.h>
 
 #define DBG_LEVEL_HYCALL	6U
 
@@ -905,8 +906,14 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t pa
 				vdev = pci_find_vdev(vpci, bdf);
 				spinlock_release(&vpci->lock);
 				if ((vdev != NULL) && (vdev->pdev->bdf.value == irq.phys_bdf)) {
-					ret = ptirq_add_intx_remapping(target_vm, irq.intx.virt_pin,
-						irq.intx.phys_pin, irq.intx.pic_pin);
+					if ((((!irq.intx.pic_pin) && (irq.intx.virt_pin < vioapic_pincount(target_vm))) ||
+							((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount()))) &&
+							ioapic_irq_is_gsi(irq.intx.phys_pin)) {
+						ret = ptirq_add_intx_remapping(target_vm, irq.intx.virt_pin,
+							irq.intx.phys_pin, irq.intx.pic_pin);
+					} else {
+						pr_err("%s: Invalid phys pin or virt pin\n", __func__);
+					}
 				}
 			} else {
 				pr_err("%s: Invalid irq type: %u\n", __func__, irq.type);
@@ -948,8 +955,13 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 				vdev = pci_find_vdev(vpci, bdf);
 				spinlock_release(&vpci->lock);
 				if ((vdev != NULL) && (vdev->pdev->bdf.value == irq.phys_bdf)) {
-					ptirq_remove_intx_remapping(target_vm, irq.intx.virt_pin, irq.intx.pic_pin);
-					ret = 0;
+					if (((!irq.intx.pic_pin) && (irq.intx.virt_pin < vioapic_pincount(target_vm))) ||
+						((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount()))) {
+						ptirq_remove_intx_remapping(target_vm, irq.intx.virt_pin, irq.intx.pic_pin);
+						ret = 0;
+					} else {
+						pr_err("%s: Invalid virt pin\n", __func__);
+					}
 				}
 			} else {
 				pr_err("%s: Invalid irq type: %u\n", __func__, irq.type);

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -353,7 +353,7 @@ int32_t hcall_set_irqline(const struct acrn_vm *vm, uint16_t vmid,
 	int32_t ret = -1;
 
 	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
-		if (ops->gsi < vioapic_pincount(vm)) {
+		if (ops->gsi < get_vm_gsicount(vm)) {
 			if (ops->gsi < vpic_pincount()) {
 				/*
 				 * IRQ line for 8254 timer is connected to
@@ -905,8 +905,13 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t pa
 				spinlock_obtain(&vpci->lock);
 				vdev = pci_find_vdev(vpci, bdf);
 				spinlock_release(&vpci->lock);
+				/*
+				 * TODO: Change the hc_ptdev_irq structure member names
+				 * virt_pin to virt_gsi
+				 * phys_pin to phys_gsi
+				 */
 				if ((vdev != NULL) && (vdev->pdev->bdf.value == irq.phys_bdf)) {
-					if ((((!irq.intx.pic_pin) && (irq.intx.virt_pin < vioapic_pincount(target_vm))) ||
+					if ((((!irq.intx.pic_pin) && (irq.intx.virt_pin < get_vm_gsicount(target_vm))) ||
 							((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount()))) &&
 							is_gsi_valid(irq.intx.phys_pin)) {
 						ret = ptirq_add_intx_remapping(target_vm, irq.intx.virt_pin,
@@ -954,8 +959,13 @@ hcall_reset_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 				spinlock_obtain(&vpci->lock);
 				vdev = pci_find_vdev(vpci, bdf);
 				spinlock_release(&vpci->lock);
+				/*
+				 * TODO: Change the hc_ptdev_irq structure member names
+				 * virt_pin to virt_gsi
+				 * phys_pin to phys_gsi
+				 */
 				if ((vdev != NULL) && (vdev->pdev->bdf.value == irq.phys_bdf)) {
-					if (((!irq.intx.pic_pin) && (irq.intx.virt_pin < vioapic_pincount(target_vm))) ||
+					if (((!irq.intx.pic_pin) && (irq.intx.virt_pin < get_vm_gsicount(target_vm))) ||
 						((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount()))) {
 						ptirq_remove_intx_remapping(target_vm, irq.intx.virt_pin, irq.intx.pic_pin);
 						ret = 0;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -908,7 +908,7 @@ int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, uint16_t vmid, uint64_t pa
 				if ((vdev != NULL) && (vdev->pdev->bdf.value == irq.phys_bdf)) {
 					if ((((!irq.intx.pic_pin) && (irq.intx.virt_pin < vioapic_pincount(target_vm))) ||
 							((irq.intx.pic_pin) && (irq.intx.virt_pin < vpic_pincount()))) &&
-							ioapic_irq_is_gsi(irq.intx.phys_pin)) {
+							is_gsi_valid(irq.intx.phys_pin)) {
 						ret = ptirq_add_intx_remapping(target_vm, irq.intx.virt_pin,
 							irq.intx.phys_pin, irq.intx.pic_pin);
 					} else {

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -1173,7 +1173,7 @@ static void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 	uint32_t delmode, vector, dest;
 	bool level, phys, remote_irr, mask;
 	struct acrn_vm *vm = get_vm_from_vmid(vmid);
-	uint32_t gsi, pincount;
+	uint32_t gsi, gsi_count;
 
 	if (is_poweroff_vm(vm)) {
 		len = snprintf(str, size, "\r\nvm is not exist for vmid %hu", vmid);
@@ -1192,9 +1192,12 @@ static void get_vioapic_info(char *str_arg, size_t str_max, uint16_t vmid)
 	size -= len;
 	str += len;
 
-	pincount = vioapic_pincount(vm);
+	gsi_count = get_vm_gsicount(vm);
 	rte.full = 0UL;
-	for (gsi = 0U; gsi < pincount; gsi++) {
+	for (gsi = 0U; gsi < gsi_count; gsi++) {
+		if (is_sos_vm(vm) && (!is_gsi_valid(gsi))) {
+			continue;
+		}
 		vioapic_get_rte(vm, gsi, &rte);
 		mask = (rte.bits.intr_mask == IOAPIC_RTE_MASK_SET);
 		remote_irr = (rte.bits.remote_irr == IOAPIC_RTE_REM_IRR);

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -530,7 +530,7 @@ int32_t vioapic_mmio_access_handler(struct io_request *io_req, void *handler_pri
  * @pre vm->arch_vm.vioapic != NULL
  * @pre rte != NULL
  */
-void vioapic_get_rte(struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte)
+void vioapic_get_rte(const struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte)
 {
 	struct acrn_vioapic *vioapic;
 

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -130,10 +130,10 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
  * @return None
  */
 void
-vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
+vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation)
 {
 	struct acrn_vioapic *vioapic;
-	uint32_t pin = irqline;
+	uint32_t pin = vgsi;
 
 	vioapic = vm_ioapic(vm);
 
@@ -174,9 +174,10 @@ vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint32_t 
  * @return None
  */
 void
-vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation)
+vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation)
 {
 	uint64_t rflags;
+	uint32_t irqline = vgsi;
 	struct acrn_vioapic *vioapic = vm_ioapic(vm);
 	if (vioapic->ready) {
 		spinlock_irqsave_obtain(&(vioapic->mtx), &rflags);
@@ -524,9 +525,10 @@ int32_t vioapic_mmio_access_handler(struct io_request *io_req, void *handler_pri
  * @pre vm->arch_vm.vioapic != NULL
  * @pre rte != NULL
  */
-void vioapic_get_rte(const struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte)
+void vioapic_get_rte(const struct acrn_vm *vm, uint32_t vgsi, union ioapic_rte *rte)
 {
 	struct acrn_vioapic *vioapic;
+	uint32_t pin = vgsi;
 
 	vioapic = vm_ioapic(vm);
 	*rte = vioapic->rtbl[pin];

--- a/hypervisor/dm/vioapic.c
+++ b/hypervisor/dm/vioapic.c
@@ -36,6 +36,7 @@
 #include <ept.h>
 #include <assign.h>
 #include <logmsg.h>
+#include <ioapic.h>
 
 #define	RTBL_RO_BITS	((uint32_t)0x00004000U | (uint32_t)0x00001000U) /*Remote IRR and Delivery Status bits*/
 
@@ -45,16 +46,16 @@
 #define IOAPIC_ID_MASK		0x0f000000U
 #define MASK_ALL_INTERRUPTS   0x0001000000010000UL
 
-static inline struct acrn_vioapic *vm_ioapic(const struct acrn_vm *vm)
+static inline struct acrn_vioapics *vm_ioapics(const struct acrn_vm *vm)
 {
-	return (struct acrn_vioapic *)&(vm->arch_vm.vioapic);
+	return (struct acrn_vioapics *)&(vm->arch_vm.vioapics);
 }
 
 /**
- * @pre pin < vioapic_pincount(vm)
+ * @pre pin < vioapic->nr_pins
  */
 static void
-vioapic_generate_intr(struct acrn_vioapic *vioapic, uint32_t pin)
+vioapic_generate_intr(struct acrn_single_vioapic *vioapic, uint32_t pin)
 {
 	uint32_t vector, dest, delmode;
 	union ioapic_rte rte;
@@ -84,10 +85,10 @@ vioapic_generate_intr(struct acrn_vioapic *vioapic, uint32_t pin)
 }
 
 /**
- * @pre pin < vioapic_pincount(vm)
+ * @pre pin < vioapic->nr_pins
  */
 static void
-vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
+vioapic_set_pinstate(struct acrn_single_vioapic *vioapic, uint32_t pin, uint32_t level)
 {
 	uint32_t old_lvl;
 	union ioapic_rte rte;
@@ -113,6 +114,30 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
 	}
 }
 
+
+static struct acrn_single_vioapic *
+vgsi_to_vioapic_and_vpin(const struct acrn_vm *vm, uint32_t vgsi, uint32_t *vpin)
+{
+	struct acrn_single_vioapic *vioapic;
+	uint8_t vioapic_index = 0U;
+
+	if (is_sos_vm(vm)) {
+		/*
+		 * Utilize platform ioapic_info for SOS VM
+		 */	
+		vioapic_index = get_gsi_to_ioapic_index(vgsi);
+		if (vpin != NULL) {
+			*vpin = gsi_to_ioapic_pin(vgsi);
+		}
+	} else {
+		if (vpin != NULL) {
+			*vpin = vgsi;
+		}
+	}
+	vioapic = (struct acrn_single_vioapic *)&(vm->arch_vm.vioapics.vioapic_array[vioapic_index]);
+	return vioapic;
+}
+
 /**
  * @brief Set vIOAPIC IRQ line status.
  *
@@ -120,11 +145,11 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
  * operation be done with ioapic lock.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irqline   Target IRQ number
+ * @param[in] vgsi   	Target GSI number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irqline < vioapic_pincount(vm)
+ * @pre vgsi < get_vm_gsicount(vm)
  * @pre vm != NULL
  * @pre vioapic->ready == true
  * @return None
@@ -132,10 +157,10 @@ vioapic_set_pinstate(struct acrn_vioapic *vioapic, uint32_t pin, uint32_t level)
 void
 vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation)
 {
-	struct acrn_vioapic *vioapic;
-	uint32_t pin = vgsi;
+	struct acrn_single_vioapic *vioapic;
+	uint32_t pin;
 
-	vioapic = vm_ioapic(vm);
+	vioapic = vgsi_to_vioapic_and_vpin(vm, vgsi, &pin);
 
 	switch (operation) {
 	case GSI_SET_HIGH:
@@ -164,11 +189,11 @@ vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t ope
  * @brief Set vIOAPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irqline   Target IRQ number
+ * @param[in] vgsi  	Target GSI number
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
- * @pre irqline < vioapic_pincount(vm)
+ * @pre vgsi < get_vm_gsicount(vm)
  * @pre vm != NULL
  *
  * @return None
@@ -177,20 +202,21 @@ void
 vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation)
 {
 	uint64_t rflags;
-	uint32_t irqline = vgsi;
-	struct acrn_vioapic *vioapic = vm_ioapic(vm);
+	struct acrn_single_vioapic *vioapic;
+
+	vioapic = vgsi_to_vioapic_and_vpin(vm, vgsi, NULL);
 	if (vioapic->ready) {
 		spinlock_irqsave_obtain(&(vioapic->mtx), &rflags);
-		vioapic_set_irqline_nolock(vm, irqline, operation);
+		vioapic_set_irqline_nolock(vm, vgsi, operation);
 		spinlock_irqrestore_release(&(vioapic->mtx), rflags);
 	}
 }
 
 static uint32_t
-vioapic_indirect_read(const struct acrn_vioapic *vioapic, uint32_t addr)
+vioapic_indirect_read(const struct acrn_single_vioapic *vioapic, uint32_t addr)
 {
 	uint32_t regnum, ret = 0U;
-	uint32_t pin, pincount = vioapic_pincount(vioapic->vm);
+	uint32_t pin, pincount = vioapic->nr_pins;
 
 	regnum = addr & 0xffU;
 	switch (regnum) {
@@ -229,7 +255,7 @@ vioapic_indirect_read(const struct acrn_vioapic *vioapic, uint32_t addr)
 	return ret;
 }
 
-static inline bool vioapic_need_intr(const struct acrn_vioapic *vioapic, uint16_t pin)
+static inline bool vioapic_need_intr(const struct acrn_single_vioapic *vioapic, uint16_t pin)
 {
 	uint32_t lvl;
 	union ioapic_rte rte;
@@ -250,11 +276,11 @@ static inline bool vioapic_need_intr(const struct acrn_vioapic *vioapic, uint16_
  * spinlock_irqsave_obtain(&(vioapic->mtx), &rflags) & spinlock_irqrestore_release(&(vioapic->mtx), rflags)
  * by caller.
  */
-static void vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr, uint32_t data)
+static void vioapic_indirect_write(struct acrn_single_vioapic *vioapic, uint32_t addr, uint32_t data)
 {
 	union ioapic_rte last, new, changed;
 	uint32_t regnum;
-	uint32_t pin, pincount = vioapic_pincount(vioapic->vm);
+	uint32_t pin, pincount = vioapic->nr_pins;
 
 	regnum = addr & 0xffUL;
 	switch (regnum) {
@@ -332,7 +358,8 @@ static void vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr, 
 			if ((new.bits.intr_mask == IOAPIC_RTE_MASK_CLR) || (last.bits.intr_mask  == IOAPIC_RTE_MASK_CLR)) {
 				/* VM enable intr */
 				/* NOTE: only support max 256 pin */
-				(void)ptirq_intx_pin_remap(vioapic->vm, pin, INTX_CTLR_IOAPIC);
+				
+				(void)ptirq_intx_pin_remap(vioapic->vm, vioapic->gsi_base + pin, INTX_CTLR_IOAPIC);
 			}
 
 			/*
@@ -352,7 +379,7 @@ static void vioapic_indirect_write(struct acrn_vioapic *vioapic, uint32_t addr, 
 }
 
 static void
-vioapic_mmio_rw(struct acrn_vioapic *vioapic, uint64_t gpa,
+vioapic_mmio_rw(struct acrn_single_vioapic *vioapic, uint64_t gpa,
 		uint32_t *data, bool do_read)
 {
 	uint32_t offset;
@@ -396,11 +423,10 @@ vioapic_mmio_rw(struct acrn_vioapic *vioapic, uint64_t gpa,
  * @pre vm != NULL
  * @pre vioapic->ready == true
  */
-void
-vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
+static void
+vioapic_process_eoi(struct acrn_single_vioapic *vioapic, uint32_t vector)
 {
-	struct acrn_vioapic *vioapic;
-	uint32_t pin, pincount = vioapic_pincount(vm);
+	uint32_t pin, pincount = vioapic->nr_pins;
 	union ioapic_rte rte;
 	uint64_t rflags;
 
@@ -408,7 +434,6 @@ vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
 		pr_err("vioapic_process_eoi: invalid vector %u", vector);
 	}
 
-	vioapic = vm_ioapic(vm);
 	dev_dbg(DBG_LEVEL_VIOAPIC, "ioapic processing eoi for vector %u", vector);
 
 	/* notify device to ack if assigned pin */
@@ -419,7 +444,7 @@ vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
 			continue;
 		}
 
-		ptirq_intx_ack(vm, pin, INTX_CTLR_IOAPIC);
+		ptirq_intx_ack(vioapic->vm, vioapic->gsi_base + pin, INTX_CTLR_IOAPIC);
 	}
 
 	/*
@@ -444,14 +469,28 @@ vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector)
 	spinlock_irqrestore_release(&(vioapic->mtx), rflags);
 }
 
-void
-vioapic_reset(struct acrn_vm *vm)
+void vioapic_broadcast_eoi(const struct acrn_vm *vm, uint32_t vector)
+{
+	struct acrn_single_vioapic *vioapic;
+	uint8_t vioapic_index;
+
+	/*
+	 * For platforms with multiple IO-APICs, EOI message from LAPIC is
+	 * broadcast to all IO-APICs. Emulating the same behavior here.
+	 */
+
+	for (vioapic_index = 0U; vioapic_index < vm->arch_vm.vioapics.ioapic_num; vioapic_index++) {
+		vioapic = &(vm_ioapics(vm)->vioapic_array[vioapic_index]);
+		vioapic_process_eoi(vioapic, vector);
+	}
+}
+
+static void reset_one_vioapic(struct acrn_single_vioapic *vioapic)
 {
 	uint32_t pin, pincount;
-	struct acrn_vioapic *vioapic = vm_ioapic(vm);
 
 	/* Initialize all redirection entries to mask all interrupts */
-	pincount = vioapic_pincount(vm);
+	pincount = vioapic->nr_pins;
 	for (pin = 0U; pin < pincount; pin++) {
 		vioapic->rtbl[pin].full = MASK_ALL_INTERRUPTS;
 	}
@@ -459,35 +498,80 @@ vioapic_reset(struct acrn_vm *vm)
 	vioapic->ioregsel = 0U;
 }
 
+void reset_vioapics(const struct acrn_vm *vm)
+{
+	struct acrn_vioapics *vioapics = vm_ioapics(vm);
+	uint8_t vioapic_index;
+
+	for (vioapic_index = 0U; vioapic_index < vioapics->ioapic_num; vioapic_index++) {
+		reset_one_vioapic(&vioapics->vioapic_array[vioapic_index]);
+	}
+}
+
 void
 vioapic_init(struct acrn_vm *vm)
 {
-	vm->arch_vm.vioapic.vm = vm;
-	spinlock_init(&(vm->arch_vm.vioapic.mtx));
+	struct ioapic_info *platform_ioapic_info;
+	uint8_t platform_ioapic_num;
+	uint8_t vioapic_index;
+	struct acrn_single_vioapic *vioapic;
 
-	vm->arch_vm.vioapic.base_addr = VIOAPIC_BASE;
 	if (is_sos_vm(vm)) {
-		vm->arch_vm.vioapic.nr_pins = REDIR_ENTRIES_HW;
+		platform_ioapic_num = get_platform_ioapic_info(&platform_ioapic_info);
+		vm->arch_vm.vioapics.ioapic_num = platform_ioapic_num;
+		for (vioapic_index = 0U; vioapic_index < platform_ioapic_num; vioapic_index++) {
+			vioapic = &vm->arch_vm.vioapics.vioapic_array[vioapic_index];
+			spinlock_init(&(vioapic->mtx));
+			vioapic->nr_pins = platform_ioapic_info[vioapic_index].nr_pins;
+			vioapic->base_addr = platform_ioapic_info[vioapic_index].addr;
+			vioapic->gsi_base = platform_ioapic_info[vioapic_index].gsi_base;
+
+			vioapic->vm = vm;
+			reset_one_vioapic(vioapic);
+
+			register_mmio_emulation_handler(vm,
+					vioapic_mmio_access_handler,
+					(uint64_t)vioapic->base_addr,
+					(uint64_t)vioapic->base_addr + VIOAPIC_SIZE,
+					(void *)vioapic, false);
+			ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
+					(uint64_t)vioapic->base_addr, VIOAPIC_SIZE);
+			vioapic->ready = true;
+		}
+		/*
+		 * Maximum number of GSI is computed as GSI base of the IOAPIC i.e. enumerated last in ACPI MADT
+		 * plus the number of interrupt pins of that IOAPIC.
+		 */
+		vm->arch_vm.vioapics.nr_gsi = platform_ioapic_info[platform_ioapic_num - 1U].gsi_base +
+						platform_ioapic_info[platform_ioapic_num - 1U].nr_pins;
 	} else {
-		vm->arch_vm.vioapic.nr_pins = VIOAPIC_RTE_NUM;
+		vm->arch_vm.vioapics.ioapic_num = 1U;
+		vioapic = &vm->arch_vm.vioapics.vioapic_array[0U];
+		spinlock_init(&(vioapic->mtx));
+		vioapic->nr_pins = VIOAPIC_RTE_NUM;
+		vioapic->base_addr = VIOAPIC_BASE;
+		vioapic->gsi_base = 0U;
+		vioapic->vm = vm;
+		reset_one_vioapic(&vm->arch_vm.vioapics.vioapic_array[0U]);
+
+
+		register_mmio_emulation_handler(vm,
+				vioapic_mmio_access_handler,
+				(uint64_t)vioapic->base_addr,
+				(uint64_t)vioapic->base_addr + VIOAPIC_SIZE,
+				(void *)vioapic, false);
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
+				(uint64_t)vioapic->base_addr, VIOAPIC_SIZE);
+		vioapic->ready = true;
+
+		vm->arch_vm.vioapics.nr_gsi = VIOAPIC_RTE_NUM;
 	}
-
-	vioapic_reset(vm);
-
-	register_mmio_emulation_handler(vm,
-			vioapic_mmio_access_handler,
-			(uint64_t)vm->arch_vm.vioapic.base_addr,
-			(uint64_t)vm->arch_vm.vioapic.base_addr + VIOAPIC_SIZE,
-			(void *)&vm->arch_vm.vioapic, false);
-	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
-			(uint64_t)vm->arch_vm.vioapic.base_addr, VIOAPIC_SIZE);
-	vm->arch_vm.vioapic.ready = true;
 }
 
 uint32_t
-vioapic_pincount(const struct acrn_vm *vm)
+get_vm_gsicount(const struct acrn_vm *vm)
 {
-	return vm->arch_vm.vioapic.nr_pins;
+	return vm->arch_vm.vioapics.nr_gsi;
 }
 
 /*
@@ -496,7 +580,7 @@ vioapic_pincount(const struct acrn_vm *vm)
  */
 int32_t vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private_data)
 {
-	struct acrn_vioapic *vioapic = (struct acrn_vioapic *)handler_private_data;
+	struct acrn_single_vioapic *vioapic = (struct acrn_single_vioapic *)handler_private_data;
 	struct mmio_request *mmio = &io_req->reqs.mmio;
 	uint64_t gpa = mmio->address;
 	int32_t ret = 0;
@@ -522,14 +606,15 @@ int32_t vioapic_mmio_access_handler(struct io_request *io_req, void *handler_pri
 }
 
 /**
- * @pre vm->arch_vm.vioapic != NULL
+ * @pre vm->arch_vm.vioapics != NULL
+ * @pre vgsi < get_vm_gsicount(vm)
  * @pre rte != NULL
  */
 void vioapic_get_rte(const struct acrn_vm *vm, uint32_t vgsi, union ioapic_rte *rte)
 {
-	struct acrn_vioapic *vioapic;
-	uint32_t pin = vgsi;
+	struct acrn_single_vioapic *vioapic;
+	uint32_t pin;
+	vioapic = vgsi_to_vioapic_and_vpin(vm, vgsi, &pin);
 
-	vioapic = vm_ioapic(vm);
 	*rte = vioapic->rtbl[pin];
 }

--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -616,13 +616,13 @@ static void vuart_deinit_connection(struct acrn_vuart *vu)
 	vu->target_vu = NULL;
 }
 
-bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_pin)
+bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_gsi)
 {
 	uint8_t i;
 	bool ret = false;
 
 	for (i = 0U; i < MAX_VUART_NUM_PER_VM; i++) {
-		if ((vm->vuart[i].active) && (vm->vuart[i].irq == intx_pin)) {
+		if ((vm->vuart[i].active) && (vm->vuart[i].irq == intx_gsi)) {
 			ret = true;
 		}
 	}

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -122,7 +122,7 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, uint32_t
  * @pre vm != NULL
  *
  */
-void ptirq_remove_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, bool pic_pin);
+void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_pin, bool pic_pin);
 
 /**
  * @brief Remove interrupt remapping entry/entries for MSI/MSI-x.

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -29,15 +29,15 @@
  * Acknowledge a virtual legacy interrupt for a passthrough device.
  *
  * @param[in] vm pointer to acrn_vm
- * @param[in] virt_pin virtual pin number associated with the passthrough device
- * @param[in] vpin_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
+ * @param[in] virt_gsi virtual GSI number associated with the passthrough device
+ * @param[in] vgsi_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
  *
  * @return None
  *
  * @pre vm != NULL
  *
  */
-void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_pin, enum intx_ctlr vpin_ctlr);
+void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ctlr vgsi_ctlr);
 
 /**
  * @brief MSI/MSI-x remapping for passthrough device.
@@ -72,8 +72,8 @@ int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_
  * This is the main entry for PCI/Legacy device assignment with INTx, calling from vIOAPIC or vPIC.
  *
  * @param[in] vm pointer to acrn_vm
- * @param[in] virt_pin virtual pin number associated with the passthrough device
- * @param[in] vpin_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
+ * @param[in] virt_gsi virtual GSI number associated with the passthrough device
+ * @param[in] vgsi_ctlr INTX_CTLR_IOAPIC or INTX_CTLR_PIC
  *
  * @return
  *    - 0: on success
@@ -84,7 +84,7 @@ int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_
  * @pre vm != NULL
  *
  */
-int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, enum intx_ctlr vpin_ctlr);
+int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ctlr vgsi_ctlr);
 
 /**
  * @brief Add an interrupt remapping entry for INTx as pre-hold mapping.
@@ -94,8 +94,8 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, enum intx_ct
  * Currently, one phys_pin can only be held by one pin source (vPIC or vIOAPIC).
  *
  * @param[in] vm pointer to acrn_vm
- * @param[in] virt_pin virtual pin number associated with the passthrough device
- * @param[in] phys_pin physical pin number associated with the passthrough device
+ * @param[in] virt_gsi virtual pin number associated with the passthrough device
+ * @param[in] phys_gsi physical pin number associated with the passthrough device
  * @param[in] pic_pin true for pic, false for ioapic
  *
  * @return
@@ -106,7 +106,7 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_pin, enum intx_ct
  * @pre vm != NULL
  *
  */
-int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, uint32_t phys_pin, bool pic_pin);
+int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_gsi, uint32_t phys_gsi, bool pic_pin);
 
 /**
  * @brief Remove an interrupt remapping entry for INTx.
@@ -114,7 +114,7 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, uint32_t
  * Deactivate & remove mapping entry of the given virt_pin for given vm.
  *
  * @param[in] vm pointer to acrn_vm
- * @param[in] virt_pin virtual pin number associated with the passthrough device
+ * @param[in] virt_gsi virtual pin number associated with the passthrough device
  * @param[in] pic_pin true for pic, false for ioapic
  *
  * @return None
@@ -122,7 +122,7 @@ int32_t ptirq_add_intx_remapping(struct acrn_vm *vm, uint32_t virt_pin, uint32_t
  * @pre vm != NULL
  *
  */
-void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_pin, bool pic_pin);
+void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, bool pic_pin);
 
 /**
  * @brief Remove interrupt remapping entry/entries for MSI/MSI-x.

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -107,7 +107,7 @@ struct vm_arch {
 	void *sworld_eptp;
 	struct memory_ops ept_mem_ops;
 
-	struct acrn_vioapic vioapic;	/* Virtual IOAPIC base address */
+	struct acrn_vioapics vioapics;	/* Virtual IOAPIC/s */
 	struct acrn_vpic vpic;      /* Virtual PIC */
 #ifdef CONFIG_HYPERV_ENABLED
 	struct acrn_hyperv hyperv;

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -35,14 +35,13 @@ uint8_t ioapic_irq_to_ioapic_id(uint32_t irq);
  */
 
 /**
- * @brief Get irq num from pin num
+ * @brief Get irq num from gsi num
  *
- * @param[in]	pin The pin number
+ * @param[in]	gsi The gsi number
  *
  * @return irq number
  */
-uint32_t ioapic_pin_to_irq(uint32_t pin);
-
+uint32_t ioapic_gsi_to_irq(uint32_t gsi);
 /**
  * @brief Set the redirection table entry
  *

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -21,8 +21,8 @@ struct ioapic_info {
 
 void ioapic_setup_irqs(void);
 
-bool ioapic_irq_is_gsi(uint32_t irq);
-uint32_t ioapic_irq_to_pin(uint32_t irq);
+bool is_ioapic_irq(uint32_t irq);
+uint32_t gsi_to_ioapic_pin(uint32_t gsi);
 int32_t init_ioapic_id_info(void);
 uint8_t ioapic_irq_to_ioapic_id(uint32_t irq);
 
@@ -88,15 +88,26 @@ void ioapic_gsi_unmask_irq(uint32_t irq);
 
 void ioapic_get_rte_entry(void *ioapic_base, uint32_t pin, union ioapic_rte *rte);
 
+/*
+ * is_valid is by default false when all the
+ * static variables, part of .bss, are initialized to 0s
+ * It is set to true, if the corresponding
+ * gsi falls in ranges identified by IOAPIC data
+ * in ACPI MADT in ioapic_setup_irqs.
+ */
+
 struct gsi_table {
-	uint8_t ioapic_id;
-	uint32_t pin;
-	void  *addr;
+	bool is_valid;
+	struct {
+		uint8_t acpi_id;
+		uint8_t index;
+		uint32_t pin;
+		void  *base_addr;
+	} ioapic_info;
 };
 
 void *gsi_to_ioapic_base(uint32_t gsi);
-uint32_t ioapic_get_nr_gsi(void);
+uint32_t get_max_nr_gsi(void);
 uint32_t get_pic_pin_from_ioapic_pin(uint32_t pin_index);
-bool ioapic_is_pin_valid(uint32_t pin);
-
+bool is_gsi_valid(uint32_t gsi);
 #endif /* IOAPIC_H */

--- a/hypervisor/include/arch/x86/ioapic.h
+++ b/hypervisor/include/arch/x86/ioapic.h
@@ -26,6 +26,8 @@ uint32_t gsi_to_ioapic_pin(uint32_t gsi);
 int32_t init_ioapic_id_info(void);
 uint8_t ioapic_irq_to_ioapic_id(uint32_t irq);
 
+uint8_t get_platform_ioapic_info (struct ioapic_info **plat_ioapic_info);
+
 /**
  * @defgroup ioapic_ext_apis IOAPIC External Interfaces
  *
@@ -108,6 +110,7 @@ struct gsi_table {
 
 void *gsi_to_ioapic_base(uint32_t gsi);
 uint32_t get_max_nr_gsi(void);
+uint8_t get_gsi_to_ioapic_index(uint32_t gsi);
 uint32_t get_pic_pin_from_ioapic_pin(uint32_t pin_index);
 bool is_gsi_valid(uint32_t gsi);
 #endif /* IOAPIC_H */

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -25,7 +25,7 @@ enum intx_ctlr {
 union source_id (name) = {.msi_id = {.bdf = (a), .entry_nr = (b)} }
 
 #define DEFINE_INTX_SID(name, a, b)	\
-union source_id (name) = {.intx_id = {.pin = (a), .ctlr = (b)} }
+union source_id (name) = {.intx_id = {.gsi = (a), .ctlr = (b)} }
 
 union irte_index {
 	uint16_t index;
@@ -49,7 +49,7 @@ union source_id {
 	 */
 	struct {
 		enum intx_ctlr ctlr;
-		uint32_t pin;
+		uint32_t gsi;
 	} intx_id;
 };
 

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -42,7 +42,6 @@
 
 #define	VIOAPIC_BASE	0xFEC00000UL
 #define	VIOAPIC_SIZE	4096UL
-#define	VIOAPIC_MAX_PIN	 256U
 
 #define REDIR_ENTRIES_HW	120U /* SOS align with native ioapic */
 #define STATE_BITMAP_SIZE	INT_DIV_ROUNDUP(REDIR_ENTRIES_HW, 64U)
@@ -58,7 +57,6 @@ struct acrn_vioapic {
 	union ioapic_rte rtbl[REDIR_ENTRIES_HW];
 	/* pin_state status bitmap: 1 - high, 0 - low */
 	uint64_t pin_state[STATE_BITMAP_SIZE];
-	struct ptirq_remapping_info *vpin_to_pt_entry[VIOAPIC_MAX_PIN];
 };
 
 void    vioapic_init(struct acrn_vm *vm);
@@ -104,7 +102,7 @@ void	vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);
 void	vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector);
-void	vioapic_get_rte(struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte);
+void	vioapic_get_rte(const struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte);
 int32_t	vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 
 /**

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -51,6 +51,8 @@
 struct acrn_vioapic {
 	struct acrn_vm	*vm;
 	spinlock_t	mtx;
+	uint32_t	base_addr;
+	uint32_t	nr_pins;
 	uint32_t	id;
 	bool		ready;
 	uint32_t	ioregsel;

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -76,7 +76,7 @@ void	vioapic_reset(struct acrn_vm *vm);
  * @brief Set vIOAPIC IRQ line status.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irqline   Target IRQ number
+ * @param[in] vgsi	GSI for the virtual interrupt
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
@@ -84,7 +84,7 @@ void	vioapic_reset(struct acrn_vm *vm);
  *
  * @return None
  */
-void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
+void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation);
 
 /**
  * @brief Set vIOAPIC IRQ line status.
@@ -93,18 +93,18 @@ void	vioapic_set_irqline_lock(const struct acrn_vm *vm, uint32_t irqline, uint32
  * operation be done with ioapic lock.
  *
  * @param[in] vm        Pointer to target VM
- * @param[in] irqline   Target IRQ number
+ * @param[in] vgsi      GSI for the virtual interrupt
  * @param[in] operation Action options: GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @pre irqline < vioapic_pincount(vm)
  * @return None
  */
-void	vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t irqline, uint32_t operation);
+void	vioapic_set_irqline_nolock(const struct acrn_vm *vm, uint32_t vgsi, uint32_t operation);
 
 uint32_t	vioapic_pincount(const struct acrn_vm *vm);
 void	vioapic_process_eoi(struct acrn_vm *vm, uint32_t vector);
-void	vioapic_get_rte(const struct acrn_vm *vm, uint32_t pin, union ioapic_rte *rte);
+void	vioapic_get_rte(const struct acrn_vm *vm, uint32_t vgsi, union ioapic_rte *rte);
 int32_t	vioapic_mmio_access_handler(struct io_request *io_req, void *handler_private_data);
 
 /**

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -149,13 +149,13 @@ void vpic_init(struct acrn_vm *vm);
  * @brief Set vPIC IRQ line status.
  *
  * @param[in] vpic      Pointer to target VM's vpic table
- * @param[in] irqline   Target IRQ number
+ * @param[in] vgsi      GSI for the virtual interrupt
  * @param[in] operation action options:GSI_SET_HIGH/GSI_SET_LOW/
  *			GSI_RAISING_PULSE/GSI_FALLING_PULSE
  *
  * @return None
  */
-void vpic_set_irqline(struct acrn_vpic *vpic, uint32_t irqline, uint32_t operation);
+void vpic_set_irqline(struct acrn_vpic *vpic, uint32_t vgsi, uint32_t operation);
 
 /**
  * @brief Get pending virtual interrupts for vPIC.
@@ -179,7 +179,7 @@ void vpic_pending_intr(struct acrn_vpic *vpic, uint32_t *vecptr);
  * @pre vm != NULL
  */
 void vpic_intr_accepted(struct acrn_vpic *vpic, uint32_t vector);
-void vpic_get_irqline_trigger_mode(const struct acrn_vpic *vpic, uint32_t irqline, enum vpic_trigger *trigger);
+void vpic_get_irqline_trigger_mode(const struct acrn_vpic *vpic, uint32_t vgsi, enum vpic_trigger *trigger);
 uint32_t vpic_pincount(void);
 struct acrn_vpic *vm_pic(const struct acrn_vm *vm);
 

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -134,7 +134,6 @@ struct acrn_vpic {
 	struct acrn_vm		*vm;
 	spinlock_t	lock;
 	struct i8259_reg_state	i8259[2];
-	struct ptirq_remapping_info *vpin_to_pt_entry[NR_VPIC_PINS_TOTAL];
 };
 
 void vpic_init(struct acrn_vm *vm);

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -88,5 +88,5 @@ void vuart_putchar(struct acrn_vuart *vu, char ch);
 char vuart_getchar(struct acrn_vuart *vu);
 void vuart_toggle_intr(const struct acrn_vuart *vu);
 
-bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_pin);
+bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_gsi);
 #endif /* VUART_H */


### PR DESCRIPTION
This patchset adds support for emulating multiple vIO-APICs for SOS
on platforms with more than one IO-APIC.

Tracked-On: #4151
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@Intel.com>
