### PR TITLE
vpci: some minor refine

### DIFF
--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -35,7 +35,6 @@
 /*
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static void vdev_pt_unmap_msix(struct pci_vdev *vdev)
 {
@@ -63,7 +62,6 @@ static void vdev_pt_unmap_msix(struct pci_vdev *vdev)
 /*
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 void vdev_pt_map_msix(struct pci_vdev *vdev, bool hold_lock)
 {
@@ -89,7 +87,6 @@ void vdev_pt_map_msix(struct pci_vdev *vdev, bool hold_lock)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static void vdev_pt_unmap_mem_vbar(struct pci_vdev *vdev, uint32_t idx)
 {
@@ -111,7 +108,6 @@ static void vdev_pt_unmap_mem_vbar(struct pci_vdev *vdev, uint32_t idx)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static void vdev_pt_map_mem_vbar(struct pci_vdev *vdev, uint32_t idx)
 {
@@ -136,7 +132,6 @@ static void vdev_pt_map_mem_vbar(struct pci_vdev *vdev, uint32_t idx)
  * @brief Allow IO bar access
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static void vdev_pt_allow_io_vbar(struct pci_vdev *vdev, uint32_t idx)
 {
@@ -155,7 +150,6 @@ static void vdev_pt_allow_io_vbar(struct pci_vdev *vdev, uint32_t idx)
  * @brief Deny IO bar access
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static void vdev_pt_deny_io_vbar(struct pci_vdev *vdev, uint32_t idx)
 {
@@ -242,7 +236,6 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
  *
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  *
  * @return None
@@ -365,7 +358,6 @@ static void init_bars(struct pci_vdev *vdev, bool is_sriov_bar)
  *
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  *
  * @return None

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -390,7 +390,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 			pci_pdev_write_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U, pci_command);
 		}
 	} else {
-		if (!is_own_device(vpci2vm(vdev->phyfun->vpci), vdev)) {
+		if (vdev->phyfun->vpci != vdev->vpci) {
 			/* VF is assigned to a UOS */
 			uint32_t vid, did;
 
@@ -426,7 +426,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 void deinit_vdev_pt(struct pci_vdev *vdev) {
 
 	/* Check if the vdev is an unassigned SR-IOV VF device */
-	if ((vdev->phyfun != NULL) && (is_own_device(vpci2vm(vdev->phyfun->vpci), vdev))) {
+	if ((vdev->phyfun != NULL) && (vdev->phyfun->vpci == vdev->vpci)) {
 		uint32_t bar_idx;
 
 		/* Delete VF MMIO from EPT table since the VF physical device has gone */

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -86,10 +86,15 @@ static void init_vhostbridge(struct pci_vdev *vdev)
 	pci_vdev_write_vcfg(vdev, 0xf5U, 1U, 0xfU);
 	pci_vdev_write_vcfg(vdev, 0xf6U, 1U, 0x1cU);
 	pci_vdev_write_vcfg(vdev, 0xf7U, 1U, 0x1U);
+
+	vdev->parent_user = NULL;
+	vdev->user = vdev;
 }
 
 static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
 {
+	vdev->parent_user = NULL;
+	vdev->user = NULL;
 }
 
 

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -42,7 +42,6 @@
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static void init_vhostbridge(struct pci_vdev *vdev)
 {
@@ -101,7 +100,6 @@ static void deinit_vhostbridge(__unused struct pci_vdev *vdev)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static int32_t read_vhostbridge_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t *val)
@@ -114,7 +112,6 @@ static int32_t read_vhostbridge_cfg(const struct pci_vdev *vdev, uint32_t offset
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 static int32_t write_vhostbridge_cfg(struct pci_vdev *vdev, uint32_t offset,
 	uint32_t bytes, uint32_t val)

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -127,10 +127,11 @@ void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-void deinit_vmsi(const struct pci_vdev *vdev)
+void deinit_vmsi(struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
 		ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->bdf.value, 1U);
+		(void)memset((void *)&vdev->msi, 0U, sizeof(struct pci_msi));
 	}
 }
 

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -128,7 +128,7 @@ void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
 void deinit_vmsi(struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
-		ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->bdf.value, 1U);
+		ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->pdev->bdf.value, 1U);
 		(void)memset((void *)&vdev->msi, 0U, sizeof(struct pci_msi));
 	}
 }

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -57,7 +57,6 @@ static inline void enable_disable_msi(const struct pci_vdev *vdev, bool enable)
  *
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  */
 static void remap_vmsi(const struct pci_vdev *vdev)
