### PR TITLE
acrn-config: P2SB Bridge Passthrough and expose GPIO Chassis Interrupt to the Safety VM as INTx

### DIFF
--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -177,7 +177,7 @@ struct acrn_vm_config {
 	struct acrn_vm_os_config os_config;		/* OS information the VM */
 
 	/*
-	 * below are varaible length members (per build).
+	 * below are variable length members (per build).
 	 * SOS can get the vm_configs[] array through hypercall, but SOS may not
 	 * need to parse these members.
 	 */
@@ -189,6 +189,8 @@ struct acrn_vm_config {
 
 	bool pt_tpm2;
 	struct acrn_mmiodev mmiodevs[MAX_MMIO_DEV_NUM];
+
+	bool pt_p2sb_bar; /* whether to passthru p2sb bridge to pre-launched VM or not */
 } __aligned(8);
 
 struct acrn_vm_config *get_vm_config(uint16_t vm_id);

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -153,6 +153,11 @@ struct acrn_vm_pci_dev_config {
 	const struct pci_vdev_ops *vdev_ops;		/* operations for PCI CFG read/write */
 } __aligned(8);
 
+struct pt_intx_config {
+	uint32_t phys_gsi;	/* physical IOAPIC gsi to be forwarded to the VM */
+	uint32_t virt_gsi;	/* virtual IOAPIC gsi triggered on the vIOAPIC */
+} __aligned(8);
+
 struct acrn_vm_config {
 	enum acrn_vm_load_order load_order;		/* specify the load order of VM */
 	char name[MAX_VM_OS_NAME_LEN];			/* VM name identifier, useful for debug. */
@@ -191,6 +196,9 @@ struct acrn_vm_config {
 	struct acrn_mmiodev mmiodevs[MAX_MMIO_DEV_NUM];
 
 	bool pt_p2sb_bar; /* whether to passthru p2sb bridge to pre-launched VM or not */
+
+	uint16_t pt_intx_num; /* number of pt_intx_config entries pointed by pt_intx */
+	struct pt_intx_config *pt_intx; /* stores the base address of struct pt_intx_config array */
 } __aligned(8);
 
 struct acrn_vm_config *get_vm_config(uint16_t vm_id);

--- a/misc/acrn-config/board_config/board_info_h.py
+++ b/misc/acrn-config/board_config/board_info_h.py
@@ -97,4 +97,9 @@ def generate_file(config):
         print("", file=config)
         print("#define P2SB_BAR_ADDR\t\t\t0x{:X}UL".format(board_cfg_lib.find_p2sb_bar_addr()), file=config)
 
+    if board_cfg_lib.is_matched_board(("ehl-crb-b")):
+        print("", file=config)
+        print("#define BASE_GPIO_PORT_ID\t\t0x69U", file=config)
+        print("#define MAX_GPIO_COMMUNITIES\t0x6U", file=config)
+
     print(BOARD_INFO_ENDIF, file=config)

--- a/misc/acrn-config/board_config/board_info_h.py
+++ b/misc/acrn-config/board_config/board_info_h.py
@@ -5,6 +5,7 @@
 
 import common
 import board_cfg_lib
+import scenario_cfg_lib
 
 BOARD_INFO_DEFINE="""#ifndef BOARD_INFO_H
 #define BOARD_INFO_H
@@ -89,5 +90,11 @@ def generate_file(config):
 
     # generate HI_MMIO_START/HI_MMIO_END
     find_hi_mmio_window(config)
+
+    if (common.VM_TYPES.get(0) is not None and
+        scenario_cfg_lib.VM_DB[common.VM_TYPES[0]]['load_type'] == "PRE_LAUNCHED_VM"
+        and board_cfg_lib.is_p2sb_passthru_possible()):
+        print("", file=config)
+        print("#define P2SB_BAR_ADDR\t\t\t0x{:X}UL".format(board_cfg_lib.find_p2sb_bar_addr()), file=config)
 
     print(BOARD_INFO_ENDIF, file=config)

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -39,6 +39,8 @@ KNOWN_CAPS_PCI_DEVS_DB = {
     "TSN":TSN_DEVS,
 }
 
+P2SB_PASSTHRU_BOARD = ('ehl-crb-b')
+
 def get_info(board_info, msg_s, msg_e):
     """
     Get information which specify by argument
@@ -680,3 +682,36 @@ def get_ram_range():
                 continue
 
     return ram_range
+
+
+def is_p2sb_passthru_possible():
+
+    p2sb_passthru = False
+    (_, board) = common.get_board_name()
+    if board in P2SB_PASSTHRU_BOARD:
+        p2sb_passthru = True
+
+    return p2sb_passthru
+
+
+def is_matched_board(boardlist):
+
+    (_, board) = common.get_board_name()
+
+    return board in boardlist
+
+
+def find_p2sb_bar_addr():
+    if not is_matched_board(('ehl-crb-b')):
+        common.print_red('find_p2sb_bar_addr() can only be called for board ehl-crb-b', err=True)
+        sys.exit(1)
+
+    iomem_lines = get_info(common.BOARD_INFO_FILE, "<IOMEM_INFO>", "</IOMEM_INFO>")
+
+    for line in iomem_lines:
+        if 'INTC1020:' in line:
+            start_addr = int(line.split('-')[0], 16) & 0xFF000000
+            return start_addr
+
+    common.print_red('p2sb device is not found in board file %s!\n' % common.BOARD_INFO_FILE, err=True)
+    sys.exit(1)

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -526,3 +526,25 @@ def get_avl_dev_info(bdf_desc_map, pci_sub_class):
                 tmp_pci_desc.append(pci_desc_value.strip())
 
     return tmp_pci_desc
+
+
+def str2bool(v):
+    return v.lower() in ("yes", "true", "t", "y", "1") if v else False
+
+
+def get_leaf_tag_map_bool(config_file, branch_tag, tag_str=''):
+    """
+    This convert and return map's value from string to bool
+    """
+
+    result = {}
+
+    tag_map = get_leaf_tag_map(config_file, branch_tag, tag_str)
+    for vm_i, s in tag_map.items():
+        result[vm_i] = str2bool(s)
+
+    return result
+
+
+def hpa2gpa(vm_id, hpa, size):
+    return hpa

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 
+
 ACRN_CONFIG_TARGET = ''
 SOURCE_ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../')
 HV_LICENSE_FILE = SOURCE_ROOT_DIR + 'misc/acrn-config/library/hypervisor_license'
@@ -548,3 +549,14 @@ def get_leaf_tag_map_bool(config_file, branch_tag, tag_str=''):
 
 def hpa2gpa(vm_id, hpa, size):
     return hpa
+
+
+def str2int(x):
+    s = x.replace(" ", "").lower()
+
+    if s:
+        base = 10
+        if s.startswith('0x'): base = 16
+        return int(s, base)
+
+    return 0

--- a/misc/acrn-config/library/hv_cfg_lib.py
+++ b/misc/acrn-config/library/hv_cfg_lib.py
@@ -30,10 +30,10 @@ def empty_check(val, prime_item, item, sub_item=''):
     if not val or val == None:
         if sub_item:
             key = 'hv,{},{},{}'.format(prime_item, item, sub_item)
-            ERR_LIST[key] = "{} should not empty".format(sub_item)
+            ERR_LIST[key] = "{} should not be empty".format(sub_item)
         else:
             key = 'hv,{},{}'.format(prime_item, item)
-            ERR_LIST[key] = "{} should not empty".format(item)
+            ERR_LIST[key] = "{} should not be empty".format(item)
         return True
 
     return False

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -798,3 +798,24 @@ def share_mem_check(shmem_regions, raw_shmem_regions, vm_type_info, prime_item, 
                     or (2 in bar_attr_dic.keys() and int(bar_attr_dic[2].addr, 16) < 0x100000000):
                     ERR_LIST[key] = "Failed to get the start address of the shared memory, please check the size of it."
                     return
+
+
+def check_p2sb(enable_p2sb):
+
+    for vm_i,p2sb in enable_p2sb.items():
+        if vm_i != 0:
+            key = "vm:id={},p2sb".format(vm_i)
+            ERR_LIST[key] = "Can only specify p2sb passthru for VM0"
+            return
+
+        if p2sb and not VM_DB[common.VM_TYPES[0]]['load_type'] == "PRE_LAUNCHED_VM":
+            ERR_LIST["vm:id=0,p2sb"] = "p2sb passthru can only be enabled for Pre-launched VM"
+            return
+
+        if p2sb and not board_cfg_lib.is_p2sb_passthru_possible():
+            ERR_LIST["vm:id=0,p2sb"] = "p2sb passthru is not allowed for this board"
+            return
+
+        if p2sb and board_cfg_lib.is_tpm_passthru():
+            ERR_LIST["vm:id=0,p2sb"] = "Cannot enable p2sb and tpm passthru at the same time"
+            return

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -819,3 +819,42 @@ def check_p2sb(enable_p2sb):
         if p2sb and board_cfg_lib.is_tpm_passthru():
             ERR_LIST["vm:id=0,p2sb"] = "Cannot enable p2sb and tpm passthru at the same time"
             return
+
+
+def check_pt_intx(phys_gsi, virt_gsi):
+
+    if not phys_gsi and not virt_gsi:
+        return
+
+    if not board_cfg_lib.is_matched_board(('ehl-crb-b')):
+        ERR_LIST["pt_intx"] = "only board ehl-crb-b is supported"
+        return
+
+    if not VM_DB[common.VM_TYPES[0]]['load_type'] == "PRE_LAUNCHED_VM":
+       ERR_LIST["pt_intx"] = "pt_intx can only be specified for pre-launched VM"
+       return
+
+    for (id1,p), (id2,v) in zip(phys_gsi.items(), virt_gsi.items()):
+        if id1 != 0 or id2 != 0:
+            ERR_LIST["pt_intx"] = "virt_gsi and phys_gsi can only be specified for VM0"
+            return
+
+        if len(p) != len(v):
+            ERR_LIST["vm:id=0,pt_intx"] = "virt_gsi and phys_gsi must have same length"
+            return
+
+        if len(p) != len(set(p)):
+            ERR_LIST["vm:id=0,pt_intx"] = "phys_gsi contains duplicates"
+            return
+
+        if len(v) != len(set(v)):
+            ERR_LIST["vm:id=0,pt_intx"] = "virt_gsi contains duplicates"
+            return
+
+        if len(p) > 120:
+            ERR_LIST["vm:id=0,pt_intx"] = "# of phys_gsi and virt_gsi pairs must not be greater than 120"
+            return
+
+        if not all(pin < 120 for pin in v):
+            ERR_LIST["vm:id=0,pt_intx"] = "virt_gsi must be less than 120"
+            return

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -27,8 +27,10 @@ GEN_FILE = ["vm_configurations.h", "vm_configurations.c", "pci_dev.c", ".config"
 
 def get_scenario_item_values(board_info, scenario_info):
     """
-    Get items which capable multi select for user
-    :param board_info: it is a file what contains board information for script to read from
+    Glue code to provide user selectable options to config UI tool.
+    Return a dictionary of key-value pairs containing features and corresponding lists of
+    user selectable values to the config UI tool.
+    :param board_info: file that contains board information
     """
     hv_cfg_lib.ERR_LIST = {}
     scenario_item_values = {}
@@ -41,7 +43,7 @@ def get_scenario_item_values(board_info, scenario_info):
     common.get_vm_num(scenario_info)
     common.get_vm_types()
 
-    # pre scenario
+    # per scenario
     guest_flags = copy.deepcopy(common.GUEST_FLAG)
     guest_flags.remove('0UL')
     scenario_item_values['vm,vm_type'] = scenario_cfg_lib.LOAD_VM_TYPE
@@ -52,7 +54,7 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["vm,os_config,kern_type"] = scenario_cfg_lib.KERN_TYPE_LIST
     scenario_item_values.update(scenario_cfg_lib.avl_vuart_ui_select(scenario_info))
 
-    # pre board_private
+    # board
     (scenario_item_values["vm,board_private,rootfs"], num) = board_cfg_lib.get_rootfs(board_info)
 
     scenario_item_values["hv,DEBUG_OPTIONS,RELEASE"] = hv_cfg_lib.N_Y
@@ -82,10 +84,10 @@ def get_scenario_item_values(board_info, scenario_info):
 
 def validate_scenario_setting(board_info, scenario_info):
     """
-    This is validate the data setting from scenario xml
-    :param board_info: it is a file what contains board information for script to read from
-    :param scenario_info: it is a file what user have already setting to
-    :return: return a dictionary contain errors
+    Validate settings in scenario xml
+    :param board_info: board file
+    :param scenario_info: scenario file
+    :return: return a dictionary that contains errors
     """
     hv_cfg_lib.ERR_LIST = {}
     scenario_cfg_lib.ERR_LIST = {}
@@ -111,8 +113,8 @@ def validate_scenario_setting(board_info, scenario_info):
 
 def main(args):
     """
-    This is main function to start generate source code related with board
-    :param args: it is a command line args for the script
+    Generate board related source code
+    :param args: command line args
     """
     err_dic = {}
 
@@ -139,13 +141,13 @@ def main(args):
         return err_dic
 
     if common.VM_COUNT > common.MAX_VM_NUM:
-        err_dic['vm count'] = "The vm count in config xml should be less or equal {}!".format(common.MAX_VM_NUM)
+        err_dic['vm count'] = "Number of VMs in scenario xml file should be no greater than {}!".format(common.MAX_VM_NUM)
         return err_dic
 
-    # check if this is the scenario config which matched board info
+    # check if this is the scenario config which matches board info
     (err_dic, status) = common.is_config_file_match()
     if not status:
-        err_dic['scenario config'] = "The board xml and scenario xml should be matched!"
+        err_dic['scenario config'] = "The board xml file does not match scenario xml file!"
         return err_dic
 
     if params['--out']:
@@ -170,7 +172,7 @@ def main(args):
     get_scenario_item_values(params['--board'], params['--scenario'])
     (err_dic, scenario_items) = validate_scenario_setting(params['--board'], params['--scenario'])
     if err_dic:
-        common.print_red("Validate the scenario item failure", err=True)
+        common.print_red("Scenario xml file validation failed:", err=True)
         return err_dic
 
     # generate board defconfig
@@ -199,9 +201,9 @@ def main(args):
         pci_dev_c.generate_file(scenario_items['vm'], config)
 
     if not err_dic:
-        print("Scenario configurations for {} is generated successfully.".format(scenario))
+        print("Scenario configuration files were created successfully.")
     else:
-        print("Scenario configurations for {} is generated failed.".format(scenario))
+        print("Failed to create scenario configuration files.")
 
     return err_dic
 

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -52,6 +52,7 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["vm,clos,vcpu_clos"] = hw_info.get_clos_val()
     scenario_item_values["vm,pci_devs"] = scenario_cfg_lib.avl_pci_devs()
     scenario_item_values["vm,os_config,kern_type"] = scenario_cfg_lib.KERN_TYPE_LIST
+    scenario_item_values["vm,mmio_resources,p2sb"] = hv_cfg_lib.N_Y
     scenario_item_values.update(scenario_cfg_lib.avl_vuart_ui_select(scenario_info))
 
     # board

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -272,6 +272,29 @@ class LoadOrderNum:
         self.sos_vm = scenario_cfg_lib.get_load_vm_cnt(load_vm, "SOS_VM")
         self.post_vm = scenario_cfg_lib.get_load_vm_cnt(load_vm, "POST_LAUNCHED_VM")
 
+
+class MmioResourcesInfo:
+    """ This is Abstract of class of mmio resource setting information """
+    p2sb = False
+
+    def __init__(self, scenario_file):
+        self.scenario_info = scenario_file
+
+    def get_info(self):
+        """
+        Get all items which belong to this class
+        :return: None
+        """
+        self.p2sb = common.get_leaf_tag_map_bool(self.scenario_info, "mmio_resources", "p2sb")
+
+    def check_item(self):
+        """
+        Check all items in this class
+        :return: None
+        """
+        scenario_cfg_lib.check_p2sb(self.p2sb)
+
+
 class VmInfo:
     """ This is Abstract of class of VM setting """
     name = {}
@@ -292,6 +315,8 @@ class VmInfo:
         self.cfg_pci = CfgPci(self.scenario_info)
         self.load_order_cnt = LoadOrderNum()
         self.shmem = ShareMem(self.scenario_info)
+        self.mmio_resource_info = MmioResourcesInfo(self.scenario_info)
+
 
     def get_info(self):
         """
@@ -313,6 +338,7 @@ class VmInfo:
         self.vuart.get_info()
         self.cfg_pci.get_info()
         self.load_order_cnt.get_info(self.load_vm)
+        self.mmio_resource_info.get_info()
 
     def set_ivshmem(self, ivshmem_regions):
         """
@@ -352,4 +378,5 @@ class VmInfo:
         self.cfg_pci.check_item()
         self.vuart.check_item()
         self.shmem.check_items()
+        self.mmio_resource_info.check_item()
         scenario_cfg_lib.ERR_LIST.update(err_dic)

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -6,7 +6,7 @@
 import common
 import board_cfg_lib
 import scenario_cfg_lib
-
+import re
 
 class HwInfo:
     """ This is Abstract of class of Hardware information """
@@ -295,6 +295,57 @@ class MmioResourcesInfo:
         scenario_cfg_lib.check_p2sb(self.p2sb)
 
 
+class PtIntxInfo:
+    """ This is Abstract of class of pt intx setting information """
+    phys_gsi = {}
+    virt_gsi = {}
+
+    def __init__(self, scenario_file):
+        self.scenario_info = scenario_file
+
+    def get_info(self):
+        """
+        Get all items which belong to this class
+        :return: None
+        """
+        pt_intx_map = common.get_leaf_tag_map(self.scenario_info, "pt_intx")
+
+        # translation table to normalize the paired phys_gsi and virt_gsi string
+        table = {ord('[') : ord('('), ord(']') : ord(')'), ord('{') : ord('('),
+            ord('}') : ord(')'), ord(';') : ord(','),
+            ord('\n') : None, ord('\r') : None, ord(' ') : None}
+
+        for vm_i, s in pt_intx_map.items():
+            #normalize the phys_gsi and virt_gsi pair string
+            s = s.translate(table)
+
+            #extract the phys_gsi and virt_gsi pairs between parenthesis to a list
+            s = re.findall(r'\(([^)]+)', s)
+
+            self.phys_gsi[vm_i] = [];
+            self.virt_gsi[vm_i] = [];
+
+            for part in s:
+                if not part: continue
+                assert ',' in part, "you need to use ',' to separate phys_gsi and virt_gsi!"
+                a, b = part.split(',')
+                if not a and not b: continue
+                assert a and b, "you need to specify both phys_gsi and virt_gsi!"
+                a, b = common.str2int(a), common.str2int(b)
+
+                self.phys_gsi[vm_i].append(a)
+                self.virt_gsi[vm_i].append(b)
+
+
+    def check_item(self):
+        """
+        Check all items in this class
+        :return: None
+        """
+
+        scenario_cfg_lib.check_pt_intx(self.phys_gsi, self.virt_gsi)
+
+
 class VmInfo:
     """ This is Abstract of class of VM setting """
     name = {}
@@ -316,6 +367,7 @@ class VmInfo:
         self.load_order_cnt = LoadOrderNum()
         self.shmem = ShareMem(self.scenario_info)
         self.mmio_resource_info = MmioResourcesInfo(self.scenario_info)
+        self.pt_intx_info = PtIntxInfo(self.scenario_info)
 
 
     def get_info(self):
@@ -339,6 +391,7 @@ class VmInfo:
         self.cfg_pci.get_info()
         self.load_order_cnt.get_info(self.load_vm)
         self.mmio_resource_info.get_info()
+        self.pt_intx_info.get_info()
 
     def set_ivshmem(self, ivshmem_regions):
         """
@@ -379,4 +432,5 @@ class VmInfo:
         self.vuart.check_item()
         self.shmem.check_items()
         self.mmio_resource_info.check_item()
+        self.pt_intx_info.check_item()
         scenario_cfg_lib.ERR_LIST.update(err_dic)

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -370,6 +370,12 @@ def gen_pre_launch_vm(vm_type, vm_i, scenario_items, config):
         print("\t\t},", file=config)
         print("#endif", file=config)
 
+    if (vm_i == 0 and board_cfg_lib.is_matched_board(("ehl-crb-b"))
+        and vm_info.pt_intx_info.phys_gsi.get(vm_i) is not None
+        and len(vm_info.pt_intx_info.phys_gsi[vm_i]) > 0):
+        print("\t\t.pt_intx_num = {}U,".format(len(vm_info.pt_intx_info.phys_gsi[vm_i])), file=config)
+        print("\t\t.pt_intx = &vm0_pt_intx[0U],", file=config)
+
     print("\t},", file=config)
 
 
@@ -419,6 +425,20 @@ def generate_file(scenario_items, config):
         if pci_dev_num >= 2:
             pre_launch_definition(vm_info, config)
             break
+
+    if (board_cfg_lib.is_matched_board(("ehl-crb-b"))
+        and vm_info.pt_intx_info.phys_gsi.get(0) is not None
+        and len(vm_info.pt_intx_info.phys_gsi[0]) > 0):
+
+        print("static struct pt_intx_config vm0_pt_intx[{}U] = {{".format(len(vm_info.pt_intx_info.phys_gsi[0])), file=config)
+        for i, (p_pin, v_pin) in enumerate(zip(vm_info.pt_intx_info.phys_gsi[0], vm_info.pt_intx_info.virt_gsi[0])):
+            print("\t[{}U] = {{".format(i), file=config)
+            print("\t\t.phys_gsi = {}U,".format(p_pin), file=config)
+            print("\t\t.virt_gsi = {}U,".format(v_pin), file=config)
+            print("\t},", file=config)
+
+        print("};", file=config)
+        print("", file=config)
 
     print("struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {", file=config)
     for vm_i, vm_type in common.VM_TYPES.items():

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -357,6 +357,19 @@ def gen_pre_launch_vm(vm_type, vm_i, scenario_items, config):
         print("\t\t\t.size = VM0_TPM_BUFFER_SIZE,", file=config)
         print("\t\t},", file=config)
         print("#endif", file=config)
+
+    if (vm_i == 0 and vm_info.mmio_resource_info.p2sb.get(vm_i) is not None
+        and vm_info.mmio_resource_info.p2sb[vm_i]):
+        print("#ifdef P2SB_BAR_ADDR", file=config)
+        print("\t\t.pt_p2sb_bar = true,", file=config)
+        print("\t\t.mmiodevs[0] = {", file=config)
+        gpa = common.hpa2gpa(0, board_cfg_lib.find_p2sb_bar_addr(), 0x1000000)
+        print("\t\t\t.base_gpa = 0x{:X}UL,".format(gpa), file=config)
+        print("\t\t\t.base_hpa = P2SB_BAR_ADDR,", file=config)
+        print("\t\t\t.size = 0x1000000UL,", file=config)
+        print("\t\t},", file=config)
+        print("#endif", file=config)
+
     print("\t},", file=config)
 
 

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -382,7 +382,7 @@ def gen_post_launch_vm(vm_type, vm_i, scenario_items, config):
     print("\t},", file=config)
 
 
-def pre_launch_definiation(vm_info, config):
+def pre_launch_definition(vm_info, config):
 
     for vm_i,vm_type in common.VM_TYPES.items():
         if scenario_cfg_lib.VM_DB[vm_type]['load_type'] not in ["PRE_LAUNCHED_VM", "POST_LAUNCHED_VM"]:
@@ -404,7 +404,7 @@ def generate_file(scenario_items, config):
     gen_source_header(config)
     for vm_i,pci_dev_num in vm_info.cfg_pci.pci_dev_num.items():
         if pci_dev_num >= 2:
-            pre_launch_definiation(vm_info, config)
+            pre_launch_definition(vm_info, config)
             break
 
     print("struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {", file=config)

--- a/misc/vm_configs/scenarios/hybrid/vm_configurations.c
+++ b/misc/vm_configs/scenarios/hybrid/vm_configurations.c
@@ -38,6 +38,14 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.t_vuart.vm_id = 1U,
 			.t_vuart.vuart_id = 1U,
 		},
+#ifdef P2SB_BAR_ADDR
+		.pt_p2sb_bar = true,
+		.mmiodevs[0] = {
+			.base_gpa = 0xFD000000UL,
+			.base_hpa = P2SB_BAR_ADDR,
+			.size = 0x1000000UL,
+		},
+#endif
 	},
 	{	/* VM1 */
 		CONFIG_SOS_VM,

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -27,6 +27,10 @@
         <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM desc="IVSHMEM configuration">
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+        </IVSHMEM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -80,6 +80,8 @@
         <mmio_resources desc="MMIO resources.">
             <p2sb>n</p2sb>
         </mmio_resources>
+        <pt_intx desc="pt intx mapping.">
+        </pt_intx>
         <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
             <vcpu_clos>0</vcpu_clos>
         </clos>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -77,6 +77,9 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
+        <mmio_resources desc="MMIO resources.">
+            <p2sb>n</p2sb>
+        </mmio_resources>
         <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
             <vcpu_clos>0</vcpu_clos>
         </clos>


### PR DESCRIPTION
V2:
- Address review comments
- Added code to support config UI tool
- Renamed pin to gsi for intx passthru for both xml file and generated code
- Fix error messages in code

V1:
 - Support for direct assignment of P2SB bridge to one pre-launched safety VM for EHL
 - Expose GPIO chassis interrupts as INTx to the safety VM for EHL
 - Fix misspelled function name