### PR TITLE
HV: Fix split-locked access detection is disabled by default

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -100,7 +100,7 @@ uint64_t get_active_pcpu_bitmap(void)
 
 static void enable_ac_for_splitlock(void)
 {
-#ifdef CONFIG_ENFORCE_TURNOFF_AC
+#ifndef CONFIG_ENFORCE_TURNOFF_AC
 	uint64_t test_ctl;
 
 	if (has_core_cap(1U << 5U)) {


### PR DESCRIPTION
The commit 'HV: Config Splitlock Detection to be disable' allows
using CONFIG_ENFORCE_TURNOFF_AC to turn off splitlock #AC. If
CONFIG_ENFORCE_TURNOFF_AC is not set, splitlock #AC should be turn on

Tracked-On: #4962
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>