### PR TITLE
acrn-config: add OTN1 device config in offline ACPI table

### DIFF
--- a/misc/acrn-config/acpi_gen/acpi_const.py
+++ b/misc/acrn-config/acpi_gen/acpi_const.py
@@ -22,10 +22,10 @@ ACPI_BASE = 0x7ff00000
 ACPI_RSDP_ADDR_OFFSET = 0x0         # (36 bytes fixed)
 ACPI_XSDT_ADDR_OFFSET = 0x80        # (36 bytes + 8*7 table addrs)
 ACPI_FADT_ADDR_OFFSET = 0x100       # (244 bytes)
-ACPI_MCFG_ADDR_OFFSET = 0x300       # (60 bytes)
-ACPI_MADT_ADDR_OFFSET = 0x340       # (depends on #CPUs)
-ACPI_TPM2_ADDR_OFFSET = 0x1000      # (52 bytes)
-ACPI_DSDT_ADDR_OFFSET = 0x200       # (variable - can go up to 0x100000)
+ACPI_DSDT_ADDR_OFFSET = 0x200       # (variable)
+ACPI_MCFG_ADDR_OFFSET = 0x400       # (60 bytes)
+ACPI_MADT_ADDR_OFFSET = 0x440       # (depends on #CPUs)
+ACPI_TPM2_ADDR_OFFSET = 0x1100      # (52 bytes)
 
 ACPI_RSDP_ADDR = (ACPI_BASE + ACPI_RSDP_ADDR_OFFSET)
 ACPI_XSDT_ADDR = (ACPI_BASE + ACPI_XSDT_ADDR_OFFSET)
@@ -47,3 +47,7 @@ VIOAPIC_BASE = 0xFEC00000
 
 ACPI_MADT_TYPE_LOCAL_APIC = 0
 ACPI_MADT_TYPE_LOCAL_APIC_NMI = 4
+
+TSN_DEVICE_LIST = ['8086:4ba0',
+                   '8086:4bb0',
+                   '8086:4b32']

