### PR TITLE
HV: patch set to enable configurable bootargs

### DIFF
--- a/hypervisor/arch/x86/init.c
+++ b/hypervisor/arch/x86/init.c
@@ -78,6 +78,8 @@ void init_primary_pcpu(void)
 	/* Clear BSS */
 	(void)memset(&ld_bss_start, 0U, (size_t)(&ld_bss_end - &ld_bss_start));
 
+	init_acrn_multiboot_info();
+
 	parse_hv_cmdline();
 
 	init_debug_pre();

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -76,46 +76,42 @@ static uint32_t parse_seed_arg(void)
 }
 
 /*
- * append_seed_arg
+ * fill_seed_arg
  *
  * description:
- *     append seed argument to Guest's cmdline
+ *     fill seed argument to cmdline buffer which has MAX size of MAX_SEED_ARG_SIZE
  *
  * input:
- *    vm        pointer to target VM
+ *    cmd_dst   pointer to cmdline buffer
+ *    cmd_sz    size of cmd_dst buffer
  *
  * output:
- *    cmd_dst   pointer to cmdline for Guest
+ *    cmd_dst   pointer to cmdline buffer
  *
  * return value:
  *    none
+ *
+ * @pre cmd_dst != NULL
  */
-void append_seed_arg(char *cmd_dst, bool vm_is_sos)
+void fill_seed_arg(char *cmd_dst, size_t cmd_sz)
 {
 	uint32_t i;
-	char buf[MEM_1K];
 
-	if ((cmd_dst != NULL) && vm_is_sos) {
-		for (i = 0U; seed_arg[i].str != NULL; i++) {
-			if (seed_arg[i].addr != 0UL) {
-				(void)memset(buf, 0U, sizeof(buf));
+	for (i = 0U; seed_arg[i].str != NULL; i++) {
+		if (seed_arg[i].addr != 0UL) {
 
-				snprintf(buf, sizeof(buf), "%s0x%X ", seed_arg[i].str,
-						sos_vm_hpa2gpa(seed_arg[i].addr));
+			snprintf(cmd_dst, cmd_sz, "%s0x%X ", seed_arg[i].str, sos_vm_hpa2gpa(seed_arg[i].addr));
 
-				if (seed_arg[i].bootloader_id == BOOTLOADER_SBL) {
-					struct image_boot_params *boot_params =
-						(struct image_boot_params *)hpa2hva(seed_arg[i].addr);
+			if (seed_arg[i].bootloader_id == BOOTLOADER_SBL) {
+				struct image_boot_params *boot_params =
+					(struct image_boot_params *)hpa2hva(seed_arg[i].addr);
 
-					boot_params->p_seed_list = sos_vm_hpa2gpa(boot_params->p_seed_list);
+				boot_params->p_seed_list = sos_vm_hpa2gpa(boot_params->p_seed_list);
 
-					boot_params->p_platform_info = sos_vm_hpa2gpa(boot_params->p_platform_info);
-				}
-
-				(void)strncpy_s(cmd_dst, MAX_BOOTARGS_SIZE, buf, strnlen_s(buf, MEM_1K));
-
-				break;
+				boot_params->p_platform_info = sos_vm_hpa2gpa(boot_params->p_platform_info);
 			}
+
+			break;
 		}
 	}
 }

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -39,7 +39,7 @@ static struct physical_seed g_phy_seed;
 
 static uint32_t parse_seed_arg(void)
 {
-	char *cmd_src = NULL;
+	const char *cmd_src = NULL;
 	char *arg, *arg_end;
 	struct acrn_multiboot_info *mbi = get_multiboot_info();
 	uint32_t i = SEED_ARG_NUM - 1U;

--- a/hypervisor/boot/cmdline.c
+++ b/hypervisor/boot/cmdline.c
@@ -9,19 +9,14 @@
 #include <boot.h>
 #include <pgtable.h>
 #include <dbg_cmd.h>
-#include <logmsg.h>
 
 void parse_hv_cmdline(void)
 {
-	const char *start = NULL;
-	const char *end = NULL;
+	const char *start = NULL, *end = NULL;
+	struct acrn_multiboot_info *mbi = &acrn_mbi;
 
-	if (boot_from_multiboot1()) {
-		struct multiboot_info *mbi = (struct multiboot_info *)(hpa2hva_early((uint64_t)boot_regs[1]));
-
-		if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) {
-			start = (char *)hpa2hva_early((uint64_t)mbi->mi_cmdline);
-		}
+	if ((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) {
+		start = mbi->mi_cmdline;
 	}
 
 	while ((start != NULL) && ((*start) != '\0')) {

--- a/hypervisor/boot/guest/deprivilege_boot.c
+++ b/hypervisor/boot/guest/deprivilege_boot.c
@@ -54,9 +54,9 @@ static uint64_t get_depri_boot_ap_trampoline(void)
 	return depri_boot_ctx.ap_trampoline_buf;
 }
 
-static void* get_depri_boot_rsdp(void)
+static const void* get_depri_boot_rsdp(void)
 {
-	return hpa2hva((uint64_t)(depri_boot_ctx.rsdp));
+	return (const void*)hpa2hva((uint64_t)(depri_boot_ctx.rsdp));
 }
 
 static void init_depri_boot_irq(void)

--- a/hypervisor/boot/guest/direct_boot.c
+++ b/hypervisor/boot/guest/direct_boot.c
@@ -27,12 +27,12 @@ static uint64_t get_direct_boot_ap_trampoline(void)
 	return ap_trampoline_buf;
 }
 
-static void* get_direct_boot_rsdp(void)
+static const void* get_direct_boot_rsdp(void)
 {
 #ifdef CONFIG_MULTIBOOT2
 	struct acrn_multiboot_info *mbi = get_multiboot_info();
 
-	return mbi->mi_acpi_rsdp;
+	return mbi->mi_acpi_rsdp_va;
 #else
 	return NULL;
 #endif

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -113,15 +113,15 @@ static void init_vm_bootargs_info(struct acrn_vm *vm, const struct acrn_multiboo
 
 	if (vm_config->load_order == SOS_VM) {
 		if (strncat_s(vm->sw.bootargs_info.src_addr, MAX_BOOTARGS_SIZE, " ", 1U) == 0) {
-			char seed_args[MAX_SEED_ARG_SIZE];
+			char seed_args[MAX_SEED_ARG_SIZE] = "";
 
-			append_seed_arg(seed_args, true);
-			/* Append seed argument for SOS
+			fill_seed_arg(seed_args, true);
+			/* Fill seed argument for SOS
 			 * seed_args string ends with a white space and '\0', so no aditional delimiter is needed
 			 */
 			if (strncat_s(vm->sw.bootargs_info.src_addr, MAX_BOOTARGS_SIZE,
 					seed_args, (MAX_BOOTARGS_SIZE - 1U)) != 0) {
-				pr_err("failed to apend seed arg to SOS bootargs!");
+				pr_err("failed to fill seed arg to SOS bootargs!");
 			}
 
 			/* If there is cmdline from mbi->mi_cmdline, merge it with configured SOS bootargs. */

--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -40,55 +40,6 @@ static void init_vm_ramdisk_info(struct acrn_vm *vm, const struct multiboot_modu
 	}
 }
 
-/* There are two sources for sos_vm kernel cmdline:
- * - cmdline from direct boot mbi->cmdline
- * - cmdline from acrn stitching tool. mod[0].mm_string
- * We need to merge them together
- */
-static char kernel_cmdline[MAX_BOOTARGS_SIZE + 1U];
-
-/**
- * @pre vm != NULL && cmdline != NULL && cmdstr != NULL
- */
-static void merge_cmdline(const struct acrn_vm *vm, const char *cmdline, const char *cmdstr)
-{
-	char *cmd_dst = kernel_cmdline;
-	uint32_t cmdline_len, cmdstr_len;
-	uint32_t dst_avail; /* available room for cmd_dst[] */
-	uint32_t dst_len; /* the actual number of characters that are copied */
-
-	/*
-	 * Append seed argument for SOS
-	 * seed_arg string ends with a white space and '\0', so no aditional delimiter is needed
-	 */
-	append_seed_arg(cmd_dst, is_sos_vm(vm));
-	dst_len = strnlen_s(cmd_dst, MAX_BOOTARGS_SIZE);
-	dst_avail = MAX_BOOTARGS_SIZE + 1U - dst_len;
-	cmd_dst += dst_len;
-
-	cmdline_len = strnlen_s(cmdline, MAX_BOOTARGS_SIZE);
-	cmdstr_len = strnlen_s(cmdstr, MAX_BOOTARGS_SIZE);
-
-	/* reserve one character for the delimiter between 2 strings (one white space) */
-	if ((cmdline_len + cmdstr_len + 1U) >= dst_avail) {
-		panic("Multiboot bootarg string too long");
-	} else {
-		/* copy mbi->mi_cmdline */
-		(void)strncpy_s(cmd_dst, dst_avail, cmdline, cmdline_len);
-		dst_len = strnlen_s(cmd_dst, dst_avail);
-		dst_avail -= dst_len;
-		cmd_dst += dst_len;
-
-		/* overwrite '\0' with a white space */
-		(void)strncpy_s(cmd_dst, dst_avail, " ", 1U);
-		dst_avail -= 1U;
-		cmd_dst += 1U;
-
-		/* copy vm_config->os_config.bootargs */
-		(void)strncpy_s(cmd_dst, dst_avail, cmdstr, cmdstr_len);
-	}
-}
-
 /**
  * @pre vm != NULL
  */
@@ -156,26 +107,37 @@ static void init_vm_bootargs_info(struct acrn_vm *vm, const struct acrn_multiboo
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	char *bootargs = vm_config->os_config.bootargs;
 
-	if (vm_config->load_order == PRE_LAUNCHED_VM) {
+	if ((vm_config->load_order == PRE_LAUNCHED_VM) || (vm_config->load_order == SOS_VM)) {
 		vm->sw.bootargs_info.src_addr = bootargs;
-		vm->sw.bootargs_info.size = strnlen_s(bootargs, MAX_BOOTARGS_SIZE);
-	} else {
-		/* vm_config->load_order == SOS_VM */
-		if (((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U)
-				&& (*(mbi->mi_cmdline) != '\0')) {
-			/*
-			 * If there is cmdline from mbi->mi_cmdline, merge it with
-			 * vm_config->os_config.bootargs
-			 */
-			merge_cmdline(vm, mbi->mi_cmdline, bootargs);
-
-			vm->sw.bootargs_info.src_addr = kernel_cmdline;
-			vm->sw.bootargs_info.size = strnlen_s(kernel_cmdline, MAX_BOOTARGS_SIZE);
-		} else {
-			vm->sw.bootargs_info.src_addr = bootargs;
-			vm->sw.bootargs_info.size = strnlen_s(bootargs, MAX_BOOTARGS_SIZE);
-		}
 	}
+
+	if (vm_config->load_order == SOS_VM) {
+		if (strncat_s(vm->sw.bootargs_info.src_addr, MAX_BOOTARGS_SIZE, " ", 1U) == 0) {
+			char seed_args[MAX_SEED_ARG_SIZE];
+
+			append_seed_arg(seed_args, true);
+			/* Append seed argument for SOS
+			 * seed_args string ends with a white space and '\0', so no aditional delimiter is needed
+			 */
+			if (strncat_s(vm->sw.bootargs_info.src_addr, MAX_BOOTARGS_SIZE,
+					seed_args, (MAX_BOOTARGS_SIZE - 1U)) != 0) {
+				pr_err("failed to apend seed arg to SOS bootargs!");
+			}
+
+			/* If there is cmdline from mbi->mi_cmdline, merge it with configured SOS bootargs. */
+			if (((mbi->mi_flags & MULTIBOOT_INFO_HAS_CMDLINE) != 0U) && (*(mbi->mi_cmdline) != '\0')) {
+				if (strncat_s(vm->sw.bootargs_info.src_addr, MAX_BOOTARGS_SIZE,
+						mbi->mi_cmdline, (MAX_BOOTARGS_SIZE - 1U)) != 0) {
+					pr_err("failed to merge mbi cmdline to SOS bootargs!");
+				}
+			}
+		} else {
+			pr_err("no space to append SOS bootargs!");
+		}
+
+	}
+
+	vm->sw.bootargs_info.size = strnlen_s(vm->sw.bootargs_info.src_addr, MAX_BOOTARGS_SIZE);
 
 	/* Kernel bootarg and zero page are right before the kernel image */
 	if (vm->sw.bootargs_info.size > 0U) {

--- a/hypervisor/boot/guest/vboot_wrapper.c
+++ b/hypervisor/boot/guest/vboot_wrapper.c
@@ -42,7 +42,6 @@ void init_vboot(void)
 		{"PXELINUX", DIRECT_BOOT_MODE},
 	};
 
-	printf("Detect bootloader: %s\n", mbi->mi_loader_name);
 	for (i = 0U; i < BOOTLOADER_NUM; i++) {
 		if (strncmp(mbi->mi_loader_name, vboot_bootloader_maps[i].bootloader_name,
 			strnlen_s(vboot_bootloader_maps[i].bootloader_name, BOOTLOADER_NAME_SIZE)) == 0) {
@@ -79,7 +78,7 @@ uint64_t get_ap_trampoline_buf(void)
 }
 
 /* @pre: vboot_ops->get_rsdp != NULL */
-void *get_rsdp_ptr(void)
+const void *get_rsdp_ptr(void)
 {
 	return vboot_ops->get_rsdp();
 }

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -24,19 +24,21 @@
 struct acrn_multiboot_info {
 	uint32_t		mi_flags;	/* the flags is back-compatible with multiboot1 */
 
-	char			*mi_cmdline;
-	char			*mi_loader_name;
+	const char		*mi_cmdline;
+	const char		*mi_loader_name;
 
 	uint32_t		mi_mods_count;
+	const void		*mi_mods_va;
 	struct multiboot_module	mi_mods[MAX_MODULE_COUNT];
 
 	uint32_t 		mi_drives_length;
 	uint32_t		mi_drives_addr;
 
 	uint32_t		mi_mmap_entries;
+	const void		*mi_mmap_va;
 	struct multiboot_mmap	mi_mmap_entry[E820_MAX_ENTRIES];
 
-	void			*mi_acpi_rsdp;
+	const void		*mi_acpi_rsdp_va;
 	struct efi_info		mi_efi_info;
 };
 
@@ -72,6 +74,7 @@ int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info);
 #endif
 
 struct acrn_multiboot_info *get_multiboot_info(void);
+void init_acrn_multiboot_info(void);
 int32_t sanitize_multiboot_info(void);
 void parse_hv_cmdline(void);
 

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -73,6 +73,11 @@ static inline bool boot_from_multiboot2(void)
 int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info);
 #endif
 
+/*
+ * The extern declaration for acrn_mbi is for cmdline.c use only, other functions should use
+ * get_multiboot_info() API to access struct acrn_mbi because it has explict @post condition
+ */
+extern struct acrn_multiboot_info acrn_mbi;
 struct acrn_multiboot_info *get_multiboot_info(void);
 void init_acrn_multiboot_info(void);
 int32_t sanitize_multiboot_info(void);

--- a/hypervisor/boot/include/boot.h
+++ b/hypervisor/boot/include/boot.h
@@ -13,9 +13,11 @@
 #endif
 #include <e820.h>
 #include <zeropage.h>
+#include <vm_configurations.h>
 
 #define MAX_BOOTARGS_SIZE		2048U
-#define MAX_MODULE_COUNT		4U
+/* The modules in multiboot are for kernel and ramdisk of pre-launched VMs and SOS VM */
+#define MAX_MODULE_NUM			(2U * PRE_VM_NUM + 2U * SOS_VM_NUM)
 
 /* extended flags for acrn multiboot info from multiboot2  */
 #define	MULTIBOOT_INFO_HAS_EFI_MMAP	0x00010000U
@@ -28,8 +30,8 @@ struct acrn_multiboot_info {
 	const char		*mi_loader_name;
 
 	uint32_t		mi_mods_count;
-	const void		*mi_mods_va;
-	struct multiboot_module	mi_mods[MAX_MODULE_COUNT];
+	void			*mi_mods_va;
+	struct multiboot_module	mi_mods[MAX_MODULE_NUM];
 
 	uint32_t 		mi_drives_length;
 	uint32_t		mi_drives_addr;

--- a/hypervisor/boot/include/guest/vboot.h
+++ b/hypervisor/boot/include/guest/vboot.h
@@ -16,14 +16,14 @@ enum vboot_mode {
 struct vboot_operations {
 	void (*init)(void);
 	uint64_t (*get_ap_trampoline)(void);
-	void *(*get_rsdp)(void);
+	const void *(*get_rsdp)(void);
 	void (*init_irq)(void);
 };
 
 void init_vboot(void);
 void init_vboot_irq(void);
 uint64_t get_ap_trampoline_buf(void);
-void *get_rsdp_ptr(void);
+const void *get_rsdp_ptr(void);
 
 enum vboot_mode get_sos_boot_mode(void);
 

--- a/hypervisor/boot/multiboot.c
+++ b/hypervisor/boot/multiboot.c
@@ -11,7 +11,7 @@
 #include <rtl.h>
 #include <logmsg.h>
 
-static struct acrn_multiboot_info acrn_mbi = { 0U };
+struct acrn_multiboot_info acrn_mbi = { 0U };
 
 static int32_t mbi_status;
 
@@ -50,8 +50,10 @@ int32_t sanitize_multiboot_info(void)
 	} else if (boot_from_multiboot2()) {
 		pr_info("Multiboot2 detected.");
 		mmap_entry_size = sizeof(struct multiboot2_mmap_entry);
-	}
 #endif
+	} else {
+		/* mbi_status is still -ENODEV, nothing to do here */
+	}
 
 	if ((acrn_mbi.mi_mmap_entries != 0U) && (acrn_mbi.mi_mmap_va != NULL)) {
 		if (acrn_mbi.mi_mmap_entries > E820_MAX_ENTRIES) {

--- a/hypervisor/boot/multiboot.c
+++ b/hypervisor/boot/multiboot.c
@@ -13,66 +13,101 @@
 
 static struct acrn_multiboot_info acrn_mbi = { 0U };
 
-int32_t sanitize_multiboot_info(void)
-{
-	int32_t ret = 0;
+static int32_t mbi_status;
 
+void init_acrn_multiboot_info(void)
+{
 	if (boot_from_multiboot1()) {
 		struct multiboot_info *mbi = (struct multiboot_info *)(hpa2hva_early((uint64_t)boot_regs[1]));
 
-		pr_info("Multiboot1 detected.");
 		acrn_mbi.mi_flags = mbi->mi_flags;
 		acrn_mbi.mi_drives_addr = mbi->mi_drives_addr;
 		acrn_mbi.mi_drives_length = mbi->mi_drives_length;
 		acrn_mbi.mi_cmdline = (char *)hpa2hva_early((uint64_t)mbi->mi_cmdline);
 		acrn_mbi.mi_loader_name = (char *)hpa2hva_early((uint64_t)mbi->mi_loader_name);
-
 		acrn_mbi.mi_mmap_entries = mbi->mi_mmap_length / sizeof(struct multiboot_mmap);
-		if ((acrn_mbi.mi_mmap_entries != 0U) && (mbi->mi_mmap_addr != 0U)) {
-			if (acrn_mbi.mi_mmap_entries > E820_MAX_ENTRIES) {
-				pr_err("Too many E820 entries %d\n", acrn_mbi.mi_mmap_entries);
-				acrn_mbi.mi_mmap_entries = E820_MAX_ENTRIES;
-			}
-			(void)memcpy_s((void *)(&acrn_mbi.mi_mmap_entry[0]),
-				(acrn_mbi.mi_mmap_entries * sizeof(struct multiboot_mmap)),
-				(const void *)hpa2hva_early((uint64_t)mbi->mi_mmap_addr),
-				(acrn_mbi.mi_mmap_entries * sizeof(struct multiboot_mmap)));
-		} else {
-			acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MMAP;
-		}
-
+		acrn_mbi.mi_mmap_va = (struct multiboot_mmap *)hpa2hva_early((uint64_t)mbi->mi_mmap_addr);
 		acrn_mbi.mi_mods_count = mbi->mi_mods_count;
-		if ((mbi->mi_mods_count != 0U) && (mbi->mi_mods_addr != 0U)) {
-			if (mbi->mi_mods_count > MAX_MODULE_COUNT) {
-				pr_err("Too many multiboot modules %d\n", mbi->mi_mods_count);
-				acrn_mbi.mi_mods_count = MAX_MODULE_COUNT;
-			}
-			(void)memcpy_s((void *)(&acrn_mbi.mi_mods[0]),
-				(acrn_mbi.mi_mods_count * sizeof(struct multiboot_module)),
-				(const void *)hpa2hva_early((uint64_t)mbi->mi_mods_addr),
-				(acrn_mbi.mi_mods_count * sizeof(struct multiboot_module)));
-		} else {
-			acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MODS;
-		}
+		acrn_mbi.mi_mods_va = (struct multiboot_module *)hpa2hva_early((uint64_t)mbi->mi_mods_addr);
+		mbi_status = 0;
 #ifdef CONFIG_MULTIBOOT2
 	} else if (boot_from_multiboot2()) {
-		ret = multiboot2_to_acrn_mbi(&acrn_mbi, hpa2hva_early((uint64_t)boot_regs[1]));
+		mbi_status = multiboot2_to_acrn_mbi(&acrn_mbi, hpa2hva_early((uint64_t)boot_regs[1]));
 #endif
 	} else {
-		pr_err("no multiboot info found!");
-		ret = -ENODEV;
+		mbi_status = -ENODEV;
+	}
+}
+
+int32_t sanitize_multiboot_info(void)
+{
+	uint32_t mmap_entry_size = 0U;
+
+	if (boot_from_multiboot1()) {
+		pr_info("Multiboot1 detected.");
+		mmap_entry_size = sizeof(struct multiboot_mmap);
+#ifdef CONFIG_MULTIBOOT2
+	} else if (boot_from_multiboot2()) {
+		pr_info("Multiboot2 detected.");
+		mmap_entry_size = sizeof(struct multiboot2_mmap_entry);
+	}
+#endif
+
+	if ((acrn_mbi.mi_mmap_entries != 0U) && (acrn_mbi.mi_mmap_va != NULL)) {
+		if (acrn_mbi.mi_mmap_entries > E820_MAX_ENTRIES) {
+			pr_err("Too many E820 entries %d\n", acrn_mbi.mi_mmap_entries);
+			acrn_mbi.mi_mmap_entries = E820_MAX_ENTRIES;
+		}
+		(void)memcpy_s((void *)(&acrn_mbi.mi_mmap_entry[0]),
+			(acrn_mbi.mi_mmap_entries * mmap_entry_size),
+			(const void *)acrn_mbi.mi_mmap_va,
+			(acrn_mbi.mi_mmap_entries * mmap_entry_size));
+		acrn_mbi.mi_flags |= MULTIBOOT_INFO_HAS_MMAP;
+	} else {
+		acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MMAP;
+	}
+
+	if (acrn_mbi.mi_mods_count > MAX_MODULE_COUNT) {
+		pr_err("Too many multiboot modules %d\n", acrn_mbi.mi_mods_count);
+		acrn_mbi.mi_mods_count = MAX_MODULE_COUNT;
+	}
+	if (acrn_mbi.mi_mods_count != 0U) {
+		if (boot_from_multiboot1() && (acrn_mbi.mi_mods_va != NULL)) {
+			(void)memcpy_s((void *)(&acrn_mbi.mi_mods[0]),
+				(acrn_mbi.mi_mods_count * sizeof(struct multiboot_module)),
+				(const void *)acrn_mbi.mi_mods_va,
+				(acrn_mbi.mi_mods_count * sizeof(struct multiboot_module)));
+		}
+		acrn_mbi.mi_flags |= MULTIBOOT_INFO_HAS_MODS;
+	} else {
+		acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MODS;
 	}
 
 	if ((acrn_mbi.mi_flags & MULTIBOOT_INFO_HAS_MMAP) == 0U) {
-		pr_err("no multiboot memory map info found!");
-		ret = -EINVAL;
+		pr_err("wrong multiboot flags: 0x%08x", acrn_mbi.mi_flags);
+		mbi_status = -EINVAL;
+	}
+
+	if (boot_from_multiboot2()) {
+		if (acrn_mbi.mi_efi_info.efi_memmap_hi != 0U) {
+			pr_err("the efi mmap address should be less than 4G!");
+			acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_EFI_MMAP;
+			mbi_status = -EINVAL;
+		}
+
+		if ((acrn_mbi.mi_flags & (MULTIBOOT_INFO_HAS_EFI64 | MULTIBOOT_INFO_HAS_EFI_MMAP)) == 0U) {
+			pr_err("no multiboot2 uefi info found!");
+		}
 	}
 
 	if (acrn_mbi.mi_loader_name[0] == '\0') {
 		pr_err("no bootloader name found!");
-		ret = -EINVAL;
+		mbi_status = -EINVAL;
+	} else {
+		printf("Detect bootloader: %s\n", acrn_mbi.mi_loader_name);
 	}
-	return ret;
+
+	return mbi_status;
 }
 
 /*

--- a/hypervisor/boot/multiboot.c
+++ b/hypervisor/boot/multiboot.c
@@ -69,9 +69,9 @@ int32_t sanitize_multiboot_info(void)
 		acrn_mbi.mi_flags &= ~MULTIBOOT_INFO_HAS_MMAP;
 	}
 
-	if (acrn_mbi.mi_mods_count > MAX_MODULE_COUNT) {
+	if (acrn_mbi.mi_mods_count > MAX_MODULE_NUM) {
 		pr_err("Too many multiboot modules %d\n", acrn_mbi.mi_mods_count);
-		acrn_mbi.mi_mods_count = MAX_MODULE_COUNT;
+		acrn_mbi.mi_mods_count = MAX_MODULE_NUM;
 	}
 	if (acrn_mbi.mi_mods_count != 0U) {
 		if (boot_from_multiboot1() && (acrn_mbi.mi_mods_va != NULL)) {

--- a/hypervisor/boot/multiboot2.c
+++ b/hypervisor/boot/multiboot2.c
@@ -72,6 +72,10 @@ int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info)
 
 	while ((mb2_tag->type != MULTIBOOT2_TAG_TYPE_END) && (mb2_tag < mb2_tag_end)) {
 		switch (mb2_tag->type) {
+		case MULTIBOOT2_TAG_TYPE_CMDLINE:
+			mbi->mi_cmdline = ((struct multiboot2_tag_string *)mb2_tag)->string;
+			mbi->mi_flags |= MULTIBOOT_INFO_HAS_CMDLINE;
+			break;
 		case MULTIBOOT2_TAG_TYPE_MMAP:
 			mb2_mmap_to_mbi(mbi, (const struct multiboot2_tag_mmap *)mb2_tag);
 			break;

--- a/hypervisor/boot/multiboot2.c
+++ b/hypervisor/boot/multiboot2.c
@@ -25,7 +25,7 @@ static void mb2_mmap_to_mbi(struct acrn_multiboot_info *mbi, const struct multib
 static void mb2_mods_to_mbi(struct acrn_multiboot_info *mbi,
 			uint32_t mbi_mod_idx, const struct multiboot2_tag_module *mb2_tag_mods)
 {
-	if (mbi_mod_idx < MAX_MODULE_COUNT) {
+	if (mbi_mod_idx < MAX_MODULE_NUM) {
 		mbi->mi_mods[mbi_mod_idx].mm_mod_start = mb2_tag_mods->mod_start;
 		mbi->mi_mods[mbi_mod_idx].mm_mod_end = mb2_tag_mods->mod_end;
 		mbi->mi_mods[mbi_mod_idx].mm_string = (uint32_t)(uint64_t)mb2_tag_mods->cmdline;

--- a/hypervisor/boot/multiboot2.c
+++ b/hypervisor/boot/multiboot2.c
@@ -8,28 +8,15 @@
 #include <errno.h>
 #include <boot.h>
 #include <pgtable.h>
-#include <util.h>
-#include <logmsg.h>
 
 /**
  * @pre mbi != NULL && mb2_tag_mmap != NULL
  */
 static void mb2_mmap_to_mbi(struct acrn_multiboot_info *mbi, const struct multiboot2_tag_mmap *mb2_tag_mmap)
 {
-	uint32_t i;
-
 	/* multiboot2 mmap tag header occupied 16 bytes */
 	mbi->mi_mmap_entries = (mb2_tag_mmap->size - 16U) / sizeof(struct multiboot2_mmap_entry);
-	if (mbi->mi_mmap_entries > E820_MAX_ENTRIES) {
-		pr_err("Too many E820 entries %d\n", mbi->mi_mmap_entries);
-		mbi->mi_mmap_entries = E820_MAX_ENTRIES;
-	}
-	for (i = 0U; i < mbi->mi_mmap_entries; i++) {
-		mbi->mi_mmap_entry[i].baseaddr = mb2_tag_mmap->entries[i].addr;
-		mbi->mi_mmap_entry[i].length = mb2_tag_mmap->entries[i].len;
-		mbi->mi_mmap_entry[i].type = mb2_tag_mmap->entries[i].type;
-	}
-	mbi->mi_flags |= MULTIBOOT_INFO_HAS_MMAP;
+	mbi->mi_mmap_va = (struct multiboot2_mmap_entry *)mb2_tag_mmap->entries;
 }
 
 /**
@@ -38,15 +25,11 @@ static void mb2_mmap_to_mbi(struct acrn_multiboot_info *mbi, const struct multib
 static void mb2_mods_to_mbi(struct acrn_multiboot_info *mbi,
 			uint32_t mbi_mod_idx, const struct multiboot2_tag_module *mb2_tag_mods)
 {
-	if (mbi_mod_idx >= MAX_MODULE_COUNT) {
-		pr_err("unhandled multiboot2 module: 0x%x", mb2_tag_mods->mod_start);
-	} else {
+	if (mbi_mod_idx < MAX_MODULE_COUNT) {
 		mbi->mi_mods[mbi_mod_idx].mm_mod_start = mb2_tag_mods->mod_start;
 		mbi->mi_mods[mbi_mod_idx].mm_mod_end = mb2_tag_mods->mod_end;
 		mbi->mi_mods[mbi_mod_idx].mm_string = (uint32_t)(uint64_t)mb2_tag_mods->cmdline;
-		mbi->mi_mods_count = mbi_mod_idx + 1U;
 	}
-	mbi->mi_flags |= MULTIBOOT_INFO_HAS_MODS;
 }
 
 /**
@@ -62,23 +45,15 @@ static void mb2_efi64_to_mbi(struct acrn_multiboot_info *mbi, const struct multi
 /**
  * @pre mbi != NULL && mb2_tag_efimmap != 0
  */
-static int32_t mb2_efimmap_to_mbi(struct acrn_multiboot_info *mbi,
+static void mb2_efimmap_to_mbi(struct acrn_multiboot_info *mbi,
 			const struct multiboot2_tag_efi_mmap *mb2_tag_efimmap)
 {
-	int32_t ret = 0;
-
 	mbi->mi_efi_info.efi_memdesc_size = mb2_tag_efimmap->descr_size;
 	mbi->mi_efi_info.efi_memdesc_version = mb2_tag_efimmap->descr_vers;
 	mbi->mi_efi_info.efi_memmap = (uint32_t)(uint64_t)mb2_tag_efimmap->efi_mmap;
 	mbi->mi_efi_info.efi_memmap_size = mb2_tag_efimmap->size - 16U;
 	mbi->mi_efi_info.efi_memmap_hi = (uint32_t)(((uint64_t)mb2_tag_efimmap->efi_mmap) >> 32U);
-	if (mbi->mi_efi_info.efi_memmap_hi != 0U) {
-		pr_err("the efi mmap address should be less than 4G!");
-		ret = -EINVAL;
-	} else {
-		mbi->mi_flags |= MULTIBOOT_INFO_HAS_EFI64;
-	}
-	return ret;
+	mbi->mi_flags |= MULTIBOOT_INFO_HAS_EFI_MMAP;
 }
 
 /**
@@ -108,30 +83,25 @@ int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info)
 			mbi->mi_loader_name = ((struct multiboot2_tag_string *)mb2_tag)->string;
 			break;
 		case MULTIBOOT2_TAG_TYPE_ACPI_NEW:
-			mbi->mi_acpi_rsdp = ((struct multiboot2_tag_new_acpi *)mb2_tag)->rsdp;
+			mbi->mi_acpi_rsdp_va = ((struct multiboot2_tag_new_acpi *)mb2_tag)->rsdp;
 			break;
 		case MULTIBOOT2_TAG_TYPE_EFI64:
 			mb2_efi64_to_mbi(mbi, (const struct multiboot2_tag_efi64 *)mb2_tag);
 			break;
 		case MULTIBOOT2_TAG_TYPE_EFI_MMAP:
-			ret = mb2_efimmap_to_mbi(mbi, (const struct multiboot2_tag_efi_mmap *)mb2_tag);
+			mb2_efimmap_to_mbi(mbi, (const struct multiboot2_tag_efi_mmap *)mb2_tag);
 			break;
 		default:
-			if (mb2_tag->type <= MULTIBOOT2_TAG_TYPE_LOAD_BASE_ADDR) {
-				pr_warn("unhandled multiboot2 tag type: %d", mb2_tag->type);
-			} else {
-				pr_err("unknown multiboot2 tag type: %d", mb2_tag->type);
+			if (mb2_tag->type > MULTIBOOT2_TAG_TYPE_LOAD_BASE_ADDR) {
 				ret = -EINVAL;
 			}
 			break;
 		}
 		if (mb2_tag->size == 0U) {
-			pr_err("the multiboot2 tag size should not be 0!");
 			ret = -EINVAL;
 		}
 
 		if (ret != 0) {
-			pr_err("multiboot2 info format error!");
 			break;
 		}
 		/*
@@ -141,8 +111,8 @@ int32_t multiboot2_to_acrn_mbi(struct acrn_multiboot_info *mbi, void *mb2_info)
 		mb2_tag = (struct multiboot2_tag *)((uint8_t *)mb2_tag
 				+ ((mb2_tag->size + (MULTIBOOT2_INFO_ALIGN - 1U)) & ~(MULTIBOOT2_INFO_ALIGN - 1U)));
 	}
-	if ((mbi->mi_flags & (MULTIBOOT_INFO_HAS_EFI64 | MULTIBOOT_INFO_HAS_EFI_MMAP)) == 0U) {
-		pr_err("no multiboot2 uefi info found!");
-	}
+
+	mbi->mi_mods_count = mod_idx;
+
 	return ret;
 }

--- a/hypervisor/include/arch/x86/seed.h
+++ b/hypervisor/include/arch/x86/seed.h
@@ -28,7 +28,7 @@ struct physical_seed {
 
 void init_seed(void);
 
-void append_seed_arg(char *cmd_dst, bool vm_is_sos);
+void fill_seed_arg(char *cmd_dst, size_t cmd_sz);
 
 bool derive_virtual_seed(struct seed_info *seed_list, uint32_t *num_seeds,
 			 const uint8_t *salt, size_t salt_len, const uint8_t *info, size_t info_len);

--- a/hypervisor/include/arch/x86/seed.h
+++ b/hypervisor/include/arch/x86/seed.h
@@ -9,6 +9,7 @@
 
 #define BOOTLOADER_SEED_MAX_ENTRIES     10U
 #define BUP_MKHI_BOOTLOADER_SEED_LEN    64U
+#define MAX_SEED_ARG_SIZE		1024U
 
 /* Structure of seed info */
 struct seed_info {

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -39,7 +39,7 @@ void *memset(void *base, uint8_t v, size_t n);
 int32_t memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
 int64_t strtol_deci(const char *nptr);
 uint64_t strtoul_hex(const char *nptr);
-char *strstr_s(const char *str1, size_t maxlen1,
-			const char *str2, size_t maxlen2);
+char *strstr_s(const char *str1, size_t maxlen1, const char *str2, size_t maxlen2);
+int32_t strncat_s(char *dest, size_t dmax, const char *src, size_t slen);
 
 #endif /* RTL_H */

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -36,7 +36,7 @@ char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg);
 char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);
-void *memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
+int32_t memcpy_s(void *d, size_t dmax, const void *s, size_t slen);
 int64_t strtol_deci(const char *nptr);
 uint64_t strtoul_hex(const char *nptr);
 char *strstr_s(const char *str1, size_t maxlen1,

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -32,7 +32,7 @@ static inline bool is_space(char c)
 /* Function prototypes */
 int32_t strcmp(const char *s1_arg, const char *s2_arg);
 int32_t strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg);
-char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg);
+int32_t strncpy_s(char *d, size_t dmax, const char *s, size_t slen);
 char *strchr(char *s_arg, char ch);
 size_t strnlen_s(const char *str_arg, size_t maxlen_arg);
 void *memset(void *base, uint8_t v, size_t n);

--- a/hypervisor/include/lib/rtl.h
+++ b/hypervisor/include/lib/rtl.h
@@ -29,6 +29,11 @@ static inline bool is_space(char c)
 	return ((c == ' ') || (c == '\t'));
 }
 
+static inline bool is_eol(char c)
+{
+	return ((c == 0x0d) || (c == 0x0a) || (c == '\0'));
+}
+
 /* Function prototypes */
 int32_t strcmp(const char *s1_arg, const char *s2_arg);
 int32_t strncmp(const char *s1_arg, const char *s2_arg, size_t n_arg);

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -98,87 +98,35 @@ char *strchr(char *s_arg, char ch)
  *              string.
  *
  * return value:
- *    dest      pointer to dest string if source string is copied
- *              successfully, or else return null.
+ *    0		if source string is copied successfully;
+ *    -1	if there is a runtime-constraint violation.
  *
  * notes:
- *    1) both dmax and slen should not be 0.
- *    2) both d and s should not be null pointers.
- *    3) will assert() if overlap happens or dest buffer has no
- *       enough space.
+ *    1) dmax shall not be 0.
+ *    2) both d and s shall not be null pointers.
+ *    3) Copying shall not take place between objects that overlap.
+ *    4) If slen is not less than dmax, then dmax shall be more than strnlen_s(s, dmax).
+ *    5) d[0] shall be set to '\0' if there is a runtime-constraint violation.
  */
-char *strncpy_s(char *d_arg, size_t dmax, const char *s_arg, size_t slen_arg)
+int32_t strncpy_s(char *d, size_t dmax, const char *s, size_t slen)
 {
-	const char *s = s_arg;
-	char *d = d_arg;
-	char *pret;
-	size_t dest_avail;
-	uint64_t overlap_guard;
-	size_t slen = slen_arg;
+	char *dest = d;
+	int32_t ret = -1;
+	size_t len = strnlen_s(s, dmax);
 
-	if ((d == NULL) || (s == NULL)) {
-		pr_err("%s: invlaid src or dest buffer", __func__);
-		pret = NULL;
+	if ((slen < dmax) || (dmax > len)) {
+		ret = memcpy_s(d, dmax, s, len);
+	}
+
+	if (ret == 0) {
+		*(dest + len) = '\0';
 	} else {
-		pret = d_arg;
-	}
-
-	if (pret != NULL) {
-		if ((dmax == 0U) || (slen == 0U)) {
-			pr_err("%s: invlaid length of src or dest buffer", __func__);
-			pret =  NULL;
+		if ((d != NULL) && (dmax > 0U)) {
+			*dest = '\0';
 		}
 	}
 
-	/* if d equal to s, just return d; else execute the below code */
-	if ((pret != NULL) && (d != s)) {
-		overlap_guard = (uint64_t)((d > s) ? (d - s - 1) : (s - d - 1));
-		dest_avail = dmax;
-
-		while (dest_avail > 0U) {
-			bool complete = false;
-
-			if (overlap_guard == 0U) {
-				pr_err("%s: overlap happened.", __func__);
-				d--;
-				*d = '\0';
-				pret = NULL;
-				/* copy complete */
-				complete = true;
-			} else {
-				if (slen == 0U) {
-					*d = '\0';
-					/* copy complete */
-					complete = true;
-				} else {
-					*d = *s;
-					if (*d == '\0') {
-						/* copy complete */
-						complete = true;
-					} else {
-						d++;
-						s++;
-						slen--;
-						dest_avail--;
-						overlap_guard--;
-					}
-				}
-			}
-
-			if (complete) {
-				break;
-			}
-		}
-
-		if (dest_avail == 0U) {
-			pr_err("%s: dest buffer has no enough space.", __func__);
-
-			/* to avoid a string that is not null-terminated in dest buffer */
-			pret[dmax - 1] = '\0';
-		}
-	}
-
-	return pret;
+	return ret;
 }
 
 /**

--- a/hypervisor/lib/string.c
+++ b/hypervisor/lib/string.c
@@ -262,3 +262,44 @@ char *strstr_s(const char *str1, size_t maxlen1, const char *str2, size_t maxlen
 
 	return (char *)pret;
 }
+
+/*
+ * strncat_s
+ *
+ * description:
+ *    append src string to the end of dest string
+ *
+ * input:
+ *    dest      pointer to the string to be appended.
+ *
+ *    dmax      maximum length of dest buffer including the NULL char.
+ *
+ *    src       pointer to the string that to be concatenated to string dest.
+ *
+ *    slen      maximum characters to append.
+ *
+ * return value:
+ *     0 for success, -1 for failure.
+ */
+int32_t strncat_s(char *dest, size_t dmax, const char *src, size_t slen)
+{
+	int32_t ret = -1;
+	size_t len_d, len_s;
+	char *d = dest, *start;
+
+	len_d = strnlen_s(dest, dmax);
+	len_s = strnlen_s(src, slen);
+	start = dest + len_d;
+
+	if ((dest != NULL) && (src != NULL) && (dmax > (len_d + len_s))
+			&& ((dest > (src + len_s)) || (src > (dest + len_d)))) {
+		(void)memcpy_s(start, (dmax - len_d), src, len_s);
+		*(start + len_s) = '\0';
+		ret = 0;
+	} else {
+		if (dest != NULL) {
+			*d = '\0';	/* set dest[0] to NULL char on runtime-constraint violation */
+		}
+	}
+	return ret;
+}


### PR DESCRIPTION
Previously the VM kernel bootargs for pre-launched VMs and direct boot mode
of SOS VM are built-in hypervisor binary so end users have no way to change
it. Now we provide another option that the multiboot module string could be
used as bootargs also. This would bring convenience to end users when they
use GRUB as bootloader because the bootargs could be configurable in GRUB
menu.
The usage is if there is any string follows configured kernel_mod_tag in
module string, the string will be used as new kernel bootargs instead of
built-in kernel bootargs. If there is no string follows kernel_mod_tag,
then the built-in bootargs will be the default kernel bootargs.
Please note kernel_mod_tag must be the first word in module string in any
case, it is used to specify the module for which VM.
The multiboot cmdline could also be used to override SOS bootargs, it will
be appended to the end of configured SOS bootargs and per Linux cmdline
parse rule the later one would win if same parameters configured in kernel
cmdline.

Tracked-On: #4885
Signed-off-by: Victor Sun victor.sun@intel.com
Reviewed-by: Yonghua Huang yonghua.huang@intel.com
Reviewed-by: Yin Fengwei fengwei.yin@intel.com
Acked-by: Eddie Dong eddie.dong@intel.com