### PR TITLE
hv: Enable accessed bit in EPT paging

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -360,7 +360,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	 * TODO: introduce API to make this data driven based
 	 * on VMX_EPT_VPID_CAP
 	 */
-	value64 = hva2hpa(vm->arch_vm.nworld_eptp) | (3UL << 3U) | 6UL;
+	value64 = hva2hpa(vm->arch_vm.nworld_eptp) | (3UL << 3U) | 6UL | (1UL << 6U);
 	exec_vmwrite64(VMX_EPT_POINTER_FULL, value64);
 	pr_dbg("VMX_EPT_POINTER: 0x%016lx ", value64);
 

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -379,10 +379,10 @@ static int32_t xsetbv_vmexit_handler(struct acrn_vcpu *vcpu)
 
 static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 {
-	if (has_rt_vm() == false) {
+	if (has_rt_vm() == false || is_rt_vm(vcpu->vm)) {
 		cache_flush_invalidate_all();
 	} else {
-		walk_ept_table(vcpu->vm, ept_flush_leaf_page);
+		walk_ept_table(vcpu->vm, ept_flush_leaf_page, true);
 	}
 
 	return 0;

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -37,6 +37,11 @@ static inline void ppt_clflush_pagewalk(const void* entry __attribute__((unused)
 {
 }
 
+static inline uint64_t ppt_pgentry_accessed(uint64_t pte)
+{
+	return pte & PAGE_ACCESSED;
+}
+
 static inline uint64_t ppt_pgentry_present(uint64_t pte)
 {
 	return pte & PAGE_PRESENT;
@@ -71,6 +76,7 @@ const struct memory_ops ppt_mem_ops = {
 	.large_page_enabled = true,
 	.get_default_access_right = ppt_get_default_access_right,
 	.pgentry_present = ppt_pgentry_present,
+	.pgentry_accessed = ppt_pgentry_accessed,
 	.get_pml4_page = ppt_get_pml4_page,
 	.get_pdpt_page = ppt_get_pdpt_page,
 	.get_pd_page = ppt_get_pd_page,
@@ -145,6 +151,11 @@ static inline uint64_t ept_get_default_access_right(void)
 static inline uint64_t ept_pgentry_present(uint64_t pte)
 {
 	return pte & EPT_RWX;
+}
+
+static inline uint64_t ept_pgentry_accessed(uint64_t pte)
+{
+	return pte & EPT_ACCESSED;
 }
 
 static inline void ept_clflush_pagewalk(const void* etry)
@@ -250,6 +261,7 @@ void init_ept_mem_ops(struct memory_ops *mem_ops, uint16_t vm_id)
 	mem_ops->info = &ept_pages_info[vm_id];
 	mem_ops->get_default_access_right = ept_get_default_access_right;
 	mem_ops->pgentry_present = ept_pgentry_present;
+	mem_ops->pgentry_accessed = ept_pgentry_accessed;
 	mem_ops->get_pml4_page = ept_get_pml4_page;
 	mem_ops->get_pdpt_page = ept_get_pdpt_page;
 	mem_ops->get_pd_page = ept_get_pd_page;

--- a/hypervisor/include/arch/x86/guest/ept.h
+++ b/hypervisor/include/arch/x86/guest/ept.h
@@ -127,6 +127,7 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa,
  * @return None
  */
 void ept_flush_leaf_page(uint64_t *pge, uint64_t size);
+void ept_clear_accessed(uint64_t *pge, uint64_t size);
 
 /**
  * @brief Get EPT pointer of the vm
@@ -145,10 +146,11 @@ void *get_ept_entry(struct acrn_vm *vm);
  * @param[in] cb the pointer that points to walk_ept_table callback, the callback
  * 		will be invoked when getting a present page entry from EPT, and
  *		the callback could get the page entry and page size parameters.
+ * @param[in] only_accessed walk accessed ept entries or not
  *
  * @return None
  */
-void walk_ept_table(struct acrn_vm *vm, pge_handler cb);
+void walk_ept_table(struct acrn_vm *vm, pge_handler cb, bool only_accessed);
 
 /**
  * @brief EPT misconfiguration handling

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -80,6 +80,7 @@ struct memory_ops {
 	bool large_page_enabled;
 	uint64_t (*get_default_access_right)(void);
 	uint64_t (*pgentry_present)(uint64_t pte);
+	uint64_t (*pgentry_accessed)(uint64_t pte);
 	struct page *(*get_pml4_page)(const union pgtable_pages_info *info);
 	struct page *(*get_pdpt_page)(const union pgtable_pages_info *info, uint64_t gpa);
 	struct page *(*get_pd_page)(const union pgtable_pages_info *info, uint64_t gpa);

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -107,6 +107,8 @@
  */
 /* End of ept_mem_type */
 
+#define EPT_ACCESSED		(1UL << 8U)
+
 #define EPT_MT_MASK		(7UL << EPT_MT_SHIFT)
 /* VTD: Second-Level Paging Entries: Snoop Control */
 #define EPT_SNOOP_CTRL		(1UL << 11U)


### PR DESCRIPTION
Also clear all accessed bit in pagetables when the VM do wbinvd. Then
the next wbinvd will benefit from it.

Tracked-On: #4703
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>