### PR TITLE
hv: fix deadloop in sleep_thread_sync

### DIFF
--- a/hypervisor/common/schedule.c
+++ b/hypervisor/common/schedule.c
@@ -203,8 +203,10 @@ void sleep_thread(struct thread_object *obj)
 		} else {
 			make_reschedule_request(pcpu_id, DEL_MODE_IPI);
 		}
+		obj->be_blocking = true;
+	} else {
+		set_thread_status(obj, THREAD_STS_BLOCKED);
 	}
-	obj->be_blocking = true;
 	release_schedule_lock(pcpu_id, rflag);
 }
 


### PR DESCRIPTION
As we only set BLOCKED status in context switch_out, which means, only
running thread can be changed to BLOCKED, but runnable thread can not.
This lead to the deadloop in sleep_thread_sync.

To solve the problem, in sleep_thread, we set the status to BLOCKED
directly when the original thread status is RUNNABLE.

Tracked-On: #5115
Signed-off-by: Conghui Chen <conghui.chen@intel.com>