### PR TITLE
Acrnctl: Clean up pause/continue cmd

### DIFF
--- a/devicemodel/core/monitor.c
+++ b/devicemodel/core/monitor.c
@@ -338,8 +338,6 @@ static void name(struct mngr_msg *msg, int client_fd, void *param)	\
 }
 
 DEFINE_HANDLER(handle_suspend, suspend);
-DEFINE_HANDLER(handle_pause, pause);
-DEFINE_HANDLER(handle_continue, unpause);
 
 static void handle_stop(struct mngr_msg *msg, int client_fd, void *param)
 {
@@ -489,8 +487,6 @@ int monitor_init(struct vmctx *ctx)
 	ret += mngr_add_handler(monitor_fd, DM_STOP, handle_stop, NULL);
 	ret += mngr_add_handler(monitor_fd, DM_SUSPEND, handle_suspend, NULL);
 	ret += mngr_add_handler(monitor_fd, DM_RESUME, handle_resume, NULL);
-	ret += mngr_add_handler(monitor_fd, DM_PAUSE, handle_pause, NULL);
-	ret += mngr_add_handler(monitor_fd, DM_CONTINUE, handle_continue, NULL);
 	ret += mngr_add_handler(monitor_fd, DM_QUERY, handle_query, NULL);
 	ret += mngr_add_handler(monitor_fd, DM_BLKRESCAN, handle_blkrescan, NULL);
 

--- a/misc/acrn-manager/README.rst
+++ b/misc/acrn-manager/README.rst
@@ -27,8 +27,6 @@ You can see the available ``acrnctl`` commands by running:
      stop [--force/-f]
      del
      add
-     pause
-     continue
      suspend
      resume
      reset

--- a/misc/acrn-manager/acrn_mngr.h
+++ b/misc/acrn-manager/acrn_mngr.h
@@ -39,7 +39,7 @@ struct mngr_msg {
 		/* Arguments to rescan virtio-blk device */
 		char devargs[PARAM_LEN];
 
-		/* ack of DM_STOP, DM_SUSPEND, DM_RESUME, DM_PAUSE, DM_CONTINUE,
+		/* ack of DM_STOP, DM_SUSPEND, DM_RESUME,
 		   ACRND_TIMER, ACRND_STOP, ACRND_RESUME, RTC_TIMER */
 		int err;
 
@@ -94,8 +94,6 @@ enum dm_msgid {
 	DM_STOP = MSG_MAX + 1,	/* Stop this UOS */
 	DM_SUSPEND,		/* Suspend this UOS from running state */
 	DM_RESUME,		/* Resume this UOS from suspend state */
-	DM_PAUSE,		/* Freeze this virtual machine */
-	DM_CONTINUE,		/* Unfreeze this virtual machine */
 	DM_QUERY,		/* Ask power state of this UOS */
 	DM_BLKRESCAN,		/* Rescan virtio-blk device for any changes in UOS */
 	DM_MAX,

--- a/misc/acrn-manager/acrn_vm_ops.c
+++ b/misc/acrn-manager/acrn_vm_ops.c
@@ -22,7 +22,6 @@ const char *state_str[] = {
 	[VM_STATE_UNKNOWN] = "unknown",
 	[VM_CREATED] = "stopped",
 	[VM_STARTED] = "started",
-	[VM_PAUSED] = "paused",
 	[VM_SUSPENDED] = "suspended",
 	[VM_UNTRACKED] = "untracked",
 };
@@ -383,41 +382,6 @@ int stop_vm(const char *vmname, int force)
 	if (ack.data.err) {
 		printf("Error happens when try to stop vm. errno(%d)\n",
 			ack.data.err);
-	}
-
-	return ack.data.err;
-}
-
-int pause_vm(const char *vmname)
-{
-	struct mngr_msg req;
-	struct mngr_msg ack;
-
-	req.magic = MNGR_MSG_MAGIC;
-	req.msgid = DM_PAUSE;
-	req.timestamp = time(NULL);
-
-	send_msg(vmname, &req, &ack);
-	if (ack.data.err) {
-		printf("Unable to pause vm. errno(%d)\n", ack.data.err);
-	}
-
-	return ack.data.err;
-}
-
-int continue_vm(const char *vmname)
-{
-	struct mngr_msg req;
-	struct mngr_msg ack;
-
-	req.magic = MNGR_MSG_MAGIC;
-	req.msgid = DM_CONTINUE;
-	req.timestamp = time(NULL);
-
-	send_msg(vmname, &req, &ack);
-
-	if (ack.data.err) {
-		printf("Unable to continue vm. errno(%d)\n", ack.data.err);
 	}
 
 	return ack.data.err;

--- a/misc/acrn-manager/acrnctl.c
+++ b/misc/acrn-manager/acrnctl.c
@@ -32,8 +32,6 @@
 #define STOP_DESC      "Stop virtual machine VM_NAME, [--force/-f, force to stop VM]"
 #define DEL_DESC       "Delete virtual machine VM_NAME"
 #define ADD_DESC       "Add one virtual machine with SCRIPTS and OPTIONS"
-#define PAUSE_DESC     "Block all vCPUs of virtual machine VM_NAME"
-#define CONTINUE_DESC  "Start virtual machine from pause state"
 #define SUSPEND_DESC   "Switch virtual machine to suspend state"
 #define RESUME_DESC    "Resume virtual machine from suspend state"
 #define RESET_DESC     "Stop and then start virtual machine VM_NAME"
@@ -572,55 +570,6 @@ static int acrnctl_do_start(int argc, char *argv[])
 
 }
 
-static int acrnctl_do_pause(int argc, char *argv[])
-{
-	struct vmmngr_struct *s;
-	int ret = -1;
-
-	s = vmmngr_find(argv[1]);
-	if (!s) {
-		printf("Can't find vm %s\n", argv[1]);
-		return ret;
-	}
-
-	/* Send pause cmd to arcn-dm only when vm is in VM_STARTED */
-	switch (s->state) {
-		case VM_STARTED:
-			ret = pause_vm(argv[1]);
-			break;
-		default:
-			printf("%s current state %s, can't pause\n", argv[1], state_str[s->state]);
-	}
-
-	return ret;
-}
-
-static int acrnctl_do_continue(int argc, char *argv[])
-{
-	struct vmmngr_struct *s;
-	int ret = -1;
-
-	s = vmmngr_find(argv[1]);
-	if (!s) {
-		printf("Can't find vm %s\n", argv[1]);
-		return ret;
-	}
-
-	/* Per current implemention, we can't know if vm is in paused
-	   state. Send continue cmd to acrn-dm when VM_STARTED and will
-           correct it later when we have a way to check if vm has been
-	   paused */
-	switch (s->state) {
-		case VM_STARTED:
-			ret = continue_vm(argv[1]);
-			break;
-		default:
-			printf("%s current state %s, can't continue\n", argv[1], state_str[s->state]);
-	}
-
-	return ret;
-}
-
 static int acrnctl_do_suspend(int argc, char *argv[])
 {
 	struct vmmngr_struct *s;
@@ -795,8 +744,6 @@ struct acrnctl_cmd acmds[] = {
 	ACMD("stop", acrnctl_do_stop, STOP_DESC, df_valid_args),
 	ACMD("del", acrnctl_do_del, DEL_DESC, df_valid_args),
 	ACMD("add", acrnctl_do_add, ADD_DESC, valid_add_args),
-	ACMD("pause", acrnctl_do_pause, PAUSE_DESC, df_valid_args),
-	ACMD("continue", acrnctl_do_continue, CONTINUE_DESC, df_valid_args),
 	ACMD("suspend", acrnctl_do_suspend, SUSPEND_DESC, df_valid_args),
 	ACMD("resume", acrnctl_do_resume, RESUME_DESC, df_valid_args),
 	ACMD("reset", acrnctl_do_reset, RESET_DESC, df_valid_args),


### PR DESCRIPTION
The 'pause/continue' acrnctl cmd is never used and their action are not
defined for ACRN VMs. Should be removed.