### PR TITLE
use variables for installation directories.

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -2,6 +2,8 @@
 # ACRN-DM
 #
 include ../VERSION
+include ../paths.make
+
 FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)
 BASEDIR := $(shell pwd)
 DM_OBJDIR ?= $(CURDIR)/build
@@ -228,19 +230,19 @@ $(DM_OBJDIR)/%.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c $< -o $@ -MMD -MT $@
 
 install: $(DM_OBJDIR)/$(PROGRAM) install-samples-nuc install-samples-mrb install-bios install-samples-up2
-	install -D --mode=0755 $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)/usr/bin/$(PROGRAM)
+	install -D --mode=0755 $(DM_OBJDIR)/$(PROGRAM) $(DESTDIR)$(bindir)/$(PROGRAM)
 
 install-samples-up2: $(SAMPLES_UP2)
-	install -D -t $(DESTDIR)/usr/share/acrn/samples/apl-up2 $^
+	install -D -t $(DESTDIR)$(datadir)/acrn/samples/apl-up2 $^
 
 install-samples-nuc: $(SAMPLES_NUC)
-	install -D -t $(DESTDIR)/usr/share/acrn/samples/nuc $^
+	install -D -t $(DESTDIR)$(datadir)/acrn/samples/nuc $^
 
 install-samples-mrb: $(SAMPLES_MRB)
-	install -D -t $(DESTDIR)/usr/share/acrn/samples/apl-mrb $^
-	install -d $(DESTDIR)/usr/lib/systemd/system/
-	install -p -D -m 0644 ./samples/apl-mrb/acrn_guest.service $(DESTDIR)/usr/lib/systemd/system
+	install -D -t $(DESTDIR)$(datadir)/acrn/samples/apl-mrb $^
+	install -d $(DESTDIR)$(systemd_unitdir)/system/
+	install -p -D -m 0644 ./samples/apl-mrb/acrn_guest.service $(DESTDIR)$(systemd_unitdir)/system
 
 install-bios: $(BIOS_BIN)
-	install -d $(DESTDIR)/usr/share/acrn/bios
-	install -D --mode=0664 -t $(DESTDIR)/usr/share/acrn/bios $^
+	install -d $(DESTDIR)$(datadir)/acrn/bios
+	install -D --mode=0664 -t $(DESTDIR)$(datadir)/acrn/bios $^

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -63,6 +63,8 @@ else
   SCENARIO_CFG_DIR := $(TARGET_DIR)/$(SCENARIO)
 endif
 
+include ../paths.make
+
 LD_IN_TOOL = scripts/genld.sh
 BASH = $(shell which bash)
 
@@ -403,12 +405,12 @@ endif
 all: pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 
 install: $(HV_OBJDIR)/$(HV_FILE).32.out
-	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).32.out
-	install -D $(HV_OBJDIR)/$(HV_FILE).bin $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).bin
+	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).32.out
+	install -D $(HV_OBJDIR)/$(HV_FILE).bin $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).bin
 
 install-debug: $(HV_OBJDIR)/$(HV_FILE).map $(HV_OBJDIR)/$(HV_FILE).out
-	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).out
-	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)/usr/lib/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).map
+	install -D $(HV_OBJDIR)/$(HV_FILE).out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).out
+	install -D $(HV_OBJDIR)/$(HV_FILE).map $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(FIRMWARE).$(SCENARIO).map
 
 .PHONY: pre_build
 pre_build: $(PRE_BUILD_OBJS)

--- a/misc/acrn-manager/Makefile
+++ b/misc/acrn-manager/Makefile
@@ -1,3 +1,5 @@
+include ../../paths.make
+
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
@@ -101,15 +103,15 @@ endif
 
 .PHONY: install
 install:
