### PR TITLE
doc: fix mismatched ACRN version

### DIFF
--- a/doc/tutorials/using_partition_mode_on_nuc.rst
+++ b/doc/tutorials/using_partition_mode_on_nuc.rst
@@ -136,7 +136,7 @@ Update ACRN hypervisor image
    Refer to :ref:`getting-started-building` to set up the ACRN build
    environment on your development workstation.
 
-   Clone the ACRN source code and check out to the tag v1.6:
+   Clone the ACRN source code and check out to the tag v2.1:
 
    .. code-block:: none
 


### PR DESCRIPTION
Document was updated to use v2.1 but left a references to v1.6

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>