### PR TITLE
local_gpa2hpa: INVALID_GPA also means failure of address conversion

### DIFF
--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -443,5 +443,6 @@ int32_t copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 /* gpa --> hpa -->hva */
 void *gpa2hva(struct acrn_vm *vm, uint64_t x)
 {
-	return hpa2hva(gpa2hpa(vm, x));
+	uint64_t hpa = gpa2hpa(vm, x);
+	return (hpa == INVALID_HPA) ? NULL : hpa2hva(hpa);
 }


### PR DESCRIPTION
Either INVALID_GPA or NULL returned from local_gpa2hpa means the
page walk failure. But current code only take care of NULL and
leave INVALID_GPA not detected.

It could trigger ACRN crash in root mode when guest have a invalid
gva.

We add INVALID_GPA check as well.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>