### PR TITLE
acrn-config: Add missing MBA_delay configuration in scenario xml

### DIFF
--- a/misc/acrn-config/hv_config/hv_item.py
+++ b/misc/acrn-config/hv_config/hv_item.py
@@ -105,6 +105,7 @@ class Features:
         self.rdt_enabled = ''
         self.cdp_enabled = ''
         self.cat_max_mask = []
+        self.mba_delay = []
         self.scheduler = ''
         self.hyperv_enabled = ''
         self.iommu_enforce_snp = ''
@@ -117,6 +118,7 @@ class Features:
         self.rdt_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "RDT", "RDT_ENABLED")
         self.cdp_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "RDT", "CDP_ENABLED")
         self.cat_max_mask = common.get_hv_item_tag(self.hv_file, "FEATURES", "RDT", "CLOS_MASK")
+        self.mba_delay = common.get_hv_item_tag(self.hv_file, "FEATURES", "RDT", "MBA_DELAY")
         self.scheduler = common.get_hv_item_tag(self.hv_file, "FEATURES", "SCHEDULER")
         self.reloc = common.get_hv_item_tag(self.hv_file, "FEATURES", "RELOC")
         self.hyperv_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "HYPERV_ENABLED")
@@ -130,6 +132,7 @@ class Features:
         hv_cfg_lib.ny_support_check(self.rdt_enabled, "FEATURES", "RDT", "RDT_ENABLED")
         hv_cfg_lib.ny_support_check(self.cdp_enabled, "FEATURES", "RDT", "CDP_ENABLED")
         hv_cfg_lib.cat_max_mask_check(self.cat_max_mask, "FEATURES", "RDT", "CLOS_MASK")
+        hv_cfg_lib.mba_delay_check(self.mba_delay, "FEATURES", "RDT", "MBA_DELAY")
         hv_cfg_lib.scheduler_check(self.scheduler, "FEATURES", "SCHEDULER")
         hv_cfg_lib.ny_support_check(self.reloc, "FEATURES", "RELOC")
         hv_cfg_lib.ny_support_check(self.hyperv_enabled, "FEATURES", "HYPERV_ENABLED")

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -432,13 +432,13 @@ def get_hv_item_tag(config_file, branch_tag, tag_str='', leaf_str=''):
                             tmp_list = []
                             for leaf_s in leaf:
                                 if leaf_s.tag == leaf_str and leaf_s.text and leaf_s.text != None:
-                                    if leaf_str == "CLOS_MASK":
+                                    if leaf_str == "CLOS_MASK" or leaf_str == "MBA_DELAY":
                                         tmp_list.append(leaf_s.text)
                                     else:
                                         tmp = leaf_s.text
                                 continue
 
-                            if leaf_str == "CLOS_MASK":
+                            if leaf_str == "CLOS_MASK" or leaf_str == "MBA_DELAY":
                                 tmp = tmp_list
                                 break
 

--- a/misc/acrn-config/library/hv_cfg_lib.py
+++ b/misc/acrn-config/library/hv_cfg_lib.py
@@ -196,3 +196,28 @@ def cat_max_mask_check(cat_mask_list, feature, cat_str, max_mask_str):
             key = 'hv,{},{},{}'.format(feature, cat_str, max_mask_str)
             ERR_LIST[key] = "CLOS_MASK {} should be contiguous bit set.".format(max_mask_str, clos_max_mask_str)
             return
+
+def mba_delay_check(mba_delay_list, feature, mba_str, max_mask_str):
+
+    if not board_cfg_lib.is_rdt_supported():
+        return
+
+    (_, rdt_res_clos_max, clos_max_mask_list) = board_cfg_lib.clos_info_parser(common.BOARD_INFO_FILE)
+
+    clos_max = common.num2int(min(rdt_res_clos_max))
+    mba_delay_settings_len = len(mba_delay_list)
+    if clos_max != mba_delay_settings_len:
+        key = 'hv,{},{},{}'.format(feature, mba_str, max_mask_str)
+        ERR_LIST[key] = "MBA_DELAY values in scenaio xml should equal to MAX_PLATFORM_CLOS_NUM.".format(clos_max)
+        return
+
+    mba_delay_str = clos_max_mask_list[1].strip('"').strip("'")
+    mba_delay = common.num2int(mba_delay_str)
+    for val_str in mba_delay_list:
+        if empty_check(val_str, feature, mba_str, max_mask_str):
+            return
+        value = common.num2int(val_str)
+        if value > mba_delay:
+            key = 'hv,{},{},{}'.format(feature, mba_str, max_mask_str)
+            ERR_LIST[key] = "{} should be in range[0,{}]".format(max_mask_str, mba_delay_str)
+            return

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -67,6 +67,7 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["hv,FEATURES,RDT,RDT_ENABLED"] = board_cfg_lib.get_rdt_select_opt()
     scenario_item_values["hv,FEATURES,RDT,CDP_ENABLED"] = board_cfg_lib.get_rdt_select_opt()
     scenario_item_values["hv,FEATURES,RDT,CLOS_MASK"] = board_cfg_lib.get_clos_mask_num()
+    scenario_item_values["hv,FEATURES,RDT,MBA_DELAY"] = board_cfg_lib.get_clos_mask_num()
     scenario_item_values["hv,FEATURES,SCHEDULER"] = hv_cfg_lib.SCHEDULER_TYPE
     scenario_item_values["hv,FEATURES,RELOC"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,FEATURES,HYPERV_ENABLED"] = hv_cfg_lib.N_Y


### PR DESCRIPTION
This patch adds support to configure MBA delay values from
scenario xml files just as it is done for CAT mask. This will
improve user experience when configuring RDT resource mask
values.

Tracked-On: #4943
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>