### PR TITLE
acrn-config: support configuration for Inter-VM Communication

### DIFF
--- a/misc/acrn-config/board_config/pci_devices_h.py
+++ b/misc/acrn-config/board_config/pci_devices_h.py
@@ -62,5 +62,16 @@ def generate_file(config):
 
             i_cnt += 1
 
+    ivshmem_enabled = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
+    raw_shmem_regions = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "IVSHMEM", "IVSHMEM_REGION")
+    if ivshmem_enabled == 'y':
+        shmem_cnt = 0
+        for raw_shmem_region in raw_shmem_regions:
+            if raw_shmem_region and raw_shmem_region.strip != '':
+                name = raw_shmem_region.split(',')[0].strip()
+                print("", file=config)
+                print("#define IVSHMEM_SHM_REGION_%-21d"%shmem_cnt, end="", file=config)
+                print('"{}"'.format(name), file=config)
+                shmem_cnt += 1
     # write the end to the pci devices
     print("{0}".format(PCI_END_HEADER), file=config)

--- a/misc/acrn-config/board_config/vbar_base_h.py
+++ b/misc/acrn-config/board_config/vbar_base_h.py
@@ -78,4 +78,26 @@ def generate_file(config):
 
             i_cnt += 1
 
+    ivshmem_enabled = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
+    if ivshmem_enabled == 'y':
+        board_cfg_lib.parse_mem()
+        for shm_name, bar_attr_dic in board_cfg_lib.PCI_DEV_BAR_DESC.shm_bar_dic.items():
+            index = shm_name[:shm_name.find('_')]
+            i_cnt = 0
+            for bar_i, bar_attr in bar_attr_dic.items():
+                i_cnt += 1
+                if bar_i == 0:
+                    if len(bar_attr_dic.keys()) == 1:
+                        print("#define IVSHMEM_DEVICE_%-23s" % (str(index) + "_VBAR"),
+                              "       .vbar_base[{}] = {}UL".format(bar_i, bar_attr.addr), file=config)
+                    else:
+                        print("#define IVSHMEM_DEVICE_%-23s" % (str(index) + "_VBAR"),
+                              "       .vbar_base[{}] = {}UL, \\".format(bar_i, bar_attr.addr), file=config)
+                elif i_cnt == len(bar_attr_dic.keys()):
+                    print("{}.vbar_base[{}] = {}UL".format(' ' * 54, bar_i, bar_attr.addr), file=config)
+                else:
+                    print("{}.vbar_base[{}] = {}UL, \\".format(' ' * 54, bar_i, bar_attr.addr), file=config)
+
+            print("", file=config)
+
     print(VBAR_INFO_ENDIF, file=config)

