### PR TITLE
hv: vpci: a minor fix about is_zombie_vf

### DIFF
--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -112,6 +112,20 @@ static inline bool msicap_access(const struct pci_vdev *vdev, uint32_t offset)
 	return (has_msi_cap(vdev) && in_range(offset, vdev->msi.capoff, vdev->msi.caplen));
 }
 
+/**
+ * @brief Check if the specified vdev is a zombie VF instance
+ *
+ * @pre: The vdev is a VF instance
+ *
+ * @param vdev Pointer to vdev instance
+ *
+ * @return If the vdev is a zombie VF instance return true, otherwise return false
+ */
+static inline bool is_zombie_vf(const struct pci_vdev *vdev)
+{
+	return (vdev->user == NULL);
+}
+
 void init_vdev_pt(struct pci_vdev *vdev, bool is_pf_vdev);
 void deinit_vdev_pt(struct pci_vdev *vdev);
 void vdev_pt_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val);

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -208,18 +208,6 @@ static inline uint16_t vmid_2_rel_vmid(uint16_t sos_vmid, uint16_t vmid) {
 	return (vmid - sos_vmid);
 }
 
-/**
- * @brief Check if the specified vdev is a zombie VF instance
- *
- * @param vdev Pointer to vdev instance
- *
- * @return If the vdev is a zombie VF instance return true, otherwise return false
- */
-static inline bool is_zombie_vf(const struct pci_vdev *vdev)
-{
-	return (vdev->vpci == NULL);
-}
-
 void make_shutdown_vm_request(uint16_t pcpu_id);
 bool need_shutdown_vm(uint16_t pcpu_id);
 int32_t shutdown_vm(struct acrn_vm *vm);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -137,7 +137,7 @@ struct pci_vdev {
 	 * user       | vdev in HV | vdev in pre-VM |   vdev in SOS  |   vdev in post-VM  | vdev in post-VM
 	 */
 	struct pci_vdev *parent_user;
-	struct pci_vdev *user;
+	struct pci_vdev *user;	/* NULL means this device is not used or is a zombie VF */
 	struct hlist_node link;
 };
 


### PR DESCRIPTION
Now we check whether a device is zombie by the ->user != NULL.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>