### PR TITLE
acrn-config: P2SB Bridge Passthrough and expose GPIO Chassis Interrupt to the Safety VM as INTx

### DIFF
--- a/misc/acrn-config/board_config/board_info_h.py
+++ b/misc/acrn-config/board_config/board_info_h.py
@@ -112,4 +112,9 @@ def generate_file(config):
         print("", file=config)
         print("#define P2SB_BAR_ADDR\t\t\t0x{:X}UL".format(find_p2sb_bar_addr()), file=config)
 
+    if board_cfg_lib.is_matched_board(("ehl-crb-b")):
+        print("", file=config)
+        print("#define BASE_GPIO_PORT_ID\t\t0x69U", file=config)
+        print("#define MAX_GPIO_COMMUNITIES\t0x6U", file=config)
+
     print(BOARD_INFO_ENDIF, file=config)

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -39,6 +39,9 @@ KNOWN_CAPS_PCI_DEVS_DB = {
     "TSN":TSN_DEVS,
 }
 
+P2SB_PASSTHRU_BOARD = ('ehl-crb-b')
+P2SB_PASSTHRU_SCENARIO = ('hybrid', 'hybrid_rt')
+
 def get_info(board_info, msg_s, msg_e):
     """
     Get information which specify by argument
@@ -680,3 +683,14 @@ def get_ram_range():
                 continue
 
     return ram_range
+
+
+def is_p2sb_passthru_possible():
+
+    p2sb_passthru = False
+    (_, board) = common.get_board_name()
+    (_, scenario) = common.get_scenario_name()
+    if board in P2SB_PASSTHRU_BOARD and scenario in P2SB_PASSTHRU_SCENARIO:
+        p2sb_passthru = True
+
+    return p2sb_passthru

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -694,3 +694,10 @@ def is_p2sb_passthru_possible():
         p2sb_passthru = True
 
     return p2sb_passthru
+
+
+def is_matched_board(boardlist):
+
+    (_, board) = common.get_board_name()
+
+    return board in boardlist

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 
+
 ACRN_CONFIG_TARGET = ''
 SOURCE_ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../')
 HV_LICENSE_FILE = SOURCE_ROOT_DIR + 'misc/acrn-config/library/hypervisor_license'
@@ -544,3 +545,14 @@ def get_leaf_tag_map_bool(config_file, branch_tag, tag_str=''):
         result[vm_i] = str2bool(s)
 
     return result
+
+
+def str2int(x):
+    s = x.replace(" ", "").lower()
+
+    if s:
+        base = 10
+        if s.startswith('0x'): base = 16
+        return int(s, base)
+
+    return 0

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -526,3 +526,21 @@ def get_avl_dev_info(bdf_desc_map, pci_sub_class):
                 tmp_pci_desc.append(pci_desc_value.strip())
 
     return tmp_pci_desc
+
+
+def str2bool(v):
+    return v.lower() in ("yes", "true", "t", "y", "1") if v else False
+
+
+def get_leaf_tag_map_bool(config_file, branch_tag, tag_str=''):
+    """
+    This convert and return map's value from string to bool
+    """
+
+    result = {}
+
+    tag_map = get_leaf_tag_map(config_file, branch_tag, tag_str)
+    for vm_i, s in tag_map.items():
+        result[vm_i] = str2bool(s)
+
+    return result

--- a/misc/acrn-config/library/hv_cfg_lib.py
+++ b/misc/acrn-config/library/hv_cfg_lib.py
@@ -30,10 +30,10 @@ def empty_check(val, prime_item, item, sub_item=''):
     if not val or val == None:
         if sub_item:
             key = 'hv,{},{},{}'.format(prime_item, item, sub_item)
-            ERR_LIST[key] = "{} should not empty".format(sub_item)
+            ERR_LIST[key] = "{} should not be empty".format(sub_item)
         else:
             key = 'hv,{},{}'.format(prime_item, item)
-            ERR_LIST[key] = "{} should not empty".format(item)
+            ERR_LIST[key] = "{} should not be empty".format(item)
         return True
 
     return False

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -792,3 +792,20 @@ def share_mem_check(shmem_regions, raw_shmem_regions, vm_type_info, prime_item, 
                     or (2 in bar_attr_dic.keys() and int(bar_attr_dic[2].addr, 16) < 0x100000000):
                     ERR_LIST[key] = "Failed to get the start address of the shared memory, please check the size of it."
                     return
+
+
+def check_p2sb(enable_p2sb):
+
+    for vm_i,p2sb in enable_p2sb.items():
+        if vm_i != 0:
+            key = "vm:id={},p2sb".format(vm_i)
+            ERR_LIST[key] = "Can only specify p2sb for VM0"
+            return
+
+        if p2sb and not board_cfg_lib.is_p2sb_passthru_possible():
+            ERR_LIST["vm:id=0,p2sb"] = "p2sb can only be enabled for EHL hybrid/hybrid-rt"
+            return
+
+        if p2sb and board_cfg_lib.is_tpm_passthru():
+            ERR_LIST["vm:id=0,p2sb"] = "Cannot enable p2sb and tpm passthru at the same time"
+            return

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -809,3 +809,56 @@ def check_p2sb(enable_p2sb):
         if p2sb and board_cfg_lib.is_tpm_passthru():
             ERR_LIST["vm:id=0,p2sb"] = "Cannot enable p2sb and tpm passthru at the same time"
             return
+
+
+def check_pt_intx(phys_pin, virt_pin):
+
+    if not phys_pin and not virt_pin:
+        return
+
+    (_, board) = common.get_board_name()
+    if board != "ehl-crb-b":
+        ERR_LIST["pt_intx"] = "only board ehl-crb-b is supported"
+        return
+
+    (_, scenario) = common.get_scenario_name()
+    if scenario != "hybrid" and scenario != "hybrid_rt":
+        ERR_LIST["pt_intx"] = "only scenario hybrid/hybrid_rt is supported"
+        return
+
+    if not phys_pin and virt_pin:
+        ERR_LIST["pt_intx"] = "phys_pin is not specified"
+        return
+
+    if phys_pin and not virt_pin:
+        ERR_LIST["pt_intx"] = "virt_pin is not specified"
+        return
+
+    for (id1,p), (id2,v) in zip(phys_pin.items(), virt_pin.items()):
+        if id1 != 0 or id2 != 0:
+            ERR_LIST["pt_intx"] = "virt_pin and phys_pin can only be specified for VM0"
+            return
+
+        if len(p) != len(v):
+            ERR_LIST["pt_intx"] = "virt_pin and phys_pin must have same length"
+            return
+
+        if len(p) != len(set(p)):
+            ERR_LIST["pt_intx"] = "phys_pin contains duplicates"
+            return
+
+        if len(v) != len(set(v)):
+            ERR_LIST["pt_intx"] = "virt_pin contains duplicates"
+            return
+
+        if len(p) > 120:
+            ERR_LIST["pt_intx"] = "# of phys_pin must not be greater than 120"
+            return
+
+        if not all(pin < 120 for pin in p):
+            ERR_LIST["pt_intx"] = "phys_pin must be less than 120"
+            return
+
+        if not all(pin < 120 for pin in v):
+            ERR_LIST["pt_intx"] = "virt_pin must be less than 120"
+            return

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -170,7 +170,7 @@ def main(args):
     get_scenario_item_values(params['--board'], params['--scenario'])
     (err_dic, scenario_items) = validate_scenario_setting(params['--board'], params['--scenario'])
     if err_dic:
-        common.print_red("Validate the scenario item failure", err=True)
+        common.print_red("Scenario xml file validation failed:", err=True)
         return err_dic
 
     # generate board defconfig

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -272,6 +272,29 @@ class LoadOrderNum:
         self.sos_vm = scenario_cfg_lib.get_load_vm_cnt(load_vm, "SOS_VM")
         self.post_vm = scenario_cfg_lib.get_load_vm_cnt(load_vm, "POST_LAUNCHED_VM")
 
+
+class MmioResourcesInfo:
+    """ This is Abstract of class of mmio resource setting information """
+    p2sb = False
+
+    def __init__(self, scenario_file):
+        self.scenario_info = scenario_file
+
+    def get_info(self):
+        """
+        Get all items which belong to this class
+        :return: None
+        """
+        self.p2sb = common.get_leaf_tag_map_bool(self.scenario_info, "mmio_resources", "p2sb")
+
+    def check_item(self):
+        """
+        Check all items in this class
+        :return: None
+        """
+        scenario_cfg_lib.check_p2sb(self.p2sb)
+
+
 class VmInfo:
     """ This is Abstract of class of VM setting """
     name = {}
@@ -292,6 +315,8 @@ class VmInfo:
         self.cfg_pci = CfgPci(self.scenario_info)
         self.load_order_cnt = LoadOrderNum()
         self.shmem = ShareMem(self.scenario_info)
+        self.mmio_resource_info = MmioResourcesInfo(self.scenario_info)
+
 
     def get_info(self):
         """