@@ -125,7 +124,6 @@ void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 void deinit_vmsi(struct pci_vdev *vdev)
 {

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -195,7 +195,7 @@ int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_
 
 	vdev = (struct pci_vdev *)handler_private_data;
 	/* This device has not be assigned to other OS */
-	if (vdev->new_owner == NULL) {
+	if (vdev->user == vdev) {
 		offset = mmio->address - vdev->msix.mmio_gpa;
 
 		if (msixtable_access(vdev, (uint32_t)offset)) {

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -264,7 +264,7 @@ void deinit_vmsix(struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {
-			ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->bdf.value, vdev->msix.table_count);
+			ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->pdev->bdf.value, vdev->msix.table_count);
 			(void)memset((void *)&vdev->msix, 0U, sizeof(struct pci_msix));
 		}
 	}

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -262,11 +262,12 @@ void init_vmsix(struct pci_vdev *vdev)
  * @pre vdev->vpci != NULL
  * @pre vdev->vpci->vm != NULL
  */
-void deinit_vmsix(const struct pci_vdev *vdev)
+void deinit_vmsix(struct pci_vdev *vdev)
 {
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {
 			ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->bdf.value, vdev->msix.table_count);
+			(void)memset((void *)&vdev->msix, 0U, sizeof(struct pci_msix));
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -72,7 +72,6 @@ static void mask_one_msix_vector(const struct pci_vdev *vdev, uint32_t index)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  * @pre vdev->pdev != NULL
  */
 static void remap_one_vmsix_entry(const struct pci_vdev *vdev, uint32_t index)
@@ -260,7 +259,6 @@ void init_vmsix(struct pci_vdev *vdev)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
  */
 void deinit_vmsix(struct pci_vdev *vdev)
 {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -299,8 +299,7 @@ void deinit_vpci(struct acrn_vm *vm)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
- * @pre vdev->vpci->vm->iommu != NULL
+ * @pre vpci2vm(vdev->vpci)->iommu != NULL
  */
 static void assign_vdev_pt_iommu_domain(struct pci_vdev *vdev)
 {
@@ -317,8 +316,7 @@ static void assign_vdev_pt_iommu_domain(struct pci_vdev *vdev)
 /**
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
- * @pre vdev->vpci->vm != NULL
- * @pre vdev->vpci->vm->iommu != NULL
+ * @pre vpci2vm(vdev->vpci)->iommu != NULL
  */
 static void remove_vdev_pt_iommu_domain(const struct pci_vdev *vdev)
 {
@@ -351,7 +349,6 @@ static void remove_vdev_pt_iommu_domain(const struct pci_vdev *vdev)
  * @param bdf  Indicate the vdev's BDF
  *
  * @pre vpci != NULL
- * @pre vpci->vm != NULL
  *
  * @return Return a available vdev instance, otherwise return NULL
  */

--- a/hypervisor/dm/vpci/vpci_bridge.c
+++ b/hypervisor/dm/vpci/vpci_bridge.c
@@ -70,10 +70,15 @@ static void init_vpci_bridge(struct pci_vdev *vdev)
 	pci_vdev_write_vcfg(vdev, PCIR_HDRTYPE, 1U, (PCIM_HDRTYPE_BRIDGE | PCIM_MFDEV));
 	pci_vdev_write_vcfg(vdev, PCIR_CLASS, 1U, PCIC_BRIDGE);
 	pci_vdev_write_vcfg(vdev, PCIR_SUBCLASS, 1U, PCIS_BRIDGE_PCI);
+
+	vdev->parent_user = NULL;
+	vdev->user = vdev;
 }
 
 static void deinit_vpci_bridge(__unused struct pci_vdev *vdev)
 {
+	vdev->parent_user = NULL;
+	vdev->user = NULL;
 }
 
 static int32_t read_vpci_bridge_cfg(const struct pci_vdev *vdev, uint32_t offset,

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -120,13 +120,13 @@ void vdev_pt_map_msix(struct pci_vdev *vdev, bool hold_lock);
 void init_vmsi(struct pci_vdev *vdev);
 void read_vmsi_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void deinit_vmsi(const struct pci_vdev *vdev);
+void deinit_vmsi(struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_private_data);
 void read_vmsix_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_vmsix_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void deinit_vmsix(const struct pci_vdev *vdev);
+void deinit_vmsix(struct pci_vdev *vdev);
 
 void init_vsriov(struct pci_vdev *vdev);
 void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -208,7 +208,6 @@ static void enable_vfs(struct pci_vdev *pf_vdev)
 			} else {
 				/* Re-activate a zombie VF */
 				if (is_zombie_vf(vf_vdev)) {
-					vf_vdev->vpci = pf_vdev->vpci;
 					vf_vdev->vdev_ops->init_vdev(vf_vdev);
 				}
 			}
@@ -252,7 +251,6 @@ static void disable_vfs(struct pci_vdev *pf_vdev)
 		if ((vf_vdev != NULL) && (!is_zombie_vf(vf_vdev))) {
 			/* set disabled VF as zombie vdev instance */
 			vf_vdev->vdev_ops->deinit_vdev(vf_vdev);
-			vf_vdev->vpci = NULL;
 		}
 	}
 }

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -130,7 +130,7 @@ void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, bo
  * Remove the mapping of given number of vectors of the given virtual BDF for the given vm.
  *
  * @param[in] vm pointer to acrn_vm
- * @param[in] virt_bdf virtual bdf associated with the passthrough device
+ * @param[in] phys_bdf physical bdf associated with the passthrough device
  * @param[in] vector_count number of vectors
  *
  * @return None
@@ -138,7 +138,7 @@ void ptirq_remove_intx_remapping(const struct acrn_vm *vm, uint32_t virt_gsi, bo
  * @pre vm != NULL
  *
  */
-void ptirq_remove_msix_remapping(const struct acrn_vm *vm, uint16_t virt_bdf, uint32_t vector_count);
+void ptirq_remove_msix_remapping(const struct acrn_vm *vm, uint16_t phys_bdf, uint32_t vector_count);
 
 /**
   * @}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -209,19 +209,6 @@ static inline uint16_t vmid_2_rel_vmid(uint16_t sos_vmid, uint16_t vmid) {
 }
 
 /**
- * @brief Check if the vdev belongs to the vm
- *
- * @param vm   Pointer to a vm instance
- * @param vdev Pointer to a vdev instance
- *
- * @return  If the vm owns the vdev device return true, otherwsie return false
- */
-static inline bool is_own_device(const struct acrn_vm *vm, const struct pci_vdev *vdev)
-{
-	return (&vm->vpci == vdev->vpci);
-}
-
-/**
  * @brief Check if the specified vdev is a zombie VF instance
  *
  * @param vdev Pointer to vdev instance

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -96,7 +96,7 @@ struct pci_vdev_ops {
 };
 
 struct pci_vdev {
-	const struct acrn_vpci *vpci;
+	struct acrn_vpci *vpci;
 	/* The bus/device/function triple of the virtual PCI device. */
 	union pci_bdf bdf;
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -123,8 +123,16 @@ struct pci_vdev {
 	/* Pointer to corressponding operations */
 	const struct pci_vdev_ops *vdev_ops;
 
-	/* For SOS, if the device is latterly assigned to a UOS, we use this field to track the new owner. */
-	struct pci_vdev *new_owner;
+	/*
+	 * vdev in    |   HV       |   pre-VM       |               SOS                   | post-VM
+	 *            |            |                |vdev used by SOS|vdev used by post-VM|
+	 * -----------------------------------------------------------------------------------------------
+	 * parent_user| NULL(HV)   |   NULL(HV)     |   NULL(HV)     |   NULL(HV)         | vdev in SOS
+	 * -----------------------------------------------------------------------------------------------
+	 * user       | vdev in HV | vdev in pre-VM |   vdev in SOS  |   vdev in post-VM  | vdev in post-VM
+	 */
+	struct pci_vdev *parent_user;
+	struct pci_vdev *user;
 };
 
 union pci_cfg_addr_reg {


### PR DESCRIPTION
v3:
Split the patch v2 [1/3] into three small patches and detial the comment.

v2:
refine the patch [1/3] comments

Li Fei1 (5):
  hv: vpci: minor refine the vdev ownership data structure
  hv: vpci: remove is_own_device()
  hv: vpci: refine vpci deinit
  hv: vpci: remove vpci->vm not equal to null pre-condition
  hv: ptdev: refine look up MSI ptirq entry

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>