### PR TITLE
acrn-config: write direct rootfs/console in OS bootargs instead of select them from UI optional items

### DIFF
--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -37,6 +37,7 @@ PT_SUB_PCI['ethernet'] = ['Ethernet controller', 'Network controller', '802.1a c
                         '802.1b controller', 'Wireless controller']
 PT_SUB_PCI['sata'] = ['SATA controller']
 PT_SUB_PCI['nvme'] = ['Non-Volatile memory controller']
+PT_SUB_PCI['usb'] = ['USB controller']
 UUID_DB = {
     'SOS_VM':['dbbbd434-7a57-4216-a12c-2201f1ab0240'],
     'SAFETY_VM':['fc836901-8685-4bc0-8b71-6e31dc36fa47'],
@@ -574,6 +575,9 @@ def avl_pci_devs():
     pci_dev_list.extend(tmp_pci_list)
     tmp_pci_list = common.get_avl_dev_info(bdf_desc_map, PT_SUB_PCI['nvme'])
     pci_dev_list.extend(tmp_pci_list)
+    tmp_pci_list = common.get_avl_dev_info(bdf_desc_map, PT_SUB_PCI['usb'])
+    pci_dev_list.extend(tmp_pci_list)
+    pci_dev_list.insert(0, '')
 
     return pci_dev_list
 

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -381,19 +381,6 @@ def os_kern_args_check(id_kern_args_dic, prime_item, item):
             ERR_LIST[key] = "VM os config kernel service os should be SOS_VM_BOOTARGS"
 
 
-def os_kern_console_check(tty_console, prime_item, item):
-    """
-    Check os kernel console
-    :param prime_item: the prime item in xml file
-    :param item: vm os config console item in xml
-    :return: None
-    """
-
-    if tty_console and "ttyS" not in tty_console:
-        key = "hv:{},{}".format(prime_item, item)
-        ERR_LIST[key] = "VM os config kernel console should be ttyS[0..3]"
-
-
 def os_kern_load_addr_check(id_kern_load_addr_dic, prime_item, item):
     """
     Check os kernel load address

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -434,20 +434,6 @@ def os_kern_entry_addr_check(id_kern_entry_addr_dic, prime_item, item):
             ERR_LIST[key] = "VM os config kernel entry address should Hex format"
 
 
-def os_kern_root_dev_check(id_kern_rootdev_dic, prime_item, item):
-    """
-    Check os kernel rootfs partitions
-    :param prime_item: the prime item in xml file
-    :param item: vm os config rootdev item in xml
-    :return: None
-    """
-
-    for id_key, kern_rootdev in id_kern_rootdev_dic.items():
-        if not kern_rootdev:
-            key = "vm:id={},{},{}".format(id_key, prime_item, item)
-            ERR_LIST[key] = "VM os config kernel root device should not empty"
-
-
 def pci_devs_check(pci_bdf_devs, branch_tag, tag_str):
     """
     Check vm pci devices

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -54,9 +54,6 @@ def get_scenario_item_values(board_info, scenario_info):
     # pre board_private
     (scenario_item_values["vm,board_private,rootfs"], num) = board_cfg_lib.get_rootfs(board_info)
 
-    # os config
-    (scenario_item_values["vm,os_config,rootfs"], num) = board_cfg_lib.get_rootfs(board_info)
-
     scenario_item_values["hv,DEBUG_OPTIONS,RELEASE"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,DEBUG_OPTIONS,NPK_LOGLEVEL"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_LEVEL")
     scenario_item_values["hv,DEBUG_OPTIONS,MEM_LOGLEVEL"] = hv_cfg_lib.get_select_range("DEBUG_OPTIONS", "LOG_LEVEL")

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -73,7 +73,6 @@ class CfgOsKern:
     kern_type = {}
     kern_mod = {}
     kern_args = {}
-    kern_console = {}
     kern_load_addr = {}
     kern_entry_addr = {}
     ramdisk_mod = {}
@@ -93,8 +92,6 @@ class CfgOsKern:
             self.scenario_info, "os_config", "kern_mod")
         self.kern_args = common.get_leaf_tag_map(
             self.scenario_info, "os_config", "bootargs")
