### PR TITLE
hv: vioapic: expose ioapic to guest unconditionally

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -272,17 +272,17 @@ basl_fwrite_madt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "\n");
 	}
 
-	if (!is_rtvm) {
-		/* Always a single IOAPIC entry, with ID 0 */
-		EFPRINTF(fp, "[0001]\t\tSubtable Type : 01\n");
-		EFPRINTF(fp, "[0001]\t\tLength : 0C\n");
-		/* iasl expects a hex value for the i/o apic id */
-		EFPRINTF(fp, "[0001]\t\tI/O Apic ID : %02x\n", 0);
-		EFPRINTF(fp, "[0001]\t\tReserved : 00\n");
-		EFPRINTF(fp, "[0004]\t\tAddress : fec00000\n");
-		EFPRINTF(fp, "[0004]\t\tInterrupt : 00000000\n");
-		EFPRINTF(fp, "\n");
+	/* Always a single IOAPIC entry, with ID 0 */
+	EFPRINTF(fp, "[0001]\t\tSubtable Type : 01\n");
+	EFPRINTF(fp, "[0001]\t\tLength : 0C\n");
+	/* iasl expects a hex value for the i/o apic id */
+	EFPRINTF(fp, "[0001]\t\tI/O Apic ID : %02x\n", 0);
+	EFPRINTF(fp, "[0001]\t\tReserved : 00\n");
+	EFPRINTF(fp, "[0004]\t\tAddress : fec00000\n");
+	EFPRINTF(fp, "[0004]\t\tInterrupt : 00000000\n");
+	EFPRINTF(fp, "\n");
 
+	if (!is_rtvm) {
 		/* Legacy IRQ0 is connected to pin 2 of the IOAPIC */
 		EFPRINTF(fp, "[0001]\t\tSubtable Type : 02\n");
 		EFPRINTF(fp, "[0001]\t\tLength : 0A\n");

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -471,10 +471,12 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 		/* vpic wire_mode default is INTR */
 		vm->wire_mode = VPIC_WIRE_INTR;
 
-		/* Init full emulated vIOAPIC instance */
-		if (!is_lapic_pt_configured(vm)) {
-			vioapic_init(vm);
-		}
+		/* Init full emulated vIOAPIC instance:
+		 * Present a virtual IOAPIC to guest, as a placeholder interrupt controller,
+		 * even if the guest uses PT LAPIC. This is to satisfy the guest OSes,
+		 * in some cases, though the functionality of vIOAPIC doesn't work.
+		 */
+		vioapic_init(vm);
 
 		/* Populate return VM handle */
 		*rtn_vm = vm;

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -57,7 +57,6 @@ struct acrn_single_vioapic {
 	spinlock_t	lock;
 	struct acrn_vm  *vm;
 	struct ioapic_info chipinfo;
-	bool		ready;
 	uint32_t	ioregsel;
 	union ioapic_rte rtbl[REDIR_ENTRIES_HW];
 	/* pin_state status bitmap: 1 - high, 0 - low */


### PR DESCRIPTION
Some OSes assume the platform must have the IOAPIC. For example:
Linux Kernel allocates IRQ force from GSI (0 if there's no PIC and IOAPIC) on x86.
And it thinks IRQ 0 is an architecture special IRQ, not for device driver. As a
result, the device driver may goes wrong if the allocated IRQ is 0 for RTVM.

This patch expose vIOAPIC to RTVM with LAPIC passthru even though the RTVM can't
use IOAPIC, it servers as a place holder to fullfil the guest assumption.

After vIOAPIC has exposed to guest unconditionally, the 'ready' field could be
removed since we do vIOAPIC initialization for each guest.

Tracked-On: #4691
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>