### PR TITLE
Refine status transition of thread object

### DIFF
--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -213,6 +213,14 @@ void sleep_thread(struct thread_object *obj)
 	release_schedule_lock(pcpu_id, rflag);
 }
 
+void sleep_thread_sync(struct thread_object *obj)
+{
+	sleep_thread(obj);
+	while (!is_blocked(obj)) {
+		asm_pause();
+	}
+}
+
 void wake_thread(struct thread_object *obj)
 {
 	uint16_t pcpu_id = obj->pcpu_id;

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -265,7 +265,6 @@ struct acrn_vcpu {
 
 	struct thread_object thread_obj;
 	bool launched; /* Whether the vcpu is launched on target pcpu */
-	volatile bool running; /* vcpu is picked up and run? */
 
 	struct instr_emul_ctxt inst_ctxt;
 	struct io_request req; /* used by io/ept emulation */

--- a/hypervisor/include/arch/x86/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/guest/vcpu.h
@@ -666,7 +666,7 @@ void launch_vcpu(struct acrn_vcpu *vcpu);
  *
  * @return None
  */
-void kick_vcpu(const struct acrn_vcpu *vcpu);
+void kick_vcpu(struct acrn_vcpu *vcpu);
 
 /**
  * @brief create a vcpu for the vm and mapped to the pcpu.

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -37,6 +37,7 @@ struct thread_object {
 	struct sched_control *sched_ctl;
 	thread_entry_t thread_entry;
 	volatile enum thread_object_state status;
+	bool be_blocking;
 	enum sched_notify_mode notify_mode;
 
 	uint64_t host_sp;

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -114,6 +114,7 @@ bool need_reschedule(uint16_t pcpu_id);
 
 void run_thread(struct thread_object *obj);
 void sleep_thread(struct thread_object *obj);
+void sleep_thread_sync(struct thread_object *obj);
 void wake_thread(struct thread_object *obj);
 void kick_thread(const struct thread_object *obj);
 void yield_current(void);

--- a/hypervisor/include/common/schedule.h
+++ b/hypervisor/include/common/schedule.h
@@ -116,7 +116,6 @@ void run_thread(struct thread_object *obj);
 void sleep_thread(struct thread_object *obj);
 void sleep_thread_sync(struct thread_object *obj);
 void wake_thread(struct thread_object *obj);
-void kick_thread(const struct thread_object *obj);
 void yield_current(void);
 void schedule(void);
 


### PR DESCRIPTION
Thread object's status is changed without context switch done. This is
not accurate. Move the status transition after context switch to make it
more accurate.

Also move kick_thread() logic from schedule framework to vcpu layer,
because it's more about vcpu notification which has less relevant with
scheduling.

Tracked-On: #5057
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Reviewed-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>