### PR TITLE
doc: update Zephyr document to indicate a serial port is needed

### DIFF
--- a/doc/tutorials/using_zephyr_as_uos.rst
+++ b/doc/tutorials/using_zephyr_as_uos.rst
@@ -7,6 +7,10 @@ This tutorial describes how to run Zephyr as the User VM on the ACRN hypervisor.
 Kaby Lake-based NUC (model NUC7i5DNHE) in this tutorial.
 Other :ref:`ACRN supported platforms <hardware>` should work as well.
 
+.. note::
+   A serial port connection to your platform is needed to see the Zephyr output
+   if you use a different scenario than SDC (the default in this document).
+
 Introduction to Zephyr
 **********************
 


### PR DESCRIPTION
Update the "Run Zephyr as the User VM" document to add a note indicating a
serial port connection to the platform is needed to see the Zephyr output.

Tracked-On: #4553
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>