### PR TITLE
HV: add support for VT-d Posted Interrupts (backporting)

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -229,6 +229,7 @@ HW_C_SRCS += arch/x86/ioapic.c
 HW_C_SRCS += arch/x86/lapic.c
 HW_C_SRCS += arch/x86/cpu.c
 HW_C_SRCS += arch/x86/cpu_caps.c
+HW_C_SRCS += arch/x86/platform_caps.c
 HW_C_SRCS += arch/x86/security.c
 HW_C_SRCS += arch/x86/mmu.c
 HW_C_SRCS += arch/x86/e820.c

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -229,7 +229,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 
 		timer_init();
 		setup_notification();
-		setup_posted_intr_notification();
+		setup_pi_notification();
 
 		if (init_iommu() != 0) {
 			panic("failed to initialize iommu!");

--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -107,13 +107,13 @@ static void ptirq_build_physical_msi(struct acrn_vm *vm, struct ptirq_msi_info *
 	dest_mask = calculate_logical_dest_mask(pdmask);
 
 	/* Using phys_irq as index in the corresponding IOMMU */
-	irte.entry.lo_64 = 0UL;
-	irte.entry.hi_64 = 0UL;
-	irte.bits.vector = vector;
-	irte.bits.delivery_mode = delmode;
-	irte.bits.dest_mode = MSI_ADDR_DESTMODE_LOGICAL;
-	irte.bits.rh = MSI_ADDR_RH;
-	irte.bits.dest = dest_mask;
+	irte.value.lo_64 = 0UL;
+	irte.value.hi_64 = 0UL;
+	irte.bits.remap.vector = vector;
+	irte.bits.remap.delivery_mode = delmode;
+	irte.bits.remap.dest_mode = MSI_ADDR_DESTMODE_LOGICAL;
+	irte.bits.remap.rh = MSI_ADDR_RH;
+	irte.bits.remap.dest = dest_mask;
 
 	intr_src.is_msi = true;
 	intr_src.src.msi.value = entry->phys_sid.msi_id.bdf;
@@ -203,13 +203,13 @@ ptirq_build_physical_rte(struct acrn_vm *vm, struct ptirq_remapping_info *entry)
 		vector = irq_to_vector(phys_irq);
 		dest_mask = calculate_logical_dest_mask(pdmask);
 
-		irte.entry.lo_64 = 0UL;
-		irte.entry.hi_64 = 0UL;
-		irte.bits.vector = vector;
-		irte.bits.delivery_mode = delmode;
-		irte.bits.dest_mode = IOAPIC_RTE_DESTMODE_LOGICAL;
-		irte.bits.dest = dest_mask;
-		irte.bits.trigger_mode = rte.bits.trigger_mode;
+		irte.value.lo_64 = 0UL;
+		irte.value.hi_64 = 0UL;
+		irte.bits.remap.vector = vector;
+		irte.bits.remap.delivery_mode = delmode;
+		irte.bits.remap.dest_mode = IOAPIC_RTE_DESTMODE_LOGICAL;
+		irte.bits.remap.dest = dest_mask;
+		irte.bits.remap.trigger_mode = rte.bits.trigger_mode;
 
 		intr_src.is_msi = false;
 		intr_src.src.ioapic_id = ioapic_irq_to_ioapic_id(phys_irq);

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -469,7 +469,7 @@ int32_t create_vcpu(uint16_t pcpu_id, struct acrn_vm *vm, struct acrn_vcpu **rtn
 		 * the "enable VPID" VM-execution control is 1, the current VPID
 		 * is the value of the VPID VM-execution control field in the VMCS.
 		 *
-		 * This assignment guarantees a unique non-zero per vcpu vpid in runtime.
+		 * This assignment guarantees a unique non-zero per vcpu vpid at runtime.
 		 */
 		vcpu->arch.vpid = 1U + (vm->vm_id * MAX_VCPUS_PER_VM) + vcpu->vcpu_id;
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -90,10 +90,9 @@ static inline void vlapic_dump_isr(__unused const struct acrn_vlapic *vlapic, __
 
 const struct acrn_apicv_ops *apicv_ops;
 
-static bool
-apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector);
+static bool apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector);
 
-static void apicv_post_intr(uint16_t dest_pcpu_id);
+static void apicv_trigger_pi_anv(uint16_t dest_pcpu_id, uint32_t anv);
 
 static void vlapic_x2apic_self_ipi_handler(struct acrn_vlapic *vlapic);
 
@@ -573,7 +572,7 @@ static void apicv_advanced_accept_intr(struct acrn_vlapic *vlapic, uint32_t vect
 		bitmap_set_lock(ACRN_REQUEST_EVENT, &vlapic->vcpu->arch.pending_req);
 
 		if (get_pcpu_id() != pcpuid_from_vcpu(vlapic->vcpu)) {
-			apicv_post_intr(pcpuid_from_vcpu(vlapic->vcpu));
+			apicv_trigger_pi_anv(pcpuid_from_vcpu(vlapic->vcpu), (uint32_t)(vlapic->vcpu->arch.pid.control.bits.nv));
 		}
 	}
 }
@@ -604,12 +603,13 @@ static void vlapic_accept_intr(struct acrn_vlapic *vlapic, uint32_t vector, bool
  * If pCPU in root-mode, virtual interrupt will be injected in next VM entry.
  *
  * @param[in] dest_pcpu_id Target CPU ID.
+ * @param[in] anv Activation Notification Vectors (ANV)
  *
  * @return None
  */
-static void apicv_post_intr(uint16_t dest_pcpu_id)
+static void apicv_trigger_pi_anv(uint16_t dest_pcpu_id, uint32_t anv)
 {
-	send_single_ipi(dest_pcpu_id, POSTED_INTR_VECTOR);
+	send_single_ipi(dest_pcpu_id, anv);
 }
 
 /**

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -31,6 +31,7 @@
 #include <sbuf.h>
 #include <pci_dev.h>
 #include <vacpi.h>
+#include <platform_caps.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -113,6 +114,20 @@ bool is_rt_vm(const struct acrn_vm *vm)
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 
 	return ((vm_config->guest_flags & GUEST_FLAG_RT) != 0U);
+}
+
+/**
+ * @brief VT-d PI posted mode can possibly be used for PTDEVs assigned
+ * to this VM if platform supports VT-d PI AND lapic passthru is not configured
+ * for this VM.
+ * However, as we can only post single destination IRQ, so meeting these 2 conditions
+ * does not necessarily mean posted mode will be used for all PTDEVs belonging
+ * to the VM, unless the IRQ is single-destination for the specific PTDEV
+ * @pre vm != NULL
+ */
+bool is_pi_capable(const struct acrn_vm *vm)
+{
+	return (platform_caps.pi && (!is_lapic_pt_configured(vm)));
 }
 
 static struct acrn_vm *get_highest_severity_vm(void)

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -353,7 +353,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 
 		exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0U);
 		exec_vmwrite16(VMX_POSTED_INTR_VECTOR, POSTED_INTR_VECTOR);
-		exec_vmwrite64(VMX_PIR_DESC_ADDR_FULL, apicv_get_pir_desc_paddr(vcpu));
+		exec_vmwrite64(VMX_PIR_DESC_ADDR_FULL, hva2hpa(get_pi_desc(vcpu)));
 	}
 
 	/* Load EPTP execution control

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -352,7 +352,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 		exec_vmwrite64(VMX_EOI_EXIT3_FULL, 0UL);
 
 		exec_vmwrite16(VMX_GUEST_INTR_STATUS, 0U);
-		exec_vmwrite16(VMX_POSTED_INTR_VECTOR, POSTED_INTR_VECTOR);
+		exec_vmwrite16(VMX_POSTED_INTR_VECTOR, (uint16_t)(vcpu->arch.pid.control.bits.nv));
 		exec_vmwrite64(VMX_PIR_DESC_ADDR_FULL, hva2hpa(get_pi_desc(vcpu)));
 	}
 

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -98,11 +98,19 @@ void setup_notification(void)
 		notification_irq, irq_to_vector(notification_irq));
 }
 
-static void handle_pi_notification(__unused uint32_t irq, __unused void *data)
+/*
+ * posted interrupt handler
+ * @pre (irq - POSTED_INTR_IRQ) < CONFIG_MAX_VM_NUM
+ */
+static void handle_pi_notification(uint32_t irq, __unused void *data)
 {
+	uint32_t vcpu_index = irq - POSTED_INTR_IRQ;
+
+	ASSERT(vcpu_index < CONFIG_MAX_VM_NUM, "");
+	vcpu_handle_pi_notification(vcpu_index);
 }
 
