### PR TITLE
ACRN/DM: Initialize the igd_lpc bridge to ISA_BRIDGE to make Linux gu…

### DIFF
--- a/devicemodel/hw/pci/lpc.c
+++ b/devicemodel/hw/pci/lpc.c
@@ -501,6 +501,8 @@ pci_igd_lpc_init(struct vmctx *ctx, struct pci_vdev *pi, char *opts)
 	pci_set_cfgdata16(pi, PCIR_SUBVEND_0, (host_config[0x01] << 8) | host_config[0x00]);
 	pci_set_cfgdata16(pi, PCIR_SUBDEV_0, (host_config[0x03] << 8) | host_config[0x02]);
 
+	pci_set_cfgdata8(pi, PCIR_CLASS, PCIC_BRIDGE);
+	pci_set_cfgdata8(pi, PCIR_SUBCLASS, PCIS_BRIDGE_ISA);
 	return 0;
 }
 


### PR DESCRIPTION
…est happy

Currently the class type of igd_lpc bridge PCI device is not initialized.
In such case the guest driver doesn't detect the platform correctly when it
is in GVT-d mode. Then the linux i915 driver can't work.

Traced-On: #4745
Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>