@@ -313,6 +338,7 @@ class VmInfo:
         self.vuart.get_info()
         self.cfg_pci.get_info()
         self.load_order_cnt.get_info(self.load_vm)
+        self.mmio_resource_info.get_info()
 
     def set_ivshmem(self, ivshmem_regions):
         """
@@ -352,4 +378,5 @@ class VmInfo:
         self.cfg_pci.check_item()
         self.vuart.check_item()
         self.shmem.check_items()
+        self.mmio_resource_info.check_item()
         scenario_cfg_lib.ERR_LIST.update(err_dic)

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -6,7 +6,7 @@
 import common
 import board_cfg_lib
 import scenario_cfg_lib
-
+import re
 
 class HwInfo:
     """ This is Abstract of class of Hardware information """
@@ -295,6 +295,56 @@ class MmioResourcesInfo:
         scenario_cfg_lib.check_p2sb(self.p2sb)
 
 
+class PtIntxInfo:
+    """ This is Abstract of class of pt intx setting information """
+    phys_pin = {}
+    virt_pin = {}
+
+    def __init__(self, scenario_file):
+        self.scenario_info = scenario_file
+
+    def get_info(self):
+        """
+        Get all items which belong to this class
+        :return: None
+        """
+        pt_intx_map = common.get_leaf_tag_map(self.scenario_info, "pt_intx")
+
+        # translation table to normalize the paired phys_pin and virt_pin string
+        table = {ord('[') : ord('('), ord(']') : ord(')'), ord('{') : ord('('),
+            ord('}') : ord(')'), ord(';') : ord(','),
+            ord('\n') : None, ord('\r') : None, ord(' ') : None}
+
+        for vm_i, s in pt_intx_map.items():
+            #normalize the phys_pin and virt_pin pair string
+            s = s.translate(table)
+
+            #extract the phys_pin and virt_pin pairs between parenthesis to a list
+            s = re.findall(r'\(([^)]+)', s)
+
+            self.phys_pin[vm_i] = [];
+            self.virt_pin[vm_i] = [];
+
+            for part in s:
+                assert ',' in part, "you need to use ',' to separate phys_pin and virt_pin!"
+                a, b = part.split(',')
+                assert a, "phys_pin is not specified"
+                assert b, "virt_pin is not specified"
+                a, b = common.str2int(a), common.str2int(b)
+
+                self.phys_pin[vm_i].append(a)
+                self.virt_pin[vm_i].append(b)
+
+
+    def check_item(self):
+        """
+        Check all items in this class
+        :return: None
+        """
+
+        scenario_cfg_lib.check_pt_intx(self.phys_pin, self.virt_pin)
+
+
 class VmInfo:
     """ This is Abstract of class of VM setting """
     name = {}
@@ -316,6 +366,7 @@ class VmInfo:
         self.load_order_cnt = LoadOrderNum()
         self.shmem = ShareMem(self.scenario_info)
         self.mmio_resource_info = MmioResourcesInfo(self.scenario_info)
+        self.pt_intx_info = PtIntxInfo(self.scenario_info)
 
 
     def get_info(self):
@@ -339,6 +390,7 @@ class VmInfo:
         self.cfg_pci.get_info()
         self.load_order_cnt.get_info(self.load_vm)
         self.mmio_resource_info.get_info()
+        self.pt_intx_info.get_info()
 
     def set_ivshmem(self, ivshmem_regions):
         """
