### PR TITLE
hv/acrn-config: relocate HV to addr 256MB+ and hardcode hvlog under 256MB

### DIFF
--- a/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-mrb/misc_cfg.h
@@ -21,10 +21,9 @@
 #define SOS_COM2_IRQ		10U
 
 #ifndef CONFIG_RELEASE
-#define BOOTARG_DEBUG		"hvlog=2M@0x6de00000 "	\
-				"memmap=0x200000$0x6de00000 "	\
-				"memmap=0x400000$0x6da00000 "	\
-				"ramoops.mem_address=0x6da00000 "	\
+#define BOOTARG_DEBUG		"hvlog=2M@0xe00000 "	\
+				"memmap=0x600000$0xa00000 "	\
+				"ramoops.mem_address=0xa00000 "	\
 				"ramoops.mem_size=0x400000 "	\
 				"ramoops.console_size=0x200000 "	\
 				"reboot_panic=p,w "

--- a/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/apl-up2/misc_cfg.h
@@ -21,10 +21,9 @@
 #define SOS_COM2_IRQ		3U
 
 #ifndef CONFIG_RELEASE
-#define BOOTARG_DEBUG		"hvlog=2M@0x5de00000 "	\
-				"memmap=0x200000$0x5de00000 "	\
-				"memmap=0x400000$0x5da00000 "	\
-				"ramoops.mem_address=0x5da00000 "	\
+#define BOOTARG_DEBUG		"hvlog=2M@0xe00000 "	\
+				"memmap=0x600000$0xa00000 "	\
+				"ramoops.mem_address=0xa00000 "	\
 				"ramoops.mem_size=0x400000 "	\
 				"ramoops.console_size=0x200000 "	\
 				"reboot_panic=p,w "

--- a/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/dnv-cb2/misc_cfg.h
@@ -20,8 +20,7 @@
 #define SOS_COM2_IRQ		3U
 
 #ifndef CONFIG_RELEASE
-#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000 "	\
-				"memmap=0x200000$0x1fe00000 "
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0xE00000 memmap=0x200000$0xE00000 "
 #else
 #define SOS_BOOTARGS_DIFF	""
 #endif

--- a/hypervisor/arch/x86/configs/generic/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/generic/misc_cfg.h
@@ -21,8 +21,7 @@
 #define SOS_COM2_IRQ		3U
 
 #ifndef CONFIG_RELEASE
-#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000 "	\
-				"memmap=0x200000$0x1fe00000 "
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0xE00000 memmap=0x200000$0xE00000 "
 #else
 #define SOS_BOOTARGS_DIFF	""
 #endif

--- a/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc6cayh/misc_cfg.h
@@ -20,8 +20,7 @@
 #define SOS_COM2_IRQ		3U
 
 #ifndef CONFIG_RELEASE
-#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000 "	\
-				"memmap=0x200000$0x1fe00000 "
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0xE00000 memmap=0x200000$0xE00000 "
 #else
 #define SOS_BOOTARGS_DIFF	""
 #endif

--- a/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/nuc7i7dnb/misc_cfg.h
@@ -21,8 +21,7 @@
 #define SOS_COM2_IRQ		3U
 
 #ifndef CONFIG_RELEASE
-#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000 "	\
-				"memmap=0x200000$0x1fe00000 "
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0xE00000 memmap=0x200000$0xE00000 "
 #else
 #define SOS_BOOTARGS_DIFF	""
 #endif

--- a/hypervisor/arch/x86/configs/whl-ipc-i5/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/whl-ipc-i5/misc_cfg.h
@@ -22,8 +22,7 @@
 #define SOS_COM2_IRQ		3U
 
 #ifndef CONFIG_RELEASE
