### PR TITLE
Makefile: avoid 'clean' each time building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,6 @@ hypervisor:
 	@if [ "$(BOARD_FILE)" != "" ] && [ -f $(BOARD_FILE) ] && [ "$(SCENARIO_FILE)" != "" ] && [ -f $(SCENARIO_FILE) ] && [ "$(TARGET_DIR)" = "" ]; then \
 		echo "No TARGET_DIR parameter is specified, the original configuration source is overwritten!";\
 	fi
-	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD_FILE=$(BOARD_FILE) SCENARIO_FILE=$(SCENARIO_FILE) clean;
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD_FILE=$(BOARD_FILE) SCENARIO_FILE=$(SCENARIO_FILE) TARGET_DIR=$(abspath $(TARGET_DIR)) defconfig;
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD_FILE=$(BOARD_FILE) SCENARIO_FILE=$(SCENARIO_FILE) TARGET_DIR=$(abspath $(TARGET_DIR)) oldconfig;
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD_FILE=$(BOARD_FILE) SCENARIO_FILE=$(SCENARIO_FILE) TARGET_DIR=$(abspath $(TARGET_DIR))
@@ -198,7 +197,6 @@ hypervisor:
 	@cat $(HV_CFG_LOG)
 
 devicemodel: tools
-	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) RELEASE=$(RELEASE) clean
 	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER) RELEASE=$(RELEASE)
 
 tools:

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -221,9 +221,11 @@ $(VERSION_H):
 	echo "#define DM_BUILD_TIME "\""$$TIME"\""" >> $(VERSION_H);\
 	echo "#define DM_BUILD_USER "\""$$USER"\""" >> $(VERSION_H)
 
+-include $(OBJS:.o=.d)
+
 $(DM_OBJDIR)/%.o: %.c $(HEADERS)
 	[ ! -e $@ ] && mkdir -p $(dir $@); \
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@ -MMD -MT $@
 
 install: $(DM_OBJDIR)/$(PROGRAM) install-samples-nuc install-samples-mrb install-bios install-samples-up2
 	install -D --mode=0755 $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)/usr/bin/$(PROGRAM)

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -18,7 +18,6 @@ BASEDIR := $(shell pwd)
 HV_OBJDIR ?= $(CURDIR)/build
 HV_MODDIR ?= $(HV_OBJDIR)/modules
 HV_FILE := acrn
-SUB_MAKEFILES := $(wildcard */Makefile)
 
 LIB_MOD = $(HV_MODDIR)/lib_mod.a
 BOOT_MOD = $(HV_MODDIR)/boot_mod.a
@@ -354,12 +353,14 @@ MODULES += $(VP_TRUSTY_MOD)
 MODULES += $(VP_HCALL_MOD)
 ifeq ($(CONFIG_RELEASE),y)
 MODULES += $(LIB_RELEASE)
+LIB_BUILD = $(LIB_RELEASE)
+LIB_MK = release/Makefile
 else
 MODULES += $(LIB_DEBUG)
+LIB_BUILD = $(LIB_DEBUG)
+LIB_MK = debug/Makefile
 endif
 MODULES += $(SYS_INIT_MOD)
-
-.PHONY: $(MODULES)
 
 DISTCLEAN_OBJS := $(shell find $(BASEDIR) -name '*.o')
 VERSION := $(HV_OBJDIR)/include/version.h
@@ -415,58 +416,52 @@ pre_build: $(PRE_BUILD_OBJS)
 header: $(VERSION) $(HV_OBJDIR)/$(HV_CONFIG_H) $(TARGET_ACPI_INFO_HEADER)
 
 .PHONY: lib-mod boot-mod hw-mod vp-base-mod vp-dm-mod vp-trusty-mod vp-hcall-mod sys-init-mod
-lib-mod: $(LIB_C_OBJS) $(LIB_S_OBJS)
+$(LIB_MOD): $(LIB_C_OBJS) $(LIB_S_OBJS)
 	$(AR) $(ARFLAGS) $(LIB_MOD) $(LIB_C_OBJS) $(LIB_S_OBJS)
 
-$(LIB_MOD): lib-mod
+lib-mod: $(LIB_MOD)
 
-boot-mod: $(BOOT_S_OBJS) $(BOOT_C_OBJS)
+$(BOOT_MOD): $(BOOT_S_OBJS) $(BOOT_C_OBJS)
 	$(AR) $(ARFLAGS) $(BOOT_MOD) $(BOOT_S_OBJS) $(BOOT_C_OBJS)
 
