### PR TITLE
hv: Wake up vCPU for interrupts from vPIC

### DIFF
--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -289,6 +289,7 @@ static bool vcpu_inject_lo_exception(struct acrn_vcpu *vcpu)
 void vcpu_inject_extint(struct acrn_vcpu *vcpu)
 {
 	vcpu_make_request(vcpu, ACRN_REQUEST_EXTINT);
+	signal_event(&vcpu->events[VCPU_EVENT_VIRTUAL_INTERRUPT]);
 }
 
 /* Inject NMI to guest */


### PR DESCRIPTION
Wake up vCPUs that are blocked upon interrupts from vPIC.
Backporting from master to release_1.6

Tracked-On: #4664
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>