### PR TITLE
Clean-up some codes

### DIFF
--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -70,17 +70,20 @@ static int32_t
 drhd_find_iter(struct acpi_dmar_header *dmar_header, void *arg)
 {
 	struct find_iter_args *args;
+	int32_t ret = 1;
 
-	if (dmar_header->type != ACPI_DMAR_TYPE_HARDWARE_UNIT)
-		return 1;
-
-	args = arg;
-	if (args->i == 0U) {
-		args->res = (struct acpi_dmar_hardware_unit *)dmar_header;
-		return 0;
+	if (dmar_header->type == ACPI_DMAR_TYPE_HARDWARE_UNIT){
+		args = arg;
+		if (args->i == 0U) {
+			args->res = (struct acpi_dmar_hardware_unit *)dmar_header;
+			ret = 0;
+		}
+		else{
+			args->i--;
+			ret = 1;
+		}
 	}
-	args->i--;
-	return 1;
+	return ret;
 }
 
 static struct acpi_dmar_hardware_unit *

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -167,16 +167,16 @@ static inline uint8_t* get_ctx_table(uint32_t dmar_index, uint8_t bus_no)
 /*
  * @pre dmar_index < CONFIG_MAX_IOMMU_NUM
  */
-static inline uint8_t *get_qi_queue(uint32_t dmar_index)
+static inline void *get_qi_queue(uint32_t dmar_index)
 {
 	static struct page qi_queues[CONFIG_MAX_IOMMU_NUM] __aligned(PAGE_SIZE);
-	return qi_queues[dmar_index].contents;
+	return (void *)qi_queues[dmar_index].contents;
 }
 
-static inline uint8_t *get_ir_table(uint32_t dmar_index)
+static inline void *get_ir_table(uint32_t dmar_index)
 {
 	static struct intr_remap_table ir_tables[CONFIG_MAX_IOMMU_NUM] __aligned(PAGE_SIZE);
-	return ir_tables[dmar_index].tables[0].contents;
+	return (void *)ir_tables[dmar_index].tables[0].contents;
 }
 
 bool iommu_snoop_supported(const struct iommu_domain *iommu)

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -237,13 +237,7 @@ static uint32_t iommu_read32(const struct dmar_drhd_rt *dmar_unit, uint32_t offs
 
 static uint64_t iommu_read64(const struct dmar_drhd_rt *dmar_unit, uint32_t offset)
 {
-	uint64_t value;
-
-	value = mmio_read32(hpa2hva(dmar_unit->drhd->reg_base_addr + offset + 4U));
-	value = value << 32U;
-	value = value | mmio_read32(hpa2hva(dmar_unit->drhd->reg_base_addr + offset));
-
-	return value;
+	return mmio_read64(hpa2hva(dmar_unit->drhd->reg_base_addr + offset));
 }
 
 static void iommu_write32(const struct dmar_drhd_rt *dmar_unit, uint32_t offset, uint32_t value)
@@ -253,13 +247,7 @@ static void iommu_write32(const struct dmar_drhd_rt *dmar_unit, uint32_t offset,
 
 static void iommu_write64(const struct dmar_drhd_rt *dmar_unit, uint32_t offset, uint64_t value)
 {
-	uint32_t temp;
-
-	temp = (uint32_t)value;
-	mmio_write32(temp, hpa2hva(dmar_unit->drhd->reg_base_addr + offset));
-
-	temp = (uint32_t)(value >> 32U);
-	mmio_write32(temp, hpa2hva(dmar_unit->drhd->reg_base_addr + offset + 4U));
+	mmio_write64(value, hpa2hva(dmar_unit->drhd->reg_base_addr + offset));
 }
 
 static inline void dmar_wait_completion(const struct dmar_drhd_rt *dmar_unit, uint32_t offset,

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -22,6 +22,13 @@
 #define ACPI_MADT_ENABLED           1U
 #define ACPI_MADT_TYPE_LOCAL_APIC_NMI 4U
 
+#define ACPI_DMAR_TYPE_HARDWARE_UNIT           0U
+#define ACPI_DMAR_TYPE_RESERVED_MEMORY           1U
+#define ACPI_DMAR_TYPE_ROOT_ATS           2U
+#define ACPI_DMAR_TYPE_HARDWARE_AFFINITY           3U
+#define ACPI_DMAR_TYPE_NAMESPACE           4U
+#define ACPI_DMAR_TYPE_RESERVED           5U
+
 /* FACP field offsets */
 #define OFFSET_FACS_ADDR        36U
 #define OFFSET_RESET_REGISTER   116U
@@ -152,15 +159,6 @@ struct acpi_madt_ioapic {
 	uint32_t  gsi_base;
 } __packed;
 
-enum acpi_dmar_type {
-	ACPI_DMAR_TYPE_HARDWARE_UNIT        = 0,
-	ACPI_DMAR_TYPE_RESERVED_MEMORY      = 1,
-	ACPI_DMAR_TYPE_ROOT_ATS             = 2,
-	ACPI_DMAR_TYPE_HARDWARE_AFFINITY    = 3,
-	ACPI_DMAR_TYPE_NAMESPACE            = 4,
-	ACPI_DMAR_TYPE_RESERVED             = 5
-};
-
 struct acpi_table_dmar {
 	/* Common ACPI table header */
 	struct acpi_table_header  header;
@@ -197,7 +195,6 @@ struct acpi_dmar_device_scope {
 	uint8_t                   enumeration_id;
 	uint8_t                   bus;
 } __packed;
-
 
 void *get_acpi_tbl(const char *signature);
 

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -53,8 +53,6 @@ enum acpi_dmar_scope_type {
 };
 
 struct iommu_domain {
-	bool is_host;
-	bool is_tt_ept;     /* if reuse EPT of the domain */
 	uint16_t vm_id;
 	uint32_t addr_width;   /* address width of the domain */
 	uint64_t trans_table_ptr;


### PR DESCRIPTION
Clean-up some codes.

hypervisor/acpi_parser/dmar_parse.c:
1.removed multiple returns

hypervisor/arch/x86/vtd.c:
1.corrected the return type of some functions,
2.simplified the logic of dmar_wait_completion() and iommu_read64(),
3.renamed some static functions
4.remove some code branches about iommu_domain.is_host and iommu_domain.is_tt_ept
since their values are determined

/hypervisor/include/arch/x86/vtd.h
1.removed the "is_host" and "is_tt_ept" members of struct iommu_domain
since their values are always determined

hypervisor/hw/pci.c
1.renamed some data structures to make them more understandable