### PR TITLE
disable iommu snoop and clean related code

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -116,14 +116,6 @@ void ept_add_mr(struct acrn_vm *vm, uint64_t *pml4_page,
 	dev_dbg(DBG_LEVEL_EPT, "%s, vm[%d] hpa: 0x%016lx gpa: 0x%016lx size: 0x%016lx prot: 0x%016x\n",
 			__func__, vm->vm_id, hpa, gpa, size, prot);
 
-	/* EPT & VT-d share the same page tables, set SNP bit
-	 * to force snooping of PCIe devices if the page
-	 * is cachable
-	 */
-	if (((prot & EPT_MT_MASK) != EPT_UNCACHED) && iommu_snoop_supported(vm->iommu)) {
-		prot |= EPT_SNOOP_CTRL;
-	}
-
 	spinlock_obtain(&vm->ept_lock);
 
 	mmu_add(pml4_page, hpa, gpa, size, prot, &vm->arch_vm.ept_mem_ops);
@@ -144,10 +136,6 @@ void ept_modify_mr(struct acrn_vm *vm, uint64_t *pml4_page,
 	uint64_t local_prot = prot_set;
 
 	dev_dbg(DBG_LEVEL_EPT, "%s,vm[%d] gpa 0x%lx size 0x%lx\n", __func__, vm->vm_id, gpa, size);
-
-	if (((local_prot & EPT_MT_MASK) != EPT_UNCACHED) && iommu_snoop_supported(vm->iommu)) {
-		local_prot |= EPT_SNOOP_CTRL;
-	}
 
 	spinlock_obtain(&vm->ept_lock);
 

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -215,9 +215,7 @@ static void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0)
 						 * disabled behavior
 						 */
 						exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, PAT_ALL_UC_VALUE);
-						if (!iommu_snoop_supported(vcpu->vm->iommu)) {
-							cache_flush_invalidate_all();
-						}
+						cache_flush_invalidate_all();
 					} else {
 						/* Restore IA32_PAT to enable cache again */
 						exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL,

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -179,19 +179,6 @@ static inline void *get_ir_table(uint32_t dmar_index)
 	return (void *)ir_tables[dmar_index].tables[0].contents;
 }
 
-bool iommu_snoop_supported(const struct iommu_domain *iommu)
-{
-	bool ret;
-
-	if ((iommu == NULL) || (iommu->iommu_snoop)) {
-		ret =  true;
-	} else {
-		ret = false;
-	}
-
-	return ret;
-}
-
 static struct dmar_drhd_rt dmar_drhd_units[MAX_DRHDS];
 static bool iommu_page_walk_coherent = true;
 static struct dmar_info *platform_dmar_info = NULL;
@@ -1018,7 +1005,7 @@ static void resume_dmar(struct dmar_drhd_rt *dmar_unit)
 	dmar_enable_intr_remapping(dmar_unit);
 }
 
-static int32_t iommu_attach_device(struct iommu_domain *domain, uint8_t bus, uint8_t devfun)
+static int32_t iommu_attach_device(const struct iommu_domain *domain, uint8_t bus, uint8_t devfun)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	struct dmar_entry *root_table;
@@ -1046,8 +1033,6 @@ static int32_t iommu_attach_device(struct iommu_domain *domain, uint8_t bus, uin
 		ret = -EINVAL;
 	} else {
 		if (iommu_ecap_sc(dmar_unit->ecap) == 0U) {
-			/* TODO: remove iommu_snoop from iommu_domain */
-			domain->iommu_snoop = false;
 			dev_dbg(DBG_LEVEL_IOMMU, "vm=%d add %x:%x no snoop control!", domain->vm_id, bus, devfun);
 		}
 
@@ -1215,17 +1200,6 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 		domain->trans_table_ptr = translation_table;
 		domain->addr_width = addr_width;
 
-#ifdef CONFIG_IOMMU_ENFORCE_SNP
-		domain->iommu_snoop = true;
-#else
-		/* TODO: GPU IOMMU doesn't have snoop control capbility,
-		 * so set domain->iommu_snoop false to enable gvt-d by default.
-		 * If want to refine iommu snoop control policy,
-		 * need to change domain->iommu_snoop dynamically.
-		 */
-		domain->iommu_snoop = false;
-#endif
-
 		dev_dbg(DBG_LEVEL_IOMMU, "create domain [%d]: vm_id = %hu, ept@0x%x",
 			vmid_to_domainid(domain->vm_id), domain->vm_id, domain->trans_table_ptr);
 	}
@@ -1246,7 +1220,7 @@ void destroy_iommu_domain(struct iommu_domain *domain)
  * @pre (from_domain != NULL) || (to_domain != NULL)
  */
 
-int32_t move_pt_device(const struct iommu_domain *from_domain, struct iommu_domain *to_domain, uint8_t bus, uint8_t devfun)
+int32_t move_pt_device(const struct iommu_domain *from_domain, const struct iommu_domain *to_domain, uint8_t bus, uint8_t devfun)
 {
 	int32_t status = 0;
 	uint16_t bus_local = bus;

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -108,8 +108,6 @@
 /* End of ept_mem_type */
 
 #define EPT_MT_MASK		(7UL << EPT_MT_SHIFT)
-/* VTD: Second-Level Paging Entries: Snoop Control */
-#define EPT_SNOOP_CTRL		(1UL << 11U)
 #define EPT_VE			(1UL << 63U)
 /* EPT leaf entry bits (bit 52 - bit 63) should be maksed  when calculate PFN */
 #define EPT_PFN_HIGH_MASK	0xFFF0000000000000UL

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -56,7 +56,6 @@ struct iommu_domain {
 	uint16_t vm_id;
 	uint32_t addr_width;   /* address width of the domain */
 	uint64_t trans_table_ptr;
-	bool iommu_snoop;
 };
 
 union source {
@@ -598,7 +597,7 @@ struct iommu_domain;
  * @pre domain != NULL
  *
  */
-int32_t move_pt_device(const struct iommu_domain *from_domain, struct iommu_domain *to_domain, uint8_t bus, uint8_t devfun);
+int32_t move_pt_device(const struct iommu_domain *from_domain, const struct iommu_domain *to_domain, uint8_t bus, uint8_t devfun);
 
 /**
  * @brief Create a iommu domain for a VM specified by vm_id.
@@ -668,17 +667,6 @@ void resume_iommu(void);
  *
  */
 int32_t init_iommu(void);
-
-/**
- * @brief check the iommu if support cache snoop.
- *
- * @param[in] iommu pointer to iommu domain to check
- *
- * @retval true support
- * @retval false not support
- *
- */
-bool iommu_snoop_supported(const struct iommu_domain *iommu);
 
 /**
  * @brief Assign RTE for Interrupt Remapping Table.


### PR DESCRIPTION
Due to the fact that i915 iommu doesn't support snoop, hence it can't
access memory when the SNOOP bit of Secondary Level page PTE (SL-PTE)
is set, this will cause many undefined issues such as invisible cursor
in WaaG etc.

And further, ACRN disables Snoop Control in VT-d DMAR engines for simplifing
the implementation. Also, since the snoop behavior of PCIE transactions
can be controlled by guest drivers, some devices may take the advantage
of the NO_SNOOP_ATTRIBUTE of PCIE transactions for better performance
when snoop is not needed.

Tracked-On: #4509
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@Intel.com>