### PR TITLE
doc: Known Limitation regarding PCI devices and resources assignment

### DIFF
--- a/doc/reference/hardware.rst
+++ b/doc/reference/hardware.rst
@@ -27,6 +27,15 @@ Known Limitations
 *****************
 Platforms with multiple PCI segments
 
+ACRN assumes the following conditions are satisfied from the Platform BIOS
+
+* All the PCI device BARs should be assigned resources, including SR-IOv VF BARs if a device supports.
+
+* Bridge windows for PCI bridge devices and the resources for root bus, should be programmed with values
+  that enclose resources used by all the downstream devices.
+
+* There should be no conflict in resources among the PCI devices and also between PCI devices and other platform devices.
+
 Verified Platforms According to ACRN Usage
 ******************************************
 


### PR DESCRIPTION
ACRN assumes certain state for the PCI devices w.r.t. resources assigned to them
before the platform BIOS hands control over to itself.
When the same BIOS is used with native OS boot, there should not be a need for
native kernel to re-program device BARs or bridge windows for bridge devices.

Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>