### PR TITLE
HV: add support for VT-d Posted Interrupts (series #2)

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -233,6 +233,7 @@ HW_C_SRCS += arch/x86/ioapic.c
 HW_C_SRCS += arch/x86/lapic.c
 HW_C_SRCS += arch/x86/cpu.c
 HW_C_SRCS += arch/x86/cpu_caps.c
+HW_C_SRCS += arch/x86/platform_caps.c
 HW_C_SRCS += arch/x86/security.c
 HW_C_SRCS += arch/x86/mmu.c
 HW_C_SRCS += arch/x86/e820.c

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -229,7 +229,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 
 		timer_init();
 		setup_notification();
-		setup_posted_intr_notification();
+		setup_pi_notification();
 
 		if (init_iommu() != 0) {
 			panic("failed to initialize iommu!");

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -469,7 +469,7 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 		 * the "enable VPID" VM-execution control is 1, the current VPID
 		 * is the value of the VPID VM-execution control field in the VMCS.
 		 *
-		 * This assignment guarantees a unique non-zero per vcpu vpid in runtime.
+		 * This assignment guarantees a unique non-zero per vcpu vpid at runtime.
 		 */
 		vcpu->arch.vpid = 1U + (vm->vm_id * MAX_VCPUS_PER_VM) + vcpu->vcpu_id;
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -31,6 +31,7 @@
 #include <sbuf.h>
 #include <pci_dev.h>
 #include <vacpi.h>
+#include <platform_caps.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -113,6 +114,20 @@ bool is_rt_vm(const struct acrn_vm *vm)
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 
 	return ((vm_config->guest_flags & GUEST_FLAG_RT) != 0U);
+}
+
+/**
+ * @brief VT-d PI posted mode can possibly be used for PTDEVs assigned
+ * to this VM if platform supports VT-d PI AND lapic passthru is not configured
+ * for this VM.
+ * However, as we can only post single destination IRQ, so meeting these 2 conditions
+ * does not necessarily mean posted mode will be used for all PTDEVs belonging
+ * to the VM, unless the IRQ is single-destination for the specific PTDEV
+ * @pre vm != NULL
+ */
+bool is_pi_capable(const struct acrn_vm *vm)
+{
+	return (platform_caps.pi && (!is_lapic_pt_configured(vm)));
 }
 
 static struct acrn_vm *get_highest_severity_vm(void)

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -352,7 +352,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 		exec_vmwrite64(VMX_EOI_EXIT3_FULL, 0UL);
 
 		exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0U);
-		exec_vmwrite16(VMX_POSTED_INTR_VECTOR, POSTED_INTR_VECTOR);
+		exec_vmwrite16(VMX_POSTED_INTR_VECTOR, (uint16_t)vcpu->arch.pid.control.bits.nv);
 		exec_vmwrite64(VMX_PIR_DESC_ADDR_FULL, hva2hpa(get_pi_desc(vcpu)));
 	}
 

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -98,11 +98,19 @@ void setup_notification(void)
 		notification_irq, irq_to_vector(notification_irq));
 }
 
-static void handle_pi_notification(__unused uint32_t irq, __unused void *data)
+/*
+ * posted interrupt handler
+ * @pre (irq - POSTED_INTR_IRQ) < CONFIG_MAX_VM_NUM
+ */
+static void handle_pi_notification(uint32_t irq, __unused void *data)
 {
+	uint32_t vcpu_index = irq - POSTED_INTR_IRQ;
+
+	ASSERT(vcpu_index < CONFIG_MAX_VM_NUM, "");
+	vcpu_handle_pi_notification(vcpu_index);
 }
 
-/*pre-conditon: be called only by BSP initialization proccess*/
+/*pre-condition: be called only by BSP initialization proccess*/
 void setup_pi_notification(void)
 {
 	uint32_t i;

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -98,21 +98,20 @@ void setup_notification(void)
 		notification_irq, irq_to_vector(notification_irq));
 }
 
-static void posted_intr_notification(__unused uint32_t irq, __unused void *data)
+static void handle_pi_notification(__unused uint32_t irq, __unused void *data)
 {
-	/* Dummy IRQ handler for case that Posted-Interrupt Notification
-	 * is sent to vCPU in root mode(isn't running),interrupt will be
-	 * picked up in next vmentry,do nothine here.
-	 */
 }
 
 /*pre-conditon: be called only by BSP initialization proccess*/
