### PR TITLE
doc: remove "Glossary" icon box on home page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -64,13 +64,6 @@ through an open source platform.
            </a>
            <p>Supported hardware platforms and boards</p>
        </li>
-       <li class="grid-item">
-           <a href="glossary.html">
-               <img alt="" src="_static/images/ACRNlogo80w.png"/>
-               <h2>Glossary<br/>of Terms</h2>
-           </a>
-           <p>Glossary of useful terms</p>
-       </li>
    </ul>
 
 


### PR DESCRIPTION
Adding a big box for the glossary disturbed the home page layout and is
overkill for this one document. Adding the glossary to the left
navigation menu is sufficient.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>