### PR TITLE
acrn-config: find 64-bit mmio for HI_MMIO_START/HI_MMIO_END

### DIFF
--- a/misc/acrn-config/board_config/new_board_kconfig.py
+++ b/misc/acrn-config/board_config/new_board_kconfig.py
@@ -61,9 +61,12 @@ def get_ram_range():
     # read system ram from board_info.xml
     ram_range = {}
 
-    sys_mem_lines = board_cfg_lib.get_info(
-        board_cfg_lib.BOARD_INFO_FILE, "<SYSTEM_RAM_INFO>", "</SYSTEM_RAM_INFO>")
-    for line in sys_mem_lines:
+    io_mem_lines = board_cfg_lib.get_info(
+        board_cfg_lib.BOARD_INFO_FILE, "<IOMEM_INFO>", "</IOMEM_INFO>")
+
+    for line in io_mem_lines:
+        if 'System RAM' not in line:
+            continue
         start_addr = int(line.split('-')[0], 16)
         end_addr = int(line.split('-')[1].split(':')[0], 16)
         mem_range = end_addr - start_addr

--- a/misc/acrn-config/target/misc.py
+++ b/misc/acrn-config/target/misc.py
@@ -145,19 +145,17 @@ def dump_system_ram(config):
     """This will get systemd ram which are usable
     :param config: file pointer that opened for writing board config information
     """
-    print("\t<SYSTEM_RAM_INFO>", file=config)
+    print("\t<IOMEM_INFO>", file=config)
     with open(MEM_PATH[0], 'rt') as mem_info:
 
         while True:
-            line = mem_info.readline().strip()
+            line = mem_info.readline().strip('\n')
             if not line:
                 break
 
-            pat_type = line.split(':')[1].strip()
-            if pat_type == "System RAM":
-                print("\t{}".format(line), file=config)
+            print("\t{}".format(line), file=config)
 
-    print("\t</SYSTEM_RAM_INFO>", file=config)
+    print("\t</IOMEM_INFO>", file=config)
     print("", file=config)
 
 

--- a/misc/acrn-config/xmls/board-xmls/apl-mrb.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-mrb.xml
@@ -264,12 +264,226 @@
 	rdt resource mask max: '0xff'
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
+	  00000000-00000000 : intel_punit_ipc
+	    00000000-00000000 : intel_punit_ipc
+	      00000000-00000000 : intel_punit_ipc
+	        00000000-00000000 : intel_punit_ipc
 	00001000-00097fff : System RAM
+	00098000-0009ffff : Reserved
+	000c0000-000fffff : Reserved
+	  000f0000-000fffff : System ROM
 	00100000-0fffffff : System RAM
+	10000000-121fffff : Reserved
 	12200000-7afd5fff : System RAM
