### PR TITLE
acrn-config: generate pci_dev.c file for logical partition

### DIFF
--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -186,11 +186,8 @@ def main(args):
             return err_dic
 
     # generate pci_dev.c
-    for vm_i,pci_dev_num in scenario_items['vm'].cfg_pci.pci_dev_num.items():
-        if pci_dev_num >= 2:
-            with open(pci_config_c, 'w') as config:
-                pci_dev_c.generate_file(scenario_items['vm'], config)
-            break
+    with open(pci_config_c, 'w') as config:
+        pci_dev_c.generate_file(scenario_items['vm'], config)
 
     if not err_dic:
         print("Scenario configurations for {} is generated successfully.".format(scenario))


### PR DESCRIPTION
With current acrn-config code, there would be no pci_dev.c generated
if no PCI devices were selected. This would cause a bug for logical_partition
scenario because of an old pci_dev.c is already in the folder and involved
for compiling. The configure tool should override the pci_dev.c, in this case,
to avoid building error.

Tracked-On; #4813
Signed-off-by: Wei Liu <weix.w.liu@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>