### PR TITLE
doc: fix references to misc/vm_configs folder

### DIFF
--- a/doc/developer-guides/hld/vuart-virt-hld.rst
+++ b/doc/developer-guides/hld/vuart-virt-hld.rst
@@ -96,7 +96,7 @@ Usage
 -  For console vUART
 
    To enable the console port for a VM, change the
-   port_base and IRQ in ``acrn-hypervisor/hypervisor/scenarios/<scenario
+   port_base and IRQ in ``misc/vm_configs/scenarios/<scenario
    name>/vm_configurations.c``. If the IRQ number has been used in your
    system ( ``cat /proc/interrupt``), you can choose other IRQ number. Set
    the .irq =0, the vUART will work in polling mode.

--- a/doc/tutorials/acrn_configuration_tool.rst
+++ b/doc/tutorials/acrn_configuration_tool.rst
@@ -26,7 +26,7 @@ The hypervisor configuration uses the ``Kconfig`` mechanism.  The configuration
 file is located at ``acrn-hypervisor/hypervisor/arch/x86/Kconfig``.
 
 A board-specific ``defconfig`` file, for example
-``acrn-hypervisor/misc/vm_configs/scenarios/$(SCENARIO)/$(BOARD)/$(BOARD).config``
+``misc/vm_configs/scenarios/$(SCENARIO)/$(BOARD)/$(BOARD).config``
 is loaded first; it is the default ``Kconfig`` for the specified board.
 
 Board configuration