@@ -379,4 +431,5 @@ class VmInfo:
         self.vuart.check_item()
         self.shmem.check_items()
         self.mmio_resource_info.check_item()
+        self.pt_intx_info.check_item()
         scenario_cfg_lib.ERR_LIST.update(err_dic)

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -355,6 +355,18 @@ def gen_pre_launch_vm(vm_type, vm_i, scenario_items, config):
         print("\t\t\t.size = VM0_TPM_BUFFER_SIZE,", file=config)
         print("\t\t},", file=config)
         print("#endif", file=config)
+
+    if (vm_i == 0 and vm_info.mmio_resource_info.p2sb.get(vm_i) is not None
+        and vm_info.mmio_resource_info.p2sb[vm_i]):
+        print("#ifdef P2SB_BAR_ADDR", file=config)
+        print("\t\t.pt_p2sb_bar = true,", file=config)
+        print("\t\t.mmiodevs[0] = {", file=config)
+        print("\t\t\t.base_gpa = P2SB_BAR_ADDR,", file=config)
+        print("\t\t\t.base_hpa = P2SB_BAR_ADDR,", file=config)
+        print("\t\t\t.size = 0x1000000UL,", file=config)
+        print("\t\t},", file=config)
+        print("#endif", file=config)
+
     print("\t},", file=config)
 
 

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -367,6 +367,12 @@ def gen_pre_launch_vm(vm_type, vm_i, scenario_items, config):
         print("\t\t},", file=config)
         print("#endif", file=config)
 
