### PR TITLE
acrn-config: fix the issue of failure to create a new launch setting.

### DIFF
--- a/misc/acrn-config/config_app/static/main.js
+++ b/misc/acrn-config/config_app/static/main.js
@@ -30,7 +30,7 @@ $().ready(function(){
                     alert(result.status);
                }
 
-               window.location.reload();
+               window.location = 'http://'+ window.location.host+"/scenario";
            },
            error: function(e){
                console.log(e.status);
@@ -141,7 +141,7 @@ $().ready(function(){
             data : JSON.stringify(data),
             success : function(result) {
                 console.log(result);
-                window.location.reload(true);
+                window.location = 'http://'+ window.location.host+"/scenario";
             },
             error : function(e){
                 console.log(e.status);

--- a/misc/acrn-config/config_app/views.py
+++ b/misc/acrn-config/config_app/views.py
@@ -388,7 +388,8 @@ def save_launch():
     if not error_list:
         launch_config.save(launch_config_data['new_launch_name'])
         if old_launch_name != launch_config_data['new_launch_name']:
-            os.remove(os.path.join(current_app.config.get('CONFIG_PATH'), xml_configs[1], old_launch_name + '.xml'))
+            os.remove(os.path.join(current_app.config.get('CONFIG_PATH'), xml_configs[1], 'user_defined',
+                                   old_launch_name + '.xml'))
 
     if os.path.isfile(tmp_launch_file):
         os.remove(tmp_launch_file)

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -568,9 +568,12 @@ def is_linux_like(uos_type):
 
 def set_shm_regions(launch_item_values, scenario_info):
 
-    raw_shmem_regions = common.get_hv_item_tag(scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_REGION")
-    vm_types = common.get_leaf_tag_map(scenario_info, "vm_type")
-    shm_enabled = common.get_hv_item_tag(scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
+    try:
+        raw_shmem_regions = common.get_hv_item_tag(scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_REGION")
+        vm_types = common.get_leaf_tag_map(scenario_info, "vm_type")
+        shm_enabled = common.get_hv_item_tag(scenario_info, "FEATURES", "IVSHMEM", "IVSHMEM_ENABLED")
+    except:
+        return
 
     sos_vm_id = 0
     for vm_id, vm_type in vm_types.items():


### PR DESCRIPTION
When creating a new launch setting, config app can't fine the
scenario config which caused the app failed to load the new
launch setting.

Tracked-On: #5282

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>