### PR TITLE
HV: Config Splitlock Detection to be disable

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -337,3 +337,10 @@ config IOMMU_ENFORCE_SNP
 	help
 	  GPU IOMMU doesn't support snoop control capability,
 	  To enable gvt-d,disable IOMMU snoop control by default.
+
+config ENFORCE_TURNOFF_AC
+	bool "Force to disable #AC for Split-locked Access"
+	default n
+	help
+	  If CPU has #AC for split-locked access, HV enable it and VMs can't disable.
+	  Set this to enforce turn off that #AC, for community developer only.

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -100,6 +100,7 @@ uint64_t get_active_pcpu_bitmap(void)
 
 static void enable_ac_for_splitlock(void)
 {
+#ifdef CONFIG_ENFORCE_TURNOFF_AC
 	uint64_t test_ctl;
 
 	if (has_core_cap(1U << 5U)) {
@@ -107,6 +108,7 @@ static void enable_ac_for_splitlock(void)
 		test_ctl |= (1U << 29U);
 		msr_write(MSR_TEST_CTL, test_ctl);
 	}
+#endif /*CONFIG_ENFORCE_TURNOFF_AC*/
 }
 
 void init_pcpu_pre(bool is_bsp)


### PR DESCRIPTION
 #AC should be normally enabled for slpitlock detection, however,
community developers may want to run ACRN on buggy system.
In this case, CONFIG_ENFORCE_TURNOFF_AC can be used to turn off the
 #AC, to let the guest run without #AC.

Tracked-On: #4765
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>