### PR TITLE
HV: refine usage of idle=halt in sos cmdline

### DIFF
--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -23,6 +23,12 @@
 #define MAX_VM_OS_NAME_LEN	32U
 #define MAX_MOD_TAG_LEN		32U
 
+#ifdef CONFIG_SCHED_NOOP
+#define SOS_IDLE		""
+#else
+#define SOS_IDLE		"idle=halt "
+#endif
+
 #define PCI_DEV_TYPE_PTDEV	(1U << 0U)
 #define PCI_DEV_TYPE_HVEMUL	(1U << 1U)
 #define PCI_DEV_TYPE_SOSEMUL	(1U << 2U)

--- a/hypervisor/scenarios/hybrid/vm_configurations.h
+++ b/hypervisor/scenarios/hybrid/vm_configurations.h
@@ -37,6 +37,7 @@
 					"i915.avail_planes_per_pipe=0x010700 "	\
 					"i915.domain_plane_owners=0x011100001111 " \
 					"i915.enable_gvt=1 "	\
+					SOS_IDLE \
 					SOS_BOOTARGS_DIFF
 
 #define VM2_CONFIG_VCPU_AFFINITY	{AFFINITY_CPU(2U)}

--- a/hypervisor/scenarios/industry/vm_configurations.h
+++ b/hypervisor/scenarios/industry/vm_configurations.h
@@ -32,7 +32,8 @@
 					"i915.nuclear_pageflip=1 " \
 					"i915.avail_planes_per_pipe=0x01010F "	\
 					"i915.domain_plane_owners=0x011111110000 " \
-					"i915.enable_gvt=1 idle=halt "	\
+					"i915.enable_gvt=1 "	\
+					SOS_IDLE \
 					SOS_BOOTARGS_DIFF
 
 #define	VM1_CONFIG_VCPU_AFFINITY	{AFFINITY_CPU(0U), AFFINITY_CPU(1U)}

--- a/hypervisor/scenarios/sdc/vm_configurations.h
+++ b/hypervisor/scenarios/sdc/vm_configurations.h
@@ -32,7 +32,8 @@
 					"i915.nuclear_pageflip=1 " \
 					"i915.avail_planes_per_pipe=0x01010F "	\
 					"i915.domain_plane_owners=0x011111110000 " \
-					"i915.enable_gvt=1 idle=halt "	\
+					"i915.enable_gvt=1 "	\
+					SOS_IDLE \
 					SOS_BOOTARGS_DIFF
 
 #if CONFIG_MAX_KATA_VM_NUM > 0

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -114,6 +114,7 @@ def gen_sos_header(vm_info, config):
     print("", file=config)
     print("#define SOS_VM_BOOTARGS\t\t\tSOS_ROOTFS\t\\", file=config)
     print("\t\t\t\t\tSOS_CONSOLE\t\\", file=config)
+    print("\t\t\t\t\tSOS_IDLE\t\\", file=config)
     print("\t\t\t\t\tSOS_BOOTARGS_DIFF", file=config)
 
 


### PR DESCRIPTION
The parameter of "idle=halt" for SOS cmdline is only needed when cpu sharing is enabled, otherwise it will impact SOS power.
    
Tracked-On: #4329

Signed-off-by: Victor Sun <victor.sun@intel.com>
