### PR TITLE
Add support for VT-d Posted Interrupts (series #1)

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -107,13 +107,13 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	dest_mask = calculate_logical_dest_mask(pdmask);
 
 	/* Using phys_irq as index in the corresponding IOMMU */
-	irte.entry.lo_64 = 0UL;
-	irte.entry.hi_64 = 0UL;
-	irte.bits.vector = vector;
-	irte.bits.delivery_mode = delmode;
-	irte.bits.dest_mode = MSI_ADDR_DESTMODE_LOGICAL;
-	irte.bits.rh = MSI_ADDR_RH;
-	irte.bits.dest = dest_mask;
+	irte.value.lo_64 = 0UL;
+	irte.value.hi_64 = 0UL;
+	irte.bits.remap.vector = vector;
+	irte.bits.remap.delivery_mode = delmode;
+	irte.bits.remap.dest_mode = MSI_ADDR_DESTMODE_LOGICAL;
+	irte.bits.remap.rh = MSI_ADDR_RH;
+	irte.bits.remap.dest = dest_mask;
 
 	intr_src.is_msi = true;
 	intr_src.src.msi.value = entry->phys_sid.msi_id.bdf;
@@ -203,13 +203,13 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		vector = irq_to_vector(phys_irq);
 		dest_mask = calculate_logical_dest_mask(pdmask);
 
-		irte.entry.lo_64 = 0UL;
-		irte.entry.hi_64 = 0UL;
-		irte.bits.vector = vector;
-		irte.bits.delivery_mode = delmode;
-		irte.bits.dest_mode = IOAPIC_RTE_DESTMODE_LOGICAL;
-		irte.bits.dest = dest_mask;
-		irte.bits.trigger_mode = rte.bits.trigger_mode;
+		irte.value.lo_64 = 0UL;
+		irte.value.hi_64 = 0UL;
+		irte.bits.remap.vector = vector;
+		irte.bits.remap.delivery_mode = delmode;
+		irte.bits.remap.dest_mode = IOAPIC_RTE_DESTMODE_LOGICAL;
+		irte.bits.remap.dest = dest_mask;
+		irte.bits.remap.trigger_mode = rte.bits.trigger_mode;
 
 		intr_src.is_msi = false;
 		intr_src.src.ioapic_id = ioapic_irq_to_ioapic_id(phys_irq);

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -353,7 +353,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 
 		exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0U);
 		exec_vmwrite16(VMX_POSTED_INTR_VECTOR, POSTED_INTR_VECTOR);
