### PR TITLE
acrn-config: support passthroug GVT for WaaG by default

### DIFF
--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -54,6 +54,7 @@ PM_CHANNEL_DIC = {
 }
 
 MOUNT_FLAG_DIC = {}
+GPU_BDF = "00:02.0"
 
 
 def usage(file_name):
@@ -548,3 +549,13 @@ def bdf_duplicate_check(bdf_dic):
                 return
             else:
                 bdf_used.append(dev_bdf)
+
+
+def get_gpu_vpid():
+
+    vpid = ''
+    vpid_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<PCI_VID_PID>", "</PCI_VID_PID>")
+    for vpid_line in vpid_lines:
+        if GPU_BDF in vpid_line:
+            vpid = vpid_line.split()[2]
+    return vpid

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
-	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">VXWORKS</uos_type>
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">WINDOWS</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">WINDOWS</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
@@ -37,7 +37,7 @@
 	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
-	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">CLEARLINUX</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">ZEPHYR</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
-	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">VXWORKS</uos_type>
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">WINDOWS</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">WINDOWS</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">4096</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>
@@ -37,7 +37,7 @@
 	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
 	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
 	<mem_size desc="UOS memory size in MByte">1024</mem_size>
-	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs." readonly="true">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">CLEARLINUX</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">2048</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -3,7 +3,7 @@
 	<uos_type desc="UOS type">ZEPHYR</uos_type>
 	<rtos_type desc="UOS Realtime capability">no</rtos_type>
 	<mem_size desc="UOS memory size in MByte">128</mem_size>
-	<gvt_args desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<cpu_sharing desc="Whether the binding pCPUs are sharing with other VMs.">Disabled</cpu_sharing>


### PR DESCRIPTION
Modify launch config tool to support passthroug GVT for WaaG by default.

Tracked-On: #4625
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>
Acked-by: Terry Zou <terry.zou@intel.com>