-	install -d $(DESTDIR)/usr/bin
-	install -d $(DESTDIR)/usr/lib/systemd/system
-	install -d $(DESTDIR)/usr/lib64/
-	install -d $(DESTDIR)/usr/include/acrn
+	install -d $(DESTDIR)$(bindir)
+	install -d $(DESTDIR)$(systemd_unitdir)/system
+	install -d $(DESTDIR)$(libdir)
+	install -d $(DESTDIR)$(includedir)/acrn
 ifeq ($(RELEASE),0)
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnctl
+	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/acrnctl
 endif
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnd
-	install -m 0644 -t $(DESTDIR)/usr/lib64/ $(OUT_DIR)/libacrn-mngr.a
-	install -m 0644 -t $(DESTDIR)/usr/include/acrn $(OUT_DIR)/acrn_mngr.h
-	install -m 0644 -t $(DESTDIR)/usr/include/acrn $(MANAGER_HEADERS)
-	install -p -D -m 0644 $(OUT_DIR)/acrnd.service $(DESTDIR)/usr/lib/systemd/system
+	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/acrnd
+	install -m 0644 -t $(DESTDIR)$(libdir) $(OUT_DIR)/libacrn-mngr.a
+	install -m 0644 -t $(DESTDIR)$(includedir)/acrn $(OUT_DIR)/acrn_mngr.h
+	install -m 0644 -t $(DESTDIR)$(includedir)/acrn $(MANAGER_HEADERS)
+	install -p -D -m 0644 $(OUT_DIR)/acrnd.service $(DESTDIR)$(systemd_unitdir)/system

--- a/misc/acrnbridge/Makefile
+++ b/misc/acrnbridge/Makefile
@@ -1,6 +1,6 @@
+include ../../paths.make
 
 OUT_DIR ?= .
-SYSTEMD_NETWORKDIR := usr/lib
 
 all:
 	cp acrn.netdev $(OUT_DIR)
@@ -9,8 +9,8 @@ all:
 	cp eth.network $(OUT_DIR)
 
 install:
-	install -d $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network
-	install -p -D -m 0644 $(OUT_DIR)/acrn.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn.netdev
-	install -p -D -m 0644 $(OUT_DIR)/acrn.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-acrn.network
-	install -p -D -m 0644 $(OUT_DIR)/tap0.netdev $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-tap0.netdev
-	install -p -D -m 0644 $(OUT_DIR)/eth.network $(DESTDIR)/$(SYSTEMD_NETWORKDIR)/systemd/network/50-eth.network
+	install -d $(DESTDIR)$(systemd_unitdir)/network
+	install -p -D -m 0644 $(OUT_DIR)/acrn.netdev $(DESTDIR)$(systemd_unitdir)/network/50-acrn.netdev
+	install -p -D -m 0644 $(OUT_DIR)/acrn.network $(DESTDIR)$(systemd_unitdir)/network/50-acrn.network
+	install -p -D -m 0644 $(OUT_DIR)/tap0.netdev $(DESTDIR)$(systemd_unitdir)/network/50-tap0.netdev
+	install -p -D -m 0644 $(OUT_DIR)/eth.network $(DESTDIR)$(systemd_unitdir)/network/50-eth.network

--- a/misc/tools/acrn-crashlog/Makefile
+++ b/misc/tools/acrn-crashlog/Makefile
@@ -2,6 +2,8 @@
 # ACRN-Crashlog Makefile
 #
 
+include ../../../paths.make
+
 BASEDIR 	:= $(shell pwd)
 OUT_DIR 	?= $(BASEDIR)
 BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
@@ -97,60 +99,60 @@ clean:
 
 .PHONY:install
 install:
