### PR TITLE
vacpi: complete ACPI table to describe resource for pre-launched VM

### DIFF
--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -87,6 +87,12 @@ static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 			.address = 0xFEE00000U, /* Local APIC Address */
 			.flags = 0x1U, /* PC-AT Compatibility=1 */
 		},
+		.ioapic_struct = {
+			.header.type = ACPI_MADT_TYPE_IOAPIC,
+			.header.length = sizeof(struct acpi_madt_ioapic),
+			.id = 0x1U,
+			.addr = VIOAPIC_BASE,
+		},
 		.lapic_nmi = {
 			.header.type = ACPI_MADT_TYPE_LOCAL_APIC_NMI,
 			.header.length = sizeof(struct acpi_madt_local_apic_nmi),
@@ -166,7 +172,7 @@ void build_vacpi(struct acrn_vm *vm)
 	}
 
 	madt = &acpi_table_template[vm->vm_id].madt;
-	madt->header.length = sizeof(struct acpi_table_madt)
+	madt->header.length = sizeof(struct acpi_table_madt) + sizeof(struct acpi_madt_ioapic)
 		+ sizeof(struct acpi_madt_local_apic_nmi)
 		+ (sizeof(struct acpi_madt_local_apic) * (size_t)vm->hw.created_vcpus);
 	madt->header.checksum = calculate_checksum8(madt, madt->header.length);

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -139,6 +139,19 @@ struct acpi_table_fadt {
 	uint8_t unused3[128];		/* ACRN doesn't use these fields */
 } __packed;
 
