### PR TITLE
acrn-config: add pse-gpio to vmsix_on_msi devices list

### DIFF
--- a/misc/acrn-config/board_config/board_c.py
+++ b/misc/acrn-config/board_config/board_c.py
@@ -265,7 +265,7 @@ def gen_known_caps_pci_devs(config):
     """Generate information for known capabilities of pci devices"""
     known_caps_pci_devs = board_cfg_lib.get_known_caps_pci_devs()
     for dev,bdf_list in known_caps_pci_devs.items():
-        if dev == "TSN":
+        if dev == "VMSIX":
             print("", file=config)
             bdf_list_len = len(bdf_list)
             if bdf_list_len == 0:

--- a/misc/acrn-config/board_config/board_info_h.py
+++ b/misc/acrn-config/board_config/board_info_h.py
@@ -19,7 +19,7 @@ def gen_known_caps_pci_head(config):
     bdf_list_len = 0
     known_caps_pci_devs = board_cfg_lib.get_known_caps_pci_devs()
     for dev,bdf_list in known_caps_pci_devs.items():
-        if dev == "TSN":
+        if dev == "VMSIX":
             bdf_list_len = len(bdf_list)
     print("#define MAX_VMSIX_ON_MSI_PDEVS_NUM\t{}U".format(bdf_list_len), file=config)
 

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -33,10 +33,11 @@ KNOWN_HIDDEN_PDEVS_BOARD_DB = {
 
 TSN_DEVS = ["8086:4b30", "8086:4b31", "8086:4b32", "8086:4ba0", "8086:4ba1", "8086:4ba2",
             "8086:4bb0", "8086:4bb1", "8086:4bb2", "8086:a0ac", "8086:43ac", "8086:43a2"]
+GPIO_DEVS = ["8086:4b88", "8086:4b89"]
 TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7', 'tgl-rvp']
 
 KNOWN_CAPS_PCI_DEVS_DB = {
-    "TSN":TSN_DEVS,
+    "VMSIX":TSN_DEVS + GPIO_DEVS,
 }
 
 P2SB_PASSTHRU_BOARD = ('ehl-crb-b')

--- a/misc/vm_configs/xmls/board-xmls/ehl-crb-b.xml
+++ b/misc/vm_configs/xmls/board-xmls/ehl-crb-b.xml
@@ -26,6 +26,10 @@
 	Region 0: Memory at 83444000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:13.0 Serial bus controller [0c80]: Intel Corporation Device 4b84
 	Region 0: Memory at 834d8000 (64-bit, non-prefetchable) [disabled] [size=8K]
+	00:13.4 Communication controller: Intel Corporation Device 4b88
+	Region 0: Memory at 84600000 (64-bit, non-prefetchable) [size=16K]
+	00:13.5 Communication controller: Intel Corporation Device 4b89
+	Region 0: Memory at 845fc000 (64-bit, non-prefetchable) [size=16K]
 	00:14.0 USB controller: Intel Corporation Device 4b7d
 	Region 0: Memory at 834c0000 (64-bit, non-prefetchable) [size=64K]
 	00:14.2 RAM memory: Intel Corporation Device 4b7f
@@ -93,6 +97,8 @@
 	00:10.0 0c80: 8086:4b44
 	00:10.1 0c80: 8086:4b45
 	00:13.0 0c80: 8086:4b84
+	00:13.4 0780: 8086:4b88
+	00:13.5 0780: 8086:4b89
 	00:14.0 0c03: 8086:4b7d
 	00:14.2 0500: 8086:4b7f
 	00:15.0 0c80: 8086:4b78


### PR DESCRIPTION
Two PSE-GPIO controllers of EHL CRB require MSI-X emulation for
pass-thru because it uses multiple MSI vectors. Currently acrn-config
enables MSI-X emulation for only TSN devices. Enable MSI-X emulation
for PSE-GPIOs, too.

Tracked-On: #5242

Signed-off-by: Toshiki Nishioka <toshiki.nishioka@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>