### PR TITLE
acrn-config: add swiotlb to sos kernel bootargs to increase bounce bufs

### DIFF
--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -164,7 +164,7 @@
             <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
             <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -159,7 +159,7 @@
             <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p2</rootfs>
             <bootargs desc="Specify kernel boot arguments">
             rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-            i915.nuclear_pageflip=1
+            i915.nuclear_pageflip=1 swiotlb=131072
             </bootargs>
         </board_private>
     </vm>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -107,7 +107,7 @@
             <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p2</rootfs>
             <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -107,7 +107,7 @@
             <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
             <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1
+        i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>


### PR DESCRIPTION
EHL PSE TSN GbE driver is default set to use 32bit of dma addressing.

net: stmmac: configure PSE Gbe to 32bit dma addressing
https://github.com/intel/linux-intel-lts/commit/011c8f

When VM has more than 4GB physical memory, Linux kernel uses the bounce
buffers (swiotlb) to translate kernel data in 64bit memory to 32bit
range for the sake of the DMA because iommu is not available. The
default swiotlb value 32768 is insufficient to support two PSE TSN GbEs
at the same time. Increase the value to 131072 otherwise two GbEs can't
link up.

Tracked-On: #5243

Signed-off-by: Toshiki Nishioka <toshiki.nishioka@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>