### PR TITLE
hv: fix for waag 2 core reboot issue

### DIFF
--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -108,6 +108,8 @@ uint32_t alloc_irq_vector(uint32_t irq);
 #define HV_ARCH_VCPU_RFLAGS_RF              (1UL<<16U)
 
 /* Interruptability State info */
+
+#define HV_ARCH_VCPU_BLOCKED_BY_NMI         (1UL<<3U)
 #define HV_ARCH_VCPU_BLOCKED_BY_MOVSS       (1UL<<1U)
 #define HV_ARCH_VCPU_BLOCKED_BY_STI         (1UL<<0U)
 


### PR DESCRIPTION
Waag will send NMIs to all its cores during reboot. But currently,
NMI cannot be injected to vcpu which is in HLT state.
To fix the problem, need to wakeup target vcpu, and inject NMI through
interrupt-window.

Tracked-On: #4620
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>