-	@install -d $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/acrnprobe/bin/acrnprobe $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/debugger $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_c $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_s $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 data/crashlogctl $(DESTDIR)/usr/bin/
-	@install -p -D -m 0755 data/usercrash-wrapper $(DESTDIR)/usr/bin/
-	@install -d $(DESTDIR)/usr/share/acrn/crashlog
-	@install -p -D -m 0644 data/40-watchdog.conf $(DESTDIR)/usr/share/acrn/crashlog
-	@install -p -D -m 0644 data/80-coredump.conf $(DESTDIR)/usr/share/acrn/crashlog
-	@install -d $(DESTDIR)/usr/share/defaults/telemetrics/
-	@install -p -D -m 0644 data/acrnprobe.xml $(DESTDIR)/usr/share/defaults/telemetrics/
-	@install -d $(DESTDIR)/usr/lib/systemd/system/
-	@install -p -D -m 0644 data/acrnprobe.service $(DESTDIR)/usr/lib/systemd/system/
-	@install -p -D -m 0644 data/usercrash.service $(DESTDIR)/usr/lib/systemd/system/
-	@install -d $(DESTDIR)/usr/lib/tmpfiles.d
-	@install -p -D -m 0644 data/acrn-crashlog-dirs.conf $(DESTDIR)/usr/lib/tmpfiles.d/
+	@install -d $(DESTDIR)$(bindir)/
+	@install -p -D -m 0755 $(BUILDDIR)/acrnprobe/bin/acrnprobe $(DESTDIR)$(bindir)/
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/debugger $(DESTDIR)$(bindir)/
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_c $(DESTDIR)$(bindir)/
+	@install -p -D -m 0755 $(BUILDDIR)/usercrash/bin/usercrash_s $(DESTDIR)$(bindir)/
+	@install -p -D -m 0755 data/crashlogctl $(DESTDIR)$(bindir)/
+	@install -p -D -m 0755 data/usercrash-wrapper $(DESTDIR)$(bindir)/
+	@install -d $(DESTDIR)$(datadir)/acrn/crashlog
+	@install -p -D -m 0644 data/40-watchdog.conf $(DESTDIR)$(datadir)/acrn/crashlog
+	@install -p -D -m 0644 data/80-coredump.conf $(DESTDIR)$(datadir)/acrn/crashlog
+	@install -d $(DESTDIR)$(datadir)/defaults/telemetrics/
+	@install -p -D -m 0644 data/acrnprobe.xml $(DESTDIR)$(datadir)/defaults/telemetrics/
+	@install -d $(DESTDIR)$(systemd_unitdir)/system/
+	@install -p -D -m 0644 data/acrnprobe.service $(DESTDIR)$(systemd_unitdir)/system/
+	@install -p -D -m 0644 data/usercrash.service $(DESTDIR)$(systemd_unitdir)/system/
+	@install -d $(DESTDIR)$(libdir)/tmpfiles.d
+	@install -p -D -m 0644 data/acrn-crashlog-dirs.conf $(DESTDIR)$(libdir)/tmpfiles.d/
 
 .PHONY:uninstall
 uninstall:
-	@if [ -e "$(DESTDIR)/usr/bin/acrnprobe" ];then \
-		$(RM) $(DESTDIR)/usr/bin/acrnprobe; \
+	@if [ -e "$(DESTDIR)$(bindir)/acrnprobe" ];then \
+		$(RM) $(DESTDIR)$(bindir)/acrnprobe; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/crashlogctl" ];then \
-		$(DESTDIR)/usr/bin/crashlogctl disable && \
-		$(RM) $(DESTDIR)/usr/bin/crashlogctl; \
+	@if [ -e "$(DESTDIR)$(bindir)/crashlogctl" ];then \
+		$(DESTDIR)$(bindir)/crashlogctl disable && \
+		$(RM) $(DESTDIR)$(bindir)/crashlogctl; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/debugger" ];then \
-		$(RM) $(DESTDIR)/usr/bin/debugger; \
+	@if [ -e "$(DESTDIR)$(bindir)/debugger" ];then \
+		$(RM) $(DESTDIR)$(bindir)/debugger; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/usercrash_c" ];then \
-		$(RM) $(DESTDIR)/usr/bin/usercrash_c; \
+	@if [ -e "$(DESTDIR)$(bindir)/usercrash_c" ];then \
+		$(RM) $(DESTDIR)$(bindir)/usercrash_c; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/usercrash_s" ];then \
-		$(RM) $(DESTDIR)/usr/bin/usercrash_s; \
+	@if [ -e "$(DESTDIR)$(bindir)/usercrash_s" ];then \
+		$(RM) $(DESTDIR)$(bindir)/usercrash_s; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/bin/usercrash-wrapper" ];then \
-		$(RM) $(DESTDIR)/usr/bin/usercrash-wrapper; \
+	@if [ -e "$(DESTDIR)$(bindir)/usercrash-wrapper" ];then \
+		$(RM) $(DESTDIR)$(bindir)/usercrash-wrapper; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/share/acrn/crashlog/40-watchdog.conf" ];then \
-		$(RM) $(DESTDIR)/usr/share/acrn/crashlog/40-watchdog.conf; \
+	@if [ -e "$(DESTDIR)$(datadir)/acrn/crashlog/40-watchdog.conf" ];then \
+		$(RM) $(DESTDIR)$(datadir)/acrn/crashlog/40-watchdog.conf; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/share/acrn/crashlog/80-coredump.conf" ];then \
-		$(RM) $(DESTDIR)/usr/share/acrn/crashlog/80-coredump.conf; \
+	@if [ -e "$(DESTDIR)$(datadir)/acrn/crashlog/80-coredump.conf" ];then \
+		$(RM) $(DESTDIR)$(datadir)/acrn/crashlog/80-coredump.conf; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/share/defaults/telemetrics/acrnprobe.xml" ];then \
-		$(RM) $(DESTDIR)/usr/share/defaults/telemetrics/acrnprobe.xml; \
+	@if [ -e "$(DESTDIR)$(datadir)/defaults/telemetrics/acrnprobe.xml" ];then \
+		$(RM) $(DESTDIR)$(datadir)/defaults/telemetrics/acrnprobe.xml; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/lib/systemd/system/acrnprobe.service" ];then \
-		$(RM) $(DESTDIR)/usr/lib/systemd/system/acrnprobe.service; \
+	@if [ -e "$(DESTDIR)$(systemd_unitdir)/system/acrnprobe.service" ];then \
+		$(RM) $(DESTDIR)$(systemd_unitdir)/system/acrnprobe.service; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/lib/systemd/system/usercrash.service" ];then \
-		$(RM) $(DESTDIR)/usr/lib/systemd/system/usercrash.service; \
+	@if [ -e "$(DESTDIR)$(systemd_unitdir)/system/usercrash.service" ];then \
+		$(RM) $(DESTDIR)$(systemd_unitdir)/system/usercrash.service; \
 	fi
