### PR TITLE
Add MMIO device pass through support

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -132,6 +132,7 @@ SRCS += hw/pci/uart.c
 SRCS += hw/pci/gvt.c
 SRCS += hw/pci/npk.c
 SRCS += hw/pci/ivshmem.c
+SRCS += hw/mmio/core.c
 
 # core
 #SRCS += core/bootrom.c

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -573,6 +573,18 @@ vm_deassign_pcidev(struct vmctx *ctx, struct acrn_assign_pcidev *pcidev)
 }
 
 int
+vm_assign_mmiodev(struct vmctx *ctx, struct acrn_mmiodev *mmiodev)
+{
+	return ioctl(ctx->fd, IC_ASSIGN_MMIODEV, mmiodev);
+}
+
+int
+vm_deassign_mmiodev(struct vmctx *ctx, struct acrn_mmiodev *mmiodev)
+{
+	return ioctl(ctx->fd, IC_DEASSIGN_MMIODEV, mmiodev);
+}
+
+int
 vm_map_ptdev_mmio(struct vmctx *ctx, int bus, int slot, int func,
 		   vm_paddr_t gpa, size_t len, vm_paddr_t hpa)
 {

--- a/devicemodel/hw/mmio/core.c
+++ b/devicemodel/hw/mmio/core.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <assert.h>
+#include <stdbool.h>
+
+#include "dm.h"
+#include "vmmapi.h"
+#include "acpi.h"
+#include "inout.h"
+#include "mem.h"
+#include "log.h"
+
+
+struct mmio_dev {
+	char name[16];
+};
+
+#define MAX_MMIO_DEV_NUM	2
+
+static struct mmio_dev mmio_devs[MAX_MMIO_DEV_NUM];
+
+struct mmio_dev_ops {
+	char *name;
+	uint64_t base_gpa;
+	uint64_t base_hpa;
+	uint64_t size;
+	int (*init)(struct vmctx *, struct acrn_mmiodev *);
+	void (*deinit)(struct vmctx *, struct acrn_mmiodev *);
+};
+
+
+SET_DECLARE(mmio_dev_ops_set, struct mmio_dev_ops);
+#define DEFINE_MMIO_DEV(x)	DATA_SET(mmio_dev_ops_set, x)
+
+struct mmio_dev_ops pt_mmiodev;
+
+int parse_pt_acpidev(char *opt)
+{
+	int err = -EINVAL;
+	if (strncmp(opt, "MSFT0101", 8) == 0) {
+		strncpy(mmio_devs[0].name, "MSFT0101", 8);
+		pt_tpm2 = true;
+		err = 0;
+	}
+
+	return err;
+}
+
+int parse_pt_mmiodev(char *opt)
+{
+
+	int err = -EINVAL;
+	uint64_t base_hpa, size;
+	char *cp;
+
+	if((!dm_strtoul(opt, &cp, 16, &base_hpa) && *cp == ',') &&
+		(!dm_strtoul(cp + 1, &cp, 16, &size))) {
+		printf("%s pt mmiodev base: 0x%lx, size: 0x%lx\n", __func__, base_hpa, size);
+		strncpy(mmio_devs[1].name, pt_mmiodev.name, 8);
+		pt_mmiodev.base_hpa = base_hpa;
+		pt_mmiodev.size = size;
+	} else {
+		printf("%s, %s invalid, please check!\n", __func__, opt);
+	}
+
+	return err;
+}
+
+static struct mmio_dev_ops *mmio_dev_finddev(char *name)
+{
+	struct mmio_dev_ops **mdpp, *mdp;
+
+	SET_FOREACH(mdpp, mmio_dev_ops_set) {
+		mdp = *mdpp;
+		if (!strcmp(mdp->name, name))
+			return mdp;
+	}
+
+	return NULL;
+}
+
+int init_mmio_dev(struct vmctx *ctx, struct mmio_dev_ops *ops)
+{
+	struct acrn_mmiodev mmiodev = {
+		.base_gpa = ops->base_gpa,
+		.base_hpa = ops->base_hpa,
+		.size = ops->size,
+	};
+
+	return ops->init(ctx, &mmiodev);
+}
+
+void deinit_mmio_dev(struct vmctx *ctx, struct mmio_dev_ops *ops)
+{
+	struct acrn_mmiodev mmiodev = {
+		.base_gpa = ops->base_gpa,
+		.base_hpa = ops->base_hpa,
+		.size = ops->size,
+	};
+
+	ops->deinit(ctx, &mmiodev);
+}
+
+int init_mmio_devs(struct vmctx *ctx)
+{
+	int i, err = 0;
+	struct mmio_dev_ops *ops;
+
+	for (i = 0; i < MAX_MMIO_DEV_NUM; i++) {
+		ops = mmio_dev_finddev(mmio_devs[i].name);	
+		if (ops != NULL)
+			err = init_mmio_dev(ctx, ops);
+
+		if (err != 0)
+			goto init_mmio_devs_fail;
+	}
+
+	return 0;
+
+init_mmio_devs_fail:
+	for (; i>=0; i--) {
+		ops = mmio_dev_finddev(mmio_devs[i].name);	
+		if (ops != NULL)
+			deinit_mmio_dev(ctx, ops);
+	}
+
+	return err;
+}
+
+void deinit_mmio_devs(struct vmctx *ctx)
+{
+	int i;
+	struct mmio_dev_ops *ops;
+
+	for (i = 0; i < MAX_MMIO_DEV_NUM; i++) {
+		ops = mmio_dev_finddev(mmio_devs[i].name);	
+		if (ops != NULL)
+			deinit_mmio_dev(ctx, ops);
+
+	}
+}
+
+static int init_pt_mmiodev(struct vmctx *ctx, struct acrn_mmiodev *dev)
+{
+	return vm_assign_mmiodev(ctx, dev);
+}
+
+static void deinit_pt_mmiodev(struct vmctx *ctx, struct acrn_mmiodev *dev)
+{
+	vm_deassign_mmiodev(ctx, dev);
+}
+
+struct mmio_dev_ops tpm2 = {
+	.name		= "MSFT0101",
+	/* ToDo: we may allocate the gpa MMIO resource in a reserved MMIO region
+	 * rether than hard-coded here.
+	 */
+	.base_gpa	= 0xFED40000UL,
+	.base_hpa	= 0xFED40000UL,
+	.size		= 0x00005000UL,
+	.init		= init_pt_mmiodev,
+	.deinit		= deinit_pt_mmiodev,
+};
+DEFINE_MMIO_DEV(tpm2);
+
+struct mmio_dev_ops pt_mmiodev = {
+	.name		= "MMIODEV",
+	/* ToDo: we may allocate the gpa MMIO resource in a reserved MMIO region
+	 * rether than hard-coded here.
+	 */
+	.base_gpa	= 0xF0000000UL,
+	.init		= init_pt_mmiodev,
+	.deinit		= deinit_pt_mmiodev,
+};
+DEFINE_MMIO_DEV(pt_mmiodev);

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -182,7 +182,7 @@ basl_fwrite_rsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
 		    basl_acpi_base + NHLT_OFFSET);
 
