### PR TITLE
Change to a permissive check with broken DMAR table

### DIFF
--- a/hypervisor/acpi_parser/dmar_parse.c
+++ b/hypervisor/acpi_parser/dmar_parse.c
@@ -192,8 +192,9 @@ int32_t parse_dmar_table(struct dmar_info *plat_dmar_info)
 
 			/* Only support single PCI Segment */
 			if (acpi_drhd->flags & DRHD_FLAG_INCLUDE_PCI_ALL_MASK) {
-				ASSERT(!is_include_all_emulated,
-						"DRHD with INCLUDE_PCI_ALL flag should be the last one");
+				if (!is_include_all_emulated) {
+					pr_warn("DRHD with INCLUDE_PCI_ALL flag is NOT the last one!");
+				}
 				is_include_all_emulated = true;
 			}
 

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -522,11 +522,11 @@ static void pci_parse_iommu_devscopes(struct pci_bdf_mapping_group *const bdfs_f
 				 */
 			}
 		}
-	}
 
-	if ((plat_dmar_info.drhd_units[plat_dmar_info.drhd_count - 1U].flags & DRHD_FLAG_INCLUDE_PCI_ALL_MASK)
-			== DRHD_FLAG_INCLUDE_PCI_ALL_MASK) {
-		*drhd_idx_pci_all = plat_dmar_info.drhd_count - 1U;
+		if ((plat_dmar_info.drhd_units[drhd_index].flags & DRHD_FLAG_INCLUDE_PCI_ALL_MASK)
+				== DRHD_FLAG_INCLUDE_PCI_ALL_MASK) {
+			*drhd_idx_pci_all = drhd_index;
+		}
 	}
 }
 


### PR DESCRIPTION
    From the VT-d spec 8.3:
    If a DRHD structure with INCLUDE_PCI_ALL flag Set is reported for a
    Segment, it must be enumerated by BIOS after all other DRHD structures
    for the same Segment.
    
    However, some broken BIOS violate the rules. To bring up ACRN with them,
    change the ASSERT to a permissive check to unblock the BIOS limitation.
    Also, scan the DRHD list to find the one who has INCLUDE_PCI_ALL flag.
