### PR TITLE
dm:refine graphics data stolen memory passthru for EHL platform

### DIFF
--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1067,7 +1067,7 @@
 
 /* Graphics definitions */
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
-#define PCIM_BDSM_GSM_MASK  		0xFFF00000 /* bits 31:20 contains the base address of stolen memory */
+#define PCIM_BDSM_MASK  		0xFFF00000
 #define PCIR_ASLS_CTL			0xFC /* Opregion start addr register */
 #define PCIM_ASLS_OPREGION_MASK	0xFFFFF000 /* opregion need 4KB aligned */
 #endif

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,7 +1066,10 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
+#define INTEL_ELKHARTLAKE		0x4551
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
+#define PCIR_GEN11_BDSM_DW0		0xC0
+#define PCIR_GEN11_BDSM_DW1		0xC4
 #define PCIM_BDSM_MASK  		0xFFF00000
 #define PCIR_ASLS_CTL			0xFC /* Opregion start addr register */
 #define PCIM_ASLS_OPREGION_MASK	0xFFFFF000 /* opregion need 4KB aligned */


### PR DESCRIPTION
EHL graphics data stolen memory(DSM) info has diff with KBL/WHL, which includes two parts:
(1) DSM register location in pci config: on KBL/WHL, the register locates on 0X5C, while on EHL, the register locates on 0xC0.
(2) DSM address length: On KBL/WHL,
DSM addr has 32 bits, while on EHL,DSM addr has 64 bits.

Here, refine graphics data stolen memory passthru to enable GVT-d on EHL platforms.