+	  4c000000-4d0031d0 : Kernel code
+	  4d0031d1-4d9dc8ff : Kernel data
+	  4dc28000-4ddfffff : Kernel bss
+	7afd6000-7afdcfff : ACPI Tables
+	7afdd000-7afdffff : ACPI Non-volatile Storage
+	7afe0000-7fffffff : Reserved
+	  7b800001-7bffffff : PCI Bus 0000:00
+	  7c000001-7fffffff : PCI Bus 0000:00
+	    7c000001-7ffffffe : Graphics Stolen Memory
+	80000000-cfffffff : PCI Bus 0000:00
+	  80000000-801fffff : PCI Bus 0000:01
+	  80200000-803fffff : PCI Bus 0000:01
+	  80400000-805fffff : PCI Bus 0000:02
+	  80600000-809fffff : PCI Bus 0000:03
+	  80a00000-80bfffff : PCI Bus 0000:04
+	  80c00000-80dfffff : PCI Bus 0000:04
+	  80e00000-80e00fff : 0000:00:18.2
+	    80e00000-80e001ff : lpss_dev
+	      80e00000-80e0001f : serial
+	    80e00200-80e002ff : lpss_priv
+	  a0000000-afffffff : 0000:00:02.0
+	  b1000000-b1ffffff : .text.unlikely
+	  b2000000-b2ffffff : 0000:00:02.0
+	  b3000000-b31fffff : dwc_usb3
+	    b3000000-b31fffff : 0000:00:15.1
+	      b300c100-b31fffff : dwc_usb3
+	  b3200000-b33fffff : PCI Bus 0000:03
+	    b3200000-b32fffff : 0000:03:00.0
+	    b3300000-b33fffff : 0000:03:00.0
+	  b3400000-b34fffff : PCI Bus 0000:02
+	    b3400000-b347ffff : 0000:02:00.0
+	      b3400000-b347ffff : igb_avb
+	    b3480000-b3483fff : 0000:02:00.0
+	      b3480000-b3483fff : igb_avb
+	  b3500000-b35fffff : 0000:00:0e.0
+	    b3500000-b35fffff : Skylake HD audio
+	  b3600000-b360ffff : 0000:00:15.0
+	    b3600000-b360ffff : xhci-hcd
+	      b3608070-b360846f : intel_xhci_usb_sw
+	  b3610000-b3611fff : 0000:00:12.0
+	    b3610000-b3611fff : ahci
+	  b3618000-b361ffff : 0000:00:00.1
+	  b3620000-b3623fff : 0000:00:0e.0
+	    b3620000-b3623fff : Skylake HD audio
+	  b3624000-b3625fff : 0000:00:11.0
+	  b362a000-b362a0ff : 0000:00:1f.1
+	  b362b000-b362bfff : 0000:00:1e.0
+	  b362c000-b362cfff : 0000:00:1e.0
+	    b362c000-b362cfff : mmc2
+	  b362d000-b362dfff : 0000:00:1c.0
+	  b362e000-b362efff : 0000:00:1c.0
+	    b362e000-b362efff : mmc1
+	  b362f000-b362ffff : 0000:00:1b.0
+	  b3630000-b3630fff : 0000:00:1b.0
+	    b3630000-b3630fff : mmc0
+	  b3631000-b3631fff : 0000:00:1a.0
+	  b3632000-b3632fff : 0000:00:1a.0
+	    b3632000-b3632fff : 0000:00:1a.0
+	  b3633000-b3633fff : 0000:00:19.2
+	  b3634000-b3634fff : 0000:00:19.2
+	    b3634000-b36341ff : lpss_dev
+	      b3634000-b36341ff : lpss_dev
+	    b3634200-b36342ff : lpss_priv
+	    b3634800-b3634fff : idma64.14
+	      b3634800-b3634fff : idma64.14
+	  b3635000-b3635fff : 0000:00:19.1
+	  b3636000-b3636fff : 0000:00:19.1
+	    b3636000-b36361ff : lpss_dev
+	      b3636000-b36361ff : lpss_dev
+	    b3636200-b36362ff : lpss_priv
+	    b3636800-b3636fff : idma64.13
+	      b3636800-b3636fff : idma64.13
+	  b3637000-b3637fff : 0000:00:19.0
+	  b3638000-b3638fff : 0000:00:19.0
+	    b3638000-b36381ff : lpss_dev
+	      b3638000-b36381ff : lpss_dev
+	    b3638200-b36382ff : lpss_priv
+	    b3638800-b3638fff : idma64.12
+	      b3638800-b3638fff : idma64.12
+	  b3639000-b3639fff : 0000:00:18.3
+	  b363a000-b363afff : 0000:00:18.3
+	    b363a000-b363a1ff : lpss_dev
+	      b363a000-b363a01f : serial
+	    b363a200-b363a2ff : lpss_priv
+	  b363b000-b363bfff : 0000:00:18.2
+	  b363d000-b363dfff : 0000:00:18.1
+	  b363e000-b363efff : 0000:00:18.1
+	    b363e000-b363e1ff : lpss_dev
+	      b363e000-b363e01f : serial
+	    b363e200-b363e2ff : lpss_priv
+	    b363e800-b363efff : idma64.9
+	      b363e800-b363efff : idma64.9
+	  b363f000-b363ffff : 0000:00:18.0
+	  b3640000-b3640fff : 0000:00:18.0
+	    b3640000-b36401ff : lpss_dev
+	      b3640000-b364001f : serial
+	    b3640200-b36402ff : lpss_priv
+	    b3640800-b3640fff : idma64.8
+	      b3640800-b3640fff : idma64.8
+	  b3641000-b3641fff : 0000:00:17.3
+	  b3642000-b3642fff : 0000:00:17.3
+	    b3642000-b36421ff : lpss_dev
+	      b3642000-b36421ff : lpss_dev
+	    b3642200-b36422ff : lpss_priv
+	    b3642800-b3642fff : idma64.7
+	      b3642800-b3642fff : idma64.7
+	  b3643000-b3643fff : 0000:00:17.2
+	  b3644000-b3644fff : 0000:00:17.2
+	    b3644000-b36441ff : lpss_dev
+	      b3644000-b36441ff : lpss_dev
+	    b3644200-b36442ff : lpss_priv
+	    b3644800-b3644fff : idma64.6
+	      b3644800-b3644fff : idma64.6
+	  b3645000-b3645fff : 0000:00:17.1
+	  b3646000-b3646fff : 0000:00:17.1
+	    b3646000-b36461ff : lpss_dev
+	      b3646000-b36461ff : lpss_dev
+	    b3646200-b36462ff : lpss_priv
+	    b3646800-b3646fff : idma64.5
+	      b3646800-b3646fff : idma64.5
+	  b3647000-b3647fff : 0000:00:17.0
+	  b3648000-b3648fff : 0000:00:17.0
+	    b3648000-b36481ff : lpss_dev
+	      b3648000-b36481ff : lpss_dev
+	    b3648200-b36482ff : lpss_priv
+	    b3648800-b3648fff : idma64.4
+	      b3648800-b3648fff : idma64.4
+	  b3649000-b3649fff : 0000:00:16.3
+	  b364a000-b364afff : 0000:00:16.3
+	    b364a000-b364a1ff : lpss_dev
+	      b364a000-b364a1ff : lpss_dev
+	    b364a200-b364a2ff : lpss_priv
+	    b364a800-b364afff : idma64.3
+	      b364a800-b364afff : idma64.3
+	  b364b000-b364bfff : 0000:00:16.2
+	  b364c000-b364cfff : 0000:00:16.2
+	    b364c000-b364c1ff : lpss_dev
+	      b364c000-b364c1ff : lpss_dev
+	    b364c200-b364c2ff : lpss_priv
+	    b364c800-b364cfff : idma64.2
+	      b364c800-b364cfff : idma64.2
+	  b364d000-b364dfff : 0000:00:16.1
+	  b364e000-b364efff : 0000:00:16.1
+	    b364e000-b364e1ff : lpss_dev
+	      b364e000-b364e1ff : lpss_dev
+	    b364e200-b364e2ff : lpss_priv
+	    b364e800-b364efff : idma64.1
+	      b364e800-b364efff : idma64.1
+	  b364f000-b364ffff : 0000:00:16.0
+	  b3650000-b3650fff : 0000:00:16.0
+	    b3650000-b36501ff : lpss_dev
+	      b3650000-b36501ff : lpss_dev
+	    b3650200-b36502ff : lpss_priv
+	    b3650800-b3650fff : idma64.0
+	      b3650800-b3650fff : idma64.0
+	  b3652000-b36527ff : 0000:00:12.0
+	    b3652000-b36527ff : ahci
+	  b3653000-b36530ff : 0000:00:12.0
+	    b3653000-b36530ff : ahci
+	  b3654000-b3654fff : 0000:00:11.0
+	  b3655000-b3655fff : 0000:00:0f.2
+	  b3656000-b3656fff : 0000:00:0f.1
+	  b3657000-b3657fff : 0000:00:0f.0
+	    b3657000-b3657fff : mei_me
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : Reserved
+	    e0000000-efffffff : PCI Bus 0000:00
+	      e0000000-efffffff : pnp 00:01
+	f8c00000-f8c00653 : INT3452:03
+	  f8c00000-f8c00653 : INT3452:03
+	f8c40000-f8c40763 : INT3452:01
+	  f8c40000-f8c40763 : INT3452:01
+	f8c50000-f8c5076b : INT3452:00
+	  f8c50000-f8c5076b : INT3452:00
+	f8c70000-f8c70673 : INT3452:02
+	  f8c70000-f8c70673 : INT3452:02
+	fe042000-fe043fff : INT34D2:00
+	  fe042000-fe043fff : INT34D2:00
+	fe044000-fe045fff : INT34D2:00
+	  fe045a00-fe045aef : intel_telemetry
+	    fe045a00-fe045aef : intel_telemetry
+	  fe045b00-fe045bef : intel_telemetry
+	    fe045b00-fe045bef : intel_telemetry
+	fea00000-feafffff : pnp 00:01
+	fec00000-fec003ff : IOAPIC 0
+	fed00000-fedfffff : Reserved
+	  fed00000-fed003ff : HPET 0
+	    fed00000-fed003ff : PNP0103:00
+	  fed01000-fed01fff : intel-spi
+	    fed01000-fed01fff : pnp 00:01
+	  fed03000-fed03fff : pnp 00:01
+	  fed06000-fed06fff : pnp 00:01
+	  fed08000-fed09fff : pnp 00:01
+	  fed17080-fed17083 : INT34D2:00
+	    fed17080-fed17083 : INT34D2:00
+	      fed17080-fed17083 : INT34D2:00
+	  fed17084-fed17087 : INT34D2:00
+	    fed17084-fed17087 : INT34D2:00
+	      fed17084-fed17087 : INT34D2:00
+	  fed1c000-fed1cfff : pnp 00:01
+	  fed40000-fed44fff : MSFT0101:00
+	  fed80000-fedbffff : pnp 00:01
+	fee00000-feefffff : pnp 00:01
+	  fee00000-fee00fff : Local APIC
+	ff800000-ffffffff : Unusable memory
 	100000000-27fffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/mmcblk1p1: TYPE="ext4"

--- a/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2-n3350.xml
@@ -238,18 +238,200 @@
 	rdt resource mask max: '0xff'
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
 	00001000-0003efff : System RAM
+	0003f000-0003ffff : Reserved
 	00040000-0009dfff : System RAM
+	0009e000-000fffff : Reserved
+	  000f0000-000fffff : System ROM
 	00100000-0fffffff : System RAM
