### PR TITLE
dm: support to provide ACPI SSDT for UOS

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -144,7 +144,7 @@ usage(int code)
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
 		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--debugexit] \n"
 		"       %*s [--logger-setting param_setting] [--pm_notify_channel]\n"
-		"       %*s [--pm_by_vuart vuart_node] <vm>\n"
+		"       %*s [--pm_by_vuart vuart_node] [--acpi_ssdt ssdt_aml_path] <vm>\n"
 		"       -A: create ACPI tables\n"
 		"       -B: bootargs for kernel\n"
 		"       -E: elf image path\n"
@@ -168,6 +168,7 @@ usage(int code)
 		"       --vsbl: vsbl file path\n"
 		"       --ovmf: ovmf file path\n"
 		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
+		"       --acpi_ssdt: acpi SSDT aml file path\n"
 		"       --part_info: guest partition info file path\n"
 		"       --enable_trusty: enable trusty for guest\n"
 		"       --debugexit: enable debug exit function\n"
@@ -736,6 +737,7 @@ enum {
 	CMD_OPT_VSBL = 1000,
 	CMD_OPT_OVMF,
 	CMD_OPT_CPU_AFFINITY,
+	CMD_OPT_ACPI_SSDT,
 	CMD_OPT_PART_INFO,
 	CMD_OPT_TRUSTY_ENABLE,
 	CMD_OPT_VIRTIO_POLL_ENABLE,
@@ -778,6 +780,7 @@ static struct option long_options[] = {
 	{"vsbl",		required_argument,	0, CMD_OPT_VSBL},
 	{"ovmf",		required_argument,	0, CMD_OPT_OVMF},
 	{"cpu_affinity",	required_argument,	0, CMD_OPT_CPU_AFFINITY},
+	{"acpi_ssdt",		required_argument,	0, CMD_OPT_ACPI_SSDT},
 	{"part_info",		required_argument,	0, CMD_OPT_PART_INFO},
 	{"enable_trusty",	no_argument,		0,
 					CMD_OPT_TRUSTY_ENABLE},
@@ -900,6 +903,10 @@ main(int argc, char *argv[])
 		case CMD_OPT_CPU_AFFINITY:
 			if (acrn_parse_cpu_affinity(optarg) != 0)
 				errx(EX_USAGE, "invalid pcpu param %s", optarg);
+			break;
+		case CMD_OPT_ACPI_SSDT:
+			if (acrn_parse_acpiargs(optarg))
+				errx(EX_USAGE, "invalid acpi_ssdt param %s", optarg);
 			break;
 		case CMD_OPT_PART_INFO:
 			if (acrn_parse_guest_part_info(optarg) != 0) {

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -41,7 +41,9 @@
 
 /* All dynamic table entry no. */
 #define NHLT_ENTRY_NO		8
+#define SSDT_ENTRY_NO		11
 
+int acrn_parse_acpiargs(char *arg);
 void acpi_table_enable(int num);
 uint32_t get_acpi_base(void);
 uint32_t get_acpi_table_length(void);


### PR DESCRIPTION
SSDT is a continuation of the DSDT, those device belonging to sepcific
board should better been add to SSDT.

We can describe devices in a SSDT ASL file, compile the SSDT asl file
using ACPI compiler(e.g. iasl) before passing it to acrn-dm by
--acpi_ssdt parameter, then dm will combine it with other ACPI tables.

Tracked-On: #5148
Signed-off-by: Cai Yulong <yulongc@hwtc.com.cn>