### PR TITLE
dm: Do not link to zlib

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -66,7 +66,6 @@ LIBS = -lrt
 LIBS += -lpthread
 LIBS += -lcrypto
 LIBS += -lpciaccess
-LIBS += -lz
 LIBS += -luuid
 LIBS += -lusb-1.0
 LIBS += -lacrn-mngr


### PR DESCRIPTION
Since zlib is not used, remove linking to it. This reduces build
dependencies.

Tracked-On: #4838
Signed-off-by: Helmut Buchsbaum <helmut.buchsbaum@opensource.tttech-industrial.com>