### PR TITLE
doc: fix columns issue with 404 page display

### DIFF
--- a/doc/404.rst
+++ b/doc/404.rst
@@ -5,7 +5,7 @@
 Page Not Found
 ##############
 
-.. rst-class:: rst-columns
+.. rst-class:: rst-columns2
 
    .. image:: images/ACRN-fall-from-tree-small.png
       :align: left


### PR DESCRIPTION
A previous error (now fixed) in how the rst-columns CSS was written,
caused the default rst-columns to use 3 columns, when before (because of
the error) it being ignored.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>