### PR TITLE
acrn-config: Fixes for BAR remapping logic

### DIFF
--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -43,7 +43,7 @@ SIZE_K = common.SIZE_K
 SIZE_M = common.SIZE_M
 SIZE_2G = common.SIZE_2G
 SIZE_4G = common.SIZE_4G
-
+SIZE_G = common.SIZE_G
 
 def prepare():
     """ check environment """

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -29,7 +29,7 @@ SIZE_K = 1024
 SIZE_M = SIZE_K * 1024
 SIZE_2G = 2 * SIZE_M * SIZE_K
 SIZE_4G = 2 * SIZE_2G
-
+SIZE_G = SIZE_M * 1024
 
 class MultiItem():
 


### PR DESCRIPTION
This patch does the following
1) Removes the limitation on BAR size for 1 GB
2) Align the BAR address to the BAR size

Tracked-On: #4586
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Terry Zou <terry.zou@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>