-#define SOS_BOOTARGS_DIFF	"hvlog=2M@0x1FE00000 "	\
-				"memmap=0x200000$0x1fe00000 "
+#define SOS_BOOTARGS_DIFF	"hvlog=2M@0xE00000 memmap=0x200000$0xE00000 "
 #else
 #define SOS_BOOTARGS_DIFF	""
 #endif

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -135,7 +135,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
-        hvlog=2M@0x6de00000 memmap=0x600000$0x6da00000 ramoops.mem_address=0x6da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+        hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x6de00000 memmap=0x600000$0x6da00000 ramoops.mem_address=0x6da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+        hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x6de00000 memmap=0x600000$0x6da00000 ramoops.mem_address=0x6da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+        hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -135,7 +135,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
-        hvlog=2M@0x5de00000 memmap=0x600000$0x5da00000 ramoops.mem_address=0x5da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+        hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x5de00000 memmap=0x600000$0x5da00000 ramoops.mem_address=0x5da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+        hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x5de00000 memmap=0x600000$0x5da00000 ramoops.mem_address=0x5da00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
+        hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -135,7 +135,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
@@ -89,7 +89,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -89,7 +89,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -135,7 +135,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -135,7 +135,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -135,7 +135,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -88,7 +88,7 @@
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
-        hvlog=2M@0x1fe00000 memmap=0x200000$0x1fe00000
+        hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>

--- a/misc/efi-stub/boot.c
+++ b/misc/efi-stub/boot.c
@@ -481,9 +481,13 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 	 * hypervisor is able to do relocation, the only requirement is that
 	 * it need to reside in memory below 4GB, call emalloc_reserved_mem()
 	 * instead.
+	 *
+	 * Don't relocate hypervisor binary under 256MB, which could be where
+	 * guest Linux kernel boots from, and other usage, e.g. hvlog buffer
 	 */
 #ifdef CONFIG_RELOC
-	err = emalloc_reserved_aligned(&hv_hpa, CONFIG_HV_RAM_SIZE, 1 << 21, MEM_ADDR_4GB);
+	err = emalloc_reserved_aligned(&hv_hpa, CONFIG_HV_RAM_SIZE, 2U * MEM_ADDR_1MB,
+		256U * MEM_ADDR_1MB, MEM_ADDR_4GB);
 #else
 	err = emalloc_fixed_addr(&hv_hpa, CONFIG_HV_RAM_SIZE, CONFIG_HV_RAM_START);
 #endif

--- a/misc/efi-stub/clearlinux/acrn.conf
+++ b/misc/efi-stub/clearlinux/acrn.conf
@@ -1,3 +1,3 @@
 title The ACRN Service OS
 linux   /EFI/org.clearlinux/kernel-org.clearlinux.iot-lts2018-sos.4.19.13-1901141830
-options console=tty0 console=ttyS0 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0x1FE00000 memmap=2M$0x1FE00000
+options console=tty0 console=ttyS0 root=PARTUUID=<UUID of rootfs partition> rw rootwait ignore_loglevel no_timer_check consoleblank=0 i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 i915.enable_guc=0 hvlog=2M@0xE00000 memmap=2M$0xE00000

--- a/misc/efi-stub/efilinux.h
+++ b/misc/efi-stub/efilinux.h
@@ -53,7 +53,8 @@ extern EFI_SYSTEM_TABLE *sys_table;
 extern EFI_BOOT_SERVICES *boot;
 
 extern EFI_STATUS
-emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align, EFI_PHYSICAL_ADDRESS maxaddr);
+emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align,
+		EFI_PHYSICAL_ADDRESS minaddr, EFI_PHYSICAL_ADDRESS maxaddr);
 
 /**
  * allocate_pages - Allocate memory pages from the system

--- a/misc/efi-stub/malloc.c
+++ b/misc/efi-stub/malloc.c
@@ -96,7 +96,7 @@ failed:
 
 EFI_STATUS
 emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align,
-		EFI_PHYSICAL_ADDRESS maxaddr)
+		EFI_PHYSICAL_ADDRESS minaddr, EFI_PHYSICAL_ADDRESS maxaddr)
 {
 	UINTN msize, mkey, desc_sz, desc_addr, pages;
 	UINT32 desc_version;
@@ -137,6 +137,10 @@ emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align,
 		if (start < 4096) {
 			start = 4096;
 		}
+
+		if (start < minaddr) {
+			start = minaddr;
+		}
 		start = (start + align - 1) & ~(align - 1);
 
 		 /* Since this routine is called during booting, memory block is large
@@ -151,7 +155,6 @@ emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align,
 				break;
 			}
 		}
-
 	}
 	if (desc_addr < (UINTN)mbuf) {
 		err = EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
Currently in most boards, hvlog and ramoops buffers are hardcoded at SOS GPA near 512MB, this could be conflicted with the relocated hypervisor image.
