### PR TITLE
add ACRN CDP support

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -248,6 +248,15 @@ config RDT_ENABLED
 	  various amount of HW resources such as L2 or/and L3 to VMs to achieve
 	  different Class of Service (COS, or CLOS).
 
+config CDP_ENABLED
+	bool "Enable CDP (Code and Data Prioritization)"
+	depends on RDT_ENABLED
+	default n
+	help
+	  CDP is an extension of CAT. It enables isolation and separate
+	  prioritization of code and data fetches to the L2 or L3 cache in a
+	  software configurable manner, depending on hardware support.
+
 config GPU_SBDF
 	hex "Segment, Bus, Device, and function of the GPU"
 	depends on ACPI_PARSE_ENABLED

--- a/hypervisor/arch/x86/configs/vm_config.c
+++ b/hypervisor/arch/x86/configs/vm_config.c
@@ -103,9 +103,9 @@ static bool check_vm_clos_config(uint16_t vm_id)
 	struct acrn_vm_config *vm_config = get_vm_config(vm_id);
 
 	for (i = 0U; i < vm_config->vcpu_num; i++) {
-		if (vm_config->clos[i] >= platform_clos_num) {
+		if (vm_config->clos[i] >= valid_clos_num) {
 			pr_err("vm%u: vcpu%u clos(%u) exceed the max clos(%u).",
-				vm_id, i, vm_config->clos[i], platform_clos_num);
+				vm_id, i, vm_config->clos[i], valid_clos_num);
 			ret = false;
 			break;
 		}

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -167,7 +167,7 @@ void init_pcpu_pre(bool is_bsp)
 		}
 
 #ifdef CONFIG_RDT_ENABLED
-		init_rdt_cap_info();
+		init_rdt_info();
 #endif
 
 		/* NOTE: this must call after MMCONFIG is parsed in init_vboot and before APs are INIT.

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -167,10 +167,7 @@ void init_pcpu_pre(bool is_bsp)
 		}
 
 #ifdef CONFIG_RDT_ENABLED
-		ret = init_rdt_cap_info();
-		if (ret != 0) {
-			panic("Platform RDT info is incorrect!");
-		}
+		init_rdt_cap_info();
 #endif
 
 		/* NOTE: this must call after MMCONFIG is parsed in init_vboot and before APs are INIT.
@@ -288,9 +285,7 @@ void init_pcpu_post(uint16_t pcpu_id)
 	init_sched(pcpu_id);
 
 #ifdef CONFIG_RDT_ENABLED
-	if (!setup_clos(pcpu_id)) {
-		panic("CLOS resource MSRs setup incorrectly!");
-	}
+	setup_clos(pcpu_id);
 #endif
 
 	enable_smep();

--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -19,7 +19,7 @@
 
 static struct rdt_info res_cap_info[RDT_NUM_RESOURCES] = {
 	[RDT_RESOURCE_L3] = {
-		.cache = {
+		.res.cache = {
 			.bitmask = 0U,
 			.cbm_len = 0U,
 		},
@@ -29,7 +29,7 @@ static struct rdt_info res_cap_info[RDT_NUM_RESOURCES] = {
 		.platform_clos_array = NULL
 	},
 	[RDT_RESOURCE_L2] = {
-		.cache = {
+		.res.cache = {
 			.bitmask = 0U,
 			.cbm_len = 0U,
 		},
@@ -39,7 +39,7 @@ static struct rdt_info res_cap_info[RDT_NUM_RESOURCES] = {
 		.platform_clos_array = NULL
 	},
 	[RDT_RESOURCE_MBA] = {
-		.membw = {
+		.res.membw = {
 			.mba_max = 0U,
 			.delay_linear = true,
 		},
@@ -67,8 +67,8 @@ static void rdt_read_cat_capability(int res)
 	 * CPUID.(EAX=0x10,ECX=ResID):EDX[15:0] reports the maximun CLOS supported
 	 */
 	cpuid_subleaf(CPUID_RDT_ALLOCATION, res_cap_info[res].res_id, &eax, &ebx, &ecx, &edx);
-	res_cap_info[res].cache.cbm_len = (uint16_t)((eax & 0x1fU) + 1U);
-	res_cap_info[res].cache.bitmask = ebx;
+	res_cap_info[res].res.cache.cbm_len = (uint16_t)((eax & 0x1fU) + 1U);
+	res_cap_info[res].res.cache.bitmask = ebx;
 	res_cap_info[res].clos_max = (uint16_t)(edx & 0xffffU) + 1U;
 }
 
@@ -82,8 +82,8 @@ static void rdt_read_mba_capability(int res)
 	 * CPUID.(EAX=0x10,ECX=ResID):EDX[15:0] reports the maximun CLOS supported
 	 */
 	cpuid_subleaf(CPUID_RDT_ALLOCATION, res_cap_info[res].res_id, &eax, &ebx, &ecx, &edx);
-	res_cap_info[res].membw.mba_max = (uint16_t)((eax & 0xfffU) + 1U);
-	res_cap_info[res].membw.delay_linear = ((ecx & 0x4U) != 0U) ? true : false;
+	res_cap_info[res].res.membw.mba_max = (uint16_t)((eax & 0xfffU) + 1U);
+	res_cap_info[res].res.membw.delay_linear = ((ecx & 0x4U) != 0U) ? true : false;
 	res_cap_info[res].clos_max = (uint16_t)(edx & 0xffffU) + 1U;
 }
 