-	12151000-70ecd017 : System RAM
-	70ecd018-70edd057 : System RAM
-	70edd058-77b2efff : System RAM
-	7a09b000-7a408fff : System RAM
-	7a424000-7a964fff : System RAM
+	10000000-12150fff : Reserved
+	12151000-70770017 : System RAM
+	70770018-70780057 : System RAM
+	70780058-77b30fff : System RAM
+	77b31000-79c3afff : Reserved
+	79c3b000-79c53fff : ACPI Tables
+	79c54000-79cb3fff : ACPI Non-volatile Storage
+	79cb4000-7a09cfff : Reserved
+	7a09d000-7a40afff : System RAM
+	7a40b000-7a40bfff : ACPI Non-volatile Storage
+	7a40c000-7a425fff : Reserved
+	7a426000-7a964fff : System RAM
+	7a965000-7a966fff : Reserved
 	7a967000-7affffff : System RAM
+	7b000000-7fffffff : Reserved
+	  7b800001-7bffffff : PCI Bus 0000:00
+	  7c000001-7fffffff : PCI Bus 0000:00
+	    7c000001-7ffffffe : Graphics Stolen Memory
+	80000000-cfffffff : PCI Bus 0000:00
+	  80000000-8fffffff : 0000:00:02.0
+	  90000000-90ffffff : 0000:00:02.0
+	  91000000-911fffff : 0000:00:15.1
+	  91200000-912fffff : 0000:00:0e.0
+	    91200000-912fffff : ICH HD audio
+	  91300000-913fffff : PCI Bus 0000:03
+	    91300000-91303fff : 0000:03:00.0
+	    91304000-91304fff : 0000:03:00.0
+	      91304000-91304fff : r8169
+	  91400000-914fffff : PCI Bus 0000:02
+	    91400000-91403fff : 0000:02:00.0
+	    91404000-91404fff : 0000:02:00.0
+	      91404000-91404fff : r8169
+	  91500000-9150ffff : 0000:00:15.0
+	    91500000-9150ffff : xhci-hcd
+	      91508070-9150846f : intel_xhci_usb_sw
+	  91510000-91513fff : 0000:00:0e.0
+	    91510000-91513fff : ICH HD audio
+	  91514000-91515fff : 0000:00:12.0
+	    91514000-91515fff : ahci
+	  91516000-915160ff : 0000:00:1f.1
+	  91517000-91517fff : 0000:00:1e.0
+	  91518000-91518fff : 0000:00:1e.0
+	    91518000-91518fff : mmc1
+	  91519000-91519fff : 0000:00:1c.0
+	  9151a000-9151afff : 0000:00:1c.0
+	    9151a000-9151afff : mmc0
+	  9151b000-9151bfff : 0000:00:1a.0
+	  9151c000-9151cfff : 0000:00:1a.0
+	    9151c000-9151cfff : 0000:00:1a.0
+	  9151d000-9151dfff : 0000:00:19.2
+	  9151e000-9151efff : 0000:00:19.2
+	    9151e000-9151e1ff : lpss_dev
+	      9151e000-9151e1ff : lpss_dev
+	    9151e200-9151e2ff : lpss_priv
+	    9151e800-9151efff : idma64.12
+	      9151e800-9151efff : idma64.12
+	  9151f000-9151ffff : 0000:00:19.1
+	  91520000-91520fff : 0000:00:19.1
+	    91520000-915201ff : lpss_dev
+	      91520000-915201ff : lpss_dev
+	    91520200-915202ff : lpss_priv
+	    91520800-91520fff : idma64.11
+	      91520800-91520fff : idma64.11
+	  91521000-91521fff : 0000:00:19.0
+	  91522000-91522fff : 0000:00:19.0
+	    91522000-915221ff : lpss_dev
+	      91522000-915221ff : lpss_dev
+	    91522200-915222ff : lpss_priv
+	    91522800-91522fff : idma64.10
+	      91522800-91522fff : idma64.10
+	  91523000-91523fff : 0000:00:18.1
+	  91524000-91524fff : 0000:00:18.1
+	    91524000-915241ff : lpss_dev
+	      91524000-9152401f : serial
+	    91524200-915242ff : lpss_priv
+	    91524800-91524fff : idma64.9
+	      91524800-91524fff : idma64.9
+	  91525000-91525fff : 0000:00:18.0
+	  91526000-91526fff : 0000:00:18.0
+	    91526000-915261ff : lpss_dev
+	      91526000-9152601f : serial
+	    91526200-915262ff : lpss_priv
+	    91526800-91526fff : idma64.8
+	      91526800-91526fff : idma64.8
+	  91527000-91527fff : 0000:00:17.3
+	  91528000-91528fff : 0000:00:17.3
+	    91528000-915281ff : lpss_dev
+	      91528000-915281ff : lpss_dev
+	    91528200-915282ff : lpss_priv
+	    91528800-91528fff : idma64.7
+	      91528800-91528fff : idma64.7
+	  91529000-91529fff : 0000:00:17.2
+	  9152a000-9152afff : 0000:00:17.2
+	    9152a000-9152a1ff : lpss_dev
+	      9152a000-9152a1ff : lpss_dev
+	    9152a200-9152a2ff : lpss_priv
+	    9152a800-9152afff : idma64.6
+	      9152a800-9152afff : idma64.6
+	  9152b000-9152bfff : 0000:00:17.1
+	  9152c000-9152cfff : 0000:00:17.1
+	    9152c000-9152c1ff : lpss_dev
+	      9152c000-9152c1ff : lpss_dev
+	    9152c200-9152c2ff : lpss_priv
+	    9152c800-9152cfff : idma64.5
+	      9152c800-9152cfff : idma64.5
+	  9152d000-9152dfff : 0000:00:17.0
+	  9152e000-9152efff : 0000:00:17.0
+	    9152e000-9152e1ff : lpss_dev
+	      9152e000-9152e1ff : lpss_dev
+	    9152e200-9152e2ff : lpss_priv
+	    9152e800-9152efff : idma64.4
+	      9152e800-9152efff : idma64.4
+	  9152f000-9152ffff : 0000:00:16.3
+	  91530000-91530fff : 0000:00:16.3
+	    91530000-915301ff : lpss_dev
+	      91530000-915301ff : lpss_dev
+	    91530200-915302ff : lpss_priv
+	    91530800-91530fff : idma64.3
+	      91530800-91530fff : idma64.3
+	  91531000-91531fff : 0000:00:16.2
+	  91532000-91532fff : 0000:00:16.2
+	    91532000-915321ff : lpss_dev
+	      91532000-915321ff : lpss_dev
+	    91532200-915322ff : lpss_priv
+	    91532800-91532fff : idma64.2
+	      91532800-91532fff : idma64.2
+	  91533000-91533fff : 0000:00:16.1
+	  91534000-91534fff : 0000:00:16.1
+	    91534000-915341ff : lpss_dev
+	      91534000-915341ff : lpss_dev
+	    91534200-915342ff : lpss_priv
+	    91534800-91534fff : idma64.1
+	      91534800-91534fff : idma64.1
+	  91535000-91535fff : 0000:00:16.0
+	  91536000-91536fff : 0000:00:16.0
+	    91536000-915361ff : lpss_dev
+	      91536000-915361ff : lpss_dev
+	    91536200-915362ff : lpss_priv
+	    91536800-91536fff : idma64.0
+	      91536800-91536fff : idma64.0
+	  91537000-91537fff : 0000:00:15.1
+	  91538000-915387ff : 0000:00:12.0
+	    91538000-915387ff : ahci
+	  91539000-915390ff : 0000:00:12.0
+	    91539000-915390ff : ahci
+	  9153c000-9153cfff : 0000:00:0f.0
+	    9153c000-9153cfff : mei_me
+	d0000000-d0ffffff : Reserved
+	  d0c00000-d0c00653 : INT3452:03
+	    d0c00000-d0c00653 : INT3452:03
+	  d0c40000-d0c40763 : INT3452:01
+	    d0c40000-d0c40763 : INT3452:01
+	  d0c50000-d0c5076b : INT3452:00
+	    d0c50000-d0c5076b : INT3452:00
+	  d0c70000-d0c70673 : INT3452:02
+	    d0c70000-d0c70673 : INT3452:02
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : Reserved
+	    e0000000-efffffff : PCI Bus 0000:00
+	      e0000000-efffffff : pnp 00:01
+	fe042000-fe044fff : Reserved
+	fe900000-fe902fff : Reserved
+	fea00000-feafffff : pnp 00:01
+	fec00000-fec00fff : Reserved
+	  fec00000-fec003ff : IOAPIC 0
+	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
+	fed01000-fed01fff : intel-spi
+	  fed01000-fed01fff : Reserved
+	    fed01000-fed01fff : pnp 00:01
+	fed03000-fed03fff : pnp 00:01
+	fed06000-fed06fff : pnp 00:01
+	fed08000-fed09fff : pnp 00:01
+	fed1c000-fed1cfff : pnp 00:01
+	fed40000-fed44fff : MSFT0101:00
+	fed64000-fed64fff : dmar0
+	fed65000-fed65fff : dmar1
+	fed80000-fedbffff : pnp 00:01
+	fee00000-fee00fff : Local APIC
+	  fee00000-fee00fff : Reserved
+	ff000000-ffffffff : Reserved
 	100000000-17fffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	  179000000-17a005560 : Kernel code
