### PR TITLE
HV: misra fix for multiboot2.c

### DIFF
--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -51,6 +51,9 @@ static inline bool boot_from_multiboot1(void)
 }
 
 #ifdef CONFIG_MULTIBOOT2
+/*
+ * @post boot_regs[1] stores the address pointer that point to a valid multiboot2 info
+ */
 static inline bool boot_from_multiboot2(void)
 {
 	/*


### PR DESCRIPTION
The patch fixed a few misra violations for multiboot2.c;

Tracked-On: #4419

Signed-off-by: Victor Sun <victor.sun@intel.com>