### PR TITLE
hv:add per-vm lock for vm & vcpu state change

### DIFF
--- a/hypervisor/arch/x86/guest/pm.c
+++ b/hypervisor/arch/x86/guest/pm.c
@@ -152,6 +152,7 @@ static bool pm1ab_io_read(struct acrn_vcpu *vcpu, uint16_t addr, size_t width)
 
 static inline void enter_s5(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
 {
+	get_vm_lock(vm);
 	/*
 	 * It's possible that ACRN come here from SOS and pre-launched VM. Currently, we
 	 * assume SOS has full ACPI power management stack. That means the value from SOS
@@ -162,12 +163,14 @@ static inline void enter_s5(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t 
 	}
 	pause_vm(vm);
 	(void)shutdown_vm(vm);
+	put_vm_lock(vm);
 }
 
 static inline void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t pm1b_cnt_val)
 {
 	uint32_t guest_wakeup_vec32;
 
+	get_vm_lock(vm);
 	/* Save the wakeup vec set by guest OS. Will return to guest
 	 * with this wakeup vec as entry.
 	 */
@@ -178,6 +181,7 @@ static inline void enter_s3(struct acrn_vm *vm, uint32_t pm1a_cnt_val, uint32_t 
 	pause_vm(vm);	/* pause sos_vm before suspend system */
 	host_enter_s3(vm->pm.sx_state_data, pm1a_cnt_val, pm1b_cnt_val);
 	resume_vm_from_s3(vm, guest_wakeup_vec32);	/* jump back to vm */
+	put_vm_lock(vm);
 }
 
 /**

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -1101,6 +1101,7 @@ vlapic_calc_dest_lapic_pt(struct acrn_vm *vm, uint64_t *dmask, bool is_broadcast
 static void
 vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t icr_low)
 {
+	get_vm_lock(target_vcpu->vm);
 	if (mode == APIC_DELMODE_INIT) {
 		if ((icr_low & APIC_LEVEL_MASK) != APIC_LEVEL_DEASSERT) {
 
@@ -1144,6 +1145,7 @@ vlapic_process_init_sipi(struct acrn_vcpu* target_vcpu, uint32_t mode, uint32_t 
 	} else {
 		/* No other state currently, do nothing */
 	}
+	put_vm_lock(target_vcpu->vm);
 	return;
 }
 

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -14,11 +14,6 @@
 #include <trace.h>
 #include <logmsg.h>
 
-static spinlock_t vmm_hypercall_lock = {
-	.head = 0U,
-	.tail = 0U,
-};
-
 static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 {
 	struct acrn_vm *sos_vm = vcpu->vm;
@@ -36,9 +31,7 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	switch (hypcall_id) {
 	case HC_SOS_OFFLINE_CPU:
-		spinlock_obtain(&vmm_hypercall_lock);
 		ret = hcall_sos_offline_cpu(sos_vm, param1);
-		spinlock_release(&vmm_hypercall_lock);
 		break;
 	case HC_GET_API_VERSION:
 		ret = hcall_get_api_version(sos_vm, param1);
@@ -54,44 +47,34 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 		break;
 
 	case HC_CREATE_VM:
-		spinlock_obtain(&vmm_hypercall_lock);
 		ret = hcall_create_vm(sos_vm, param1);
-		spinlock_release(&vmm_hypercall_lock);
 		break;
 
 	case HC_DESTROY_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {
-			spinlock_obtain(&vmm_hypercall_lock);
 			ret = hcall_destroy_vm(vm_id);
-			spinlock_release(&vmm_hypercall_lock);
 		}
 		break;
 
 	case HC_START_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {
-			spinlock_obtain(&vmm_hypercall_lock);
 			ret = hcall_start_vm(vm_id);
-			spinlock_release(&vmm_hypercall_lock);
 		}
 		break;
 
 	case HC_RESET_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {
-			spinlock_obtain(&vmm_hypercall_lock);
 			ret = hcall_reset_vm(vm_id);
-			spinlock_release(&vmm_hypercall_lock);
 		}
 		break;
 
 	case HC_PAUSE_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {
-			spinlock_obtain(&vmm_hypercall_lock);
 			ret = hcall_pause_vm(vm_id);
-			spinlock_release(&vmm_hypercall_lock);
 		}
 		break;
 
@@ -102,9 +85,7 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 	case HC_SET_VCPU_REGS:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {
-			spinlock_obtain(&vmm_hypercall_lock);
 			ret = hcall_set_vcpu_regs(sos_vm, vm_id, param2);
-			spinlock_release(&vmm_hypercall_lock);
 		}
 		break;
 
@@ -126,9 +107,7 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 	case HC_SET_IOREQ_BUFFER:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {
-			spinlock_obtain(&vmm_hypercall_lock);
 			ret = hcall_set_ioreq_buffer(sos_vm, vm_id, param2);
-			spinlock_release(&vmm_hypercall_lock);
 		}
 		break;
 

--- a/hypervisor/common/hv_main.c
+++ b/hypervisor/common/hv_main.c
@@ -35,7 +35,9 @@ void vcpu_thread(struct thread_object *obj)
 		ret = acrn_handle_pending_request(vcpu);
 		if (ret < 0) {
 			pr_fatal("vcpu handling pending request fail");
+			get_vm_lock(vcpu->vm);
 			zombie_vcpu(vcpu, VCPU_ZOMBIE);
+			put_vm_lock(vcpu->vm);
 			/* Fatal error happened (triple fault). Stop the vcpu running. */
 			continue;
 		}
@@ -47,7 +49,9 @@ void vcpu_thread(struct thread_object *obj)
 		ret = run_vcpu(vcpu);
 		if (ret != 0) {
 			pr_fatal("vcpu resume failed");
+			get_vm_lock(vcpu->vm);
 			zombie_vcpu(vcpu, VCPU_ZOMBIE);
+			put_vm_lock(vcpu->vm);
 			/* Fatal error happened (resume vcpu failed). Stop the vcpu running. */
 			continue;
 		}


### PR DESCRIPTION
-- replace global hypercall lock with per-vm lock
-- add spinlock protection for vm & vcpu state change

v1-->v2:
   change get_vm_lock/put_vm_lock parameter from vm_id to vm
   move lock obtain before vm state check
   move all lock from vmcall.c to hypercall.c

Tracked-On: #4958
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>