### PR TITLE
Makefile: do not override RELEASE when build with XML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,6 @@ else
 	FIRMWARE ?= uefi
 endif
 
-RELEASE ?= 1
 SCENARIO ?= sdc
 
 O ?= build

--- a/hypervisor/scripts/makefile/cfg_update.mk
+++ b/hypervisor/scripts/makefile/cfg_update.mk
@@ -31,6 +31,14 @@ ifeq ($(CONFIG_XML_ENABLED),true)
     endif
     override BOARD := $(BOARD_IN_XML)
     override SCENARIO := $(SCENARIO_IN_XML)
+    RELEASE_IN_XML := $(shell echo `sed -n '/<RELEASE/p' $(SCENARIO_FILE) | sed -r 's/.*<RELEASE(.*)>(.*)<(.*)/\2/g'`)
+    ifndef RELEASE
+        ifeq ($(RELEASE_IN_XML),y)
+            override RELEASE := 1
+        else
+            override RELEASE := 0
+        endif
+    endif
 endif
 
 update_config:
@@ -51,9 +59,10 @@ ifeq ($(CONFIG_XML_ENABLED),true)
 		fi;\
 		cat $(UPDATE_RESULT);\
 		if [ "`sed -n /successfully/p $(UPDATE_RESULT)`" = "" ]; then rm -f $(UPDATE_RESULT); exit 1;	fi;\
-		echo "Import hypervisor Board/VM configuration from XMLs, configurations in source code has been overwritten!";\
+		echo "Import hypervisor Board/VM configuration from XMLs.";\
+		if [ "$(TARGET_DIR)" = "" ]; then echo "Warning: configurations in source code has been overwritten!"; fi;\
 	elif [ "`sed -n /successfully/p $(UPDATE_RESULT)`" = "" ]; then \
-		echo "Problem is found on Board/VM configration patching, please rebuild."; rm -f $(UPDATE_RESULT); exit 1; \
+		echo "Problem is found on Board/VM configuration patching, please rebuild."; rm -f $(UPDATE_RESULT); exit 1; \
 	else \
 		echo "Configurations is patched already!";\
 	fi;

--- a/hypervisor/scripts/makefile/kconfig.mk
+++ b/hypervisor/scripts/makefile/kconfig.mk
@@ -38,7 +38,9 @@ ifeq ($(shell [ $(HV_OBJDIR)/$(HV_CONFIG) -nt $(HV_OBJDIR)/$(HV_CONFIG_MK) ] && 
 endif
 $(eval $(call override_config,BOARD,apl-mrb))
 $(eval $(call override_config,SCENARIO,))
-$(eval $(call override_config,RELEASE,n))
+$(eval $(call override_config,RELEASE,y))
+
+override RELEASE := $(CONFIG_RELEASE)
 
 $(eval $(call check_dep_exec,python3,KCONFIG_DEPS))
 $(eval $(call check_dep_py3lib,kconfiglib,KCONFIG_DEPS))
@@ -72,7 +74,10 @@ defconfig: $(KCONFIG_DEPS)
 		if [ "$(KCONFIG_FILE)" != "" ] && [ -f $(KCONFIG_FILE) ]; then \
 			echo "Writing $(HV_OBJDIR)/$(HV_CONFIG) with $(KCONFIG_FILE)"; \
 			cp $(KCONFIG_FILE) $(HV_OBJDIR)/$(HV_CONFIG); \
-		elif [ "$(CONFIG_XML_ENABLED)" = "true" ] && [ "$(TARGET_DIR)" != "" ] && [ -d $(TARGET_DIR) ]; then \
+		elif [ "$(TARGET_DIR)" != "" ] && [ -d $(TARGET_DIR) ]; then \
+			if [ ! -f $(TARGET_DIR)/$(BOARD).config ]; then \
+				echo "Board defconfig file $(BOARD).config is not found under $(TARGET_DIR)."; exit 1; \
+			fi; \
 			echo "Writing $(HV_OBJDIR)/$(HV_CONFIG) with $(TARGET_DIR)/$(BOARD).config"; \
 			cp $(TARGET_DIR)/$(BOARD).config $(HV_OBJDIR)/$(HV_CONFIG); \
 		fi; \


### PR DESCRIPTION
SCENARIO XML file has included RELEASE or DEBUG info already, so if RELEASE is not specified in make command, Makefile should not override RELEASE info in SCENARIO XML. If RELEASE is specified in make command, then RELEASE info in SCENARIO XML could be overridden by make command.

The patch also fixed a issue that get correct board defconfig when build
hypervisor from TARGET_DIR;

Tracked-On: #4688

Signed-off-by: Victor Sun <victor.sun@intel.com>