+	  17a005561-17a9c0f7f : Kernel data
+	  17ab14000-17abfffff : Kernel bss
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/sda3: TYPE="ext4"

--- a/misc/acrn-config/xmls/board-xmls/apl-up2.xml
+++ b/misc/acrn-config/xmls/board-xmls/apl-up2.xml
@@ -238,18 +238,198 @@
 	rdt resource mask max: '0xff'
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
-	00001000-0003efff : System RAM
-	00040000-0009dfff : System RAM
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
+	00001000-0009ffff : System RAM
+	000a0000-000fffff : Reserved
+	  000a0000-000bffff : PCI Bus 0000:00
+	  000c0000-000dffff : PCI Bus 0000:00
+	  000e0000-000fffff : PCI Bus 0000:00
+	    000f0000-000fffff : System ROM
 	00100000-0fffffff : System RAM
-	12151000-70884017 : System RAM
-	70884018-70894057 : System RAM
-	70894058-77b0afff : System RAM
-	7a08b000-7a3f8fff : System RAM
-	7a424000-7a964fff : System RAM
-	7a967000-7affffff : System RAM
+	10000000-12150fff : Reserved
+	12151000-79703fff : System RAM
+	  25000000-260031d0 : Kernel code
+	  260031d1-269e8cbf : Kernel data
+	  26c37000-26dfffff : Kernel bss
+	79704000-7a003fff : Reserved
+	7a004000-7a06bfff : ACPI Tables
+	7a06c000-7a073fff : ACPI Non-volatile Storage
+	7a074000-7fffffff : Reserved
+	  7b800001-7bffffff : PCI Bus 0000:00
+	  7c000001-7fffffff : PCI Bus 0000:00
+	    7c000001-7ffffffe : Graphics Stolen Memory
+	80000000-cfffffff : PCI Bus 0000:00
+	  80000000-80ffffff : 0000:00:02.0
+	  81000000-811fffff : dwc_usb3
+	    81000000-811fffff : 0000:00:15.1
+	      8100c100-811fffff : dwc_usb3
+	  81200000-812fffff : PCI Bus 0000:03
+	    81200000-81200fff : 0000:03:00.0
+	      81200000-81200fff : r8169
+	  81300000-813fffff : PCI Bus 0000:02
+	    81300000-81300fff : 0000:02:00.0
+	      81300000-81300fff : r8169
+	  81400000-814fffff : 0000:00:0e.0
+	  81500000-8150ffff : 0000:00:15.0
+	    81500000-8150ffff : xhci-hcd
+	      81508070-8150846f : intel_xhci_usb_sw
+	  81510000-81517fff : 0000:00:00.1
+	  81518000-8151bfff : 0000:00:0e.0
+	  8151c000-8151dfff : 0000:00:12.0
+	    8151c000-8151dfff : ahci
+	  8151e000-8151ffff : 0000:00:11.0
+	  81520000-815200ff : 0000:00:1f.1
+	  81521000-81521fff : 0000:00:1e.0
+	  81522000-81522fff : 0000:00:1e.0
+	    81522000-81522fff : mmc1
+	  81523000-81523fff : 0000:00:1c.0
+	  81524000-81524fff : 0000:00:1c.0
+	    81524000-81524fff : mmc0
+	  81525000-81525fff : 0000:00:19.2
+	  81526000-81526fff : 0000:00:19.2
+	    81526000-815261ff : lpss_dev
+	      81526000-815261ff : lpss_dev
+	    81526200-815262ff : lpss_priv
+	    81526800-81526fff : idma64.14
+	      81526800-81526fff : idma64.14
+	  81527000-81527fff : 0000:00:19.1
+	  81528000-81528fff : 0000:00:19.1
+	    81528000-815281ff : lpss_dev
+	      81528000-815281ff : lpss_dev
+	    81528200-815282ff : lpss_priv
+	    81528800-81528fff : idma64.13
+	      81528800-81528fff : idma64.13
+	  81529000-81529fff : 0000:00:19.0
+	  8152a000-8152afff : 0000:00:19.0
+	    8152a000-8152a1ff : lpss_dev
+	      8152a000-8152a1ff : lpss_dev
+	    8152a200-8152a2ff : lpss_priv
+	    8152a800-8152afff : idma64.12
+	      8152a800-8152afff : idma64.12
+	  8152b000-8152bfff : 0000:00:18.3
+	  8152c000-8152cfff : 0000:00:18.3
+	    8152c000-8152c1ff : lpss_dev
+	      8152c000-8152c01f : serial
+	    8152c200-8152c2ff : lpss_priv
+	  8152d000-8152dfff : 0000:00:18.2
+	  8152e000-8152efff : 0000:00:18.2
+	    8152e000-8152e1ff : lpss_dev
+	      8152e000-8152e01f : serial
+	    8152e200-8152e2ff : lpss_priv
+	  8152f000-8152ffff : 0000:00:18.1
+	  81530000-81530fff : 0000:00:18.1
+	    81530000-815301ff : lpss_dev
+	      81530000-8153001f : serial
+	    81530200-815302ff : lpss_priv
+	    81530800-81530fff : idma64.9
+	      81530800-81530fff : idma64.9
+	  81531000-81531fff : 0000:00:18.0
+	  81532000-81532fff : 0000:00:18.0
+	    81532000-815321ff : lpss_dev
+	      81532000-8153201f : serial
+	    81532200-815322ff : lpss_priv
+	    81532800-81532fff : idma64.8
+	      81532800-81532fff : idma64.8
+	  81533000-81533fff : 0000:00:17.3
+	  81534000-81534fff : 0000:00:17.3
+	    81534000-815341ff : lpss_dev
+	      81534000-815341ff : lpss_dev
+	    81534200-815342ff : lpss_priv
+	    81534800-81534fff : idma64.7
+	      81534800-81534fff : idma64.7
+	  81535000-81535fff : 0000:00:17.2
+	  81536000-81536fff : 0000:00:17.2
+	    81536000-815361ff : lpss_dev
+	      81536000-815361ff : lpss_dev
+	    81536200-815362ff : lpss_priv
+	    81536800-81536fff : idma64.6
+	      81536800-81536fff : idma64.6
+	  81537000-81537fff : 0000:00:17.1
+	  81538000-81538fff : 0000:00:17.1
+	    81538000-815381ff : lpss_dev
+	      81538000-815381ff : lpss_dev
+	    81538200-815382ff : lpss_priv
+	    81538800-81538fff : idma64.5
+	      81538800-81538fff : idma64.5
+	  81539000-81539fff : 0000:00:17.0
+	  8153a000-8153afff : 0000:00:17.0
+	    8153a000-8153a1ff : lpss_dev
+	      8153a000-8153a1ff : lpss_dev
+	    8153a200-8153a2ff : lpss_priv
+	    8153a800-8153afff : idma64.4
+	      8153a800-8153afff : idma64.4
+	  8153b000-8153bfff : 0000:00:16.3
+	  8153c000-8153cfff : 0000:00:16.3
+	    8153c000-8153c1ff : lpss_dev
+	      8153c000-8153c1ff : lpss_dev
+	    8153c200-8153c2ff : lpss_priv
+	    8153c800-8153cfff : idma64.3
+	      8153c800-8153cfff : idma64.3
+	  8153d000-8153dfff : 0000:00:16.2
+	  8153e000-8153efff : 0000:00:16.2
+	    8153e000-8153e1ff : lpss_dev
+	      8153e000-8153e1ff : lpss_dev
+	    8153e200-8153e2ff : lpss_priv
+	    8153e800-8153efff : idma64.2
+	      8153e800-8153efff : idma64.2
+	  8153f000-8153ffff : 0000:00:16.1
+	  81540000-81540fff : 0000:00:16.1
+	    81540000-815401ff : lpss_dev
+	      81540000-815401ff : lpss_dev
+	    81540200-815402ff : lpss_priv
+	    81540800-81540fff : idma64.1
+	      81540800-81540fff : idma64.1
+	  81541000-81541fff : 0000:00:16.0
+	  81542000-81542fff : 0000:00:16.0
+	    81542000-815421ff : lpss_dev
+	      81542000-815421ff : lpss_dev
+	    81542200-815422ff : lpss_priv
+	    81542800-81542fff : idma64.0
+	      81542800-81542fff : idma64.0
+	  81543000-81543fff : 0000:00:15.1
+	  81544000-815447ff : 0000:00:12.0
+	    81544000-815447ff : ahci
+	  81545000-815450ff : 0000:00:12.0
+	    81545000-815450ff : ahci
+	  81546000-81546fff : 0000:00:11.0
+	  81547000-81547fff : 0000:00:0f.2
+	  81548000-81548fff : 0000:00:0f.1
+	  81549000-81549fff : 0000:00:0f.0
+	    81549000-81549fff : mei_me
+	  90000000-9fffffff : 0000:00:02.0
+	  a0000000-a00fffff : PCI Bus 0000:03
+	    a0000000-a0003fff : 0000:03:00.0
+	  a0100000-a01fffff : PCI Bus 0000:02
+	    a0100000-a0103fff : 0000:02:00.0
+	d0c00000-d0c00653 : INT3452:03
+	  d0c00000-d0c00653 : INT3452:03
+	d0c40000-d0c40763 : INT3452:01
+	  d0c40000-d0c40763 : INT3452:01
+	d0c50000-d0c5076b : INT3452:00
+	  d0c50000-d0c5076b : INT3452:00
+	d0c70000-d0c70673 : INT3452:02
+	  d0c70000-d0c70673 : INT3452:02
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : PCI Bus 0000:00
+	    e0000000-efffffff : pnp 00:01
+	fea00000-feafffff : pnp 00:01
+	fec00000-fec003ff : IOAPIC 0
+	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
+	fed01000-fed01fff : intel-spi
+	  fed01000-fed01fff : pnp 00:01
+	fed03000-fed03fff : pnp 00:01
+	fed06000-fed06fff : pnp 00:01
+	fed08000-fed09fff : pnp 00:01
+	fed1c000-fed1cfff : pnp 00:01
+	fed40000-fed44fff : MSFT0101:00
+	fed80000-fedbffff : pnp 00:01
+	fee00000-feefffff : pnp 00:01
+	  fee00000-fee00fff : Local APIC
+	ff800000-ffffffff : Reserved
 	100000000-27fffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/sda3: TYPE="ext4"

