### PR TITLE
vmsix emulation on msi

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -467,6 +467,22 @@ passthru_gpu_dsm_opregion(struct vmctx *ctx, struct passthru_dev *ptdev,
 	pcidev->type = QUIRK_PTDEV;
 }
 
+static int
+parse_vmsix_on_msi_bar_id(char *s, int *id, int base)
+{
+	char *str, *cp;
+	int ret = 0;
+
+	if (s == NULL)
+		return -EINVAL;
+
+	str = cp = strdup(s);
+	ret = dm_strtoi(cp, &cp, base, id);
+	free(str);
+
+	return ret;
+}
+
 /*
  * Passthrough device initialization function:
  * - initialize virtual config space
@@ -488,6 +504,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	char *opt;
 	bool keep_gsi = false;
 	bool need_reset = true;
+	int vmsix_on_msi_bar_id = -1;
 	struct acrn_assign_pcidev pcidev = {};
 	uint16_t vendor = 0, device = 0;
 
@@ -519,6 +536,13 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 			/* Create the dedicated "igd-lpc" on 00:1f.0 for IGD passthrough */
 			if (pci_parse_slot("31,igd-lpc") != 0)
 				warnx("faild to create igd-lpc");
+		} else if (!strncmp(opt, "vmsix_on_msi", 12)) {
+			opt = strsep(&opts, ",");
+			if (parse_vmsix_on_msi_bar_id(opt, &vmsix_on_msi_bar_id, 10) != 0) {
+				warnx("faild to parse msix emulation bar id");
+				return -EINVAL;
+			}
+
 		} else
 			warnx("Invalid passthru options:%s", opt);
 	}
@@ -589,6 +613,13 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	if (error < 0)
 		goto done;
 
+	if (vmsix_on_msi_bar_id != -1) {
+		error = pci_emul_alloc_pbar(dev, vmsix_on_msi_bar_id, 0, PCIBAR_MEM32, 4096);
+		if (error < 0)
+			goto done;
+		error = IRQ_MSI;
+	}
+
 	if (ptdev->phys_bdf == PCI_BDF_GPU)
 		passthru_gpu_dsm_opregion(ctx, ptdev, &pcidev, device);
 
@@ -602,7 +633,7 @@ passthru_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 	 * Forge Guest to use MSI/MSIX in this case to mitigate IRQ sharing
 	 * issue
 	 */