--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -728,7 +728,7 @@ function save_scenario(generator=null){
     $("input").each(function(){
         var id = $(this).attr('id');
         var value = $(this).val();
-        if(id.indexOf('CLOS_MASK')>=0 || id.indexOf('MBA_DELAY')>=0) {
+        if(id.indexOf('CLOS_MASK')>=0 || id.indexOf('MBA_DELAY')>=0 || id.indexOf('IVSHMEM_REGION')>=0) {
             if(id in scenario_config) {
                 scenario_config[id].push(value);
             } else {
@@ -795,7 +795,7 @@ function save_scenario(generator=null){
                                 index = index.replace(new RegExp(jquerySpecialChars[i],
                                     "g"), "\\" + jquerySpecialChars[i]);
                             }
-                            $("#"+index).parents(".form-group").addClass("has-error");
+                            $("#"+index+"_err").parents(".form-group").addClass("has-error");
                             $("#"+index+"_err").text(item);
                         })
                         if(no_err == true && status == 'success') {

--- a/misc/acrn-config/config_app/templates/scenario.html
+++ b/misc/acrn-config/config_app/templates/scenario.html
@@ -209,32 +209,13 @@ the source files will be generated into default path and overwirte the previous 
                     != '0')%}
                         {% if 'multiselect' not in elem.attrib or elem.attrib['multiselect'] != 'true' %}
                             {% set first_child = [] %}
+                            {% set first_multi_child = {'IVSHMEM_REGION': 0} %}
                             {% for sub_elem in elem.getchildren() %}
                                 {% set sub_elem_text = sub_elem.text if sub_elem.text != None else '' %}
 
-                                {% if sub_elem.tag == 'RDT' %}
+                                {% if sub_elem.tag in ['RDT', 'IVSHMEM'] %}
                                     {% for sub_elem_2 in sub_elem.getchildren() %}
-                                    {% if ','.join([vm.tag, elem.tag, sub_elem.tag, sub_elem_2.tag]) not in scenario_item_values %}
-                                    <div class="form-group">
-                                        <label class="col-sm-1 control-label" data-toggle="tooltip"
-                                               title="{{elem.attrib['desc'] if 'desc' in elem.attrib else elem.tag}}">
-                                        </label>
-                                        <label class="col-sm-2 control-label" data-toggle="tooltip"
-                                               title="{{sub_elem_2.attrib['desc'] if 'desc' in sub_elem_2.attrib else sub_elem.attrib['desc']}}">
-                                        {{sub_elem.tag}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{sub_elem_2.tag}}</label>
-                                        <div class="col-sm-6">
-                                        {% if 'readonly' in sub_elem_2.attrib and sub_elem_2.attrib['readonly'] == 'true' %}
-                                        <input type="text" class="form-control"
-                                               id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}"
-                                               readonly vaule={{sub_elem_2.text}}></input>
-                                        {% else %}
-                                        <input type="text" class="form-control"
-				               id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}" value={{sub_elem_2.text}}></input>
-                                        {% endif %}
-                                        </div>
-                                        <p id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}_err" class="col-sm-3"></p>
-                                    </div>
-                                    {% elif sub_elem_2.tag not in ['CLOS_MASK', 'MBA_DELAY'] %}
+                                    {% if ','.join([vm.tag, elem.tag, sub_elem.tag, sub_elem_2.tag]) in scenario_item_values %}
                                     <div class="form-group">
                                         <label class="col-sm-1 control-label" data-toggle="tooltip"
                                                title="{{elem.attrib['desc'] if 'desc' in elem.attrib else elem.tag}}">
@@ -262,19 +243,44 @@ the source files will be generated into default path and overwirte the previous 
                                         </div>
                                         <p id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}_err" class="col-sm-3"></p>
                                     </div>
-				    {% else %}
+				                    {% else %}
                                     <div class="form-group">
                                         <label class="col-sm-1 control-label" data-toggle="tooltip"
                                                title="{{elem.attrib['desc'] if 'desc' in elem.attrib else elem.tag}}">
                                         </label>
                                         <label class="col-sm-2 control-label" data-toggle="tooltip"
-				               title={{sub_elem_2.attrib['desc'] if 'desc' in sub_elem_2.attrib else sub_elem.attrib['desc']}}>
-                                               {{sub_elem.tag}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{sub_elem_2.tag}}</label>
+                                               title="{{sub_elem_2.attrib['desc'] if 'desc' in sub_elem_2.attrib else sub_elem.attrib['desc']}}">
+                                        {{sub_elem.tag}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{sub_elem_2.tag}}</label>
+                                        {% if sub_elem_2.tag in ['IVSHMEM_REGION'] %}
+                                        <div class="col-sm-5">
+                                        {% else %}
                                         <div class="col-sm-6">
-                                            <input type="text" class="form-control"
-				                   id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}" value={{'' if sub_elem_2.text == None else sub_elem_2.text}}></input>
+                                        {% endif %}
+                                        {% if 'readonly' in sub_elem_2.attrib and sub_elem_2.attrib['readonly'] == 'true' %}
+                                        <input type="text" class="form-control"
+                                               id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}"
+                                               readonly vaule="{{sub_elem_2.text}}"></input>
+                                        {% else %}
+                                        <input type="text" class="form-control"
+				                            id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}" value="{{sub_elem_2.text}}"></input>
+                                        {% endif %}
                                         </div>
