### PR TITLE
doc: add sphinx-tabs extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,8 +35,11 @@ if "RELEASE" in os.environ:
 # ones.
 
 sys.path.insert(0, os.path.join(os.path.abspath('.'), 'extensions'))
-extensions = ['breathe', 'sphinx.ext.graphviz', 'sphinx.ext.extlinks',
-              'kerneldoc', 'eager_only', 'html_redirects']
+extensions = [
+   'breathe', 'sphinx.ext.graphviz', 'sphinx.ext.extlinks',
+   'kerneldoc', 'eager_only', 'html_redirects',
+   'sphinx_tabs.tabs'
+]
 
 # extlinks provides a macro template
 

--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -3,3 +3,4 @@ sphinx==1.7.7
 docutils==0.14
 sphinx_rtd_theme==0.4.0
 kconfiglib>=10.2
+sphinx-tabs


### PR DESCRIPTION
The sphinx-tabs extension let's us create a document that can
dynamically display alternate material based on clicking a tab, as used
in the Zephyr getting started guide:
https://docs.zephyrproject.org/latest/getting_started/index.html

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>