-	if (error != IRQ_MSI && !keep_gsi) {
+	if (error != IRQ_MSI || keep_gsi) {
 		/* Allocates the virq if ptdev only support INTx */
 		pci_lintr_request(dev);
 

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -301,6 +301,7 @@ VP_DM_C_SRCS += dm/vpci/vpci_bridge.c
 VP_DM_C_SRCS += dm/vpci/pci_pt.c
 VP_DM_C_SRCS += dm/vpci/vmsi.c
 VP_DM_C_SRCS += dm/vpci/vmsix.c
+VP_DM_C_SRCS += dm/vpci/vmsix_on_msi.c
 VP_DM_C_SRCS += dm/vpci/vsriov.c
 VP_DM_C_SRCS += arch/x86/guest/vlapic.c
 VP_DM_C_SRCS += arch/x86/guest/pm.c

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -289,6 +289,7 @@ config MAX_IOAPIC_LINES
 
 config MAX_IR_ENTRIES
 	int "Maximum number of Interrupt Remapping Entries"
+	range 256 512
 	default 256
 	help
 	  Minimum value is 256. Value must be 2^n.

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -1290,6 +1290,33 @@ static bool is_irte_reserved(const struct dmar_drhd_rt *dmar_unit, uint16_t inde
 	return ((dmar_unit->irte_reserved_bitmap[index >> 6U] & (1UL << (index & 0x3FU))) != 0UL);
 }
 
+int32_t dmar_reserve_irte(const struct intr_source *intr_src, uint16_t num, uint16_t *start_id)
+{
+	struct dmar_drhd_rt *dmar_unit;
+	union pci_bdf sid;
+	uint64_t mask = (1UL << num) - 1U;
+	int32_t ret = -EINVAL;
+
+	if (intr_src->is_msi) {
+		dmar_unit = device_to_dmaru((uint8_t)intr_src->src.msi.bits.b, intr_src->src.msi.fields.devfun);
+		sid.value = (uint16_t)(intr_src->src.msi.value);
+	} else {
+		dmar_unit = ioapic_to_dmaru(intr_src->src.ioapic_id, &sid);
+	}
+
+	if (is_dmar_unit_valid(dmar_unit, sid)) {
+		*start_id = alloc_irtes(dmar_unit, num);
+		if (*start_id < CONFIG_MAX_IR_ENTRIES) {
+			dmar_unit->irte_reserved_bitmap[*start_id >> 6U] |= mask << (*start_id & 0x3FU);
+		}
+		ret = 0;
+	}
+
+	pr_dbg("%s: for dev 0x%x:%x.%x, reserve %u entry for MSI(%d), start from %d",
+		__func__, sid.bits.b, sid.bits.d, sid.bits.f, num, intr_src->is_msi, *start_id);
+	return ret;
+}
+
 int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry *irte,
 	uint16_t idx_in, uint16_t *idx_out)
 {

--- a/hypervisor/common/ptdev.c
+++ b/hypervisor/common/ptdev.c
@@ -11,6 +11,7 @@
 #include <ptdev.h>
 #include <irq.h>
 #include <logmsg.h>
+#include <vtd.h>
 
 #define PTIRQ_ENTRY_HASHBITS	9U
 #define PTIRQ_ENTRY_HASHSIZE	(1U << PTIRQ_ENTRY_HASHBITS)
@@ -127,6 +128,7 @@ struct ptirq_remapping_info *ptirq_alloc_entry(struct acrn_vm *vm, uint32_t intr
 		entry->intr_type = intr_type;
 		entry->vm = vm;
 		entry->intr_count = 0UL;
+		entry->irte_idx = INVALID_IRTE_ID;
 
 		INIT_LIST_HEAD(&entry->softirq_node);
 

--- a/hypervisor/dm/vpci/pci_pt.c
+++ b/hypervisor/dm/vpci/pci_pt.c
@@ -374,6 +374,7 @@ void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev)
 	/* Initialize the vdev BARs except SRIOV VF, VF BARs are initialized directly from create_vf function */
 	if (vdev->phyfun == NULL) {
 		init_bars(vdev, is_pf_vdev);
+		init_vmsix_on_msi(vdev);
 		if (is_prelaunched_vm(vpci2vm(vdev->vpci)) && (!is_pf_vdev)) {
 			pci_command = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, PCIR_COMMAND, 2U);
 

--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -31,6 +31,7 @@
 #include <ptdev.h>
 #include <assign.h>
 #include <vpci.h>
+#include <vtd.h>
 #include "vpci_priv.h"
 
 
@@ -78,7 +79,7 @@ static void remap_vmsi(const struct pci_vdev *vdev)
 	info.addr.full = (uint64_t)vmsi_addrlo | ((uint64_t)vmsi_addrhi << 32U);
 	info.data.full = vmsi_msgdata;
 
-	if (ptirq_prepare_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info) == 0) {
+	if (ptirq_prepare_msix_remap(vm, vdev->bdf.value, pbdf.value, 0U, &info, INVALID_IRTE_ID) == 0) {
 		pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR, 0x4U, (uint32_t)info.addr.full);
 		if (vdev->msi.is_64bit) {
 			pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR_HIGH, 0x4U,

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -36,6 +36,7 @@
 #include <ept.h>
 #include <mmu.h>
 #include <logmsg.h>
+#include <vtd.h>
 #include "vpci_priv.h"
 
 /**
@@ -87,7 +88,8 @@ static void remap_one_vmsix_entry(const struct pci_vdev *vdev, uint32_t index)
 		info.addr.full = vdev->msix.table_entries[index].addr;
 		info.data.full = vdev->msix.table_entries[index].data;
 
-		ret = ptirq_prepare_msix_remap(vpci2vm(vdev->vpci), vdev->bdf.value, vdev->pdev->bdf.value, (uint16_t)index, &info);
+		ret = ptirq_prepare_msix_remap(vpci2vm(vdev->vpci), vdev->bdf.value, vdev->pdev->bdf.value,
+					       (uint16_t)index, &info, INVALID_IRTE_ID);
 		if (ret == 0) {
 			/* Write the table entry to the physical structure */
 			pentry = get_msix_table_entry(vdev, index);

--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm.h>
+#include <ptdev.h>
+#include <assign.h>
+#include <vpci.h>
+#include <vtd.h>
+#include <board.h>
+#include "vpci_priv.h"
+
+#define PER_VECTOR_MASK_CAP 0x0100U
+
+/* Pre-assumptions for vMSI-x on MSI emulation:
+ * 1. The device is in vmsix_on_msi_devs array.
+ * 2. The device should support MSI capability as well as per-vector mask
+ * 3. The device doesn't support MSI-x capability.
+ * 4. The device should have an unused BAR (this condition is checked inside init_vmsix_on_msi).
+ * 5. HV doesn't emulate PBA according to physcial device status, the device driver should not rely on PBA
+ *    for functionality.
+ */
+static bool need_vmsix_on_msi_emulation(__unused struct pci_pdev *pdev, __unused uint16_t *vector_count)
+{
+	bool ret = false;
+#if (MAX_VMSIX_ON_MSI_PDEVS_NUM > 0)
+	uint16_t msgctrl;
+	uint32_t i;
+
+	for(i = 0U; i < MAX_VMSIX_ON_MSI_PDEVS_NUM; i++) {
+		if (pdev->bdf.value == vmsix_on_msi_devs[i].bdf.value) {
+			if ((pdev->msi_capoff != 0U) && (pdev->msix.capoff == 0U)) {
+				msgctrl = (uint16_t)pci_pdev_read_cfg(pdev->bdf, pdev->msi_capoff + PCIR_MSI_CTRL, 2U);
+				*vector_count = 1U << ((msgctrl & PCIM_MSICTRL_MMC_MASK) >> 1U);
+				if ((*vector_count > 1U) && ((msgctrl & PER_VECTOR_MASK_CAP) != 0U)) {
+					ret = true;
+				}
+			}
+			break;
+		}
+	}
+#endif
+
+	return ret;
+}
+
+void reserve_vmsix_on_msi_irtes(struct pci_pdev *pdev)
+{
+	struct intr_source intr_src;
+	uint16_t count = 0;
+	int32_t ret;
+
+	if (need_vmsix_on_msi_emulation(pdev, &count)) {
+		intr_src.is_msi = true;
+		intr_src.src.msi.value = pdev->bdf.value;
+		ret = dmar_reserve_irte(&intr_src, count, &pdev->irte_start);
+		if ((ret == 0) && (pdev->irte_start != INVALID_IRTE_ID)) {
+			pdev->irte_count = count;
+		}
+	}
+}
+
+static inline uint32_t get_mask_bits_offset(const struct pci_vdev *vdev)
+{
+	return vdev->msi.is_64bit ? (vdev->msix.capoff + 0x10U) : (vdev->msix.capoff + 0xCU);
+}
+
+/**
+ * @pre vdev != NULL
+ * @pre vdev->pdev != NULL
+ */
+void init_vmsix_on_msi(struct pci_vdev *vdev)
+{
+	struct pci_pdev *pdev = vdev->pdev;
+	uint32_t i;
+
+	/* irte_count > 1 only when the device needs vMSI-x on MSI emulation and IRTEs are reserved successfully */
+	if (pdev->irte_count > 1U) {
+		/* find an unused BAR */
+		for (i = 0U; i < vdev->nr_bars; i++) {
+			if (vdev->vbars[i].base_hpa == 0UL){
+				break;
+			}
+			if (vdev->vbars[i].type == PCIBAR_MEM64) {
+				i++;
+			}
+		}
+		if (i < vdev->nr_bars) {
+			vdev->msix.capoff = pdev->msi_capoff;
+			vdev->msi.capoff = 0U;
+			vdev->msix.is_vmsix_on_msi = true;
+			/* For a device support MSI with per-vector mask, the length of MSI cap is at least 20 bytes */
+			vdev->msix.caplen = MSIX_CAPLEN;
+			vdev->msix.table_bar = i;
+			vdev->msix.table_offset = 0U;
+			vdev->msix.table_count = pdev->irte_count;
+
+			/* capability ID */
+			pci_vdev_write_vcfg(vdev, vdev->msix.capoff, 1U, 0x11U);
+			/* message control, MSI-X Diabled, Function unamsked */
+			pci_vdev_write_vcfg(vdev, vdev->msix.capoff + 2U, 2U, pdev->irte_count - 1U);
+			/* Init MSIX table vBAR, offset is 0 */
+			pci_vdev_write_vcfg(vdev, vdev->msix.capoff + 4U, 4U, i);
+			/* Init PBA table vBAR, offset is 2048 */
+			pci_vdev_write_vcfg(vdev, vdev->msix.capoff + 8U, 4U, 2048U + i);
+
+			vdev->vbars[i].type = PCIBAR_MEM32;
+			vdev->vbars[i].size = 4096U;
+			vdev->vbars[i].base_hpa = 0x0UL;
+			vdev->vbars[i].mask = 0xFFFFF000U & PCI_BASE_ADDRESS_MEM_MASK;
+			/* fixed for memory, 32bit, non-prefetchable */
+			vdev->vbars[i].fixed = 0U;
+
+			/* About MSI-x bar GPA:
+			 * - For Service VM: when first time init, it is programmed as 0, then OS will program
+			 * the value later and the value is stored in  vdev->vbars[MSI-X_BAR_ID].base_gpa.
+			 * When the device is assigned to UOS and then assgined back to SOS, the stored base
+			 * GPA will be used.
+			 * - For Post-launched VM: The GPA is assigned by device model.
+			 * - For Pre-launched VM: Not supported yet.
+			 */
+			vdev->msix.mmio_gpa = vdev->vbars[i].base_gpa;
+			vdev_pt_write_vbar(vdev, i, (uint32_t)(vdev->vbars[i].base_gpa & 0xFFFFFFFFUL));
+		}
+	}
+}
+
+void write_vmsix_cap_reg_on_msi(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val)
+{
+	uint16_t old_msgctrl, msgctrl;
+	uint16_t msi_msgctrl;
+
+	old_msgctrl = (uint16_t)pci_vdev_read_vcfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
+	/* Write to vdev */
+	pci_vdev_write_vcfg(vdev, offset, bytes, val);
+	msgctrl = (uint16_t)pci_vdev_read_vcfg(vdev, vdev->msix.capoff + PCIR_MSIX_CTRL, 2U);
+
+	if (((old_msgctrl ^ msgctrl) & (PCIM_MSIXCTRL_MSIX_ENABLE | PCIM_MSIXCTRL_FUNCTION_MASK)) != 0U) {
+		msi_msgctrl = (uint16_t)pci_pdev_read_cfg(vdev->pdev->bdf, offset, 2U);
+
+		msi_msgctrl = msi_msgctrl & (~PCIM_MSICTRL_MME_MASK);
+		msi_msgctrl &= ~ PCIM_MSICTRL_MSI_ENABLE;
+
+		/* If MSI Enable is being set, make sure INTxDIS bit is set */
+		if ((msgctrl & PCIM_MSIXCTRL_MSIX_ENABLE) != 0U) {
+			enable_disable_pci_intx(vdev->pdev->bdf, false);
+			msi_msgctrl |= (msi_msgctrl & PCIM_MSICTRL_MMC_MASK) << 3U;
+			msi_msgctrl |= PCIM_MSICTRL_MSI_ENABLE;
+		}
+		pci_pdev_write_cfg(vdev->pdev->bdf, offset, 2U, msi_msgctrl);
+
+		if ((msgctrl & PCIM_MSIXCTRL_FUNCTION_MASK) != 0U) {
+			pci_pdev_write_cfg(vdev->pdev->bdf, get_mask_bits_offset(vdev), 4U, 0xFFFFFFFFU);
+		}
+	}
+}
+
+void remap_one_vmsix_entry_on_msi(struct pci_vdev *vdev, uint32_t index)
+{
+	const struct msix_table_entry *ventry;
+	uint32_t mask_bits;
+	uint32_t vector_mask = 1U << index;
+	struct msi_info info = {};
+	union pci_bdf pbdf = vdev->pdev->bdf;
+	union irte_index ir_index;
+	int32_t ret = 0;
+	uint32_t capoff = vdev->msix.capoff;
+
+	mask_bits = pci_pdev_read_cfg(pbdf, get_mask_bits_offset(vdev), 4U);
+	mask_bits |= vector_mask;
+	pci_pdev_write_cfg(pbdf, get_mask_bits_offset(vdev), 4U, mask_bits);
+
+	ventry = &vdev->msix.table_entries[index];
+	if ((ventry->vector_control & PCIM_MSIX_VCTRL_MASK) == 0U) {
+		info.addr.full = vdev->msix.table_entries[index].addr;
+		info.data.full = vdev->msix.table_entries[index].data;
+
+		ret = ptirq_prepare_msix_remap(vpci2vm(vdev->vpci), vdev->bdf.value, pbdf.value,
+			(uint16_t)index, &info, vdev->pdev->irte_start + (uint16_t)index);
+		if (ret == 0) {
+			if (!vdev->msix.is_vmsix_on_msi_programmed) {
+				ir_index.index = vdev->pdev->irte_start;
+				info.addr.ir_bits.shv = 1U;
+				info.addr.ir_bits.intr_index_high = ir_index.bits.index_high;
+				info.addr.ir_bits.intr_index_low = ir_index.bits.index_low;
+				pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR, 0x4U, (uint32_t)info.addr.full);
+				if (vdev->msi.is_64bit) {
+					pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_ADDR_HIGH, 0x4U,
+							(uint32_t)(info.addr.full >> 32U));
+					pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_DATA_64BIT, 0x2U,
+							(uint16_t)info.data.full);
+				} else {
+					pci_pdev_write_cfg(pbdf, capoff + PCIR_MSI_DATA, 0x2U,
+							(uint16_t)info.data.full);
+				}
+				vdev->msix.is_vmsix_on_msi_programmed = true;
+			}
+			mask_bits &= ~vector_mask;
+		}
+	}
+	pci_pdev_write_cfg(pbdf, get_mask_bits_offset(vdev), 4U, mask_bits);
+}

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -500,7 +500,11 @@ static int32_t write_pt_dev_cfg(struct pci_vdev *vdev, uint32_t offset,
 	} else if (msicap_access(vdev, offset)) {
 		write_vmsi_cap_reg(vdev, offset, bytes, val);
 	} else if (msixcap_access(vdev, offset)) {
-		write_vmsix_cap_reg(vdev, offset, bytes, val);
+		if (vdev->msix.is_vmsix_on_msi) {
+			write_vmsix_cap_reg_on_msi(vdev, offset, bytes, val);
+		} else {
+			write_vmsix_cap_reg(vdev, offset, bytes, val);
+		}
 	} else if (sriovcap_access(vdev, offset)) {
 		write_sriov_cap_reg(vdev, offset, bytes, val);
 	} else {

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -128,6 +128,10 @@ void read_vmsix_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t b
 void write_vmsix_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
 void deinit_vmsix(struct pci_vdev *vdev);
 
+void init_vmsix_on_msi(struct pci_vdev *vdev);
+void write_vmsix_cap_reg_on_msi(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
+void remap_one_vmsix_entry_on_msi(struct pci_vdev *vdev, uint32_t index);
+
 void init_vsriov(struct pci_vdev *vdev);
 void read_sriov_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -767,6 +767,7 @@ struct pci_pdev *init_pdev(uint16_t pbdf, uint32_t drhd_index)
 
 			pdev->drhd_index = drhd_index;
 			num_pci_pdev++;
+			reserve_vmsix_on_msi_irtes(pdev);
 		} else {
 			pr_err("%s, %x:%x.%x unsupported headed type: 0x%x\n",
 				__func__, bdf.bits.b, bdf.bits.d, bdf.bits.f, hdr_type);

--- a/hypervisor/include/arch/x86/guest/assign.h
+++ b/hypervisor/include/arch/x86/guest/assign.h
@@ -50,6 +50,7 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ctlr vgsi_c
  * @param[in] phys_bdf virtual bdf associated with the passthrough device
  * @param[in] entry_nr indicate coming vectors, entry_nr = 0 means first vector
  * @param[in] info structure used for MSI/MSI-x remapping
+ * @param[in] irte_idx caller can pass a valid IRTE index, otherwise, use INVALID_IRTE_ID
  *
  * @return
  *    - 0: on success
@@ -62,7 +63,7 @@ void ptirq_intx_ack(struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ctlr vgsi_c
  *
  */
 int32_t ptirq_prepare_msix_remap(struct acrn_vm *vm, uint16_t virt_bdf,  uint16_t phys_bdf,
-				uint16_t entry_nr, struct msi_info *info);
+				uint16_t entry_nr, struct msi_info *info, uint16_t irte_idx);
 
 
 /**

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -11,6 +11,7 @@
 #include <platform_acpi_info.h>
 
 #define INVALID_DRHD_INDEX 0xFFFFFFFFU
+#define INVALID_IRTE_ID 0xFFFFU
 
 /*
  * Intel IOMMU register specification per version 1.0 public spec.
@@ -675,13 +676,15 @@ int32_t init_iommu(void);
  *
  * @param[in] intr_src filled with type of interrupt source and the source
  * @param[in] irte filled with info about interrupt deliverymode, destination and destination mode
- * @param[in] index into Interrupt Remapping Table
+ * @param[in] idx_in if this value is INVALID_IRTE_ID, a new IRTE will be allocated, otherwise, use the IRTE directly.
+ * @param[out] idx_out return the actual IRTE index used, need to check whether the returned value is valid or not.
  *
- * @retval -EINVAL if corresponding DMAR is not present
- * @retval 0 otherwise
+ * @retval -EINVAL if corresponding DMAR is not preset
+ * @retval 0 on success, caller should check whether the returned start index is valid or not.
  *
  */
-int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry *irte, uint16_t index);
+int32_t dmar_assign_irte(const struct intr_source *intr_src, union dmar_ir_entry *irte,
+	uint16_t idx_in, uint16_t *idx_out);
 
 /**
  * @brief Free RTE for Interrupt Remapping Table.

--- a/hypervisor/include/arch/x86/vtd.h
+++ b/hypervisor/include/arch/x86/vtd.h
@@ -672,6 +672,21 @@ void resume_iommu(void);
 int32_t init_iommu(void);
 
 /**
+ * @brief Reserve num continuous IRTEs.
+ *
+ * @param[in] intr_src filled with type of interrupt source and the source
+ * @param[in] num number of IRTEs to reserve
+ * @param[out] start_id stard index of reserved IRTEs, caller should check the value is INVALID_IRTE_ID or not.
+ *
+ * @retval 0 on success, caller should check whether the returned start index is valid or not.
+ * @retval -EINVAL if corresponding DMAR is not preset.
+ *
+ * @pre num can only be 2, 4, 8, 16 or 32
+ *
+ */
+int32_t dmar_reserve_irte(const struct intr_source *intr_src, uint16_t num, uint16_t *start_id);
+
+/**
  * @brief Assign RTE for Interrupt Remapping Table.
  *
  * @param[in] intr_src filled with type of interrupt source and the source

--- a/hypervisor/include/common/ptdev.h
+++ b/hypervisor/include/common/ptdev.h
@@ -133,6 +133,7 @@ struct ptirq_remapping_info {
 	struct list_head softirq_node;
 	struct msi_info vmsi;
 	struct msi_info pmsi;
+	uint16_t irte_idx;
 
 	uint64_t intr_count;
 	struct hv_timer intr_delay_timer; /* used for delay intr injection */

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -67,6 +67,8 @@ struct pci_msix {
 	uint32_t  table_bar;
 	uint32_t  table_offset;
 	uint32_t  table_count;
+	bool      is_vmsix_on_msi;
+	bool	  is_vmsix_on_msi_programmed;
 };
 
 /* SRIOV capability structure */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -228,6 +228,9 @@ struct pci_pdev {
 
 	/* IOMMU responsible for DMA and Interrupt Remapping for this device */
 	uint32_t drhd_index;
+	/* Used for vMSI-x on MSI emulation */
+	uint16_t irte_start;
+	uint16_t irte_count;
 
 	/* The bar info of the physical PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
@@ -359,4 +362,5 @@ bool is_plat_hidden_pdev(union pci_bdf bdf);
 bool pdev_need_bar_restore(const struct pci_pdev *pdev);
 void pdev_restore_bar(const struct pci_pdev *pdev);
 void pci_switch_to_mmio_cfg_ops(void);
+void reserve_vmsix_on_msi_irtes(struct pci_pdev *pdev);
 #endif /* PCI_H_ */

--- a/hypervisor/pre_build/static_checks.c
+++ b/hypervisor/pre_build/static_checks.c
@@ -29,6 +29,10 @@ typedef int32_t CAT_(CTA_DummyType,__LINE__)[(expr) ? 1 : -1]
 #error "CONFIG_HV_RAM_SIZE must be integral multiple of 2MB"
 #endif
 
+#if ((CONFIG_MAX_IR_ENTRIES < 256U) || (CONFIG_MAX_IR_ENTRIES & (CONFIG_MAX_IR_ENTRIES -1)) != 0U)
+#error "CONFIG_MAX_IR_ENTRIES must >=256 and be 2^n"
+#endif
+
 /* Build time sanity checks to make sure hard-coded offset
 *  is matching the actual offset!
 */

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -55,8 +55,8 @@
             <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
             <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
             <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">32</MAX_MSIX_TABLE_NUM>
             <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -55,8 +55,8 @@
             <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
             <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
             <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">32</MAX_MSIX_TABLE_NUM>
             <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>


### PR DESCRIPTION
Some passthrough devices require multiple MSI vectors, but don't
support MSI-X. In meanwhile, Linux kernel doesn't support continuous
vector allocation.
On native platform, this issue can be mitigated by IOMMU via interrupt
remapping. However, on ACRN, there is no vIOMMU.
vMSI-X on MSI emulation is one solution to mitigate this problem on ACRN.

This patch adds MSI-X emulation on MSI capability.
For the device needs to do MSI-X emulation, HV will hide MSI capability
and present MSI-X capability to guest.

The guest driver may need to modify to reqeust MSI-X vector.
For example:
ret = pci_alloc_irq_vectors(pdev, 1, STMMAC_MSI_VEC_MAX,
 \-                                   PCI_IRQ_MSI);
\+                                   PCI_IRQ_MSI | PCI_IRQ_MSIX);

To enable MSI-X emulation, the device should:
- 1. The device should be in vmsix_on_msi_devs array.
- 2. Support MSI, but don't support MSI-X.
- 3. MSI capability should support per-vector mask.
- 4. The device should have an unused BAR.
- 5. The device driver should not rely on PBA for functionality.

Tracked-On: #4831
Signed-off-by: Binbin Wu <binbin.wu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>