+                                        {% if sub_elem_2.tag in ['IVSHMEM_REGION'] %}
+                                            <div class="col-sm-1">
+                                                <button type="button" class="btn" id="add_ivshmem_{{sub_elem.tag}}_{{first_multi_child[sub_elem_2.tag]}}">+</button>
+                                                {% if first_multi_child[sub_elem_2.tag] == 0 %}
+                                                <button type="button" disabled class="btn" id="remove_ivshmem_{{sub_elem.tag}}_{{first_multi_child[sub_elem_2.tag]}}">-</button>
+                                                {% else %}
+                                                <button type="button" class="btn" id="remove_ivshmem_{{sub_elem.tag}}_{{first_multi_child[sub_elem_2.tag]}}">-</button>
+                                                {% endif %}
+                                            </div>
+                                            {% do first_multi_child.update({sub_elem_2.tag: first_multi_child[sub_elem_2.tag]+1}) %}
+                                        {% endif%}
+                                        {% if sub_elem_2.tag in ['IVSHMEM_REGION'] %}
+                                        <p id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+(first_multi_child[sub_elem_2.tag]-1)|string()}}_err" class="col-sm-3"></p>
+                                        {% else %}
                                         <p id="{{vm_type+','+elem.tag+','+sub_elem.tag+','+sub_elem_2.tag}}_err" class="col-sm-3"></p>
+                                        {% endif %}
                                     </div>
                                     {% endif %}
                                     {% endfor %}
@@ -323,6 +329,7 @@ the source files will be generated into default path and overwirte the previous 
                                                        value="{{sub_elem_text}}">
                                                 {% endif %}
                                                 </div>
