### PR TITLE
dm: acpi: validate minimal length of PSDS

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -85,8 +85,7 @@
 #define FACS_OFFSET		0x3C0
 #define NHLT_OFFSET		0x400
 #define TPM2_OFFSET		0xC00
-#define PSDS_OFFSET		0xE40		/* Reserve 0xC0 for PSD table */
-#define DSDT_OFFSET		0xF00
+#define DSDT_OFFSET		0xE40
 
 #define	ASL_TEMPLATE	"dm.XXXXXXX"
 #define ASL_SUFFIX	".aml"
@@ -95,7 +94,6 @@
 #endif
 
 uint64_t audio_nhlt_len = 0;
-uint32_t csme_sec_cap = 0;
 
 static int basl_keep_temps;
 static int basl_verbose_iasl;
@@ -126,7 +124,6 @@ struct basl_fio {
 #define EFFLUSH(x) fflush(x)
 
 static bool acpi_table_is_valid(int num);
-static int psds_fd = -1;
 
 static int
 basl_fwrite_rsdp(FILE *fp, struct vmctx *ctx)
@@ -189,9 +186,6 @@ basl_fwrite_rsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
-	if (acpi_table_is_valid(PSDS_ENTRY_NO))
-		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
-		    basl_acpi_base + PSDS_OFFSET);
 	EFFLUSH(fp);
 
 	return 0;
@@ -234,9 +228,6 @@ basl_fwrite_xsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
-	if (acpi_table_is_valid(PSDS_ENTRY_NO))
-		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
-		    basl_acpi_base + PSDS_OFFSET);
 	EFFLUSH(fp);
 
 	return 0;
@@ -675,98 +666,6 @@ basl_fwrite_nhlt(FILE *fp, struct vmctx *ctx)
 	return 0;
 }
 
