### PR TITLE
acrn-config: add maxcpus to sos kernel cmdline in hybrid scenario

### DIFF
--- a/misc/acrn-config/config_app/views.py
+++ b/misc/acrn-config/config_app/views.py
@@ -159,6 +159,8 @@ def save_scenario():
     old_scenario_name = scenario_config_data['old_scenario_name']
     scenario_config.set_curr(old_scenario_name)
     for key in scenario_config_data:
+        if scenario_config_data[key] in [None, 'None']:
+            scenario_config_data[key] = ''
         if key not in ['old_scenario_name', 'new_scenario_name', 'generator', 'add_vm_type']:
             if isinstance(scenario_config_data[key], list):
                 scenario_config.set_curr_list(scenario_config_data[key], *tuple(key.split(',')))
@@ -285,6 +287,8 @@ def save_launch():
                                       'user_defined', scenario_name + '.xml')
 
     for key in launch_config_data:
+        if launch_config_data[key] in [None, 'None']:
+            launch_config_data[key] = ''
         if key not in ['old_launch_name', 'new_launch_name', 'generator', 'add_launch_type', 'scenario_name']:
             if isinstance(launch_config_data[key], list):
                 launch_config.set_curr_list(launch_config_data[key], *tuple(key.split(',')))

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -520,9 +520,18 @@ def cpus_assignment(cpus_per_vm, index):
     """
     vm_cpu_bmp = {}
     if "SOS_VM" == common.VM_TYPES[index]:
-        if index not in cpus_per_vm:
+        if index not in cpus_per_vm or cpus_per_vm[index] == [None]:
             sos_extend_all_cpus = board_cfg_lib.get_processor_info()
-            cpus_per_vm[index] = sos_extend_all_cpus
+            pre_all_cpus = []
+            for vmid, cpu_list in cpus_per_vm.items():
+                if vmid in common.VM_TYPES:
+                    vm_type = common.VM_TYPES[vmid]
+                    load_type = ''
+                    if vm_type in VM_DB:
+                        load_type = VM_DB[vm_type]['load_type']
+                    if load_type == "PRE_LAUNCHED_VM":
+                        pre_all_cpus += cpu_list
+            cpus_per_vm[index] = list(set(sos_extend_all_cpus) - set(pre_all_cpus))
 
     for i in range(len(cpus_per_vm[index])):
         if i == 0:


### PR DESCRIPTION
We use sos kernel cmdline maxcpus to limit the pCPU number of SOS
for hybrid or hybrid_rt scenarios by vcpu numbers calculation.

v2: add SOS CPU affinity calculation by total pCPU plus pCPUs
    occupied by pre-launched VMs when no pcpuid configured
    in SOS.

Tracked-On: #5216

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>