### PR TITLE
tools: improve Makefile to build life-mngr

### DIFF
--- a/misc/Makefile
+++ b/misc/Makefile
@@ -4,9 +4,9 @@ RELEASE ?= 0
 
 .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
 ifeq ($(RELEASE),0)
-all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge
+all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
 else
-all: acrn-manager acrnbridge
+all: acrn-manager acrnbridge life_mngr
 endif
 
 acrn-crashlog:
@@ -38,9 +38,10 @@ clean:
 
 .PHONY: install
 ifeq ($(RELEASE),0)
-install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install
+install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install \
+	acrn-life-mngr-install
 else
-install: acrn-manager-install acrnbridge-install
+install: acrn-manager-install acrnbridge-install acrn-life-mngr-install
 endif
 
 acrn-crashlog-install:
@@ -57,3 +58,6 @@ acrntrace-install:
 
 acrnbridge-install:
 	$(MAKE) -C $(T)/acrnbridge OUT_DIR=$(OUT_DIR) install
+
+acrn-life-mngr-install:
+	$(MAKE) -C $(T)/life_mngr OUT_DIR=$(OUT_DIR) install

--- a/misc/life_mngr/Makefile
+++ b/misc/life_mngr/Makefile
@@ -51,3 +51,7 @@ ifneq ($(OUT_DIR),.)
 	rm -rf $(OUT_DIR)
 endif
 
+.PHONY: install
+install:
+	install -d $(DESTDIR)/usr/bin
+	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/life_mngr


### PR DESCRIPTION
1. add life-mngr as a target in misc/Makefile, so it is
convenient to build and used in Yocto system.
2. add install target in life-mngr/Makefile to be packaged
into device file-system.

Tracked-On: #4870
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Reviewed-by: Binbin Wu <binbin.wu@intel.com>