### PR TITLE
acrn-config: zephyr entry and load address update

### DIFF
--- a/misc/vm_configs/scenarios/hybrid/vm_configurations.c
+++ b/misc/vm_configs/scenarios/hybrid/vm_configurations.c
@@ -23,8 +23,8 @@ struct acrn_vm_config vm_configs[CONFIG_MAX_VM_NUM] = {
 			.name = "Zephyr",
 			.kernel_type = KERNEL_ZEPHYR,
 			.kernel_mod_tag = "Zephyr_RawImage",
-			.kernel_load_addr = 0x100000,
-			.kernel_entry_addr = 0x100000,
+			.kernel_load_addr = 0x8000,
+			.kernel_entry_addr = 0x8000,
 		},
 		.vuart[0] = {
 			.type = VUART_LEGACY_PIO,

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -88,8 +88,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -88,8 +88,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -101,8 +101,8 @@
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs desc="Specify kernel boot arguments"></bootargs>
-            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
         </os_config>
         <vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -86,8 +86,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -88,8 +88,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -84,8 +84,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -84,8 +84,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -84,8 +84,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -84,8 +84,8 @@
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
+        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
+        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>


### PR DESCRIPTION
After below commit in https://github.com/zephyrproject-rtos/zephyr

commit d0126a037d23484feebba00d2c0eac27e6393fef
Author: Zide Chen <zide.chen@intel.com>
Date:   Wed Feb 5 08:32:00 2020 -0800

    boards/x86/acrn: build it in x86_64 mode and switch to X2APIC

The zephyr image for acrn would be built in x86_64 mode by default, then the
load/entry address for pre-launched Zephyr image should be changed from
0x100000 to 0x8000 accordingly per below definition in zephyr .ld file:

zephyrproject_src/zephyr/include/arch/x86/intel64/linker.ld

SECTIONS
{
	/*
	 * The "locore" must be in the 64K of RAM, so that 16-bit code (with
	 * segment registers == 0x0000) and 32/64-bit code agree on addresses.
	 * ... there is no 16-bit code yet, but there will be when we add SMP.
	 */

	.locore 0x8000 : ALIGN(16)
	{
	_locore_start = .;

The commit in zephyrproject is merged before zephyr v2.2 release, so from v2.2
on, HV need this fix to boot Zephyr as pre-launched VM.

Tracked-On: #5259

Signed-off-by: Victor Sun <victor.sun@intel.com>