### PR TITLE
HV: add a specific stack space used in CPU booting

### DIFF
--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -237,10 +237,8 @@ cpu_primary_start_64:
 
 primary_start_long_mode:
 
-    /* Initialize temporary stack pointer */
-    lea     ld_bss_end(%rip), %rsp
-    /*0x1000 = PAGE_SIZE*/
-    add     $0x1000,%rsp
+    /* Initialize temporary stack pointer, size = 0x1000 */
+    lea     stack_for_boot(%rip), %rsp
     /* 16 = CPU_STACK_ALIGN */
     and     $(~(16 - 1)),%rsp
 

--- a/hypervisor/bsp/ld/link_ram.ld.in
+++ b/hypervisor/bsp/ld/link_ram.ld.in
@@ -71,6 +71,14 @@ SECTIONS
 
     } > ram
 
+    .boot_stack :
+    {
+    /* 4K for the boot stack */
+        . += 4096;
+        stack_for_boot = .;
+        . = ALIGN(4);
+    } > ram
+
     .bss_noinit (NOLOAD):
     {
 	. = ALIGN(4) ;


### PR DESCRIPTION
The original stack used in CPU booting is: ld_bss_end + 4KB;
which could be out of the RAM size limit defined in link_ram file.

So add a specific stack space in link_ram file, and used in
CPU booting.

Tracked-On: #4738
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>