### PR TITLE
acrn-config: fix the issue of generating the vuart with incorrect name

### DIFF
--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -10,7 +10,6 @@ import scenario_cfg_lib
 MISC_CFG_HEADER = """#ifndef MISC_CFG_H
 #define MISC_CFG_H"""
 
-NATIVE_TTYS_DIC = {}
 MISC_CFG_END = """#endif /* MISC_CFG_H */"""
 
 
@@ -21,83 +20,6 @@ class Vuart:
     v_type = {}
     v_base = {}
     v_irq = {}
-
-
-def get_valid_ttys_for_vuart(ttys_n):
-    """
-    Get available ttysn list for vuart0/vuart1
-    :param ttys_n: the serial port was chosen as hv console
-     """
-    vuart0_valid = []
-    vuart1_valid = ['ttyS0', 'ttyS1', 'ttyS2', 'ttyS3']
-    ttys_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<TTYS_INFO>", "</TTYS_INFO>")
-    if ttys_lines:
-        vuart0_valid.clear()
-        for tty_line in ttys_lines:
-            tmp_dic = {}
-            #seri:/dev/ttySx type:mmio base:0x91526000 irq:4 [bdf:"00:18.0"]
-            #seri:/dev/ttySy type:portio base:0x2f8 irq:5
-            tty = tty_line.split('/')[2].split()[0]
-            ttys_irq = tty_line.split()[3].split(':')[1].strip()
-            ttys_type = tty_line.split()[1].split(':')[1].strip()
-            tmp_dic['irq'] = int(ttys_irq)
-            tmp_dic['type'] = ttys_type
-            NATIVE_TTYS_DIC[tty] = tmp_dic
-            vuart0_valid.append(tty)
-            if tty and tty in vuart1_valid:
-                vuart1_valid.remove(tty)
-
-    if not vuart1_valid:
-        common.print_yel("ttyS are fully used. ttyS0 is used for hv_console, ttyS1 is used for vuart1!", warn=True)
-        vuart1_valid = ['ttyS0', 'ttyS1', 'ttyS2', 'ttyS3']
-        if ttys_n in vuart1_valid:
-            vuart1_valid.remove(ttys_n)
-
-    return (vuart0_valid, vuart1_valid)
-
-
-def get_vuart_settings():
-    """
-    Get vuart setting from scenario setting
-    :return: vuart0/vuart1 setting dictionary
-    """
-    err_dic = {}
-    vuart0_setting = {}
-    vuart1_setting = {}
-
-    (err_dic, ttys_n) = board_cfg_lib.parser_hv_console()
-    if err_dic:
-        return err_dic
-
-    if ttys_n:
-        (vuart0_valid, vuart1_valid) = get_valid_ttys_for_vuart(ttys_n)
-
-        # VUART0 setting
-        if ttys_n not in list(NATIVE_TTYS_DIC.keys()):
-            vuart0_setting['ttyS0'] = board_cfg_lib.alloc_irq()
-        else:
-            if int(NATIVE_TTYS_DIC[ttys_n]['irq']) >= 16:
-                vuart0_setting[ttys_n] = board_cfg_lib.alloc_irq()
-            else:
-                vuart0_setting[ttys_n] = NATIVE_TTYS_DIC[ttys_n]['irq']
-    else:
-        vuart1_valid = ['ttyS1']
-
-    # VUART1 setting
-    # The IRQ of vUART1(COM2) might be hard-coded by SOS ACPI table(i.e. host ACPI),
-    # so we had better follow native COM2 IRQ assignment for vUART1 if COM2 is a legacy ttyS,
-    # otherwise function of vUART1 would be failed. If host COM2 does not exist or it is a PCI ttyS,
-    # then we could allocate a free IRQ for vUART1.
-
-    if 'ttyS1' in NATIVE_TTYS_DIC.keys() \
-        and NATIVE_TTYS_DIC['ttyS1']['type'] == "portio" \
-        and 'irq' in list(NATIVE_TTYS_DIC['ttyS1'].keys()) \
-        and NATIVE_TTYS_DIC['ttyS1']['irq'] < 16:
-        vuart1_setting['ttyS1'] = NATIVE_TTYS_DIC['ttyS1']['irq']
-    else:
-        vuart1_setting[vuart1_valid[0]] = board_cfg_lib.alloc_irq()
-
-    return (err_dic, vuart0_setting, vuart1_setting)
 
 
 def sos_bootarg_diff(sos_cmdlines, config):
@@ -129,12 +51,12 @@ def parse_boot_info():
     if 'SOS_VM' in common.VM_TYPES.values():
         sos_cmdlines = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "board_private", "bootargs").values())
         sos_rootfs = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "board_private", "rootfs").values())
-        (err_dic, vuart0_dic, vuart1_dic) = get_vuart_settings()
+        (err_dic, vuart0_dic, vuart1_dic) = scenario_cfg_lib.get_sos_vuart_settings(launch_flag=False)
     else:
         sos_cmdlines = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "os_config", "bootargs").values())
 
         sos_rootfs = list(common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "os_config", "rootfs").values())
-        (err_dic, vuart0_dic, vuart1_dic) = get_vuart_settings()
+        (err_dic, vuart0_dic, vuart1_dic) = scenario_cfg_lib.get_sos_vuart_settings(launch_flag=False)
 
     return (err_dic, sos_cmdlines, sos_rootfs, vuart0_dic, vuart1_dic)
 

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -587,7 +587,8 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
                 err_key = "uos:id={}:poweroff_channel".format(vmid)
                 launch_cfg_lib.ERR_LIST[err_key] = "vuart1 of VM{} in scenario file should select 'SOS_COM2_BASE'".format(sos_vmid + vmid)
                 return