--- a/misc/acrn-config/xmls/board-xmls/nuc6cayh.xml
+++ b/misc/acrn-config/xmls/board-xmls/nuc6cayh.xml
@@ -194,20 +194,140 @@
 	rdt resource mask max: '0xff'
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
 	00001000-0003efff : System RAM
-	00040000-0009efff : System RAM
+	0003f000-0003ffff : Reserved
+	00040000-0009dfff : System RAM
+	0009e000-000fffff : Reserved
+	  000f0000-000fffff : System ROM
 	00100000-0fffffff : System RAM
-	12151000-6ff60017 : System RAM
-	6ff60018-6ff6e057 : System RAM
-	6ff6e058-6ff6f017 : System RAM
-	6ff6f018-6ff7f057 : System RAM
-	6ff7f058-7710dfff : System RAM
+	10000000-12150fff : Reserved
+	12151000-6ff5e017 : System RAM
+	6ff5e018-6ff6c057 : System RAM
+	6ff6c058-6ff6d017 : System RAM
+	6ff6d018-6ff7d057 : System RAM
+	6ff7d058-7710dfff : System RAM
+	7710e000-79232fff : Reserved
+	79233000-7924dfff : ACPI Tables
+	7924e000-79651fff : ACPI Non-volatile Storage
+	79652000-799f5fff : Reserved
 	799f6000-79d78fff : System RAM
+	79d79000-79d79fff : ACPI Non-volatile Storage
+	79d7a000-79da3fff : Reserved
 	79da4000-7a9defff : System RAM
+	7a9df000-7a9e0fff : Reserved
 	7a9e1000-7affffff : System RAM
