### PR TITLE
doc: use consistent month names in release notes

### DIFF
--- a/doc/release_notes/release_notes_1.0.2.rst
+++ b/doc/release_notes/release_notes_1.0.2.rst
@@ -1,7 +1,7 @@
 .. _release_notes_1.0.2:
 
-ACRN v1.0.2 (November 2019)
-###########################
+ACRN v1.0.2 (Nov 2019)
+######################
 
 We are pleased to announce the release of ACRN version 1.0.2. This is a
 maintenance release based on the v1.0 branch that primarily fixes some

--- a/doc/release_notes/release_notes_1.1.rst
+++ b/doc/release_notes/release_notes_1.1.rst
@@ -1,7 +1,7 @@
 .. _release_notes_1.1:
 
-ACRN v1.1 (June 2019)
-#####################
+ACRN v1.1 (Jun 2019)
+####################
 
 We are pleased to announce the release of ACRN version 1.1.
 

--- a/doc/release_notes/release_notes_2.0.rst
+++ b/doc/release_notes/release_notes_2.0.rst
@@ -1,7 +1,7 @@
 .. _release_notes_2.0:
 
-ACRN v2.0 (June 2020)
-#####################
+ACRN v2.0 (Jun 2020)
+####################
 
 We are pleased to announce the second major release of the Project ACRN
 hypervisor.

--- a/doc/release_notes/release_notes_2.1.rst
+++ b/doc/release_notes/release_notes_2.1.rst
@@ -1,7 +1,7 @@
 .. _release_notes_2.1:
 
-ACRN v2.1 (August 2020)
-#######################
+ACRN v2.1 (Aug 2020)
+####################
 
 We are pleased to announce the release of the Project ACRN
 hypervisor version 2.1.


### PR DESCRIPTION
Some months were spelled out, others were abbreviated, making the list
of all release notes look a bit off.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>