### PR TITLE
doc: add note about capricious UP2 EFI firmware

### DIFF
--- a/doc/tutorials/up2.rst
+++ b/doc/tutorials/up2.rst
@@ -77,6 +77,13 @@ You will need to keep these in mind in a few places:
      # efibootmgr -c -l "\EFI\acrn\acrn.efi" -d /dev/mmcblk0 -p 1 -L "ACRN Hypervisor" \
          -u "bootloader=\EFI\org.clearlinux\bootloaderx64.efi uart=bdf@0:18.1"
 
+  .. note::
+     There have been reports that the UP2 EFI firmware does not always keep
+     these settings during a reboot. Make sure to always double-check the
+     settings if ACRN is not running correctly. There is no reliable way to
+     set this boot order and you may want to remove other, unused boot entries
+     and also change the boot order (``-o`` option).
+
 UP2 serial port setting
 =======================
 


### PR DESCRIPTION
The UP2 EFI firmware is a bit capricious and does not consistantly keep the
boot order after adding one using `efibootmgr`. There is no magic recipe (or
known reliable sequence) and hence we add a note warning the user that this
can happen, and when it does the only solution is to try modifying some more
the list of boot entries (inc. re-ordering them).

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>