+	7b000000-7fffffff : Reserved
+	  7b800001-7bffffff : PCI Bus 0000:00
+	  7c000001-7fffffff : PCI Bus 0000:00
+	    7c000001-7ffffffe : Graphics Stolen Memory
+	80000000-cfffffff : PCI Bus 0000:00
+	  80000000-8fffffff : 0000:00:02.0
+	  90000000-90ffffff : 0000:00:02.0
+	  91000000-910fffff : 0000:00:0e.0
+	    91000000-910fffff : ICH HD audio
+	  91100000-911fffff : PCI Bus 0000:03
+	    91100000-91103fff : 0000:03:00.0
+	    91104000-91104fff : 0000:03:00.0
+	      91104000-91104fff : r8169
+	  91200000-912fffff : PCI Bus 0000:02
+	    91200000-91201fff : 0000:02:00.0
+	      91200000-91201fff : iwlwifi
+	  91300000-913fffff : PCI Bus 0000:01
+	    91300000-91300fff : 0000:01:00.0
+	      91300000-91300fff : rtsx_pci
+	  91400000-9140ffff : 0000:00:15.0
+	    91400000-9140ffff : xhci-hcd
+	      91408070-9140846f : intel_xhci_usb_sw
+	  91410000-91413fff : 0000:00:0e.0
+	    91410000-91413fff : ICH HD audio
+	  91414000-91415fff : 0000:00:12.0
+	    91414000-91415fff : ahci
+	  91416000-914160ff : 0000:00:1f.1
+	  91417000-91417fff : 0000:00:1a.0
+	  91418000-91418fff : 0000:00:1a.0
+	    91418000-91418fff : 0000:00:1a.0
+	  91419000-91419fff : 0000:00:19.2
+	  9141a000-9141afff : 0000:00:19.2
+	    9141a000-9141a1ff : lpss_dev
+	      9141a000-9141a1ff : pxa2xx-spi.4
+	    9141a200-9141a2ff : lpss_priv
+	    9141a800-9141afff : idma64.4
+	      9141a800-9141afff : idma64.4
+	  9141b000-9141bfff : 0000:00:19.1
+	  9141c000-9141cfff : 0000:00:19.1
+	    9141c000-9141c1ff : lpss_dev
+	      9141c000-9141c1ff : pxa2xx-spi.3
+	    9141c200-9141c2ff : lpss_priv
+	    9141c800-9141cfff : idma64.3
+	      9141c800-9141cfff : idma64.3
+	  9141d000-9141dfff : 0000:00:19.0
+	  9141e000-9141efff : 0000:00:19.0
+	    9141e000-9141e1ff : lpss_dev
+	      9141e000-9141e1ff : pxa2xx-spi.2
+	    9141e200-9141e2ff : lpss_priv
+	    9141e800-9141efff : idma64.2
+	      9141e800-9141efff : idma64.2
+	  9141f000-9141ffff : 0000:00:18.0
+	  91420000-91420fff : 0000:00:18.0
+	    91420000-914201ff : lpss_dev
+	      91420000-9142001f : serial
+	    91420200-914202ff : lpss_priv
+	    91420800-91420fff : idma64.1
+	      91420800-91420fff : idma64.1
+	  91421000-91421fff : 0000:00:16.0
+	  91422000-91422fff : 0000:00:16.0
+	    91422000-914221ff : lpss_dev
+	      91422000-914221ff : i2c_designware.0
+	    91422200-914222ff : lpss_priv
+	    91422800-91422fff : idma64.0
+	      91422800-91422fff : idma64.0
+	  91423000-914237ff : 0000:00:12.0
+	    91423000-914237ff : ahci
+	  91424000-914240ff : 0000:00:12.0
+	    91424000-914240ff : ahci
+	  91427000-91427fff : 0000:00:0f.0
+	    91427000-91427fff : mei_me
+	d0000000-d0ffffff : Reserved
+	  d0c00000-d0c00653 : INT3452:03
+	    d0c00000-d0c00653 : INT3452:03
+	  d0c40000-d0c40763 : INT3452:01
+	    d0c40000-d0c40763 : INT3452:01
+	  d0c50000-d0c5076b : INT3452:00
+	    d0c50000-d0c5076b : INT3452:00
+	  d0c70000-d0c70673 : INT3452:02
+	    d0c70000-d0c70673 : INT3452:02
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : Reserved
+	    e0000000-efffffff : PCI Bus 0000:00
+	      e0000000-efffffff : pnp 00:02
+	fe042000-fe044fff : Reserved
+	fe900000-fe902fff : Reserved
+	fea00000-feafffff : pnp 00:02
+	fec00000-fec00fff : Reserved
+	  fec00000-fec003ff : IOAPIC 0
+	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
+	fed01000-fed01fff : intel-spi
+	  fed01000-fed01fff : Reserved
+	    fed01000-fed01fff : pnp 00:02
+	fed03000-fed03fff : pnp 00:02
+	fed06000-fed06fff : pnp 00:02
+	fed08000-fed09fff : pnp 00:02
+	fed1c000-fed1cfff : pnp 00:02
+	fed40000-fed44fff : MSFT0101:00
+	fed64000-fed64fff : dmar0
+	fed65000-fed65fff : dmar1
+	fed80000-fedbffff : pnp 00:02
+	fee00000-fee00fff : Local APIC
+	  fee00000-fee00fff : Reserved
+	ff000000-ffffffff : Reserved
 	100000000-27fffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	  101000000-1022048b0 : Kernel code
+	  1022048b1-102bce3ff : Kernel data
+	  102d36000-1035fffff : Kernel bss
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/sda3: TYPE="ext4"

--- a/misc/acrn-config/xmls/board-xmls/nuc7i7dnb.xml
+++ b/misc/acrn-config/xmls/board-xmls/nuc7i7dnb.xml
@@ -189,15 +189,106 @@
 	<CLOS_INFO>
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
 	00001000-00057fff : System RAM
