### PR TITLE
mmu: release 1GB cpu side support constrain

### DIFF
--- a/hypervisor/arch/x86/boot/trampoline.S
+++ b/hypervisor/arch/x86/boot/trampoline.S
@@ -179,8 +179,7 @@ trampoline_gdt_ptr:
     .short  (trampoline_gdt_end - trampoline_gdt) - 1
     .quad   trampoline_gdt
 
-/* PML4 and PDPT tables initialized to map first 4 GBytes of memory */
-/* Assumes CPU supports 1GB large pages */
+/* PML4, PDPT, and PD tables initialized to map first 4 GBytes of memory */
     .align  4
     .global cpu_boot_page_tables_ptr
 cpu_boot_page_tables_ptr:
@@ -198,9 +197,19 @@ cpu_boot_page_tables_start:
 trampoline_pdpt_addr:
     address = 0
     .rept   4
-    /* 0x83 = (PAGE_PRESENT | PAGE_PSE | PAGE_RW) */
-    .quad   address + 0x83
-    address = address + 0x40000000
+    /* 0x3 = (PAGE_PRESENT | PAGE_RW) */
+    .quad   trampoline_pdt_addr + address + 0x3
+    /*0x1000 = PAGE_SIZE*/
+    address = address + 0x1000
+    .endr
+    /*0x1000 = PAGE_SIZE*/
+    .align  0x1000
+trampoline_pdt_addr:
+    address = 0
+    .rept  2048
+    /* 0x83 = (PAGE_PSE | PAGE_PRESENT | PAGE_RW) */
+    .quad  address + 0x83
+    address = address + 0x200000
     .endr
 
     .end

--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -385,9 +385,14 @@ static int32_t check_vmx_mmu_cap(void)
 		!pcpu_has_vmx_vpid_cap(VMX_VPID_INVVPID_GLOBAL_CONTEXT)) {
 		printf("%s, invvpid not supported\n", __func__);
 		ret = -ENODEV;
-	} else if (!pcpu_has_vmx_ept_cap(VMX_EPT_1GB_PAGE)) {
-		printf("%s, ept not support 1GB large page\n", __func__);
+	} else if (!pcpu_has_vmx_ept_cap(VMX_EPT_2MB_PAGE)) {
+		printf("%s, ept not support 2MB large page\n", __func__);
 		ret = -ENODEV;
+	} else if (pcpu_has_vmx_ept_cap(VMX_EPT_1GB_PAGE) !=
+				pcpu_has_cap(X86_FEATURE_PAGE1GB)) {
+		/* This just for simple large_page_support in arch/x86/page.c */
+		ret = -ENODEV;
+		printf("%s ept support 1GB large page while mmu is not or opposite\n", __func__);
 	} else {
 		/* No other state currently, do nothing */
 	}
@@ -438,9 +443,6 @@ int32_t detect_hardware_support(void)
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_CLFLUSHOPT)) {
 		printf("%s, CLFLUSHOPT not supported\n", __func__);
-		ret = -ENODEV;
-	} else if (!pcpu_has_cap(X86_FEATURE_PAGE1GB)) {
-		printf("%s, not support 1GB page\n", __func__);
 		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_VMX)) {
 		printf("%s, vmx not supported\n", __func__);

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -296,7 +296,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 			pr_fatal("%s, pde 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			if (mem_ops->pgentry_present(*pde) == 0UL) {
-				if (mem_ops->large_page_enabled &&
+				if (mem_ops->large_page_support(IA32E_PD) &&
 					mem_aligned_check(paddr, PDE_SIZE) &&
 					mem_aligned_check(vaddr, PDE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {
@@ -344,7 +344,7 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 			pr_fatal("%s, pdpte 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			if (mem_ops->pgentry_present(*pdpte) == 0UL) {
-				if (mem_ops->large_page_enabled &&
+				if (mem_ops->large_page_support(IA32E_PDPT) &&
 					mem_aligned_check(paddr, PDPTE_SIZE) &&
 					mem_aligned_check(vaddr, PDPTE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -59,13 +59,11 @@ uint64_t get_trampoline_start16_paddr(void)
 	return trampoline_start16_paddr;
 }
 
-/*
- * @pre pcpu_has_cap(X86_FEATURE_PAGE1GB) == true
- */
 static void update_trampoline_code_refs(uint64_t dest_pa)
 {
 	void *ptr;
 	uint64_t val;
+	int32_t i;
 
 	/*
 	 * calculate the fixup CS:IP according to fixup target address
@@ -88,6 +86,11 @@ static void update_trampoline_code_refs(uint64_t dest_pa)
 
 	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&cpu_boot_page_tables_start));
 	*(uint64_t *)(ptr) += dest_pa;
+
+	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_pdpt_addr));
+	for (i = 0; i < 4; i++) {
+		*(uint64_t *)(ptr + sizeof(uint64_t) * i) += dest_pa;
+	}
 
 	/* update the gdt base pointer with relocated offset */
 	ptr = hpa2hva(dest_pa + trampoline_relo_addr(&trampoline_gdt_ptr));

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -76,28 +76,6 @@ static inline uint64_t round_pde_down(uint64_t val)
 	return (val & PDE_MASK);
 }
 
-/**
- * @brief Page tables level in IA32 paging mode
- */
-enum _page_table_level {
-        /**
-         * @brief The PML4 level in the page tables
-         */
-	IA32E_PML4 = 0,
-        /**
-         * @brief The Page-Directory-Pointer-Table level in the page tables
-         */
-	IA32E_PDPT = 1,
-        /**
-         * @brief The Page-Directory level in the page tables
-         */
-	IA32E_PD = 2,
-        /**
-         * @brief The Page-Table level in the page tables
-         */
-	IA32E_PT = 3,
-};
-
 /* Page size */
 #define PAGE_SIZE_4K	MEM_4K
 #define PAGE_SIZE_2M	MEM_2M

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -51,6 +51,28 @@
 #define TRUSTY_PGTABLE_PAGE_NUM(size)	\
 (TRUSTY_PML4_PAGE_NUM(size) + TRUSTY_PDPT_PAGE_NUM(size) + TRUSTY_PD_PAGE_NUM(size) + TRUSTY_PT_PAGE_NUM(size))
 
+/**
+ * @brief Page tables level in IA32 paging mode
+ */
+enum _page_table_level {
+        /**
+         * @brief The PML4 level in the page tables
+         */
+	IA32E_PML4 = 0,
+        /**
+         * @brief The Page-Directory-Pointer-Table level in the page tables
+         */
+	IA32E_PDPT = 1,
+        /**
+         * @brief The Page-Directory level in the page tables
+         */
+	IA32E_PD = 2,
+        /**
+         * @brief The Page-Table level in the page tables
+         */
+	IA32E_PT = 3,
+};
+
 struct acrn_vm;
 
 struct page {
@@ -77,7 +99,7 @@ union pgtable_pages_info {
 
 struct memory_ops {
 	union pgtable_pages_info *info;
-	bool large_page_enabled;
+	bool (*large_page_support)(enum _page_table_level level);
 	uint64_t (*get_default_access_right)(void);
 	uint64_t (*pgentry_present)(uint64_t pte);
 	struct page *(*get_pml4_page)(const union pgtable_pages_info *info);


### PR DESCRIPTION
There're some platforms still doesn't support 1GB large page on CPU side.
Such as lakefield, TNT and EHL platforms on which have some silicon bug and
this case CPU don't support 1GB large page.

This patch tries to release this constrain to support more hardware platform.

Note this patch doesn't release the constrain on IOMMU side.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>
