### PR TITLE
acrn-config:  Add ehl board xml to support

### DIFF
--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -11,6 +11,7 @@ MISC_CFG_HEADER = """
 #define MISC_CFG_H
 """
 
+NATIVE_TTYS_DIC = {}
 MISC_CFG_END = """#endif /* MISC_CFG_H */"""
 
 
@@ -21,6 +22,83 @@ class Vuart:
     v_type = {}
     v_base = {}
     v_irq = {}
+
+
+def get_valid_ttys_for_vuart(ttys_n):
+    """
+    Get available ttysn list for vuart0/vuart1
+    :param ttys_n: the serial port was chosen as hv console
+     """
+    vuart0_valid = []
+    vuart1_valid = ['ttyS0', 'ttyS1', 'ttyS2', 'ttyS3']
+    ttys_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<TTYS_INFO>", "</TTYS_INFO>")
+    if ttys_lines:
+        vuart0_valid.clear()
+        for tty_line in ttys_lines:
+            tmp_dic = {}
+            #seri:/dev/ttySx type:mmio base:0x91526000 irq:4 bdf:"00:18.0"
+            #seri:/dev/ttySy type:portio base:0x2f8 irq:5
+            tty = tty_line.split('/')[2].split()[0]
+            ttys_irq = tty_line.split()[3].split(':')[1].strip()
+            ttys_type = tty_line.split()[1].split(':')[1].strip()
+            tmp_dic['irq'] = int(ttys_irq)
+            tmp_dic['type'] = ttys_type
+            NATIVE_TTYS_DIC[tty] = tmp_dic
+            vuart0_valid.append(tty)
+            if tty and tty in vuart1_valid:
+                vuart1_valid.remove(tty)
+
+    if not vuart1_valid:
+        common.print_yel("ttyS are fully used. ttyS0 is used for hv_console, ttyS1 is used for vuart1!", warn=True)
+        vuart1_valid = ['ttyS0', 'ttyS1', 'ttyS2', 'ttyS3']
+        if ttys_n in vuart1_valid:
+            vuart1_valid.remove(ttys_n)
+
+    return (vuart0_valid, vuart1_valid)
+
+
+def get_vuart_settings():
+    """
+    Get vuart setting from scenario setting
+    :return: vuart0/vuart1 setting dictionary
+    """
+    err_dic = {}
+    vuart0_setting = {}
+    vuart1_setting = {}
+
+    (err_dic, ttys_n) = board_cfg_lib.parser_hv_console()
+    if err_dic:
+        return err_dic
+
+    if ttys_n:
+        (vuart0_valid, vuart1_valid) = get_valid_ttys_for_vuart(ttys_n)
+
+        # VUART0 setting
+        if ttys_n not in list(NATIVE_TTYS_DIC.keys()):
+            vuart0_setting['ttyS0'] = board_cfg_lib.alloc_irq()
+        else:
+            if int(NATIVE_TTYS_DIC[ttys_n]['irq']) >= 16:
+                vuart0_setting[ttys_n] = board_cfg_lib.alloc_irq()
+            else:
+                vuart0_setting[ttys_n] = NATIVE_TTYS_DIC[ttys_n]['irq']
+    else:
+        vuart1_valid = ['ttyS1']
+
+    # VUART1 setting
+    # The IRQ of vUART1(COM2) might be hard-coded by SOS ACPI table(i.e. host ACPI),
+    # so we had better follow native COM2 IRQ assignment for vUART1 if COM2 is a legacy ttyS,
+    # otherwise function of vUART1 would be failed. If host COM2 does not exist or it is a PCI ttyS,
+    # then we could allocate a free IRQ for vUART1.
+
+    if 'ttyS1' in NATIVE_TTYS_DIC.keys() \
+        and NATIVE_TTYS_DIC['ttyS1']['type'] == "portio" \
+        and 'irq' in list(NATIVE_TTYS_DIC['ttyS1'].keys()) \
+        and NATIVE_TTYS_DIC['ttyS1']['irq'] < 16:
+        vuart1_setting['ttyS1'] = NATIVE_TTYS_DIC['ttyS1']['irq']
+    else:
+        vuart1_setting[vuart1_valid[0]] = board_cfg_lib.alloc_irq()
+
+    return (err_dic, vuart0_setting, vuart1_setting)
 
 
 def sos_bootarg_diff(sos_cmdlines, config):
@@ -52,12 +130,12 @@ def parse_boot_info():
     if 'SOS_VM' in common.VM_TYPES.values():
         sos_cmdlines = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "board_private", "bootargs").values())
         sos_rootfs = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "board_private", "rootfs").values())
-        (err_dic, vuart0_dic, vuart1_dic) = board_cfg_lib.get_board_private_vuart("board_private", "console")
+        (err_dic, vuart0_dic, vuart1_dic) = get_vuart_settings()
     else:
         sos_cmdlines = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "os_config", "bootargs").values())
 
         sos_rootfs = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "os_config", "rootfs").values())
-        (err_dic, vuart0_dic, vuart1_dic) = board_cfg_lib.get_board_private_vuart("os_config", "console")
+        (err_dic, vuart0_dic, vuart1_dic) = get_vuart_settings()
 
     return (err_dic, sos_cmdlines, sos_rootfs, vuart0_dic, vuart1_dic)
 
@@ -115,7 +193,7 @@ def generate_file(config):
     max_cpu_num = len(cpu_list)
 
     # get the vuart0/vuart1 which user chosed from scenario.xml of board_private section
