### PR TITLE
doc: update robots.txt exclusion list

### DIFF
--- a/doc/scripts/publish-robots.txt
+++ b/doc/scripts/publish-robots.txt
@@ -8,3 +8,9 @@ Disallow: /0.5/
 Disallow: /0.6/
 Disallow: /0.7/
 Disallow: /0.8/
+Disallow: /1.0/
+Disallow: /1.1/
+Disallow: /1.2/
+Disallow: /1.3/
+Disallow: /1.4/
+Disallow: /1.5/


### PR DESCRIPTION
Developers using google search can accidentally find older versions of
documents and lead to confusion.  While we do maintain previous release
documentation on the site, we should have a preference for the latest
documentation when using external search engines.  (Note the on-site
search always returns version-specific results.)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>