### PR TITLE
sample: don't restore passthrough devices on exit by default

### DIFF
--- a/devicemodel/samples/nuc/launch_xenomai.sh
+++ b/devicemodel/samples/nuc/launch_xenomai.sh
@@ -189,6 +189,9 @@ fi
 
 passthru_pci_devs
 
+#logger_setting, format: logger_name,level; like following
+logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
+
 /usr/bin/acrn-dm -A -m $mem_size -s 0:0,hostbridge \
 -k /tmp/bzImage.xenomai \
 -U 495ae2e5-2603-4d64-af76-d4bc5a8ec0e5 \
@@ -197,6 +200,7 @@ passthru_pci_devs
 --virtio_poll 1000000 \
 -s 1,virtio-console,@stdio:stdio_port \
 $dev_opts \
+$logger_setting \
 -B "root=$vdisk rw rootwait nohpet console=hvc0 consoleblank=0 \
 no_timer_check ignore_loglevel log_buf_len=16M nmi_watchdog=0 nosoftlockup \
 processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable idle=poll \

--- a/devicemodel/samples/nuc/launch_xenomai.sh
+++ b/devicemodel/samples/nuc/launch_xenomai.sh
@@ -6,10 +6,11 @@
 
 usage()
 {
-	echo "$0 [-b disk | -f img] [-k kernel.tar.gz] {-n ethernet} {-B mem_size}"
+	echo "$0 [-b disk | -f img] [-k kernel.tar.gz] {-n ethernet} {-B mem_size} {-r}"
 	echo "   example:"
 	echo "   $0 -b /dev/sdb3 -k ~/linux-4.19.tar.gz -n eth0"
 	echo "   $0 -f clearlinux.img -k ../linux-5.2.tar -n eth0 -B 512M"
+	echo "   $0 -f clearlinux.img -k ../linux-5.2.tar -n eth0 -r # restore passthroughed eth0 when script returns"
 	exit
 }
 
@@ -83,20 +84,21 @@ function de_passthru_pci_devs()
 	done
 }
 
-# restore pci device driver on exit
-trap de_passthru_pci_devs EXIT
-
 mem_size=1024M
 eth=
 disk=
 img=
 kernel=
 passthrus=()
-while getopts hn:b:f:k:B: opt
+while getopts hn:b:f:k:B:r opt
 do
 	case "${opt}" in
 		h)
 			usage;
+			;;
+		r)
+			# restore pci device driver on exit
+			trap de_passthru_pci_devs EXIT
 			;;
 		n)
 			eth=${OPTARG}


### PR DESCRIPTION
Passthroughed devices won't be restored back to SOS once launch
script exits by default. However you could revert this behavior
by specifying '-r' parameter if you want.

Signed-off-by: Tw <wei.tan@intel.com>
Tracked-On: #4514