### PR TITLE
DM USB: xHCI: [REVERTME] release memory on port resetting.

### DIFF
--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1094,10 +1094,6 @@ usb_dev_init(void *pdata, char *opt)
 		goto errout;
 	}
 
-	if (usb_dev_native_toggle_if_drivers(udev, 0) < 0) {
-		UPRINTF(LWRN, "fail to detach interface driver.\r\n");
-		goto errout;
-	}
 	return udev;
 
 errout:

--- a/devicemodel/include/usb_core.h
+++ b/devicemodel/include/usb_core.h
@@ -188,6 +188,7 @@ struct usb_native_devinfo {
 	uint16_t bcd;
 	uint16_t pid;
 	uint16_t vid;
+	uint32_t slot;
 	enum usb_native_devtype type;
 	struct usb_devpath path;
 	void *priv_data;


### PR DESCRIPTION
There is fd leakage during guest OS rebooting process, and this is
a WA patch to fix it. Formal patch will be made later.

Tracked-On: #4897
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>