### PR TITLE
HV: correct hpa calculation for pre-launched VM

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -239,15 +239,17 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 					|| (entry->type == E820_TYPE_ACPI_NVS)) {
 				ept_add_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, base_hpa, entry->baseaddr,
 					entry->length, EPT_RWX | EPT_WB);
+				base_hpa += entry->length;
+				remaining_hpa_size -= entry->length;
 			}
 
 			/* GPAs under 1MB are always backed by physical memory */
 			if ((entry->type != E820_TYPE_RAM) && (entry->baseaddr < (uint64_t)MEM_1M)) {
 				ept_add_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, base_hpa, entry->baseaddr,
 					entry->length, EPT_RWX | EPT_UNCACHED);
+				base_hpa += entry->length;
+				remaining_hpa_size -= entry->length;
 			}
-			base_hpa += entry->length;
-			remaining_hpa_size -= entry->length;
 		} else if (entry->type == E820_TYPE_RAM) {
 			pr_warn("%s: HPA size incorrectly configured in v820\n", __func__);
 		}


### PR DESCRIPTION
The commit of da81a0041d72e78a340a183c6531e67e763c4efa
"HV: add e820 ACPI entry for pre-launched VM" introduced a issue that the
base_hpa and remaining_hpa_size are also calculated on the entry of 32bit
PCI hole which from 0x80000000 to 0xffffffff, which is incorrect;

Tracked-On: #5266

Signed-off-by: Victor Sun <victor.sun@intel.com>