-$(BOOT_MOD): boot-mod
+boot-mod: $(BOOT_MOD)
 
-hw-mod: $(HW_S_OBJS) $(HW_C_OBJS)
+$(HW_MOD): $(HW_S_OBJS) $(HW_C_OBJS)
 	$(AR) $(ARFLAGS) $(HW_MOD) $(HW_S_OBJS) $(HW_C_OBJS)
 
-$(HW_MOD): hw-mod
+hw-mod: $(HW_MOD)
 
-vp-base-mod: $(VP_BASE_S_OBJS) $(VP_BASE_C_OBJS)
+$(VP_BASE_MOD): $(VP_BASE_S_OBJS) $(VP_BASE_C_OBJS)
 	$(AR) $(ARFLAGS) $(VP_BASE_MOD) $(VP_BASE_S_OBJS) $(VP_BASE_C_OBJS)
 
-$(VP_BASE_MOD): vp-base-mod
+vp-base-mod: $(VP_BASE_MOD)
 
-vp-dm-mod: $(VP_DM_C_OBJS)
+$(VP_DM_MOD): $(VP_DM_C_OBJS)
 	$(AR) $(ARFLAGS) $(VP_DM_MOD) $(VP_DM_C_OBJS)
 
-$(VP_DM_MOD): vp-dm-mod
+vp-dm-mod: $(VP_DM_MOD)
 
-vp-trusty-mod: $(VP_TRUSTY_C_OBJS)
+$(VP_TRUSTY_MOD): $(VP_TRUSTY_C_OBJS)
 	$(AR) $(ARFLAGS) $(VP_TRUSTY_MOD) $(VP_TRUSTY_C_OBJS)
 
-$(VP_TRUSTY_MOD): vp-trusty-mod
+vp-trusty-mod: $(VP_TRUSTY_MOD)
 
-vp-hcall-mod: $(VP_HCALL_C_OBJS)
+$(VP_HCALL_MOD): $(VP_HCALL_C_OBJS)
 	$(AR) $(ARFLAGS) $(VP_HCALL_MOD) $(VP_HCALL_C_OBJS)
 
-$(VP_HCALL_MOD): vp-hcall-mod
+vp-hcall-mod: $(VP_HCALL_MOD)
 
-sys-init-mod: $(SYS_INIT_C_OBJS)
+$(SYS_INIT_MOD): $(SYS_INIT_C_OBJS)
 	$(AR) $(ARFLAGS) $(SYS_INIT_MOD) $(SYS_INIT_C_OBJS)
 
-$(SYS_INIT_MOD): sys-init-mod
+sys-init-mod: $(SYS_INIT_MOD)
 
 .PHONY: lib
-lib: $(SUB_MAKEFILES)
 
-.PHONY: $(SUB_MAKEFILES)
-$(SUB_MAKEFILES): header
-	for Makefile in $(SUB_MAKEFILES); do \
-		$(MAKE) -f $$Makefile MKFL_NAME=$$Makefile; \
-	done
+$(LIB_BUILD): header
+	$(MAKE) -f $(LIB_MK) MKFL_NAME=$(LIB_MK)
 
-$(LIB_RELEASE): lib
-
-$(LIB_DEBUG): lib
+lib: $(LIB_BUILD)
 
 $(HV_OBJDIR)/$(HV_FILE).32.out: $(HV_OBJDIR)/$(HV_FILE).out
 	$(OBJCOPY) -S --section-alignment=0x1000 -O elf32-i386 $< $@