-	if (ctx->tpm_dev)
+	if (ctx->tpm_dev || pt_tpm2)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
@@ -224,7 +224,7 @@ basl_fwrite_xsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
 		    basl_acpi_base + NHLT_OFFSET);
 
-	if (ctx->tpm_dev)
+	if (ctx->tpm_dev || pt_tpm2)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
@@ -859,7 +859,7 @@ basl_fwrite_dsdt(FILE *fp, struct vmctx *ctx)
 
 	pm_write_dsdt(ctx, basl_ncpu);
 
-	if (ctx->tpm_dev)
+	if (ctx->tpm_dev || pt_tpm2)
 		tpm2_crb_fwrite_dsdt();
 
 	dsdt_line("}");
@@ -1124,7 +1124,7 @@ acpi_build(struct vmctx *ctx, int ncpu)
 	 */
 	while (!err && (i < ARRAY_SIZE(basl_ftables))) {
 		if ((basl_ftables[i].offset == TPM2_OFFSET) &&
-			(ctx->tpm_dev != NULL)) {
+			(ctx->tpm_dev != NULL || pt_tpm2)) {
 				basl_ftables[i].valid = true;
 		}
 

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -48,6 +48,7 @@ extern bool stdio_in_use;
 extern char *mac_seed;
 extern bool lapic_pt;
 extern bool is_rtvm;
+extern bool pt_tpm2;
 extern bool is_winvm;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,

--- a/devicemodel/include/mmio_dev.h
+++ b/devicemodel/include/mmio_dev.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#ifndef _MMIO_DEV_H_
+#define _MMIO_DEV_H_
+
+int parse_pt_acpidev(char *arg);
+int parse_pt_mmiodev(char *arg);
+
+int init_mmio_devs(struct vmctx *ctx);
+int deinit_mmio_devs(struct vmctx *ctx);
+
+#endif /* _MMIO_DEV_H_ */

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -107,6 +107,8 @@
 #define IC_RESET_PTDEV_INTR_INFO       _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x04)
 #define IC_ASSIGN_PCIDEV               _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x05)
 #define IC_DEASSIGN_PCIDEV             _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x06)
+#define IC_ASSIGN_MMIODEV              _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x07)
+#define IC_DEASSIGN_MMIODEV            _IC_ID(IC_ID, IC_ID_PCI_BASE + 0x08)
 
 /* Power management */
 #define IC_ID_PM_BASE                   0x60UL
@@ -179,6 +181,24 @@ struct acrn_assign_pcidev {
 
 	/** reserved for extension */
 	uint32_t rsvd2[6];
+
+} __attribute__((aligned(8)));
+
+/**
+ * @brief Info to assign or deassign a MMIO device for a VM
+ */
+struct acrn_mmiodev {
+	/** the gpa of the MMIO region for the MMIO device */
+	uint64_t base_gpa;
+
+	/** the hpa of the MMIO region for the MMIO device */
+	uint64_t base_hpa;
+
+	/** the size of the MMIO region for the MMIO device */
+	uint64_t size;
+
+	/** reserved for extension */
+	uint64_t reserved[13];
 
 } __attribute__((aligned(8)));
 

--- a/devicemodel/include/tpm.h
+++ b/devicemodel/include/tpm.h
@@ -9,7 +9,7 @@
 #define _TPM_H_
 
 #define TPM_CRB_MMIO_ADDR 0xFED40000UL
-#define TPM_CRB_MMIO_SIZE 0x1000U
+#define TPM_CRB_MMIO_SIZE 0x5000U
 
 /* TPM CRB registers */
 enum {

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -126,6 +126,8 @@ int	vm_lapic_msi(struct vmctx *ctx, uint64_t addr, uint64_t msg);
 int	vm_set_gsi_irq(struct vmctx *ctx, int gsi, uint32_t operation);
 int	vm_assign_pcidev(struct vmctx *ctx, struct acrn_assign_pcidev *pcidev);
 int	vm_deassign_pcidev(struct vmctx *ctx, struct acrn_assign_pcidev *pcidev);
+int	vm_assign_mmiodev(struct vmctx *ctx, struct acrn_mmiodev *mmiodev);
+int	vm_deassign_mmiodev(struct vmctx *ctx, struct acrn_mmiodev *mmiodev);
 int	vm_map_ptdev_mmio(struct vmctx *ctx, int bus, int slot, int func,
 			  vm_paddr_t gpa, size_t len, vm_paddr_t hpa);
 int	vm_unmap_ptdev_mmio(struct vmctx *ctx, int bus, int slot, int func,

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -306,6 +306,7 @@ VP_DM_C_SRCS += dm/vpci/vmsi.c
 VP_DM_C_SRCS += dm/vpci/vmsix.c
 VP_DM_C_SRCS += dm/vpci/vmsix_on_msi.c
 VP_DM_C_SRCS += dm/vpci/vsriov.c
+VP_DM_C_SRCS += dm/mmio_dev.c
 VP_DM_C_SRCS += arch/x86/guest/vlapic.c
 VP_DM_C_SRCS += arch/x86/guest/pm.c
 VP_DM_C_SRCS += arch/x86/guest/assign.c

--- a/hypervisor/arch/x86/configs/vacpi.c
+++ b/hypervisor/arch/x86/configs/vacpi.c
@@ -10,6 +10,19 @@
 #include <pgtable.h>
 #include <platform_acpi_info.h>
 
+#define ACPI_TABLE_HEADER(SIGNATURE, LENGTH, REVISION, OEM_ID,			\
+	OEM_TABLE_ID, OEM_REVISION, ASL_COMPILER_ID, ASL_COMPILER_REVISION) 	\
+	{									\
+		.signature = (SIGNATURE),					\
+		.length = (LENGTH),						\
+		.revision = (REVISION),						\
+		.oem_id = (OEM_ID),						\
+		.oem_table_id = (OEM_TABLE_ID),					\
+		.oem_revision = (OEM_REVISION),					\
+		.asl_compiler_id = (ASL_COMPILER_ID),				\
+		.asl_compiler_revision = (ASL_COMPILER_REVISION),		\
+	}
+
 /* ACPI tables for pre-launched VM and SOS */
 static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 	[0U ... (CONFIG_MAX_VM_NUM - 1U)] = {
@@ -21,25 +34,14 @@ static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 			.xsdt_physical_address = ACPI_XSDT_ADDR,
 		},
 		.xsdt = {
-			.header.revision = 0x1U,
-			.header.oem_revision = 0x1U,
-			.header.asl_compiler_revision = ACPI_ASL_COMPILER_VERSION,
-			.header.signature = ACPI_SIG_XSDT,
-			.header.oem_id = ACPI_OEM_ID,
-			.header.oem_table_id = "ACRNXSDT",
-			.header.asl_compiler_id = ACPI_ASL_COMPILER_ID,
+			.header = ACPI_TABLE_HEADER(ACPI_SIG_XSDT, 0U, 0x1U, ACPI_OEM_ID,
+					"ACRNXSDT", 0x1U, ACPI_ASL_COMPILER_ID, ACPI_ASL_COMPILER_VERSION),
 
 			.table_offset_entry[0] = ACPI_MADT_ADDR,
 		},
 		.fadt = {
-			.header.revision = 0x3U,
-			.header.length = 0xF4U,
-			.header.oem_revision = 0x1U,
-			.header.asl_compiler_revision = ACPI_ASL_COMPILER_VERSION,
-			.header.signature = ACPI_SIG_FADT,
-			.header.oem_id = ACPI_OEM_ID,
-			.header.oem_table_id = "ACRNMADT",
-			.header.asl_compiler_id = ACPI_ASL_COMPILER_ID,
+			.header = ACPI_TABLE_HEADER(ACPI_SIG_FADT, 0xF4U, 0x3U, ACPI_OEM_ID,
+					"ACRNFADT", 0x1U, ACPI_ASL_COMPILER_ID, ACPI_ASL_COMPILER_VERSION),
 
 			.dsdt = ACPI_DSDT_ADDR,
 
@@ -50,24 +52,11 @@ static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 
 			.flags = 0x00001125U,	/* HEADLESS | TMR_VAL_EXT | SLP_BUTTON | PROC_C1 | WBINVD */
 		},
-		.dsdt = {
-			.revision = 0x3U,
-			.length = sizeof(struct acpi_table_header),
-			.oem_revision = 0x1U,
-			.asl_compiler_revision = ACPI_ASL_COMPILER_VERSION,
-			.signature = ACPI_SIG_DSDT,
-			.oem_id = ACPI_OEM_ID,
-			.oem_table_id = "ACRNMADT",
-			.asl_compiler_id = ACPI_ASL_COMPILER_ID,
-		},
+		.dsdt = ACPI_TABLE_HEADER(ACPI_SIG_DSDT, sizeof(struct acpi_table_header), 0x3U, ACPI_OEM_ID,
+					"ACRNDSDT", 0x1U, ACPI_ASL_COMPILER_ID, ACPI_ASL_COMPILER_VERSION),
 		.mcfg = {
-			.header.revision = 0x3U,
-			.header.oem_revision = 0x1U,
-			.header.asl_compiler_revision = ACPI_ASL_COMPILER_VERSION,
-			.header.signature = ACPI_SIG_MCFG,
-			.header.oem_id = ACPI_OEM_ID,
-			.header.oem_table_id = "ACRNMADT",
-			.header.asl_compiler_id = ACPI_ASL_COMPILER_ID,
+			.header = ACPI_TABLE_HEADER(ACPI_SIG_MCFG, 0U, 0x3U, ACPI_OEM_ID,
+					"ACRNMCFG", 0x1U, ACPI_ASL_COMPILER_ID, ACPI_ASL_COMPILER_VERSION),
 		},
 		.mcfg_entry = {
 			.address = VIRT_PCI_MMCFG_BASE,
@@ -76,13 +65,8 @@ static struct acpi_table_info acpi_table_template[CONFIG_MAX_VM_NUM] = {
 			.end_bus_number = 0xFFU,
 		},
 		.madt = {
-			.header.revision = 0x3U,
-			.header.oem_revision = 0x1U,
-			.header.asl_compiler_revision = ACPI_ASL_COMPILER_VERSION,
-			.header.signature = ACPI_SIG_MADT,
-			.header.oem_id = ACPI_OEM_ID,
-			.header.oem_table_id = "ACRNMADT",
-			.header.asl_compiler_id = ACPI_ASL_COMPILER_ID,
+			.header = ACPI_TABLE_HEADER(ACPI_SIG_MADT, 0U, 0x3U, ACPI_OEM_ID,
+					"ACRNMADT", 0x1U, ACPI_ASL_COMPILER_ID, ACPI_ASL_COMPILER_VERSION),
 
 			.address = 0xFEE00000U, /* Local APIC Address */
 			.flags = 0x1U, /* PC-AT Compatibility=1 */

--- a/hypervisor/arch/x86/configs/whl-ipc-i5/misc_cfg.h
+++ b/hypervisor/arch/x86/configs/whl-ipc-i5/misc_cfg.h
@@ -33,5 +33,8 @@
 #define HI_MMIO_START		~0UL
 #define HI_MMIO_END		0UL
 
+#define VM0_PASSTHROUGH_TPM
+#define VM0_TPM_BUFFER_BASE_ADDR    0xFED40000UL
+#define VM0_TPM_BUFFER_SIZE         0x5000UL
 
 #endif /* MISC_CFG_H */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -93,6 +93,10 @@ bool is_postlaunched_vm(const struct acrn_vm *vm)
 	return (get_vm_config(vm->vm_id)->load_order == POST_LAUNCHED_VM);
 }
 
+bool is_valid_postlaunched_vmid(uint16_t vm_id)
+{
+	return ((vm_id < CONFIG_MAX_VM_NUM) && is_postlaunched_vm(get_vm_from_vmid(vm_id)));
+}
 /**
  * @pre vm != NULL
  * @pre vm->vmid < CONFIG_MAX_VM_NUM

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -32,6 +32,7 @@
 #include <pci_dev.h>
 #include <vacpi.h>
 #include <platform_caps.h>
+#include <mmio_dev.h>
 
 vm_sw_loader_t vm_sw_loader;
 
@@ -257,6 +258,10 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 			remaining_hpa_size = vm_config->memory.size_hpa2;
 		}
 	}
+
+	for (i = 0U; i < MAX_MMIO_DEV_NUM; i++) {
+		(void)assign_mmio_dev(vm, &vm_config->mmiodevs[i]);
+	}
 }
 
 /**
@@ -327,6 +332,10 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 		vm_config = get_vm_config(vm_id);
 		if (vm_config->load_order == PRE_LAUNCHED_VM) {
 			ept_del_mr(vm, pml4_page, vm_config->memory.start_hpa, vm_config->memory.size);
+		}
+
+		for (i = 0U; i < MAX_MMIO_DEV_NUM; i++) {
+			(void)deassign_mmio_dev(vm, &vm_config->mmiodevs[i]);
 		}
 	}
 

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -160,6 +160,20 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 		}
 		break;
 
+	case HC_ASSIGN_MMIODEV:
+		/* param1: relative vmid to sos, vm_id: absolute vmid */
+		if (vmid_is_valid) {
+			ret = hcall_assign_mmiodev(sos_vm, vm_id, param2);
+		}
+		break;
+
+	case HC_DEASSIGN_MMIODEV:
+		/* param1: relative vmid to sos, vm_id: absolute vmid */
+		if (vmid_is_valid) {
+			ret = hcall_deassign_mmiodev(sos_vm, vm_id, param2);
+		}
+		break;
+
 	case HC_SET_PTDEV_INTR_INFO:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
 		if (vmid_is_valid) {

--- a/hypervisor/arch/x86/guest/vmcall.c
+++ b/hypervisor/arch/x86/guest/vmcall.c
@@ -26,7 +26,6 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 	/* hypercall param1 is a relative vm id from SOS view */
 	uint16_t relative_vm_id = (uint16_t)param1;
 	uint16_t vm_id = rel_vmid_2_vmid(sos_vm->vm_id, relative_vm_id);
-	bool vmid_is_valid = (vm_id < CONFIG_MAX_VM_NUM) ? true : false;
 	int32_t ret = -1;
 
 	switch (hypcall_id) {
@@ -52,28 +51,28 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	case HC_DESTROY_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_destroy_vm(vm_id);
 		}
 		break;
 
 	case HC_START_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_start_vm(vm_id);
 		}
 		break;
 
 	case HC_RESET_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_reset_vm(vm_id);
 		}
 		break;
 
 	case HC_PAUSE_VM:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_pause_vm(vm_id);
 		}
 		break;
@@ -84,14 +83,14 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	case HC_SET_VCPU_REGS:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_set_vcpu_regs(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_SET_IRQLINE:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_set_irqline(sos_vm, vm_id,
 					(struct acrn_irqline_ops *)&param2);
 		}
@@ -99,14 +98,14 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	case HC_INJECT_MSI:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_inject_msi(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_SET_IOREQ_BUFFER:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_set_ioreq_buffer(sos_vm, vm_id, param2);
 		}
 		break;
@@ -114,7 +113,7 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 	case HC_NOTIFY_REQUEST_FINISH:
 		/* param1: relative vmid to sos, vm_id: absolute vmid
 		 * param2: vcpu_id */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_notify_ioreq_finish(vm_id,
 				(uint16_t)param2);
 		}
