### PR TITLE
hv: Reserve space for VMs'  EPT 4k pages after boot

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -337,6 +337,9 @@ SYS_INIT_C_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(SYS_INIT_C_SRCS))
 ifneq ($(CONFIG_RELEASE),y)
 CFLAGS += -DHV_DEBUG -DPROFILING_ON -fno-omit-frame-pointer
 endif
+ifneq ($(FIRMWARE),uefi)
+CFLAGS += -DCONFIG_LAST_LEVEL_EPT_AT_BOOT
+endif
 PRE_BUILD_SRCS += pre_build/static_checks.c
 PRE_BUILD_OBJS := $(patsubst %.c,$(HV_OBJDIR)/%.o,$(PRE_BUILD_SRCS))
 

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -243,6 +243,12 @@ void init_pcpu_post(uint16_t pcpu_id)
 			panic("failed to initialize sgx!");
 		}
 
+		/*
+		 * Reserve memory from platform E820 for EPT 4K pages for all VMs
+		 */
+#ifdef CONFIG_LAST_LEVEL_EPT_AT_BOOT
+		reserve_buffer_for_ept_pages();
+#endif
 		/* Start all secondary cores */
 		startup_paddr = prepare_trampoline();
 		if (!start_pcpus(AP_MASK)) {

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -320,7 +320,7 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 
 	/* unmap AP trampoline code for security
 	 * 'allocate_pages()' in depri boot mode or
-	 * 'e820_alloc_low_memory()' in direct boot
+	 * 'e820_alloc_memory()' in direct boot
 	 * mode will ensure the base address of tramploline
 	 * code be page-aligned.
 	 */

--- a/hypervisor/boot/guest/direct_boot.c
+++ b/hypervisor/boot/guest/direct_boot.c
@@ -11,13 +11,14 @@
 #include <cpu.h>
 #include <boot.h>
 #include <direct_boot.h>
+#include <mmu.h>
 
 /* AP trampoline code buffer base address. */
 static uint64_t ap_trampoline_buf;
 
 static void init_direct_boot(void)
 {
-	ap_trampoline_buf = e820_alloc_low_memory(CONFIG_LOW_RAM_SIZE);
+	ap_trampoline_buf = e820_alloc_memory(CONFIG_LOW_RAM_SIZE, MEM_1M);
 }
 
 /* @post: return != 0UL */

--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -37,9 +37,7 @@ struct mem_range {
 /* HV read multiboot header to get e820 entries info and calc total RAM info */
 void init_e820(void);
 
-/* get some RAM below 1MB in e820 entries, hide it from sos_vm, return its start address */
-uint64_t e820_alloc_low_memory(uint32_t size_arg);
-
+uint64_t e820_alloc_memory(uint32_t size_arg, uint64_t max_addr);
 /* get total number of the e820 entries */
 uint32_t get_e820_entries_count(void);
 

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -40,6 +40,10 @@
 
 #define PRE_VM_EPT_ADDRESS_SPACE(size)	(PTDEV_HI_MMIO_START + PTDEV_HI_MMIO_SIZE)
 
+#define TOTAL_EPT_4K_PAGES_SIZE		(PRE_VM_NUM*(PT_PAGE_NUM(PRE_VM_EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))*MEM_4K)) + \
+						(SOS_VM_NUM*(PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_SOS_RAM_SIZE))*MEM_4K)) + \
+						(MAX_POST_VM_NUM*(PT_PAGE_NUM(EPT_ADDRESS_SPACE(CONFIG_UOS_RAM_SIZE))*MEM_4K))
+
 #define TRUSTY_PML4_PAGE_NUM(size)	(1UL)
 #define TRUSTY_PDPT_PAGE_NUM(size)	(1UL)
 #define TRUSTY_PD_PAGE_NUM(size)	(PD_PAGE_NUM(size))
@@ -90,4 +94,7 @@ extern const struct memory_ops ppt_mem_ops;
 void init_ept_mem_ops(struct memory_ops *mem_ops, uint16_t vm_id);
 void *get_reserve_sworld_memory_base(void);
 
+#ifdef CONFIG_LAST_LEVEL_EPT_AT_BOOT
+void reserve_buffer_for_ept_pages(void);
+#endif
 #endif /* PAGE_H */

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -38,9 +38,10 @@
  * POST_LAUNCHED_VM is launched by ACRN devicemodel, with/without LAPIC_PT depends on usecases.
  */
 enum acrn_vm_load_order {
-	PRE_LAUNCHED_VM = 1,
+	PRE_LAUNCHED_VM = 0,
 	SOS_VM,
-	POST_LAUNCHED_VM	/* Launched by Devicemodel in SOS_VM */
+	POST_LAUNCHED_VM,	/* Launched by Devicemodel in SOS_VM */
+	MAX_LOAD_ORDER
 };
 
 /* ACRN guest severity */


### PR DESCRIPTION
As ACRN prepares to support servers with large amounts of memory
current logic to allocate space for 4K pages of EPT at compile time
will increase the size of .bss section of ACRN binary.

Bootloaders could run into a situation where they cannot
find enough contiguous space to load ACRN binary under 4GB,
which is typically heavily fragmented with E820 types Reserved,
ACPI data, 32-bit PCI hole etc.

This patch does the following
1) Works only for "direct" mode of vboot
2) reserves space for 4K pages of EPT, after boot by parsing
platform E820 table, for all types of VMs.

Size comparison:

w/o patch
Size of DRAM            Size of .bss
48 GB                   0xe1bbc98 (~226 MB)
128 GB                  0x222abc98 (~548 MB)

w/ patch
Size of DRAM            Size of .bss
48 GB                   0x1991c98 (~26 MB)
128 GB                  0x1a81c98 (~28 MB)

Tracked-On: #4563
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>