### PR TITLE
dm: fixed an issue that VM can't communicate with peer after rebooting/shutdown

### DIFF
--- a/devicemodel/hw/pci/ivshmem.c
+++ b/devicemodel/hw/pci/ivshmem.c
@@ -294,11 +294,15 @@ pci_ivshmem_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 		close(vdev->fd);
 	if (vdev->name) {
 		/*
-		 * unlink will only remove the shared memory file object,
+		 * shm_unlink will only remove the shared memory file object,
 		 * the shared memory will be released until all processes
-		 * which opened the shared memory file close the file.
+		 * which opened the shared memory close the file.
+		 *
+		 * Don't invoke shm_unlink(vdev->name) to remove file object now,
+		 * so that the acrn-dm can communicate with the peer again after
+		 * rebooting/shutdown, the side effect is that the shared memory
+		 * will not be released even if all peers exit.
 		 */
-		shm_unlink(vdev->name);
 		free(vdev->name);
 	}
 	free(vdev);


### PR DESCRIPTION
Due to there is no inter-vm communication shared memory management
module, so each acrn-dm will call shm_unlink when VM rebooting/shutdown.
It causes one issue that if one of the two VMs is rebooting/shutdown,
the VM can't communicate with the peer again.

Currently, we don't release the shared memory to fix this issue.

Tracked-On: #4853
Signed-off-by: Yuan Liu <yuan1.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>