### PR TITLE
doc: Add note about the maximum number of regions for hv-land

### DIFF
--- a/doc/tutorials/enable_ivshmem.rst
+++ b/doc/tutorials/enable_ivshmem.rst
@@ -62,6 +62,8 @@ enable it using the  :ref:`acrn_configuration_tool` with these steps:
 	   communication and separate it with ``:``. For example, the
 	   communication between VM0 and VM2, it can be written as ``0:2``
 
+   .. note:: You can define up to eight ``ivshmem`` hv-land shared regions.
+
 - Build the XML configuration, refer to :ref:`getting-started-building`
 
 Inter-VM Communication Examples


### PR DESCRIPTION
The maximum number of ivshmem shared memory regions cannot exceed 8

Signed-off-by: Yuan Liu <yuan1.liu@intel.com>