### PR TITLE
crashlog: fix build issue under latest clearlinux

### DIFF
--- a/misc/tools/acrn-crashlog/acrnprobe/loop.c
+++ b/misc/tools/acrn-crashlog/acrnprobe/loop.c
@@ -231,7 +231,7 @@ int loopdev_check_parname(const char *loopdev, const char *parname)
 		/* only look into the primary super block */
 		if (super.s_volume_name[0]) {
 			close(fd);
-			return !strcmp(super.s_volume_name, parname);
+			return !strcmp((const char *)super.s_volume_name, parname);
 		}
 		break;
 	}


### PR DESCRIPTION
gcc in latest clearlinux enabled the pointer-sign warning as
default. This breaks the acrn-crashlog build.

Make acrn-crashlog build issue fixed by convert to correct
pointer type.

Tracked-On: #4636
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>