-void setup_posted_intr_notification(void)
+void setup_pi_notification(void)
 {
-	if (request_irq(POSTED_INTR_IRQ,
-			posted_intr_notification,
-			NULL, IRQF_NONE) < 0) {
-		pr_err("Failed to setup posted-intr notification");
+	uint32_t i;
+
+	for (i = 0U; i < CONFIG_MAX_VM_NUM; i++) {
+		if (request_irq(POSTED_INTR_IRQ + i, handle_pi_notification, NULL, IRQF_NONE) < 0) {
+			pr_err("Failed to setup pi notification");
+			break;
+		}
 	}
 }
 

--- a/hypervisor/arch/x86/platform_caps.c
+++ b/hypervisor/arch/x86/platform_caps.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <platform_caps.h>
+
+struct platform_caps_x86 platform_caps = {.pi = true};

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1351,18 +1351,37 @@ int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry
 		ret = -EINVAL;
 	} else {
 		dmar_enable_intr_remapping(dmar_unit);
-		irte->bits.remap.svt = 0x1UL;
-		irte->bits.remap.sq = 0x0UL;
-		irte->bits.remap.sid = sid.value;
-		irte->bits.remap.present = 0x1UL;
-		irte->bits.remap.mode = 0x0UL;
-		irte->bits.remap.trigger_mode = trigger_mode;
-		irte->bits.remap.fpd = 0x0UL;
+
 		ir_table = (union dmar_ir_entry *)hpa2hva(dmar_unit->ir_table_addr);
 		ir_entry = ir_table + index;
-		ir_entry->value.hi_64 = irte->value.hi_64;
-		ir_entry->value.lo_64 = irte->value.lo_64;
 
+		if (intr_src->pid_paddr != 0UL) {
+			union dmar_ir_entry irte_pi;
+
+			/* irte is in remapped mode format, convert to posted mode format */
+			irte_pi.value.lo_64 = 0UL;
+			irte_pi.value.hi_64 = 0UL;
+
+			irte_pi.bits.post.vector = irte->bits.remap.vector;
+
+			irte_pi.bits.post.svt = 0x1UL;
+			irte_pi.bits.post.sid = sid.value;
+			irte_pi.bits.post.present = 0x1UL;
+			irte_pi.bits.post.mode = 0x1UL;
+
+			irte_pi.bits.post.pda_l = (intr_src->pid_paddr) >> 6U;
+			irte_pi.bits.post.pda_h = (intr_src->pid_paddr) >> 32U;
+
+			*ir_entry = irte_pi;
+		} else {
+			/* Fields that have not been initialized explicitly default to 0 */
+			irte->bits.remap.svt = 0x1UL;
+			irte->bits.remap.sid = sid.value;
+			irte->bits.remap.present = 0x1UL;
+			irte->bits.remap.trigger_mode = trigger_mode;
+
+			*ir_entry = *irte;
+		}
 		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);
 	}

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -22,6 +22,7 @@
 #include <board.h>
 #include <vm_config.h>
 #include <pci.h>
+#include <platform_caps.h>
 
 #define DBG_IOMMU 0
 
@@ -206,6 +207,7 @@ static inline uint16_t vmid_to_domainid(uint16_t vm_id)
 
 static int32_t dmar_register_hrhd(struct dmar_drhd_rt *dmar_unit);
 static struct dmar_drhd_rt *device_to_dmaru(uint8_t bus, uint8_t devfun);
+
 static int32_t register_hrhd_units(void)
 {
 	struct dmar_drhd_rt *drhd_rt;
@@ -223,6 +225,10 @@ static int32_t register_hrhd_units(void)
 		ret = dmar_register_hrhd(drhd_rt);
 		if (ret != 0) {
 			break;
+		}
+
+		if ((iommu_cap_pi(drhd_rt->cap) == 0U) || (!is_apicv_advanced_feature_supported())) {
+			platform_caps.pi = false;
 		}
 	}
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -700,6 +700,19 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id);
  */
 uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask);
 bool is_lapic_pt_enabled(struct acrn_vcpu *vcpu);
