### PR TITLE
doc: specify component versions used by Kata-on-ACRN tutorial

### DIFF
--- a/doc/tutorials/run_kata_containers.rst
+++ b/doc/tutorials/run_kata_containers.rst
@@ -20,8 +20,12 @@ Prerequisites
 #. For a default prebuilt ACRN binary in the E2E package, you must have 4
    CPU cores or enable "CPU Hyper-Threading" in order to have 4 CPU threads for 2 CPU cores.
 #. Follow :ref:`these instructions <Ubuntu Service OS>` to set up the ACRN Service VM
-   based on Ubuntu. Please note that only ACRN hypervisors compiled for
+   based on Ubuntu, this article is validated on the following configurations.
+   Please note that only ACRN hypervisors compiled for
    SDC scenario support Kata Containers currently.
+
+   - ACRN v1.6.1 (tag: acrn-2020w18.4-140000p)
+   - Ubuntu 18.04.4
 
 
 Install Docker


### PR DESCRIPTION
This commit calls out specific ACRN and Ubuntu versions used for running the Kata Containers on ACRN.

Tracked-On: #4879
Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>