### PR TITLE
Ehl uart enable

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -126,6 +126,11 @@ config SERIAL_LEGACY
 	  Select this if the serial port shall be accessed via legacy port in/out
 	  instructions.
 
+config SERIAL_MMIO
+	bool "MMIO"
+	help
+	  Select this if the serial port shall be accessed via MMIO registers.
+
 endchoice
 
 config SERIAL_PCI_BDF
@@ -143,6 +148,13 @@ config SERIAL_PIO_BASE
 	help
 	  The base address of the serial ports. This is logically 16-bit but used
 	  as a 64-bit integer.
+
+config SERIAL_MMIO_BASE
+	hex "Base address of MMIO UART"
+	depends on SERIAL_MMIO
+	default 0xfe040000
+	help
+	  The base address of the MMIO serial port.
 
 config CONSOLE_LOGLEVEL_DEFAULT
 	int "Default loglevel on the serial console"

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -127,10 +127,17 @@
 /* UART oscillator clock */
 #define UART_CLOCK_RATE	1843200U	/* 1.8432 MHz */
 
+enum serial_dev_type {
+	INVALID,
+	PIO,
+	PCI,
+	MMIO,
+};
+
 void uart16550_init(bool early_boot);
 char uart16550_getc(void);
 size_t uart16550_puts(const char *buf, uint32_t len);
-void uart16550_set_property(bool enabled, bool port_mapped, uint64_t base_addr);
+void uart16550_set_property(bool enabled, enum serial_dev_type uart_type, uint64_t base_addr);
 bool is_pci_dbg_uart(union pci_bdf bdf_value);
 
 #endif /* !UART16550_H */

--- a/misc/vm_configs/xmls/board-xmls/ehl-crb-b.xml
+++ b/misc/vm_configs/xmls/board-xmls/ehl-crb-b.xml
@@ -397,10 +397,11 @@
 	seri:/dev/ttyS0 type:mmio base:0x83449000 irq:33 bdf:"00:19.2"
 	seri:/dev/ttyS1 type:mmio base:0x8344A000 irq:16 bdf:"00:1e.0"
 	seri:/dev/ttyS2 type:mmio base:0x8344B000 irq:17 bdf:"00:1e.1"
+	seri:/dev/ttyS3 type:mmio base:0xfe042000 irq:3
 	</TTYS_INFO>
 
 	<AVAILABLE_IRQ_INFO>
-	3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15
+	4, 5, 6, 7, 10, 11, 12, 13, 14, 15
 	</AVAILABLE_IRQ_INFO>
 
 	<TOTAL_MEM_INFO>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
             <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>


### PR DESCRIPTION
    hv: debug: Enable MMIO UART support

    New board, EHL CRB, does not have legacy port IO UART. Even the PCI UART
    are not work due to BIOS's bug workaround(the BARs on LPSS PCI are reset
    after BIOS hand over control to OS). For ACRN console usage, expose the
    debug UART via ACPI PnP device (access by MMIO) and add support in
    hypervisor debug code.

    Another special thing is that register width of UART of EHL CRB is
    1byte. Introduce reg_width for each struct console_uart.

    Tracked-On: #4937
    Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
    Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
