### PR TITLE
hv: vpci: don't pass through bridge to SOS if has prelaunched vm

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -617,9 +617,12 @@ struct pci_vdev *vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_c
 	if (dev_config->vdev_ops != NULL) {
 		vdev->vdev_ops = dev_config->vdev_ops;
 	} else {
+	#if PRE_VM_NUM == 0U
 		if (get_highest_severity_vm(false) == vpci2vm(vpci)) {
 			vdev->vdev_ops = &pci_pt_dev_ops;
-		} else {
+		}
+	#endif
+		if (vdev->vdev_ops == NULL) {
 			if (is_bridge(vdev->pdev)) {
 				vdev->vdev_ops = &vpci_bridge_ops;
 			} else if (is_host_bridge(vdev->pdev)) {


### PR DESCRIPTION
If we need to assign a PCI device to pre-launched VM, then we should not pass
through PCI Bridge to SOS. Otherwise, the SOS could reset the PCI Bridge as well
as the device behinds it.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>