### PR TITLE
acrn-config: upload generated ASL code of ACPI tables for pre-launche…

### DIFF
--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/apic.asl
@@ -1,0 +1,46 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/apic.asl
@@ -1,0 +1,46 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/apic.asl
@@ -1,0 +1,46 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/apic.asl
@@ -1,0 +1,46 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/dsdt.asl
@@ -1,0 +1,32 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+    Device (TPM)
+    {
+        Name (_HID, "MSFT0101" /* TPM 2.0 Security Device */)  // _HID: Hardware ID
+        Name (_CRS, ResourceTemplate ()  // _CRS: Current Resource Settings
+        {
+            Memory32Fixed (ReadWrite,
+                0xFED40000,         // Address Base
+                0x00005000,         // Address Length
+                )
+        })
+    }
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/tpm2.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/tpm2.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [TPM2]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "TPM2"    [Trusted Platform Module hardware interface table]
+[0004]                 Table Length : 00000034
+[0001]                     Revision : 03
+[0001]                     Checksum : 67
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNTPM2"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]                     Reserved : 00000000
+[0008]              Control Address : 00000000FED40040
+[0004]                 Start Method : 07

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/xsdt.asl
@@ -1,0 +1,24 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   3 : 000000007FF01000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/dsdt.asl
@@ -1,0 +1,32 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+    Device (TPM)
+    {
+        Name (_HID, "MSFT0101" /* TPM 2.0 Security Device */)  // _HID: Hardware ID
+        Name (_CRS, ResourceTemplate ()  // _CRS: Current Resource Settings
+        {
+            Memory32Fixed (ReadWrite,
+                0xFED40000,         // Address Base
+                0x00005000,         // Address Length
+                )
+        })
+    }
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/tpm2.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/tpm2.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [TPM2]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "TPM2"    [Trusted Platform Module hardware interface table]
+[0004]                 Table Length : 00000034
+[0001]                     Revision : 03
+[0001]                     Checksum : 67
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNTPM2"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]                     Reserved : 00000000
+[0008]              Control Address : 00000000FED40040
+[0004]                 Start Method : 07

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/xsdt.asl
@@ -1,0 +1,24 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   3 : 000000007FF01000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/dsdt.asl
@@ -1,0 +1,32 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+    Device (TPM)
+    {
+        Name (_HID, "MSFT0101" /* TPM 2.0 Security Device */)  // _HID: Hardware ID
+        Name (_CRS, ResourceTemplate ()  // _CRS: Current Resource Settings
+        {
+            Memory32Fixed (ReadWrite,
+                0xFED40000,         // Address Base
+                0x00005000,         // Address Length
+                )
+        })
+    }
+
+}
+

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/tpm2.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/tpm2.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [TPM2]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "TPM2"    [Trusted Platform Module hardware interface table]
+[0004]                 Table Length : 00000034
+[0001]                     Revision : 03
+[0001]                     Checksum : 67
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNTPM2"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]                     Reserved : 00000000
+[0008]              Control Address : 00000000FED40040
+[0004]                 Start Method : 07

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/xsdt.asl
@@ -1,0 +1,24 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   3 : 000000007FF01000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/apic.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/apic.asl
@@ -1,0 +1,54 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [APIC]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "APIC"    [Multiple APIC Description Table (MADT)]
+[0004]                 Table Length : 0000004E
+[0001]                     Revision : 03
+[0001]                     Checksum : 9B
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMADT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0004]           Local Apic Address : FEE00000
+[0004]        Flags (decoded below) : 00000001
+                PC-AT Compatibility : 1
+
+[0001]                Subtable Type : 01 [I/O APIC]
+[0001]                       Length : 0C
+[0001]                  I/O Apic ID : 01
+[0001]                     Reserved : 00
+[0004]                      Address : FEC00000
+[0004]                    Interrupt : 00000000
+
+[0001]                Subtable Type : 04 [Local APIC NMI]
+[0001]                       Length : 06
+[0001]                 Processor ID : FF
+[0002]        Flags (decoded below) : 0005
+                           Polarity : 1
+                       Trigger Mode : 1
+[0001]         Interrupt Input LINT : 01
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 00
+[0001]                Local Apic ID : 00
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0
+
+[0001]                Subtable Type : 00 [Processor Local APIC]
+[0001]                       Length : 08
+[0001]                 Processor ID : 01
+[0001]                Local Apic ID : 01
+[0004]        Flags (decoded below) : 00000001
+                  Processor Enabled : 1
+             Runtime Online Capable : 0

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/dsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/dsdt.asl
@@ -1,0 +1,21 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000051 (81)
+ *     Revision         0x03
+ *     Checksum         0xF0
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20190703 (538511107)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+
+}
+

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/facp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/facp.asl
@@ -1,0 +1,157 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [FACP]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]      FieldName : FieldValue
+ */
+
+[0004]                        Signature : "FACP"    [Fixed ACPI Description Table (FADT)]
+[0004]                     Table Length : 000000F4
+[0001]                         Revision : 03
+[0001]                         Checksum : 28
+[0006]                           Oem ID : "ACRN  "
+[0008]                     Oem Table ID : "ACRNFADT"
+[0004]                     Oem Revision : 00000001
+[0004]                  Asl Compiler ID : "INTL"
+[0004]            Asl Compiler Revision : 20190703
+
+[0004]                     FACS Address : 00000000
+[0004]                     DSDT Address : 7FF00200
+[0001]                            Model : 00
+[0001]                       PM Profile : 00 [Unspecified]
+[0002]                    SCI Interrupt : 0000
+[0004]                 SMI Command Port : 00000000
+[0001]                ACPI Enable Value : 00
+[0001]               ACPI Disable Value : 00
+[0001]                   S4BIOS Command : 00
+[0001]                  P-State Control : 00
+[0004]         PM1A Event Block Address : 00001800
+[0004]         PM1B Event Block Address : 00000000
+[0004]       PM1A Control Block Address : 00001804
+[0004]       PM1B Control Block Address : 00000000
+[0004]        PM2 Control Block Address : 00000000
+[0004]           PM Timer Block Address : 00000000
+[0004]               GPE0 Block Address : 00000000
+[0004]               GPE1 Block Address : 00000000
+[0001]           PM1 Event Block Length : 04
+[0001]         PM1 Control Block Length : 02
+[0001]         PM2 Control Block Length : 00
+[0001]            PM Timer Block Length : 00
+[0001]                GPE0 Block Length : 00
+[0001]                GPE1 Block Length : 00
+[0001]                 GPE1 Base Offset : 00
+[0001]                     _CST Support : 00
+[0002]                       C2 Latency : 0000
+[0002]                       C3 Latency : 0000
+[0002]                   CPU Cache Size : 0000
+[0002]               Cache Flush Stride : 0000
+[0001]                Duty Cycle Offset : 00
+[0001]                 Duty Cycle Width : 00
+[0001]              RTC Day Alarm Index : 00
+[0001]            RTC Month Alarm Index : 00
+[0001]                RTC Century Index : 00
+[0002]       Boot Flags (decoded below) : 0000
+          Legacy Devices Supported (V2) : 0
+       8042 Present on ports 60/64 (V2) : 0
+                   VGA Not Present (V4) : 0
+                 MSI Not Supported (V4) : 0
+           PCIe ASPM Not Supported (V4) : 0
+              CMOS RTC Not Present (V5) : 0
+[0001]                         Reserved : 00
+[0004]            Flags (decoded below) : 00001125
+ WBINVD instruction is operational (V1) : 1
+         WBINVD flushes all caches (V1) : 0
+               All CPUs support C1 (V1) : 1
+             C2 works on MP system (V1) : 0
+       Control Method Power Button (V1) : 0
+       Control Method Sleep Button (V1) : 1
+    RTC wake not in fixed reg space (V1) : 0
+       RTC can wake system from S4 (V1) : 0
+                   32-bit PM Timer (V1) : 1
+                 Docking Supported (V1) : 0
+          Reset Register Supported (V2) : 0
+                       Sealed Case (V3) : 0
+               Headless - No Video (V3) : 1
+   Use native instr after SLP_TYPx (V3) : 0
+         PCIEXP_WAK Bits Supported (V4) : 0
+                Use Platform Timer (V4) : 0
+          RTC_STS valid on S4 wake (V4) : 0
+           Remote Power-on capable (V4) : 0
+            Use APIC Cluster Model (V4) : 0
+Use APIC Physical Destination Mode (V4) : 0
+                  Hardware Reduced (V5) : 0
+                 Low Power S0 Idle (V5) : 0
+
+[0012]                   Reset Register : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0001]             Value to cause reset : 00
+[0002]        ARM Flags (decoded below) : 0000
+                         PSCI Compliant : 0
+                  Must use HVC for PSCI : 0
+
+[0001]              FADT Minor Revision : 00
+[0008]                     FACS Address : 0000000000000000
+[0008]                     DSDT Address : 0000000000000000
+[0012]                 PM1A Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                 PM1B Event Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1A Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]               PM1B Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                PM2 Control Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                   PM Timer Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE0 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000
+
+[0012]                       GPE1 Block : [Generic Address Structure]
+[0001]                         Space ID : 00 [SystemMemory]
+[0001]                        Bit Width : 00
+[0001]                       Bit Offset : 00
+[0001]             Encoded Access Width : 00 [Undefined/Legacy]
+[0008]                          Address : 0000000000000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/mcfg.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/mcfg.asl
@@ -1,0 +1,27 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [MCFG]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "MCFG"    [Memory Mapped Configuration table]
+[0004]                 Table Length : 0000003C
+[0001]                     Revision : 03
+[0001]                     Checksum : A5
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNMCFG"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]                     Reserved : 0000000000000000
+
+[0008]                 Base Address : 00000000E0000000
+[0002]         Segment Group Number : 0000
+[0001]             Start Bus Number : 00
+[0001]               End Bus Number : FF
+[0004]                     Reserved : 00000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/rsdp.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/rsdp.asl
@@ -1,0 +1,16 @@
+/*
+ * Intel ACPI Component Architecture
+ * iASL Compiler/Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * Template for [RSDP] ACPI Table (AML byte code table)
+ */
+[0008]                          Signature : "RSD PTR "
+[0001]                           Checksum : 43
+[0006]                             Oem ID : "ACRN  "
+[0001]                           Revision : 02
+[0004]                       RSDT Address : 0000000000000000
+[0004]                             Length : 00000024
+[0008]                       XSDT Address : 000000007FF00080
+[0001]                  Extended Checksum : DC
+[0003]                           Reserved : 000000

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/xsdt.asl
@@ -1,0 +1,23 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20190703 (64-bit version)
+ * Copyright (c) 2000 - 2019 Intel Corporation
+ *
+ * ACPI Data Table [XSDT]
+ *
+ * Format: [HexOffset DecimalOffset ByteLength]  FieldName : FieldValue
+ */
+
+[0004]                    Signature : "XSDT"    [Extended System Description Table]
+[0004]                 Table Length : 00000044
+[0001]                     Revision : 01
+[0001]                     Checksum : 75
+[0006]                       Oem ID : "ACRN  "
+[0008]                 Oem Table ID : "ACRNXSDT"
+[0004]                 Oem Revision : 00000001
+[0004]              Asl Compiler ID : "INTL"
+[0004]        Asl Compiler Revision : 20190703
+
+[0008]       ACPI Table Address   0 : 000000007FF00100
+[0008]       ACPI Table Address   1 : 000000007FF00300
+[0008]       ACPI Table Address   2 : 000000007FF00340


### PR DESCRIPTION
…d VMs

generate ASL code of ACPI tables for pre-launched VMs on nuc7i7dnb,
whl-ipc-i5, whl-ipc-i7, ehl-crb-b boards

Tracked-On: #5266

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>