### PR TITLE
doc: add note to the Celadon User VM tutorial

### DIFF
--- a/doc/tutorials/using_celadon_as_uos.rst
+++ b/doc/tutorials/using_celadon_as_uos.rst
@@ -24,6 +24,11 @@ Prerequisites
   <https://www.intel.com/content/dam/support/us/en/documents/mini-pcs/nuc-kits/NUC7i5DN_TechProdSpec.pdf>`_
   to identify the USB 3.0 port header on the main board.
 
+.. note::
+   This document uses the SDC scenario (default). You may need a serial port connection to your platform
+   or change the configuration of the User VM that will run Celadon to see its console if you use a different
+   scenario.
+
 Build Celadon from source
 *************************
 


### PR DESCRIPTION
Add a note to the "Run Celadon as the User VM" tutorial to indicate a serial
port connection to the platform (or change of the default config) may be needed
if the user uses a scenario other than SDC (the default one in the doc).

Tracked-On: #4554
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>