### PR TITLE
Kconfig/acrn-config: extend the max msix table number to 64

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -308,7 +308,7 @@ config MAX_PCI_DEV_NUM
 config MAX_MSIX_TABLE_NUM
 	int "Maximum number of MSI-X tables per device"
 	range 1 2048
-	default 16
+	default 64
 
 config ENFORCE_VALIDATED_ACPI_INFO
 	bool "Enforce the use of validated ACPI info table"

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/industry.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-mrb/sdc.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/hybrid.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/industry.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/apl-up2/sdc.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -56,7 +56,7 @@
             <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
             <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
             <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
             <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -56,7 +56,7 @@
             <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
             <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
             <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
             <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -56,7 +56,7 @@
             <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
             <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
             <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
             <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>

--- a/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -56,7 +56,7 @@
             <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
             <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
             <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
             <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>

--- a/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/hybrid.xml
@@ -43,7 +43,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/industry.xml
@@ -43,7 +43,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/logical_partition.xml
@@ -43,7 +43,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/generic/sdc.xml
@@ -43,7 +43,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/industry.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/qemu/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/qemu/sdc.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/template/HV.xml
+++ b/misc/acrn-config/xmls/config-xmls/template/HV.xml
@@ -43,7 +43,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/tgl-rvp/industry.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -42,7 +42,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 

--- a/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/acrn-config/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -46,7 +46,7 @@
         <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">16</MAX_MSIX_TABLE_NUM>
+        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device.">64</MAX_MSIX_TABLE_NUM>
         <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 


### PR DESCRIPTION
- kconfig/acrn-config: extend the max msix table number to 64

    There are some devices (like Samsung NVMe SSD SM981/PM981 which has 33 MSIX tables)
    which have more than 16 MSIX tables. Extend the default value to 64 to handle them.

Tracked-On: #4994
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Signed-off-by: Wei Liu <weix.w.liu@intel.com>