@@ -38,7 +38,7 @@ board settings, root device selection, and the kernel cmdline. It also includes
 **scenario-irrelevant** hardware-specific information such as ACPI/PCI
 and BDF information. The reference board configuration is organized as
 ``*.c/*.h`` files located in the
-``acrn-hypervisor/misc/vm_configs/boards/$(BOARD)/`` folder.
+``misc/vm_configs/boards/$(BOARD)/`` folder.
 
 VM configuration
 =================
@@ -51,12 +51,12 @@ to launch post-launched User VMs.
 
 Scenario based VM configurations are organized as ``*.c/*.h`` files. The
 reference scenarios are located in the
-``acrn-hypervisor/misc/vm_configs/scenarios/$(SCENARIO)/`` folder.
+``misc/vm_configs/scenarios/$(SCENARIO)/`` folder.
 The board specific configurations on this scenario is stored in the
-``acrn-hypervisor/misc/vm_configs/scenarios/$(SCENARIO)/$(BOARD)/`` folder.
+``misc/vm_configs/scenarios/$(SCENARIO)/$(BOARD)/`` folder.
 
 User VM launch script samples are located in the
-``acrn-hypervisor/misc/vm_configs/sample_launch_scripts/`` folder.
+``misc/vm_configs/sample_launch_scripts/`` folder.
 
 ACRN configuration XMLs
 ***********************
@@ -79,7 +79,7 @@ Board XML format
 ================
 
 The board XMLs are located in the
-``acrn-hypervisor/misc/vm_configs/xmls/board-xmls/`` folder.
+``misc/vm_configs/xmls/board-xmls/`` folder.
 The board XML has an ``acrn-config`` root element and a ``board`` attribute:
 
 .. code-block:: xml
@@ -92,7 +92,7 @@ about the format of board XML and should not modify it.
 Scenario XML format
 ===================
 The scenario XMLs are located in the
-``acrn-hypervisor/misc/vm_configs/xmls/config-xmls/`` folder.  The
+``misc/vm_configs/xmls/config-xmls/`` folder.  The
 scenario XML has an ``acrn-config`` root element as well as ``board``
 and ``scenario`` attributes:
 
@@ -328,7 +328,7 @@ Additional scenario XML elements:
 Launch XML format
 =================
 The launch XMLs are located in the
-``acrn-hypervisor/misc/vm_configs/xmls/config-xmls/`` folder.
+``misc/vm_configs/xmls/config-xmls/`` folder.
 The launch XML has an ``acrn-config`` root element as well as
 ``board``, ``scenario`` and ``uos_launcher`` attributes:
 
@@ -437,7 +437,7 @@ Board and VM configuration workflow
 ===================================
 
 Python offline tools are provided to configure Board and VM configurations.
-The tool source folder is ``acrn-hypervisor/misc/acrn-config/``.
+The tool source folder is ``misc/acrn-config/``.
 
 Here is the offline configuration tool workflow:
 
@@ -601,7 +601,7 @@ Instructions
      scenario setting for the current board.
 
    The default scenario configuration xmls are located at
-   ``acrn-hypervisor/misc/vm_configs/xmls/config-xmls/[board]/``.
+   ``misc/vm_configs/xmls/config-xmls/[board]/``.
    We can edit the scenario name when creating or loading a scenario. If the
    current scenario name is duplicated with an existing scenario setting
    name, rename the current scenario name or overwrite the existing one
@@ -646,7 +646,7 @@ Instructions
 
    .. note::
       All customized scenario xmls will be in user-defined groups which are
-      located in ``acrn-hypervisor/misc/vm_configs/xmls/config-xmls/[board]/user_defined/``.
+      located in ``misc/vm_configs/xmls/config-xmls/[board]/user_defined/``.
 
    Before saving the scenario xml, the configuration app validates the
    configurable items. If errors exist, the configuration app lists all
@@ -667,9 +667,9 @@ Instructions
    otherwise, the source code is generated into default folders and
    overwrite the old ones. The board-related configuration source
    code is located at
-   ``acrn-hypervisor/misc/vm_configs/boards/[board]/`` and the
+   ``misc/vm_configs/boards/[board]/`` and the
    scenario-based VM configuration source code is located at
-   ``acrn-hypervisor/misc/vm_configs/scenarios/[scenario]/``.
+   ``misc/vm_configs/scenarios/[scenario]/``.
 
 The **Launch Setting** is quite similar to the **Scenario Setting**:
 

--- a/doc/tutorials/debug.rst
+++ b/doc/tutorials/debug.rst
@@ -151,7 +151,7 @@ reason and times of each vm_exit after we have done some operations.
       # acrnalyze.py -i /home/trace/acrntrace/20190219-001529/1 -o vmexit --vm_exit
 
    .. note:: The acrnalyze.py script is in the
-      ``acrn-hypervisor/misc/tools/acrntrace/scripts`` folder.  The location
+      ``misc/tools/acrntrace/scripts`` folder.  The location
       of the trace files produced by ``acrntrace`` may be different in your system.
 
    .. figure:: images/debug_image28.png
@@ -174,7 +174,7 @@ shown in the following example:
       trace event id
 
 2. Add the following format to
-   ``acrn-hypervisor/misc/tools/acrntrace/scripts/formats``:
+   ``misc/tools/acrntrace/scripts/formats``:
 
    .. figure:: images/debug_image1.png
       :align: center
@@ -224,7 +224,7 @@ shown in the following example:
         formats /home/trace/acrntrace/20190219-001529/1 | grep "trace test"
 
    .. note:: The acrnalyze.py script is in the
-      ``acrn-hypervisor/misc/tools/acrntrace/scripts`` folder.  The location
+      ``misc/tools/acrntrace/scripts`` folder.  The location
       of the trace files produced by ``acrntrace`` may be different in your system.
 
    and we will get the following log:

--- a/doc/tutorials/vuart_configuration.rst
+++ b/doc/tutorials/vuart_configuration.rst
@@ -8,7 +8,8 @@ Introduction
 
 The virtual universal asynchronous receiver-transmitter (vUART) supports two functions: one is the console, the other is communication. vUART only works on a single function.
 
-Currently, only two vUART configurations are added to the ``hypervisor/scenarios/<xxx>/vm_configuration.c`` file, but you can change the value in it.
+Currently, only two vUART configurations are added to the
+``misc/vm_configs/scenarios/<xxx>/vm_configuration.c`` file, but you can change the value in it.
 
 .. code-block:: none
 


### PR DESCRIPTION
As noticed in PR #5134 scenario configurations were moved out of the
hypervisor folder over to the misc folder (within the acrn-hypervisor
repo).  Fix references and make them all consistent (referencing
misc/vm_configs)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>