### PR TITLE
hv: Fix issue in size used for memset in create_vm

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -407,8 +407,13 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 
 	/* Allocate memory for virtual machine */
 	vm = &vm_array[vm_id];
-	/* the vm_state lock field need to remain unchanged in vm data structure */
-	(void)memset((void *)&vm->arch_vm, 0U, (sizeof(struct acrn_vm) - sizeof(spinlock_t)));
+	/*
+	 * the vm_state lock field need to remain unchanged in vm data structure
+	 * Since arch_vm struct is page aligned, size used for memeset should consider
+	 * subtracting 4K from the total size of acrn_vm.
+	 * Using offset_of macro to avoid hardcoding 4k here.
+	 */
+	(void)memset((void *)&vm->arch_vm, 0U, (sizeof(struct acrn_vm) - offsetof(struct acrn_vm, arch_vm)));
 	vm->vm_id = vm_id;
 	vm->hw.created_vcpus = 0U;
 


### PR DESCRIPTION
arch_vm member of struct acrn_vm is page aligned. memset used in create_vm
subtracts only 8 bytes, sizeof(spinlock_t) from the size of acrn_vm and uses
the vm->arch_vm as the destination address. To do it right, it should subtract
4096 bytes. This would result in writing memory beyond the acrn_vm struct.

This patch fixes the issue by using offsetof compiler macro and subtracts the
right amount of size corresponding to the beginning of arch_vm member in
struct acrn_vm.

Tracked-On: #5107
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>