-	00059000-0009dfff : System RAM
-	00100000-3fffffff : System RAM
-	40400000-7da93fff : System RAM
-	7da96000-8a0dafff : System RAM
-	8afff000-8affffff : System RAM
-	100000000-26dffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	00058000-00058fff : Reserved
+	00059000-0009efff : System RAM
+	0009f000-000fffff : Reserved
+	  000a0000-000bffff : PCI Bus 0000:00
+	  000c0000-000cffff : Video ROM
+	  000d0000-000d0fff : Adapter ROM
+	  000f0000-000fffff : System ROM
+	00100000-797d4017 : System RAM
+	797d4018-797e4e57 : System RAM
+	797e4e58-797e5017 : System RAM
+	797e5018-797f5057 : System RAM
+	797f5058-7e126fff : System RAM
+	7e127000-7e127fff : ACPI Non-volatile Storage
+	7e128000-7e128fff : Reserved
+	7e129000-89d8afff : System RAM
+	89d8b000-8a21afff : Reserved
+	8a21b000-8a25dfff : ACPI Tables
+	8a25e000-8aa39fff : ACPI Non-volatile Storage
+	8aa3a000-8affdfff : Reserved
+	8affe000-8affefff : System RAM
+	8afff000-8fffffff : Reserved
+	  8c000000-8fffffff : Graphics Stolen Memory
+	90000000-dfffffff : PCI Bus 0000:00
+	  c0000000-cfffffff : 0000:00:02.0
+	  d0000000-d09fffff : PCI Bus 0000:01
+	  de000000-deffffff : 0000:00:02.0
+	  df000000-df9fffff : PCI Bus 0000:01
+	  dfa00000-dfafffff : PCI Bus 0000:03
+	    dfa00000-dfa00fff : 0000:03:00.0
+	      dfa00000-dfa00fff : rtsx_pci
+	  dfb00000-dfbfffff : PCI Bus 0000:02
+	    dfb00000-dfb01fff : 0000:02:00.0
+	      dfb00000-dfb01fff : iwlwifi
+	  dfc00000-dfc1ffff : 0000:00:1f.6
+	    dfc00000-dfc1ffff : e1000e
+	  dfc20000-dfc2ffff : 0000:00:1f.3
+	    dfc20000-dfc2ffff : ICH HD audio
+	  dfc30000-dfc3ffff : 0000:00:14.0
+	    dfc30000-dfc3ffff : xhci-hcd
+	      dfc38070-dfc3846f : intel_xhci_usb_sw
+	  dfc40000-dfc43fff : 0000:00:1f.3
+	    dfc40000-dfc43fff : ICH HD audio
+	  dfc44000-dfc47fff : 0000:00:1f.2
+	  dfc48000-dfc49fff : 0000:00:17.0
+	    dfc48000-dfc49fff : ahci
+	  dfc4a000-dfc4a0ff : 0000:00:1f.4
+	  dfc4b000-dfc4b7ff : 0000:00:17.0
+	    dfc4b000-dfc4b7ff : ahci
+	  dfc4c000-dfc4c0ff : 0000:00:17.0
+	    dfc4c000-dfc4c0ff : ahci
+	  dfc4d000-dfc4dfff : 0000:00:16.0
+	    dfc4d000-dfc4dfff : mei_me
+	  dfc4e000-dfc4efff : 0000:00:14.2
+	    dfc4e000-dfc4efff : Intel PCH thermal driver
+	  dfc4f000-dfc4ffff : 0000:00:08.0
+	  dffe0000-dfffffff : pnp 00:05
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : Reserved
+	    e0000000-efffffff : pnp 00:05
+	fd000000-fe7fffff : PCI Bus 0000:00
+	  fd000000-fdabffff : pnp 00:06
+	  fdac0000-fdacffff : pnp 00:08
+	  fdad0000-fdadffff : pnp 00:06
+	  fdae0000-fdaeffff : pnp 00:08
+	  fdaf0000-fdafffff : pnp 00:08
+	  fdb00000-fdffffff : pnp 00:06
+	    fdc6000c-fdc6000f : iTCO_wdt
+	  fe000000-fe010fff : Reserved
+	  fe028000-fe028fff : pnp 00:08
+	  fe029000-fe029fff : pnp 00:08
+	  fe036000-fe03bfff : pnp 00:06
+	  fe03d000-fe3fffff : pnp 00:06
+	  fe410000-fe7fffff : pnp 00:06
+	fec00000-fec00fff : Reserved
+	  fec00000-fec003ff : IOAPIC 0
+	fed00000-fed00fff : Reserved
+	  fed00000-fed003ff : HPET 0
+	    fed00000-fed003ff : PNP0103:00
+	fed10000-fed17fff : pnp 00:05
+	fed18000-fed18fff : pnp 00:05
+	fed19000-fed19fff : pnp 00:05
+	fed20000-fed3ffff : pnp 00:05
+	fed40000-fed44fff : MSFT0101:00
+	fed45000-fed8ffff : pnp 00:05
+	fed90000-fed90fff : dmar0
+	fed91000-fed91fff : dmar1
+	fee00000-fee00fff : Local APIC
+	  fee00000-fee00fff : Reserved
+	ff000000-ffffffff : Reserved
+	  ff000000-ffffffff : INT0800:00
+	    ff000000-ffffffff : pnp 00:05
+	100000000-26effffff : System RAM
+	  1dd000000-1de005580 : Kernel code
+	  1de005581-1de9c61ff : Kernel data
+	  1deb1f000-1df3fffff : Kernel bss
+	26f000000-26fffffff : RAM buffer
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/sda3: TYPE="ext4"

--- a/misc/acrn-config/xmls/board-xmls/whl-ipc-i5.xml
+++ b/misc/acrn-config/xmls/board-xmls/whl-ipc-i5.xml
@@ -181,20 +181,100 @@
 	<CLOS_INFO>
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
 	00001000-0005efff : System RAM
+	0005f000-0005ffff : Reserved
 	00060000-0009ffff : System RAM
-	00100000-1fdfffff : System RAM
-	20000000-3fffffff : System RAM
-	40400000-8276e017 : System RAM
-	8276e018-8277e657 : System RAM
-	8277e658-8277f017 : System RAM
-	8277f018-8278f057 : System RAM
-	8278f058-85b3dfff : System RAM
-	85b40000-8bfbafff : System RAM
-	8ceff000-8cefffff : System RAM
+	000a0000-000fffff : Reserved
+	  000a0000-000bffff : PCI Bus 0000:00
+	  000c0000-000cffff : Video ROM
+	  000f0000-000fffff : System ROM
+	00100000-3fffffff : System RAM
+	  00c5fffc-00c5ffff : iTCO_wdt
+	40000000-403fffff : Reserved
+	  40000000-403fffff : pnp 00:00
+	40400000-808a6017 : System RAM
+	808a6018-808b6657 : System RAM
+	808b6658-808b7017 : System RAM
+	808b7018-808c7057 : System RAM
+	808c7058-83536fff : System RAM
+	83537000-83537fff : ACPI Non-volatile Storage
+	83538000-83538fff : Reserved
+	83539000-89f8afff : System RAM
+	89f8b000-8a3f6fff : Reserved
+	8a3f7000-8a473fff : ACPI Tables
+	8a474000-8a8a8fff : ACPI Non-volatile Storage
+	8a8a9000-8aefefff : Reserved
+	8aeff000-8aefffff : System RAM
+	8af00000-8fffffff : Reserved
+	  8c000000-8fffffff : Graphics Stolen Memory
+	90000000-dfffffff : PCI Bus 0000:00
+	  90000000-9fffffff : 0000:00:02.0
+	  a0000000-a0ffffff : 0000:00:02.0
+	  a1000000-a10fffff : 0000:00:1f.3
+	  a1100000-a11fffff : PCI Bus 0000:04
+	    a1100000-a111ffff : 0000:04:00.0
+	      a1100000-a111ffff : igb
+	    a1120000-a1123fff : 0000:04:00.0
+	      a1120000-a1123fff : igb
+	  a1200000-a12fffff : PCI Bus 0000:03
+	    a1200000-a121ffff : 0000:03:00.0
+	      a1200000-a121ffff : igb
+	    a1220000-a1223fff : 0000:03:00.0
+	      a1220000-a1223fff : igb
+	  a1300000-a13fffff : PCI Bus 0000:02
+	    a1300000-a1303fff : 0000:02:00.0
+	      a1300000-a1303fff : nvme
+	  a1400000-a140ffff : 0000:00:14.0
+	    a1400000-a140ffff : xhci-hcd
+	  a1410000-a1413fff : 0000:00:1f.3
+	  a1414000-a1415fff : 0000:00:17.0
+	    a1414000-a1415fff : ahci
+	  a1416000-a1417fff : 0000:00:14.2
+	  a1418000-a14180ff : 0000:00:1f.4
+	  a1419000-a1419fff : 0000:00:1a.0
+	    a1419000-a1419fff : mmc0
+	  a141a000-a141a7ff : 0000:00:17.0
+	    a141a000-a141a7ff : ahci
+	  a141b000-a141b0ff : 0000:00:17.0
+	    a141b000-a141b0ff : ahci
+	  a141c000-a141cfff : 0000:00:16.0
+	  a141d000-a141dfff : 0000:00:14.2
+	  a141e000-a141efff : 0000:00:12.0
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : Reserved
+	    e0000000-efffffff : pnp 00:0d
+	fc800000-fe7fffff : PCI Bus 0000:00
+	  fd000000-fd69ffff : pnp 00:0e
+	  fd6a0000-fd6affff : pnp 00:10
+	  fd6b0000-fd6cffff : pnp 00:0e
+	  fd6d0000-fd6dffff : pnp 00:10
+	  fd6e0000-fd6effff : pnp 00:10
+	  fd6f0000-fdffffff : pnp 00:0e
+	  fe000000-fe010fff : Reserved
+	    fe010000-fe010fff : 0000:00:1f.5
+	  fe200000-fe7fffff : pnp 00:0e
+	fec00000-fec00fff : Reserved
+	  fec00000-fec003ff : IOAPIC 0
+	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
+	fed10000-fed17fff : pnp 00:0d
+	fed18000-fed18fff : pnp 00:0d
+	fed19000-fed19fff : pnp 00:0d
+	fed20000-fed3ffff : pnp 00:0d
+	fed45000-fed8ffff : pnp 00:0d
+	fed90000-fed93fff : pnp 00:0d
+	fee00000-fee00fff : Local APIC
+	  fee00000-fee00fff : Reserved
+	ff000000-ffffffff : Reserved
+	  ff000000-ffffffff : pnp 00:0e
 	100000000-26dffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	  207400000-2084031d0 : Kernel code
