### PR TITLE
dm:refine graphics stolen memory passthru for EHL platform

### DIFF
--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,8 +1066,6 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
-#define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
-#define PCIM_BDSM_GSM_MASK  		0xFFF00000 /* bits 31:20 contains the base address of stolen memory */
 #define PCIR_ASLS_CTL			0xFC /* Opregion start addr register */
 #define PCIM_ASLS_OPREGION_MASK	0xFFFFF000 /* opregion need 4KB aligned */
 #endif


### PR DESCRIPTION
EHL graphics stolen memory(GSM) info has diff with KBL/WHL,
which includes two parts:
(1) GSM register location in pci config: on KBL/WHL, the register
locates on 0X5C, while on EHL, the register locates on 0xC0.
(2) GSM address length: On KBL/WHL,
GSM addr has 32 bits, while on EHL,GSM addr has 64 bits.

Here, refine graphics stolen memory passthru to enable GVT-d on EHL platforms.

v1 -> v2:
	* add callback functions for scalability

Tracked-On: #4360

Signed-off-by: Junming Liu <junming.liu@intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>