-        self.kern_console = common.get_hv_item_tag(
-            self.scenario_info, "DEBUG_OPTIONS", "SERIAL_CONSOLE")
         self.kern_load_addr = common.get_leaf_tag_map(
             self.scenario_info, "os_config", "kern_load_addr")
         self.kern_entry_addr = common.get_leaf_tag_map(
@@ -111,7 +108,6 @@ class CfgOsKern:
         scenario_cfg_lib.os_kern_type_check(self.kern_type, "os_config", "kern_type")
         scenario_cfg_lib.os_kern_mod_check(self.kern_mod, "os_config", "kern_mod")
         scenario_cfg_lib.os_kern_args_check(self.kern_args, "os_config", "kern_args")
-        scenario_cfg_lib.os_kern_console_check(self.kern_console, "DEBUG_OPTIONS", "SERIAL_CONSOLE")
         scenario_cfg_lib.os_kern_load_addr_check(self.kern_load_addr, "os_config", "kern_load_addr")
         scenario_cfg_lib.os_kern_entry_addr_check(self.kern_entry_addr, "os_config", "kern_entry_addr")
 

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -76,8 +76,6 @@ class CfgOsKern:
     kern_console = {}
     kern_load_addr = {}
     kern_entry_addr = {}
-    kern_root_dev = {}
-    kern_args_append = {}
     ramdisk_mod = {}
 
     def __init__(self, scenario_file):
@@ -101,12 +99,8 @@ class CfgOsKern:
             self.scenario_info, "os_config", "kern_load_addr")
         self.kern_entry_addr = common.get_leaf_tag_map(
             self.scenario_info, "os_config", "kern_entry_addr")
-        self.kern_root_dev = common.get_leaf_tag_map(
-            self.scenario_info, "os_config", "rootfs")
         self.ramdisk_mod = common.get_leaf_tag_map(
             self.scenario_info, "os_config", "ramdisk_mod")
-        self.kern_args_append = common.get_leaf_tag_map(
-            self.scenario_info, "boot_private", "bootargs")
 
     def check_item(self):
         """
@@ -120,7 +114,6 @@ class CfgOsKern:
         scenario_cfg_lib.os_kern_console_check(self.kern_console, "DEBUG_OPTIONS", "SERIAL_CONSOLE")
         scenario_cfg_lib.os_kern_load_addr_check(self.kern_load_addr, "os_config", "kern_load_addr")
         scenario_cfg_lib.os_kern_entry_addr_check(self.kern_entry_addr, "os_config", "kern_entry_addr")
-        scenario_cfg_lib.os_kern_root_dev_check(self.kern_root_dev, "os_config", "rootdev")
 
 
 class VuartInfo:

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -308,7 +308,6 @@ def gen_pre_launch_vm(vm_type, vm_i, vm_info, config):
     if vm_i in vm_info.os_cfg.kern_args.keys() and vm_info.os_cfg.kern_args[vm_i]:
         print("\t\t\t.bootargs = VM{0}_CONFIG_OS_BOOTARG_CONSOLE\t\\".format(vm_i), file=config)
         print("\t\t\t\tVM{0}_CONFIG_OS_BOOTARG_MAXCPUS\t\t\\".format(vm_i), file=config)
-        print("\t\t\t\tVM{0}_CONFIG_OS_BOOTARG_ROOT\t\t\\".format(vm_i), file=config)
         split_cmdline(vm_info.os_cfg.kern_args[vm_i].strip(), config)
     print("\t\t},", file=config)
     # VUART

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -136,6 +136,29 @@ def vuart_output(vm_type, i, vm_info, config):
     print("\t\t},", file=config)
 
 
+def split_cmdline(cmd_str, config):
+
+    cmd_list = [i for i in cmd_str.strip('"').split() if i != '']
+
+    if cmd_list:
+        cmd_len = len(cmd_list)
+        i = 0
+        for cmd_arg in cmd_list:
+            if not cmd_arg.strip():
+                continue
+
+            if i == 0:
+                print('"', end="", file=config)
+
+            if i % 4 == 0 and i != 0:
+                print("\\\n\t\t\t\t", end="", file=config)
+
+            print('{} '.format(cmd_arg), end="", file=config)
+            i += 1
+            if i == cmd_len:
+                print('"', file=config)
+
+
 def is_need_epc(epc_section, i, config):
     """
     Check if it is need epc section
@@ -306,8 +329,7 @@ def gen_pre_launch_vm(vm_type, vm_i, vm_info, config):
         print("\t\t\t.kernel_entry_addr = {0},".format(vm_info.os_cfg.kern_entry_addr[vm_i]), file=config)
 
     if vm_i in vm_info.os_cfg.kern_args.keys() and vm_info.os_cfg.kern_args[vm_i]:
-        print("\t\t\t.bootargs = VM{0}_CONFIG_OS_BOOTARG_CONSOLE\t\\".format(vm_i), file=config)
-        print("\t\t\t\tVM{0}_CONFIG_OS_BOOTARG_MAXCPUS\t\t\\".format(vm_i), file=config)
+        print("\t\t\t.bootargs = ", end="", file=config)
         split_cmdline(vm_info.os_cfg.kern_args[vm_i].strip(), config)
     print("\t\t},", file=config)
     # VUART
@@ -335,29 +357,6 @@ def gen_post_launch_vm(vm_type, vm_i, vm_info, config):
         return err_dic
 
     print("\t},", file=config)
