### PR TITLE
doc: add mmio-dev-passthrough to TOC

### DIFF
--- a/doc/developer-guides/hld/hld-hypervisor.rst
+++ b/doc/developer-guides/hld/hld-hypervisor.rst
@@ -18,6 +18,7 @@ Hypervisor high-level design
    Virtual Interrupt <hv-virt-interrupt>
    VT-d <hv-vt-d>
    Device Passthrough <hv-dev-passthrough>
+   mmio-dev-passthrough
    hv-partitionmode
    Power Management <hv-pm>
    Console, Shell, and vUART <hv-console>


### PR DESCRIPTION
Doc was merged but not included in the TOC (CI indicated a pass on that
PR even though doc build failed).  This fixes that undetected error.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>