### PR TITLE
doc: add dependencies for building acrn-libvirt independently

### DIFF
--- a/doc/tutorials/setup_openstack_libvirt.rst
+++ b/doc/tutorials/setup_openstack_libvirt.rst
@@ -176,7 +176,9 @@ Set up libvirt
 1. Install the required packages::
 
      $ sudo apt install libdevmapper-dev libnl-route-3-dev libnl-3-dev python \
-       automake autoconf autopoint libtool xsltproc libxml2-utils gettext
+       automake autoconf autopoint libtool xsltproc libxml2-utils gettext \
+       libxml2-dev libpciaccess-dev
+
 
 2. Download libvirt/ACRN::
 


### PR DESCRIPTION
This commit adds the required dependencies for building the `acrn-libvirt` from source. The missing packages were installed for building the ACRN source code, it's no harm to `apt install` the packages if they are already installed, but this commit makes the build of `acrn-libvirt` independently.

Tracked-On: #4910 
Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>