@@ -152,7 +152,7 @@ static bool setup_res_clos_msr(uint16_t pcpu_id, uint16_t res, struct platform_c
 		switch (res) {
 		case RDT_RESOURCE_L3:
 		case RDT_RESOURCE_L2:
-			if ((fls32(res_clos_info->clos_mask) >= res_cap_info[res].cache.cbm_len) ||
+			if ((fls32(res_clos_info->clos_mask) >= res_cap_info[res].res.cache.cbm_len) ||
 				(res_clos_info->msr_index != (res_cap_info[res].msr_base + i))) {
 				ret = false;
 				pr_err("Fix CLOS %d mask=0x%x and(/or) MSR index=0x%x for Res_ID %d in board.c",
@@ -162,7 +162,7 @@ static bool setup_res_clos_msr(uint16_t pcpu_id, uint16_t res, struct platform_c
 			}
 			break;
 		case RDT_RESOURCE_MBA:
-			if ((res_clos_info->mba_delay > res_cap_info[res].membw.mba_max) ||
+			if ((res_clos_info->mba_delay > res_cap_info[res].res.membw.mba_max) ||
 				(res_clos_info->msr_index != (res_cap_info[res].msr_base + i))) {
 				ret = false;
 				pr_err("Fix CLOS %d delay=0x%x and(/or) MSR index=0x%x for Res_ID %d in board.c",

--- a/hypervisor/include/arch/x86/rdt.h
+++ b/hypervisor/include/arch/x86/rdt.h
@@ -23,21 +23,19 @@ enum {
 extern const uint16_t hv_clos;
 extern const uint16_t platform_clos_num;
 
-struct rdt_cache {
-	uint32_t bitmask;	/* A bitmask where each set bit indicates the corresponding cache way
-				   may be used by other entities in the platform (e.g. GPU) */
-	uint16_t cbm_len;	/* Length of Cache mask in bits */
-};
-
-struct rdt_membw {
-	uint16_t mba_max;	/* Max MBA delay throttling value supported */
-	bool delay_linear;	/* True if memory B/W delay is in linear scale */
-};
-
 /* The intel Resource Director Tech(RDT) based Allocation Tech support */
 struct rdt_info {
-	struct rdt_cache	cache;
-	struct rdt_membw	membw;
+	union {
+		struct {
+			uint32_t bitmask;	/* A bitmask where each set bit indicates the corresponding cache way
+						   may be used by other entities in the platform (e.g. GPU) */
+			uint16_t cbm_len;	/* Length of Cache mask in bits */
+		} cache;
+		struct rdt_membw {
+			uint16_t mba_max;	/* Max MBA delay throttling value supported */
+			bool delay_linear;	/* True if memory B/W delay is in linear scale */
+		} membw;
+	} res;
 	uint16_t clos_max;	/* Maximum CLOS supported, 0 indicates resource is not supported.*/
 	uint32_t res_id;
 	uint32_t msr_base;	/* MSR base to program clos mask*/

--- a/hypervisor/include/arch/x86/rdt.h
+++ b/hypervisor/include/arch/x86/rdt.h
@@ -30,6 +30,8 @@ struct rdt_info {
 			uint32_t bitmask;	/* A bitmask where each set bit indicates the corresponding cache way
 						   may be used by other entities in the platform (e.g. GPU) */
 			uint16_t cbm_len;	/* Length of Cache mask in bits */
+			bool is_cdp_enabled;	/* True if support CDP */
+			uint32_t msr_qos_cfg;	/* MSR addr to IA32_L3/L2_QOS_CFG */
 		} cache;
 		struct rdt_membw {
 			uint16_t mba_max;	/* Max MBA delay throttling value supported */
@@ -42,7 +44,7 @@ struct rdt_info {
 	struct platform_clos_info *platform_clos_array; /* user configured mask and MSR info for each CLOS*/
 };
 
-void init_rdt_cap_info(void);
+void init_rdt_info(void);
 void setup_clos(uint16_t pcpu_id);
 uint64_t clos2pqr_msr(uint16_t clos);
 bool is_platform_rdt_capable(void);

--- a/hypervisor/include/arch/x86/rdt.h
+++ b/hypervisor/include/arch/x86/rdt.h
@@ -21,7 +21,7 @@ enum {
 #define RDT_RESID_MBA   3U
 
 extern const uint16_t hv_clos;
-extern const uint16_t platform_clos_num;
+extern uint16_t valid_clos_num;
 
 /* The intel Resource Director Tech(RDT) based Allocation Tech support */
 struct rdt_info {
@@ -42,8 +42,8 @@ struct rdt_info {
 	struct platform_clos_info *platform_clos_array; /* user configured mask and MSR info for each CLOS*/
 };
 
-int32_t init_rdt_cap_info(void);
-bool setup_clos(uint16_t pcpu_id);
+void init_rdt_cap_info(void);
+void setup_clos(uint16_t pcpu_id);
 uint64_t clos2pqr_msr(uint16_t clos);
 bool is_platform_rdt_capable(void);
 


### PR DESCRIPTION
These commits add CDP support to ACRN and do some RDT code refinement.
CDP is an extension of CAT. It enables isolation and separate prioritization of
code and data fetches to the L2 or L3 cache in a software configurable manner,
depending on hardware support.

The patches are verified on EHL only for now, because it's the only platform with CDP capability we have.

Tracked-On: #4604
