### PR TITLE
pci: mcfg: limit device bus numbers which could access by ECAM

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -244,7 +244,6 @@ void init_pcpu_post(uint16_t pcpu_id)
 			panic("failed to initialize iommu!");
 		}
 
-		hv_access_memory_region_update(get_mmcfg_base(), PCI_MMCONFIG_SIZE);
 #ifdef CONFIG_IVSHMEM_ENABLED
 		init_ivshmem_shared_memory();
 #endif

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -292,6 +292,7 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	uint32_t entries_count = vm->e820_entry_num;
 	const struct e820_entry *p_e820 = vm->e820_entries;
 	const struct mem_range *p_mem_range_info = get_mem_range_info();
+	struct pci_mmcfg_region *pci_mmcfg;
 
 	pr_dbg("sos_vm: bottom memory - 0x%lx, top memory - 0x%lx\n",
 		p_mem_range_info->mem_bottom, p_mem_range_info->mem_top);
@@ -354,7 +355,8 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	ept_del_mr(vm, pml4_page, get_ap_trampoline_buf(), CONFIG_LOW_RAM_SIZE);
 
 	/* unmap PCIe MMCONFIG region since it's owned by hypervisor */
-	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, get_mmcfg_base(), PCI_MMCONFIG_SIZE);
+	pci_mmcfg = get_mmcfg_region();
+	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, pci_mmcfg->address, get_pci_mmcfg_size(pci_mmcfg));
 }
 
 /* Add EPT mapping of EPC reource for the VM */