--- a/misc/acrn-config/acpi_gen/bin_gen.py
+++ b/misc/acrn-config/acpi_gen/bin_gen.py
@@ -132,9 +132,19 @@ def check_iasl():
     :return: True if iasl installed.
     '''
     try:
-        output = subprocess.check_output(['iasl', '-h']).decode('utf8')
-        if 'Usage: iasl [Options] [Files]' in output:
-            return True
+        p_version = 'ASL+ Optimizing Compiler/Disassembler version'
+        min_version = 20190703
+        output = subprocess.check_output(['iasl', '-v']).decode('utf8')
+        if p_version in output:
+            try:
+                for line in output.split('\n'):
+                    if line.find(p_version) >= 0:
+                        version = int(line.split(p_version)[1].strip())
+                        if version >= min_version:
+                            return True
+            except:
+                pass
+            return False
         elif 'command not found' in output:
             return False
         else:
@@ -154,7 +164,7 @@ def main(args):
     else:
         DEST_ACPI_PATH = os.path.join(common.SOURCE_ROOT_DIR, args.asl, 'scenarios', scenario_name, board_type)
     if args.out is None:
-        DEST_ACPI_BIN_PATH = os.path.join(os.getcwd(), 'build', 'acpi')
+        DEST_ACPI_BIN_PATH = os.path.join(common.SOURCE_ROOT_DIR, 'build', 'hypervisor', 'acpi')
     else:
         DEST_ACPI_BIN_PATH = args.out
 
@@ -162,7 +172,7 @@ def main(args):
         shutil.rmtree(DEST_ACPI_BIN_PATH)
 
     if not check_iasl():
-        print("Please install iasl tool from https://www.acpica.org/downloads before ACPI generation.")
+        print("Please install iasl tool with version >= 20190703 from https://www.acpica.org/downloads before ACPI generation.")
         return 1
 
     for config in os.listdir(DEST_ACPI_PATH):
@@ -186,7 +196,7 @@ if __name__ == '__main__':
     parser.add_argument("--asl", default=None, help="the input folder to store the ACPI ASL code. "
                                                     "If not specified, the path for the ASL code is"
                                                     "misc/vm_configs/scenarios/[scenario]/[board]/")
-    parser.add_argument("--out", default="build/hypervisor/", help="the output folder to store the ACPI binary code. "
+    parser.add_argument("--out", default=None, help="the output folder to store the ACPI binary code. "
                                                     "If not specified, the path for the binary code is"
                                                     "build/acpi/")
 

--- a/misc/vm_configs/acpi/template/dsdt_tsn_otn1.asl
+++ b/misc/vm_configs/acpi/template/dsdt_tsn_otn1.asl
@@ -1,0 +1,64 @@
+/*
+ * Intel ACPI Component Architecture
+ * AML/ASL+ Disassembler version 20180105 (64-bit version)
+ * Copyright (c) 2000 - 2018 Intel Corporation
+ *
+ * Original Table Header:
+ *     Signature        "DSDT"
+ *     Length           0x00000102 (258)
+ *     Revision         0x03
+ *     Checksum         0x08
+ *     OEM ID           "ACRN  "
+ *     OEM Table ID     "ACRNDSDT"
+ *     OEM Revision     0x00000001 (1)
+ *     Compiler ID      "INTL"
+ *     Compiler Version 0x20180105 (538444037)
+ */
+DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
+{
+    Scope (_SB)
+    {
+        Device (OTN1)
+        {
+            Name (_ADR, 0x00020000)  // _ADR: Address
+            OperationRegion (TSRT, PCI_Config, Zero, 0x0100)
+            Field (TSRT, AnyAcc, NoLock, Preserve)
+            {
+                DVID,   16,
+                Offset (0x10),
+                TADL,   32,
+                TADH,   32
+            }
+        }
+
+        Device (PCS2)
+        {
+            Name (_HID, "INTC1033")  // _HID: Hardware ID
+            Name (_UID, Zero)  // _UID: Unique ID
+            Method (_STA, 0, NotSerialized)  // _STA: Status
+            {
+                Return (0x0F)
+            }
+
+            Method (_CRS, 0, Serialized)  // _CRS: Current Resource Settings
+            {
+                Name (PCSR, ResourceTemplate ()
+                {
+                    Memory32Fixed (ReadWrite,
+                        0x00000000,         // Address Base
+                        0x00000004,         // Address Length
+                        _Y00)
+                    Memory32Fixed (ReadWrite,
+                        0x00000000,         // Address Base
+                        0x00000004,         // Address Length
+                        _Y01)
+                })
+                CreateDWordField (PCSR, \_SB.PCS2._CRS._Y00._BAS, MAL0)  // _BAS: Base Address
+                MAL0 = ((^^OTN1.TADL & 0xFFFFF000) + 0x0200)
+                CreateDWordField (PCSR, \_SB.PCS2._CRS._Y01._BAS, MDL0)  // _BAS: Base Address
+                MDL0 = ((^^OTN1.TADL & 0xFFFFF000) + 0x0204)
+                Return (PCSR) /* \_SB_.PCS2._CRS.PCSR */
+            }
+        }
+    }
+}

--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/dsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/dsdt.asl
@@ -16,6 +16,51 @@
  */
 DefinitionBlock ("", "DSDT", 3, "ACRN  ", "ACRNDSDT", 0x00000001)
 {
+    Scope (_SB)
+    {
+        Device (OTN1)
+        {
+            Name (_ADR, 0x00020000)  // _ADR: Address
+            OperationRegion (TSRT, PCI_Config, Zero, 0x0100)
+            Field (TSRT, AnyAcc, NoLock, Preserve)
+            {
+                DVID,   16,
+                Offset (0x10),
+                TADL,   32,
+                TADH,   32
+            }
+        }
+
+        Device (PCS2)
+        {
+            Name (_HID, "INTC1033")  // _HID: Hardware ID
+            Name (_UID, Zero)  // _UID: Unique ID
+            Method (_STA, 0, NotSerialized)  // _STA: Status
+            {
+                Return (0x0F)
+            }
+
+            Method (_CRS, 0, Serialized)  // _CRS: Current Resource Settings
+            {
+                Name (PCSR, ResourceTemplate ()
+                {
+                    Memory32Fixed (ReadWrite,
+                        0x00000000,         // Address Base
+                        0x00000004,         // Address Length
+                        _Y00)
+                    Memory32Fixed (ReadWrite,
+                        0x00000000,         // Address Base
+                        0x00000004,         // Address Length
+                        _Y01)
+                })
+                CreateDWordField (PCSR, \_SB.PCS2._CRS._Y00._BAS, MAL0)  // _BAS: Base Address
+                MAL0 = ((^^OTN1.TADL & 0xFFFFF000) + 0x0200)
+                CreateDWordField (PCSR, \_SB.PCS2._CRS._Y01._BAS, MDL0)  // _BAS: Base Address
+                MDL0 = ((^^OTN1.TADL & 0xFFFFF000) + 0x0204)
+                Return (PCSR) /* \_SB_.PCS2._CRS.PCSR */
+            }
+        }
+    }
     Device (TPM)
     {
         Name (_HID, "MSFT0101" /* TPM 2.0 Security Device */)  // _HID: Hardware ID

--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/VM0/xsdt.asl
@@ -19,6 +19,6 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
-[0008]       ACPI Table Address   3 : 000000007FF01000
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440
+[0008]       ACPI Table Address   3 : 000000007FF01100

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/VM0/xsdt.asl
@@ -19,6 +19,6 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
-[0008]       ACPI Table Address   3 : 000000007FF01000
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440
+[0008]       ACPI Table Address   3 : 000000007FF01100

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/VM0/xsdt.asl
@@ -19,6 +19,6 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
-[0008]       ACPI Table Address   3 : 000000007FF01000
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440
+[0008]       ACPI Table Address   3 : 000000007FF01100

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/ehl-crb-b/VM1/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/nuc7i7dnb/VM1/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i5/VM1/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM0/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440

--- a/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/xsdt.asl
+++ b/misc/vm_configs/scenarios/logical_partition/whl-ipc-i7/VM1/xsdt.asl
@@ -19,5 +19,5 @@
 [0004]        Asl Compiler Revision : 20190703
 
 [0008]       ACPI Table Address   0 : 000000007FF00100
-[0008]       ACPI Table Address   1 : 000000007FF00300
-[0008]       ACPI Table Address   2 : 000000007FF00340
+[0008]       ACPI Table Address   1 : 000000007FF00400
+[0008]       ACPI Table Address   2 : 000000007FF00440


### PR DESCRIPTION
add TSN device OTN1 config into offline ACPI table for TSN device
passthrough to pre-launched RTVM.

Tracked-On: #5266

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>