+struct acpi_table_mcfg {
+	struct acpi_table_header header;	/* Common ACPI table header */
+	uint8_t reserved[8];
+} __packed;
+
+struct acpi_mcfg_allocation {
+	uint64_t address;		/* Base address, processor-relative */
+	uint16_t pci_segment;		/* PCI segment group number */
+	uint8_t start_bus_number;	/* Starting PCI Bus number */
+	uint8_t end_bus_number;		/* Final PCI Bus number */
+	uint32_t reserved;
+} __packed;
+
 struct acpi_table_madt {
 	/* Common ACPI table header */
 	struct acpi_table_header     header;

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -56,6 +56,7 @@
 #define ACPI_SIG_MADT            "APIC" /* Multiple APIC Description Table */
 #define ACPI_SIG_DMAR            "DMAR"
 #define ACPI_SIG_MCFG            "MCFG" /* Memory Mapped Configuration table */
+#define ACPI_SIG_DSDT            "DSDT" /* Differentiated System Description Table */
 
 struct packed_gas {
 	uint8_t 	space_id;
@@ -119,6 +120,23 @@ struct acpi_table_xsdt {
 	struct acpi_table_header    header;
 	/* Array of pointers to ACPI tables */
 	uint64_t                    table_offset_entry[1];
+} __packed;
+
+struct acpi_table_fadt {
+	struct acpi_table_header header;/* Common ACPI table header */
+	uint32_t facs;			/* 32-bit physical address of FACS */
+	uint32_t dsdt;			/* 32-bit physical address of DSDT */
+	uint8_t unused0[12];		/* ACRN doesn't use these fields */
+	uint32_t pm1a_event_block;	/* 32-bit port address of Power Mgt 1a Event Reg Blk */
+	uint32_t pm1b_event_block;	/* 32-bit port address of Power Mgt 1b Event Reg Blk */
+	uint32_t pm1a_control_block;	/* 32-bit port address of Power Mgt 1a Control Reg Blk */
+	uint32_t pm1b_control_block;	/* 32-bit port address of Power Mgt 1b Control Reg Blk */
+	uint8_t unused1[16];		/* ACRN doesn't use these fields */
+	uint8_t pm1_event_length;	/* Byte Length of ports at pm1x_event_block */
+	uint8_t pm1_control_length;	/* Byte Length of ports at pm1x_control_block */
+	uint8_t unused2[22];		/* ACRN doesn't use these fields */
+	uint32_t flags;			/* Miscellaneous flag bits (see below for individual flags) */
+	uint8_t unused3[128];		/* ACRN doesn't use these fields */
 } __packed;
 
 struct acpi_table_madt {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -33,6 +33,7 @@
 #include <vtd.h>
 #include <io.h>
 #include <mmu.h>
+#include <vacpi.h>
 #include <logmsg.h>
 #include "vpci_priv.h"
 #include "pci_dev.h"
@@ -248,13 +249,11 @@ void init_vpci(struct acrn_vm *vm)
 	vpci_init_vdevs(vm);
 
 	vm_config = get_vm_config(vm->vm_id);
-	if (vm_config->load_order != PRE_LAUNCHED_VM) {
-		/* PCI MMCONFIG for post-launched VM is fixed to 0xE0000000 */
-		pci_mmcfg_base = (vm_config->load_order == SOS_VM) ? get_mmcfg_base() : 0xE0000000UL;
-		vm->vpci.pci_mmcfg_base = pci_mmcfg_base;
-		register_mmio_emulation_handler(vm, vpci_mmio_cfg_access,
+	/* virtual PCI MMCONFIG for SOS is same with the physical value */
+	pci_mmcfg_base = (vm_config->load_order == SOS_VM) ? get_mmcfg_base() : VIRT_PCI_MMCFG_BASE;
+	vm->vpci.pci_mmcfg_base = pci_mmcfg_base;
+	register_mmio_emulation_handler(vm, vpci_mmio_cfg_access,
 			pci_mmcfg_base, pci_mmcfg_base + PCI_MMCONFIG_SIZE, &vm->vpci, false);
-	}
 
 	/* Intercept and handle I/O ports CF8h */
 	register_pio_emulation_handler(vm, PCI_CFGADDR_PIO_IDX, &pci_cfgaddr_range,

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -66,6 +66,7 @@ struct acpi_table_info {
 		struct acpi_table_mcfg mcfg;
 		struct acpi_mcfg_allocation mcfg_entry;	/* mcfg_entry msut be declared fellowing mcfg */
 		struct acpi_table_madt madt;
+		struct acpi_madt_ioapic ioapic_struct;
 		struct acpi_madt_local_apic_nmi lapic_nmi;
 		struct acpi_madt_local_apic lapic_array[MAX_PCPU_NUM];
 	} __packed;

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -36,6 +36,7 @@
  *     XSDT  ->   0xf2480    (36 bytes + 8*7 table addrs, 4 used)
  *       FADT  ->   0xf2500  (244 bytes fixed for ACPI 2.0)
  *         DSDT -> 0xf2600      (36 bytes fixed for an empty DSDT)
+ *       MCFG  ->   0xf2700  (36 bytes fixed + 8 bytes reserved + 1 * 16 bytes)
  *       MADT  ->   0xf2740  (depends on #CPUs)
  */
 #define ACPI_BASE         0xf2400U
@@ -44,11 +45,15 @@
 #define ACPI_XSDT_ADDR    (ACPI_BASE + 0x080U)
 #define ACPI_FADT_ADDR    (ACPI_BASE + 0x100U)
 #define ACPI_DSDT_ADDR    (ACPI_BASE + 0x200U)
+#define ACPI_MCFG_ADDR    (ACPI_BASE + 0x300U)
 #define ACPI_MADT_ADDR    (ACPI_BASE + 0x340U)
 
 #define ACPI_OEM_ID           "ACRN  "
 #define ACPI_ASL_COMPILER_ID  "INTL"
 #define ACPI_ASL_COMPILER_VERSION  0x20190802U
+
+/* virtual PCI MMCFG address base for pre/post-launched VM. */
+#define VIRT_PCI_MMCFG_BASE	0xE0000000UL
 
 struct acrn_vm;
 struct acpi_table_info {
@@ -58,6 +63,8 @@ struct acpi_table_info {
 	struct {
 		struct acpi_table_fadt fadt;
 		struct acpi_table_header dsdt;	/* an empty DSDT */
+		struct acpi_table_mcfg mcfg;
+		struct acpi_mcfg_allocation mcfg_entry;	/* mcfg_entry msut be declared fellowing mcfg */
 		struct acpi_table_madt madt;
 		struct acpi_madt_local_apic_nmi lapic_nmi;
 		struct acpi_madt_local_apic lapic_array[MAX_PCPU_NUM];

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -34,13 +34,17 @@
  *  ------
  *   RSDP  ->   0xf2400    (36 bytes fixed)
  *     XSDT  ->   0xf2480    (36 bytes + 8*7 table addrs, 4 used)
- *       MADT  ->   0xf2500  (depends on #CPUs)
+ *       FADT  ->   0xf2500  (244 bytes fixed for ACPI 2.0)
+ *         DSDT -> 0xf2600      (36 bytes fixed for an empty DSDT)
+ *       MADT  ->   0xf2740  (depends on #CPUs)
  */
 #define ACPI_BASE         0xf2400U
 
 #define ACPI_RSDP_ADDR    (ACPI_BASE + 0x0U)
 #define ACPI_XSDT_ADDR    (ACPI_BASE + 0x080U)
-#define ACPI_MADT_ADDR    (ACPI_BASE + 0x100U)
+#define ACPI_FADT_ADDR    (ACPI_BASE + 0x100U)
+#define ACPI_DSDT_ADDR    (ACPI_BASE + 0x200U)
+#define ACPI_MADT_ADDR    (ACPI_BASE + 0x340U)
 
 #define ACPI_OEM_ID           "ACRN  "
 #define ACPI_ASL_COMPILER_ID  "INTL"
@@ -52,6 +56,8 @@ struct acpi_table_info {
 	struct acpi_table_xsdt xsdt;
 
 	struct {
+		struct acpi_table_fadt fadt;
+		struct acpi_table_header dsdt;	/* an empty DSDT */
 		struct acpi_table_madt madt;
 		struct acpi_madt_local_apic_nmi lapic_nmi;
 		struct acpi_madt_local_apic lapic_array[MAX_PCPU_NUM];


### PR DESCRIPTION
v2:
1. add ioapic madt table
2. re-define acpi_table_fadt structure to reduce some code

v1:
1. We need to add S5 support for pre-launched VM which needs FADT table.
2. We need to support pre-launched VM PCIe external CFG space ECAM access which needs MCFG

Tracked-On: #4623
Signed-off-by: Li Fei1 <fei1.li@intel.com>
