### PR TITLE
acrn-config: make ivshmem size configured in decimal and MB

### DIFF
--- a/misc/acrn-config/hv_config/board_defconfig.py
+++ b/misc/acrn-config/hv_config/board_defconfig.py
@@ -93,10 +93,7 @@ def get_memory(hv_info, config):
                     and raw_shm_splited[1].strip() != '' and len(raw_shm_splited[2].strip().split(':')) >= 1:
                 try:
                     size = raw_shm_splited[1].strip()
-                    if size.isdecimal():
-                        int_size = int(size)
-                    else:
-                        int_size = int(size, 16)
+                    int_size = int(size) * 0x100000
                     total_shm_size += int_size
                 except Exception as e:
                     print(e)

--- a/misc/acrn-config/library/board_cfg_lib.py
+++ b/misc/acrn-config/library/board_cfg_lib.py
@@ -34,7 +34,7 @@ KNOWN_HIDDEN_PDEVS_BOARD_DB = {
 TSN_DEVS = ["8086:4b30", "8086:4b31", "8086:4b32", "8086:4ba0", "8086:4ba1", "8086:4ba2",
             "8086:4bb0", "8086:4bb1", "8086:4bb2", "8086:a0ac", "8086:43ac", "8086:43a2"]
 GPIO_DEVS = ["8086:4b88", "8086:4b89"]
-TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7', 'tgl-rvp', 'ehl-crb-b']
+TPM_PASSTHRU_BOARD = ['whl-ipc-i5', 'whl-ipc-i7', 'tgl-rvp']
 
 KNOWN_CAPS_PCI_DEVS_DB = {
     "VMSIX":TSN_DEVS + GPIO_DEVS,
@@ -496,10 +496,10 @@ def parse_mem():
         name = shm_splited[0].strip()
         size = shm_splited[1].strip()
 
-        if size.isdecimal():
-            int_size = int(size)
-        else:
-            int_size = int(size, 16)
+        try:
+            int_size = int(size) * 0x100000
+        except:
+            int_size = 0
         ram_range = get_ram_range()
         tmp_bar_dict  = {}
         hv_start_offset = 0x80000000

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -591,13 +591,9 @@ def set_shm_regions(launch_item_values, scenario_info):
                         shm_splited = shmem_region.split(',')
                         name = shm_splited[0].strip()
                         size = shm_splited[1].strip()
-                        if size.isdecimal():
-                            int_size = int(size)
-                        else:
-                            int_size = int(size, 16)
                         vm_id_list = [x.strip() for x in shm_splited[2].split(':')]
                         if str(vm_id) in vm_id_list:
-                            launch_item_values[shm_region_key].append(','.join([name, str(int_size)]))
+                            launch_item_values[shm_region_key].append(','.join([name, size]))
                     except Exception as e:
                         print(e)
 
@@ -609,9 +605,7 @@ def check_shm_regions(launch_shm_regions, scenario_info):
     for uos_id, shm_regions in launch_shm_regions.items():
         shm_region_key = 'uos:id={},shm_regions,shm_region'.format(uos_id)
         for shm_region in shm_regions:
-            print(shm_region)
-            print(launch_item_values[shm_region_key])
             if shm_region_key not in launch_item_values.keys() or shm_region not in launch_item_values[shm_region_key]:
                 ERR_LIST[shm_region_key] = "shm {} should be configured in scenario setting and the size should be decimal" \
-                                           " and spaces should not exist.".format(shm_region)
+                                           "in MB and spaces should not exist.".format(shm_region)
                 return

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -735,7 +735,7 @@ def share_mem_check(shmem_regions, raw_shmem_regions, vm_type_info, prime_item, 
             try:
                 curr_vm_id = int(shm_i)
             except:
-                ERR_LIST[key] = "share memory region should be configured with format like this: hv:/shm_region_0, 0x200000, 0:2"
+                ERR_LIST[key] = "The shared memory region should be configured with format like this: hv:/shm_region_0, 2, 0:2"
                 return
             name = shm_str_splited[0].strip()
             size = shm_str_splited[1].strip()
@@ -770,15 +770,12 @@ def share_mem_check(shmem_regions, raw_shmem_regions, vm_type_info, prime_item, 
 
             int_size = 0
             try:
-                if size.isdecimal():
-                    int_size = int(size)
-                else:
-                    int_size = int(size, 16)
+                int_size = int(size) * 0x100000
             except:
-                ERR_LIST[key] = "The size of share Memory region should be decimal or hexadecimal."
+                ERR_LIST[key] = "The size of the shared memory region should be a decimal number."
                 return
             if int_size < 0x200000 or int_size > 0x20000000:
-                ERR_LIST[key] = "The size of share Memory region should be in [2MB, 512MB]."
+                ERR_LIST[key] = "The size of the shared memory region should be in the range of [2MB, 512MB]."
                 return
             if not ((int_size & (int_size-1) == 0) and int_size != 0):
                 ERR_LIST[key] = "The size of share Memory region should be a power of 2."

--- a/misc/acrn-config/scenario_config/ivshmem_cfg_h.py
+++ b/misc/acrn-config/scenario_config/ivshmem_cfg_h.py
@@ -54,10 +54,7 @@ def write_shmem_regions(config):
             int_size = 0
             size = shmem_region[1]
             try:
-                if size.isdecimal():
-                    int_size = int(size)
-                else:
-                    int_size = int(size, 16)
+                int_size = int(size) * 0x100000
             except Exception as e:
                 print('the format of shm size error: ', str(e))
             total_shm_size += int_size
@@ -75,13 +72,10 @@ def write_shmem_regions(config):
             print("\t{ \\", file=config)
             print('\t\t.name = IVSHMEM_SHM_REGION_{}, \\'.format(shmem_cnt), file=config)
             try:
-                if shmem[1].isdecimal():
-                    int_m_size = int(int(shmem[1])/0x100000)
-                else:
-                    int_m_size = int(int(shmem[1], 16)/0x100000)
+                int_size = int(shmem[1]) * 0x100000
             except:
-                int_m_size = 0
-            print('\t\t.size = {}UL,\t\t/* {}M */ \\'.format(shmem[1], int_m_size), file=config)
+                int_size = 0
+            print('\t\t.size = {}UL,\t\t/* {}M */ \\'.format(hex(int_size), shmem[1]), file=config)
             if shmem_cnt < len(shmem_regions) - 1:
                 print("\t}, \\", file=config)
             else:

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
        <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -41,7 +41,7 @@
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
                 <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -41,7 +41,7 @@
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
                 <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
+                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
@@ -41,7 +41,7 @@
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
                 <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -41,7 +41,7 @@
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
                 <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_vxworks.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_waag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_6uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -86,8 +86,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-	    <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		    <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	    <shm_regions desc="List of shared memory regions for inter-VM communication.">
+		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -122,8 +122,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		    <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -158,8 +158,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -194,8 +194,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -41,7 +41,7 @@
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
                 <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -41,7 +41,7 @@
             <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
             <IVSHMEM desc="IVSHMEM configuration">
                 <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_zephyr.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -27,7 +27,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -27,7 +27,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/generic/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry.xml
@@ -27,7 +27,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -48,8 +48,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
@@ -27,7 +27,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
@@ -27,7 +27,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>
@@ -50,8 +50,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_6uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>
@@ -50,8 +50,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>
@@ -88,8 +88,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -124,8 +124,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -160,8 +160,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -196,8 +196,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-	    <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		    <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	    <shm_regions desc="List of shared memory regions for inter-VM communication.">
+		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_6uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -86,8 +86,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -122,8 +122,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -158,8 +158,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -194,8 +194,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/template/HV.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/HV.xml
@@ -27,7 +27,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_RT_VM.xml
@@ -11,8 +11,8 @@
 		<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 			<pcpu_id></pcpu_id>
 		</cpu_affinity>
-		<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-			<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+		<shm_regions desc="List of shared memory regions for inter-VM communication.">
+			<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 		</shm_regions>
 
 		<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_STD_VM.xml
@@ -11,8 +11,8 @@
 		<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 			<pcpu_id></pcpu_id>
 		</cpu_affinity>
-		<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-			<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+		<shm_regions desc="List of shared memory regions for inter-VM communication.">
+			<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 		</shm_regions>
 
 		<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_1uos_waag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_zephyr.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_6uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -86,8 +86,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -122,8 +122,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -158,8 +158,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		    <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -194,8 +194,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2">hv:/shm_region_0, 0x200000, 0:2</IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_6uos.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -49,8 +49,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -86,8 +86,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -122,8 +122,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -158,8 +158,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
@@ -194,8 +194,8 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
         </cpu_affinity>
-        <shm_regions desc="List of shared memrory regions for inter-VM communication.">
-            <shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -25,7 +25,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -29,7 +29,7 @@
         <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
         <IVSHMEM desc="IVSHMEM configuration">
             <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the name, size, colon separated IDs of communication VMs of share memory region, separated by comma like this: hv:/shm_region_0, 0x200000, 0:2"></IVSHMEM_REGION>
+            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -11,8 +11,8 @@
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
-	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
-		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
 
 	<passthrough_devices>


### PR DESCRIPTION
make ivshmem size configured in decimal and MB in config tool UI and XMLs to simplify input from users.

Tracked-On: #4853

Signed-off-by: Shuang Zheng shuang.zheng@intel.com
Acked-by: Victor Sun victor.sun@intel.com