### PR TITLE
hv: add cpu_affinity to struct acrn_vm

### DIFF
--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -42,6 +42,7 @@ struct vm_hw_info {
 	/* vcpu array of this VM */
 	struct acrn_vcpu vcpu_array[MAX_VCPUS_PER_VM];
 	uint16_t created_vcpus;	/* Number of created vcpus */
+	uint64_t cpu_affinity;	/* Actual pCPUs this VM runs on. The set bits represent the pCPU IDs */
 } __aligned(PAGE_SIZE);
 
 struct sw_module_info {
@@ -239,7 +240,7 @@ void pause_vm(struct acrn_vm *vm);
 void resume_vm_from_s3(struct acrn_vm *vm, uint32_t wakeup_vec);
 void start_vm(struct acrn_vm *vm);
 int32_t reset_vm(struct acrn_vm *vm);
-int32_t create_vm(uint16_t vm_id, struct acrn_vm_config *vm_config, struct acrn_vm **rtn_vm);
+int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *vm_config, struct acrn_vm **rtn_vm);
 void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config);
 void launch_vms(uint16_t pcpu_id);
 bool is_poweroff_vm(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -145,9 +145,11 @@ struct acrn_vm_config {
 	enum acrn_vm_load_order load_order;		/* specify the load order of VM */
 	char name[MAX_VM_OS_NAME_LEN];			/* VM name identifier, useful for debug. */
 	const uint8_t uuid[16];				/* UUID of the VM */
-	uint16_t vcpu_num;				/* Number of vCPUs for the VM */
+	uint8_t reserved[2];				/* Temporarily reserve it so that don't need to update
+							 * the users of get_platform_info frequently.
+							 */
 	uint8_t severity;				/* severity of the VM */
-	uint64_t cpu_affinity_bitmap;			/* The set bits represent the pCPUs the vCPUs of
+	uint64_t cpu_affinity;				/* The set bits represent the pCPUs the vCPUs of
 							 * the VM may run on.
 							 */
 	uint64_t guest_flags;				/* VM flags that we want to configure for guest

--- a/hypervisor/scenarios/hybrid/vm_configurations.c
+++ b/hypervisor/scenarios/hybrid/vm_configurations.c
@@ -13,7 +13,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 		CONFIG_SAFETY_VM(1),
 		.name = "ACRN PRE-LAUNCHED VM0",
 		.guest_flags = 0UL,
-		.cpu_affinity_bitmap = VM0_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM0_CONFIG_CPU_AFFINITY,
 		.memory = {
 			.start_hpa = VM0_CONFIG_MEM_START_HPA,
 			.size = VM0_CONFIG_MEM_SIZE,
@@ -68,7 +68,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM2 */
 		CONFIG_POST_STD_VM(1),
-		.cpu_affinity_bitmap = VM2_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM2_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,

--- a/hypervisor/scenarios/industry/vm_configurations.c
+++ b/hypervisor/scenarios/industry/vm_configurations.c
@@ -39,7 +39,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM1 */
 		CONFIG_POST_STD_VM(1),
-		.cpu_affinity_bitmap = VM1_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM1_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,
@@ -53,7 +53,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM2 */
 		CONFIG_POST_RT_VM(1),
 		.guest_flags = 0UL,
-		.cpu_affinity_bitmap = VM2_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM2_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,
@@ -69,7 +69,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM3 */
 		CONFIG_POST_STD_VM(2),
-		.cpu_affinity_bitmap = VM3_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM3_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,
@@ -82,7 +82,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM4 */
 		CONFIG_POST_STD_VM(3),
-		.cpu_affinity_bitmap = VM4_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM4_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,
@@ -95,7 +95,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM5 */
 		CONFIG_POST_STD_VM(4),
-		.cpu_affinity_bitmap = VM5_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM5_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,
@@ -108,7 +108,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM6 */
 		CONFIG_POST_STD_VM(5),
-		.cpu_affinity_bitmap = VM6_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM6_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,
@@ -121,7 +121,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM7 */
 		CONFIG_KATA_VM(1),
-		.cpu_affinity_bitmap = VM7_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM7_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = COM1_BASE,

--- a/hypervisor/scenarios/logical_partition/vm_configurations.c
+++ b/hypervisor/scenarios/logical_partition/vm_configurations.c
@@ -14,7 +14,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM0 */
 		CONFIG_PRE_STD_VM(1),
 		.name = "ACRN PRE-LAUNCHED VM0",
-		.cpu_affinity_bitmap = VM0_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM0_CONFIG_CPU_AFFINITY,
 		.memory = {
 			.start_hpa = VM0_CONFIG_MEM_START_HPA,
 			.size = VM0_CONFIG_MEM_SIZE,
@@ -48,7 +48,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	{	/* VM1 */
 		CONFIG_PRE_STD_VM(2),
 		.name = "ACRN PRE-LAUNCHED VM1",
-		.cpu_affinity_bitmap = VM1_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM1_CONFIG_CPU_AFFINITY,
 		.guest_flags = (GUEST_FLAG_RT | GUEST_FLAG_LAPIC_PASSTHROUGH),
 		.memory = {
 			.start_hpa = VM1_CONFIG_MEM_START_HPA,

--- a/hypervisor/scenarios/sdc/vm_configurations.c
+++ b/hypervisor/scenarios/sdc/vm_configurations.c
@@ -37,7 +37,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 	},
 	{	/* VM1 */
 		CONFIG_POST_STD_VM(1),
-		.cpu_affinity_bitmap = VM1_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM1_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = INVALID_COM_BASE,
@@ -51,7 +51,7 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 #if CONFIG_MAX_KATA_VM_NUM > 0
 	{	/* VM2 */
 		CONFIG_KATA_VM(1),
-		.cpu_affinity_bitmap = VM2_CONFIG_CPU_AFFINITY,
+		.cpu_affinity = VM2_CONFIG_CPU_AFFINITY,
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,
 			.addr.port_base = INVALID_COM_BASE,

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -171,7 +171,7 @@ def cpu_affinity_output(vm_info, i, config):
         return
 
     cpu_bits = vm_info.get_cpu_bitmap(i)
-    print("\t\t.cpu_affinity_bitmap = VM{}_CONFIG_CPU_AFFINITY,".format(i), file=config)
+    print("\t\t.cpu_affinity = VM{}_CONFIG_CPU_AFFINITY,".format(i), file=config)
 
 
 def clos_output(vm_info, i, config):


### PR DESCRIPTION
This is to have separate cpu_affinity in both acrn_vm and vm_config, so that the configured affinity in vm_config will never be overwritten by acrn-dm. 

- add vm->hw.cpu_affinity
- change vmn_config->cpu_affinity_bitmap to vm_config->cpu_affinity
- removed vm_config->vcpu_num
