### PR TITLE
acrn-config: create temporary scenario file folder if it doesn't exist

### DIFF
--- a/misc/acrn-config/config_app/views.py
+++ b/misc/acrn-config/config_app/views.py
@@ -527,6 +527,9 @@ def upload_scenario():
             tmp_scenario_name = 'tmp_' + scenario_file_name + '.xml'
             tmp_scenario_file = os.path.join(current_app.config.get('CONFIG_PATH'), board_type,
                                              'user_defined', tmp_scenario_name)
+            tmp_scenario_folder = os.path.dirname(tmp_scenario_file)
+            if not os.path.exists(tmp_scenario_folder):
+                os.makedirs(tmp_scenario_folder)
             if os.path.isfile(tmp_scenario_file):
                 os.remove(tmp_scenario_file)
 


### PR DESCRIPTION
This commit creates the folder for hosting the temporary scenario .xml files if the folder doesn't exist to avoid the FileNotFound python exception.

Tracked-On: #4522
Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>