### PR TITLE
hv: fix possible SSE region mismatch issue

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -481,6 +481,9 @@ int32_t detect_hardware_support(void)
 	} else if (!pcpu_has_cap(X86_FEATURE_XSAVES)) {
 		printf("%s, XSAVES not supported\n", __func__);
 		ret = -ENODEV;
+	} else if (!pcpu_has_cap(X86_FEATURE_SSE)) {
+		printf("%s, SSE not supported\n", __func__);
+		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_COMPACTION_EXT)) {
 		printf("%s, Compaction extensions in XSAVE is not supported\n", __func__);
 		ret = -ENODEV;

--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -745,14 +745,16 @@ void save_xsave_area(struct ext_context *ectx)
 {
 	ectx->xcr0 = read_xcr(0);
 	ectx->xss = msr_read(MSR_IA32_XSS);
+	write_xcr(0, ectx->xcr0 | XSAVE_SSE);
 	xsaves(&ectx->xs_area, UINT64_MAX);
 }
 
 void rstore_xsave_area(const struct ext_context *ectx)
 {
-	write_xcr(0, ectx->xcr0);
+	write_xcr(0, ectx->xcr0 | XSAVE_SSE);
 	msr_write(MSR_IA32_XSS, ectx->xss);
 	xrstors(&ectx->xs_area, UINT64_MAX);
+	write_xcr(0, ectx->xcr0);
 }
 
 /* TODO:

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -158,6 +158,7 @@
 #define XSAVE_COMPACTED_FORMAT			(1UL << 63U)
 
 #define XSAVE_FPU				(1UL << 0U)
+#define XSAVE_SSE				(1UL << 1U)
 
 #define	CPU_CONTEXT_OFFSET_RAX			0U
 #define	CPU_CONTEXT_OFFSET_RCX			8U


### PR DESCRIPTION
XSAVE area has the following format:
 - The legacy region.
    - X87 state
    - SSE state
 - The XSAVE header.
 - The extended region.

Instructions fxsave/fxrstor operate the legacy region by default.
Instructions xsaves/xrstors operate the XSAVE area according to the
state componment bits in XCR0. The hypervisor use xsaves/xrstors to
save/restore the XSAVE area of each vCPU in context switch. So the
state componment in legacy region shoud be always covered during context
switch.

Set SSE feature bit in XCR0 during context switch.

Tracked-On: #5062
Signed-off-by: Conghui Chen <conghui.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>