### PR TITLE
hv: fix stos and stosq asm instruction emulation error

### DIFF
--- a/hypervisor/arch/x86/guest/instr_emul.c
+++ b/hypervisor/arch/x86/guest/instr_emul.c
@@ -162,11 +162,11 @@ static const struct instr_emul_vie_op one_byte_opcodes[256] = {
 	},
 	[0xAA] = {
 		.op_type = VIE_OP_TYPE_STOS,
-		.op_flags = VIE_OP_F_NO_MODRM | VIE_OP_F_BYTE_OP,
+		.op_flags = VIE_OP_F_NO_MODRM | VIE_OP_F_BYTE_OP | VIE_OP_F_CHECK_GVA_DI,
 	},
 	[0xAB] = {
 		.op_type = VIE_OP_TYPE_STOS,
-		.op_flags = VIE_OP_F_NO_MODRM
+		.op_flags = VIE_OP_F_NO_MODRM | VIE_OP_F_CHECK_GVA_DI,
 	},
 	[0xC6] = {
 		/* XXX Group 11 extended opcode - not just MOV */


### PR DESCRIPTION
This patch is used to fix asm instruction error such as stos and stosq.

Tracked-On: #5165
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>