+    if (vm_i == 0 and board_cfg_lib.is_matched_board(("ehl-crb-b"))
+        and vm_info.pt_intx_info.phys_pin.get(vm_i) is not None
+        and len(vm_info.pt_intx_info.phys_pin[vm_i]) > 0):
+        print("\t\t.pt_intx_num = {}U,".format(len(vm_info.pt_intx_info.phys_pin[vm_i])), file=config)
+        print("\t\t.pt_intx = &vm0_pt_intx[0U],", file=config)
+
     print("\t},", file=config)
 
 
@@ -416,6 +422,20 @@ def generate_file(scenario_items, config):
         if pci_dev_num >= 2:
             pre_launch_definition(vm_info, config)
             break
+
+    if (board_cfg_lib.is_matched_board(("ehl-crb-b"))
+        and vm_info.pt_intx_info.phys_pin.get(0) is not None
+        and len(vm_info.pt_intx_info.phys_pin[0]) > 0):
+
+        print("static struct pt_intx_config vm0_pt_intx[{}U] = {{".format(len(vm_info.pt_intx_info.phys_pin[0])), file=config)
+        for i, (p_pin, v_pin) in enumerate(zip(vm_info.pt_intx_info.phys_pin[0], vm_info.pt_intx_info.virt_pin[0])):
+            print("\t[{}U] = {{".format(i), file=config)
+            print("\t\t.phys_pin = {}U,".format(p_pin), file=config)
+            print("\t\t.virt_pin = {}U,".format(v_pin), file=config)
+            print("\t},", file=config)
+
+        print("};", file=config)
+        print("", file=config)
 
     print("struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {", file=config)
     for vm_i, vm_type in common.VM_TYPES.items():

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -380,7 +380,7 @@ def gen_post_launch_vm(vm_type, vm_i, scenario_items, config):
     print("\t},", file=config)
 
 
-def pre_launch_definiation(vm_info, config):
+def pre_launch_definition(vm_info, config):
 
     for vm_i,vm_type in common.VM_TYPES.items():
         if scenario_cfg_lib.VM_DB[vm_type]['load_type'] not in ["PRE_LAUNCHED_VM", "POST_LAUNCHED_VM"]:
@@ -402,7 +402,7 @@ def generate_file(scenario_items, config):
     gen_source_header(config)
     for vm_i,pci_dev_num in vm_info.cfg_pci.pci_dev_num.items():
         if pci_dev_num >= 2:
-            pre_launch_definiation(vm_info, config)
+            pre_launch_definition(vm_info, config)
             break
 
     print("struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {", file=config)


### PR DESCRIPTION
-  Support for direct assignment of P2SB bridge to one pre-launched safety VM for EHL
 - Expose GPIO chassis interrupts as INTx to the safety VM for EHL
 - Fix misspelled function name

Tracked-On: #5220
Tracked-On: #5221