### PR TITLE
hv: pause all other vCPUs in same VM when do wbinvd emulation

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -241,6 +241,17 @@ void walk_ept_table(struct acrn_vm *vm, pge_handler cb)
 					}
 				}
 			}
+			/*
+			 * Walk through the whole page tables of one VM is a time-consuming
+			 * operation. Preemption is not support by hypervisor scheduling
+			 * currently, so the walk through page tables operation might occupy
+			 * CPU for long time what starve other threads.
+			 *
+			 * Give chance to release CPU to make other threads happy.
+			 */
+			if (need_reschedule(get_pcpu_id())) {
+				schedule();
+			}
 		}
 	}
 }

--- a/hypervisor/arch/x86/guest/virq.c
+++ b/hypervisor/arch/x86/guest/virq.c
@@ -374,6 +374,9 @@ int32_t acrn_handle_pending_request(struct acrn_vcpu *vcpu)
 		pr_fatal("Triple fault happen -> shutdown!");
 		ret = -EFAULT;
 	} else {
+		if (bitmap_test_and_clear_lock(ACRN_REQUEST_WAIT_WBINVD, pending_req_bits)) {
+			wait_event(&vcpu->events[VCPU_EVENT_SYNC_WBINVD]);
+		}
 
 		if (bitmap_test_and_clear_lock(ACRN_REQUEST_EPT_FLUSH, pending_req_bits)) {
 			invept(vcpu->vm->arch_vm.nworld_eptp);

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -94,6 +94,11 @@
 #define ACRN_REQUEST_INIT_VMCS			8U
 
 /**
+ * @brief Request for sync waiting WBINVD
+ */
+#define ACRN_REQUEST_WAIT_WBINVD		9U
+
+/**
  * @}
  */
 /* End of virt_int_injection */
@@ -149,7 +154,8 @@ enum vm_cpu_mode {
 
 #define	VCPU_EVENT_IOREQ		0
 #define	VCPU_EVENT_VIRTUAL_INTERRUPT	1
-#define	VCPU_EVENT_NUM			2
+#define	VCPU_EVENT_SYNC_WBINVD		2
+#define	VCPU_EVENT_NUM			3
 
 enum reset_mode;
 


### PR DESCRIPTION
Invalidate cache by scanning and flushing the whole guest memory is
inefficient which might cause long execution time for WBINVD emulation.
A long execution in hypervisor might cause a vCPU stuck phenomenon what
impact Windows Guest booting.

This patch introduce a workaround method that pausing all other vCPUs in
the same VM when do wbinvd emulation.

Tracked-On: #4703
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>