### PR TITLE
gpa2hva: add INVAVLID_HPA return value check

### DIFF
--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -113,6 +113,7 @@ static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 /**
  * @pre vm != NULL
  * @pre vm->vm_id < CONFIG_MAX_VM_NUM
+ * @pre (vm->min_mem_addr <= ACPI_XSDT_ADDR) && (ACPI_XSDT_ADDR < vm->max_mem_addr)
  */
 void build_vacpi(struct acrn_vm *vm)
 {

--- a/hypervisor/arch/x86/guest/guest_memory.c
+++ b/hypervisor/arch/x86/guest/guest_memory.c
@@ -437,5 +437,6 @@ int32_t copy_from_gva(struct acrn_vcpu *vcpu, void *h_ptr, uint64_t gva,
 /* gpa --> hpa -->hva */
 void *gpa2hva(struct acrn_vm *vm, uint64_t x)
 {
-	return hpa2hva(gpa2hpa(vm, x));
+	uint64_t hpa = gpa2hpa(vm, x);
+	return (hpa == INVALID_HPA) ? NULL : hpa2hva(hpa);
 }

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -55,6 +55,7 @@ static uint32_t create_zeropage_e820(struct zero_page *zp, const struct acrn_vm 
 
 /**
  * @pre vm != NULL
+ * @pre (vm->min_mem_addr <= kernel_load_addr) && (kernel_load_addr < vm->max_mem_addr)
  */
 static uint64_t create_zero_page(struct acrn_vm *vm)
 {


### PR DESCRIPTION
For return value of local_gpa2hpa, either INVALID_HPA or NULL
means the EPT walking failure. Current code only take care of
NULL return and leave INVALID_HPA as correct case.

In some cases (if guest page table is filled with invalid memory
address), it could crash ACRN from guest.

Add INVALID_HPA return check as well.
Also add @pre assumptions for some gpa2hpa usages.

Tracked-On: #4730
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>