### PR TITLE
HV: Make: remove sdc scenario build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ else
 	FIRMWARE ?= uefi
 endif
 
-SCENARIO ?= sdc
+SCENARIO ?= industry
 
 O ?= build
 ROOT_OUT := $(shell mkdir -p $(O);cd $(O);pwd)
@@ -232,46 +232,28 @@ ifeq ($(FIRMWARE),uefi)
 	$(MAKE) -C $(T)/misc/efi-stub HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) FIRMWARE=$(FIRMWARE) SCENARIO=$(SCENARIO) EFI_OBJDIR=$(HV_OUT)/$(EFI_OUT) all install-debug
 endif
 
-apl-mrb-sbl-sdc:
-	$(call build_acrn,sbl,apl-mrb,sdc)
-apl-up2-sbl-sdc:
-	$(call build_acrn,sbl,apl-up2,sdc)
 kbl-nuc-i7-uefi-industry:
 	$(call build_acrn,uefi,nuc7i7dnb,industry)
 apl-up2-uefi-hybrid:
 	$(call build_acrn,uefi,apl-up2,hybrid)
 
-sbl-hypervisor: apl-mrb-sbl-sdc \
-                apl-up2-sbl-sdc \
-                kbl-nuc-i7-uefi-industry \
+sbl-hypervisor: kbl-nuc-i7-uefi-industry \
                 apl-up2-uefi-hybrid
 
-apl-mrb-sbl-sdc-install:
-	$(call install_acrn,sbl,apl-mrb,sdc)
-apl-up2-sbl-sdc-install:
-	$(call install_acrn,sbl,apl-up2,sdc)
 kbl-nuc-i7-uefi-industry-install:
 	$(call install_acrn,uefi,nuc7i7dnb,industry)
 apl-up2-uefi-hybrid-install:
 	$(call install_acrn,uefi,apl-up2,hybrid)
 
-sbl-hypervisor-install: apl-mrb-sbl-sdc-install \
-                        apl-up2-sbl-sdc-install \
-                        kbl-nuc-i7-uefi-industry-install \
+sbl-hypervisor-install: kbl-nuc-i7-uefi-industry-install \
                         apl-up2-uefi-hybrid-install
 
-apl-mrb-sbl-sdc-install-debug:
-	$(call install_acrn_debug,sbl,apl-mrb,sdc)
-apl-up2-sbl-sdc-install-debug:
-	$(call install_acrn_debug,sbl,apl-up2,sdc)
 kbl-nuc-i7-uefi-industry-install-debug:
 	$(call install_acrn_debug,uefi,nuc7i7dnb,industry)
 apl-up2-uefi-hybrid-install-debug:
 	$(call install_acrn_debug,uefi,apl-up2,hybrid)
 
-sbl-hypervisor-install-debug: apl-mrb-sbl-sdc-install-debug \
-			      apl-up2-sbl-sdc-install-debug \
-			      kbl-nuc-i7-uefi-industry-install-debug \
+sbl-hypervisor-install-debug: kbl-nuc-i7-uefi-industry-install-debug \
 			      apl-up2-uefi-hybrid-install-debug
 
 devicemodel-install:

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -1,11 +1,9 @@
 config SCENARIO
 	string "ACRN scenario"
-	default "sdc"
+	default "industry"
 	help
 	  By specifying SCENARIO name, ACRN will load corresponding VM configurations
 	  to build the hypervisor. Currently ACRN provides below reference scenarios:
-	  sdc: Typical scenario for automotive Software Defined Cockpit system.
-	  sdc will have one pre-launched SOS VM and one post-launched VM;
 	  industry: Typical scenario for industry usage with 8 VMs: one pre-launched SOS VM,
 	  one post-launched KATA VM, one post-launched RT VM for real-time control,
 	  and up to five post-launched Standard VMs;


### PR DESCRIPTION
The SDC scenario configurations will not be validated so remove it from
build makefile;

Tracked-On: #5077

Signed-off-by: Victor Sun <victor.sun@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>