### PR TITLE
doc: update intro link to project roadmap

### DIFF
--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -23,11 +23,12 @@ partitioning hypervisors. The ACRN hypervisor architecture partitions
 the system into different functional domains, with carefully selected
 user VM sharing optimizations for IoT and embedded devices.
 
-ACRN Open Source Roadmap 2020
-*****************************
+ACRN Open Source Roadmap
+************************
 
-Stay informed on what's ahead for ACRN in 2020 by visiting the
-`ACRN 2020 Roadmap <https://projectacrn.org/wp-content/uploads/sites/59/2020/03/ACRN-Roadmap-External-2020.pdf>`_.
+Stay informed on what's ahead for ACRN by visiting the
+`ACRN Project Roadmap <https://projectacrn.org/#resources>`_ on the
+projectacrn.org website.
 
 For up-to-date happenings, visit the `ACRN blog <https://projectacrn.org/blog/>`_.
 


### PR DESCRIPTION
Instead of linking to a specific doc on projectacrn.org, update to just
link to the area on projectacrn.org/#resources where the roadmap doc can
be found.  Also remove mention of 2020 to keep it generic so it won't
need updating in 2021.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>