-/* read len bytes from file specified by fd from offset, and write to file specified by fp */
-static int
-copy_table_pos_len(int fd, int offset, int len, FILE *fp)
-{
-	int pos, i;
-	uint8_t data;
-
-	if ((fd < 0) || (fp == NULL))
-		return -1;
-
-	pos = lseek(fd, offset, SEEK_SET);
-	if (pos != offset)
-		return -1;
-
-	for (i = 0; i < len; i++) {
-		if (read(fd, &data, 1) != 1) {
-			pr_err("%s: read fail! %s\n", __func__, strerror(errno));
-			return -1;
-		}
-		EFPRINTF(fp, "UINT8 : %02X\n", data);
-	}
-	return 0;
-}
-
-/* Intel Platform Security Discovery is designed specifically to allow other applications at
- * runtime to know what hardware security capabilities are available on the platform.
- * Format of the PSD structure:
- * [0024] 36 byte common header
- * [0004] PSD Version
- * [0004] CSME Sec Capabilities
- * [0002] SGX Capabilities
- * [0004] FW Version Minor
- * [0004] FW Version Major
- * [0004] FW Version Build Number
- * [0004] FW Version Hot Fix
- * [0010] FW Vendor
- * [0001] EOM State
- * [0001] Secure Boot Enabled
- * [0001] Measured Boot Enabled
- * [0001] Hwrot Type
- * [0001] fwHashIndex
- * [0001] fwHashDataLen
- * [xxxx] fwHashData (if fwHashDataLen != 0)
- */
-static int
-basl_fwrite_psds(FILE *fp, struct vmctx *ctx)
-{
-	EFPRINTF(fp, "/*\n");
-	EFPRINTF(fp, " * dm PSDS template\n");
-	EFPRINTF(fp, " */\n");
-	EFPRINTF(fp, "[0004]\t\tSignature : \"PSDS\"\n");
-	EFPRINTF(fp, "[0004]\t\tTable Length : 00000000\n");
-	EFPRINTF(fp, "[0001]\t\tRevision : 00\n");
-	EFPRINTF(fp, "[0001]\t\tChecksum : 00\n");
-	EFPRINTF(fp, "[0006]\t\tOem ID : \"INTEL \"\n");
-	EFPRINTF(fp, "[0008]\t\tOem Table ID : \"EDK2    \"\n");
-	EFPRINTF(fp, "[0004]\t\tOem Revision : 00000001\n");
-	/* iasl will fill in the compiler ID/revision fields */
-	EFPRINTF(fp, "[0004]\t\tAsl Compiler ID : \"xxxx\"\n");
-	EFPRINTF(fp, "[0004]\t\tAsl Compiler Revision : 00000000\n");
-
-	/* passthru the following @36 - 4 bytes:
-	 * [0004]PSD Version
-	 */
-	if (copy_table_pos_len(psds_fd, 36, 4, fp) != 0) {
-		pr_err("Failed to read psds table!\n");
-		return -1;
-	}
-
-	EFPRINTF(fp, "UINT32 : %08X\n", csme_sec_cap);		/* [0004]CSME Sec Capabilities */
-	EFPRINTF(fp, "UINT16 : 0000\n");			/* [0002]SGX Capabilities */
-
-	/* passthru the following @46 - 33 bytes:
-	 * [0010]FW Versions
-	 * [0010]FW Vendor
-	 * [0001]EOM State
-	 */
-	if (copy_table_pos_len(psds_fd, 46, 33, fp) !=0) {
-		pr_err("Failed to read psds table!\n");
-		return -1;
-	}
-
-	EFPRINTF(fp, "UINT8 : 00\n");				/* [0001]Secure Boot Enabled */
-	EFPRINTF(fp, "UINT8 : 00\n");				/* [0001]Measured Boot Enabled */
-	EFPRINTF(fp, "UINT8 : 00\n");				/* [0001]Hwrot Type */
-	EFPRINTF(fp, "UINT8 : 00\n");				/* [0001]fwHashIndex */
-	EFPRINTF(fp, "UINT8 : 00\n");				/* [0001]fwHashDataLen */
-
-	EFFLUSH(fp);
-	return 0;
-}
-
 static int
 basl_fwrite_facs(FILE *fp, struct vmctx *ctx)
 {
@@ -1162,7 +1061,6 @@ static struct {
 	{ basl_fwrite_facs, FACS_OFFSET, true  },
 	{ basl_fwrite_nhlt, NHLT_OFFSET, false }, /*valid with audio ptdev*/
 	{ basl_fwrite_tpm2, TPM2_OFFSET, false },
-	{ basl_fwrite_psds, PSDS_OFFSET, false }, /*valid when psds present in sos */
 	{ basl_fwrite_dsdt, DSDT_OFFSET, true  }
 };
 
@@ -1220,11 +1118,6 @@ acpi_build(struct vmctx *ctx, int ncpu)
 	i = 0;
 	err = basl_make_templates();
 
-	/* Check PSDS in SOS, only present PSDS table to UOS when PSDS present in SOS */
-	psds_fd = open("/sys/firmware/acpi/tables/PSDS", O_RDONLY);
-	if (psds_fd >=0)
-		acpi_table_enable(PSDS_ENTRY_NO);
-
 	/*
 	 * Run through all the ASL files, compiling them and
 	 * copying them into guest memory
@@ -1240,9 +1133,6 @@ acpi_build(struct vmctx *ctx, int ncpu)
 					basl_ftables[i].offset);
 		i++;
 	}
-
-	if (psds_fd >=0)
-		close(psds_fd);
 
 	return err;
 }

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -41,7 +41,6 @@
 
 /* All dynamic table entry no. */
 #define NHLT_ENTRY_NO		8
-#define PSDS_ENTRY_NO		10
 
 void acpi_table_enable(int num);
 uint32_t get_acpi_base(void);


### PR DESCRIPTION
Kontron COMe-mAL10 does not provide an ACPI PSDS table as expected.
basl_fwrite_psds() expects to copy 33 bytes beginning at offset 46, thus
accessing the table up to offset 79. The PSDS table provided here is
shorter and thus should be ignored. Introduce a minimum length check
to achieve this.

Tracked-On: #4846
Signed-off-by: Helmut Buchsbaum <helmut.buchsbaum@opensource.tttech-industrial.com>