### PR TITLE
hv: vpci: minor refine about MSI/MSI-X de-initialization

### DIFF
--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -134,11 +134,10 @@ void write_vmsi_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
  * @pre vdev != NULL
  * @pre vdev->vpci != NULL
  */
-void deinit_vmsi(struct pci_vdev *vdev)
+void deinit_vmsi(const struct pci_vdev *vdev)
 {
 	if (has_msi_cap(vdev)) {
 		ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->pdev->bdf.value, 1U);
-		(void)memset((void *)&vdev->msi, 0U, sizeof(struct pci_msi));
 	}
 }
 

--- a/hypervisor/dm/vpci/vmsix.c
+++ b/hypervisor/dm/vpci/vmsix.c
@@ -284,7 +284,8 @@ void deinit_vmsix(struct pci_vdev *vdev)
 	if (has_msix_cap(vdev)) {
 		if (vdev->msix.table_count != 0U) {
 			ptirq_remove_msix_remapping(vpci2vm(vdev->vpci), vdev->pdev->bdf.value, vdev->msix.table_count);
-			(void)memset((void *)&vdev->msix, 0U, sizeof(struct pci_msix));
+			(void)memset((void *)&vdev->msix.table_entries, 0U, sizeof(vdev->msix.table_entries));
+			vdev->msix.is_vmsix_on_msi_programmed = false;
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vpci_priv.h
+++ b/hypervisor/dm/vpci/vpci_priv.h
@@ -134,7 +134,7 @@ void vdev_pt_map_msix(struct pci_vdev *vdev, bool hold_lock);
 void init_vmsi(struct pci_vdev *vdev);
 void read_vmsi_cap_reg(const struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t *val);
 void write_vmsi_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, uint32_t val);
-void deinit_vmsi(struct pci_vdev *vdev);
+void deinit_vmsi(const struct pci_vdev *vdev);
 
 void init_vmsix(struct pci_vdev *vdev);
 int32_t vmsix_handle_table_mmio_access(struct io_request *io_req, void *handler_private_data);


### PR DESCRIPTION
About the MSI/MSI-X Capability, there're some fields of it would never been changed
once they had been initialized. So it's no need to reset them once the vdev instance
is still used. What need to reset are the fields which would been changed by guest
at runtime.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>