### PR TITLE
DM: xHCI: Release all device resource when received HCRST.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -1192,9 +1192,26 @@ pci_xhci_reset(struct pci_xhci_vdev *xdev)
 	xdev->rtsregs.er_enq_idx = 0;
 	xdev->rtsregs.er_enq_seg = 0;
 	xdev->rtsregs.event_pcs = 1;
+	struct pci_xhci_dev_emu *dev;
+
+	for (i = 1; i <= XHCI_MAX_DEVS; i++)
+	{
+		dev = xdev->devices[i];
+		if (dev) {
+			xdev->devices[i] = NULL;
+			pci_xhci_dev_destroy(dev);
+			/* FIXME: The ndevices hasn't
+			 * aligned between ++ and --
+			 * */
+			xdev->ndevices--;
+		}
+	}
 
 	for (i = 1; i <= XHCI_MAX_SLOTS; i++)
-		pci_xhci_reset_slot(xdev, i);
+	{
+		xdev->slots[i] = NULL;
+		xdev->slot_allocated[i] = false;
+	}
 }
 
 static uint32_t


### PR DESCRIPTION
There has one bug that the pci_xhci_dev_emu objects recorded in
xdev->devices haven't destroied when OVMF transfer to guest OS.
This will cause the the fds of usbfs can't be freed in libusb.
The OVMF xHCI driver needs to disable all enabled slots during
graceful existing flow, but it doesn't.
The USBCMD.HCRST bit is used for xHCI reset that will be triggered
in xHCI driver initialization. We can use this chance to clear all
pci_xhci_dev_emu objects

Tracked-On: #4897
Signed-off-by: Long Liu <long.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>