### PR TITLE
acrn-config: add clearlinux UOS for launch config xmls

### DIFF
--- a/misc/acrn-config/hv_config/board_defconfig.py
+++ b/misc/acrn-config/hv_config/board_defconfig.py
@@ -203,10 +203,10 @@ def get_capacities(hv_info, config):
 def get_log_opt(hv_info, config):
 
     print("CONFIG_LOG_BUF_SIZE={}".format(hv_info.log.buf_size), file=config)
-    print("CONFIG_NPK_LOGLEVEL={}".format(hv_info.log.level.npk), file=config)
-    print("CONFIG_MEM_LOGLEVEL={}".format(hv_info.log.level.mem), file=config)
+    print("CONFIG_NPK_LOGLEVEL_DEFAULT={}".format(hv_info.log.level.npk), file=config)
+    print("CONFIG_MEM_LOGLEVEL_DEFAULT={}".format(hv_info.log.level.mem), file=config)
     print("CONFIG_LOG_DESTINATION={}".format(hv_info.log.dest), file=config)
-    print("CONFIG_CONSOLE_LOGLEVEL={}".format(hv_info.log.level.console), file=config)
+    print("CONFIG_CONSOLE_LOGLEVEL_DEFAULT={}".format(hv_info.log.level.console), file=config)
 
 
 def generate_file(hv_info, config):

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_6uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry_launch_6uos.xml
@@ -1,0 +1,205 @@
+<acrn-config board="nuc6cayh" scenario="industry" uos_launcher="6">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:0e.0 Audio device: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series Audio Cluster (rev 0b)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+    <uos id="3">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="4">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="5">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="6">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_6uox.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry_launch_6uox.xml
@@ -1,0 +1,205 @@
+<acrn-config board="nuc7i7dnb" scenario="industry" uos_launcher="6">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+    <uos id="3">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="4">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="5">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="6">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_6uox.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry_launch_6uox.xml
@@ -1,0 +1,205 @@
+<acrn-config board="whl-ipc-i5" scenario="industry" uos_launcher="6">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+    <uos id="3">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="4">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="5">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="6">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_6uox.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry_launch_6uox.xml
@@ -1,0 +1,205 @@
+<acrn-config board="whl-ipc-i7" scenario="industry" uos_launcher="6">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+    <uos id="3">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="4">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="5">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="6">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+</acrn-config>


### PR DESCRIPTION
add 6 clearlinux UOSes for launch config xmls.
fix macros log level for board defconfig.

Tracked-On: #4641
Signed-off-by: Wei Liu <weix.w.liu@intel.com>