### PR TITLE
vpci: refine pci device assignment logic

### DIFF
--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -9,13 +9,7 @@
 #include <pci_dev.h>
 #include <vpci.h>
 
-struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM] = {
-	{
-		.emu_type = PCI_DEV_TYPE_HVEMUL,
-		.vbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U},
-		.vdev_ops = &vhostbridge_ops,
-	},
-};
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 /*
  * @pre pdev != NULL;
@@ -28,24 +22,18 @@ static bool is_allocated_to_prelaunched_vm(struct pci_pdev *pdev)
 	struct acrn_vm_config *vm_config;
 	struct acrn_vm_pci_dev_config *dev_config;
 
-	for (vmid = 0U; vmid < CONFIG_MAX_VM_NUM; vmid++) {
+	for (vmid = 0U; (vmid < CONFIG_MAX_VM_NUM) && !found; vmid++) {
 		vm_config = get_vm_config(vmid);
-		if (vm_config->load_order != PRE_LAUNCHED_VM) {
-			continue;
-		}
-
-		for (pci_idx = 0U; pci_idx < vm_config->pci_dev_num; pci_idx++) {
-			dev_config = &vm_config->pci_devs[pci_idx];
-			if ((dev_config->emu_type == PCI_DEV_TYPE_PTDEV) &&
-					bdf_is_equal(dev_config->pbdf, pdev->bdf)) {
-				dev_config->pdev = pdev;
-				found = true;
-				break;
+		if (vm_config->load_order == PRE_LAUNCHED_VM) {
+			for (pci_idx = 0U; pci_idx < vm_config->pci_dev_num; pci_idx++) {
+				dev_config = &vm_config->pci_devs[pci_idx];
+				if ((dev_config->emu_type == PCI_DEV_TYPE_PTDEV) &&
+						bdf_is_equal(dev_config->pbdf, pdev->bdf)) {
+					dev_config->pdev = pdev;
+					found = true;
+					break;
+				}
 			}
-		}
-
-		if (found) {
-			break;
 		}
 	}
 

--- a/hypervisor/arch/x86/configs/whl-ipc-i5/pci_devices.h
+++ b/hypervisor/arch/x86/configs/whl-ipc-i5/pci_devices.h
@@ -22,7 +22,6 @@
 
 #define PTDEV_HI_MMIO_SIZE			0UL
 
-#define HOST_BRIDGE                             .pbdf.bits = {.b = 0x00U, .d = 0x00U, .f = 0x00U}
 #define VGA_COMPATIBLE_CONTROLLER_0             .pbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U}, \
                                                 .vbar_base[0] = 0xa0000000UL, \
                                                 .vbar_base[2] = 0x90000000UL

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -138,15 +138,12 @@ bool is_pi_capable(const struct acrn_vm *vm)
 	return (platform_caps.pi && (!is_lapic_pt_configured(vm)));
 }
 
-static struct acrn_vm *get_highest_severity_vm(void)
+struct acrn_vm *get_highest_severity_vm(bool runtime)
 {
 	uint16_t vm_id, highest_vm_id = 0U;
-	struct acrn_vm *vm = NULL;
 
 	for (vm_id = 1U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
-		vm = get_vm_from_vmid(vm_id);
-
-		if (is_poweroff_vm(vm)) {
+		if (runtime && is_poweroff_vm(get_vm_from_vmid(vm_id))) {
 			/* If vm is non-existed or shutdown, it's not highest severity VM */
 			continue;
 		}
@@ -157,14 +154,6 @@ static struct acrn_vm *get_highest_severity_vm(void)
 	}
 
 	return get_vm_from_vmid(highest_vm_id);
