### PR TITLE
hv: enlarge vuart number from 2 to 4 for each vm

### DIFF
--- a/hypervisor/dm/vuart.c
+++ b/hypervisor/dm/vuart.c
@@ -515,7 +515,7 @@ static bool vuart_read(struct acrn_vcpu *vcpu, uint16_t offset_arg, __unused siz
 }
 
 /*
- * @pre: vuart_idx = 0 or 1
+ * @pre: vuart_idx = 0, 1, 2 or 3
  */
 static bool vuart_register_io_handler(struct acrn_vm *vm, uint16_t port_base, uint32_t vuart_idx)
 {
@@ -532,6 +532,12 @@ static bool vuart_register_io_handler(struct acrn_vm *vm, uint16_t port_base, ui
 		break;
 	case 1U:
 		pio_idx = UART_PIO_IDX1;
+		break;
+	case 2U:
+		pio_idx = UART_PIO_IDX2;
+		break;
+	case 3U:
+		pio_idx = UART_PIO_IDX3;
 		break;
 	default:
 		printf("Not support vuart index %d, will not register \n", vuart_idx);
@@ -638,6 +644,7 @@ void init_vuart(struct acrn_vm *vm, const struct vuart_config *vu_config)
 		/* This vuart is not exist */
 		if ((vu_config[i].type == VUART_LEGACY_PIO) &&
 				(vu_config[i].addr.port_base == INVALID_COM_BASE)) {
+			pr_info("vm %d vuart %d is invalid", vm->vm_id, i);
 			continue;
 		}
 		setup_vuart(vm, &vu_config[i], i);

--- a/hypervisor/include/arch/x86/guest/vmx_io.h
+++ b/hypervisor/include/arch/x86/guest/vmx_io.h
@@ -18,7 +18,9 @@
 /* When MAX_VUART_NUM_PER_VM is larger than 2, UART_PIO_IDXn should also be added here */
 #define UART_PIO_IDX0			(PCI_CFGDATA_PIO_IDX + 1U)
 #define UART_PIO_IDX1			(UART_PIO_IDX0 + 1U)
-#define PM1A_EVT_PIO_IDX		(UART_PIO_IDX1 + 1U)
+#define UART_PIO_IDX2			(UART_PIO_IDX1 + 1U)
+#define UART_PIO_IDX3			(UART_PIO_IDX2 + 1U)
+#define PM1A_EVT_PIO_IDX		(UART_PIO_IDX3 + 1U)
 #define PM1A_CNT_PIO_IDX		(PM1A_EVT_PIO_IDX + 1U)
 #define PM1B_EVT_PIO_IDX		(PM1A_CNT_PIO_IDX + 1U)
 #define PM1B_CNT_PIO_IDX		(PM1B_EVT_PIO_IDX + 1U)

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -21,7 +21,7 @@
 
 #define AFFINITY_CPU(n)		(1UL << (n))
 #define MAX_VCPUS_PER_VM	MAX_PCPU_NUM
-#define MAX_VUART_NUM_PER_VM	2U
+#define MAX_VUART_NUM_PER_VM	4U
 #define MAX_VM_OS_NAME_LEN	32U
 #define MAX_MOD_TAG_LEN		32U
 


### PR DESCRIPTION
Currently, there are 2 vuarts for each VM, vuart 0 is for console, vuart
1 is for communication.
As the requirement for communication between more VMs, add 2 additional
vuarts for each VM.

Tracked-On: #5138
Signed-off-by: Conghui Chen <conghui.chen@intel.com>