### PR TITLE
HV: correct RO mask of MSI cap structure

### DIFF
--- a/hypervisor/dm/vpci/vmsi.c
+++ b/hypervisor/dm/vpci/vmsi.c
@@ -112,7 +112,7 @@ void write_vmsi_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes, 
 {
 	/* Capability ID, Next Capability Pointer and Message Control
 	 * (Except MSI Enable bit and Multiple Message Enable) are RO */
-	static const uint8_t msi_ro_mask[0xEU] = { 0xffU, 0xffU, 0x1eU, 0xffU };
+	static const uint8_t msi_ro_mask[0xEU] = { 0xffU, 0xffU, 0x8eU, 0xffU };
 	uint32_t msgctrl, old, ro_mask = ~0U;
 
 	enable_disable_msi(vdev, false);


### PR DESCRIPTION
In MSI Capability Structure, bit 7 (64 bit address capable) of MSICTRL
is RO;

Tracked-On: #5125

Signed-off-by: Victor Sun <victor.sun@intel.com>
Reviewed-by: Li Fei <fei1.li@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>