### PR TITLE
TGL: pre-launched VM0 tpm passthrough

### DIFF
--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -32,7 +32,7 @@ KNOWN_HIDDEN_PDEVS_BOARD_DB = {
 
 TSN_DEVS = ["8086:4b30", "8086:4b31", "8086:4b32", "8086:4ba0", "8086:4ba1", "8086:4ba2",
             "8086:4bb0", "8086:4bb1", "8086:4bb2", "8086:a0ac", "8086:43ac", "8086:43a2"]
-TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7']
+TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7', 'tgl-rvp']
 
 KNOWN_CAPS_PCI_DEVS_DB = {
     "TSN":TSN_DEVS,


### PR DESCRIPTION
Enable TPM passthrough configuration for pre-launched VM feature, on
TGL, by adding 'tgl-rvp' to TPM_PASSTHRU_BOARD.

Tracked-On: #5205
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>