### PR TITLE
HV: set default MCFG base for generic board

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -252,7 +252,10 @@ config ACPI_PARSE_ENABLED
 	bool "Enable ACPI runtime parsing"
 	default y
 	help
-	  Whether to parse the ACPI tables at runtime.
+	  Platform specific ACPI info may be retrieved thru boot-time parse
+	  of ACPI table, or thru parse of off-line tool. This option enables
+	  the boot-time parse of ACPI table, and overwrite the information
+	  from off-line tool.
 
 config HYPERV_ENABLED
 	bool "Enable Hyper-V enlightenment"

--- a/hypervisor/arch/x86/configs/platform_acpi_info.h
+++ b/hypervisor/arch/x86/configs/platform_acpi_info.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/* This is a template header file for platform ACPI info definition,
- * we should use a user space tool running on target to generate
- * board specific acpi info file named as $(CONFIG_BOARD)_acpi_info.h
- * and put it in hypervisor/arch/x86/configs/$(CONFIG_BOARD)/.
+/* This is a template header file for generic platform ACPI info definition,
+ * we should use acrn-config tool to generate board specific acpi info file
+ * which named as $(CONFIG_BOARD)_acpi_info.h and put it under
+ * hypervisor/arch/x86/configs/$(CONFIG_BOARD)/.
  */
 #ifndef PLATFORM_ACPI_INFO_H
 #define PLATFORM_ACPI_INFO_H
@@ -25,7 +25,7 @@
 #define RESET_REGISTER_SPACE_ID 0UL
 
 /* PCI mmcfg base of MCFG, pre-assumption is platform only has one PCI segment group */
-#define DEFAULT_PCI_MMCFG_BASE	0UL
+#define DEFAULT_PCI_MMCFG_BASE	0xE0000000UL
 
 /* DRHD of DMAR */
 #define DRHD_COUNT		8U


### PR DESCRIPTION
On most board the MCFG base is set to 0xe0000000, so modify this value in
platform_acpi_info.h for generic boards;

The description of ACPI_PARSE_ENABLED is modified also to match its usage.

Tracked-On: #4157

Signed-off-by: Victor Sun <victor.sun@intel.com>