### PR TITLE
hv: cpuid: remove cpuid()

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -495,7 +495,7 @@ static void init_pcpu_xsave(void)
 	CPU_CR_WRITE(cr4, val64);
 
 	if (get_pcpu_id() == BSP_CPU_ID) {
-		cpuid(CPUID_FEATURES, &unused, &unused, &ecx, &unused);
+		cpuid_subleaf(CPUID_FEATURES, 0x0U, &unused, &unused, &ecx, &unused);
 
 		/* if set, update it */
 		if ((ecx & CPUID_ECX_OSXSAVE) != 0U) {

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -204,7 +204,7 @@ static void detect_xsave_cap(void)
 {
 	uint32_t unused;
 
-	cpuid_subleaf(CPUID_XSAVE_FEATURES, 0U,
+	cpuid_subleaf(CPUID_XSAVE_FEATURES, 0x0U,
 		&boot_cpu_data.cpuid_leaves[FEAT_D_0_EAX],
 		&unused,
 		&unused,
@@ -234,11 +234,11 @@ void init_pcpu_capabilities(void)
 	uint32_t eax, unused;
 	uint32_t family, model;
 
-	cpuid(CPUID_VENDORSTRING,
+	cpuid_subleaf(CPUID_VENDORSTRING, 0x0U,
 		&boot_cpu_data.cpuid_level,
 		&unused, &unused, &unused);
 
-	cpuid(CPUID_FEATURES, &eax, &unused,
+	cpuid_subleaf(CPUID_FEATURES, 0x0U, &eax, &unused,
 		&boot_cpu_data.cpuid_leaves[FEAT_1_ECX],
 		&boot_cpu_data.cpuid_leaves[FEAT_1_EDX]);
 	family = (eax >> 8U) & 0xfU;
@@ -254,28 +254,28 @@ void init_pcpu_capabilities(void)
 	boot_cpu_data.model = (uint8_t)model;
 
 
-	cpuid(CPUID_EXTEND_FEATURE, &unused,
+	cpuid_subleaf(CPUID_EXTEND_FEATURE, 0x0U, &unused,
 		&boot_cpu_data.cpuid_leaves[FEAT_7_0_EBX],
 		&boot_cpu_data.cpuid_leaves[FEAT_7_0_ECX],
 		&boot_cpu_data.cpuid_leaves[FEAT_7_0_EDX]);
 
-	cpuid(CPUID_MAX_EXTENDED_FUNCTION,
+	cpuid_subleaf(CPUID_MAX_EXTENDED_FUNCTION, 0x0U,
 		&boot_cpu_data.extended_cpuid_level,
 		&unused, &unused, &unused);
 
 	if (boot_cpu_data.extended_cpuid_level >= CPUID_EXTEND_FUNCTION_1) {
-		cpuid(CPUID_EXTEND_FUNCTION_1, &unused, &unused,
+		cpuid_subleaf(CPUID_EXTEND_FUNCTION_1, 0x0U, &unused, &unused,
 			&boot_cpu_data.cpuid_leaves[FEAT_8000_0001_ECX],
 			&boot_cpu_data.cpuid_leaves[FEAT_8000_0001_EDX]);
 	}
 
 	if (boot_cpu_data.extended_cpuid_level >= CPUID_EXTEND_INVA_TSC) {
-		cpuid(CPUID_EXTEND_INVA_TSC, &eax, &unused, &unused,
+		cpuid_subleaf(CPUID_EXTEND_INVA_TSC, 0x0U, &eax, &unused, &unused,
 			&boot_cpu_data.cpuid_leaves[FEAT_8000_0007_EDX]);
 	}
 
 	if (boot_cpu_data.extended_cpuid_level >= CPUID_EXTEND_ADDRESS_SIZE) {
-		cpuid(CPUID_EXTEND_ADDRESS_SIZE, &eax,
+		cpuid_subleaf(CPUID_EXTEND_ADDRESS_SIZE, 0x0U, &eax,
 			&boot_cpu_data.cpuid_leaves[FEAT_8000_0008_EBX],
 			&unused, &unused);
 
@@ -318,17 +318,17 @@ bool pcpu_has_vmx_vpid_cap(uint32_t bit_mask)
 
 void init_pcpu_model_name(void)
 {
-	cpuid(CPUID_EXTEND_FUNCTION_2,
+	cpuid_subleaf(CPUID_EXTEND_FUNCTION_2, 0x0U,
 		(uint32_t *)(boot_cpu_data.model_name),
 		(uint32_t *)(&boot_cpu_data.model_name[4]),
 		(uint32_t *)(&boot_cpu_data.model_name[8]),
 		(uint32_t *)(&boot_cpu_data.model_name[12]));
-	cpuid(CPUID_EXTEND_FUNCTION_3,
+	cpuid_subleaf(CPUID_EXTEND_FUNCTION_3, 0x0U,
 		(uint32_t *)(&boot_cpu_data.model_name[16]),
 		(uint32_t *)(&boot_cpu_data.model_name[20]),
 		(uint32_t *)(&boot_cpu_data.model_name[24]),
 		(uint32_t *)(&boot_cpu_data.model_name[28]));
-	cpuid(CPUID_EXTEND_FUNCTION_4,
+	cpuid_subleaf(CPUID_EXTEND_FUNCTION_4, 0x0U,
 		(uint32_t *)(&boot_cpu_data.model_name[32]),
 		(uint32_t *)(&boot_cpu_data.model_name[36]),
 		(uint32_t *)(&boot_cpu_data.model_name[40]),

--- a/hypervisor/arch/x86/guest/ucode.c
+++ b/hypervisor/arch/x86/guest/ucode.c
@@ -25,7 +25,7 @@ uint64_t get_microcode_version(void)
 	uint32_t eax, ebx, ecx, edx;
 
 	msr_write(MSR_IA32_BIOS_SIGN_ID, 0U);
-	cpuid(CPUID_FEATURES, &eax, &ebx, &ecx, &edx);
+	cpuid_subleaf(CPUID_FEATURES, 0x0U, &eax, &ebx, &ecx, &edx);
 	val = msr_read(MSR_IA32_BIOS_SIGN_ID);
 
 	return val;

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -400,7 +400,7 @@ static void guest_cpuid_01h(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx
 	uint32_t apicid = vlapic_get_apicid(vcpu_vlapic(vcpu));
 	uint64_t guest_ia32_misc_enable = vcpu_get_guest_msr(vcpu, MSR_IA32_MISC_ENABLE);
 
-	cpuid(0x1U, eax, ebx, ecx, edx);
+	cpuid_subleaf(0x1U, 0x0U, eax, ebx, ecx, edx);
 	/* Patching initial APIC ID */
 	*ebx &= ~APIC_ID_MASK;
 	*ebx |= (apicid <<  APIC_ID_SHIFT);
@@ -517,7 +517,7 @@ static void guest_cpuid_80000001h(const struct acrn_vcpu *vcpu,
 	uint32_t leaf = 0x80000001U;
 
 	if ((entry_check != NULL) && (entry_check->eax >= leaf)) {
-		cpuid(leaf, eax, ebx, ecx, edx);
+		cpuid_subleaf(leaf, 0x0U, eax, ebx, ecx, edx);
 		/* SDM Vol4 2.1, XD Bit Disable of MSR_IA32_MISC_ENABLE
 		 * When set to 1, the Execute Disable Bit feature (XD Bit) is disabled and the XD Bit
 		 * extended feature flag will be clear (CPUID.80000001H: EDX[20]=0)

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -272,7 +272,7 @@ static uint64_t native_calibrate_tsc(void)
 	if (cpu_info->cpuid_level >= 0x15U) {
 		uint32_t eax_denominator, ebx_numerator, ecx_hz, reserved;
 
-		cpuid(0x15U, &eax_denominator, &ebx_numerator,
+		cpuid_subleaf(0x15U, 0x0U, &eax_denominator, &ebx_numerator,
 			&ecx_hz, &reserved);
 
 		if ((eax_denominator != 0U) && (ebx_numerator != 0U)) {
@@ -283,7 +283,7 @@ static uint64_t native_calibrate_tsc(void)
 
 	if ((tsc_hz == 0UL) && (cpu_info->cpuid_level >= 0x16U)) {
 		uint32_t eax_base_mhz, ebx_max_mhz, ecx_bus_mhz, edx;
-		cpuid(0x16U, &eax_base_mhz, &ebx_max_mhz, &ecx_bus_mhz, &edx);
+		cpuid_subleaf(0x16U, 0x0U, &eax_base_mhz, &ebx_max_mhz, &ecx_bus_mhz, &edx);
 		tsc_hz = (uint64_t) eax_base_mhz * 1000000U;
 	}
 

--- a/hypervisor/include/arch/x86/cpuid.h
+++ b/hypervisor/include/arch/x86/cpuid.h
@@ -134,16 +134,6 @@ static inline void asm_cpuid(uint32_t *eax, uint32_t *ebx,
 			: "memory");
 }
 
-static inline void cpuid(uint32_t leaf,
-			uint32_t *eax, uint32_t *ebx,
-			uint32_t *ecx, uint32_t *edx)
-{
-	*eax = leaf;
-	*ecx = 0U;
-
-	asm_cpuid(eax, ebx, ecx, edx);
-}
-
 static inline void cpuid_subleaf(uint32_t leaf, uint32_t subleaf,
 				uint32_t *eax, uint32_t *ebx,
 				uint32_t *ecx, uint32_t *edx)


### PR DESCRIPTION
The cupid() can be replaced with cupid_subleaf, which is more clear.
Having both APIs makes reading difficult.

Tracked-On: #4526
Signed-off-by: Li Fei1 <fei1.li@intel.com>