@@ -126,7 +125,7 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	case HC_VM_WRITE_PROTECT_PAGE:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_write_protect_page(sos_vm, vm_id, param2);
 		}
 		break;
@@ -141,49 +140,49 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	case HC_VM_GPA2HPA:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if ((vm_id < CONFIG_MAX_VM_NUM) && !is_prelaunched_vm(get_vm_from_vmid(vm_id))) {
 			ret = hcall_gpa_to_hpa(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_ASSIGN_PCIDEV:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_assign_pcidev(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_DEASSIGN_PCIDEV:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_deassign_pcidev(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_ASSIGN_MMIODEV:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_assign_mmiodev(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_DEASSIGN_MMIODEV:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_deassign_mmiodev(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_SET_PTDEV_INTR_INFO:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_set_ptdev_intr_info(sos_vm, vm_id, param2);
 		}
 		break;
 
 	case HC_RESET_PTDEV_INTR_INFO:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_reset_ptdev_intr_info(sos_vm, vm_id, param2);
 		}
 		break;
@@ -194,7 +193,7 @@ static int32_t dispatch_sos_hypercall(const struct acrn_vcpu *vcpu)
 
 	case HC_VM_INTR_MONITOR:
 		/* param1: relative vmid to sos, vm_id: absolute vmid */
-		if (vmid_is_valid) {
+		if (is_valid_postlaunched_vmid(vm_id)) {
 			ret = hcall_vm_intr_monitor(sos_vm, vm_id, param2);
 		}
 		break;

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -57,6 +57,7 @@
 #define ACPI_SIG_DMAR            "DMAR"
 #define ACPI_SIG_MCFG            "MCFG" /* Memory Mapped Configuration table */
 #define ACPI_SIG_DSDT            "DSDT" /* Differentiated System Description Table */
+#define ACPI_SIG_TPM2            "TPM2" /* Trusted Platform Module hardware interface table */
 
 struct packed_gas {
 	uint8_t 	space_id;
@@ -225,6 +226,14 @@ struct acpi_dmar_device_scope {
 	uint16_t                  reserved;
 	uint8_t                   enumeration_id;
 	uint8_t                   bus;
+} __packed;
+
+struct acpi_table_tpm2 {
+	struct acpi_table_header header;
+	uint16_t platform_class;
+	uint16_t reserved;
+	uint64_t control_address;
+	uint32_t start_method;
 } __packed;
 
 void *get_acpi_tbl(const char *signature);

--- a/hypervisor/dm/mmio_dev.c
+++ b/hypervisor/dm/mmio_dev.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <util.h>
+#include <acrn_hv_defs.h>
+#include <pgtable.h>
+#include <vm.h>
+#include <ept.h>
+
+int32_t assign_mmio_dev(struct acrn_vm *vm, const struct acrn_mmiodev *mmiodev)
+{
+	int32_t ret = -EINVAL;
+
+	if (mem_aligned_check(mmiodev->base_gpa, PAGE_SIZE) &&
+			mem_aligned_check(mmiodev->base_hpa, PAGE_SIZE) &&
+			mem_aligned_check(mmiodev->size, PAGE_SIZE)) {
+		ept_add_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, mmiodev->base_hpa,
+				is_sos_vm(vm) ? mmiodev->base_hpa : mmiodev->base_gpa,
+				mmiodev->size, EPT_RWX | EPT_UNCACHED);
+		ret = 0;
+	}
+
+	return ret;
+}
+
+int32_t deassign_mmio_dev(struct acrn_vm *vm, const struct acrn_mmiodev *mmiodev)
+{
+	int32_t ret = -EINVAL;
+
+	if (mem_aligned_check(mmiodev->base_gpa, PAGE_SIZE) &&
+			mem_aligned_check(mmiodev->base_hpa, PAGE_SIZE) &&
+			mem_aligned_check(mmiodev->size, PAGE_SIZE)) {
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
+				is_sos_vm(vm) ? mmiodev->base_hpa : mmiodev->base_gpa, mmiodev->size);
+		ret = 0;
+	}
+
+	return ret;
+}

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -225,6 +225,7 @@ bool is_created_vm(const struct acrn_vm *vm);
 bool is_paused_vm(const struct acrn_vm *vm);
 bool is_sos_vm(const struct acrn_vm *vm);
 bool is_postlaunched_vm(const struct acrn_vm *vm);
+bool is_valid_postlaunched_vmid(uint16_t vm_id);
 bool is_prelaunched_vm(const struct acrn_vm *vm);
 uint16_t get_vmid_by_uuid(const uint8_t *uuid);
 struct acrn_vm *get_vm_from_vmid(uint16_t vm_id);

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -14,6 +14,7 @@
 #include <vm_uuids.h>
 #include <vm_configurations.h>
 #include <sgx.h>
+#include <acrn_hv_defs.h>
 
 #define CONFIG_MAX_VM_NUM	(PRE_VM_NUM + SOS_VM_NUM + MAX_POST_VM_NUM)
 
@@ -32,6 +33,8 @@
 #define PCI_DEV_TYPE_PTDEV	(1U << 0U)
 #define PCI_DEV_TYPE_HVEMUL	(1U << 1U)
 #define PCI_DEV_TYPE_SOSEMUL	(1U << 2U)
+
+#define MAX_MMIO_DEV_NUM	2U
 
 #define CONFIG_SOS_VM		.load_order = SOS_VM,	\
 				.uuid = SOS_VM_UUID,	\
@@ -174,6 +177,8 @@ struct acrn_vm_config {
 							 */
 
 	struct vuart_config vuart[MAX_VUART_NUM_PER_VM];/* vuart configuration for VM */
+
+	struct acrn_mmiodev mmiodevs[MAX_MMIO_DEV_NUM];
 } __aligned(8);
 
 struct acrn_vm_config *get_vm_config(uint16_t vm_id);

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -178,6 +178,7 @@ struct acrn_vm_config {
 
 	struct vuart_config vuart[MAX_VUART_NUM_PER_VM];/* vuart configuration for VM */
 
+	bool pt_tpm2;
 	struct acrn_mmiodev mmiodevs[MAX_MMIO_DEV_NUM];
 } __aligned(8);
 

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -435,7 +435,7 @@ int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu);
  * @pre Pointer vm shall point to SOS_VM
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_callback_vector(const struct acrn_vm *vm, uint64_t param);
+int32_t hcall_set_callback_vector(__unused const struct acrn_vm *vm, uint64_t param);
 
 /**
  * @}

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -275,6 +275,32 @@ int32_t hcall_assign_pcidev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 int32_t hcall_deassign_pcidev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
 
 /**
+ * @brief Assign one MMIO dev to VM.
+ *
+ * @param vm Pointer to VM data structure
+ * @param vmid ID of the VM
+ * @param param guest physical address. This gpa points to data structure of
+ *              acrn_mmiodev including assign MMIO device info
+ *
+ * @pre Pointer vm shall point to SOS_VM
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_assign_mmiodev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
+
+/**
+ * @brief Deassign one MMIO dev to VM.
+ *
+ * @param vm Pointer to VM data structure
+ * @param vmid ID of the VM
+ * @param param guest physical address. This gpa points to data structure of
+ *              acrn_mmiodev including deassign MMIO device info
+ *
+ * @pre Pointer vm shall point to SOS_VM
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_deassign_mmiodev(struct acrn_vm *vm, uint16_t vmid, uint64_t param);
+
+/**
  * @brief Set interrupt mapping info of ptdev.
  *
  * @param vm Pointer to VM data structure

--- a/hypervisor/include/dm/mmio_dev.h
+++ b/hypervisor/include/dm/mmio_dev.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MMIO_DEV_H
+#define MMIO_DEV_H
+
+int32_t assign_mmio_dev(struct acrn_vm *vm, const struct acrn_mmiodev *mmiodev);
+int32_t deassign_mmio_dev(struct acrn_vm *vm, const struct acrn_mmiodev *mmiodev);
+
+#endif /* MMIO_DEV_H */

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -47,6 +47,7 @@
 #define ACPI_DSDT_ADDR    (ACPI_BASE + 0x200U)
 #define ACPI_MCFG_ADDR    (ACPI_BASE + 0x300U)
 #define ACPI_MADT_ADDR    (ACPI_BASE + 0x340U)
+#define ACPI_TPM2_ADDR    (ACPI_BASE + 0x1000U)
 
 #define ACPI_OEM_ID           "ACRN  "
 #define ACPI_ASL_COMPILER_ID  "INTL"

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -66,6 +66,8 @@
 #define HC_RESET_PTDEV_INTR_INFO    BASE_HC_ID(HC_ID, HC_ID_PCI_BASE + 0x04UL)
 #define HC_ASSIGN_PCIDEV            BASE_HC_ID(HC_ID, HC_ID_PCI_BASE + 0x05UL)
 #define HC_DEASSIGN_PCIDEV          BASE_HC_ID(HC_ID, HC_ID_PCI_BASE + 0x06UL)
+#define HC_ASSIGN_MMIODEV           BASE_HC_ID(HC_ID, HC_ID_PCI_BASE + 0x07UL)
+#define HC_DEASSIGN_MMIODEV         BASE_HC_ID(HC_ID, HC_ID_PCI_BASE + 0x08UL)
 
 /* DEBUG */
 #define HC_ID_DBG_BASE              0x60UL
@@ -297,6 +299,26 @@ struct acrn_assign_pcidev {
 
 	/** reserved for extension */
 	uint32_t rsvd2[6];
+
+} __attribute__((aligned(8)));
+
+/**
+ * @brief Info to assign or deassign a MMIO device for a VM
+ *
+ * the parameter for HC_ASSIGN_MMIODEV or HC_DEASSIGN_MMIODEV hypercall
+ */
+struct acrn_mmiodev {
+	/** the gpa of the MMIO region for the MMIO device */
+	uint64_t base_gpa;
+
+	/** the hpa of the MMIO region for the MMIO device */
+	uint64_t base_hpa;
+
+	/** the size of the MMIO region for the MMIO device */
+	uint64_t size;
+
+	/** reserved for extension */
+	uint64_t reserved[13];
 
 } __attribute__((aligned(8)));
 

--- a/hypervisor/scenarios/hybrid/vm_configurations.c
+++ b/hypervisor/scenarios/hybrid/vm_configurations.c
@@ -37,7 +37,15 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.irq = COM2_IRQ,
 			.t_vuart.vm_id = 1U,
 			.t_vuart.vuart_id = 1U,
-		}
+		},
+	#ifdef VM0_PASSTHROUGH_TPM
+		.pt_tpm2 = true,
+		.mmiodevs[0] = {
+			.base_gpa = VM0_TPM_BUFFER_BASE_ADDR,
+			.base_hpa = 0xFED40000UL,
+			.size = VM0_TPM_BUFFER_SIZE,
+		},
+	#endif
 	},
 	{	/* VM1 */
 		CONFIG_SOS_VM,


### PR DESCRIPTION
v4:
1. refine the DM cmdline to pass MMIO PT parameter
2. add a MACRO to enable MMIO PT for pre-launched VM
3. check vm id is valid in dispatch_sos_hypercall

v3:
1. remove reserved0 in acrn_mmiodev structure.
2. refine the logic of TPM ACPI Table construct for pre-launched VM.
3. refine the MMIO passthrough Doc

v2:
1. add doc to describe how to pass through MMIO device in ACRN
2. enlarge TPM_CRB_MMIO_SIZE form 0x1000 to 0x5000
3. move TPM_BUFFER_XXX MACRO from platform_acpi_info.h to misc_cfg.h
4. Add two new ToDo and one FIXME
        ToDo: a.1 refine cmdline from --tpm2 HID to --mmiopt HID if we support more type PT MMIO device
              a.2 allocate MMIO resource in a reserved MMIO region rather than hard-coded
        FIXME: Now we will don't allow pass through TPM device and emulate the vTPM at the same time
              since their HIDs are the same and share the same MMIO resource.
5. limitation:
        Now we only support pass through TPM2 device which must use Start Method 7
        (Uses the Command Response Buffer Interface) to notify the TPM 2.0 device
        that a command is available for processing.



v1:
a) For post-launched VM,
we will pass MMIO device through the cmdline by "--MMIO_device_type MMIO_device_HID".
IE, TPM use "--tpm2 MSFT0101". Then ACRN-DM will check whether we already have supported
this MMIO device pass through by check the if there's a mmio_dev_ops with it. Now all
the MMIO device related resourece is hard code in mmio_dev_ops.

b) For pre-launched VM,
we will describe the MMIO device resource in vm_config by scenarios.

ToDo:
To save pass through MMIO devices in vm structure for resources claim if acrn-dm crash by exception.

Tracked-On: #5053
Signed-off-by: Li Fei1 <fei1.li@intel.com>