### PR TITLE
HV: explicitly init pci device lock

### DIFF
--- a/hypervisor/debug/logmsg.c
+++ b/hypervisor/debug/logmsg.c
@@ -29,6 +29,8 @@ void init_logmsg(uint32_t flags)
 {
 	logmsg_ctl.flags = flags;
 	logmsg_ctl.seq = 0;
+
+	spinlock_init(&(logmsg_ctl.lock));
 }
 
 void do_logmsg(uint32_t severity, const char *fmt, ...)

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -610,6 +610,9 @@ void init_pci_pdev_list(void)
 	uint16_t bus;
 	bool was_visited = false;
 
+	/* explicitly init the lock before using it */
+	spinlock_init(&pci_device_lock);
+
 	pci_parse_iommu_devscopes(&bdfs_from_drhds, &drhd_idx_pci_all);
 
 	/* TODO: iterate over list of PCI Host Bridges found in ACPI namespace */


### PR DESCRIPTION
1. though "pci_device_lock" is set to 0 when system dose memory
initialization, it is better to explicitly init it before using.
2. unify spinlock_init usage

Tracked-On: #4827
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>