### PR TITLE
vm vcpu state cleanup

### DIFF
--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -160,7 +160,7 @@ static inline void enter_s5(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t 
 	if (is_sos_vm(vm)) {
 		save_s5_reg_val(pm1a_cnt_val, pm1b_cnt_val);
 	}
-
+	pause_vm(vm);
 	(void)shutdown_vm(vm);
 }
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -584,8 +584,6 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 	struct acrn_vm_config *vm_config = NULL;
 	int32_t ret = 0;
 
-	pause_vm(vm);
-
 	/* Only allow shutdown paused vm */
 	if (vm->state == VM_PAUSED) {
 		vm->state = VM_POWERED_OFF;

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -39,6 +39,7 @@ void triple_fault_shutdown_vm(struct acrn_vcpu *vcpu)
 				struct acrn_vm *pl_vm = get_vm_from_vmid(vm_id);
 
 				if (!is_poweroff_vm(pl_vm) && is_postlaunched_vm(pl_vm) && !is_rt_vm(pl_vm)) {
+					pause_vm(pl_vm);
 					(void)shutdown_vm(pl_vm);
 				}
 			}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -203,7 +203,7 @@ int32_t hcall_destroy_vm(uint16_t vmid)
 	int32_t ret = -1;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (is_paused_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		/* TODO: check target_vm guest_flags */
 		ret = shutdown_vm(target_vm);
 	}
@@ -278,7 +278,7 @@ int32_t hcall_reset_vm(uint16_t vmid)
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 	int32_t ret = -1;
 
-	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	if (is_paused_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		/* TODO: check target_vm guest_flags */
 		ret = reset_vm(target_vm);
 	}

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -613,7 +613,7 @@ int32_t run_vcpu(struct acrn_vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @pre vcpu != NULL
- *
+ * @pre vcpu->state == VCPU_ZOMBIE
  * @return None
  */
 void offline_vcpu(struct acrn_vcpu *vcpu);
@@ -625,7 +625,8 @@ void offline_vcpu(struct acrn_vcpu *vcpu);
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] mode the reset mode
- *
+ * @pre vcpu != NULL
+ * @pre vcpu->state == VCPU_ZOMBIE
  * @return None
  */
 void reset_vcpu(struct acrn_vcpu *vcpu, enum reset_mode mode);
@@ -659,7 +660,8 @@ int32_t resume_vcpu(struct acrn_vcpu *vcpu);
  * Adds a vCPU into the run queue and make a reschedule request for it. It sets the vCPU state to VCPU_RUNNING.
  *
  * @param[inout] vcpu pointer to vcpu data structure
- *
+ * @pre vcpu != NULL
+ * @pre vcpu->state == VCPU_INIT
  * @return None
  */
 void launch_vcpu(struct acrn_vcpu *vcpu);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -244,6 +244,7 @@ void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config);
 void launch_vms(uint16_t pcpu_id);
 bool is_poweroff_vm(const struct acrn_vm *vm);
 bool is_created_vm(const struct acrn_vm *vm);
+bool is_paused_vm(const struct acrn_vm *vm);
 bool is_sos_vm(const struct acrn_vm *vm);
 bool is_postlaunched_vm(const struct acrn_vm *vm);
 bool is_prelaunched_vm(const struct acrn_vm *vm);


### PR DESCRIPTION
 add pre-condition for vm & cpu state transition instead of
 check state before state transition.

Tracked-On: #4320