### PR TITLE
porting patch: hv: virq: refine pending event inject sequence

### DIFF
--- a/hypervisor/include/arch/x86/guest/vlapic.h
+++ b/hypervisor/include/arch/x86/guest/vlapic.h
@@ -90,7 +90,7 @@ struct acrn_vlapic {
 
 struct acrn_apicv_ops {
 	void (*accept_intr)(struct acrn_vlapic *vlapic, uint32_t vector, bool level);
-	bool (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
+	void (*inject_intr)(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 	bool (*has_pending_delivery_intr)(struct acrn_vcpu *vcpu);
 	bool (*has_pending_intr)(struct acrn_vcpu *vcpu);
 	bool (*apic_read_access_may_valid)(uint32_t offset);
@@ -110,7 +110,7 @@ void vlapic_set_apicv_ops(void);
  * @{
  */
 
-bool vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
+void vlapic_inject_intr(struct acrn_vlapic *vlapic, bool guest_irq_enabled, bool injected);
 bool vlapic_has_pending_delivery_intr(struct acrn_vcpu *vcpu);
 bool vlapic_has_pending_intr(struct acrn_vcpu *vcpu);
 


### PR DESCRIPTION
Inject pending exception prior pending interrupt to complete the previous instruction.

Tracked-On: #1842
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>