### PR TITLE
doc: open external links in new tab

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -299,3 +299,10 @@ div.numbered-step h2::before {
 .rst-content  .toctree-l1 > a {
   font-weight: bold;
 }
+
+/* add icon on external links */
+a.reference.external::after {
+   font-family: 'FontAwesome';
+   font-size: 80%;
+   content: " \f08e";
+}

--- a/doc/static/acrn-custom.js
+++ b/doc/static/acrn-custom.js
@@ -1,7 +1,11 @@
-/* tweak logo link */
+/* Extra acrn-specific javascript */
 
 $(document).ready(function(){
-   $( ".icon-home" ).attr("href", "https://projectacrn.org/");
+   /* tweak logo link to the marketing site instead of doc site */
+   $( ".icon-home" ).attr({href: "https://projectacrn.org/", target: "_blank"});
+
+   /* open external links in a new tab */
+   $('a[class*=external]').attr({target: '_blank', rel: 'noopener'});
 });
 
 /* Global site tag (gtag.js) - Google Analytics */


### PR DESCRIPTION
As a UX improvement, use a separate tab when opening links to external
sites (use the same tab for internal links).  Also, use rel=noopener
attribute to improve security when linking to external sites.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>