### PR TITLE
acrn-config: minor fix mac seed for launch config

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -51,7 +51,7 @@ def tap_uos_net(names, virt_io, vmid, config):
     print("#vm-name used to generate uos-mac address", file=config)
     print("mac=$(cat /sys/class/net/e*/address)", file=config)
     print("vm_name=post_vm_id$1", file=config)
-    print("mac_seed=${mac:9:8}-${vm_name}", file=config)
+    print("mac_seed=${mac}-${vm_name}", file=config)
     print("", file=config)
 
 


### PR DESCRIPTION
Minor fix for mac seed when generating launch script.

Tracked-On: #5039
Signed-off-by: Wei Liu <weix.w.liu@intel.com>