### PR TITLE
acrn-config: update the size range of ivshmem memory region

### DIFF
--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -763,8 +763,8 @@ def share_mem_check(shmem_regions, raw_shmem_regions, vm_type_info, prime_item, 
             except:
                 ERR_LIST[key] = "The size of share Memory region should be decimal or hexadecimal."
                 return
-            if int_size < 0x200000 or int_size >= 0x40000000:
-                ERR_LIST[key] = "The size of share Memory region should be in [2M, 1G)."
+            if int_size < 0x200000 or int_size > 0x20000000:
+                ERR_LIST[key] = "The size of share Memory region should be in [2MB, 512MB]."
                 return
             if not ((int_size & (int_size-1) == 0) and int_size != 0):
                 ERR_LIST[key] = "The size of share Memory region should be a power of 2."

--- a/misc/acrn-config/scenario_config/ivshmem_cfg_h.py
+++ b/misc/acrn-config/scenario_config/ivshmem_cfg_h.py
@@ -39,7 +39,7 @@ def write_shmem_regions(config):
     print("", file=config)
     print("/*", file=config)
     print(" * The IVSHMEM_SHM_SIZE is the sum of all memory regions.", file=config)
-    print(" * The size range of each memory region is [2M, 1G) and is a power of 2.", file=config)
+    print(" * The size range of each memory region is [2MB, 512MB] and is a power of 2.", file=config)
     print(" */", file=config)
     total_shm_size = 0
     if len(shmem_regions) > 0:

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/ivshmem_cfg.h
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/ivshmem_cfg.h
@@ -12,7 +12,7 @@
 
 /*
  * The IVSHMEM_SHM_SIZE is the sum of all memory regions.
- * The size range of each memory region is [2M, 1G) and is a power of 2.
+ * The size range of each memory region is [2MB, 512MB] and is a power of 2.
  */
 #define IVSHMEM_SHM_SIZE	0x200000UL
 #define IVSHMEM_DEV_NUM		2UL


### PR DESCRIPTION
update the size of ivshmem memory region to [2MB, 512MB].

Tracked-On: #4853

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Yuan Liu <yuan1.liu@intel.com>