### PR TITLE
acrn-dm: change command option name from "pcpu_list" to "cpu_affinity"

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -164,7 +164,7 @@ usage(int code)
 #endif
 		"       --vsbl: vsbl file path\n"
 		"       --ovmf: ovmf file path\n"
-		"       --pcpu_list: list of pCPUs assigned to this VM\n"
+		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
 		"       --part_info: guest partition info file path\n"
 		"       --enable_trusty: enable trusty for guest\n"
 		"       --debugexit: enable debug exit function\n"
@@ -719,7 +719,7 @@ sig_handler_term(int signo)
 enum {
 	CMD_OPT_VSBL = 1000,
 	CMD_OPT_OVMF,
-	CMD_OPT_PCPU_LIST,
+	CMD_OPT_CPU_AFFINITY,
 	CMD_OPT_PART_INFO,
 	CMD_OPT_TRUSTY_ENABLE,
 	CMD_OPT_VIRTIO_POLL_ENABLE,
@@ -759,7 +759,7 @@ static struct option long_options[] = {
 #endif
 	{"vsbl",		required_argument,	0, CMD_OPT_VSBL},
 	{"ovmf",		required_argument,	0, CMD_OPT_OVMF},
-	{"pcpu_list",		required_argument,	0, CMD_OPT_PCPU_LIST},
+	{"cpu_affinity",	required_argument,	0, CMD_OPT_CPU_AFFINITY},
 	{"part_info",		required_argument,	0, CMD_OPT_PART_INFO},
 	{"enable_trusty",	no_argument,		0,
 					CMD_OPT_TRUSTY_ENABLE},
@@ -877,8 +877,8 @@ main(int argc, char *argv[])
 				errx(EX_USAGE, "invalid ovmf param %s", optarg);
 			skip_pci_mem64bar_workaround = true;
 			break;
-		case CMD_OPT_PCPU_LIST:
-			if (acrn_parse_pcpu_list(optarg) != 0)
+		case CMD_OPT_CPU_AFFINITY:
+			if (acrn_parse_cpu_affinity(optarg) != 0)
 				errx(EX_USAGE, "invalid pcpu param %s", optarg);
 			break;
 		case CMD_OPT_PART_INFO:

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -99,12 +99,12 @@ static void add_one_pcpu(int pcpu_id)
 
 /*
  * example options:
- *   --pcpu_list 1,2,3
- *   --pcpu_list 1-3
- *   --pcpu_list 1,3,4-6
- *   --pcpu_list 1,3,4-6,9
+ *   --cpu_affinity 1,2,3
+ *   --cpu_affinity 1-3
+ *   --cpu_affinity 1,3,4-6
+ *   --cpu_affinity 1,3,4-6,9
  */
-int acrn_parse_pcpu_list(char *opt)
+int acrn_parse_cpu_affinity(char *opt)
 {
 	char *str, *cp;
 	int pcpu_id;

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -134,7 +134,7 @@ int	vm_set_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 int	vm_reset_ptdev_intx_info(struct vmctx *ctx, uint16_t virt_bdf,
 	uint16_t phys_bdf, int virt_pin, bool pic_pin);
 
-int	acrn_parse_pcpu_list(char *arg);
+int	acrn_parse_cpu_affinity(char *arg);
 int	vm_create_vcpu(struct vmctx *ctx, uint16_t vcpu_id);
 int	vm_set_vcpu_regs(struct vmctx *ctx, struct acrn_set_vcpu_regs *cpu_regs);
 


### PR DESCRIPTION
commit 71bdc27a0f9 ("acrn-dm: implement cpu_affinity command line argument")
doesn't use correct name.

Tracked-On: #4616
Signed-off-by: Zide Chen <zide.chen@intel.com>