### PR TITLE
acrn-manager: build and install 'acrnctl' (release and debug)

### DIFF
--- a/misc/acrn-manager/Makefile
+++ b/misc/acrn-manager/Makefile
@@ -65,11 +65,7 @@ MANAGER_LDFLAGS += -lacrn-mngr
 MANAGER_LDFLAGS += $(LDFLAGS)
 
 .PHONY: all
-ifeq ($(RELEASE),0)
 all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnctl $(OUT_DIR)/acrnd
-else
-all: $(OUT_DIR)/libacrn-mngr.a $(OUT_DIR)/acrn_mngr.h $(OUT_DIR)/acrnd
-endif
 
 $(OUT_DIR)/libacrn-mngr.a: acrn_mngr.c acrn_mngr.h $(MANAGER_HEADERS)
 	$(CC) $(MANAGER_CFLAGS) -c acrn_mngr.c -o $(OUT_DIR)/acrn_mngr.o
@@ -107,9 +103,7 @@ install:
 	install -d $(DESTDIR)$(systemd_unitdir)/system
 	install -d $(DESTDIR)$(libdir)
 	install -d $(DESTDIR)$(includedir)/acrn
-ifeq ($(RELEASE),0)
 	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/acrnctl
-endif
 	install -t $(DESTDIR)$(bindir) $(OUT_DIR)/acrnd
 	install -m 0644 -t $(DESTDIR)$(libdir) $(OUT_DIR)/libacrn-mngr.a
 	install -m 0644 -t $(DESTDIR)$(includedir)/acrn $(OUT_DIR)/acrn_mngr.h


### PR DESCRIPTION
Build and install 'acrnctl' for regardless of the RELEASE value. Kata Containers
depends on 'acrnctl' in order to work correctly and we therefore need to make
sure that it is built and installed correctly regardless of whether this is a
debug or a release build.

Tracked-On: #4940
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>