### PR TITLE
acrn-config: Enable pre-launch VM sharing CPU with other VMs

### DIFF
--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -273,9 +273,6 @@ def vm_cpu_affinity_check(config_file, id_cpus_per_vm_dic, item):
             if pre_launch_cpus.count(pcpu) >= 2:
                 key = "Pre launched VM cpu_affinity"
                 err_dic[key] = "Pre_launched_vm vm should not have the same cpus assignment"
-            if pcpu in post_launch_cpus:
-                key = "Pre launched vm and Post launchded VM cpu_affinity"
-                err_dic[key] = "Pre launched_vm and Post launched vm should not have the same cpus assignment"
 
     return err_dic
 


### PR DESCRIPTION
CPU sharing between pre-launch VMs and SOS, post-launch VMs were
forbidden.

Remove the limitation.

Tracked-On: #5153
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Terry Zou <terry.zou@intel.com>