+
+/**
+ * @brief handle posted interrupts
+ *
+ * VT-d PI handler, find the corresponding vCPU for this IRQ,
+ * if the associated PID's bit ON is set, wake it up.
+ *
+ * @param[in] vcpu_index a zero based index of where the vCPU is located in the vCPU list for current pCPU
+ * @pre vcpu_index < CONFIG_MAX_VM_NUM
+ *
+ * @return None
+ */
+void vcpu_handle_pi_notification(uint32_t vcpu_index);
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -263,6 +263,7 @@ void vrtc_init(struct acrn_vm *vm);
 
 bool is_lapic_pt_configured(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
+bool is_pi_capable(const struct acrn_vm *vm);
 bool has_rt_vm(void);
 bool is_highest_severity_vm(const struct acrn_vm *vm);
 bool vm_hide_mtrr(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -25,7 +25,24 @@
 #define NR_IRQS			256U
 #define IRQ_INVALID		0xffffffffU
 
-#define NR_STATIC_MAPPINGS     (4U)
+/* # of NR_STATIC_MAPPINGS_1 entries for timer, vcpu notify, and PMI */
+#define NR_STATIC_MAPPINGS_1	3U
+
+/*
+ * The static IRQ/Vector mapping table in irq.c consists of the following entries:
+ * # of NR_STATIC_MAPPINGS_1 entries for timer, vcpu notify, and PMI
+ *
+ * # of CONFIG_MAX_VM_NUM entries for posted interrupt notification, platform
+ * specific but known at build time:
+ * Allocate unique Activation Notification Vectors (ANV) for each vCPU that belongs
+ * to the same pCPU, the ANVs need only be unique within each pCPU, not across all
+ * vCPUs. The max numbers of vCPUs may be running on top of a pCPU is CONFIG_MAX_VM_NUM,
+ * since ACRN does not support 2 vCPUs of same VM running on top of same pCPU.
+ * This reduces # of pre-allocated ANVs for posted interrupts to CONFIG_MAX_VM_NUM,
+ * and enables ACRN to avoid switching between active and wake-up vector values
+ * in the posted interrupt descriptor on vCPU scheduling state changes.
+ */
+#define NR_STATIC_MAPPINGS	(NR_STATIC_MAPPINGS_1 + CONFIG_MAX_VM_NUM)
 
 #define HYPERVISOR_CALLBACK_VHM_VECTOR	0xF3U
 
@@ -39,13 +56,23 @@
 
 #define TIMER_VECTOR		(VECTOR_FIXED_START)
 #define NOTIFY_VCPU_VECTOR	(VECTOR_FIXED_START + 1U)
-#define POSTED_INTR_VECTOR	(VECTOR_FIXED_START + 2U)
-#define PMI_VECTOR		(VECTOR_FIXED_START + 3U)
+#define PMI_VECTOR		(VECTOR_FIXED_START + 2U)
+/*
+ * Starting vector for posted interrupts
+ * # of CONFIG_MAX_VM_NUM (POSTED_INTR_VECTOR ~ (POSTED_INTR_VECTOR + CONFIG_MAX_VM_NUM - 1U))
+ * consecutive vectors reserved for posted interrupts
+ */
+#define POSTED_INTR_VECTOR	(VECTOR_FIXED_START + NR_STATIC_MAPPINGS_1)
 
 #define TIMER_IRQ		(NR_IRQS - 1U)
 #define NOTIFY_VCPU_IRQ		(NR_IRQS - 2U)
-#define POSTED_INTR_IRQ		(NR_IRQS - 3U)
-#define PMI_IRQ			(NR_IRQS - 4U)
+#define PMI_IRQ			(NR_IRQS - 3U)
+/*
+ * Starting IRQ for posted interrupts
+ * # of CONFIG_MAX_VM_NUM (POSTED_INTR_IRQ ~ (POSTED_INTR_IRQ + CONFIG_MAX_VM_NUM - 1U))
+ * consecutive IRQs reserved for posted interrupts
+ */
+#define POSTED_INTR_IRQ	(NR_IRQS - NR_STATIC_MAPPINGS_1 - CONFIG_MAX_VM_NUM)
 
 /* the maximum number of msi entry is 2048 according to PCI
  * local bus specification
@@ -95,7 +122,7 @@ void init_default_irqs(uint16_t cpu_id);
 void dispatch_exception(struct intr_excp_ctx *ctx);
 
 void setup_notification(void);
-void setup_posted_intr_notification(void);
+void setup_pi_notification(void);
 
 typedef void (*spurious_handler_t)(uint32_t vector);
 extern spurious_handler_t spurious_handler;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -59,6 +59,14 @@ struct per_cpu_region {
 #endif
 	uint16_t shutdown_vm_id;
 	uint64_t tsc_suspend;
+	/*
+	 * We maintain a per-pCPU array of vCPUs. vCPUs of a VM won't
+	 * share same pCPU. So the maximum possible # of vCPUs that can
+	 * run on a pCPU is CONFIG_MAX_VM_NUM.
+	 * vcpu_array address must be aligned to 64-bit for atomic access
+	 * to avoid contention between offline_vcpu and posted interrupt handler
+	 */
+	struct acrn_vcpu *vcpu_array[CONFIG_MAX_VM_NUM] __aligned(8);
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
 extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];

--- a/hypervisor/include/arch/x86/platform_caps.h
+++ b/hypervisor/include/arch/x86/platform_caps.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PLATFORM_CAPS_H
+#define PLATFORM_CAPS_H
+
+struct platform_caps_x86 {
+	/* true if posted interrupt is supported by all IOMMUs */
+	bool pi;
+};
+
+extern struct platform_caps_x86 platform_caps;
+
+#endif /* PLATFORM_CAPS_H */

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -67,6 +67,13 @@ union source {
 struct intr_source {
 	bool is_msi;
 	union source src;
+	/*
+	 * pid_paddr = 0: invalid address, indicate that remapped mode shall be used
+	 *
+	 * pid_paddr != 0: physical address of posted interrupt descriptor, indicate
+	 * that posted mode shall be used
+	 */
+	uint64_t pid_paddr;
 };
 
 static inline uint8_t dmar_ver_major(uint64_t version)


### PR DESCRIPTION
If VT-d Posted interrupts are supported by the platform , hypervisor shall be able to use it to deliver interrupts directly to partitions

Enable VT-d posted interrupts for eligible platforms such as ANL, if vt-d posted interrupt is detected and vm-config is set to use vt-d posted interrupt, pt devices for that vm will use vt-d posted interrupt to deliver interrupts to guest without vm-exits, which can improve performance for the pt devices.


[External_System_ID] ACRN-6085