-    (err_dic, ttys_n) = board_cfg_lib.parser_vuart_console()
+    (err_dic, ttys_n) = board_cfg_lib.parser_hv_console()
     if err_dic:
         return err_dic
 
@@ -135,8 +213,8 @@ def generate_file(config):
     # parse the setting ttys vuatx dic: {vmid:base/irq}
     vuart0_setting = Vuart()
     vuart1_setting = Vuart()
-    vuart0_setting = board_cfg_lib.get_vuart_info_id(common.SCENARIO_INFO_FILE, 0)
-    vuart1_setting = board_cfg_lib.get_vuart_info_id(common.SCENARIO_INFO_FILE, 1)
+    vuart0_setting = common.get_vuart_info_id(common.SCENARIO_INFO_FILE, 0)
+    vuart1_setting = common.get_vuart_info_id(common.SCENARIO_INFO_FILE, 1)
 
     # sos command lines information
     sos_cmdlines = [i for i in sos_cmdlines[0].split() if i != '']

--- a/misc/acrn-config/hv_config/board_defconfig.py
+++ b/misc/acrn-config/hv_config/board_defconfig.py
@@ -88,7 +88,7 @@ def get_serial_type():
     ttys_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<TTYS_INFO>", "</TTYS_INFO>")
 
     # Get ttySx from scenario config file which selected by user
-    (err_dic, ttyn) = board_cfg_lib.parser_vuart_console()
+    (err_dic, ttyn) = board_cfg_lib.parser_hv_console()
     if err_dic:
         hv_cfg_lib.ERR_LIST.update(err_dic)
 

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -50,12 +50,12 @@ def tap_uos_net(names, virt_io, vmid, config):
 
         print("#vm-name used to generate uos-mac address", file=config)
         print("mac=$(cat /sys/class/net/e*/address)", file=config)
-        print("vm_name=vm$1", file=config)
+        print("vm_name=post_vm_id$1", file=config)
         print("mac_seed=${mac:9:8}-${vm_name}", file=config)
         print("", file=config)
 
     if uos_type in ("VXWORKS", "ZEPHYR", "WINDOWS", "PREEMPT-RT LINUX"):
-        print("vm_name={}_vm$1".format(vm_name), file=config)
+        print("vm_name=post_vm_id$1", file=config)
 
     for net in virt_io['network'][vmid]:
         if net:
@@ -329,18 +329,18 @@ def uos_launch(names, args, virt_io, vmid, config):
         else:
             print("else", file=config)
             if gvt_args == "gvtd":
-                print('    launch_{} 1'.format(launch_uos), file=config)
+                print('    launch_{} {}'.format(launch_uos, vmid), file=config)
             elif gvt_args:
-                print('    launch_{} 1 "{}"'.format(launch_uos, gvt_args), file=config)
+                print('    launch_{} {} "{}"'.format(launch_uos, vmid, gvt_args), file=config)
             print("fi", file=config)
     else:
         if uos_type in ("VXWORKS", "PREEMPT-RT LINUX", "ZEPHYR"):
-            print("launch_{} 1".format(launch_uos), file=config)
+            print("launch_{} {}".format(launch_uos, vmid), file=config)
         if uos_type in ("CLEARLINUX", "WINDOWS"):
             if gvt_args == "gvtd":
-                print('launch_{} 1'.format(launch_uos), file=config)
+                print('launch_{} {}'.format(launch_uos, vmid), file=config)
             else:
-                print('launch_{} 1 "{}"'.format(launch_uos, gvt_args), file=config)
+                print('launch_{} {} "{}"'.format(launch_uos, vmid, gvt_args), file=config)
 
     if is_mount_needed(virt_io, vmid):
         print("", file=config)

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -356,6 +356,56 @@ def get_leaf_tag_map(config_file, branch_tag, tag_str=''):
     return dict(sorted(tmp.tag.items()))
 
 
+def get_vuart_id(tmp_vuart, leaf_tag, leaf_text):
+    """
+    Get all vuart id member of class
+    :param tmp_vuart: a dictionary to store member:value
+    :param leaf_tag: key pattern of item tag
+    :param leaf_text: key pattern of item tag's value
+    :return: a dictionary to which stored member:value
+    """
+    if leaf_tag == "type":
+        tmp_vuart['type'] = leaf_text
+    if leaf_tag == "base":
+        tmp_vuart['base'] = leaf_text
+    if leaf_tag == "irq":
+        tmp_vuart['irq'] = leaf_text
+
+    if leaf_tag == "target_vm_id":
+        tmp_vuart['target_vm_id'] = leaf_text
+    if leaf_tag == "target_uart_id":
+        tmp_vuart['target_uart_id'] = leaf_text
+
+    return tmp_vuart
+
+
+def get_vuart_info_id(config_file, idx):
+    """
+    Get vuart information by vuart id indexx
+    :param config_file: it is a file what contains information for script to read from
+    :param idx: vuart index in range: [0,1]
+    :return: dictionary which stored the vuart-id
+    """
+    tmp_tag = {}
+    vm_id = 0
+    root = get_config_root(config_file)
+    for item in root:
+        if item.tag == "vm":
+            vm_id = int(item.attrib['id'])
+
+        for sub in item:
+            tmp_vuart = {}
+            for leaf in sub:
+                if sub.tag == "vuart" and int(sub.attrib['id']) == idx:
+                    tmp_vuart = get_vuart_id(tmp_vuart, leaf.tag, leaf.text)
+
+            # append vuart for each vm
+            if tmp_vuart and sub.tag == "vuart":
+                tmp_tag[vm_id] = tmp_vuart
+
+    return tmp_tag
+
+
 def get_hv_item_tag(config_file, branch_tag, tag_str=''):
 
     tmp = ''

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -443,7 +443,7 @@ def get_pt_dev():
 
 def get_vuart1_from_scenario(vmid):
     """Get the vmid's  vuart1 base"""
