### PR TITLE
Revert "hv:refine vm & vcpu lock" for release2.2_branch

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -411,6 +411,13 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 
 	/* Allocate memory for virtual machine */
 	vm = &vm_array[vm_id];
+	/*
+	 * the vm_state lock field need to remain unchanged in vm data structure
+	 * Since arch_vm struct is page aligned, size used for memset should consider
+	 * subtracting 4K from the total size of acrn_vm.
+	 * Using offset_of macro to avoid hardcoding 4k here.
+	 */
+	(void)memset((void *)&vm->arch_vm, 0U, (sizeof(struct acrn_vm) - offsetof(struct acrn_vm, arch_vm)));
 	vm->vm_id = vm_id;
 	vm->hw.created_vcpus = 0U;
 
@@ -459,8 +466,6 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 
 		vm->arch_vm.vlapic_mode = VM_VLAPIC_XAPIC;
 		vm->intr_inject_delay_delta = 0UL;
-		vm->nr_emul_mmio_regions = 0U;
-		vm->vcpuid_entry_nr = 0U;
 
 		/* Set up IO bit-mask such that VM exit occurs on
 		 * selected IO ranges
@@ -628,8 +633,6 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 	deinit_vuart(vm);
 
 	deinit_vpci(vm);
-
-	deinit_emul_io(vm);
 
 	/* Free EPT allocated resources assigned to VM */
 	destroy_ept(vm);

--- a/hypervisor/dm/io_req.c
+++ b/hypervisor/dm/io_req.c
@@ -475,7 +475,7 @@ hv_emulate_mmio(struct acrn_vcpu *vcpu, struct io_request *io_req)
 	size = mmio_req->size;
 
 	spinlock_obtain(&vcpu->vm->emul_mmio_lock);
-	for (idx = 0U; idx <= vcpu->vm->nr_emul_mmio_regions; idx++) {
+	for (idx = 0U; idx <= vcpu->vm->max_emul_mmio_regions; idx++) {
 		mmio_handler = &(vcpu->vm->emul_mmio[idx]);
 		if (mmio_handler->read_write != NULL) {
 			base = mmio_handler->range_start;
@@ -657,8 +657,8 @@ static inline struct mem_io_node *find_free_mmio_node(struct acrn_vm *vm)
 
 	if (mmio_node != NULL) {
 		idx = (uint16_t)(uint64_t)(mmio_node - &(vm->emul_mmio[0U]));
-		if (vm->nr_emul_mmio_regions < idx) {
-			vm->nr_emul_mmio_regions = idx;
+		if (vm->max_emul_mmio_regions < idx) {
+			vm->max_emul_mmio_regions = idx;
 		}
 	}
 
@@ -723,10 +723,4 @@ void unregister_mmio_emulation_handler(struct acrn_vm *vm,
 		(void)memset(mmio_node, 0U, sizeof(struct mem_io_node));
 	}
 	spinlock_release(&vm->emul_mmio_lock);
-}
-
-void deinit_emul_io(struct acrn_vm *vm)
-{
-	(void)memset(vm->emul_mmio, 0U, sizeof(vm->emul_mmio));
-	(void)memset(vm->emul_pio, 0U, sizeof(vm->emul_pio));
 }

--- a/hypervisor/include/arch/x86/guest/vm.h
+++ b/hypervisor/include/arch/x86/guest/vm.h
@@ -82,7 +82,7 @@ struct vm_pm_info {
 
 /* Enumerated type for VM states */
 enum vm_state {
-	VM_POWERED_OFF = 0,   /* MUST set 0 because vm_state's initialization depends on clear BSS section */
+	VM_POWERED_OFF = 0,
 	VM_CREATED,	/* VM created / awaiting start (boot) */
 	VM_RUNNING,	/* VM running */
 	VM_READY_TO_POWEROFF,     /* RTVM only, it is trying to poweroff by itself */
@@ -120,6 +120,10 @@ struct vm_arch {
 } __aligned(PAGE_SIZE);
 
 struct acrn_vm {
+	/* vm_state_lock MUST be the first field in VM structure it will not clear zero when creating VM
+	 * this lock initialization depends on the clear BSS section
+	 */
+	spinlock_t vm_state_lock;/* Spin-lock used to protect vm/vcpu state transition for a VM */
 	struct vm_arch arch_vm; /* Reference to this VM's arch information */
 	struct vm_hw_info hw;	/* Reference to this VM's HW information */
 	struct vm_sw_info sw;	/* Reference to SW associated with this VM */
@@ -131,14 +135,10 @@ struct acrn_vm {
 	struct acrn_vuart vuart[MAX_VUART_NUM_PER_VM];		/* Virtual UART */
 	enum vpic_wire_mode wire_mode;
 	struct iommu_domain *iommu;	/* iommu domain of this VM */
-	/* vm_state_lock used to protect vm/vcpu state transition,
-	 * the initialization depends on the clear BSS section
-	 */
-	spinlock_t vm_state_lock;
 	spinlock_t vlapic_mode_lock;	/* Spin-lock used to protect vlapic_mode modifications for a VM */
 	spinlock_t ept_lock;	/* Spin-lock used to protect ept add/modify/remove for a VM */
 	spinlock_t emul_mmio_lock;	/* Used to protect emulation mmio_node concurrent access for a VM */
-	uint16_t nr_emul_mmio_regions;	/* the emulated mmio_region number */
+	uint16_t max_emul_mmio_regions;	/* max index of the emulated mmio_region */
 	struct mem_io_node emul_mmio[CONFIG_MAX_EMULATED_MMIO_REGIONS];
 
 	struct vm_io_handler_desc emul_pio[EMUL_PIO_IDX_MAX];

--- a/hypervisor/include/dm/io_req.h
+++ b/hypervisor/include/dm/io_req.h
@@ -286,7 +286,7 @@ void register_mmio_emulation_handler(struct acrn_vm *vm,
  */
 void unregister_mmio_emulation_handler(struct acrn_vm *vm,
 					uint64_t start, uint64_t end);
-void deinit_emul_io(struct acrn_vm *vm);
+
 /**
  * @}
  */


### PR DESCRIPTION
This reverts commit a67a85c70dc55dfaf39b65b059e09d33e31b72ea.

this revert only for release_2.2 branch to fix WaaG reboot failed，
restore memset in create_vm because sub-module use uninitialized data
in vm structure after reboot

Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Tracked-On: #4958