### PR TITLE
Refine: use contain_of to cast a member of a structure out to the containing structure.

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -232,7 +232,7 @@ struct acrn_vcpu *get_running_vcpu(uint16_t pcpu_id)
 	struct acrn_vcpu *vcpu = NULL;
 
 	if ((curr != NULL) && (!is_idle_thread(curr))) {
-		vcpu = list_entry(curr, struct acrn_vcpu, thread_obj);
+		vcpu = container_of(curr, struct acrn_vcpu, thread_obj);
 	}
 
 	return vcpu;
@@ -746,7 +746,7 @@ void rstore_xsave_area(const struct ext_context *ectx)
  */
 static void context_switch_out(struct thread_object *prev)
 {
-	struct acrn_vcpu *vcpu = list_entry(prev, struct acrn_vcpu, thread_obj);
+	struct acrn_vcpu *vcpu = container_of(prev, struct acrn_vcpu, thread_obj);
 	struct ext_context *ectx = &(vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx);
 
 	/* We don't flush TLB as we assume each vcpu has different vpid */
@@ -762,7 +762,7 @@ static void context_switch_out(struct thread_object *prev)
 
 static void context_switch_in(struct thread_object *next)
 {
-	struct acrn_vcpu *vcpu = list_entry(next, struct acrn_vcpu, thread_obj);
+	struct acrn_vcpu *vcpu = container_of(next, struct acrn_vcpu, thread_obj);
 	struct ext_context *ectx = &(vcpu->arch.contexts[vcpu->arch.cur_context].ext_ctx);
 
 	load_vmcs(vcpu);

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -64,6 +64,11 @@ static inline uint32_t prio(uint32_t x)
 
 #define DBG_LEVEL_VLAPIC		6U
 
+static inline struct acrn_vcpu *vlapic2vcpu(const struct acrn_vlapic *vlapic)
+{
+	return container_of(container_of(vlapic, struct acrn_vcpu_arch, vlapic), struct acrn_vcpu, arch);
+}
+
 #if VLAPIC_VERBOS
 static inline void vlapic_dump_irr(const struct acrn_vlapic *vlapic, const char *msg)
 {
@@ -165,7 +170,7 @@ vlapic_get_apicid(const struct acrn_vlapic *vlapic)
 static inline uint32_t
 vlapic_build_id(const struct acrn_vlapic *vlapic)
 {
-	const struct acrn_vcpu *vcpu = vlapic->vcpu;
+	const struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 	uint32_t vlapic_id, lapic_regs_id;
 
 	if (is_sos_vm(vcpu->vm)) {
@@ -299,7 +304,7 @@ static void vlapic_init_timer(struct acrn_vlapic *vlapic)
 	(void)memset(vtimer, 0U, sizeof(struct vlapic_timer));
 
 	initialize_timer(&vtimer->timer,
-			vlapic_timer_expired, vlapic->vcpu,
+			vlapic_timer_expired, vlapic2vcpu(vlapic),
 			0UL, 0, 0UL);
 }
 
@@ -427,23 +432,24 @@ static void vlapic_write_icrtmr(struct acrn_vlapic *vlapic)
 uint64_t vlapic_get_tsc_deadline_msr(const struct acrn_vlapic *vlapic)
 {
 	uint64_t ret;
+	struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 
-	if (is_lapic_pt_enabled(vlapic->vcpu)) {
+	if (is_lapic_pt_enabled(vcpu)) {
 		/* If physical TSC_DEADLINE is zero which means it's not armed (automatically disarmed
 		 * after timer triggered), return 0 and reset the virtual TSC_DEADLINE;
 		 * If physical TSC_DEADLINE is not zero, return the virtual TSC_DEADLINE value.
 		 */
 		if (msr_read(MSR_IA32_TSC_DEADLINE) == 0UL) {
-			vcpu_set_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE, 0UL);
+			vcpu_set_guest_msr(vcpu, MSR_IA32_TSC_DEADLINE, 0UL);
 			ret = 0UL;
 		} else {
-			ret = vcpu_get_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE);
+			ret = vcpu_get_guest_msr(vcpu, MSR_IA32_TSC_DEADLINE);
 		}
 	} else if (!vlapic_lvtt_tsc_deadline(vlapic)) {
 		ret = 0UL;
 	} else {
 		ret = (vlapic->vtimer.timer.fire_tsc == 0UL) ? 0UL :
-			vcpu_get_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE);
+			vcpu_get_guest_msr(vcpu, MSR_IA32_TSC_DEADLINE);
 	}
 
 	return ret;
@@ -453,9 +459,10 @@ void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic, uint64_t val_arg)
 {
 	struct hv_timer *timer;
 	uint64_t val = val_arg;
+	struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 
-	if (is_lapic_pt_enabled(vlapic->vcpu)) {
-		vcpu_set_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE, val);
+	if (is_lapic_pt_enabled(vcpu)) {
+		vcpu_set_guest_msr(vcpu, MSR_IA32_TSC_DEADLINE, val);
 		/* If val is not zero, which mean guest intends to arm the tsc_deadline timer,
 		 * if the calculated value to write to the physical TSC_DEADLINE msr is zero,
 		 * we plus 1 to not disarm the physcial timer falsely;
@@ -472,7 +479,7 @@ void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic, uint64_t val_arg)
 			msr_write(MSR_IA32_TSC_DEADLINE, 0);
 		}
 	} else if (vlapic_lvtt_tsc_deadline(vlapic)) {
-		vcpu_set_guest_msr(vlapic->vcpu, MSR_IA32_TSC_DEADLINE, val);
+		vcpu_set_guest_msr(vcpu, MSR_IA32_TSC_DEADLINE, val);
 
 		timer = &vlapic->vtimer.timer;
 		del_timer(timer);
@@ -510,11 +517,11 @@ vlapic_set_tmr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
 	struct lapic_reg *tmrptr = &(vlapic->apic_page.tmr[0]);
 	if (level) {
 		if (!bitmap32_test_and_set_lock((uint16_t)(vector & 0x1fU), &tmrptr[(vector & 0xffU) >> 5U].v)) {
-			vcpu_set_eoi_exit_bitmap(vlapic->vcpu, vector);
+			vcpu_set_eoi_exit_bitmap(vlapic2vcpu(vlapic), vector);
 		}
 	} else {
 		if (bitmap32_test_and_clear_lock((uint16_t)(vector & 0x1fU), &tmrptr[(vector & 0xffU) >> 5U].v)) {
-			vcpu_clear_eoi_exit_bitmap(vlapic->vcpu, vector);
+			vcpu_clear_eoi_exit_bitmap(vlapic2vcpu(vlapic), vector);
 		}
 	}
 }
@@ -533,7 +540,7 @@ vlapic_reset_tmr(struct acrn_vlapic *vlapic)
 		lapic->tmr[i].v = 0U;
 	}
 
-	vcpu_reset_eoi_exit_bitmaps(vlapic->vcpu);
+	vcpu_reset_eoi_exit_bitmaps(vlapic2vcpu(vlapic));
 }
 
 static void apicv_basic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool level)
@@ -550,7 +557,7 @@ static void apicv_basic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector,
 	if (!bitmap32_test_and_set_lock((uint16_t)(vector & 0x1fU), &irrptr[idx].v)) {
 		/* update TMR if interrupt trigger mode has changed */
 		vlapic_set_tmr(vlapic, vector, level);
-		vcpu_make_request(vlapic->vcpu, ACRN_REQUEST_EVENT);
+		vcpu_make_request(vlapic2vcpu(vlapic), ACRN_REQUEST_EVENT);
 	}
 }
 
@@ -560,6 +567,7 @@ static void apicv_advanced_accept_intr(struct acrn_vlapic *vlapic, uint32_t vect
 	vlapic_set_tmr(vlapic, vector, level);
 
 	if (apicv_set_intr_ready(vlapic, vector)) {
+		struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 		/*
 		 * Send interrupt to vCPU via posted interrupt way:
 		 * 1. If target vCPU is in root mode(isn't running),
@@ -570,10 +578,10 @@ static void apicv_advanced_accept_intr(struct acrn_vlapic *vlapic, uint32_t vect
 		 *    send PI notification to vCPU and hardware will
 		 *    sync PIR to vIRR automatically.
 		 */
-		bitmap_set_lock(ACRN_REQUEST_EVENT, &vlapic->vcpu->arch.pending_req);
+		bitmap_set_lock(ACRN_REQUEST_EVENT, &vcpu->arch.pending_req);
 
-		if (get_pcpu_id() != pcpuid_from_vcpu(vlapic->vcpu)) {
-			apicv_post_intr(pcpuid_from_vcpu(vlapic->vcpu));
+		if (get_pcpu_id() != pcpuid_from_vcpu(vcpu)) {
+			apicv_post_intr(pcpuid_from_vcpu(vcpu));
 		}
 	}
 }
@@ -590,7 +598,7 @@ static void vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool
 	if ((lapic->svr.v & APIC_SVR_ENABLE) == 0U) {
 		dev_dbg(DBG_LEVEL_VLAPIC, "vlapic is software disabled, ignoring interrupt %u", vector);
 	} else {
-		signal_event(&vlapic->vcpu->events[VCPU_EVENT_VIRTUAL_INTERRUPT]);
+		signal_event(&vlapic2vcpu(vlapic)->events[VCPU_EVENT_VIRTUAL_INTERRUPT]);
 		vlapic->ops->accept_intr(vlapic, vector, level);
 	}
 }
@@ -758,12 +766,13 @@ vlapic_write_lvt(struct acrn_vlapic *vlapic, uint32_t offset)
 	if ((offset == APIC_OFFSET_LINT0_LVT) &&
 		((val & APIC_LVT_DM) == APIC_LVT_DM_EXTINT)) {
 		uint32_t last = vlapic_get_lvt(vlapic, offset);
+		struct acrn_vm *vm = vlapic2vcpu(vlapic)->vm;
 
 		/* mask -> unmask: may from every vlapic in the vm */
 		if (((last & APIC_LVT_M) != 0U) && ((val & APIC_LVT_M) == 0U)) {
-			if ((vlapic->vm->wire_mode == VPIC_WIRE_INTR) ||
-				(vlapic->vm->wire_mode == VPIC_WIRE_NULL)) {
-				vlapic->vm->wire_mode = VPIC_WIRE_LAPIC;
+			if ((vm->wire_mode == VPIC_WIRE_INTR) ||
+				(vm->wire_mode == VPIC_WIRE_NULL)) {
+				vm->wire_mode = VPIC_WIRE_LAPIC;
 				dev_dbg(DBG_LEVEL_VLAPIC,
 					"vpic wire mode -> LAPIC");
 			} else {
@@ -772,8 +781,8 @@ vlapic_write_lvt(struct acrn_vlapic *vlapic, uint32_t offset)
 			}
 		/* unmask -> mask: only from the vlapic LINT0-ExtINT enabled */
 		} else if (((last & APIC_LVT_M) == 0U) && ((val & APIC_LVT_M) != 0U)) {
-			if (vlapic->vm->wire_mode == VPIC_WIRE_LAPIC) {
-				vlapic->vm->wire_mode = VPIC_WIRE_NULL;
+			if (vm->wire_mode == VPIC_WIRE_LAPIC) {
+				vm->wire_mode = VPIC_WIRE_NULL;
 				dev_dbg(DBG_LEVEL_VLAPIC,
 						"vpic wire mode -> NULL");
 			}
@@ -826,13 +835,10 @@ vlapic_mask_lvts(struct acrn_vlapic *vlapic)
 static void
 vlapic_fire_lvt(struct acrn_vlapic *vlapic, uint32_t lvt)
 {
-	uint32_t vec, mode;
-	struct acrn_vcpu *vcpu = vlapic->vcpu;
-
 	if ((lvt & APIC_LVT_M) == 0U) {
-
-		vec = lvt & APIC_LVT_VECTOR;
-		mode = lvt & APIC_LVT_DM;
+		struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
+		uint32_t vec = lvt & APIC_LVT_VECTOR;
+		uint32_t mode = lvt & APIC_LVT_DM;
 
 		switch (mode) {
 		case APIC_LVT_DM_FIXED:
@@ -904,10 +910,10 @@ vlapic_process_eoi(struct acrn_vlapic *vlapic)
 			 * Register of the LAPIC.
 			 * TODO: Check if the bit 12 "Suppress EOI Broadcasts" is set.
 			 */
-			vioapic_broadcast_eoi(vlapic->vm, vector);
+			vioapic_broadcast_eoi(vlapic2vcpu(vlapic)->vm, vector);
 		}
 
-		vcpu_make_request(vlapic->vcpu, ACRN_REQUEST_EVENT);
+		vcpu_make_request(vlapic2vcpu(vlapic), ACRN_REQUEST_EVENT);
 	}
 
 	dev_dbg(DBG_LEVEL_VLAPIC, "Gratuitous EOI");
@@ -941,9 +947,9 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t lvt_index)
 {
 	uint32_t lvt;
 	int32_t ret = 0;
-	struct acrn_vcpu *vcpu = vlapic->vcpu;
 
 	if (vlapic_enabled(vlapic) == false) {
+		struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 		/*
 		 * When the local APIC is global/hardware disabled,
 		 * LINT[1:0] pins are configured as INTR and NMI pins,
@@ -1114,7 +1120,7 @@ vlapic_calc_dest(struct acrn_vm *vm, uint64_t *dmask, bool is_broadcast,
 		}
 
 		if (lowprio && (lowprio_dest != NULL)) {
-			bitmap_set_nolock(lowprio_dest->vcpu->vcpu_id, dmask);
+			bitmap_set_nolock(vlapic2vcpu(lowprio_dest)->vcpu_id, dmask);
 		}
 	}
 }
@@ -1240,6 +1246,7 @@ static void vlapic_write_icrlo(struct acrn_vlapic *vlapic)
 			|| (mode == APIC_DELMODE_STARTUP))) {
 		dev_dbg(DBG_LEVEL_VLAPIC, "Invalid ICR value");
 	} else {
+		struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 
 		dev_dbg(DBG_LEVEL_VLAPIC,
 			"icrlo 0x%08x icrhi 0x%08x triggered ipi %u",
@@ -1247,17 +1254,17 @@ static void vlapic_write_icrlo(struct acrn_vlapic *vlapic)
 
 		switch (shorthand) {
 		case APIC_DEST_DESTFLD:
-			vlapic_calc_dest(vlapic->vm, &dmask, is_broadcast, dest, phys, false);
+			vlapic_calc_dest(vcpu->vm, &dmask, is_broadcast, dest, phys, false);
 			break;
 		case APIC_DEST_SELF:
-			bitmap_set_nolock(vlapic->vcpu->vcpu_id, &dmask);
+			bitmap_set_nolock(vcpu->vcpu_id, &dmask);
 			break;
 		case APIC_DEST_ALLISELF:
-			dmask = vm_active_cpus(vlapic->vm);
+			dmask = vm_active_cpus(vcpu->vm);
 			break;
 		case APIC_DEST_ALLESELF:
-			dmask = vm_active_cpus(vlapic->vm);
-			bitmap_clear_nolock(vlapic->vcpu->vcpu_id, &dmask);
+			dmask = vm_active_cpus(vcpu->vm);
+			bitmap_clear_nolock(vlapic2vcpu(vlapic)->vcpu_id, &dmask);
 			break;
 		default:
 			/*
@@ -1267,9 +1274,9 @@ static void vlapic_write_icrlo(struct acrn_vlapic *vlapic)
 			break;
 		}
 
-		for (vcpu_id = 0U; vcpu_id < vlapic->vm->hw.created_vcpus; vcpu_id++) {
+		for (vcpu_id = 0U; vcpu_id < vcpu->vm->hw.created_vcpus; vcpu_id++) {
 			if ((dmask & (1UL << vcpu_id)) != 0UL) {
-				target_vcpu = vcpu_from_vid(vlapic->vm, vcpu_id);
+				target_vcpu = vcpu_from_vid(vcpu->vm, vcpu_id);
 
 				if (mode == APIC_DELMODE_FIXED) {
 					vlapic_set_intr(target_vcpu, vec, LAPIC_TRIG_EDGE);
@@ -1405,6 +1412,7 @@ vlapic_write_svr(struct acrn_vlapic *vlapic)
 	changed = old ^ new;
 	if ((changed & APIC_SVR_ENABLE) != 0U) {
 		if ((new & APIC_SVR_ENABLE) == 0U) {
+			struct acrn_vm *vm = vlapic2vcpu(vlapic)->vm;
 			/*
 			 * The apic is now disabled so stop the apic timer
 			 * and mask all the LVT entries.
@@ -1414,8 +1422,8 @@ vlapic_write_svr(struct acrn_vlapic *vlapic)
 
 			vlapic_mask_lvts(vlapic);
 			/* the only one enabled LINT0-ExtINT vlapic disabled */
-			if (vlapic->vm->wire_mode == VPIC_WIRE_NULL) {
-				vlapic->vm->wire_mode = VPIC_WIRE_INTR;
+			if (vm->wire_mode == VPIC_WIRE_NULL) {
+				vm->wire_mode = VPIC_WIRE_INTR;
 				dev_dbg(DBG_LEVEL_VLAPIC,
 					"vpic wire mode -> INTR");
 			}
@@ -1657,7 +1665,7 @@ vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops, enum 
 
 	vlapic->msr_apicbase = DEFAULT_APIC_BASE;
 
-	if (vlapic->vcpu->vcpu_id == BSP_CPU_ID) {
+	if (vlapic2vcpu(vlapic)->vcpu_id == BSP_CPU_ID) {
 		vlapic->msr_apicbase |= APICBASE_BSP;
 	}
 	if (mode == INIT_RESET) {
@@ -1702,8 +1710,8 @@ vlapic_reset(struct acrn_vlapic *vlapic, const struct acrn_apicv_ops *ops, enum 
 }
 
 /**
- * @pre vlapic->vm != NULL
- * @pre vlapic->vcpu->vcpu_id < MAX_VCPUS_PER_VM
+ * @pre vlapic-...->vm != NULL
+ * @pre vlapic-...->vcpu->vcpu_id < MAX_VCPUS_PER_VM
  */
 void
 vlapic_init(struct acrn_vlapic *vlapic)
@@ -1746,13 +1754,13 @@ uint64_t vlapic_get_apicbase(const struct acrn_vlapic *vlapic)
 static void ptapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, __unused bool level)
 {
 	pr_err("Invalid op %s, VM%u, vCPU%u, vector %u", __func__,
-			vlapic->vm->vm_id, vlapic->vcpu->vcpu_id, vector);
+			vlapic2vcpu(vlapic)->vm->vm_id, vlapic2vcpu(vlapic)->vcpu_id, vector);
 }
 
 static bool ptapic_inject_intr(struct acrn_vlapic *vlapic,
 				__unused bool guest_irq_enabled, __unused bool injected)
 {
-	pr_err("Invalid op %s, VM%u, vCPU%u", __func__, vlapic->vm->vm_id, vlapic->vcpu->vcpu_id);
+	pr_err("Invalid op %s, VM%u, vCPU%u", __func__, vlapic2vcpu(vlapic)->vm->vm_id, vlapic2vcpu(vlapic)->vcpu_id);
 	return injected;
 }
 
@@ -1787,8 +1795,6 @@ int32_t vlapic_set_apicbase(struct acrn_vlapic *vlapic, uint64_t new)
 	int32_t ret = 0;
 	uint64_t changed;
 	bool change_in_vlapic_mode = false;
-	struct acrn_vcpu *vcpu = vlapic->vcpu;
-
 
 	if (vlapic->msr_apicbase != new) {
 		changed = vlapic->msr_apicbase ^ new;
@@ -1798,20 +1804,21 @@ int32_t vlapic_set_apicbase(struct acrn_vlapic *vlapic, uint64_t new)
 		 * TODO: Logic to check for change in Reserved Bits and Inject GP
 		 */
 
-
 		/*
 		 * Logic to check for change in Bits 11:10 for vLAPIC mode switch
 		 */
 		if (change_in_vlapic_mode) {
 			if ((new & APICBASE_LAPIC_MODE) ==
 						(APICBASE_XAPIC | APICBASE_X2APIC)) {
+				struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
+
 				if (is_lapic_pt_configured(vcpu->vm)) {
 					/* vlapic need to be reset to make sure it is in correct state */
 					vlapic_reset(vlapic, &ptapic_ops, SOFTWARE_RESET);
 				}
 				vlapic->msr_apicbase = new;
 				vlapic_build_x2apic_id(vlapic);
-				switch_apicv_mode_x2apic(vlapic->vcpu);
+				switch_apicv_mode_x2apic(vcpu);
 				update_vm_vlapic_state(vcpu->vm);
 			} else {
 				/*
@@ -2191,9 +2198,6 @@ int32_t vlapic_x2apic_write(struct acrn_vcpu *vcpu, uint32_t msr, uint64_t val)
 
 void vlapic_create(struct acrn_vcpu *vcpu)
 {
-	vcpu->arch.vlapic.vm = vcpu->vm;
-	vcpu->arch.vlapic.vcpu = vcpu;
-
 	if (is_vcpu_bsp(vcpu)) {
 		uint64_t *pml4_page =
 			(uint64_t *)vcpu->vm->arch_vm.nworld_eptp;
@@ -2518,7 +2522,7 @@ int32_t veoi_vmexit_handler(struct acrn_vcpu *vcpu)
 
 	if (bitmap32_test((uint16_t)(vector & 0x1fU), &tmrptr[idx].v)) {
 		/* hook to vIOAPIC */
-		vioapic_broadcast_eoi(vlapic->vm, vector);
+		vioapic_broadcast_eoi(vcpu->vm, vector);
 	}
 
 	TRACE_2L(TRACE_VMEXIT_APICV_VIRT_EOI, vector, 0UL);
@@ -2530,16 +2534,14 @@ static void vlapic_x2apic_self_ipi_handler(struct acrn_vlapic *vlapic)
 {
 	struct lapic_regs *lapic;
 	uint32_t vector;
-	struct acrn_vcpu *target_vcpu;
 
 	lapic = &(vlapic->apic_page);
 	vector = lapic->self_ipi.v & APIC_VECTOR_MASK;
-	target_vcpu = vlapic->vcpu;
 	if (vector < 16U) {
 		vlapic_set_error(vlapic, APIC_ESR_SEND_ILLEGAL_VECTOR);
 		dev_dbg(DBG_LEVEL_VLAPIC, "Ignoring invalid IPI %u", vector);
 	} else {
-		vlapic_set_intr(target_vcpu, vector, LAPIC_TRIG_EDGE);
+		vlapic_set_intr(vlapic2vcpu(vlapic), vector, LAPIC_TRIG_EDGE);
 	}
 }
 

--- a/hypervisor/arch/x86/timer.c
+++ b/hypervisor/arch/x86/timer.c
@@ -50,7 +50,7 @@ static inline void update_physical_timer(struct per_cpu_timers *cpu_timer)
 
 	/* find the next event timer */
 	if (!list_empty(&cpu_timer->timer_list)) {
-		timer = list_entry((&cpu_timer->timer_list)->next,
+		timer = container_of((&cpu_timer->timer_list)->next,
 			struct hv_timer, node);
 
 		/* it is okay to program a expired time */
@@ -70,7 +70,7 @@ static bool local_add_timer(struct per_cpu_timers *cpu_timer,
 
 	prev = &cpu_timer->timer_list;
 	list_for_each(pos, &cpu_timer->timer_list) {
-		tmp = list_entry(pos, struct hv_timer, node);
+		tmp = container_of(pos, struct hv_timer, node);
 		if (tmp->fire_tsc < tsc) {
 			prev = &tmp->node;
 		}
@@ -168,7 +168,7 @@ static void timer_softirq(uint16_t pcpu_id)
 	 * already passed due to previously func()'s delay.
 	 */
 	list_for_each_safe(pos, n, &cpu_timer->timer_list) {
-		timer = list_entry(pos, struct hv_timer, node);
+		timer = container_of(pos, struct hv_timer, node);
 		/* timer expried */
 		tries--;
 		if ((timer->fire_tsc <= current_tsc) && (tries != 0U)) {

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -17,7 +17,7 @@
 
 void vcpu_thread(struct thread_object *obj)
 {
-	struct acrn_vcpu *vcpu = list_entry(obj, struct acrn_vcpu, thread_obj);
+	struct acrn_vcpu *vcpu = container_of(obj, struct acrn_vcpu, thread_obj);
 	uint32_t basic_exit_reason = 0U;
 	int32_t ret = 0;
 

--- a/hypervisor/common/sched_bvt.c
+++ b/hypervisor/common/sched_bvt.c
@@ -65,7 +65,7 @@ static void runqueue_add(struct thread_object *obj)
 		list_add(&data->list, &bvt_ctl->runqueue);
 	} else {
 		list_for_each(pos, &bvt_ctl->runqueue) {
-			iter_obj = list_entry(pos, struct thread_object, data);
+			iter_obj = container_of(pos, struct thread_object, data);
 			iter_data = (struct sched_bvt_data *)iter_obj->data;
 			if (iter_data->evt > data->evt) {
 				list_add_node(&data->list, pos->prev, pos);
@@ -240,7 +240,7 @@ static struct thread_object *sched_bvt_pick_next(struct sched_control *ctl)
 		first = bvt_ctl->runqueue.next;
 		sec = (first->next == &bvt_ctl->runqueue) ? NULL : first->next;
 
-		first_obj = list_entry(first, struct thread_object, data);
+		first_obj = container_of(first, struct thread_object, data);
 		first_data = (struct sched_bvt_data *)first_obj->data;
 
 		/* The run_countdown is used to store how may mcu the next thread
@@ -253,7 +253,7 @@ static struct thread_object *sched_bvt_pick_next(struct sched_control *ctl)
 		 * UINT64_MAX can make it run for >100 years before rescheduled.
 		 */
 		if (sec != NULL) {
-			second_obj = list_entry(sec, struct thread_object, data);
+			second_obj = container_of(sec, struct thread_object, data);
 			second_data = (struct sched_bvt_data *)second_obj->data;
 			delta_mcu = second_data->evt - first_data->evt;
 			first_data->run_countdown = v2p(delta_mcu, first_data->vt_ratio) + BVT_CSA_MCU;

--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -113,7 +113,6 @@ static void pci_vdev_update_vbar_base(struct pci_vdev *vdev, uint32_t idx)
 	enum pci_bar_type type;
 	uint64_t base = 0UL;
 	uint32_t lo, hi, offset;
-	struct acrn_vm *vm = vdev->vpci->vm;
 
 	vbar = &vdev->vbars[idx];
 	offset = pci_bar_offset(idx);
@@ -137,7 +136,7 @@ static void pci_vdev_update_vbar_base(struct pci_vdev *vdev, uint32_t idx)
 		}
 	}
 
-	if ((base != 0UL) && !ept_is_mr_valid(vm, base, vdev->vbars[idx].size)) {
+	if ((base != 0UL) && !ept_is_mr_valid(vpci2vm(vdev->vpci), base, vdev->vbars[idx].size)) {
 		pr_fatal("%s, %x:%x.%x set invalid bar[%d] base: 0x%lx, size: 0x%lx\n", __func__,
 			vdev->bdf.bits.b, vdev->bdf.bits.d, vdev->bdf.bits.f, idx, base, vdev->vbars[idx].size);
 		/* If guest set a invalid GPA, ignore it temporarily */

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -64,7 +64,7 @@ static void remap_vmsi(const struct pci_vdev *vdev)
 {
 	struct ptirq_msi_info info = {};
 	union pci_bdf pbdf = vdev->pdev->bdf;
-	struct acrn_vm *vm = vdev->vpci->vm;
+	struct acrn_vm *vm = vpci2vm(vdev->vpci);
 	uint32_t capoff = vdev->msi.capoff;
 	uint32_t vmsi_msgdata, vmsi_addrlo, vmsi_addrhi = 0U;
 
@@ -130,7 +130,7 @@ void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
 void deinit_vmsi(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
-		ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->bdf.value, 1U);
+		ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->bdf.value, 1U);
 	}
 }
 

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -88,7 +88,7 @@ static void remap_one_vmsix_entry(const struct pci_vdev *vdev, uint32_t index)
 		info.vmsi_addr.full = vdev->msix.table_entries[index].addr;
 		info.vmsi_data.full = vdev->msix.table_entries[index].data;
 
-		ret = ptirq_prepare_msix_remap(vdev->vpci->vm, vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
+		ret = ptirq_prepare_msix_remap(vpci2vm(vdev->vpci), vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
 		if (ret == 0) {
 			/* Write the table entry to the physical structure */
 			pentry = get_msix_table_entry(vdev, index);
@@ -266,7 +266,7 @@ void deinit_vmsix(const struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {
-			ptirq_remove_msix_remapping(vdev->vpci->vm, vdev->bdf.value, vdev->msix.table_count);
+			ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->bdf.value, vdev->msix.table_count);
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -30,7 +30,13 @@
 #ifndef VPCI_PRIV_H_
 #define VPCI_PRIV_H_
 
+#include <list.h>
 #include <pci.h>
+
+static inline struct acrn_vm *vpci2vm(const struct acrn_vpci *vpci)
+{
+	return container_of(vpci, struct acrn_vm, vpci);
+}
 
 static inline bool is_quirk_ptdev(const struct pci_vdev *vdev)
 {

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -96,7 +96,7 @@ static void create_vf(struct pci_vdev *pf_vdev, union pci_bdf vf_bdf, uint16_t v
 
 		dev_cfg = init_one_dev_config(vf_pdev);
 		if (dev_cfg != NULL) {
-			vf_vdev = vpci_init_vdev(&pf_vdev->vpci->vm->vpci, dev_cfg, pf_vdev);
+			vf_vdev = vpci_init_vdev(&vpci2vm(pf_vdev->vpci)->vpci, dev_cfg, pf_vdev);
 		}
 	}
 
@@ -202,7 +202,7 @@ static void enable_vfs(struct pci_vdev *pf_vdev)
 			 * The VF maybe have already existed but it is a zombie instance that vf_vdev->vpci
 			 * is NULL, in this case, we need to make the vf_vdev available again in here.
 			 */
-			vf_vdev = pci_find_vdev(&pf_vdev->vpci->vm->vpci, vf_bdf);
+			vf_vdev = pci_find_vdev(&vpci2vm(pf_vdev->vpci)->vpci, vf_bdf);
 			if (vf_vdev == NULL) {
 				create_vf(pf_vdev, vf_bdf, idx);
 			} else {
@@ -248,7 +248,7 @@ static void disable_vfs(struct pci_vdev *pf_vdev)
 
 		bdf.fields.bus = get_vf_bus(pf_vdev, first, stride, idx);
 		bdf.fields.devfun = get_vf_devfun(pf_vdev, first, stride, idx);
-		vf_vdev = pci_find_vdev(&pf_vdev->vpci->vm->vpci, bdf);
+		vf_vdev = pci_find_vdev(&vpci2vm(pf_vdev->vpci)->vpci, bdf);
 		if ((vf_vdev != NULL) && (!is_zombie_vf(vf_vdev))) {
 			/* set disabled VF as zombie vdev instance */
 			vf_vdev->vdev_ops->deinit_vdev(vf_vdev);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -69,9 +69,6 @@ struct acrn_vlapic {
 	struct lapic_regs	apic_page;
 	struct vlapic_pir_desc	pir_desc;
 
-	struct acrn_vm		*vm;
-	struct acrn_vcpu	*vcpu;
-
 	uint32_t		esr_pending;
 	int32_t			esr_firing;
 
@@ -96,6 +93,8 @@ struct acrn_vlapic {
 	uint32_t	lvt_last[VLAPIC_MAXLVT_INDEX + 1];
 } __aligned(PAGE_SIZE);
 
+
+struct acrn_vcpu;
 struct acrn_apicv_ops {
 	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
 	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);

--- a/hypervisor/include/arch/x86/guest/vmtrr.h
+++ b/hypervisor/include/arch/x86/guest/vmtrr.h
@@ -48,12 +48,12 @@ union mtrr_fixed_range_reg {
 };
 
 struct acrn_vmtrr {
-	struct acrn_vcpu		*vcpu;
 	union mtrr_cap_reg		cap;
 	union mtrr_def_type_reg		def_type;
 	union mtrr_fixed_range_reg	fixed_range[FIXED_RANGE_MTRR_NUM];
 };
 
+struct acrn_vcpu;
 /**
  * @brief Virtual MTRR MSR write
  *

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -139,12 +139,13 @@ union pci_cfg_addr_reg {
 
 struct acrn_vpci {
 	spinlock_t lock;
-	struct acrn_vm *vm;
 	union pci_cfg_addr_reg addr;
 	uint64_t pci_mmcfg_base;
 	uint32_t pci_vdev_cnt;
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 };
+
+struct acrn_vm;
 
 extern const struct pci_vdev_ops vhostbridge_ops;
 extern const struct pci_vdev_ops vpci_bridge_ops;

--- a/hypervisor/include/dm/vpic.h
+++ b/hypervisor/include/dm/vpic.h
@@ -131,11 +131,11 @@ struct i8259_reg_state {
 };
 
 struct acrn_vpic {
-	struct acrn_vm		*vm;
 	spinlock_t	lock;
 	struct i8259_reg_state	i8259[2];
 };
 
+struct acrn_vm;
 void vpic_init(struct acrn_vm *vm);
 
 /**

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -108,8 +108,8 @@ static inline void list_splice_init(struct list_head *list,
 	}
 }
 
-#define list_entry(ptr, type, member) \
-	((type *)((char *)(ptr)-(uint64_t)(&((type *)0)->member)))
+#define container_of(ptr, type, member) \
+	((type *)((char *)(ptr)-offsetof(type, member)))
 
 #define list_for_each(pos, head) \
 	for ((pos) = (head)->next; (pos) != (head); (pos) = (pos)->next)


### PR DESCRIPTION
v3:
fix some MISRA-C complaints.

v2:
minor refine about container_of.

v1:
Use contain_of to cast a member of a structure out to the containing structure instead of declaring the structure pointer in the  containing structure.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>