### PR TITLE
dm: Data Stolen Memory (DSM) passthrough support for GVT-d on TGL

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -426,6 +426,7 @@ passthru_gpu_dsm_opregion(struct vmctx *ctx, struct passthru_dev *ptdev,
 
 	switch (device) {
 	case INTEL_ELKHARTLAKE:
+	case INTEL_TIGERLAKE:
 		/* BDSM register has 64 bits.
 		 * bits 63:20 contains the base address of stolen memory
 		 */

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1067,6 +1067,7 @@
 
 /* Graphics definitions */
 #define INTEL_ELKHARTLAKE		0x4551
+#define INTEL_TIGERLAKE		0x9a49
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
 #define PCIR_GEN11_BDSM_DW0		0xC0
 #define PCIR_GEN11_BDSM_DW1		0xC4


### PR DESCRIPTION
The way of passing DSM address on TGL is the same with on EHL.
Adding these code to support GVT-d on TGL.

Tracked-On: #5020
Signed-off-by: Sun Peng <peng.p.sun@intel.com>
Acked-by: Yu Wang yu1.wang@intel.com