### PR TITLE
hv: pci: remove some unnecessary functions

### DIFF
--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -259,7 +259,7 @@ static inline bool is_host_bridge(const struct pci_pdev *pdev)
 
 static inline bool is_bridge(const struct pci_pdev *pdev)
 {
-	return pdev->hdr_type == PCIM_HDRTYPE_BRIDGE;
+	return ((pdev->hdr_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE);
 }
 
 static inline uint32_t pci_bar_offset(uint32_t idx)
@@ -350,29 +350,9 @@ static inline bool is_pci_vendor_valid(uint32_t vendor_id)
 		 (vendor_id == 0xFFFF0000U) || (vendor_id == 0xFFFFU));
 }
 
-static inline uint32_t read_pci_pdev_cfg_vendor(union pci_bdf pbdf)
-{
-	return pci_pdev_read_cfg(pbdf, PCIR_VENDOR, 2U);
-}
-
-static inline uint8_t read_pci_pdev_cfg_headertype(union pci_bdf pbdf)
-{
-	return (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_HDRTYPE, 1U);
-}
-
-static inline uint8_t read_pci_pdev_cfg_secbus(union pci_bdf pbdf)
-{
-	return (uint8_t)pci_pdev_read_cfg(pbdf, PCIR_SECBUS_1, 1U);
-}
-
 static inline bool is_pci_cfg_multifunction(uint8_t header_type)
 {
 	return ((header_type & PCIM_MFDEV) == PCIM_MFDEV);
-}
-
-static inline bool is_pci_cfg_bridge(uint8_t header_type)
-{
-	return ((header_type & PCIM_HDRTYPE) == PCIM_HDRTYPE_BRIDGE);
 }
 
 bool is_plat_hidden_pdev(union pci_bdf bdf);


### PR DESCRIPTION
We define some functions to read some fields of the CFG header registers. We
could remove them since they're not necessary since calling pci_pdev_read_cfg
is simple.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>