-
-
-def split_cmdline(cmd_str, config):
-
-    cmd_list = [i for i in cmd_str.split() if i != '']
-
-    if cmd_list:
-        cmd_len = len(cmd_list)
-        i = 0
-        for cmd_arg in cmd_list:
-            if not cmd_arg.strip():
-                continue
-
-            if i == 0:
-                print('\\\n\t\t\t\t"', end="", file=config)
-
-            if i % 4 == 0 and i != 0:
-                print("\\\n\t\t\t\t", end="", file=config)
-
-            print('{} '.format(cmd_arg), end="", file=config)
-            i += 1
-            if i == cmd_len:
-                print('"', file=config)
 
 
 def pre_launch_definiation(vm_info, config):

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -86,9 +86,6 @@ def gen_pre_launch_vm(vm_info, config):
             print("#define VM{0}_CONFIG_MEM_SIZE_HPA2\t\t{1}UL".format(
                 vm_i, vm_info.mem_info.mem_size_hpa2[vm_i]), file=config)
 
-        print('#define VM{0}_CONFIG_OS_BOOTARG_MAXCPUS\t\t"maxcpus={1} "'.format(vm_i, cpu_bits['cpu_num']), file=config)
-        if vm_info.os_cfg.kern_console:
-            print('#define VM{0}_CONFIG_OS_BOOTARG_CONSOLE\t\t"console={1} "'.format(vm_i, vm_info.os_cfg.kern_console.strip('/dev/')), file=config)
         print("", file=config)
         vm_i += 1
 

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -85,9 +85,6 @@ def gen_pre_launch_vm(vm_info, config):
                 vm_i, vm_info.mem_info.mem_start_hpa2[vm_i]), file=config)
             print("#define VM{0}_CONFIG_MEM_SIZE_HPA2\t\t{1}UL".format(
                 vm_i, vm_info.mem_info.mem_size_hpa2[vm_i]), file=config)
-        if vm_info.os_cfg.kern_root_dev:
-            print('#define VM{0}_CONFIG_OS_BOOTARG_ROOT\t\t"root={1} "'.format(
-                vm_i, vm_info.os_cfg.kern_root_dev[vm_i]), file=config)
 
         print('#define VM{0}_CONFIG_OS_BOOTARG_MAXCPUS\t\t"maxcpus={1} "'.format(vm_i, cpu_bits['cpu_num']), file=config)
         if vm_info.os_cfg.kern_console:

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -76,9 +76,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw root=/dev/mmcblk1p1 rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -127,9 +126,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -77,7 +77,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw root=/dev/mmcblk1p1 rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw root=/dev/mmcblk1p1 rootwait console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -127,7 +127,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -76,9 +76,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -126,9 +125,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -77,7 +77,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -126,7 +126,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -77,9 +77,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,9 +127,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -78,7 +78,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,7 +128,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -87,7 +87,7 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </vuart>
-        <pci_devs configurable="0" desc="pci devices list">
+        <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
     </vm>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -71,7 +71,7 @@
             <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments" />
+            <bootargs desc="Specify kernel boot arguments"></bootargs>
             <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
             <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
         </os_config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -75,7 +75,7 @@
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
         </os_config>
         <vuart id="0">
@@ -126,7 +126,7 @@
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
         </os_config>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -74,9 +74,8 @@
             <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
             <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
         </os_config>
         <vuart id="0">
@@ -126,9 +125,8 @@
             <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
             <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
         </os_config>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
@@ -79,7 +79,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -130,7 +130,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
@@ -78,9 +78,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -130,9 +129,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -77,9 +77,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,9 +127,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -78,7 +78,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,7 +128,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -77,9 +77,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -129,9 +128,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -78,7 +78,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -129,7 +129,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/template/PRE_STD_VM.xml
+++ b/misc/acrn-config/xmls/config-xmls/template/PRE_STD_VM.xml
@@ -26,7 +26,6 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR."></kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel"></rootfs>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
     </os_config>
     <vuart id="0">

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -77,9 +77,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,9 +127,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -78,7 +78,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,7 +128,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -91,7 +91,7 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </vuart>
-    <pci_devs configurable="0" desc="pci devices list">
+    <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
   </vm>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -77,9 +77,8 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,9 +127,8 @@
         <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <rootfs desc="rootfs for Linux kernel" readonly="true">/dev/sda3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -78,7 +78,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
     <vuart id="0">
@@ -128,7 +128,7 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">
-        rw rootwait root=/dev/sda3 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>


### PR DESCRIPTION

- generate console=ttyS0 for PRE Launched VM
- remove rootfs item from PRE Launched VM
- remove configurable="0" for hybrid scenario config

    Tracked-On: #4808
    Signed-off-by: Wei Liu <weix.w.liu@intel.com>
    Acked-by: Victor Sun <victor.sun@intel.com>
