### PR TITLE
vpci: add vmsix/vmsix capability registers rw permission control

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -498,7 +498,7 @@ static int32_t write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	} else if (msicap_access(vdev, offset)) {
 		write_vmsi_cap_reg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		write_vmsix_cfg(vdev, offset, bytes, val);
+		write_vmsix_cap_reg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {
 		write_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {
@@ -523,7 +523,7 @@ static int32_t read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	} else if (msicap_access(vdev, offset)) {
 		read_vmsi_cap_reg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		read_vmsix_cfg(vdev, offset, bytes, val);
+		read_vmsix_cap_reg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {
 		read_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -496,7 +496,7 @@ static int32_t write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	if (cfg_header_access(offset)) {
 		write_cfg_header(vdev, offset, bytes, val);
 	} else if (msicap_access(vdev, offset)) {
-		write_vmsi_cfg(vdev, offset, bytes, val);
+		write_vmsi_cap_reg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		write_vmsix_cfg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {
@@ -521,7 +521,7 @@ static int32_t read_pt_dev_cfg(const struct pci_vdev *vdev, uint32_t offset,
 	if (cfg_header_access(offset)) {
 		read_cfg_header(vdev, offset, bytes, val);
 	} else if (msicap_access(vdev, offset)) {
-		read_vmsi_cfg(vdev, offset, bytes, val);
+		read_vmsi_cap_reg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
 		read_vmsix_cfg(vdev, offset, bytes, val);
 	} else if (sriovcap_access(vdev, offset)) {

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -118,8 +118,8 @@ void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);
 void vdev_pt_map_msix(struct pci_vdev *vdev, bool hold_lock);
 
 void init_vmsi(struct pci_vdev *vdev);
-void read_vmsi_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-void write_vmsi_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void read_vmsi_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void write_vmsi_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsi(struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -124,8 +124,8 @@ void deinit_vmsi(struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_private_data);
-void read_vmsix_cfg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
-void write_vmsix_cfg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void read_vmsix_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
+void write_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(struct pci_vdev *vdev);
 
 void init_vsriov(struct pci_vdev *vdev);


### PR DESCRIPTION
v2:
some refine according to the comments

v1:
Guest may write a MSI/MSI-X capability register with only RW bits setting on.
This will over-write the corresponding RO bits in the vCFG space. This serial
tries to change this situation by only write RW bits in the vCFG space according
to a pre-defined RW permission mapping.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>