### PR TITLE
DM: xHCI: Fix WaaG crash issue caused by Transfer TRBS.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2423,6 +2423,11 @@ pci_xhci_cmd_set_tr(struct pci_xhci_vdev *xdev,
 	cmderr = XHCI_TRB_ERROR_SUCCESS;
 
 	dev = XHCI_SLOTDEV_PTR(xdev, slot);
+	if (!dev) {
+		UPRINTF(LDBG, "%s slot is not enabled!\r\n", __func__);
+		cmderr = XHCI_TRB_ERROR_SLOT_NOT_ON;
+		goto done;
+	}
 	UPRINTF(LDBG, "set_tr: new-tr x%016lx, SCT %u DCS %u\r\n"
 		 "      stream-id %u, slot %u, epid %u, C %u\r\n",
 		 (trb->qwTrb0 & ~0xF),  (uint32_t)((trb->qwTrb0 >> 1) & 0x7),

--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2845,11 +2845,14 @@ pci_xhci_xfer_complete(struct pci_xhci_vdev *xdev, struct usb_xfer *xfer,
 		if (err == XHCI_TRB_ERROR_SUCCESS && rem_len > 0)
 			err = XHCI_TRB_ERROR_SHORT_PKT;
 
-		/* Only interrupt if IOC or short packet */
-		if (!(trb->dwTrb3 & XHCI_TRB_3_IOC_BIT) &&
-		    !((err == XHCI_TRB_ERROR_SHORT_PKT) &&
-		      (trb->dwTrb3 & XHCI_TRB_3_ISP_BIT))) {
-
+		/* When transfer success and IOC bit not set or
+		 * transfer is short packet and ISP bit is not set.
+		 * */
+		if (((err == XHCI_TRB_ERROR_SUCCESS) &&
+			!(trb->dwTrb3 & XHCI_TRB_3_IOC_BIT)) ||
+			((err == XHCI_TRB_ERROR_SHORT_PKT) &&
+			(!(trb->dwTrb3 & XHCI_TRB_3_ISP_BIT) &&
+			!(trb->dwTrb3 & XHCI_TRB_3_IOC_BIT)))) {
 			i = index_inc(i, xfer->max_blk_cnt);
 			continue;
 		}
@@ -2871,8 +2874,10 @@ pci_xhci_xfer_complete(struct pci_xhci_vdev *xdev, struct usb_xfer *xfer,
 
 		*do_intr = 1;
 
-		err = pci_xhci_insert_event(xdev, &evtrb, 0);
-		if (err != XHCI_TRB_ERROR_SUCCESS)
+		pci_xhci_insert_event(xdev, &evtrb, *do_intr);
+		/* The xHC stop on the TRB in error.*/
+		if (err != XHCI_TRB_ERROR_SUCCESS &&
+			err != XHCI_TRB_ERROR_SHORT_PKT)
 			break;
 
 		i = index_inc(i, xfer->max_blk_cnt);


### PR DESCRIPTION
         According to xHCI Spec 4.10.1 Transfer TRBS chapter, there have three scenarios shall
    generate a Transfer Event TRB when transfer TRBs. The patch set fix the Transfer TRBs
    error handler and  Add Null pointer check in Set TR Dequeue command handle function
    to avoid Null pointer exception.

     Tracked-On: #5263
     Signed-off-by: Long Liu <long.liu@intel.com>
     Acked-by: Yu Wang yu1.wang@intel.com
