### PR TITLE
acrn-config: enable TPM2 config on ehl-crb-b board

### DIFF
--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -34,7 +34,7 @@ KNOWN_HIDDEN_PDEVS_BOARD_DB = {
 TSN_DEVS = ["8086:4b30", "8086:4b31", "8086:4b32", "8086:4ba0", "8086:4ba1", "8086:4ba2",
             "8086:4bb0", "8086:4bb1", "8086:4bb2", "8086:a0ac", "8086:43ac", "8086:43a2"]
 GPIO_DEVS = ["8086:4b88", "8086:4b89"]
-TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7', 'tgl-rvp']
+TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7', 'tgl-rvp', 'ehl-crb-b']
 
 KNOWN_CAPS_PCI_DEVS_DB = {
     "VMSIX":TSN_DEVS + GPIO_DEVS,

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -529,6 +529,7 @@ def cpus_assignment(cpus_per_vm, index):
                     if load_type == "PRE_LAUNCHED_VM":
                         pre_all_cpus += cpu_list
             cpus_per_vm[index] = list(set(sos_extend_all_cpus) - set(pre_all_cpus))
+            cpus_per_vm[index].sort()
 
     for i in range(len(cpus_per_vm[index])):
         if i == 0:

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -196,7 +196,6 @@ def main(args):
             return err_dic
 
     # generate ivshmem_cfg.h
-    print(ivshmem_config_h)
     with open(ivshmem_config_h, 'w') as config:
         ivshmem_cfg_h.generate_file(scenario_items, config)
 

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -286,6 +286,7 @@ class MmioResourcesInfo:
         :return: None
         """
         self.p2sb = common.get_leaf_tag_map_bool(self.scenario_info, "mmio_resources", "p2sb")
+        self.tpm2 = common.get_leaf_tag_map_bool(self.scenario_info, "mmio_resources", "TPM2")
 
     def check_item(self):
         """

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -106,6 +106,9 @@
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -109,6 +109,9 @@
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
@@ -160,5 +163,8 @@
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -108,6 +108,9 @@
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
@@ -157,5 +160,8 @@
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -106,6 +106,9 @@
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -110,6 +110,9 @@
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
@@ -161,5 +164,8 @@
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -40,8 +40,8 @@
             <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
@@ -115,7 +115,7 @@
             <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
         </pci_devs>
         <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+            <TPM2 desc="TPM2 device">y</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
@@ -115,6 +115,7 @@
             <pci_dev desc="pci device">00:1a.3 Non-VGA unclassified device [0000]: Intel Corporation Device 4b4a</pci_dev>
         </pci_devs>
         <mmio_resources desc="MMIO resources.">
+            <TPM2 desc="TPM2 device">n</TPM2>
             <p2sb>true</p2sb>
         </mmio_resources>
         <pt_intx desc="pt intx mapping.">

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -104,6 +104,9 @@
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -26,8 +26,8 @@
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 
@@ -102,6 +102,9 @@
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">y</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>

--- a/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
@@ -109,6 +109,9 @@
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
@@ -161,5 +164,8 @@
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -106,6 +106,9 @@
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -110,6 +110,9 @@
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
   <vm id="1">
     <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
@@ -161,5 +164,8 @@
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Network controller: Intel Corporation Device 24fb (rev 10)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/PRE_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/PRE_RT_VM.xml
@@ -45,7 +45,7 @@
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
     <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+        <TPM2 desc="TPM2 device">y</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -103,7 +103,7 @@
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
     <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">y</TPM2>
+        <TPM2 desc="TPM2 device">n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -24,8 +24,8 @@
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -107,7 +107,7 @@
         <pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V (rev 20)</pci_dev>
     </pci_devs>
     <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">y</TPM2>
+        <TPM2 desc="TPM2 device">n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
@@ -159,5 +159,8 @@
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -104,7 +104,7 @@
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
     <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+        <TPM2 desc="TPM2 device">y</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -160,5 +160,8 @@
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
         <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
+    <mmio_resources desc="mmio devices list to passthrough">
+        <TPM2 desc="TPM2 device">n</TPM2>
+    </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -24,8 +24,8 @@
         <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 
@@ -104,7 +104,7 @@
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
     <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+        <TPM2 desc="TPM2 device">y</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">


### PR DESCRIPTION
enable TPM2 config on ehl-crb-b board and update TPM2 configs on
legacy boards.

Tracked-On: #5266

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>