### PR TITLE
acrn-config: update TGL platform and SOS RAM size

### DIFF
--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -31,8 +31,8 @@
         <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
         <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
         <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x440000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x440000000</PLATFORM_RAM_SIZE>
+        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
     <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
@@ -31,8 +31,8 @@
         <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
         <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
         <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x440000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x440000000</PLATFORM_RAM_SIZE>
+        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
     <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -31,8 +31,8 @@
         <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
         <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
         <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x440000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x440000000</PLATFORM_RAM_SIZE>
+        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
     <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
@@ -31,8 +31,8 @@
         <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
         <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
         <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x440000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x440000000</PLATFORM_RAM_SIZE>
+        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
     <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">


### PR DESCRIPTION
The default memory is 16G on TGL; the value of PLATFORM_RAM_SIZE and
SOS_RAM_SIZE is a little small in default xml.

Tracked-On: # 5184

Signed-off-by: fuzhongl <fuzhong.liu@intel.com>