### PR TITLE
HV: set CONFIG_HV_RAM_START as min addr when RELOC enabled

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -196,12 +196,14 @@ config LOW_RAM_SIZE
 
 config HV_RAM_START
 	hex "2M-aligned Start physical address of the RAM region used by the hypervisor"
-	default 0x00400000
+	range 0x200000 0x80000000
+	default 0x10000000
 	help
 	  A 64-bit integer indicating the base physical address where the
 	  hypervisor should be loaded. If RELOC is disabled, the bootloader
 	  is required to load the hypervisor to this specific address.
 	  Otherwise the hypervisor will not boot. With RELOC enabled the
+	  address will be referred as the lowest possible address that hypervisor be loaded,
 	  hypervisor may relocate its symbols to where it is placed,
 	  and thus the bootloader might not place the hypervisor at this
 	  specific address.

--- a/hypervisor/arch/x86/boot/cpu_primary.S
+++ b/hypervisor/arch/x86/boot/cpu_primary.S
@@ -21,6 +21,7 @@
  * the macros involved are changed.
  */
 
+#include <config.h>
 #include <multiboot.h>
 #ifdef CONFIG_MULTIBOOT2
 #include <multiboot2.h>
@@ -103,7 +104,7 @@ relocatable_tag_start:
     .short  MULTIBOOT2_HEADER_TAG_RELOCATABLE
     .short  0
     .long   relocatable_tag_end - relocatable_tag_start
-    .long   0x10000000   /* min_addr. TODO: change it to 2MB after fixing the load_addr issue */
+    .long   CONFIG_HV_RAM_START   /* min_addr */
     .long   0x80000000   /* max_addr */
     .long   0x200000     /* image alignment */
     .long   1            /* preference: lowest possible address */


### PR DESCRIPTION
Previously the min load_addr for HV image is hard coded to 0x10000000 when
CONFIG_RELOC is enabled, now use CONFIG_HV_RAM_START as its prefer minimum
address like setting of CONFIG_PHYSICAL_START do in Linux kernel.

With this patch, we can offload the CONFIG_HV_RAM_START algorithm to
acrn-config or manually set it in scenario XML on some special boards.

Tracked-On: #5275

Signed-off-by: Victor Sun <victor.sun@intel.com>