### PR TITLE
hv: add lock for ept add/modify/del

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -124,7 +124,11 @@ void ept_add_mr(struct acrn_vm *vm, uint64_t *pml4_page,
 		prot |= EPT_SNOOP_CTRL;
 	}
 
+	spinlock_obtain(&vm->ept_lock);
+
 	mmu_add(pml4_page, hpa, gpa, size, prot, &vm->arch_vm.ept_mem_ops);
+
+	spinlock_release(&vm->ept_lock);
 
 	foreach_vcpu(i, vm, vcpu) {
 		vcpu_make_request(vcpu, ACRN_REQUEST_EPT_FLUSH);
@@ -145,7 +149,11 @@ void ept_modify_mr(struct acrn_vm *vm, uint64_t *pml4_page,
 		local_prot |= EPT_SNOOP_CTRL;
 	}
 
+	spinlock_obtain(&vm->ept_lock);
+
 	mmu_modify_or_del(pml4_page, gpa, size, local_prot, prot_clr, &(vm->arch_vm.ept_mem_ops), MR_MODIFY);
+
+	spinlock_release(&vm->ept_lock);
 
 	foreach_vcpu(i, vm, vcpu) {
 		vcpu_make_request(vcpu, ACRN_REQUEST_EPT_FLUSH);
@@ -161,7 +169,11 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t 
 
 	dev_dbg(DBG_LEVEL_EPT, "%s,vm[%d] gpa 0x%lx size 0x%lx\n", __func__, vm->vm_id, gpa, size);
 
+	spinlock_obtain(&vm->ept_lock);
+
 	mmu_modify_or_del(pml4_page, gpa, size, 0UL, 0UL, &vm->arch_vm.ept_mem_ops, MR_DEL);
+
+	spinlock_release(&vm->ept_lock);
 
 	foreach_vcpu(i, vm, vcpu) {
 		vcpu_make_request(vcpu, ACRN_REQUEST_EPT_FLUSH);

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -430,6 +430,7 @@ int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_
 		prepare_epc_vm_memmap(vm);
 
 		spinlock_init(&vm->vm_lock);
+		spinlock_init(&vm->ept_lock);
 		spinlock_init(&vm->emul_mmio_lock);
 
 		vm->arch_vm.vlapic_state = VM_VLAPIC_XAPIC;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -130,6 +130,7 @@ struct acrn_vm {
 	enum vpic_wire_mode wire_mode;
 	struct iommu_domain *iommu;	/* iommu domain of this VM */
 	spinlock_t vm_lock;	/* Spin-lock used to protect vlapic_state modifications for a VM */
+	spinlock_t ept_lock;	/* Spin-lock used to protect ept add/modify/remove for a VM */
 
 	spinlock_t emul_mmio_lock;	/* Used to protect emulation mmio_node concurrent access for a VM */
 	uint16_t max_emul_mmio_regions;	/* max index of the emulated mmio_region */


### PR DESCRIPTION
EPT table can be changed concurrently by more than one vcpus.
This patch add a lock to protect the add/modify/delete operations
from different vcpus concurrently.

Tracked-On: #4253
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Reviewed-by: Li, Fei1 <fei1.li@intel.com>