### PR TITLE
doc: fix broken links to pre-built images (release 1.6.1)

### DIFF
--- a/doc/tutorials/cl_servicevm.rst
+++ b/doc/tutorials/cl_servicevm.rst
@@ -192,7 +192,7 @@ Use the ACRN industry out-of-the-box image
 
    .. code-block:: none
 
-      # wget https://github.com/projectacrn/acrn-hypervisor/releases/download/acrn-2020w18.4-140000p/sos-industry-33050.img.xz
+      # wget https://github.com/projectacrn/acrn-hypervisor/releases/download/v1.6.1/sos-industry-33050.img.xz
 
    .. note:: You may also follow :ref:`set_up_ootb_service_vm` to build the image by yourself.
 
@@ -239,7 +239,7 @@ build the ACRN kernel for the Service VM, and then :ref:`passthrough the SATA di
 
    .. code-block:: none
 
-      # wget https://github.com/projectacrn/acrn-hypervisor/releases/download/acrn-2020w18.4-140000p/preempt-rt-33050.img.xz
+      # wget https://github.com/projectacrn/acrn-hypervisor/releases/download/v1.6.1/preempt-rt-33050.img.xz
 
    .. note:: You may also follow :ref:`set_up_ootb_rtvm` to build the Preempt-RT VM image by yourself.
 


### PR DESCRIPTION
Fix broken download links to the Service VM and RTVM images that are provided
for ACRN release 1.6.1.

Tracked-On: #4918
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>