+	  2084031d1-208b6323f : Kernel data
+	  208d1a000-208dfffff : Kernel bss
+	26e000000-26fffffff : RAM buffer
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/nvme0n1p3: TYPE="ext4"

--- a/misc/acrn-config/xmls/board-xmls/whl-ipc-i7.xml
+++ b/misc/acrn-config/xmls/board-xmls/whl-ipc-i7.xml
@@ -185,19 +185,102 @@
 	<CLOS_INFO>
 	</CLOS_INFO>
 
-	<SYSTEM_RAM_INFO>
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
 	00001000-0005efff : System RAM
+	0005f000-0005ffff : Reserved
 	00060000-0009ffff : System RAM
+	000a0000-000fffff : Reserved
+	  000a0000-000bffff : PCI Bus 0000:00
+	  000c0000-000cffff : Video ROM
+	  000f0000-000fffff : System ROM
 	00100000-3fffffff : System RAM
-	40400000-826f5017 : System RAM
-	826f5018-82705657 : System RAM
-	82705658-82706017 : System RAM
-	82706018-82716057 : System RAM
-	82716058-85b5dfff : System RAM
-	85b60000-8bfbbfff : System RAM
+	40000000-403fffff : Reserved
+	  40000000-403fffff : pnp 00:00
+	40400000-80916017 : System RAM
+	  78000000-79202390 : Kernel code
+	  79400000-799f9fff : Kernel rodata
+	  79a00000-79bed63f : Kernel data
+	  79dd6000-7a9fffff : Kernel bss
+	80916018-80926657 : System RAM
+	80926658-80927017 : System RAM
+	80927018-80937057 : System RAM
+	80937058-84dcefff : System RAM
+	84dcf000-84dcffff : ACPI Non-volatile Storage
+	84dd0000-84dd0fff : Reserved
+	84dd1000-8bfbefff : System RAM
+	8bfbf000-8c420fff : Reserved
+	8c421000-8c49dfff : ACPI Tables
+	8c49e000-8c8aafff : ACPI Non-volatile Storage
+	8c8ab000-8cefefff : Reserved
 	8ceff000-8cefffff : System RAM
+	8cf00000-8fffffff : Reserved
+	  8e000000-8fffffff : Graphics Stolen Memory
+	90000000-dfffffff : PCI Bus 0000:00
+	  90000000-9fffffff : 0000:00:02.0
+	  a0000000-a0ffffff : 0000:00:02.0
+	  a1000000-a10fffff : 0000:00:1f.3
+	    a1000000-a10fffff : ICH HD audio
+	  a1100000-a11fffff : PCI Bus 0000:02
+	    a1100000-a111ffff : 0000:02:00.0
+	      a1100000-a111ffff : igb
+	    a1120000-a1123fff : 0000:02:00.0
+	      a1120000-a1123fff : igb
+	  a1200000-a12fffff : PCI Bus 0000:01
+	    a1200000-a121ffff : 0000:01:00.0
+	      a1200000-a121ffff : igb
+	    a1220000-a1223fff : 0000:01:00.0
+	      a1220000-a1223fff : igb
+	  a1300000-a130ffff : 0000:00:14.0
+	    a1300000-a130ffff : xhci-hcd
+	  a1310000-a1313fff : 0000:00:1f.3
+	    a1310000-a1313fff : ICH HD audio
+	  a1314000-a1315fff : 0000:00:17.0
+	    a1314000-a1315fff : ahci
+	  a1316000-a1317fff : 0000:00:14.2
+	  a1318000-a13180ff : 0000:00:1f.4
+	  a1319000-a1319fff : 0000:00:1a.0
+	    a1319000-a1319fff : mmc0
+	  a131a000-a131a7ff : 0000:00:17.0
+	    a131a000-a131a7ff : ahci
+	  a131b000-a131b0ff : 0000:00:17.0
+	    a131b000-a131b0ff : ahci
+	  a131c000-a131cfff : 0000:00:16.0
+	    a131c000-a131cfff : mei_me
+	  a131d000-a131dfff : 0000:00:14.2
+	  a131e000-a131efff : 0000:00:12.0
+	    a131e000-a131efff : Intel PCH thermal driver
+	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  e0000000-efffffff : Reserved
+	    e0000000-efffffff : pnp 00:0d
+	fc800000-fe7fffff : PCI Bus 0000:00
+	  fd000000-fd69ffff : pnp 00:0e
+	  fd6a0000-fd6affff : pnp 00:10
+	  fd6b0000-fd6cffff : pnp 00:0e
+	  fd6d0000-fd6dffff : pnp 00:10
+	  fd6e0000-fd6effff : pnp 00:10
+	  fd6f0000-fdffffff : pnp 00:0e
+	  fe000000-fe010fff : Reserved
+	    fe010000-fe010fff : 0000:00:1f.5
+	  fe200000-fe7fffff : pnp 00:0e
+	fec00000-fec00fff : Reserved
+	  fec00000-fec003ff : IOAPIC 0
+	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
+	fed10000-fed17fff : pnp 00:0d
+	fed18000-fed18fff : pnp 00:0d
+	fed19000-fed19fff : pnp 00:0d
+	fed20000-fed3ffff : pnp 00:0d
+	fed45000-fed8ffff : pnp 00:0d
+	fed90000-fed90fff : dmar0
+	fed91000-fed91fff : dmar1
+	fee00000-fee00fff : Local APIC
+	  fee00000-fee00fff : Reserved
+	ff000000-ffffffff : Reserved
+	  ff000000-ffffffff : pnp 00:0e
 	100000000-26dffffff : System RAM
-	</SYSTEM_RAM_INFO>
+	26e000000-26fffffff : RAM buffer
+	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
 	/dev/nvme0n1p3: TYPE="ext4"


### PR DESCRIPTION
- find 64-bit mmio for HI_MMIO_START/HI_MMIO_END
- update IOMEM_INFO of native board config xml
- dump iomem info from /proc/iomem

    Tracked-On: #4569
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
    Acked-by: Terry Zou <terry.zou@intel.com>