-        print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
+        scenario_cfg_lib.get_sos_vuart_settings()
+        print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
 
     # set logger_setting for all VMs
     print("   $logger_setting \\", file=config)

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -49,7 +49,7 @@ PM_CHANNEL_DIC = {
     'IOC':'--pm_notify_channel ioc',
     'PowerButton':'--pm_notify_channel power_button',
     'vuart1(pty)':'--pm_notify_channel uart \\\n   --pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
-    'vuart1(tty)':'--pm_notify_channel uart --pm_by_vuart tty,/dev/ttyS1',
+    'vuart1(tty)':'--pm_notify_channel uart --pm_by_vuart tty,/dev/',
 }
 
 MOUNT_FLAG_DIC = {}

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -8,6 +8,8 @@ import common
 import board_cfg_lib
 
 HEADER_LICENSE = common.open_license()
+SOS_UART1_VALID_NUM = ""
+NATIVE_TTYS_DIC = {}
 
 START_HPA_LIST = ['0', '0x100000000', '0x120000000']
 
@@ -859,3 +861,89 @@ def check_pt_intx(phys_gsi, virt_gsi):
         if not all(pin < 120 for pin in v):
             ERR_LIST["vm:id=0,pt_intx"] = "virt_gsi must be less than 120"
             return
+
+
+def get_valid_ttys_for_sos_vuart(ttys_n):
+    """
+    Get available ttysn list for vuart0/vuart1
+    :param ttys_n: the serial port was chosen as hv console
+     """
+    vuart0_valid = []
+    vuart1_valid = ['ttyS0', 'ttyS1', 'ttyS2', 'ttyS3']
+    ttys_lines = board_cfg_lib.get_info(common.BOARD_INFO_FILE, "<TTYS_INFO>", "</TTYS_INFO>")
+    if ttys_lines:
+        vuart0_valid.clear()
+        for tty_line in ttys_lines:
+            tmp_dic = {}
+            #seri:/dev/ttySx type:mmio base:0x91526000 irq:4 [bdf:"00:18.0"]
+            #seri:/dev/ttySy type:portio base:0x2f8 irq:5
+            tty = tty_line.split('/')[2].split()[0]
+            ttys_irq = tty_line.split()[3].split(':')[1].strip()
+            ttys_type = tty_line.split()[1].split(':')[1].strip()
+            tmp_dic['irq'] = int(ttys_irq)
+            tmp_dic['type'] = ttys_type
+            NATIVE_TTYS_DIC[tty] = tmp_dic
+            vuart0_valid.append(tty)
+            if tty and tty in vuart1_valid:
+                vuart1_valid.remove(tty)
+
+    if not vuart1_valid:
+        common.print_yel("ttyS are fully used. ttyS0 is used for hv_console, ttyS1 is used for vuart1!", warn=True)
+        vuart1_valid = ['ttyS0', 'ttyS1', 'ttyS2', 'ttyS3']
+        if ttys_n in vuart1_valid:
+            vuart1_valid.remove(ttys_n)
+
+    return (vuart0_valid, vuart1_valid)
+
+
+def get_sos_vuart_settings(launch_flag=True):
+    """
+    Get vuart setting from scenario setting
+    :return: vuart0/vuart1 setting dictionary
+    """
+    global SOS_UART1_VALID_NUM
+    err_dic = {}
+    vuart0_setting = {}
+    vuart1_setting = {}
+
+    (err_dic, ttys_n) = board_cfg_lib.parser_hv_console()
+    if err_dic:
+        if launch_flag:
+            SOS_UART1_VALID_NUM += "ttyS1"
+            return
+        return err_dic
+
+    if ttys_n:
+        (vuart0_valid, vuart1_valid) = get_valid_ttys_for_sos_vuart(ttys_n)
+
+        # VUART0 setting
+        if not launch_flag:
+            if ttys_n not in list(NATIVE_TTYS_DIC.keys()):
+                vuart0_setting['ttyS0'] = board_cfg_lib.alloc_irq()
+            else:
+                if int(NATIVE_TTYS_DIC[ttys_n]['irq']) >= 16:
+                    vuart0_setting[ttys_n] = board_cfg_lib.alloc_irq()
+                else:
+                    vuart0_setting[ttys_n] = NATIVE_TTYS_DIC[ttys_n]['irq']
+    else:
+        vuart1_valid = ['ttyS1']
+
+    if launch_flag:
+        SOS_UART1_VALID_NUM += vuart1_valid[0]
+        return
+
+    # VUART1 setting
+    # The IRQ of vUART1(COM2) might be hard-coded by SOS ACPI table(i.e. host ACPI),
+    # so we had better follow native COM2 IRQ assignment for vUART1 if COM2 is a legacy ttyS,
+    # otherwise function of vUART1 would be failed. If host COM2 does not exist or it is a PCI ttyS,
+    # then we could allocate a free IRQ for vUART1.
+
+    if 'ttyS1' in NATIVE_TTYS_DIC.keys() \
+        and NATIVE_TTYS_DIC['ttyS1']['type'] == "portio" \
+        and 'irq' in list(NATIVE_TTYS_DIC['ttyS1'].keys()) \
+        and NATIVE_TTYS_DIC['ttyS1']['irq'] < 16:
+        vuart1_setting['ttyS1'] = NATIVE_TTYS_DIC['ttyS1']['irq']
+    else:
+        vuart1_setting[vuart1_valid[0]] = board_cfg_lib.alloc_irq()
+
+    return (err_dic, vuart0_setting, vuart1_setting)


### PR DESCRIPTION
When generate the launch scripts, the pm_by_vuart setting of pm_notify_channel
in launch setting should be according to the config of SOS vuart1.

Tracked-On: #5154