### PR TITLE
Makefile: minor fix on hypervisor dependency

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -489,7 +489,7 @@ distclean:
 	rm -f tags TAGS cscope.files cscope.in.out cscope.out cscope.po.out GTAGS GPATH GRTAGS GSYMS
 
 PHONY: (VERSION)
-$(VERSION):
+$(VERSION): $(HV_OBJDIR)/$(HV_CONFIG_H)
 	@if  [ "$(SCENARIO)" = "" ]; then echo "Please specify SCENARIO for the build!"; exit 1; fi;
 	@if  [ "$(BOARD)" = "" ]; then echo "Please specify BOARD for the build!"; exit 1; fi;
 	@echo "SCENARIO <$(SCENARIO)> for BOARD <$(BOARD)> is specified."

--- a/hypervisor/scripts/makefile/kconfig.mk
+++ b/hypervisor/scripts/makefile/kconfig.mk
@@ -68,7 +68,7 @@ $(HV_OBJDIR)/$(HV_CONFIG_H): $(HV_OBJDIR)/$(HV_CONFIG)
 .PHONY: defconfig
 defconfig: $(KCONFIG_DEPS)
 	@mkdir -p $(HV_OBJDIR)
-	@if [ ! -f $(KCONFIG_FILE) ] && [ "$(CONFIG_XML_ENABLED)" != "true" ]; then \
+	@if ([ "$(KCONFIG_FILE)" == "" ] || ([ "$(KCONFIG_FILE)" != "" ] && [ ! -f $(KCONFIG_FILE) ])) && [ "$(CONFIG_XML_ENABLED)" != "true" ]; then \
 		BOARD=$(CONFIG_BOARD) python3 $(KCONFIG_DIR)/defconfig.py Kconfig $(HV_OBJDIR)/$(HV_CONFIG); \
 	else \
 		if [ "$(KCONFIG_FILE)" != "" ] && [ -f $(KCONFIG_FILE) ]; then \


### PR DESCRIPTION
The $(VERSION) should be depended on config.h change. For example, when RELEASE
parameter is changed in make commmand, CONFIG_RELEASE need to be updated in
defconfig file, and then message in version.h should be updated.

The patch also fix a bug that a code path in make defconfig never be triggered
because shell will treat [ ! -f $(KCONFIG_FILE) ] as false when $(KCONFIG_FILE)
is not specified. (i.e. "$(KCONFIG_FILE)" == "")

Tracked-On: #2412

Signed-off-by: Victor Sun <victor.sun@intel.com>