### PR TITLE
lib: introduce Hashing to speed up searching

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -49,40 +49,6 @@ static struct acrn_vcpu *is_single_destination(struct acrn_vm *vm, const struct 
 	return vcpu;
 }
 
-/*
- * lookup a ptdev entry by sid
- * Before adding a ptdev remapping, should lookup by physical sid to check
- * whether the resource has been token by others.
- * When updating a ptdev remapping, should lookup by virtual sid to check
- * whether this resource is valid.
- * @pre: vm must be NULL when lookup by physical sid, otherwise,
- * vm must not be NULL when lookup by virtual sid.
- */
-static inline struct ptirq_remapping_info *
-find_ptirq_entry(uint32_t intr_type,
-		const union source_id *sid, const struct acrn_vm *vm)
-{
-	uint16_t idx;
-	struct ptirq_remapping_info *entry;
-	struct ptirq_remapping_info *entry_found = NULL;
-
-	for (idx = 0U; idx < CONFIG_MAX_PT_IRQ_ENTRIES; idx++) {
-		entry = &ptirq_entries[idx];
-		if (!is_entry_active(entry)) {
-			continue;
-		}
-		if ((intr_type == entry->intr_type) &&
-			((vm == NULL) ?
-			(sid->value == entry->phys_sid.value) :
-			((vm == entry->vm) &&
-			(sid->value == entry->virt_sid.value)))) {
-			entry_found = entry;
-			break;
-		}
-	}
-	return entry_found;
-}
-
 static uint32_t calculate_logical_dest_mask(uint64_t pdmask)
 {
 	uint32_t dest_mask = 0UL;

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -120,6 +120,8 @@ typedef void (*ptirq_arch_release_fn_t)(const struct ptirq_remapping_info *entry
  * with interrupt handler and softirq.
  */
 struct ptirq_remapping_info {
+	struct hlist_node phys_link;
+	struct hlist_node virt_link;
 	uint16_t ptdev_entry_id;
 	uint32_t intr_type;
 	union source_id phys_sid;
@@ -158,6 +160,22 @@ extern spinlock_t ptdev_lock;
  * @{
  */
 
+
+/*
+ * @brief Find a ptdev entry by sid
+ *
+ * param[in] intr_type interrupt type of the ptirq entry
+ * param[in] sid source id of the ptirq entry
+ * param[in] vm vm pointer of the ptirq entry if find the ptdev entry by virtual sid
+ *
+ * @retval NULL when \p when no ptirq entry match the sid
+ * @retval ptirq entry when \p there is available ptirq entry match the sid
+ *
+ * @pre: vm must be NULL when lookup by physical sid, otherwise,
+ * vm must not be NULL when lookup by virtual sid.
+ */
+struct ptirq_remapping_info *find_ptirq_entry(uint32_t intr_type,
+		const union source_id *sid, const struct acrn_vm *vm);
 
 /**
  * @brief Handler of softirq for passthrough device.

--- a/hypervisor/include/lib/hash.h
+++ b/hypervisor/include/lib/hash.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef HASH_H
+#define HASH_H
+
+#include <types.h>
+
+/*
+ * Hash factor is selected following below formula:
+ *  - factor64 = 2^64 * ((sqrt(5) - 1)/2)
+ * here, ((sqrt(5) - 1)/2) is golden ratio.
+ */
+#define HASH_FACTOR64 0x9E3779B9486E555EUL
+
+/*
+ * Hash function multiplies 64bit key by 64bit hash
+ * factor and returns high bits.
+ *
+ * @pre (bits < 64)
+ */
+static inline uint64_t hash64(uint64_t key, uint32_t bits)
+{
+	return (key * HASH_FACTOR64) >> (64U - bits);
+}
+
+#endif /* HASH_H */

--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -29,8 +29,18 @@
 #ifndef LIST_H_
 #define LIST_H_
 
+#include <types.h>
+
 struct list_head {
 	struct list_head *next, *prev;
+};
+
+struct hlist_head {
+	struct hlist_node *first;
+};
+
+struct hlist_node {
+	struct hlist_node *next, **pprev;
 };
 
 #define INIT_LIST_HEAD(ptr) do { (ptr)->next = (ptr); (ptr)->prev = (ptr); } \
@@ -120,5 +130,32 @@ static inline void list_splice_init(struct list_head *list,
 
 #define get_first_item(attached, type, member) \
 	((type *)((char *)((attached)->next)-(uint64_t)(&((type *)0)->member)))
+
+static inline void
+hlist_del(struct hlist_node *n)
+{
+
+        if (n->next != NULL) {
+                n->next->pprev = n->pprev;
+	}
+        *n->pprev = n->next;
+}
+
+static inline void
+hlist_add_head(struct hlist_node *n, struct hlist_head *h)
+{
+
+	n->next = h->first;
+	if (h->first != NULL) {
+		h->first->pprev = &n->next;
+	}
+	h->first = n;
+	n->pprev = &h->first;
+}
+
+#define hlist_entry(ptr, type, member) container_of(ptr,type,member)
+
+#define hlist_for_each(pos, head) \
+	for (pos = (head)->first; (pos) != NULL; pos = (pos)->next)
 
 #endif /* LIST_H_ */


### PR DESCRIPTION
Now searching in ACRN is done by walk each element in an array one by one. If the array
is big, the searching is slow. In order to improve this situation, Hashing was introduced
to ACRN. This serial is an example to use Hashing to speed up PTIRQ entry searching.


Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong<eddie.dong@Intel.com>