--- a/hypervisor/debug/Makefile
+++ b/hypervisor/debug/Makefile
@@ -7,10 +7,10 @@ SRCS += $(wildcard $(FILE_PATH)/*.c)
 OBJS += $(patsubst %.c,$(HV_OBJDIR)/%.o,$(SRCS))
 
 .PHONY: default
-default: lib
+default: $(LIB_DEBUG)
 
 ifneq ($(CONFIG_RELEASE),y)
-lib: $(OBJS)
+$(LIB_DEBUG): $(OBJS)
 	$(AR) $(ARFLAGS) $(LIB_DEBUG) $(OBJS)
 endif
 

--- a/hypervisor/release/Makefile
+++ b/hypervisor/release/Makefile
@@ -7,10 +7,10 @@ SRCS += $(wildcard $(FILE_PATH)/*.c)
 OBJS += $(patsubst %.c,$(HV_OBJDIR)/%.o,$(SRCS))
 
 .PHONY: default
-default: lib
+default: $(LIB_RELEASE)
 
 ifeq ($(CONFIG_RELEASE),y)
-lib: $(OBJS)
+$(LIB_RELEASE): $(OBJS)
 	$(AR) $(ARFLAGS) $(LIB_RELEASE) $(OBJS)
 endif
 

--- a/misc/efi-stub/Makefile
+++ b/misc/efi-stub/Makefile
@@ -88,11 +88,11 @@ LDFLAGS=-T $(LDSCRIPT) -Bsymbolic -shared -nostdlib -znocombreloc \
 		-L$(LIBDIR) $(CRT0)
 EFIBIN=$(HV_OBJDIR)/$(HV_FILE).efi
 BOOT=$(EFI_OBJDIR)/boot.efi
+HV_BIN=$(HV_OBJDIR)/$(HV_FILE).bin
 
 CONF_FILE=$(CURDIR)/clearlinux/acrn.conf
 
 all: $(EFIBIN)
-	$(OBJCOPY)  --add-section .hv="$(HV_OBJDIR)/$(HV_FILE).bin"  --change-section-vma .hv=0x6e000 --set-section-flags .hv=alloc,data,contents,load  --section-alignment 0x1000 $(EFI_OBJDIR)/boot.efi  $(EFIBIN)
 
 install: $(EFIBIN) install-conf
 	install -D $(EFIBIN) $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).efi
@@ -101,26 +101,29 @@ install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
 	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).efi.out
 	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).efi.map
 
-$(EFIBIN): $(BOOT)
+$(EFIBIN): $(BOOT) $(HV_BIN)
+	$(OBJCOPY) --add-section .hv="$(HV_BIN)"  --change-section-vma .hv=0x6e000 --set-section-flags .hv=alloc,data,contents,load  --section-alignment 0x1000 $(BOOT) $(EFIBIN)
 
-$(EFI_OBJDIR)/boot.efi: $(EFI_OBJDIR)/boot.so
+$(BOOT): $(EFI_OBJDIR)/boot.so
 
-$(EFI_OBJDIR)/boot.so: $(ACRN_OBJS) $(FS)
+$(EFI_OBJDIR)/boot.so: $(ACRN_OBJS)
 	$(LD) $(LDFLAGS) -o $@ $^  -lgnuefi -lefi $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 install-conf: $(CONF_FILE)
 	install -D --mode=0644 $^ $(DESTDIR)/usr/share/acrn/samples/nuc/acrn.conf
 
 clean:
-	rm -f $(BOOT) $(HV_OBJDIR)/$(HV_FILE).efi $(EFI_OBJDIR)/boot.so $(ACRN_OBJS) $(FS)
+	rm -f $(BOOT) $(HV_OBJDIR)/$(HV_FILE).efi $(EFI_OBJDIR)/boot.so $(ACRN_OBJS)
 
-$(EFI_OBJDIR)/%.o:%.S $(HV_OBJDIR)/$(HV_CONFIG_H)
-	[ ! -e $@ ] && mkdir -p $(dir $@); \
-	$(CC) $(CFLAGS)   -c -o $@ $<
+-include $(ACRN_OBJS:.o=.d)
 
-$(EFI_OBJDIR)/%.o: %.c $(HV_OBJDIR)/$(HV_CONFIG_H)
+$(EFI_OBJDIR)/%.o:%.S
 	[ ! -e $@ ] && mkdir -p $(dir $@); \
-	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@
+	$(CC) $(CFLAGS)   -c -o $@ $< -MMD -MT $@
+
+$(EFI_OBJDIR)/%.o: %.c
+	[ ! -e $@ ] && mkdir -p $(dir $@); \
+	$(CC) $(patsubst %, -I%, $(INCLUDE_PATH)) -I. -c $(CFLAGS) $(ARCH_CFLAGS) $< -o $@ -MMD -MT $@
 
 %.efi: %.so
 	$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym -j .rel \


### PR DESCRIPTION
1. remove 'clean' to avoid each time rebuild whole ACRN-HV/DM
2. correct some dependency to avoid unnecessary rebuilding

Tracked-On: #2412
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>
