### PR TITLE
Vioapic: two minor refines

### DIFF
--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -435,6 +435,9 @@ union ioapic_rte {
 #define IOAPIC_REDTBL22		(IOAPIC_REDTBL+0x2cU)
 #define IOAPIC_REDTBL23		(IOAPIC_REDTBL+0x2eU)
 
+#define IOAPIC_ID_MASK		0x0f000000U
+#define IOAPIC_ID_SHIFT		24U
+
 /* fields in VER, for redirection entry */
 #define IOAPIC_MAX_RTE_MASK	0x00ff0000U
 #define MAX_RTE_SHIFT		16U

--- a/hypervisor/include/dm/vioapic.h
+++ b/hypervisor/include/dm/vioapic.h
@@ -38,6 +38,7 @@
  */
 
 #include <apicreg.h>
+#include <ioapic.h>
 #include <util.h>
 
 #define	VIOAPIC_BASE	0xFEC00000UL
@@ -55,10 +56,7 @@
 struct acrn_single_vioapic {
 	spinlock_t	mtx;
 	struct acrn_vm  *vm;
-	uint32_t	base_addr;
-	uint32_t	nr_pins;
-	uint32_t	gsi_base;
-	uint32_t	id;
+	struct ioapic_info chipinfo;
 	bool		ready;
 	uint32_t	ioregsel;
 	union ioapic_rte rtbl[REDIR_ENTRIES_HW];


### PR DESCRIPTION
1. minor refine about ioapic madt parse
2. minor refine about vioapic_init

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>