### PR TITLE
hv: provide vm_config information in get_platform_info hypercall

### DIFF
--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -319,8 +319,11 @@ struct hc_platform_info {
 	/** Physical CPU number */
 	uint16_t cpu_num;
 
+	/** version of this structure */
+	uint16_t version;
+
 	/** Align the size of version & hardware info to 128Bytes. */
-	uint8_t reserved0[126];
+	uint8_t reserved0[124];
 
 	/** Configuration Information */
 	/** Maximum vCPU number for one VM. */
@@ -329,8 +332,30 @@ struct hc_platform_info {
 	/** Maximum Kata container number in SOS VM */
 	uint8_t max_kata_containers;
 
+	uint8_t reserved1[7];
+
+	/** Number of configured VMs */
+	uint16_t max_vms;
+
+	/**
+	 * The size of acrn_vm_config is various on different platforms.
+	 * This is the size of this struct which is used by the caller
+	 * to parse the vm_configs array.
+	 */
+	uint32_t vm_config_entry_size;
+
+	/**
+	 * Address to an array of struct acrn_vm_config, containing all
+	 * the configurations of all VMs. VHM treats it as an opague data
+	 * structure.
+	 *
+	 * The size of one array element is vm_config_entry_size while
+	 * the number of elements is max_vms.
+	 */
+	uint64_t vm_configs_addr;
+
 	/** Align the size of Configuration info to 128Bytes. */
-	uint8_t reserved1[125];
+	uint8_t reserved2[104];
 } __aligned(8);
 
 /**


### PR DESCRIPTION
Hypervisor reports VM configuration information to SOS which can be used to
dynamically allocate VCPU affinity.

Servise OS can get the vm_configs in this order:

1. call platform_info HC (set vm_configs_addr with 0) to get max_vms and
   vm_config_entry_size.
2. allocate memory for acrn_vm_config array based on the number of VMs
   and entry size that just got in step 1.
3. call platform_info HC again to collect VM configurations.

Tracked-On: #4616
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>