### PR TITLE
HV: add board and scenario info in log

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -528,6 +528,8 @@ $(VERSION): $(HV_OBJDIR)/$(HV_CONFIG_H)
 	echo "#define HV_BUILD_TYPE "\""$$BUILD_TYPE"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_TIME "\""$$TIME"\""" >> $(VERSION);\
 	echo "#define HV_BUILD_USER "\""$$USER"\""" >> $(VERSION);\
+	echo "#define HV_BUILD_SCENARIO "\"$(SCENARIO)\""" >> $(VERSION);\
+	echo "#define HV_BUILD_BOARD "\"$(BOARD)\""" >> $(VERSION);\
 	if [ "$(CONFIG_XML_ENABLED)" = "true" ]; then \
 		echo "#define HV_CONFIG_TOOL \" with acrn-config\"" >> $(VERSION);\
 	else	\

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -214,14 +214,13 @@ void init_pcpu_post(uint16_t pcpu_id)
 		/* Calibrate TSC Frequency */
 		calibrate_tsc();
 
-		pr_acrnlog("HV version %s-%s-%s %s (daily tag:%s) build by %s%s, start time %luus",
+		pr_acrnlog("HV version %s-%s-%s %s (daily tag:%s) %s@%s build by %s%s, start time %luus",
 				HV_FULL_VERSION,
 				HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE,
-				HV_DAILY_TAG,
+				HV_DAILY_TAG, HV_BUILD_SCENARIO, HV_BUILD_BOARD,
 				HV_BUILD_USER, HV_CONFIG_TOOL, ticks_to_us(start_tsc));
 
-		pr_acrnlog("API version %u.%u",
-				HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
+		pr_acrnlog("API version %u.%u",	HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
 
 		pr_acrnlog("Detect processor: %s", (get_pcpu_info())->model_name);
 

--- a/hypervisor/debug/shell.c
+++ b/hypervisor/debug/shell.c
@@ -574,12 +574,9 @@ static int32_t shell_version(__unused int32_t argc, __unused char **argv)
 {
 	char temp_str[MAX_STR_SIZE];
 
-	snprintf(temp_str, MAX_STR_SIZE, "HV version %s-%s-%s %s (daily tag: %s) build by %s\r\n",
-			HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_DAILY_TAG, HV_BUILD_USER);
-	shell_puts(temp_str);
-
-	(void)memset((void *)temp_str, 0, MAX_STR_SIZE);
-	snprintf(temp_str, MAX_STR_SIZE, "API version %u.%u\r\n", HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
+	snprintf(temp_str, MAX_STR_SIZE, "HV %s-%s-%s %s (daily tag: %s) %s@%s build by %s%s\nAPI %u.%u\r\n",
+		HV_FULL_VERSION, HV_BUILD_TIME, HV_BUILD_VERSION, HV_BUILD_TYPE, HV_DAILY_TAG, HV_BUILD_SCENARIO,
+		HV_BUILD_BOARD, HV_BUILD_USER, HV_CONFIG_TOOL, HV_API_MAJOR_VERSION, HV_API_MINOR_VERSION);
 	shell_puts(temp_str);
 
 	return 0;


### PR DESCRIPTION
As build variants for different board and different scenario growing, users
might make mistake on HV binary distributions. Checking board/scenario info
from log would be the fastest way to know whether the binary matches. Also
it would be of benifit to developers for confirming the correct binary they
are debugging.

Tracked-On: #4946

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>