-    vuart1 = board_cfg_lib.get_vuart_info_id(common.SCENARIO_INFO_FILE, 1)
+    vuart1 = common.get_vuart_info_id(common.SCENARIO_INFO_FILE, 1)
     return vuart1[vmid]['base']
 
 

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -61,7 +61,7 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["hv,DEBUG_OPTIONS,NPK_LOGLEVEL"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_LEVEL")
     scenario_item_values["hv,DEBUG_OPTIONS,MEM_LOGLEVEL"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_LEVEL")
     scenario_item_values["hv,DEBUG_OPTIONS,CONSOLE_LOGLEVEL"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_LEVEL")
-    scenario_item_values["hv,DEBUG_OPTIONS,SERIAL_CONSOLE"] = board_cfg_lib.get_ttys_info(board_info)
+    scenario_item_values["hv,DEBUG_OPTIONS,SERIAL_CONSOLE"] = board_cfg_lib.get_native_ttys_info(board_info)
     scenario_item_values["hv,DEBUG_OPTIONS,LOG_DESTINATION"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_DESTINATION_BITMAP")
 
     scenario_item_values["hv,CAPACITIES,MAX_IOAPIC_NUM"] = hv_cfg_lib.get_select_range("CAPACITIES", "IOAPIC_NUM")

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -39,7 +39,7 @@ class HwInfo:
         Get ttySn from board info
         :return: serial console list
         """
-        self.ttys_val = board_cfg_lib.get_ttys_info(self.board_info)
+        self.ttys_val = board_cfg_lib.get_native_ttys_info(self.board_info)
         return self.ttys_val
 
     def get_clos_val(self):
@@ -140,8 +140,8 @@ class VuartInfo:
         Get all items which belong to this class
         :return: None
         """
-        self.v0_vuart = board_cfg_lib.get_vuart_info_id(self.scenario_info, 0)
-        self.v1_vuart = board_cfg_lib.get_vuart_info_id(self.scenario_info, 1)
+        self.v0_vuart = common.get_vuart_info_id(self.scenario_info, 0)
+        self.v1_vuart = common.get_vuart_info_id(self.scenario_info, 1)
 
     def check_item(self):
         """

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -113,7 +113,6 @@ def gen_sos_header(vm_info, config):
     print("", file=config)
     print("#define SOS_VM_BOOTARGS\t\t\tSOS_ROOTFS\t\\", file=config)
     print("\t\t\t\t\tSOS_CONSOLE\t\\", file=config)
-    print("\t\t\t\t\tSOS_IDLE\t\\", file=config)
     print("\t\t\t\t\tSOS_BOOTARGS_DIFF", file=config)
 
 

--- a/misc/acrn-config/target/misc.py
+++ b/misc/acrn-config/target/misc.py
@@ -11,9 +11,12 @@ TTY_PATH = '/sys/class/tty/'
 SYS_IRQ_PATH = '/proc/interrupts'
 CPU_INFO_PATH = '/sys/devices/system/cpu/possible'
 
+# Please refer kernel_src/include/linux/serial_core.h
 ttys_type = {
-    '0': 'PORT',
-    '3': 'MMIO',
+    '0': 'PORT', # 8b I/O port access
+    '2': 'MMIO', # driver-specific
+    '3': 'MMIO', # 32b little endian
+    '6': 'MMIO', # 32b big endian
 }
 
 

--- a/misc/acrn-config/xmls/board-xmls/ehl-crb-b.xml
+++ b/misc/acrn-config/xmls/board-xmls/ehl-crb-b.xml
@@ -1,0 +1,368 @@
+<acrn-config board="ehl-crb-b">
+	<BIOS_INFO>
+	BIOS Information
+	Vendor: Intel Corporation
+	Version: EHLSFWI1.R00.2115.A00.2003130949
+	Release Date: 03/13/2020
+	</BIOS_INFO>
+
+	<BASE_BOARD_INFO>
+	Base Board Information
+	Manufacturer: Intel Corporation
+	Product Name: ElkhartLake LPDDR4x T3 CRB
+	Version: 2
+	</BASE_BOARD_INFO>
+
+	<PCI_DEVICE>
+	00:00.0 Host bridge: Intel Corporation Device 4532
+	00:02.0 VGA compatible controller: Intel Corporation Device 4551
+	Region 0: Memory at 82000000 (64-bit, non-prefetchable) [size=16M]
+	Region 2: Memory at 70000000 (64-bit, prefetchable) [size=256M]
+	00:08.0 System peripheral: Intel Corporation Device 4511
+	Region 0: Memory at 8335c000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:10.0 Serial bus controller [0c80]: Intel Corporation Device 4b44
+	Region 0: Memory at 6fc02000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:10.1 Serial bus controller [0c80]: Intel Corporation Device 4b45
+	Region 0: Memory at 6fc03000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:12.0 Serial bus controller [0c80]: Intel Corporation Device 4b37
+	Region 0: Memory at 6fc04000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:14.0 USB controller: Intel Corporation Device 4b7d
+	Region 0: Memory at 83340000 (64-bit, non-prefetchable) [size=64K]
+	00:14.2 RAM memory: Intel Corporation Device 4b7f
+	Region 0: Memory at 83350000 (64-bit, non-prefetchable) [disabled] [size=16K]
+	Region 2: Memory at 83360000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:15.0 Serial bus controller [0c80]: Intel Corporation Device 4b78
+	Region 0: Memory at 6fc05000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:15.2 Serial bus controller [0c80]: Intel Corporation Device 4b7a
+	Region 0: Memory at 6fc06000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:15.3 Serial bus controller [0c80]: Intel Corporation Device 4b7b
+	Region 0: Memory at 6fc07000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:16.0 Communication controller: Intel Corporation Device 4b70
+	Region 0: Memory at 83364000 (64-bit, non-prefetchable) [size=4K]
+	00:17.0 SATA controller: Intel Corporation Device 4b63
+	Region 0: Memory at 8335a000 (32-bit, non-prefetchable) [size=8K]
+	Region 1: Memory at 8336e000 (32-bit, non-prefetchable) [size=256]
+	Region 5: Memory at 8336d000 (32-bit, non-prefetchable) [size=2K]
+	00:19.0 Serial bus controller [0c80]: Intel Corporation Device 4b4b
+	Region 0: Memory at 6fc08000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:1a.0 SD Host controller: Intel Corporation Device 4b47
+	Region 0: Memory at 83366000 (64-bit, non-prefetchable) [size=4K]
+	00:1a.1 SD Host controller: Intel Corporation Device 4b48
+	Region 0: Memory at 83367000 (64-bit, non-prefetchable) [size=4K]
+	00:1a.3 Non-VGA unclassified device: Intel Corporation Device 4b4a
+	Region 0: Memory at 83300000 (64-bit, non-prefetchable) [disabled] [size=256K]
+	00:1d.0 System peripheral: Intel Corporation Device 4bb3
+	Region 0: Memory at 83000000 (64-bit, non-prefetchable) [size=2M]
+	00:1e.0 Communication controller: Intel Corporation Device 4b28
+	Region 0: Memory at 6fc09000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:1e.2 Serial bus controller [0c80]: Intel Corporation Device 4b2a
+	Region 0: Memory at 6fc0a000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:1e.4 Ethernet controller: Intel Corporation Device 4b32
+	Region 0: Memory at 6fc00000 (64-bit, non-prefetchable) [disabled] [size=8K]
+	Region 2: Memory at 8336a000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:1f.0 ISA bridge: Intel Corporation Device 4b00
+	00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58
+	Region 0: Memory at 83354000 (64-bit, non-prefetchable) [disabled] [size=16K]
+	Region 4: Memory at 83200000 (64-bit, non-prefetchable) [disabled] [size=1M]
+	00:1f.4 SMBus: Intel Corporation Device 4b23
+	Region 0: Memory at 8336b000 (64-bit, non-prefetchable) [size=256]
+	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 4b24
+	Region 0: Memory at 6fc0b000 (32-bit, non-prefetchable) [size=4K]
+	Region 1: Memory at 80000000 (32-bit, non-prefetchable) [size=32M]
+	</PCI_DEVICE>
+
+	<PCI_VID_PID>
+	00:00.0 0600: 8086:4532
+	00:02.0 0300: 8086:4551
+	00:08.0 0880: 8086:4511
+	00:10.0 0c80: 8086:4b44
+	00:10.1 0c80: 8086:4b45
+	00:12.0 0c80: 8086:4b37
+	00:14.0 0c03: 8086:4b7d
+	00:14.2 0500: 8086:4b7f
+	00:15.0 0c80: 8086:4b78
+	00:15.2 0c80: 8086:4b7a
+	00:15.3 0c80: 8086:4b7b
+	00:16.0 0780: 8086:4b70
+	00:17.0 0106: 8086:4b63
+	00:19.0 0c80: 8086:4b4b
+	00:1a.0 0805: 8086:4b47
+	00:1a.1 0805: 8086:4b48
+	00:1a.3 0000: 8086:4b4a
+	00:1d.0 0880: 8086:4bb3
+	00:1e.0 0780: 8086:4b28
+	00:1e.2 0c80: 8086:4b2a
+	00:1e.4 0200: 8086:4b32
+	00:1f.0 0601: 8086:4b00
+	00:1f.3 0401: 8086:4b58
+	00:1f.4 0c05: 8086:4b23
+	00:1f.5 0c80: 8086:4b24
+	</PCI_VID_PID>
+
+	<WAKE_VECTOR_INFO>
+	#define WAKE_VECTOR_32          0x66B9300CUL
+	#define WAKE_VECTOR_64          0x66B93018UL
+	</WAKE_VECTOR_INFO>
+
+	<RESET_REGISTER_INFO>
+	#define RESET_REGISTER_ADDRESS  0xCF9UL
+	#define RESET_REGISTER_SPACE_ID SPACE_SYSTEM_IO
+	#define RESET_REGISTER_VALUE    0x6U
+	</RESET_REGISTER_INFO>
+
+	<PM_INFO>
+	#define PM1A_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_EVT_BIT_WIDTH      0x20U
+	#define PM1A_EVT_BIT_OFFSET     0x0U
+	#define PM1A_EVT_ADDRESS        0x1800UL
+	#define PM1A_EVT_ACCESS_SIZE    0x2U
+	#define PM1B_EVT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_EVT_BIT_WIDTH      0x0U
+	#define PM1B_EVT_BIT_OFFSET     0x0U
+	#define PM1B_EVT_ADDRESS        0x0UL
+	#define PM1B_EVT_ACCESS_SIZE    0x2U
+	#define PM1A_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1A_CNT_BIT_WIDTH      0x10U
+	#define PM1A_CNT_BIT_OFFSET     0x0U
+	#define PM1A_CNT_ADDRESS        0x1804UL
+	#define PM1A_CNT_ACCESS_SIZE    0x2U
+	#define PM1B_CNT_SPACE_ID       SPACE_SYSTEM_IO
+	#define PM1B_CNT_BIT_WIDTH      0x0U
+	#define PM1B_CNT_BIT_OFFSET     0x0U
+	#define PM1B_CNT_ADDRESS        0x0UL
+	#define PM1B_CNT_ACCESS_SIZE    0x2U
+	</PM_INFO>
+
+	<S3_INFO>
+	#define S3_PKG_VAL_PM1A         0x5U
+	#define S3_PKG_VAL_PM1B         0U
+	#define S3_PKG_RESERVED         0x0U
+	</S3_INFO>
+
+	<S5_INFO>
+	#define S5_PKG_VAL_PM1A         0x7U
+	#define S5_PKG_VAL_PM1B         0U
+	#define S5_PKG_RESERVED         0x0U
+	</S5_INFO>
+
+	<DRHD_INFO>
+	#define DRHD_COUNT              2U
+
+	#define DRHD0_DEV_CNT           0x1U
+	#define DRHD0_SEGMENT           0x0U
+	#define DRHD0_FLAGS             0x0U
+	#define DRHD0_REG_BASE          0xFED90000UL
+	#define DRHD0_IGNORE            true
+	#define DRHD0_DEVSCOPE0_TYPE    0x1U
+	#define DRHD0_DEVSCOPE0_ID      0x0U
+	#define DRHD0_DEVSCOPE0_BUS     0x0U
+	#define DRHD0_DEVSCOPE0_PATH    0x10U
+
+	#define DRHD1_DEV_CNT           0x2U
+	#define DRHD1_SEGMENT           0x0U
+	#define DRHD1_FLAGS             0x1U
+	#define DRHD1_REG_BASE          0xFED91000UL
+	#define DRHD1_IGNORE            false
+	#define DRHD1_DEVSCOPE0_TYPE    0x3U
+	#define DRHD1_DEVSCOPE0_ID      0x2U
+	#define DRHD1_DEVSCOPE0_BUS     0x0U
+	#define DRHD1_DEVSCOPE0_PATH    0xf7U
+	#define DRHD1_DEVSCOPE1_TYPE    0x4U
+	#define DRHD1_DEVSCOPE1_ID      0x0U
+	#define DRHD1_DEVSCOPE1_BUS     0x0U
+	#define DRHD1_DEVSCOPE1_PATH    0xf6U
+
+	</DRHD_INFO>
+
+	<CPU_BRAND>
+	"Genuine Intel(R) CPU 0000 @ 1.90GHz"
+	</CPU_BRAND>
+
+	<CX_INFO>
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x00UL}, 0x01U, 0x01U, 0x00U},	/* C1 */
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x31UL}, 0x02U, 0x61U, 0x00U},	/* C2 */
+	{{SPACE_FFixedHW, 0x01U, 0x02U, 0x01U, 0x60UL}, 0x03U, 0x40AU, 0x00U},	/* C3 */
+	</CX_INFO>
+
+	<PX_INFO>
+	/* Px data is not available */
+	</PX_INFO>
+
+	<MMCFG_BASE_INFO>
+	/* PCI mmcfg base of MCFG */
+	#define DEFAULT_PCI_MMCFG_BASE   0xc0000000UL
+	</MMCFG_BASE_INFO>
+
+	<CLOS_INFO>
+	rdt resources supported: L2
+	rdt resource clos max: 16
+	rdt resource mask max: '0xfff'
+	</CLOS_INFO>
+
+	<IOMEM_INFO>
+	00000000-00000fff : Reserved
+	00001000-0009efff : System RAM
+	0009f000-000fffff : Reserved
+	  000a0000-000bffff : PCI Bus 0000:00
+	  000f0000-000fffff : System ROM
+	00100000-3fffffff : System RAM
+	40000000-403fffff : Reserved
+	40400000-61291fff : System RAM
+	61292000-6129afff : Reserved
+	6129b000-61b92fff : System RAM
+	61b93000-61b93fff : Reserved
+	61b94000-648a1fff : System RAM
+	648a2000-66b89fff : Reserved
+	66b8a000-66bd5fff : ACPI Non-volatile Storage
+	66bd6000-66c4efff : ACPI Tables
+	66c4f000-66c4ffff : System RAM
+	66c50000-6fbfffff : Reserved
+	6fc00000-bfffffff : PCI Bus 0000:00
+	  6fc00000-6fc01fff : 0000:00:1e.4
+	  6fc02000-6fc02fff : 0000:00:10.0
+	    6fc02000-6fc021ff : lpss_dev
+	      6fc02000-6fc021ff : i2c_designware.0
+	    6fc02200-6fc022ff : lpss_priv
+	  6fc03000-6fc03fff : 0000:00:10.1
+	    6fc03000-6fc031ff : lpss_dev
+	      6fc03000-6fc031ff : i2c_designware.1
+	    6fc03200-6fc032ff : lpss_priv
+	  6fc04000-6fc04fff : 0000:00:12.0
+	    6fc04000-6fc041ff : lpss_dev
+	      6fc04000-6fc041ff : pxa2xx-spi.2
+	    6fc04200-6fc042ff : lpss_priv
+	    6fc04800-6fc04fff : idma64.2
+	      6fc04800-6fc04fff : idma64.2
+	  6fc05000-6fc05fff : 0000:00:15.0
+	    6fc05000-6fc051ff : lpss_dev
+	      6fc05000-6fc051ff : i2c_designware.3
+	    6fc05200-6fc052ff : lpss_priv
+	    6fc05800-6fc05fff : idma64.3
+	      6fc05800-6fc05fff : idma64.3
+	  6fc06000-6fc06fff : 0000:00:15.2
+	    6fc06000-6fc061ff : lpss_dev
+	      6fc06000-6fc061ff : i2c_designware.4
+	    6fc06200-6fc062ff : lpss_priv
+	    6fc06800-6fc06fff : idma64.4
+	      6fc06800-6fc06fff : idma64.4
+	  6fc07000-6fc07fff : 0000:00:15.3
+	    6fc07000-6fc071ff : lpss_dev
+	      6fc07000-6fc071ff : i2c_designware.5
+	    6fc07200-6fc072ff : lpss_priv
+	    6fc07800-6fc07fff : idma64.5
+	      6fc07800-6fc07fff : idma64.5
+	  6fc08000-6fc08fff : 0000:00:19.0
+	    6fc08000-6fc081ff : lpss_dev
+	      6fc08000-6fc081ff : i2c_designware.6
+	    6fc08200-6fc082ff : lpss_priv
+	    6fc08800-6fc08fff : idma64.6
+	      6fc08800-6fc08fff : idma64.6
+	  6fc09000-6fc09fff : 0000:00:1e.0
+	    6fc09000-6fc091ff : lpss_dev
+	      6fc09000-6fc0901f : serial
+	    6fc09200-6fc092ff : lpss_priv
+	    6fc09800-6fc09fff : idma64.7
+	      6fc09800-6fc09fff : idma64.7
+	  6fc0a000-6fc0afff : 0000:00:1e.2
+	    6fc0a000-6fc0a1ff : lpss_dev
+	      6fc0a000-6fc0a1ff : pxa2xx-spi.8
+	    6fc0a200-6fc0a2ff : lpss_priv
+	    6fc0a800-6fc0afff : idma64.8
+	      6fc0a800-6fc0afff : idma64.8
+	  6fc0b000-6fc0bfff : 0000:00:1f.5
+	  70000000-7fffffff : 0000:00:02.0
+	    70000000-707e8fff : efifb
+	  80000000-81ffffff : 0000:00:1f.5
+	  82000000-82ffffff : 0000:00:02.0
+	  83000000-831fffff : 0000:00:1d.0
+	    83000000-831fffff : intel_ish_ipc
+	  83200000-832fffff : 0000:00:1f.3
+	  83300000-8333ffff : 0000:00:1a.3
+	  83340000-8334ffff : 0000:00:14.0
+	    83340000-8334ffff : xhci-hcd
+	  83350000-83353fff : 0000:00:14.2
+	  83354000-83357fff : 0000:00:1f.3
+	  83358200-83358203 : INTC1033:00
+	  83358204-83358207 : INTC1033:00
+	  8335a000-8335bfff : 0000:00:17.0
+	    8335a000-8335bfff : ahci
+	  8335c000-8335cfff : 0000:00:08.0
+	  83360000-83360fff : 0000:00:14.2
+	  83364000-83364fff : 0000:00:16.0
+	    83364000-83364fff : mei_me
+	  83366000-83366fff : 0000:00:1a.0
+	    83366000-83366fff : mmc0
+	  83367000-83367fff : 0000:00:1a.1
+	  8336a000-8336afff : 0000:00:1e.4
+	  8336b000-8336b0ff : 0000:00:1f.4
+	  8336d000-8336d7ff : 0000:00:17.0
+	    8336d000-8336d7ff : ahci
+	  8336e000-8336e0ff : 0000:00:17.0
+	    8336e000-8336e0ff : ahci
+	c0000000-cfffffff : PCI MMCONFIG 0000 [bus 00-ff]
+	  c0000000-cfffffff : pnp 00:03
+	fd000000-fd68ffff : pnp 00:04
+	fd690000-fd69ffff : INTC1020:00
+	fd6a0000-fd6affff : INTC1020:00
+	fd6b0000-fd6bffff : INTC1020:00
+	fd6c0000-fd6cffff : INTC1020:00
+	fd6d0000-fd6dffff : INTC1020:00
+	fd6e0000-fd6effff : INTC1020:00
+	fd6f0000-fdffffff : pnp 00:04
+	fe000000-fe01ffff : pnp 00:04
+	fe032000-fe032fff : pnp 00:02
+	fe033000-fe033fff : pnp 00:02
+	fe040000-fe040007 : serial
+	fe040008-fe040fff : pnp 00:06
+	fe041000-fe041fff : pnp 00:06
+	fe042000-fe042007 : pnp 00:08
+	fe042008-fe042fff : pnp 00:06
+	fe043000-fe043fff : pnp 00:06
+	fe200000-fe7fffff : pnp 00:04
+	fec00000-fec003ff : IOAPIC 0
+	fec80000-fecfffff : pnp 00:03
+	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
+	fed20000-fed7ffff : Reserved
+	  fed40000-fed44fff : INTC6001:00
+	fed90000-fed90fff : dmar0
+	fed91000-fed91fff : dmar1
+	feda0000-feda0fff : pnp 00:03
+	feda1000-feda1fff : pnp 00:03
+	fee00000-feefffff : pnp 00:03
+	  fee00000-fee00fff : Local APIC
+	ff300000-ffffffff : Reserved
+	100000000-2903fffff : System RAM
+	  16c000000-16d202390 : Kernel code
+	  16d400000-16d9f9fff : Kernel rodata
+	  16da00000-16dbed63f : Kernel data
+	  16ddd6000-16e9fffff : Kernel bss
+	290400000-293ffffff : RAM buffer
+	</IOMEM_INFO>
+
+	<BLOCK_DEVICE_INFO>
+	/dev/mmcblk0p3: TYPE="ext4"
+	/dev/sda3: TYPE="ext4"
+	/dev/sdb2: TYPE="ext4"
+	/dev/sdb3: TYPE="ext4"
+	/dev/sdb4: TYPE="ext4"
+	</BLOCK_DEVICE_INFO>
+
+	<TTYS_INFO>
+	seri:/dev/ttyS0 type:mmio base:0xFE040000 irq:17 bdf:"00:10.1"
+	seri:/dev/ttyS1 type:mmio base:0x6FC09000 irq:16 bdf:"00:10.0"
+	</TTYS_INFO>
+
+	<AVAILABLE_IRQ_INFO>
+	3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15
+	</AVAILABLE_IRQ_INFO>
+
+	<TOTAL_MEM_INFO>
+	8018660 kB
+	</TOTAL_MEM_INFO>
+
+	<CPU_PROCESSOR_INFO>
+	0, 1, 2, 3
+	</CPU_PROCESSOR_INFO>
+
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='utf-8'?>
+<acrn-config board="ehl-crb-b" scenario="hybrid">
+    <hv>
+        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
+            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
+            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
+            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        </DEBUG_OPTIONS>
+        <FEATURES>
+            <RELOC desc="Enable hypervisor relocation">y</RELOC>
+            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
+            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        </FEATURES>
+        <MEMORY>
+            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
+            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
+            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
+            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        </MEMORY>
+        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
+            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        </CAPACITIES>
+        <MISC_CFG>
+            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name.">\\EFI\\org.clearlinux\\bootloaderx64.efi</UEFI_OS_LOADER_NAME>
+        </MISC_CFG>
+    </hv>
+    <vm id="0">
+        <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
+        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id>3</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <memory>
+            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+            <size desc="The memory size in Bytes for the VM">0x20000000</size>
+            <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+            <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        </memory>
+        <os_config>
+            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
+            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
+            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
+            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
+            <bootargs desc="Specify kernel boot arguments" />
+            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
+            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        </os_config>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+        <pci_devs configurable="0" desc="pci devices list">
+            <pci_dev desc="pci device" />
+        </pci_devs>
+    </vm>
+    <vm id="1">
+        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
+        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <memory>
+            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        </memory>
+        <os_config>
+            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
+            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        </os_config>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+        <pci_devs configurable="0" desc="pci devices list">
+            <pci_dev desc="pci device" />
+        </pci_devs>
+        <board_private>
+            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+            <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
+        </bootargs>
+        </board_private>
+    </vm>
+    <vm id="2">
+        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+            <pcpu_id>2</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        </vuart>
+    </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='utf-8'?>
+<acrn-config board="ehl-crb-b" scenario="industry">
+    <hv>
+        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
+            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
+            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
+            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        </DEBUG_OPTIONS>
+        <FEATURES>
+            <RELOC desc="Enable hypervisor relocation">y</RELOC>
+            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
+            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        </FEATURES>
+        <MEMORY>
+            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
+            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
+            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
+            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        </MEMORY>
+        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
+            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        </CAPACITIES>
+        <MISC_CFG>
+            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name.">\\EFI\\org.clearlinux\\bootloaderx64.efi</UEFI_OS_LOADER_NAME>
+        </MISC_CFG>
+    </hv>
+    <vm id="0">
+        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
+        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <memory>
+            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+            <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        </memory>
+        <os_config>
+            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+            <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
+            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
+            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        </os_config>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+        <pci_devs configurable="0" desc="pci devices list">
+            <pci_dev desc="pci device" />
+        </pci_devs>
+        <board_private>
+            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+            <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        </bootargs>
+        </board_private>
+    </vm>
+    <vm id="1">
+        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+            <pcpu_id>1</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+    </vm>
+    <vm id="2">
+        <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+            <pcpu_id>2</pcpu_id>
+            <pcpu_id>3</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+    </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -1,0 +1,37 @@
+<acrn-config board="ehl-crb-b" scenario="industry" uos_launcher="1">
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_vxworks.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_vxworks.xml
@@ -1,0 +1,37 @@
+<acrn-config board="ehl-crb-b" scenario="industry" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">VXWORKS</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./VxWorks.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_waag.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_waag.xml
@@ -1,0 +1,37 @@
+<acrn-config board="ehl-crb-b" scenario="industry" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_2uos.xml
@@ -1,0 +1,73 @@
+<acrn-config board="ehl-crb-b" scenario="industry" uos_launcher="2">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry_launch_6uos.xml
@@ -1,0 +1,205 @@
+<acrn-config board="ehl-crb-b" scenario="industry" uos_launcher="6">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+    <uos id="3">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="4">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="5">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="6">
+        <uos_type desc="UOS type">CLEARLINUX</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -1,0 +1,152 @@
+<?xml version='1.0' encoding='utf-8'?>
+<acrn-config board="ehl-crb-b" scenario="logical_partition">
+    <hv>
+        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
+            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
+            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
+            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        </DEBUG_OPTIONS>
+        <FEATURES>
+            <RELOC desc="Enable hypervisor relocation">y</RELOC>
+            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
+            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        </FEATURES>
+        <MEMORY>
+            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
+            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
+            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
+            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        </MEMORY>
+        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
+            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        </CAPACITIES>
+        <MISC_CFG>
+            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name.">\\EFI\\org.clearlinux\\bootloaderx64.efi</UEFI_OS_LOADER_NAME>
+        </MISC_CFG>
+    </hv>
+    <vm id="0">
+        <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
+        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
+        <uuid configurable="0" desc="vm uuid">26c5e0d8-8f8a-47d8-8109-f201ebd61a5e</uuid>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag />
+            <guest_flag />
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id>0</pcpu_id>
+            <pcpu_id>2</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <memory>
+            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
+            <size desc="The memory size in Bytes for the VM">0x20000000</size>
+            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        </memory>
+        <os_config>
+            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
+            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+            <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        </bootargs>
+        </os_config>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+        <pci_devs desc="pci devices list">
+            <pci_dev desc="pci device" />
+            <pci_dev desc="pci device" />
+        </pci_devs>
+    </vm>
+    <vm id="1">
+        <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
+        <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
+        <uuid configurable="0" desc="vm uuid">dd87ce08-66f9-473d-bc58-7605837f935e</uuid>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>GUEST_FLAG_RT</guest_flag>
+            <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id>1</pcpu_id>
+            <pcpu_id>3</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <memory>
+            <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
+            <size desc="The memory size in Bytes for the VM">0x20000000</size>
+            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
+            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        </memory>
+        <os_config>
+            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ClearLinux</name>
+            <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
+            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
+            <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
+            <bootargs desc="Specify kernel boot arguments">
+        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        consoleblank=0 tsc=reliable
+        </bootargs>
+        </os_config>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+        <pci_devs desc="pci devices list">
+            <pci_dev desc="pci device" />
+            <pci_dev desc="pci device" />
+        </pci_devs>
+    </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -1,0 +1,143 @@
+<?xml version='1.0' encoding='utf-8'?>
+<acrn-config board="ehl-crb-b" scenario="sdc">
+    <hv>
+        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
+            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
+            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
+            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        </DEBUG_OPTIONS>
+        <FEATURES>
+            <RELOC desc="Enable hypervisor relocation">y</RELOC>
+            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
+            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        </FEATURES>
+        <MEMORY>
+            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
+            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
+            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
+            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        </MEMORY>
+        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
+            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        </CAPACITIES>
+        <MISC_CFG>
+            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name.">\\EFI\\org.clearlinux\\bootloaderx64.efi</UEFI_OS_LOADER_NAME>
+        </MISC_CFG>
+    </hv>
+    <vm id="0">
+        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
+        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <memory>
+            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
+            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        </memory>
+        <os_config>
+            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
+            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
+            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
+            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
+            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        </os_config>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+        <pci_devs configurable="0" desc="pci devices list">
+            <pci_dev desc="pci device" />
+        </pci_devs>
+        <board_private>
+            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+            <bootargs desc="Specify kernel boot arguments">
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        </bootargs>
+        </board_private>
+    </vm>
+    <vm id="1">
+        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
+        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+            <guest_flag>0</guest_flag>
+        </guest_flags>
+        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+            <pcpu_id>1</pcpu_id>
+        </cpu_affinity>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        </vuart>
+    </vm>
+    <vm configurable="1" desc="specific for Kata" id="2">
+        <vm_type desc="Specify the VM type" readonly="true">KATA_VM</vm_type>
+        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+        </clos>
+        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+            <pcpu_id>1</pcpu_id>
+        </cpu_affinity>
+        <epc_section configurable="0" desc="epc section">
+            <base desc="SGX EPC section base, must be page aligned">0</base>
+            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        </epc_section>
+        <vuart id="0">
+            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
+            <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        </vuart>
+        <vuart id="1">
+            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
+            <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
+            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
+            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        </vuart>
+    </vm>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_laag.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_laag.xml
@@ -1,0 +1,37 @@
+<acrn-config board="ehl-crb-b" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">CLEARLINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">2048</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">64 448 8</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">LaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">/home/clear/uos/uos.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_zephyr.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_zephyr.xml
@@ -1,0 +1,37 @@
+<acrn-config board="ehl-crb-b" scenario="sdc" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">ZEPHYR</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">128</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./zephyr.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@pty:pty_port</console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/generic/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         </bootargs>
     </board_private>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
@@ -87,7 +87,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -87,7 +87,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/tgl-rvp/industry.xml
@@ -86,7 +86,7 @@
         <board_private>
             <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
             <bootargs desc="Specify kernel boot arguments">        rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1 idle=halt
+        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         </bootargs>
         </board_private>
     </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -133,7 +133,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -86,7 +86,7 @@
     <board_private>
         <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 idle=halt
+        rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>


### PR DESCRIPTION
- add board and default config xmls for ehl
- refine the 'vm_name' parameter for launch script
- generate correct IRQ for VUART1
- refinement acrn-dm arguments for "Soft RT/Hard RT" VMs
- refine ttys type for mapping MMIO
- remove 'idle=halt' from sos bootargs

    Tracked-On: #4798
    Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
    Acked-by: Terry Zou <terry.zou@intel.com>
