### PR TITLE
hv: ptirq : fix a bug in ptirq_release_entry

### DIFF
--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -112,8 +112,7 @@ void ptirq_release_entry(struct ptirq_remapping_info *entry)
 	del_timer(&entry->intr_delay_timer);
 	CPU_INT_ALL_RESTORE(rflags);
 
-	bitmap_clear_nolock((entry->ptdev_entry_id) & 0x3FU,
-		&ptirq_entry_bitmaps[((entry->ptdev_entry_id) & 0x3FU) >> 6U]);
+	bitmap_clear_lock((entry->ptdev_entry_id) & 0x3FU, &ptirq_entry_bitmaps[entry->ptdev_entry_id >> 6U]);
 
 	(void)memset((void *)entry, 0U, sizeof(struct ptirq_remapping_info));
 }


### PR DESCRIPTION
The mask valuei 0x3F was added to prevent out of range in array access.
However, it should not be hardcoded.
Since in ptirq_alloc_entry_id, the valid allocated id is no greater
than CONFIG_MAX_PT_IRQ_ENTRIES, it will not cause out of range array
access without mask.
So this patch removes the mask.

Also, use bitmap_clear_lock instead of bitmap_clear_nolock becuase there
could be the chance that more than 1 core to access a same 64bit var.

Tracked-On: #4828
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>