+
                                             {% endif %}
                                         {% else %}
                                             {% set item_key = ','.join([vm.tag, elem.tag, sub_elem.tag]) if elem.tag != 'cpu_affinity'

--- a/misc/acrn-config/hv_config/board_defconfig.py
+++ b/misc/acrn-config/hv_config/board_defconfig.py
@@ -33,52 +33,6 @@ VM_NUM_MAP_TOTAL_HV_RAM_SIZE = {
 MEM_ALIGN = 2 * common.SIZE_M
 
 
-def find_avl_memory(ram_range, hpa_size, hv_start_offset):
-    """
-    This is get hv address from System RAM as host physical size
-    :param ram_range: System RAM mapping
-    :param hpa_size: fixed host physical size
-    :param hv_start_offset: base address of HV RAM start
-    :return: start host physical address
-    """
-    ret_start_addr = 0
-    tmp_order_key = 0
-
-    tmp_order_key = sorted(ram_range)
-    for start_addr in tmp_order_key:
-        mem_range = ram_range[start_addr]
-        if start_addr < hv_start_offset < start_addr +  ram_range[start_addr]:
-            # 256M address located in this start ram range
-            if start_addr + mem_range - hv_start_offset > int(hpa_size, 10):
-                ret_start_addr = hv_start_offset
-                break
-        elif start_addr > hv_start_offset:
-            # above 256M address, than return the start address of this ram range
-            ret_start_addr = start_addr
-            break
-
-    return hex(ret_start_addr)
-
-
-def get_ram_range():
-    """ Get System RAM range mapping """
-    # read system ram from board_info.xml
-    ram_range = {}
-
-    io_mem_lines = board_cfg_lib.get_info(
-        common.BOARD_INFO_FILE, "<IOMEM_INFO>", "</IOMEM_INFO>")
-
-    for line in io_mem_lines:
-        if 'System RAM' not in line:
-            continue
-        start_addr = int(line.split('-')[0], 16)
-        end_addr = int(line.split('-')[1].split(':')[0], 16)
-        mem_range = end_addr - start_addr
-        ram_range[start_addr] = mem_range
-
-    return ram_range
-
-
 def get_serial_type():
     """ Get serial console type specified by user """
     ttys_type = ''
@@ -123,17 +77,20 @@ def get_memory(hv_info, config):
         err_dic["board config: total vm number error"] = "VM num should not be greater than 8"
         return err_dic
 
-    ram_range = get_ram_range()
-
     # reseve 16M memory for hv sbuf, ramoops, etc.
     reserved_ram = 0x1000000
     # We recommend to put hv ram start address high than 0x10000000 to
     # reduce memory conflict with GRUB/SOS Kernel.
     hv_start_offset = 0x10000000
     total_size = reserved_ram + hv_ram_size
-    avl_start_addr = find_avl_memory(ram_range, str(total_size), hv_start_offset)
+    for start_addr in list(board_cfg_lib.USED_RAM_RANGE):
+        if hv_start_offset <= start_addr < 0x80000000:
+            del board_cfg_lib.USED_RAM_RANGE[start_addr]
+    ram_range = board_cfg_lib.get_ram_range()
+    avl_start_addr = board_cfg_lib.find_avl_memory(ram_range, str(total_size), hv_start_offset)
     hv_start_addr = int(avl_start_addr, 16) + int(hex(reserved_ram), 16)
     hv_start_addr = common.round_up(hv_start_addr, MEM_ALIGN)
+    board_cfg_lib.USED_RAM_RANGE[hv_start_addr] = total_size
 
     if not hv_info.mem.hv_ram_start:
         print("CONFIG_HV_RAM_START={}".format(hex(hv_start_addr)), file=config)
@@ -149,6 +106,7 @@ def get_memory(hv_info, config):
     print("CONFIG_SOS_RAM_SIZE={}".format(hv_info.mem.sos_ram_size), file=config)
     print("CONFIG_UOS_RAM_SIZE={}".format(hv_info.mem.uos_ram_size), file=config)
     print("CONFIG_STACK_SIZE={}".format(hv_info.mem.stack_size), file=config)
+    print("CONFIG_IVSHMEM_ENABLED={}".format(hv_info.mem.ivshmem_enable), file=config)
 
 
 def get_serial_console(config):

--- a/misc/acrn-config/hv_config/hv_item.py
+++ b/misc/acrn-config/hv_config/hv_item.py
@@ -153,6 +153,8 @@ class Memory:
         self.platform_ram_size = 0
         self.sos_ram_size = 0
         self.uos_ram_size = 0
+        self.ivshmem_enable = 'n'
+        self.ivshmem_region = []
 
     def get_info(self):
         self.stack_size = common.get_hv_item_tag(self.hv_file, "MEMORY", "STACK_SIZE")
@@ -162,6 +164,8 @@ class Memory:
         self.platform_ram_size = common.get_hv_item_tag(self.hv_file, "MEMORY", "PLATFORM_RAM_SIZE")
         self.sos_ram_size = common.get_hv_item_tag(self.hv_file, "MEMORY", "SOS_RAM_SIZE")
         self.uos_ram_size = common.get_hv_item_tag(self.hv_file, "MEMORY", "UOS_RAM_SIZE")
+        self.ivshmem_enable = common.get_hv_item_tag(self.hv_file, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
+        self.ivshmem_region = common.get_hv_item_tag(self.hv_file, "FEATURES", "IVSHMEM", "IVSHMEM_REGION")
 
     def check_item(self):
         hv_cfg_lib.hv_size_check(self.stack_size, "MEMORY", "STACK_SIZE")
@@ -169,6 +173,7 @@ class Memory:
         hv_cfg_lib.hv_size_check(self.platform_ram_size, "MEMORY", "PLATFORM_RAM_SIZE")
         hv_cfg_lib.hv_size_check(self.sos_ram_size, "MEMORY", "SOS_RAM_SIZE")
         hv_cfg_lib.hv_size_check(self.uos_ram_size, "MEMORY", "UOS_RAM_SIZE")
+        hv_cfg_lib.ny_support_check(self.ivshmem_enable, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
 
 
 class HvInfo:

--- a/misc/acrn-config/scenario_config/ivshmem_cfg_h.py
+++ b/misc/acrn-config/scenario_config/ivshmem_cfg_h.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2019 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import common
+import scenario_cfg_lib
+import board_cfg_lib
+
+IVSHMEM_HEADER_DEFINE = scenario_cfg_lib.HEADER_LICENSE + r"""
+#ifndef IVSHMEM_CFG_H
+#define IVSHMEM_CFG_H
+"""
+IVSHMEM_END_DEFINE = r"""#endif /* IVSHMEM_CFG_H */"""
+
+
+def gen_common_header(config):
+    """
+    This is common header for ivshmem_cfg.h
+    :param config: it is the pointer which file write to
+    :return: None
+    """
+    print("{0}".format(IVSHMEM_HEADER_DEFINE), file=config)
+
+
+def write_shmem_regions(config):
+    raw_shmem_regions = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "IVSHMEM", "IVSHMEM_REGION")
+    shmem_regions = []
+    shmem_dev_num = 0
+    for raw_shm in raw_shmem_regions:
+        if raw_shm is None or raw_shm.strip() == '':
+            continue
+        raw_shm_splited = raw_shm.split(',')
+        if len(raw_shm_splited) == 3 and raw_shm_splited[0].strip() != '' \
+            and raw_shm_splited[1].strip() != '' and len(raw_shm_splited[2].strip().split(':')) >= 1:
+            shmem_regions.append((raw_shm_splited[0].strip(), raw_shm_splited[1].strip(), raw_shm_splited[2].strip().split(':')))
+            shmem_dev_num += len(raw_shm_splited[2].strip().split(':'))
+
+    print("", file=config)
+    print("/*", file=config)
+    print(" * The IVSHMEM_SHM_SIZE is the sum of all memory regions.", file=config)
+    print(" * The size range of each memory region is [2M, 1G) and is a power of 2.", file=config)
+    print(" */", file=config)
+    total_shm_size = 0
+    if len(shmem_regions) > 0:
+        for shmem_region in shmem_regions:
+            int_size = 0
+            size = shmem_region[1]
+            try:
+                if size.isdecimal():
+                    int_size = int(size)
+                else:
+                    int_size = int(size, 16)
+            except Exception as e:
+                print('the format of shm size error: ', str(e))
+            total_shm_size += int_size
+
+    print("#define IVSHMEM_SHM_SIZE\t{}UL".format(hex(total_shm_size)), file=config)
+    print("#define IVSHMEM_DEV_NUM\t\t{}UL".format(shmem_dev_num), file=config)
+    print("", file=config)
+    print("/* All user defined memory regions */", file=config)
+    print("\nstruct ivshmem_shm_region mem_regions[] = {", file=config)
+    shmem_cnt = 0
+    for shmem in shmem_regions:
+        print("\t{", file=config)
+        print('\t\t.name = IVSHMEM_SHM_REGION_{},'.format(shmem_cnt), file=config)
+        try:
+            if shmem[1].isdecimal():
+                int_m_size = int(int(shmem[1])/0x100000)
+            else:
+                int_m_size = int(int(shmem[1], 16)/0x100000)
+        except:
+            int_m_size = 0
+        print('\t\t.size = {}UL,\t\t/* {}M */'.format(shmem[1], int_m_size), file=config)
+        print("\t},", file=config)
+        shmem_cnt += 1
+    print("};", file=config)
+    print("", file=config)
+
+
+def generate_file(scenario_items, config):
+    """
+    Start to generate ivshmem_cfg.h
+    :param scenario_items: it is the class which contain all user setting information
+    :param config: it is a file pointer of scenario information for writing to
+    """
+    vm_info = scenario_items['vm']
+    gen_common_header(config)
+
+    if vm_info.shmem.shmem_enabled == 'y':
+        print("#include <ivshmem.h>", file=config)
+        print("#include <pgtable.h>", file=config)
+        print("#include <pci_devices.h>", file=config)
+        write_shmem_regions(config)
+
+    print("{0}".format(IVSHMEM_END_DEFINE), file=config)

--- a/misc/acrn-config/scenario_config/pci_dev_c.py
+++ b/misc/acrn-config/scenario_config/pci_dev_c.py
@@ -27,6 +27,7 @@ def generate_file(vm_info, config):
     :return: None
     """
     board_cfg_lib.parser_pci()
+    board_cfg_lib.parse_mem()
 
     compared_bdf = []
 
@@ -51,14 +52,24 @@ def generate_file(vm_info, config):
     print("#include <vbar_base.h>", file=config)
     print("#include <mmu.h>", file=config)
     print("#include <page.h>", file=config)
+    if vm_info.shmem.shmem_enabled == 'y':
+        print("#include <ivshmem.h>", file=config)
     for vm_i, pci_bdf_devs_list in vm_info.cfg_pci.pci_devs.items():
         if not pci_bdf_devs_list:
             continue
         pci_cnt = 1
         if idx == 0:
             print("", file=config)
+            print("/*", file=config)
+            print(" * TODO: remove PTDEV macro and add DEV_PRIVINFO macro to initialize pbdf for", file=config)
+            print(" * passthrough device configuration and shm_name for ivshmem device configuration.", file=config)
+            print(" */", file=config)
             print("#define PTDEV(PCI_DEV)\t\tPCI_DEV, PCI_DEV##_VBAR",file=config)
         print("", file=config)
+        print("/*", file=config)
+        print(" * TODO: add DEV_PCICOMMON macro to initialize emu_type, vbdf and vdev_ops", file=config)
+        print(" * to simplify the code.", file=config)
+        print(" */", file=config)
         print("struct acrn_vm_pci_dev_config " +
               "vm{}_pci_devs[VM{}_CONFIG_PCI_DEV_NUM] = {{".format(vm_i, vm_i), file=config)
         print("\t{", file=config)
@@ -76,7 +87,7 @@ def generate_file(vm_info, config):
             fun = int(pci_bdf_dev.split('.')[1], 16)
             print("\t{", file=config)
             print("\t\t.emu_type = {},".format(PCI_DEV_TYPE[1]), file=config)
-            print("\t\t.vbdf.bits = {{.b = 0x00U, .d = 0x0{}U, .f = 0x00U}},".format(pci_cnt), file=config)
+            print("\t\t.vbdf.bits = {{.b = 0x00U, .d = 0x{0:02d}U, .f = 0x00U}},".format(pci_cnt), file=config)
             for bdf, bar_attr in board_cfg_lib.PCI_DEV_BAR_DESC.pci_dev_dic.items():
                 if bdf == pci_bdf_dev:
                     print("\t\tPTDEV({}),".format(board_cfg_lib.PCI_DEV_BAR_DESC.pci_dev_dic[bdf].name_w_i_cnt), file=config)
@@ -85,4 +96,57 @@ def generate_file(vm_info, config):
             print("\t},", file=config)
             pci_cnt += 1
 
+        if vm_info.shmem.shmem_enabled == 'y' and vm_i in vm_info.shmem.shmem_regions.keys() \
+                and len(vm_info.shmem.shmem_regions[vm_i]) > 0:
+            raw_shm_list = vm_info.shmem.shmem_regions[vm_i]
+            for shm in raw_shm_list:
+                shm_splited = shm.split(',')
+                print("\t{", file=config)
+                print("\t\t.emu_type = {},".format(PCI_DEV_TYPE[0]), file=config)
+                print("\t\t.vbdf.bits = {{.b = 0x00U, .d = 0x{0:02d}U, .f = 0x00U}},".format(pci_cnt), file=config)
+                print("\t\t.vdev_ops = &vpci_ivshmem_ops,", file=config)
+                for shm_name, bar_attr in board_cfg_lib.PCI_DEV_BAR_DESC.shm_bar_dic.items():
+                    index = shm_name[:shm_name.find('_')]
+                    shm_name = shm_name[shm_name.find('_') + 1:]
+                    if shm_name == shm_splited[0].strip():
+                        print("\t\t.shm_region_name = IVSHMEM_SHM_REGION_{},".format(index), file=config)
+                        print("\t\tIVSHMEM_DEVICE_{}_VBAR".format(index), file=config)
+                # print("\t\t.vbar_size[0] = 0x100,", file=config)
+                # print("\t\t.vbar_size[2] = {},".format(shm_splited[1].strip()), file=config)
+                # print('\t\t.shm_name = "{}",'.format(shm_splited[0].strip()), file=config)
+                print("\t},", file=config)
+                pci_cnt += 1
+
         print("};", file=config)
+
+    if vm_info.shmem.shmem_enabled == 'y':
+        for shm_i, raw_shm_list in vm_info.shmem.shmem_regions.items():
+            shm_cnt = 0
+            if shm_i not in vm_info.cfg_pci.pci_devs.keys() and len(raw_shm_list) > 0:
+                print("", file=config)
+                print("struct acrn_vm_pci_dev_config " +
+                      "vm{}_pci_devs[VM{}_CONFIG_PCI_DEV_NUM] = {{".format(shm_i, shm_i), file=config)
+                for shm in raw_shm_list:
+                    shm_splited = shm.split(',')
+                    print("\t{", file=config)
+                    print("\t\t.emu_type = {},".format(PCI_DEV_TYPE[0]), file=config)
+                    if shm_i in common.VM_TYPES.keys() and common.VM_TYPES[shm_i] in ['PRE_RT_VM', 'PRE_STD_VM', 'SAFETY_VM']:
+                        print("\t\t.vbdf.bits = {{.b = 0x00U, .d = 0x{0:02d}U, .f = 0x00U}},".format(shm_cnt), file=config)
+                    else:
+                        print("\t\t.vbdf.value = UNASSIGNED_VBDF,".format(shm_cnt), file=config)
+                    print("\t\t.vdev_ops = &vpci_ivshmem_ops,", file=config)
+                    for shm_name, bar_attr in board_cfg_lib.PCI_DEV_BAR_DESC.shm_bar_dic.items():
+                        index = shm_name[:shm_name.find('_')]
+                        shm_name = shm_name[shm_name.find('_')+1:]
+                        if shm_name == shm_splited[0].strip():
+                            if shm_i in common.VM_TYPES.keys() and common.VM_TYPES[shm_i] in ['PRE_RT_VM', 'PRE_STD_VM',
+                                                                                              'SAFETY_VM']:
+                                print("\t\t.shm_region_name = IVSHMEM_SHM_REGION_{},".format(index), file=config)
+                                print("\t\tIVSHMEM_DEVICE_{}_VBAR".format(index), file=config)
+                                break
+                            else:
+                                print("\t\t.shm_region_name = IVSHMEM_SHM_REGION_{}".format(index), file=config)
+                                break
+                    shm_cnt += 1
+                    print("\t},", file=config)
+                print("};", file=config)

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -91,7 +91,12 @@ def gen_pre_launch_vm(scenario_items, config):
             print("#define VM{0}_CONFIG_MEM_SIZE_HPA2        {1}UL".format(
                 vm_i, vm_info.mem_info.mem_size_hpa2[vm_i]), file=config)
 
-        print("#define VM{}_CONFIG_PCI_DEV_NUM          {}U".format(vm_i, vm_info.cfg_pci.pci_dev_num[vm_i]), file=config)
+        shmem_num_i = 0
+        if vm_info.shmem.shmem_enabled == 'y' and vm_i in vm_info.shmem.shmem_num.keys():
+            shmem_num_i = vm_info.shmem.shmem_num[vm_i]
+
+        print("#define VM{}_CONFIG_PCI_DEV_NUM          {}U".format(vm_i,
+            vm_info.cfg_pci.pci_dev_num[vm_i] + shmem_num_i), file=config)
         print("", file=config)
         vm_i += 1
 
@@ -108,6 +113,10 @@ def gen_post_launch_header(scenario_items, config):
         is_post_vm_available = True
         cpu_affinity_output(vm_info, vm_i, config)
         clos_config_output(scenario_items, vm_i, config)
+
+        if vm_info.shmem.shmem_enabled == 'y' and vm_i in vm_info.shmem.shmem_num.keys():
+            print("#define VM{}_CONFIG_PCI_DEV_NUM          {}U".format(vm_i,
+                vm_info.shmem.shmem_num[vm_i]), file=config)
         vm_i += 1
 
     if is_post_vm_available:

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -39,6 +39,10 @@
             <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
             <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM desc="IVSHMEM configuration">
+                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            </IVSHMEM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -39,6 +39,10 @@
             <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
             <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM desc="IVSHMEM configuration">
+                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            </IVSHMEM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -39,6 +39,10 @@
             <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
             <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM desc="IVSHMEM configuration">
+                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            </IVSHMEM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -25,6 +25,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -25,6 +25,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/generic/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry.xml
@@ -25,6 +25,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
@@ -25,6 +25,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/template/HV.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/HV.xml
@@ -25,6 +25,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -23,6 +23,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>


### PR DESCRIPTION
These patches are to support the Inter-VM communication by IVSHMEM in
config tool.
Users can confiure IVSHMEM_ENABLED to enable or disable Inter-VM
communication by IVSHMEM; users can configure the name, size,
communication VM IDs of the IVSHMEM devices in the VM settings of
scenario xmls, then config tool will generate the related IVSHMEM
configurations for Inter-VM communication.

Tracked-On: #4853

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>