-	@if [ -e "$(DESTDIR)/usr/lib/tmpfiles.d/acrn-crashlog-dirs.conf" ];then \
-		$(RM) $(DESTDIR)/usr/lib/tmpfiles.d/acrn-crashlog-dirs.conf; \
+	@if [ -e "$(DESTDIR)$(libdir)/tmpfiles.d/acrn-crashlog-dirs.conf" ];then \
+		$(RM) $(DESTDIR)$(libdir)/tmpfiles.d/acrn-crashlog-dirs.conf; \
 	fi

--- a/misc/tools/acrnlog/Makefile
+++ b/misc/tools/acrnlog/Makefile
@@ -1,3 +1,5 @@
+include ../../../paths.make
+
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
@@ -48,7 +50,7 @@ ifneq ($(OUT_DIR),.)
 endif
 
 install: $(OUT_DIR)/acrnlog
-	install -d $(DESTDIR)/usr/bin
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrnlog
-	install -d $(DESTDIR)/usr/lib/systemd/system
-	install -p -D -m 0644 $(OUT_DIR)/acrnlog.service $(DESTDIR)/usr/lib/systemd/system
+	install -d $(DESTDIR)$(bindir)
+	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/acrnlog
+	install -d $(DESTDIR)$(systemd_unitdir)/system
+	install -p -D -m 0644 $(OUT_DIR)/acrnlog.service $(DESTDIR)$(systemd_unitdir)/system

--- a/misc/tools/acrntrace/Makefile
+++ b/misc/tools/acrntrace/Makefile
@@ -1,3 +1,5 @@
+include ../../../paths.make
+
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
@@ -47,5 +49,5 @@ ifneq ($(OUT_DIR),.)
 endif
 
 install: $(OUT_DIR)/acrntrace
-	install -d $(DESTDIR)/usr/bin
-	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/acrntrace
+	install -d $(DESTDIR)$(bindir)
+	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/acrntrace

--- a/paths.make
+++ b/paths.make
@@ -1,0 +1,8 @@
+DESTDIR ?=
+prefix ?= /usr
+bindir ?= $(prefix)/bin
+libdir ?= $(prefix)/lib64
+nonarchlibdir ?= $(prefix)/lib
+datadir ?= $(prefix)/share
+includedir ?= $(prefix)/include
+systemd_unitdir ?= $(prefix)/lib/systemd


### PR DESCRIPTION
Don't hardcode install paths. Instead of hardcoding where binaries are
installed, add variables that installer can override.

Signed-off-by: Chee Yang Lee <chee.yang.lee@intel.com>
Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>