### PR TITLE
hv: vm: refine the devices unregistration sequence of vm shutdown

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -28,6 +28,7 @@
 */
 
 #include <errno.h>
+#include <ptdev.h>
 #include <vm.h>
 #include <vtd.h>
 #include <io.h>
@@ -227,7 +228,7 @@ static int32_t vpci_mmio_cfg_access(struct io_request *io_req, void *private_dat
  * @pre vm != NULL
  * @pre vm->vm_id < CONFIG_MAX_VM_NUM
  */
-void vpci_init(struct acrn_vm *vm)
+void init_vpci(struct acrn_vm *vm)
 {
 	struct vm_io_range pci_cfgaddr_range = {
 		.base = PCI_CONFIG_ADDR,
@@ -270,7 +271,7 @@ void vpci_init(struct acrn_vm *vm)
  * @pre vm != NULL
  * @pre vm->vm_id < CONFIG_MAX_VM_NUM
  */
-void vpci_cleanup(struct acrn_vm *vm)
+void deinit_vpci(struct acrn_vm *vm)
 {
 	struct acrn_vm_config *vm_config;
 
@@ -290,6 +291,11 @@ void vpci_cleanup(struct acrn_vm *vm)
 		/* Unsupported VM type - Do nothing */
 		break;
 	}
+
+	ptdev_release_all_entries(vm);
+
+	/* Free iommu */
+	destroy_iommu_domain(vm->iommu);
 }
 
 /**

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -149,8 +149,8 @@ struct acrn_vm;
 
 extern const struct pci_vdev_ops vhostbridge_ops;
 extern const struct pci_vdev_ops vpci_bridge_ops;
-void vpci_init(struct acrn_vm *vm);
-void vpci_cleanup(struct acrn_vm *vm);
+void init_vpci(struct acrn_vm *vm);
+void deinit_vpci(struct acrn_vm *vm);
 struct pci_vdev *pci_find_vdev(struct acrn_vpci *vpci, union pci_bdf vbdf);
 struct acrn_assign_pcidev;
 int32_t vpci_assign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *pcidev);


### PR DESCRIPTION
Conceptually, the devices unregistration sequence of the shutdown process should be
opposite to create.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>