### PR TITLE
hv:cleanup vcpu state

### DIFF
--- a/doc/developer-guides/hld/hv-cpu-virt.rst
+++ b/doc/developer-guides/hld/hv-cpu-virt.rst
@@ -159,10 +159,7 @@ lifecycle:
 .. doxygenfunction:: create_vcpu
    :project: Project ACRN
 
-.. doxygenfunction:: pause_vcpu
-   :project: Project ACRN
-
-.. doxygenfunction:: resume_vcpu
+.. doxygenfunction:: zombie_vcpu
    :project: Project ACRN
 
 .. doxygenfunction:: reset_vcpu

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1110,7 +1110,7 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 
 			if (target_vcpu->state != VCPU_INIT) {
 				/* put target vcpu to INIT state and wait for SIPI */
-				pause_vcpu(target_vcpu, VCPU_ZOMBIE);
+				zombie_vcpu(target_vcpu, VCPU_ZOMBIE);
 				reset_vcpu(target_vcpu, INIT_RESET);
 			}
 			/* new cpu model only need one SIPI to kick AP run,

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -698,7 +698,7 @@ void pause_vm(struct acrn_vm *vm)
 			((is_rt_vm(vm)) && (vm->state == VM_READY_TO_POWEROFF)) ||
 			(vm->state == VM_CREATED)) {
 		foreach_vcpu(i, vm, vcpu) {
-			pause_vcpu(vcpu, VCPU_ZOMBIE);
+			zombie_vcpu(vcpu, VCPU_ZOMBIE);
 		}
 		vm->state = VM_PAUSED;
 	}

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -35,7 +35,7 @@ void vcpu_thread(struct thread_object *obj)
 		ret = acrn_handle_pending_request(vcpu);
 		if (ret < 0) {
 			pr_fatal("vcpu handling pending request fail");
-			pause_vcpu(vcpu, VCPU_ZOMBIE);
+			zombie_vcpu(vcpu, VCPU_ZOMBIE);
 			/* Fatal error happened (triple fault). Stop the vcpu running. */
 			continue;
 		}
@@ -47,7 +47,7 @@ void vcpu_thread(struct thread_object *obj)
 		ret = run_vcpu(vcpu);
 		if (ret != 0) {
 			pr_fatal("vcpu resume failed");
-			pause_vcpu(vcpu, VCPU_ZOMBIE);
+			zombie_vcpu(vcpu, VCPU_ZOMBIE);
 			/* Fatal error happened (resume vcpu failed). Stop the vcpu running. */
 			continue;
 		}

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -64,7 +64,7 @@ int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, uint64_t lapicid)
 				ret = -1;
 				break;
 			}
-			pause_vcpu(vcpu, VCPU_ZOMBIE);
+			zombie_vcpu(vcpu, VCPU_ZOMBIE);
 			offline_vcpu(vcpu);
 		}
 	}

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -654,9 +654,6 @@ static int32_t shell_list_vcpu(__unused int32_t argc, __unused char **argv)
 			case VCPU_INIT:
 				(void)strncpy_s(vcpu_state_str, 32U, "Init", 32U);
 				break;
-			case VCPU_PAUSED:
-				(void)strncpy_s(vcpu_state_str, 32U, "Paused", 32U);
-				break;
 			case VCPU_RUNNING:
 				(void)strncpy_s(vcpu_state_str, 32U, "Running", 32U);
 				break;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -136,7 +136,6 @@ enum vcpu_state {
 	VCPU_OFFLINE = 0U,
 	VCPU_INIT,
 	VCPU_RUNNING,
-	VCPU_PAUSED,
 	VCPU_ZOMBIE,
 };
 
@@ -256,8 +255,6 @@ struct acrn_vcpu {
 	uint16_t vcpu_id;	/* virtual identifier for VCPU */
 	struct acrn_vm *vm;		/* Reference to the VM this VCPU belongs to */
 
-	/* State of this VCPU before suspend */
-	volatile enum vcpu_state prev_state;
 	volatile enum vcpu_state state;	/* State of this VCPU */
 
 	struct thread_object thread_obj;
@@ -634,25 +631,14 @@ void reset_vcpu(struct acrn_vcpu *vcpu, enum reset_mode mode);
 /**
  * @brief pause the vcpu and set new state
  *
- * Change a vCPU state to VCPU_PAUSED or VCPU_ZOMBIE, and make a reschedule request for it.
+ * Change a vCPU state to VCPU_ZOMBIE, and make a reschedule request for it.
  *
  * @param[inout] vcpu pointer to vcpu data structure
  * @param[in] new_state the state to set vcpu
  *
  * @return None
  */
-void pause_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state);
-
-/**
- * @brief resume the vcpu
- *
- * Change a vCPU state to VCPU_RUNNING, and make a reschedule request for it.
- *
- * @param[inout] vcpu pointer to vcpu data structure
- *
- * @return 0 on success, -1 on failure.
- */
-int32_t resume_vcpu(struct acrn_vcpu *vcpu);
+void zombie_vcpu(struct acrn_vcpu *vcpu, enum vcpu_state new_state);
 
 /**
  * @brief set the vcpu to running state, then it will be scheculed.


### PR DESCRIPTION
-- remove VCPU_PAUSED and resume_vcpu
-- remove vcpu->prev_state in vcpu structure
-- rename pause_vcpu to zombie_vcpu

Tracked-On: #4320
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>