### PR TITLE
Ww12 64 bit mmio upstream

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
@@ -43,4 +43,7 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	1U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -39,4 +39,8 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	1U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
@@ -28,4 +28,8 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	0U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/generic/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/generic/misc_cfg.h
@@ -29,4 +29,8 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	0U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
@@ -28,4 +28,8 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	0U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
@@ -29,4 +29,8 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	0U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/configs/whl-ipc-i5/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/whl-ipc-i5/misc_cfg.h
@@ -30,4 +30,8 @@
 
 #define MAX_HIDDEN_PDEVS_NUM	0U
 
+#define HI_MMIO_START		~0UL
+#define HI_MMIO_END		0UL
+
+
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -38,6 +38,7 @@
 #include <vm.h>
 #include <ld_sym.h>
 #include <logmsg.h>
+#include <misc_cfg.h>
 
 static void *ppt_mmu_pml4_addr;
 static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);
@@ -281,6 +282,16 @@ void init_paging(void)
 	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (uint64_t)get_reserve_sworld_memory_base(),
 			TRUSTY_RAM_SIZE * MAX_POST_VM_NUM, PAGE_USER, 0UL, &ppt_mem_ops, MR_MODIFY);
 #endif
+
+	/*
+	 * Users of this MMIO region needs to use access memory using stac/clac
+	 */
+
+	if ((HI_MMIO_START != ~0UL) && (HI_MMIO_END != 0UL)) {
+		mmu_add((uint64_t *)ppt_mmu_pml4_addr, HI_MMIO_START, HI_MMIO_START,
+			(HI_MMIO_END - HI_MMIO_START), attr_uc, &ppt_mem_ops);
+	}
+
 	/* Enable paging */
 	enable_paging();
 

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -13,8 +13,10 @@
 #include <security.h>
 #include <vm.h>
 
-static struct page ppt_pml4_pages[PML4_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)];
-static struct page ppt_pdpt_pages[PDPT_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)];
+#define LINEAR_ADDRESS_SPACE_48_BIT	(1UL << 48U)
+
+static struct page ppt_pml4_pages[PML4_PAGE_NUM(LINEAR_ADDRESS_SPACE_48_BIT)];
+static struct page ppt_pdpt_pages[PDPT_PAGE_NUM(LINEAR_ADDRESS_SPACE_48_BIT)];
 static struct page ppt_pd_pages[PD_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + PLATFORM_LO_MMIO_SIZE)];
 
 /* ppt: pripary page table */

--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -106,8 +106,8 @@ def find_hi_mmio_window(config):
 
     print("", file=config)
     if is_hi_mmio:
-        print("#define HI_MMIO_START\t\t0x%xUL" % mmio_min, file=config)
-        print("#define HI_MMIO_END\t\t0x%xUL" % mmio_max, file=config)
+        print("#define HI_MMIO_START\t\t0x%xUL" % common.round_down(mmio_min, common.SIZE_G), file=config)
+        print("#define HI_MMIO_END\t\t0x%xUL" % common.round_up(mmio_max, common.SIZE_G), file=config)
     else:
         print("#define HI_MMIO_START\t\t~0UL", file=config)
         print("#define HI_MMIO_END\t\t0UL", file=config)

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -466,6 +466,9 @@ def undline_name(name):
 
     return name_str
 
+def round_down(addr, mem_align):
+    """Keep memory align"""
+    return (addr & (~(mem_align - 1)))
 
 def round_up(addr, mem_align):
     """Keep memory align"""


### PR DESCRIPTION
Handle PCI devices with 64-bit MMIO BARs and BAR Base addresses > 4G.
This patch series builds hypervisor page tables for 64-bit MMIO BARs and facilitates ACRN access MMIO for MSI-x Emulation.

Tracked-On: #4586
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>