### PR TITLE
hv: vtd: use local var instead of global var

### DIFF
--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -194,7 +194,6 @@ bool iommu_snoop_supported(const struct iommu_domain *iommu)
 
 static struct dmar_drhd_rt dmar_drhd_units[MAX_DRHDS];
 static bool iommu_page_walk_coherent = true;
-static uint32_t qi_status = 0U;
 static struct dmar_info *platform_dmar_info = NULL;
 
 /* Domain id 0 is reserved in some cases per VT-d */
@@ -586,6 +585,7 @@ static struct dmar_drhd_rt *device_to_dmaru(uint8_t bus, uint8_t devfun)
 static void dmar_issue_qi_request(struct dmar_drhd_rt *dmar_unit, struct dmar_entry invalidate_desc)
 {
 	struct dmar_entry *invalidate_desc_ptr;
+	uint32_t qi_status = 0U;
 	__unused uint64_t start;
 
 	invalidate_desc_ptr = (struct dmar_entry *)(dmar_unit->qi_queue + dmar_unit->qi_tail);


### PR DESCRIPTION
In dmar_issue_qi_request, currently use a global var qi_status, which could
cause potential issue when concurrent call to dmar_issue_qi_request for different
DMAR units.
Use local var instead.

Tracked-On: #4535
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>