### PR TITLE
DM USB: xHCI: Fix XHCI_GET_SLOT value check issue

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2523,7 +2523,8 @@ done:
 
 #define XHCI_GET_SLOT(xdev, trb, slot, cmderr)			\
 	do {								\
-		slot = (XHCI_TRB_3_SLOT_GET(trb->dwTrb3)) ? 0 :		\
+		slot = (XHCI_TRB_3_SLOT_GET(trb->dwTrb3) >              \
+			XHCI_MAX_SLOTS) ? 0 :   			\
 			XHCI_TRB_3_SLOT_GET(trb->dwTrb3);		\
 		if (!slot)						\
 			cmderr = XHCI_TRB_ERROR_INVALID;		\


### PR DESCRIPTION
Fix XHCI_GET_SLOT macro check slot valid function, when the
slot value is bigger than XHCI_MAX_SLOT set the slot value
to zero.

Tracked-On: #4711

Signed-off-by: Long Liu <long.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>