--- a/hypervisor/dm/vpci/vhostbridge.c
+++ b/hypervisor/dm/vpci/vhostbridge.c
@@ -113,8 +113,10 @@ static void init_vhostbridge(struct pci_vdev *vdev)
 	pci_vdev_write_vcfg(vdev, 0xf4U, 4U, 0x011c0f00U);
 
 	if (is_prelaunched_vm(container_of(vdev->vpci, struct acrn_vm, vpci))) {
-		/* For pre-launched VMs, we only need to write an GPA that's reserved in guest ve820, and VIRT_PCI_MMCFG_BASE(0xE0000000) is fine. The trailing 1 is a ECAM enable-bit */
-		pciexbar_low = VIRT_PCI_MMCFG_BASE | 0x1U;
+		/* For pre-launched VMs, we only need to write an GPA that's reserved in guest ve820,
+		 * and UOS_VIRT_PCI_MMCFG_BASE(0xE0000000) is fine. The trailing 1 is a ECAM enable-bit
+		 */
+		pciexbar_low = UOS_VIRT_PCI_MMCFG_BASE | 0x1U;
 	}
 	else {
 		/*Inject physical ECAM value to SOS vhostbridge since SOS may check PCIe-MMIO Base Address with it */

--- a/hypervisor/include/dm/vacpi.h
+++ b/hypervisor/include/dm/vacpi.h
@@ -23,7 +23,9 @@
 #define VIRT_XSDT_ADDR		0x7ff00080UL
 
 /* virtual PCI MMCFG address base for pre/post-launched VM. */
-#define VIRT_PCI_MMCFG_BASE	0xE0000000UL
+#define UOS_VIRT_PCI_MMCFG_BASE		0xE0000000UL
+#define UOS_VIRT_PCI_MMCFG_START_BUS	0x0U
+#define UOS_VIRT_PCI_MMCFG_END_BUS	0xFFU
 
 void build_vrsdp(struct acrn_vm *vm);
 

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -155,7 +155,7 @@ union pci_cfg_addr_reg {
 struct acrn_vpci {
 	spinlock_t lock;
 	union pci_cfg_addr_reg addr;
-	uint64_t pci_mmcfg_base;
+	struct pci_mmcfg_region pci_mmcfg;
 	uint32_t pci_vdev_cnt;
 	struct pci_vdev pci_vdevs[CONFIG_MAX_PCI_DEV_NUM];
 	struct hlist_head vdevs_hlist_heads [VDEV_LIST_HASHSIZE];

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -208,6 +208,13 @@ enum pci_bar_type {
 	PCIBAR_MEM64HI,
 };
 
+struct pci_mmcfg_region {
+	uint64_t address;	/* Base address, processor-relative */
+	uint16_t pci_segment;	/* PCI segment group number */
+	uint8_t start_bus;	/* Starting PCI Bus number */
+	uint8_t end_bus;	/* Final PCI Bus number */
+} __packed;
+
 /* Basic MSIX capability info */
 struct pci_msix_cap {
 	uint32_t  capoff;
@@ -324,10 +331,15 @@ static inline bool bdf_is_equal(union pci_bdf a, union pci_bdf b)
 	return (a.value == b.value);
 }
 
+static inline uint64_t get_pci_mmcfg_size(struct pci_mmcfg_region *pci_mmcfg)
+{
+	return 0x100000UL * (pci_mmcfg->end_bus - pci_mmcfg->start_bus + 1U);
+}
+
 #ifdef CONFIG_ACPI_PARSE_ENABLED
-void set_mmcfg_base(uint64_t mmcfg_base);
+void set_mmcfg_region(struct pci_mmcfg_region *region);
 #endif
-uint64_t get_mmcfg_base(void);
+struct pci_mmcfg_region *get_mmcfg_region(void);
 
 struct pci_pdev *init_pdev(uint16_t pbdf, uint32_t drhd_index);
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);

--- a/misc/acrn-config/board_config/acpi_platform_h.py
+++ b/misc/acrn-config/board_config/acpi_platform_h.py
@@ -157,6 +157,28 @@ def write_direct_info_parser(config, msg_s, msg_e):
         print("\n#define DEFAULT_PCI_MMCFG_BASE\t0UL", file=config)
         return
 
+    if msg_name in ("IOMEM"):
+        if vector_lines:
+            for vector in vector_lines:
+                if "MMCONFIG" in vector:
+                    try:
+                        bus_list = vector.split("bus")[1].strip().split("-")
+                        start_bus_number = int(bus_list[0].strip(), 16)
+                        end_bus_number = int(bus_list[1].strip("]"), 16)
+                        print("/* PCI mmcfg bus number of MCFG */", file=config)
+                        print("#define DEFAULT_PCI_MMCFG_START_BUS \t 0x{:X}U".format(start_bus_number), file=config)
+                        print("#define DEFAULT_PCI_MMCFG_END_BUS   \t 0x{:X}U\n".format(end_bus_number), file=config)
+                        print("", file=config)
+                        return
+                    except:
+                        pass
+
+        print("/* PCI mmcfg bus number of MCFG */", file=config)
+        print("#define DEFAULT_PCI_MMCFG_START_BUS\t0U", file=config)
+        print("#define DEFAULT_PCI_MMCFG_END_BUS\t0U", file=config)
+        print("", file=config)
+        return
+
     for vector in vector_lines:
         print("{}".format(vector.strip()), file=config)
 
@@ -200,6 +222,7 @@ def platform_info_parser(config, default_platform):
     write_direct_info_parser(config, "<RESET_REGISTER_INFO>", "</RESET_REGISTER_INFO>")
     drhd_info_parser(config)
     write_direct_info_parser(config, "<MMCFG_BASE_INFO>", "</MMCFG_BASE_INFO>")
+    write_direct_info_parser(config, "<IOMEM_INFO>", "</IOMEM_INFO>")
 
 
 def generate_file(config, default_platform):

--- a/misc/vm_configs/boards/ehl-crb-b/platform_acpi_info.h
+++ b/misc/vm_configs/boards/ehl-crb-b/platform_acpi_info.h
@@ -82,4 +82,8 @@
 /* PCI mmcfg base of MCFG */
 #define DEFAULT_PCI_MMCFG_BASE   0xc0000000UL
 
+/* PCI mmcfg bus number of MCFG */
+#define DEFAULT_PCI_MMCFG_START_BUS     0x0U
+#define DEFAULT_PCI_MMCFG_END_BUS       0xFFU
+
 #endif /* PLATFORM_ACPI_INFO_H */

--- a/misc/vm_configs/boards/nuc7i7dnb/platform_acpi_info.h
+++ b/misc/vm_configs/boards/nuc7i7dnb/platform_acpi_info.h
@@ -65,4 +65,8 @@
 /* PCI mmcfg base of MCFG */
 #define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
 
+/* PCI mmcfg bus number of MCFG */
+#define DEFAULT_PCI_MMCFG_START_BUS     0x0U
+#define DEFAULT_PCI_MMCFG_END_BUS       0xFFU
+
 #endif /* PLATFORM_ACPI_INFO_H */

--- a/misc/vm_configs/boards/whl-ipc-i5/platform_acpi_info.h
+++ b/misc/vm_configs/boards/whl-ipc-i5/platform_acpi_info.h
@@ -69,4 +69,8 @@
 /* PCI mmcfg base of MCFG */
 #define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
 
+/* PCI mmcfg bus number of MCFG */
+#define DEFAULT_PCI_MMCFG_START_BUS     0x0U
+#define DEFAULT_PCI_MMCFG_END_BUS       0xFFU
+
 #endif /* PLATFORM_ACPI_INFO_H */

--- a/misc/vm_configs/boards/whl-ipc-i7/platform_acpi_info.h
+++ b/misc/vm_configs/boards/whl-ipc-i7/platform_acpi_info.h
@@ -69,4 +69,8 @@
 /* PCI mmcfg base of MCFG */
 #define DEFAULT_PCI_MMCFG_BASE   0xe0000000UL
 
+/* PCI mmcfg bus number of MCFG */
+#define DEFAULT_PCI_MMCFG_START_BUS     0x0U
+#define DEFAULT_PCI_MMCFG_END_BUS       0xFFU
+
 #endif /* PLATFORM_ACPI_INFO_H */


### PR DESCRIPTION
Per PCI Firmware Specification Revision 3.0, 4.1.2. MCFG Table Description:
Memory Mapped Enhanced Configuration Space Base Address Allocation Structure assign the Start Bus Number and the End Bus Number which could decoded by the Host Bridge. We should not access the PCI device which bus number outside of the range of [Start Bus Number, End Bus Number). The Start Bus Number and End Bus Number is retrieved from native board information.
For ACRN,  we should:
1. Don't detect PCI device which bus number outside the range of [Start Bus Number, End Bus Number) of MCFG ACPI Table.
2. Only trap the ECAM MMIO size: [MMCFG_BASE_ADDRESS, MMCFG_BASE_ADDRESS + (End Bus Number - Start Bus Number + 1) * 0x100000) for SOS.

Tracked-On: #5233

Li Fei1 (1):
  pci: mcfg: limit device bus numbers which could access by ECAM

Shixiong Zhang (2):
  acrn-config: add MACROs for mmcfg bus number
  acrn-config: add MACROs for mmcfg bus number
