### PR TITLE
doc: keep doxygen group descriptions in doc output

### DIFF
--- a/doc/static/acrn-custom.css
+++ b/doc/static/acrn-custom.css
@@ -124,8 +124,9 @@ th,td {
     vertical-align: top !important;
 }
 
-/* dbk tweak for doxygen-generated API headings (for RTD theme) */
-.rst-content dl.group>dt, .rst-content dl.group>dd>p {
+/* dbk tweak for doxygen-generated API headings (for RTD theme)
+   hide the "group" name provided by breathe, but keep the description */
+.rst-content dl.group>dt {
    display:none !important;
 }
 .rst-content dl.group {


### PR DESCRIPTION
Propagated fix from other doxygen/breathe project to keep the
description found in the doxygen comments for the group being displayed
(in case there actually is a nice description given).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>