-/*pre-conditon: be called only by BSP initialization proccess*/
+/*pre-condition: be called only by BSP initialization proccess*/
 void setup_pi_notification(void)
 {
 	uint32_t i;

--- a/hypervisor/arch/x86/notify.c
+++ b/hypervisor/arch/x86/notify.c
@@ -98,21 +98,20 @@ void setup_notification(void)
 		notification_irq, irq_to_vector(notification_irq));
 }
 
-static void posted_intr_notification(__unused uint32_t irq, __unused void *data)
+static void handle_pi_notification(__unused uint32_t irq, __unused void *data)
 {
-	/* Dummy IRQ handler for case that Posted-Interrupt Notification
-	 * is sent to vCPU in root mode(isn't running),interrupt will be
-	 * picked up in next vmentry,do nothine here.
-	 */
 }
 
 /*pre-conditon: be called only by BSP initialization proccess*/
-void setup_posted_intr_notification(void)
+void setup_pi_notification(void)
 {
-	if (request_irq(POSTED_INTR_IRQ,
-			posted_intr_notification,
-			NULL, IRQF_NONE) < 0) {
-		pr_err("Failed to setup posted-intr notification");
+	uint32_t i;
+
+	for (i = 0U; i < CONFIG_MAX_VM_NUM; i++) {
+		if (request_irq(POSTED_INTR_IRQ + i, handle_pi_notification, NULL, IRQF_NONE) < 0) {
+			pr_err("Failed to setup pi notification");
+			break;
+		}
 	}
 }
 

--- a/hypervisor/arch/x86/platform_caps.c
+++ b/hypervisor/arch/x86/platform_caps.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <platform_caps.h>
+
+struct platform_caps_x86 platform_caps = {.pi = true};

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -153,13 +153,13 @@ struct intr_remap_table {
 	struct page tables[CONFIG_MAX_IR_ENTRIES/DMAR_NUM_IR_ENTRIES_PER_PAGE];
 };
 
-static inline uint8_t* get_root_table(uint32_t dmar_index)
+static inline uint8_t *get_root_table(uint32_t dmar_index)
 {
 	static struct page root_tables[CONFIG_MAX_IOMMU_NUM] __aligned(PAGE_SIZE);
 	return root_tables[dmar_index].contents;
 }
 
-static inline uint8_t* get_ctx_table(uint32_t dmar_index, uint8_t bus_no)
+static inline uint8_t *get_ctx_table(uint32_t dmar_index, uint8_t bus_no)
 {
 	static struct context_table ctx_tables[CONFIG_MAX_IOMMU_NUM] __aligned(PAGE_SIZE);
 	return ctx_tables[dmar_index].buses[bus_no].contents;
@@ -946,7 +946,7 @@ static void dmar_setup_interrupt(struct dmar_drhd_rt *dmar_unit)
 	}
 	spinlock_release(&(dmar_unit->lock));
 	/* the panic will only happen before any VM starts running */
-	if (retval < 0 ) {
+	if (retval < 0) {
 		panic("dmar[%d] fail to setup interrupt", dmar_unit->index);
 	}
 
@@ -1265,7 +1265,7 @@ struct iommu_domain *create_iommu_domain(uint16_t vm_id, uint64_t translation_ta
 
 	if (translation_table == 0UL) {
 		pr_err("translation table is NULL");
-	        domain =  NULL;
+		domain = NULL;
 	} else {
 		/*
 		 * A hypercall is called to create an iommu domain for a valid VM,
@@ -1387,7 +1387,7 @@ int32_t init_iommu(void)
 	return ret;
 }
 
-int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, uint16_t index)
+int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry *irte, uint16_t index)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	union dmar_ir_entry *ir_table, *ir_entry;
@@ -1395,13 +1395,13 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
 	uint64_t trigger_mode;
 	int32_t ret = 0;
 
-	if (intr_src.is_msi) {
-		dmar_unit = device_to_dmaru((uint8_t)intr_src.src.msi.bits.b, intr_src.src.msi.fields.devfun);
-		sid.value = intr_src.src.msi.value;
+	if (intr_src->is_msi) {
+		dmar_unit = device_to_dmaru((uint8_t)intr_src->src.msi.bits.b, intr_src->src.msi.fields.devfun);
+		sid.value = (uint16_t)(intr_src->src.msi.value);
 		trigger_mode = 0x0UL;
 	} else {
-		dmar_unit = ioapic_to_dmaru(intr_src.src.ioapic_id, &sid);
-		trigger_mode = irte.bits.trigger_mode;
+		dmar_unit = ioapic_to_dmaru(intr_src->src.ioapic_id, &sid);
+		trigger_mode = irte->bits.trigger_mode;
 	}
 
 	if (dmar_unit == NULL) {
@@ -1415,17 +1415,17 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
 		ret = -EINVAL;
 	} else {
 		dmar_enable_intr_remapping(dmar_unit);
-		irte.bits.svt = 0x1UL;
-		irte.bits.sq = 0x0UL;
-		irte.bits.sid = sid.value;
-		irte.bits.present = 0x1UL;
-		irte.bits.mode = 0x0UL;
-		irte.bits.trigger_mode = trigger_mode;
-		irte.bits.fpd = 0x0UL;
+		irte->bits.svt = 0x1UL;
+		irte->bits.sq = 0x0UL;
+		irte->bits.sid = sid.value;
+		irte->bits.present = 0x1UL;
+		irte->bits.mode = 0x0UL;
+		irte->bits.trigger_mode = trigger_mode;
+		irte->bits.fpd = 0x0UL;
 		ir_table = (union dmar_ir_entry *)hpa2hva(dmar_unit->ir_table_addr);
 		ir_entry = ir_table + index;
-		ir_entry->entry.hi_64 = irte.entry.hi_64;
-		ir_entry->entry.lo_64 = irte.entry.lo_64;
+		ir_entry->entry.hi_64 = irte->entry.hi_64;
+		ir_entry->entry.lo_64 = irte->entry.lo_64;
 
 		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);
@@ -1433,24 +1433,24 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
 	return ret;
 }
 
-void dmar_free_irte(struct intr_source intr_src, uint16_t index)
+void dmar_free_irte(const struct intr_source *intr_src, uint16_t index)
 {
 	struct dmar_drhd_rt *dmar_unit;
 	union dmar_ir_entry *ir_table, *ir_entry;
 	union pci_bdf sid;
 
-	if (intr_src.is_msi) {
-		dmar_unit = device_to_dmaru((uint8_t)intr_src.src.msi.bits.b, intr_src.src.msi.fields.devfun);
+	if (intr_src->is_msi) {
+		dmar_unit = device_to_dmaru((uint8_t)intr_src->src.msi.bits.b, intr_src->src.msi.fields.devfun);
 	} else {
-		dmar_unit = ioapic_to_dmaru(intr_src.src.ioapic_id, &sid);
+		dmar_unit = ioapic_to_dmaru(intr_src->src.ioapic_id, &sid);
 	}
 
 	if (dmar_unit == NULL) {
-		pr_err("no dmar unit found for device: %x:%x.%x", intr_src.src.msi.bits.b,
-			intr_src.src.msi.bits.d, intr_src.src.msi.bits.f);
+		pr_err("no dmar unit found for device: %x:%x.%x", intr_src->src.msi.bits.b,
+			intr_src->src.msi.bits.d, intr_src->src.msi.bits.f);
 	} else if (dmar_unit->drhd->ignore) {
-		dev_dbg(DBG_LEVEL_IOMMU, "device is ignored :0x%x:%x.%x", intr_src.src.msi.bits.b,
-			intr_src.src.msi.bits.d, intr_src.src.msi.bits.f);
+		dev_dbg(DBG_LEVEL_IOMMU, "device is ignored :0x%x:%x.%x", intr_src->src.msi.bits.b,
+			intr_src->src.msi.bits.d, intr_src->src.msi.bits.f);
 	} else if (dmar_unit->ir_table_addr == 0UL) {
 		pr_err("IR table is not set for dmar unit");
 	} else {

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1401,7 +1401,7 @@ int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry
 		trigger_mode = 0x0UL;
 	} else {
 		dmar_unit = ioapic_to_dmaru(intr_src->src.ioapic_id, &sid);
-		trigger_mode = irte->bits.trigger_mode;
+		trigger_mode = irte->bits.remap.trigger_mode;
 	}
 
 	if (dmar_unit == NULL) {
@@ -1415,17 +1415,17 @@ int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry
 		ret = -EINVAL;
 	} else {
 		dmar_enable_intr_remapping(dmar_unit);
-		irte->bits.svt = 0x1UL;
-		irte->bits.sq = 0x0UL;
-		irte->bits.sid = sid.value;
-		irte->bits.present = 0x1UL;
-		irte->bits.mode = 0x0UL;
-		irte->bits.trigger_mode = trigger_mode;
-		irte->bits.fpd = 0x0UL;
+		irte->bits.remap.svt = 0x1UL;
+		irte->bits.remap.sq = 0x0UL;
+		irte->bits.remap.sid = sid.value;
+		irte->bits.remap.present = 0x1UL;
+		irte->bits.remap.mode = 0x0UL;
+		irte->bits.remap.trigger_mode = trigger_mode;
+		irte->bits.remap.fpd = 0x0UL;
 		ir_table = (union dmar_ir_entry *)hpa2hva(dmar_unit->ir_table_addr);
 		ir_entry = ir_table + index;
-		ir_entry->entry.hi_64 = irte->entry.hi_64;
-		ir_entry->entry.lo_64 = irte->entry.lo_64;
+		ir_entry->value.hi_64 = irte->value.hi_64;
+		ir_entry->value.lo_64 = irte->value.lo_64;
 
 		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);
@@ -1456,7 +1456,7 @@ void dmar_free_irte(const struct intr_source *intr_src, uint16_t index)
 	} else {
 		ir_table = (union dmar_ir_entry *)hpa2hva(dmar_unit->ir_table_addr);
 		ir_entry = ir_table + index;
-		ir_entry->bits.present = 0x0UL;
+		ir_entry->bits.remap.present = 0x0UL;
 
 		iommu_flush_cache(ir_entry, sizeof(union dmar_ir_entry));
 		dmar_invalid_iec(dmar_unit, index, 0U, false);

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -23,6 +23,7 @@
 #include <vm_config.h>
 #include <pci.h>
 #include <vm.h>
+#include <platform_caps.h>
 
 #define DBG_IOMMU 0
 
@@ -208,6 +209,7 @@ static inline uint16_t vmid_to_domainid(uint16_t vm_id)
 
 static int32_t dmar_register_hrhd(struct dmar_drhd_rt *dmar_unit);
 static struct dmar_drhd_rt *device_to_dmaru(uint8_t bus, uint8_t devfun);
+
 static int32_t register_hrhd_units(void)
 {
 	struct dmar_drhd_rt *drhd_rt;
@@ -225,6 +227,10 @@ static int32_t register_hrhd_units(void)
 		ret = dmar_register_hrhd(drhd_rt);
 		if (ret != 0) {
 			break;
+		}
+
+		if ((iommu_cap_pi(drhd_rt->cap) == 0U) || (!is_apicv_advanced_feature_supported())) {
+			platform_caps.pi = false;
 		}
 	}
 

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -700,6 +700,19 @@ int32_t prepare_vcpu(struct acrn_vm *vm, uint16_t pcpu_id);
  */
 uint64_t vcpumask2pcpumask(struct acrn_vm *vm, uint64_t vdmask);
 bool is_lapic_pt_enabled(struct acrn_vcpu *vcpu);
+
+/**
+ * @brief handle posted interrupts
+ *
+ * VT-d PI handler, find the corresponding vCPU for this IRQ,
+ * if the associated PID's bit ON is set, wake it up.
+ *
+ * @param[in] vcpu_index a zero based index of where the vCPU is located in the vCPU list for current pCPU
+ * @pre vcpu_index < CONFIG_MAX_VM_NUM
+ *
+ * @return None
+ */
+void vcpu_handle_pi_notification(uint32_t vcpu_index);
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -43,14 +43,6 @@
 
 #define VLAPIC_MAXLVT_INDEX	APIC_LVT_CMCI
 
-/* Posted Interrupt Descriptor (PID) in VT-d spec */
-struct pi_desc {
-	/* Posted Interrupt Requests, one bit per requested vector */
-	uint64_t pir[4];
-	uint64_t pending;
-	uint64_t unused[3];
-} __aligned(64);
-
 struct vlapic_timer {
 	struct hv_timer timer;
 	uint32_t mode;
@@ -60,16 +52,14 @@ struct vlapic_timer {
 
 struct acrn_vlapic {
 	/*
-	 * Please keep 'apic_page' and 'pid' be the first two fields in
+	 * Please keep 'apic_page' as the first field in
 	 * current structure, as below alignment restrictions are mandatory
 	 * to support APICv features:
 	 * - 'apic_page' MUST be 4KB aligned.
-	 * - 'pid' MUST be 64 bytes aligned.
 	 * IRR, TMR and PIR could be accessed by other vCPUs when deliver
 	 * an interrupt to vLAPIC.
 	 */
 	struct lapic_regs	apic_page;
-	struct pi_desc	pid;
 
 	struct acrn_vm		*vm;
 	struct acrn_vcpu	*vcpu;
@@ -123,20 +113,6 @@ void vlapic_set_apicv_ops(void);
 bool vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 bool vlapic_has_pending_delivery_intr(struct acrn_vcpu *vcpu);
 bool vlapic_has_pending_intr(struct acrn_vcpu *vcpu);
-
-/**
- * @brief Get physical address to PIR description.
- *
- * If APICv Posted-interrupt is supported, this address will be configured
- * to VMCS "Posted-interrupt descriptor address" field.
- *
- * @param[in] vcpu Target vCPU
- *
- * @return physicall address to PIR
- *
- * @pre vcpu != NULL
- */
-uint64_t apicv_get_pir_desc_paddr(struct acrn_vcpu *vcpu);
 
 uint64_t vlapic_get_tsc_deadline_msr(const struct acrn_vlapic *vlapic);
 void vlapic_set_tsc_deadline_msr(struct acrn_vlapic *vlapic, uint64_t val_arg);

--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -43,7 +43,9 @@
 
 #define VLAPIC_MAXLVT_INDEX	APIC_LVT_CMCI
 
-struct vlapic_pir_desc {
+/* Posted Interrupt Descriptor (PID) in VT-d spec */
+struct pi_desc {
+	/* Posted Interrupt Requests, one bit per requested vector */
 	uint64_t pir[4];
 	uint64_t pending;
 	uint64_t unused[3];
@@ -58,16 +60,16 @@ struct vlapic_timer {
 
 struct acrn_vlapic {
 	/*
-	 * Please keep 'apic_page' and 'pir_desc' be the first two fields in
+	 * Please keep 'apic_page' and 'pid' be the first two fields in
 	 * current structure, as below alignment restrictions are mandatory
 	 * to support APICv features:
 	 * - 'apic_page' MUST be 4KB aligned.
-	 * - 'pir_desc' MUST be 64 bytes aligned.
+	 * - 'pid' MUST be 64 bytes aligned.
 	 * IRR, TMR and PIR could be accessed by other vCPUs when deliver
 	 * an interrupt to vLAPIC.
 	 */
 	struct lapic_regs	apic_page;
-	struct vlapic_pir_desc	pir_desc;
+	struct pi_desc	pid;
 
 	struct acrn_vm		*vm;
 	struct acrn_vcpu	*vcpu;

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -263,6 +263,7 @@ void vrtc_init(struct acrn_vm *vm);
 
 bool is_lapic_pt_configured(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
+bool is_pi_capable(const struct acrn_vm *vm);
 bool has_rt_vm(void);
 bool is_highest_severity_vm(const struct acrn_vm *vm);
 bool vm_hide_mtrr(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/irq.h
+++ b/hypervisor/include/arch/x86/irq.h
@@ -25,7 +25,24 @@
 #define NR_IRQS			256U
 #define IRQ_INVALID		0xffffffffU
 
-#define NR_STATIC_MAPPINGS     (4U)
+/* # of NR_STATIC_MAPPINGS_1 entries for timer, vcpu notify, and PMI */
+#define NR_STATIC_MAPPINGS_1	3U
+
+/*
+ * The static IRQ/Vector mapping table in irq.c consists of the following entries:
+ * # of NR_STATIC_MAPPINGS_1 entries for timer, vcpu notify, and PMI
+ *
+ * # of CONFIG_MAX_VM_NUM entries for posted interrupt notification, platform
+ * specific but known at build time:
+ * Allocate unique Activation Notification Vectors (ANV) for each vCPU that belongs
+ * to the same pCPU, the ANVs need only be unique within each pCPU, not across all
+ * vCPUs. The max numbers of vCPUs may be running on top of a pCPU is CONFIG_MAX_VM_NUM,
+ * since ACRN does not support 2 vCPUs of same VM running on top of same pCPU.
+ * This reduces # of pre-allocated ANVs for posted interrupts to CONFIG_MAX_VM_NUM,
+ * and enables ACRN to avoid switching between active and wake-up vector values
+ * in the posted interrupt descriptor on vCPU scheduling state changes.
+ */
+#define NR_STATIC_MAPPINGS	(NR_STATIC_MAPPINGS_1 + CONFIG_MAX_VM_NUM)
 
 #define HYPERVISOR_CALLBACK_VHM_VECTOR	0xF3U
 
@@ -39,13 +56,23 @@
 
 #define TIMER_VECTOR		(VECTOR_FIXED_START)
 #define NOTIFY_VCPU_VECTOR	(VECTOR_FIXED_START + 1U)
-#define POSTED_INTR_VECTOR	(VECTOR_FIXED_START + 2U)
-#define PMI_VECTOR		(VECTOR_FIXED_START + 3U)
+#define PMI_VECTOR		(VECTOR_FIXED_START + 2U)
+/*
+ * Starting vector for posted interrupts
+ * # of CONFIG_MAX_VM_NUM (POSTED_INTR_VECTOR ~ (POSTED_INTR_VECTOR + CONFIG_MAX_VM_NUM - 1U))
+ * consecutive vectors reserved for posted interrupts
+ */
+#define POSTED_INTR_VECTOR	(VECTOR_FIXED_START + NR_STATIC_MAPPINGS_1)
 
 #define TIMER_IRQ		(NR_IRQS - 1U)
 #define NOTIFY_VCPU_IRQ		(NR_IRQS - 2U)
-#define POSTED_INTR_IRQ		(NR_IRQS - 3U)
-#define PMI_IRQ			(NR_IRQS - 4U)
+#define PMI_IRQ			(NR_IRQS - 3U)
+/*
+ * Starting IRQ for posted interrupts
+ * # of CONFIG_MAX_VM_NUM (POSTED_INTR_IRQ ~ (POSTED_INTR_IRQ + CONFIG_MAX_VM_NUM - 1U))
+ * consecutive IRQs reserved for posted interrupts
+ */
+#define POSTED_INTR_IRQ	(NR_IRQS - NR_STATIC_MAPPINGS_1 - CONFIG_MAX_VM_NUM)
 
 /* the maximum number of msi entry is 2048 according to PCI
  * local bus specification
@@ -95,7 +122,7 @@ void init_default_irqs(uint16_t cpu_id);
 void dispatch_exception(struct intr_excp_ctx *ctx);
 
 void setup_notification(void);
-void setup_posted_intr_notification(void);
+void setup_pi_notification(void);
 
 typedef void (*spurious_handler_t)(uint32_t vector);
 extern spurious_handler_t spurious_handler;

--- a/hypervisor/include/arch/x86/per_cpu.h
+++ b/hypervisor/include/arch/x86/per_cpu.h
@@ -59,6 +59,14 @@ struct per_cpu_region {
 #endif
 	uint16_t shutdown_vm_id;
 	uint64_t tsc_suspend;
+	/*
+	 * We maintain a per-pCPU array of vCPUs. vCPUs of a VM won't
+	 * share same pCPU. So the maximum possible # of vCPUs that can
+	 * run on a pCPU is CONFIG_MAX_VM_NUM.
+	 * vcpu_array address must be aligned to 64-bit for atomic access
+	 * to avoid contention between offline_vcpu and posted interrupt handler
+	 */
+	struct acrn_vcpu *vcpu_array[CONFIG_MAX_VM_NUM] __aligned(8);
 } __aligned(PAGE_SIZE); /* per_cpu_region size aligned with PAGE_SIZE */
 
 extern struct per_cpu_region per_cpu_data[MAX_PCPU_NUM];

--- a/hypervisor/include/arch/x86/platform_caps.h
+++ b/hypervisor/include/arch/x86/platform_caps.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PLATFORM_CAPS_H
+#define PLATFORM_CAPS_H
+
+struct platform_caps_x86 {
+	/* true if posted interrupt is supported by all IOMMUs */
+	bool pi;
+};
+
+extern struct platform_caps_x86 platform_caps;
+
+#endif /* PLATFORM_CAPS_H */

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -374,6 +374,14 @@
 #define VMX_INT_TYPE_HW_EXP		3U
 #define VMX_INT_TYPE_SW_EXP		6U
 
+/* Posted Interrupt Descriptor (PID) in VT-d spec */
+struct pi_desc {
+	/* Posted Interrupt Requests, one bit per requested vector */
+	uint64_t pir[4];
+	uint64_t pending;
+	uint32_t unused[3];
+} __aligned(64);
+
 /* External Interfaces */
 void vmx_on(void);
 void vmx_off(void);

--- a/hypervisor/include/arch/x86/vmx.h
+++ b/hypervisor/include/arch/x86/vmx.h
@@ -378,9 +378,32 @@
 struct pi_desc {
 	/* Posted Interrupt Requests, one bit per requested vector */
 	uint64_t pir[4];
-	uint64_t pending;
-	uint32_t unused[3];
+
+	union {
+		struct {
+			/* Outstanding Notification */
+			uint16_t on:1;
+
+			/* Suppress Notification, of non-urgent interrupts */
+			uint16_t sn:1;
+
+			uint16_t rsvd_1:14;
+
+			/* Notification Vector */
+			uint8_t nv;
+
+			uint8_t rsvd_2;
+
+			/* Notification destination, a physical LAPIC ID */
+			uint32_t ndst;
+		} bits;
+
+		uint64_t value;
+	} control;
+
+	uint32_t rsvd[6];
 } __aligned(64);
+
 
 /* External Interfaces */
 void vmx_on(void);
@@ -408,4 +431,5 @@ void exec_vmwrite64(uint32_t field_full, uint64_t value);
 void exec_vmclear(void *addr);
 void exec_vmptrld(void *addr);
 
+#define POSTED_INTR_ON  0U
 #endif /* VMX_H_ */

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -668,7 +668,7 @@ bool iommu_snoop_supported(const struct iommu_domain *iommu);
  * @retval 0 otherwise
  *
  */
-int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, uint16_t index);
+int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry *irte, uint16_t index);
 
 /**
  * @brief Free RTE for Interrupt Remapping Table.
@@ -677,7 +677,7 @@ int32_t dmar_assign_irte(struct intr_source intr_src, union dmar_ir_entry irte, 
  * @param[in] index into Interrupt Remapping Table
  *
  */
-void dmar_free_irte(struct intr_source intr_src, uint16_t index);
+void dmar_free_irte(const struct intr_source *intr_src, uint16_t index);
 
 /**
  * @brief Flash cacheline(s) for a specific address with specific size.

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -69,6 +69,13 @@ union source {
 struct intr_source {
 	bool is_msi;
 	union source src;
+	/*
+	 * pid_paddr = 0: invalid address, indicate that remapped mode shall be used
+	 *
+	 * pid_paddr != 0: physical address of posted interrupt descriptor, indicate
+	 * that posted mode shall be used
+	 */
+	uint64_t pid_paddr;
 };
 
 static inline uint8_t dmar_ver_major(uint64_t version)

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -511,24 +511,49 @@ struct dmar_entry {
 };
 
 union dmar_ir_entry {
-	struct dmar_entry entry;
-	struct {
-		uint64_t present:1;
-		uint64_t fpd:1;
-		uint64_t dest_mode:1;
-		uint64_t rh:1;
-		uint64_t trigger_mode:1;
-		uint64_t delivery_mode:3;
-		uint64_t sw_bits:4;
-		uint64_t rsvd_1:3;
-		uint64_t mode:1;
-		uint64_t vector:8;
-		uint64_t rsvd_2:8;
-		uint64_t dest:32;
-		uint64_t sid:16;
-		uint64_t sq:2;
-		uint64_t svt:2;
-		uint64_t rsvd_3:44;
+	struct dmar_entry value;
+
+	union {
+		/* Remapped mode */
+		struct {
+			uint64_t present:1;
+			uint64_t fpd:1;
+			uint64_t dest_mode:1;
+			uint64_t rh:1;
+			uint64_t trigger_mode:1;
+			uint64_t delivery_mode:3;
+			uint64_t avail:4;
+			uint64_t rsvd_1:3;
+			uint64_t mode:1;
+			uint64_t vector:8;
+			uint64_t rsvd_2:8;
+			uint64_t dest:32;
+
+			uint64_t sid:16;
+			uint64_t sq:2;
+			uint64_t svt:2;
+			uint64_t rsvd_3:44;
+		} remap;
+
+		/* Posted mode */
+		struct {
+			uint64_t present:1;
+			uint64_t fpd:1;
+			uint64_t rsvd_1:6;
+			uint64_t avail:4;
+			uint64_t rsvd_2:2;
+			uint64_t urgent:1;
+			uint64_t mode:1;
+			uint64_t vector:8;
+			uint64_t rsvd_3:14;
+			uint64_t pda_l:26;
+
+			uint64_t sid:16;
+			uint64_t sq:2;
+			uint64_t svt:2;
+			uint64_t rsvd_4:12;
+			uint64_t pda_h:32;
+		} post;
 	} bits __packed;
 };
 


### PR DESCRIPTION
Backporting VT-d Posted Interrupts patches from master to release_1.6


[External_System_ID] ACRN-6085