### PR TITLE
doc: fix style for lists in note

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -73,8 +73,8 @@ div.non-compliant-code div.highlight {
     color: rgba(255,255,255,1);
 }
 
-/* squish the space between a paragraph before a list */
-div > p + ul, div > p + ol {
+/* squish the space between a paragraph before a list but not in a note */
+div:not(.admonition) > p + ul, div:not(.admonition) > p + ol {
    margin-top: -20px;
 }
 


### PR DESCRIPTION
Fix CSS style for lists inside a note.  Previously the first list item
would overlap in the note heading box.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>