### PR TITLE
HV: restrict conditions to assign/deassign pcidev

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -834,12 +834,13 @@ int32_t hcall_assign_pcidev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct acrn_assign_pcidev pcidev;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	/* We should only assign a device to a post-launched VM at creating time for safety, not runtime or other cases*/
+	if (is_created_vm(target_vm) && is_postlaunched_vm(target_vm)) {
 		if (copy_from_gpa(vm, &pcidev, param, sizeof(pcidev)) == 0) {
 			ret = vpci_assign_pcidev(target_vm, &pcidev);
 		}
 	} else {
-		pr_err("%s, vm[%d] is invalid\n", __func__, vm->vm_id);
+		pr_err("%s, vm[%d] is not a postlaunched VM, or not in CREATED status to be assigned with a pcidev\n", __func__, vm->vm_id);
 	}
 
 	return ret;
@@ -862,12 +863,13 @@ int32_t hcall_deassign_pcidev(struct acrn_vm *vm, uint16_t vmid, uint64_t param)
 	struct acrn_assign_pcidev pcidev;
 	struct acrn_vm *target_vm = get_vm_from_vmid(vmid);
 
-	if (!is_poweroff_vm(target_vm) && is_postlaunched_vm(target_vm)) {
+	/* We should only de-assign a device from a post-launched VM at creating/shutdown/reset time */
+	if ((is_paused_vm(target_vm) || is_created_vm(target_vm)) && is_postlaunched_vm(target_vm)) {
 		if (copy_from_gpa(vm, &pcidev, param, sizeof(pcidev)) == 0) {
 			ret = vpci_deassign_pcidev(target_vm, &pcidev);
 		}
 	} else {
-		pr_err("%s, vm[%d] is invalid\n", __func__, vm->vm_id);
+		pr_err("%s, vm[%d] is not a postlaunched VM, or not in PAUSED/CREATED status to be deassigned from a pcidev\n", __func__, vm->vm_id);
 	}
 
 	return ret;


### PR DESCRIPTION
This patch is ported from mainline branch to v2.0 branch to fix
potential service VM hang issue when fuzzing hypercalls.

hv: hypercall: restrict the condition to assign/deassign a pci device to
a post-launched VM for safety

For the safety of post-launched VMs, pci devices assignments should
occur only when VM is being created (at VM_CREATED STATUS), and pci
devices de-assignment should occur only when VM is being created or
shutdown/reset (at VM_CREATED or VM_PAUSED status)

Tracked-On: #5024
Acked-by: Eddie Done <eddie.dong@intel.com>
Reviewed-by: Li Fei <Fei1.Li@intel.com>
Signed-off-by: Wang Qian <qian1.wang@intel.com>
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>