### PR TITLE
hv:refine vm & vcpu lock

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -407,8 +407,6 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 
 	/* Allocate memory for virtual machine */
 	vm = &vm_array[vm_id];
-	/* the vm_state lock field need to remain unchanged in vm data structure */
-	(void)memset((void *)&vm->arch_vm, 0U, (sizeof(struct acrn_vm) - sizeof(spinlock_t)));
 	vm->vm_id = vm_id;
 	vm->hw.created_vcpus = 0U;
 
@@ -457,6 +455,8 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 
 		vm->arch_vm.vlapic_mode = VM_VLAPIC_XAPIC;
 		vm->intr_inject_delay_delta = 0UL;
+		vm->nr_emul_mmio_regions = 0U;
+		vm->vcpuid_entry_nr = 0U;
 
 		/* Set up IO bit-mask such that VM exit occurs on
 		 * selected IO ranges
@@ -610,6 +610,8 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 	deinit_vuart(vm);
 
 	deinit_vpci(vm);
+
+	deinit_emul_io(vm);
 
 	/* Free EPT allocated resources assigned to VM */
 	destroy_ept(vm);

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -475,7 +475,7 @@ hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
 	size = mmio_req->size;
 
 	spinlock_obtain(&vcpu->vm->emul_mmio_lock);
-	for (idx = 0U; idx <= vcpu->vm->max_emul_mmio_regions; idx++) {
+	for (idx = 0U; idx <= vcpu->vm->nr_emul_mmio_regions; idx++) {
 		mmio_handler = &(vcpu->vm->emul_mmio[idx]);
 		if (mmio_handler->read_write != NULL) {
 			base = mmio_handler->range_start;
@@ -657,8 +657,8 @@ static inline struct mem_io_node *find_free_mmio_node(struct acrn_vm *vm)
 
 	if (mmio_node != NULL) {
 		idx = (uint16_t)(uint64_t)(mmio_node - &(vm->emul_mmio[0U]));
-		if (vm->max_emul_mmio_regions < idx) {
-			vm->max_emul_mmio_regions = idx;
+		if (vm->nr_emul_mmio_regions < idx) {
+			vm->nr_emul_mmio_regions = idx;
 		}
 	}
 
@@ -723,4 +723,10 @@ void unregister_mmio_emulation_handler(struct acrn_vm *vm,
 		(void)memset(mmio_node, 0U, sizeof(struct mem_io_node));
 	}
 	spinlock_release(&vm->emul_mmio_lock);
+}
+
+void deinit_emul_io(struct acrn_vm *vm)
+{
+	(void)memset(vm->emul_mmio, 0U, sizeof(vm->emul_mmio));
+	(void)memset(vm->emul_pio, 0U, sizeof(vm->emul_pio));
 }

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -81,7 +81,7 @@ struct vm_pm_info {
 
 /* Enumerated type for VM states */
 enum vm_state {
-	VM_POWERED_OFF = 0,
+	VM_POWERED_OFF = 0,   /* MUST set 0 because vm_state's initialization depends on clear BSS section */
 	VM_CREATED,	/* VM created / awaiting start (boot) */
 	VM_RUNNING,	/* VM running */
 	VM_READY_TO_POWEROFF,     /* RTVM only, it is trying to poweroff by itself */
@@ -119,10 +119,6 @@ struct vm_arch {
 } __aligned(PAGE_SIZE);
 
 struct acrn_vm {
-	/* vm_state_lock MUST be the first field in VM structure it will not clear zero when creating VM
-	 * this lock initialization depends on the clear BSS section
-	 */
-	spinlock_t vm_state_lock;/* Spin-lock used to protect vm/vcpu state transition for a VM */
 	struct vm_arch arch_vm; /* Reference to this VM's arch information */
 	struct vm_hw_info hw;	/* Reference to this VM's HW information */
 	struct vm_sw_info sw;	/* Reference to SW associated with this VM */
@@ -134,10 +130,14 @@ struct acrn_vm {
 	struct acrn_vuart vuart[MAX_VUART_NUM_PER_VM];		/* Virtual UART */
 	enum vpic_wire_mode wire_mode;
 	struct iommu_domain *iommu;	/* iommu domain of this VM */
+	/* vm_state_lock used to protect vm/vcpu state transition,
+	 * the initialization depends on the clear BSS section
+	 */
+	spinlock_t vm_state_lock;
 	spinlock_t vlapic_mode_lock;	/* Spin-lock used to protect vlapic_mode modifications for a VM */
 	spinlock_t ept_lock;	/* Spin-lock used to protect ept add/modify/remove for a VM */
 	spinlock_t emul_mmio_lock;	/* Used to protect emulation mmio_node concurrent access for a VM */
-	uint16_t max_emul_mmio_regions;	/* max index of the emulated mmio_region */
+	uint16_t nr_emul_mmio_regions;	/* the emulated mmio_region number */
 	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
 
 	struct vm_io_handler_desc emul_pio[EMUL_PIO_IDX_MAX];

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -286,7 +286,7 @@ void register_mmio_emulation_handler(struct acrn_vm *vm,
  */
 void unregister_mmio_emulation_handler(struct acrn_vm *vm,
 					uint64_t start, uint64_t end);
-
+void deinit_emul_io(struct acrn_vm *vm);
 /**
  * @}
  */


### PR DESCRIPTION
-- move vm_state_lock to other place in vm structure
   to avoid the memory waste because of the page-aligned.
-- remove the memset from create_vm
-- explicitly set max_emul_mmio_regions and vcpuid_entry_nr to 0
   inside create_vm to avoid use without initialization.
-- rename max_emul_mmio_regions to nr_emul_mmio_regions
v1->v2:
   add deinit_emul_io in shutdown_vm

Tracked-On: #4958
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Reviewed-by: Grandhi, Sainath <sainath.grandhi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>