### PR TITLE
doc: add pointers to meta-acrn layer repo docs

### DIFF
--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -33,6 +33,7 @@ Service VM Tutorials
    :maxdepth: 1
 
    tutorials/running_deb_as_serv_vm
+   tutorials/using_yp
 
 User VM Tutorials
 *****************

--- a/doc/tutorials/using_yp.rst
+++ b/doc/tutorials/using_yp.rst
@@ -1,0 +1,41 @@
+.. _using_yp:
+
+Using Yocto Project with ACRN
+#############################
+
+The `Yocto Project <https://yoctoproject.org>`_ (YP) is an open source
+collaboration project that helps developers create custom Linux-based
+systems.  The project provides a flexible set of tools and a space where
+embedded developers worldwide can share technologies, software stacks,
+configurations, and best practices used to create tailored Linux images
+for embedded and IOT devices, or anywhere a customized Linux OS is
+needed.
+
+Yocto Project layers support the inclusion of technologies, hardware
+components, and software components.  Layers are repositories containing
+related sets of instructions which tell the Yocto Project build system
+what to do.
+
+The meta-acrn layer
+*******************
+
+The meta-acrn layer integrates the ACRN hypervisor with OpenEmbedded,
+letting you build your Service VM or Guest VM OS with the Yocto Project.
+The `OpenEmbedded Layer Index's meta-acrn entry
+<http://layers.openembedded.org/layerindex/branch/master/layer/meta-acrn/>`_
+tracks work on this meta-acrn layer and lists the available meta-acrn
+recipes including Service and User VM OSs for Linux Kernel 4.19 and 5.4
+with the ACRN hypervisor enabled.
+
+Read more about the meta-acrn layer and how to use it, directly from the
+`meta-acrn GitHub repo documentation
+<https://github.com/intel/meta-acrn/tree/master/docs>`_:
+
+* `Getting Started guide
+  <https://github.com/intel/meta-acrn/blob/master/docs/getting-started.md>`_
+* `Booting ACRN with Slim Bootloader
+  <https://github.com/intel/meta-acrn/blob/master/docs/slimbootloader.md>`_
+* `Testing Procedure
+  <https://github.com/intel/meta-acrn/blob/master/docs/qa.md>`_
+* `References
+  <https://github.com/intel/meta-acrn/blob/master/docs/references.md>`_


### PR DESCRIPTION
meta-acrn is a Yocto Project layer repo with recipes for building a
Service and User VM OS using Yocto Project.  While the information there
is sparse, for the experienced YP developer is might be enough.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>