### PR TITLE
config: EHL passthough network to pre-launched VM for hybrid_rt

### DIFF
--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -113,6 +113,7 @@
         </vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
+            <pci_dev desc="pci device">00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
         </pci_devs>
     </vm>
     <vm id="1">


### PR DESCRIPTION
For EHL hybrid_rt scenario, the requirement needs a network device
passthough to pre-launched VM0.

Tracked-On: #5286
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>