### PR TITLE
Build: disable zero length array warning

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -78,6 +78,9 @@ CFLAGS += -m64 -mno-mmx -mno-sse -mno-sse2 -mno-80387 -mno-fp-ret-in-387
 CFLAGS += -mno-red-zone -mpopcnt
 CFLAGS += -nostdinc -nostdlib -fno-common
 CFLAGS += -Werror
+
+# ACRN depends on zero length array. Silence the gcc if Warrary-bounds is default option
+CFLAGS += -Wno-array-bounds
 CFLAGS += -O2
 ifeq (y, $(CONFIG_RELOC))
 CFLAGS += -fpie


### PR DESCRIPTION
We hit following build error when using gcc10:
  arch/x86/page.c:240:48: error: array subscript is outside
  array bounds of 'struct page[0][1]' [-Werror=array-bounds]

It happens with gcc10 on different Linux distributions.

Regarding the case that ACRN depends on zero length array in
sevaral places, we disable the zero length array warning by
gcc option.

Tracked-On: #4810
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Reviewed-by: Eddie Dong <eddie.dong@intel.com>