### PR TITLE
doc: remove stray UTF-8 characters

### DIFF
--- a/doc/developer-guides/hld/virtio-gpio.rst
+++ b/doc/developer-guides/hld/virtio-gpio.rst
@@ -45,7 +45,7 @@ GPIO mapping
 -  Each User VM has only one GPIO chip instance, its number of GPIO is
    based on acrn-dm command line and GPIO base always start from 0.
 
--  Each GPIO is exclusive, User VM can’t map the same native gpio.
+-  Each GPIO is exclusive, User VM can't map the same native gpio.
 
 -  Each acrn-dm maximum number of GPIO is 64.
 
@@ -54,12 +54,12 @@ Usage
 
 Add the following parameters into the command line::
 
-        -s <slot>,virtio-gpio,<@controller_name{offset|name[=mapping_name]:offset|name[=mapping_name]:…}@controller_name{…}…]>
+        -s <slot>,virtio-gpio,<@controller_name{offset|name[=mapping_name]:offset|name[=mapping_name]:...}@controller_name{...}...]>
 
--  **controller_name**: Input “ls /sys/bus/gpio/devices” to check native
-   gpio controller information.Usually, the devices represent the
+-  **controller_name**: Input ``ls /sys/bus/gpio/devices`` to check native
+   gpio controller information. Usually, the devices represent the
    controller_name, you can use it as controller_name directly. You can
-   also input “cat /sys/bus/gpio/device/XXX/dev” to get device id that can
+   also input ``cat /sys/bus/gpio/device/XXX/dev`` to get device id that can
    be used to match /dev/XXX, then use XXX as the controller_name. On MRB
    and NUC platforms, the controller_name are gpiochip0, gpiochip1,
    gpiochip2.gpiochip3.
@@ -74,16 +74,16 @@ Example
 *******
 
 -  Map three native gpio to User VM, they are native gpiochip0 with
-   offset of 1 and 6, and with the name “reset”. In User VM, the three
+   offset of 1 and 6, and with the name ``reset``. In User VM, the three
    gpio has no name, and base from 0.::
 
         -s 10,virtio-gpio,@gpiochip0{1:6:reset}
 
--  Map four native gpio to User VM, native gpiochip0’s gpio with offset 1
+-  Map four native gpio to User VM, native gpiochip0's gpio with offset 1
    and offset 6 map to FE virtual gpio with offset 0 and offset 1
-   without names, native gpiochip0’s gpio with name “reset” maps to FE
-   virtual gpio with offset 2 and its name is “shutdown”, native
-   gpiochip1’s gpio with offset 0 maps to FE virtual gpio with offset 3 and
-   its name is “reset”.::
+   without names, native gpiochip0's gpio with name ``reset`` maps to FE
+   virtual gpio with offset 2 and its name is ``shutdown``, native
+   gpiochip1's gpio with offset 0 maps to FE virtual gpio with offset 3 and
+   its name is ``reset`` ::
 
         -s 10,virtio-gpio,@gpiochip0{1:6:reset=shutdown}@gpiochip1{0=reset}

--- a/doc/developer-guides/hld/virtio-i2c.rst
+++ b/doc/developer-guides/hld/virtio-i2c.rst
@@ -49,10 +49,10 @@ notifies the frontend. The msg process flow is shown in
 -s <slot>,virtio-i2c,<bus>[:<slave_addr>[@<node>]][:<slave_addr>[@<node>]][,<bus>[:<slave_addr>[@<node>]][:<slave_addr>][@<node>]]
 
    bus:
-   The bus number for the native I2C adapter; “2” means “/dev/i2c-2”.
+   The bus number for the native I2C adapter; ``2`` means ``/dev/i2c-2``.
 
    slave_addr:
-   he address for the native slave devices such as “1C”, “2F”...
+   The address for the native slave devices such as ``1C``, ``2F`` ...
 
    @:
    The prefix for the acpi node.
@@ -60,7 +60,7 @@ notifies the frontend. The msg process flow is shown in
    node:
    The acpi node name supported in the current code. You can find the
    supported name in the acpi_node_table[] from the source code. Currently,
-   only ‘cam1’, ‘cam2’, and ‘hdac’ are supported for MRB. These nodes are
+   only ``cam1``, ``cam2``, and ``hdac`` are supported for MRB. These nodes are
    platform-specific.
 
 

--- a/doc/release_notes/release_notes_1.5.rst
+++ b/doc/release_notes/release_notes_1.5.rst
@@ -31,7 +31,7 @@ Version 1.5 major features
 What's New in v1.5
 ==================
 * Basic CPU sharing: Fairness Round-Robin CPU Scheduling has been added to support basic CPU sharing (the Service VM and WaaG share one CPU core).
-* 8th Gen Intel® Core ™ Processors (code name Whiskey Lake) are now supported and validated.
+* 8th Gen Intel® Core™ Processors (code name Whiskey Lake) are now supported and validated.
 * Overall stability and performance has been improved.
 * An offline configuration tool has been created to help developers port ACRN to different hardware boards.
 

--- a/doc/tutorials/enable_s5.rst
+++ b/doc/tutorials/enable_s5.rst
@@ -185,7 +185,7 @@ How to test
 
       .. code-block:: console
 
-           ● life_mngr.service - ACRN lifemngr daemon
+           * life_mngr.service - ACRN lifemngr daemon
            Loaded: loaded (/usr/lib/systemd/system/life_mngr.service; enabled; vendor p>
            Active: active (running) since Tue 2019-09-10 07:15:06 UTC; 1min 11s ago
            Main PID: 840 (life_mngr)


### PR DESCRIPTION
Convert UTF-8 characters (typically pasted from Word for smart quotes
and such) into equivalent ASCII characters.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>