-		exec_vmwrite64(VMX_PIR_DESC_ADDR_FULL, apicv_get_pir_desc_paddr(vcpu));
+		exec_vmwrite64(VMX_PIR_DESC_ADDR_FULL, hva2hpa(get_pi_desc(vcpu)));
 	}
 
 	/* Load EPTP execution control

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1385,7 +1385,7 @@ int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry
 		trigger_mode = 0x0UL;
 	} else {
 		dmar_unit = ioapic_to_dmaru(intr_src->src.ioapic_id, &sid);
-		trigger_mode = irte->bits.trigger_mode;
+		trigger_mode = irte->bits.remap.trigger_mode;
 	}
 
 	if (dmar_unit == NULL) {
@@ -1399,17 +1399,17 @@ int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry
 		ret = -EINVAL;
 	} else {
 		dmar_enable_intr_remapping(dmar_unit);
-		irte->bits.svt = 0x1UL;
-		irte->bits.sq = 0x0UL;
-		irte->bits.sid = sid.value;
-		irte->bits.present = 0x1UL;
-		irte->bits.mode = 0x0UL;
-		irte->bits.trigger_mode = trigger_mode;
-		irte->bits.fpd = 0x0UL;
+		irte->bits.remap.svt = 0x1UL;
+		irte->bits.remap.sq = 0x0UL;
+		irte->bits.remap.sid = sid.value;
+		irte->bits.remap.present = 0x1UL;
+		irte->bits.remap.mode = 0x0UL;
+		irte->bits.remap.trigger_mode = trigger_mode;
+		irte->bits.remap.fpd = 0x0UL;
 		ir_table = (union dmar_ir_entry *)hpa2hva(dmar_unit->ir_table_addr);
 		ir_entry = ir_table + index;
-		ir_entry->entry.hi_64 = irte->entry.hi_64;
-		ir_entry->entry.lo_64 = irte->entry.lo_64;
+		ir_entry->value.hi_64 = irte->value.hi_64;
+		ir_entry->value.lo_64 = irte->value.lo_64;
 
 		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);
@@ -1440,7 +1440,7 @@ void dmar_free_irte(const struct intr_source *intr_src, uint16_t index)
 	} else {
 		ir_table = (union dmar_ir_entry *)hpa2hva(dmar_unit->ir_table_addr);
 		ir_entry = ir_table + index;
-		ir_entry->bits.present = 0x0UL;
+		ir_entry->bits.remap.present = 0x0UL;
 
 		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -43,14 +43,6 @@
 
 #define VLAPIC_MAXLVT_INDEX	APIC_LVT_CMCI
 
-/* Posted Interrupt Descriptor (PID) in VT-d spec */
-struct pi_desc {
-	/* Posted Interrupt Requests, one bit per requested vector */
-	uint64_t pir[4];
-	uint64_t pending;
-	uint64_t unused[3];
-} __aligned(64);
-
 struct vlapic_timer {
 	struct hv_timer timer;
 	uint32_t mode;
@@ -60,16 +52,14 @@ struct vlapic_timer {
 
 struct acrn_vlapic {
 	/*
-	 * Please keep 'apic_page' and 'pid' be the first two fields in
+	 * Please keep 'apic_page' as the first field in
 	 * current structure, as below alignment restrictions are mandatory
 	 * to support APICv features:
 	 * - 'apic_page' MUST be 4KB aligned.
-	 * - 'pid' MUST be 64 bytes aligned.
 	 * IRR, TMR and PIR could be accessed by other vCPUs when deliver
 	 * an interrupt to vLAPIC.
 	 */
 	struct lapic_regs	apic_page;
-	struct pi_desc	pid;
 
 	struct acrn_vm		*vm;
 	struct acrn_vcpu	*vcpu;
@@ -123,20 +113,6 @@ void vlapic_set_apicv_ops(void);
 bool vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 bool vlapic_has_pending_delivery_intr(struct acrn_vcpu *vcpu);
 bool vlapic_has_pending_intr(struct acrn_vcpu *vcpu);
-
-/**
- * @brief Get physical address to PIR description.
- *
- * If APICv Posted-interrupt is supported, this address will be configured
- * to VMCS "Posted-interrupt descriptor address" field.
- *
- * @param[in] vcpu Target vCPU
- *
- * @return physicall address to PIR
- *
- * @pre vcpu != NULL
- */
-uint64_t apicv_get_pir_desc_paddr(struct acrn_vcpu *vcpu);
 
 uint64_t vlapic_get_tsc_deadline_msr(const struct acrn_vlapic *vlapic);
 void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic, uint64_t val_arg);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -43,7 +43,9 @@
 
 #define VLAPIC_MAXLVT_INDEX	APIC_LVT_CMCI
 
-struct vlapic_pir_desc {
+/* Posted Interrupt Descriptor (PID) in VT-d spec */
+struct pi_desc {
+	/* Posted Interrupt Requests, one bit per requested vector */
 	uint64_t pir[4];
 	uint64_t pending;
 	uint64_t unused[3];
@@ -58,16 +60,16 @@ struct vlapic_timer {
 
 struct acrn_vlapic {
 	/*
-	 * Please keep 'apic_page' and 'pir_desc' be the first two fields in
+	 * Please keep 'apic_page' and 'pid' be the first two fields in
 	 * current structure, as below alignment restrictions are mandatory
 	 * to support APICv features:
 	 * - 'apic_page' MUST be 4KB aligned.
-	 * - 'pir_desc' MUST be 64 bytes aligned.
+	 * - 'pid' MUST be 64 bytes aligned.
 	 * IRR, TMR and PIR could be accessed by other vCPUs when deliver
 	 * an interrupt to vLAPIC.
 	 */
 	struct lapic_regs	apic_page;
-	struct vlapic_pir_desc	pir_desc;
+	struct pi_desc	pid;
 
 	struct acrn_vm		*vm;
 	struct acrn_vcpu	*vcpu;

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -374,6 +374,14 @@
 #define VMX_INT_TYPE_HW_EXP		3U
 #define VMX_INT_TYPE_SW_EXP		6U
 
+/* Posted Interrupt Descriptor (PID) in VT-d spec */
+struct pi_desc {
+	/* Posted Interrupt Requests, one bit per requested vector */
+	uint64_t pir[4];
+	uint64_t pending;
+	uint32_t unused[3];
+} __aligned(64);
+
 /* External Interfaces */
 void vmx_on(void);
 void vmx_off(void);

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -378,9 +378,32 @@
 struct pi_desc {
 	/* Posted Interrupt Requests, one bit per requested vector */
 	uint64_t pir[4];
-	uint64_t pending;
-	uint32_t unused[3];
+
+	union {
+		struct {
+			/* Outstanding Notification */
+			uint16_t on:1;
+
+			/* Suppress Notification, of non-urgent interrupts */
+			uint16_t sn:1;
+
+			uint16_t rsvd_1:14;
+
+			/* Notification Vector */
+			uint8_t nv;
+
+			uint8_t rsvd_2;
+
+			/* Notification destination, a physical LAPIC ID */
+			uint32_t ndst;
+		} bits;
+
+		uint64_t value;
+	} control;
+
+	uint32_t rsvd[6];
 } __aligned(64);
+
 
 /* External Interfaces */
 void vmx_on(void);
@@ -408,4 +431,5 @@ void exec_vmwrite64(uint32_t field_full, uint64_t value);
 void exec_vmclear(void *addr);
 void exec_vmptrld(void *addr);
 
+#define POSTED_INTR_ON  0U
 #endif /* VMX_H_ */

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -668,7 +668,7 @@ bool iommu_snoop_supported(const struct iommu_domain *iommu);
  * @retval 0 otherwise
  *
  */
-int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, uint16_t index);
+int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry *irte, uint16_t index);
 
 /**
  * @brief Free RTE for Interrupt Remapping Table.
@@ -677,7 +677,7 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
  * @param[in] index into Interrupt Remapping Table
  *
  */
-void dmar_free_irte(struct intr_source intr_src, uint16_t index);
+void dmar_free_irte(const struct intr_source *intr_src, uint16_t index);
 
 /**
  * @brief Flash cacheline(s) for a specific address with specific size.

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -511,24 +511,49 @@ struct dmar_entry {
 };
 
 union dmar_ir_entry {
-	struct dmar_entry entry;
-	struct {
-		uint64_t present:1;
-		uint64_t fpd:1;
-		uint64_t dest_mode:1;
-		uint64_t rh:1;
-		uint64_t trigger_mode:1;
-		uint64_t delivery_mode:3;
-		uint64_t sw_bits:4;
-		uint64_t rsvd_1:3;
-		uint64_t mode:1;
-		uint64_t vector:8;
-		uint64_t rsvd_2:8;
-		uint64_t dest:32;
-		uint64_t sid:16;
-		uint64_t sq:2;
-		uint64_t svt:2;
-		uint64_t rsvd_3:44;
+	struct dmar_entry value;
+
+	union {
+		/* Remapped mode */
+		struct {
+			uint64_t present:1;
+			uint64_t fpd:1;
+			uint64_t dest_mode:1;
+			uint64_t rh:1;
+			uint64_t trigger_mode:1;
+			uint64_t delivery_mode:3;
+			uint64_t avail:4;
+			uint64_t rsvd_1:3;
+			uint64_t mode:1;
+			uint64_t vector:8;
+			uint64_t rsvd_2:8;
+			uint64_t dest:32;
+
+			uint64_t sid:16;
+			uint64_t sq:2;
+			uint64_t svt:2;
+			uint64_t rsvd_3:44;
+		} remap;
+
+		/* Posted mode */
+		struct {
+			uint64_t present:1;
+			uint64_t fpd:1;
+			uint64_t rsvd_1:6;
+			uint64_t avail:4;
+			uint64_t rsvd_2:2;
+			uint64_t urgent:1;
+			uint64_t mode:1;
+			uint64_t vector:8;
+			uint64_t rsvd_3:14;
+			uint64_t pda_l:26;
+
+			uint64_t sid:16;
+			uint64_t sq:2;
+			uint64_t svt:2;
+			uint64_t rsvd_4:12;
+			uint64_t pda_h:32;
+		} post;
 	} bits __packed;
 };
 


### PR DESCRIPTION
If VT-d Posted interrupts are supported by the platform , hypervisor shall be able to use it to deliver interrupts directly to partitions

Enable VT-d posted interrupts for eligible platforms such as ANL, if vt-d posted interrupt is detected ,pt devices for that vm will use vt-d posted interrupt to deliver interrupts to guest without vm-exits, which can improve performance for the pt devices.

This is only patch series No.1 to enable VT-d support,  more patch series will be posted soon.

[External_System_ID] ACRN-6085