-}
-
-/**
- * @pre vm != NULL && vm_config != NULL && vm->vmid < CONFIG_MAX_VM_NUM
- */
-bool is_highest_severity_vm(const struct acrn_vm *vm)
-{
-	return (get_highest_severity_vm() == vm);
 }
 
 /**

--- a/hypervisor/arch/x86/guest/vm_reset.c
+++ b/hypervisor/arch/x86/guest/vm_reset.c
@@ -84,7 +84,7 @@ static bool handle_common_reset_reg_write(struct acrn_vm *vm, bool reset)
 	bool ret = true;
 
 	if (reset) {
-		if (is_highest_severity_vm(vm)) {
+		if (get_highest_severity_vm(true) == vm) {
 			reset_host();
 		} else if (is_postlaunched_vm(vm)) {
 			/* re-inject to DM */

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -624,8 +624,10 @@ struct pci_vdev *vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_c
 	if (dev_config->vdev_ops != NULL) {
 		vdev->vdev_ops = dev_config->vdev_ops;
 	} else {
-		if (vdev->pdev->hdr_type == PCIM_HDRTYPE_BRIDGE) {
+		if (is_bridge(vdev->pdev)) {
 			vdev->vdev_ops = &vpci_bridge_ops;
+		} else if (is_host_bridge(vdev->pdev)) {
+			vdev->vdev_ops = &vhostbridge_ops;
 		} else {
 			vdev->vdev_ops = &pci_pt_dev_ops;
 		}

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -229,7 +229,7 @@ bool pdev_need_bar_restore(const struct pci_pdev *pdev)
 	bool need_restore = false;
 	uint32_t idx, bar;
 
-	for (idx = 0U; idx < PCI_STD_NUM_BARS; idx++) {
+	for (idx = 0U; idx < pdev->nr_bars; idx++) {
 		bar = pci_pdev_read_cfg(pdev->bdf, pci_bar_offset(idx), 4U);
 		if (bar != pdev->bars[idx]) {
 			need_restore = true;
@@ -244,7 +244,7 @@ static inline void pdev_save_bar(struct pci_pdev *pdev)
 {
 	uint32_t idx;
 
-	for (idx = 0U; idx < PCI_STD_NUM_BARS; idx++) {
+	for (idx = 0U; idx < pdev->nr_bars; idx++) {
 		pdev->bars[idx] = pci_pdev_read_cfg(pdev->bdf, pci_bar_offset(idx), 4U);
 	}
 }
@@ -253,7 +253,7 @@ void pdev_restore_bar(const struct pci_pdev *pdev)
 {
 	uint32_t idx;
 
-	for (idx = 0U; idx < PCI_STD_NUM_BARS; idx++) {
+	for (idx = 0U; idx < pdev->nr_bars; idx++) {
 		pci_pdev_write_cfg(pdev->bdf, pci_bar_offset(idx), 4U, pdev->bars[idx]);
 	}
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -760,6 +760,8 @@ struct pci_pdev *init_pdev(uint16_t pbdf, uint32_t drhd_index)
 			pdev = &pci_pdev_array[num_pci_pdev];
 			pdev->bdf.value = pbdf;
 			pdev->hdr_type = hdr_type;
+			pdev->base_class = (uint8_t)pci_pdev_read_cfg(bdf, PCIR_CLASS, 1U);
+			pdev->sub_class = (uint8_t)pci_pdev_read_cfg(bdf, PCIR_SUBCLASS, 1U);
 			pdev->nr_bars = pci_pdev_get_nr_bars(hdr_type);
 			if (hdr_type == PCIM_HDRTYPE_NORMAL) {
 				pdev_save_bar(pdev);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -254,7 +254,7 @@ bool is_lapic_pt_configured(const struct acrn_vm *vm);
 bool is_rt_vm(const struct acrn_vm *vm);
 bool is_pi_capable(const struct acrn_vm *vm);
 bool has_rt_vm(void);
-bool is_highest_severity_vm(const struct acrn_vm *vm);
+struct acrn_vm *get_highest_severity_vm(bool runtime);
 bool vm_hide_mtrr(const struct acrn_vm *vm);
 void update_vm_vlapic_state(struct acrn_vm *vm);
 enum vm_vlapic_state check_vm_vlapic_state(const struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/pci_dev.h
+++ b/hypervisor/include/arch/x86/pci_dev.h
@@ -9,8 +9,6 @@
 
 #include <vm_config.h>
 
-#define SOS_EMULATED_PCI_DEV_NUM	1U
-
 extern struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 struct pci_pdev;

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -36,7 +36,7 @@
 #define CONFIG_SOS_VM		.load_order = SOS_VM,	\
 				.uuid = SOS_VM_UUID,	\
 				.severity = SEVERITY_SOS,	\
-				.pci_dev_num = SOS_EMULATED_PCI_DEV_NUM,	\
+				.pci_dev_num = 0U,	\
 				.pci_devs = sos_pci_devs
 
 #define CONFIG_SAFETY_VM(idx)	.load_order = PRE_LAUNCHED_VM,	\

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -183,7 +183,6 @@
 #define PCIR_AF_CTRL          0x4U
 #define PCIM_AF_FLR           0x1U
 
-#define HOST_BRIDGE_BDF		0U
 #define PCI_STD_NUM_BARS        6U
 
 union pci_bdf {

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -223,6 +223,8 @@ struct pci_sriov_cap {
 
 struct pci_pdev {
 	uint8_t hdr_type;
+	uint8_t base_class;
+	uint8_t sub_class;
 
 	/* IOMMU responsible for DMA and Interrupt Remapping for this device */
 	uint32_t drhd_index;
@@ -249,6 +251,16 @@ struct pci_cfg_ops {
 	uint32_t (*pci_read_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 	void (*pci_write_cfg)(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 };
+
+static inline bool is_host_bridge(const struct pci_pdev *pdev)
+{
+	return (pdev->base_class == PCIC_BRIDGE) && (pdev->sub_class == PCIS_BRIDGE_HOST);
+}
+
+static inline bool is_bridge(const struct pci_pdev *pdev)
+{
+	return pdev->hdr_type == PCIM_HDRTYPE_BRIDGE;
+}
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
 {


### PR DESCRIPTION
v3:
1. add two new inline function: is_host_bridge and is_bridge
2. Add new input runtime for is_highest_severity_vm to check whether the vm is the highest severity VM on runtime or not
3. Adapt pdev_need_bar_restore/pdev_save_bar/pdev_restore_bar to Type 1 device
4. refine Patch 3 comment and coding style

v2:
1. check whether a device is host bridge or not by PCI Class
2. wrap a new function to get the highest severity VM of a scenario


v1:
two minor refine

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
