### PR TITLE
HV: Fix MP Init sequence hang by adding a delay

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -317,7 +317,7 @@ static void start_pcpu(uint16_t pcpu_id)
 	write_trampoline_stack_sym(pcpu_id);
 	clac();
 
-	send_startup_ipi(INTR_CPU_STARTUP_USE_DEST, pcpu_id, startup_paddr);
+	send_startup_ipi(pcpu_id, startup_paddr);
 
 	/* Wait until the pcpu with pcpu_id is running and set the active bitmap or
 	 * configured time-out has expired

--- a/hypervisor/include/arch/x86/lapic.h
+++ b/hypervisor/include/arch/x86/lapic.h
@@ -131,15 +131,11 @@ void send_lapic_eoi(void);
  *
  * Send an Startup IPI to a specific cpu, to notify the cpu to start booting.
  *
- * @param[in]	cpu_startup_shorthand The startup_shorthand
  * @param[in]	dest_pcpu_id The id of destination physical cpu
  * @param[in]	cpu_startup_start_address The address for the dest pCPU to start running
  *
- * @pre cpu_startup_shorthand < INTR_CPU_STARTUP_UNKNOWN
  */
-void send_startup_ipi(enum intr_cpu_startup_shorthand cpu_startup_shorthand,
-		uint16_t dest_pcpu_id,
-		uint64_t cpu_startup_start_address);
+void send_startup_ipi(uint16_t dest_pcpu_id, uint64_t cpu_startup_start_address);
 
 /**
  * @brief Send an IPI to multiple pCPUs


### PR DESCRIPTION
As per the BWG a delay should be provided between the
INIT IPI and Startup IPI. Without the delay observe hangs
on certain platforms during MP Init sequence. So Setting
a delay of 10us between assert INIT IPI and Startup IPI.

Also, as per SDM section 10.7 the the de-assert INIT IPI is
only used for Pentium and P6 processors. This is not applicable
for Pentium4 and Xeon processors so removing this sequence.

Tracked-On: #4835
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>