### PR TITLE
hv: remove UNCACHED for pSRAM EPT memmap segment

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -89,6 +89,7 @@ bool stdio_in_use;
 bool lapic_pt;
 bool is_rtvm;
 bool pt_tpm2;
+bool pt_ptct;
 bool is_winvm;
 bool skip_pci_mem64bar_workaround = false;
 

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -145,7 +145,7 @@ usage(int code)
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
 		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--debugexit] \n"
 		"       %*s [--logger-setting param_setting] [--pm_notify_channel]\n"
-		"       %*s [--psram psram_size]\n"
+		"       %*s [--psram]\n"
 		"       %*s [--pm_by_vuart vuart_node] <vm>\n"
 		"       -A: create ACPI tables\n"
 		"       -B: bootargs for kernel\n"
@@ -168,7 +168,7 @@ usage(int code)
 		"       --dump: show build-in VM configurations\n"
 #endif
 		"       --vsbl: vsbl file path\n"
-		"       --psram: <psram_size in MB> Allocate pSRAM of psram_size MB for this VM. This VM must be an RTVM\n"
+		"       --psram: Enable support for pSRAM for this VM. This VM must be an RTVM\n"
 		"       --ovmf: ovmf file path\n"
 		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
 		"       --part_info: guest partition info file path\n"
@@ -794,7 +794,7 @@ static struct option long_options[] = {
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
 	{"lapic_pt",		no_argument,		0, CMD_OPT_LAPIC_PT},
 	{"rtvm",		no_argument,		0, CMD_OPT_RTVM},
-	{"psram",                no_argument,            0, CMD_OPT_PSRAM}, /* TODO: Need argument*/
+	{"psram",		no_argument,		0, CMD_OPT_PSRAM},
 	{"logger_setting",	required_argument,	0, CMD_OPT_LOGGER_SETTING},
 	{"pm_notify_channel",	required_argument,	0, CMD_OPT_PM_NOTIFY_CHANNEL},
 	{"pm_by_vuart",	required_argument,	0, CMD_OPT_PM_BY_VUART},
@@ -939,6 +939,7 @@ main(int argc, char *argv[])
 			is_rtvm = true;
 			break;
 		case CMD_OPT_PSRAM:
+			/* TODO: we need to support parameter to specify pSRAM size in the future */
 			pt_ptct = true;
 			break;
 		case CMD_OPT_ACPIDEV_PT:

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -145,6 +145,7 @@ usage(int code)
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
 		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--debugexit] \n"
 		"       %*s [--logger-setting param_setting] [--pm_notify_channel]\n"
+		"       %*s [--psram psram_size]\n"
 		"       %*s [--pm_by_vuart vuart_node] <vm>\n"
 		"       -A: create ACPI tables\n"
 		"       -B: bootargs for kernel\n"
@@ -167,6 +168,7 @@ usage(int code)
 		"       --dump: show build-in VM configurations\n"
 #endif
 		"       --vsbl: vsbl file path\n"
+		"       --psram: <psram_size in MB> Allocate pSRAM of psram_size MB for this VM. This VM must be an RTVM\n"
 		"       --ovmf: ovmf file path\n"
 		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
 		"       --part_info: guest partition info file path\n"
@@ -185,7 +187,7 @@ usage(int code)
 		"       --pm_by_vuart:pty,/run/acrn/vuart_vmname or tty,/dev/ttySn\n"
 		"       --windows: support Oracle virtio-blk, virtio-net and virtio-input devices\n"
 		"            for windows guest with secure boot\n",
-		progname, (int)strnlen(progname, PATH_MAX), "",
+		progname, (int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
@@ -750,6 +752,7 @@ enum {
 	CMD_OPT_VTPM2,
 	CMD_OPT_LAPIC_PT,
 	CMD_OPT_RTVM,
+	CMD_OPT_PSRAM,
 	CMD_OPT_LOGGER_SETTING,
 	CMD_OPT_PM_NOTIFY_CHANNEL,
 	CMD_OPT_PM_BY_VUART,
@@ -791,6 +794,7 @@ static struct option long_options[] = {
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
 	{"lapic_pt",		no_argument,		0, CMD_OPT_LAPIC_PT},
 	{"rtvm",		no_argument,		0, CMD_OPT_RTVM},
+	{"psram",                no_argument,            0, CMD_OPT_PSRAM}, /* TODO: Need argument*/
 	{"logger_setting",	required_argument,	0, CMD_OPT_LOGGER_SETTING},
 	{"pm_notify_channel",	required_argument,	0, CMD_OPT_PM_NOTIFY_CHANNEL},
 	{"pm_by_vuart",	required_argument,	0, CMD_OPT_PM_BY_VUART},
@@ -933,6 +937,9 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_RTVM:
 			is_rtvm = true;
+			break;
+		case CMD_OPT_PSRAM:
+			pt_ptct = true;
 			break;
 		case CMD_OPT_ACPIDEV_PT:
 			if (parse_pt_acpidev(optarg) != 0)

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -268,6 +268,9 @@ acrn_create_e820_table(struct vmctx *ctx, struct e820_entry *e820)
 			removed++;
 		}
 	} else {
+		/* Fix-Me: e820[LOWRAM_E820_ENTRY+2] can be used as RAM 
+			only when ctx->lowmem is higher than PSRAM area.
+			also, the length should be adjusted to ctx->lowmem-baseaddr */
 		e820[LOWRAM_E820_ENTRY+2].type = E820_TYPE_RAM;
 	}
 

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -271,7 +271,10 @@ acrn_create_e820_table(struct vmctx *ctx, struct e820_entry *e820)
 		/* Fix-Me: e820[LOWRAM_E820_ENTRY+2] can be used as RAM 
 			only when ctx->lowmem is higher than PSRAM area.
 			also, the length should be adjusted to ctx->lowmem-baseaddr */
+		/* TODO: this is a temporary workaround. needs further refine to remove the >=2G restriction */
+		assert(ctx->lowmem >= 2 * GB);
 		e820[LOWRAM_E820_ENTRY+2].type = E820_TYPE_RAM;
+
 	}
 
 	/* remove [5GB, highmem) if it's empty */

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -1093,8 +1093,9 @@ int create_and_inject_vptct(struct vmctx *ctx)
 		.type = VM_MMIO,
 		.gpa = PSRAM_BASE_GPA,
 		.hpa = PSRAM_BASE_HPA,
-		/* TODO: the .len should be set as the psram_size passed-in via the DM argument "psram <psram_size>"*/
-		.len = 0x208000UL,
+		/* Extra 32 KB is for PTCM binary image*/
+		/* TODO: .len should be psram_size+32kb. we need to modify guest E820 to adapt to real config */
+		.len = 0x400000U + 32 * KB,
 		.prot = PROT_ALL
 	};
 

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -85,7 +85,8 @@
 #define FACS_OFFSET		0x3C0
 #define NHLT_OFFSET		0x400
 #define TPM2_OFFSET		0xC00
-#define DSDT_OFFSET		0xE40
+#define PTCT_OFFSET		0xF00
+#define DSDT_OFFSET		0x1100
 
 #define	ASL_TEMPLATE	"dm.XXXXXXX"
 #define ASL_SUFFIX	".aml"
@@ -186,6 +187,11 @@ basl_fwrite_rsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
+	if (pt_ptct) {
+		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
+			    basl_acpi_base + PTCT_OFFSET);
+	}
+
 	EFFLUSH(fp);
 
 	return 0;
@@ -227,6 +233,11 @@ basl_fwrite_xsdt(FILE *fp, struct vmctx *ctx)
 	if (ctx->tpm_dev || pt_tpm2)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
+
+	if (pt_ptct) {
+		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
+			    basl_acpi_base + PTCT_OFFSET);
+	}
 
 	EFFLUSH(fp);
 
@@ -1064,6 +1075,41 @@ static struct {
 	{ basl_fwrite_dsdt, DSDT_OFFSET, true  }
 };
 
+int create_and_inject_vptct(struct vmctx *ctx)
+{
+#define PTCT_NATIVE_FILE_PATH_IN_SOS "/sys/firmware/acpi/tables/PTCT"
+#define PTCT_BUF_LEN	0x200	/* Otherwise, need to modify DSDT_OFFSET corresponding */
+	int native_ptct_fd;
+	int rc;
+	size_t native_ptct_len;
+	size_t vptct_len;
+	uint8_t buf[PTCT_BUF_LEN] = {0};
+
+	native_ptct_fd = open(PTCT_NATIVE_FILE_PATH_IN_SOS, O_RDONLY);
+	if (native_ptct_fd < 0){
+		pr_err("failed to open /sys/firmware/acpi/tables/PTCT !!!!! errno:%d\n", errno);
+		return -1;
+	}
+	native_ptct_len = lseek(native_ptct_fd, 0, SEEK_END);
+	if (native_ptct_len > PTCT_BUF_LEN) {
+		pr_err("%s native_ptct_len = %d large than PTCT_BUF_LEN\n", __func__, native_ptct_len);
+		return -1;
+	}
+
+	(void)lseek(native_ptct_fd, 0, SEEK_SET);
+	rc = read(native_ptct_fd, buf, native_ptct_len);
+	if (rc < native_ptct_len ){
+		pr_err("Native PTCT is not fully read into buf!!!");
+		return -1;
+	}
+	close(native_ptct_fd);
+
+	vptct_len = native_ptct_len;
+
+	memcpy(vm_map_gpa(ctx, ACPI_BASE + PTCT_OFFSET, vptct_len), buf, vptct_len);
+	return 0;
+};
+
 void
 acpi_table_enable(int num)
 {
@@ -1132,6 +1178,10 @@ acpi_build(struct vmctx *ctx, int ncpu)
 			err = basl_compile(ctx, basl_ftables[i].wsect,
 					basl_ftables[i].offset);
 		i++;
+	}
+
+	if (pt_ptct) {
+		create_and_inject_vptct(ctx);
 	}
 
 	return err;

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -49,6 +49,7 @@ extern char *mac_seed;
 extern bool lapic_pt;
 extern bool is_rtvm;
 extern bool pt_tpm2;
+extern bool pt_ptct;
 extern bool is_winvm;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,

--- a/devicemodel/include/ptct.h
+++ b/devicemodel/include/ptct.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PTCT_H
+#define PTCT_H
+
+#define PSRAM_BASE_HPA	0x40080000UL
+#define PSRAM_BASE_GPA	0x40080000UL
+#define PSRAM_MAX_SIZE	0x00800000UL
+
+#endif  /* PTCT_H */

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        10
+#define NUM_E820_ENTRIES        11
 #define LOWRAM_E820_ENTRY       2
-#define HIGHRAM_E820_ENTRY      9
+#define HIGHRAM_E820_ENTRY      10
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -213,6 +213,7 @@ ifeq ($(CONFIG_MULTIBOOT2),y)
 BOOT_C_SRCS += boot/multiboot2.c
 endif
 BOOT_C_SRCS += boot/reloc.c
+BOOT_C_SRCS += arch/x86/ptcm.c
 
 # hardware management component
 HW_S_SRCS += arch/x86/idt.S

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -276,6 +276,15 @@ config CDP_ENABLED
 	  prioritization of code and data fetches to the L2 or L3 cache in a
 	  software configurable manner, depending on hardware support.
 
+config PTCM_ENABLED
+	bool "Enable PTCM (Platform Tuning Configuration Manager)"
+	depends on !CDP_ENABLED
+	default y
+	help
+	  PCTM supports RTVM to make use of pSRAM to improve the performance
+	  of RT APPs. pSRAM is a block of cache, which is separated and protected by
+	  CAT and other methods. PTCM and CDP cannot be co-existing.
+
 config GPU_SBDF
 	hex "Segment, Bus, Device, and function of the GPU"
 	depends on ACPI_PARSE_ENABLED

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -28,7 +28,7 @@
 #include <sgx.h>
 #include <uart16550.h>
 #include <ivshmem.h>
-#include <ptct.h>
+#include <ptcm.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -28,6 +28,7 @@
 #include <sgx.h>
 #include <uart16550.h>
 #include <ivshmem.h>
+#include <ptct.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
@@ -267,10 +268,14 @@ void init_pcpu_post(uint16_t pcpu_id)
 		}
 
 		ASSERT(get_pcpu_id() == BSP_CPU_ID, "");
+
+		init_psram(true);
 	} else {
 		pr_dbg("Core %hu is up", pcpu_id);
 
 		pr_warn("Skipping VM configuration check which should be done before building HV binary.");
+
+		init_psram(false);
 
 		/* Initialize secondary processor interrupts. */
 		init_interrupt(pcpu_id);

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -15,6 +15,7 @@
 #include <vtd.h>
 #include <logmsg.h>
 #include <trace.h>
+#include <ptct.h>
 
 #define DBG_LEVEL_EPT	6U
 
@@ -170,14 +171,39 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t 
  */
 void ept_flush_leaf_page(uint64_t *pge, uint64_t size)
 {
-	uint64_t hpa = INVALID_HPA;
+	uint64_t hpa = INVALID_HPA, hpa_end;
 	void *hva = NULL;
+	uint64_t flush_size = size;
 
 	if ((*pge & EPT_MT_MASK) != EPT_UNCACHED) {
 		hpa = (*pge & (~(size - 1UL)));
+		hpa_end = hpa + size;
+
+		if (hpa < psram_area_bottom) {
+			if (hpa_end > psram_area_top) {
+				flush_size = psram_area_bottom - hpa;
+				hva = hpa2hva(hpa);
+				stac();
+				flush_address_space(hva, flush_size);
+				clac();
+
+				flush_size = hpa_end - psram_area_top;
+				hpa = psram_area_top;
+			} else if (hpa_end > psram_area_bottom) {
+				flush_size = psram_area_bottom - hpa;
+			}
+		} else if (hpa < psram_area_top) {
+			if (hpa_end <= psram_area_top) {
+				flush_size = 0UL;
+			} else {
+				hpa = psram_area_top;
+				flush_size = hpa_end - psram_area_top;
+			}
+		}
+
 		hva = hpa2hva(hpa);
 		stac();
-		flush_address_space(hva, size);
+		flush_address_space(hva, flush_size);
 		clac();
 	}
 }

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -216,7 +216,9 @@ void init_paging(void)
 	uint32_t i;
 	uint64_t low32_max_ram = 0UL;
 	uint64_t high64_max_ram;
-	uint64_t attr_uc = (PAGE_PRESENT | PAGE_RW | PAGE_USER | PAGE_CACHE_UC | PAGE_NX);
+	//uint64_t attr_uc = (PAGE_PRESENT | PAGE_RW | PAGE_USER | PAGE_CACHE_UC | PAGE_NX);
+	/* FIXME: use IA32_EFER.NXE to fix this issue */
+	uint64_t attr_uc = (PAGE_PRESENT | PAGE_RW | PAGE_USER | PAGE_CACHE_UC);
 
 	const struct e820_entry *entry;
 	uint32_t entries_count = get_e820_entries_count();

--- a/hypervisor/arch/x86/ptcm.c
+++ b/hypervisor/arch/x86/ptcm.c
@@ -6,6 +6,7 @@
 #include <types.h>
 #include <logmsg.h>
 #include <misc_cfg.h>
+#include <mmu.h>
 #include <ptcm.h>
 
 uint64_t psram_area_bottom;
@@ -26,29 +27,26 @@ static void parse_ptct(void)
 	struct ptcm_mem_region *p_mem_region;
 	struct ptct_entry_data_psram *psram_entry;
 	struct ptct_entry_data_ptcm_binary* ptcm_binary_entry;
-	struct acpi_table_ptct* acpi_ptct = ((struct acpi_table_ptct *)get_acpi_tbl(ACPI_SIG_PTCT));
-	pr_fatal("find PTCT subtable in HPA %llx, length: %d", acpi_ptct, acpi_ptct->header.length);
+	struct acpi_table_ptct* acpi_ptct = (struct acpi_table_ptct *)get_acpi_tbl(ACPI_SIG_PTCT);
+	pr_info("found PTCT subtable in HPA %llx, length: %d", acpi_ptct, acpi_ptct->header.length);
 
 	entry = &acpi_ptct->ptct_first_entry;	//&acpi_ptct->ptct_entries[0];
-	pr_fatal("find PTCT base entry, in HPA %llx", entry);
 
 	psram_area_bottom = PSRAM_BASE_HPA;
 
 	while (((uint64_t)entry - (uint64_t)acpi_ptct) < acpi_ptct->header.length) {
 		switch (entry->type) {
 		case PTCT_ENTRY_TYPE_PTCM_BINARY:
-			pr_fatal("PTCT_ENTRY_TYPE_PTCM_BINARY");
 			ptcm_binary_entry = (struct ptct_entry_data_ptcm_binary *)entry->data;
 			ptcm_binary.address = ptcm_binary_entry->address;
 			ptcm_binary.size = ptcm_binary_entry->size;
 			if (psram_area_top < ptcm_binary.address + ptcm_binary.size) {
 				psram_area_top = ptcm_binary.address + ptcm_binary.size;
 			}
-			pr_fatal("find PTCM bin, in HPA %llx, size %llx", ptcm_binary.address, ptcm_binary.size);
+			pr_info("found PTCM bin, in HPA %llx, size %llx", ptcm_binary.address, ptcm_binary.size);
 			break;
 		
 		case PTCT_ENTRY_TYPE_PSRAM:
-			pr_fatal("PTCT_ENTRY_TYPE_PSRAM");
 			psram_entry = (struct ptct_entry_data_psram *)entry->data;
 			if (psram_entry->apic_id_0 >= MAX_PCPU_NUM) {
 				break;
@@ -57,7 +55,7 @@ static void parse_ptct(void)
 			p_mem_region = &ptcm_mem_regions[psram_entry->apic_id_0];
 			if (psram_entry->cache_level == 3) {
 				if (l3_psram_regions_count >= MAX_L3_PSRAM_REGIONS){
-					pr_fatal("Too many L3 regions!");
+					pr_err("Too many L3 regions!");
 					break;
 				}
 
@@ -71,10 +69,10 @@ static void parse_ptct(void)
 					psram_area_top = p_mem_region->l3_base + p_mem_region->l3_size;
 				}
 				l3_psram_regions_count++;
-				pr_fatal("found L3 psram, in HPA %llx, size %llx", p_mem_region->l3_base, p_mem_region->l3_size);
+				pr_info("found L3 psram, in HPA %llx, size %llx", p_mem_region->l3_base, p_mem_region->l3_size);
 			} else if (psram_entry->cache_level == 2) {
 				if (l2_psram_regions_count >= MAX_L2_PSRAM_REGIONS){
-					pr_fatal("Too many L2 regions!");
+					pr_err("Too many L2 regions!");
 					break;
 				}
 				p_mem_region->l2_valid = true;
@@ -87,46 +85,57 @@ static void parse_ptct(void)
 					psram_area_top = p_mem_region->l2_base + p_mem_region->l2_size;
 				}
 				l2_psram_regions_count++;
-				pr_fatal("found L2 psram, in HPA %llx, size %llx", psram_entry->base, psram_entry->size);
+				pr_info("found L2 psram, in HPA %llx, size %llx", psram_entry->base, psram_entry->size);
 			}
 			break;
-
-		/* In current phase, we ignore other entries like gt_clos and wrc_close*/
+		/* In current phase, we ignore other entries like gt_clos and wrc_close */
 		default: 
 			break;
 		}
 		/* point to next ptct entry */
-		pr_fatal("%s entry: 0x%lx, size: %d\n", __func__, entry, entry->size);
 		entry = (struct ptct_entry *)((uint64_t)entry + entry->size);
 	}
+	psram_area_top = round_page_up(psram_area_top);
+	psram_area_bottom = round_page_down(psram_area_bottom);
 }
 
 static volatile uint64_t ptcm_command_interface_offset;
 static volatile struct ptct_entry* ptct_base_entry;
 static volatile ptcm_command_abi ptcm_command_interface = NULL;
+/* psram_is_initialized is used to tell whether psram is successfully initialized for all cores */
 static volatile bool psram_is_initialized = false;
 
-void init_psram(bool is_bsp)
+int32_t init_psram(bool is_bsp)
 {
 	uint32_t magic,version;
-	int ret;
+	int32_t ptcm_ret_code;
+	int ret = 0;
 
-	if (get_acpi_tbl(ACPI_SIG_PTCT) != NULL) {
+	/* When we shut down an RTVM, its pCPUs will be re-initialized
+	we must ensure init_psram() will only be executed at the first time when a pcpu is booted */
+	if (get_acpi_tbl(ACPI_SIG_PTCT) != NULL && psram_is_initialized == false) {
 		if (is_bsp) {
 			parse_ptct();
-			pr_fatal("PTCT is parsed by BSP");
+			pr_info("PTCT is parsed by BSP");
 			ptct_base_entry = (struct ptct_entry*)((uint64_t)get_acpi_tbl(ACPI_SIG_PTCT) + 0x24);
-			pr_fatal("ptct_base_entry is found by BSP at %llx", ptct_base_entry);
+			pr_info("ptct_base_entry is found by BSP at %llx", ptct_base_entry);
 			magic = ((uint32_t *)ptcm_binary.address)[0];
 			version = ((uint32_t *)ptcm_binary.address)[1];
-			ptcm_command_interface_offset =*(uint64_t *)(ptcm_binary.address + 0x8);
-			pr_fatal("ptcm_bin_address:%llx", ptcm_binary.address);
-			pr_fatal("ptcm_command_interface_offset is %llx", ptcm_command_interface_offset);
-			pr_fatal("magic:%x", magic);
-			pr_fatal("version:%x", version);
+			ptcm_command_interface_offset = *(uint64_t *)(ptcm_binary.address + 0x8);
+			pr_info("ptcm_bin_address:%llx", ptcm_binary.address);
+			pr_info("ptcm magic:%x", magic);
+			pr_info("ptcm version:%x", version);
 
-			ptcm_command_interface = (ptcm_command_abi)(ptcm_binary.address + ptcm_command_interface_offset);
-			pr_fatal("ptcm_command_interface is found at %llx",ptcm_command_interface);
+			if (magic != PTCM_MAGIC ){
+				pr_err("Incorrect PTCM magic! Please turn off 'Above 4G MMIO Assignment' option in BIOS");
+				psram_area_bottom = psram_area_top = 0;
+				ptcm_command_interface = (ptcm_command_abi)(-1);
+			}
+			else
+			{
+				ptcm_command_interface = (ptcm_command_abi)(ptcm_binary.address + ptcm_command_interface_offset);
+				pr_info("ptcm command interface is found at %llx",ptcm_command_interface);
+			}
 		} else {
 			//all AP should wait until BSP finishes parsing PTCT and finding the command interface.
 			while (!ptcm_command_interface) {
@@ -134,24 +143,31 @@ void init_psram(bool is_bsp)
 			}
 		}
 
-		ret = ptcm_command_interface(PTCM_CMD_INIT_PSRAM, (void *)ptct_base_entry);
-		pr_fatal("PTCM initialization for core %d with return code %d!!!!!!!!!!!!!", get_pcpu_id(), ret);
-		/* TODO: to handle the return errno gracefully */
-		ASSERT(ret == PTCM_STATUS_SUCCESS);
-
-		/* wait until all cores finishes pSRAM initialization*/
-		if (is_bsp){
-			psram_is_initialized = true;
-			pr_fatal("BSP pSRAM has been initialized\n");
-		} else{
-			while (psram_is_initialized) {
-				continue;
+		if ((int64_t)ptcm_command_interface != -1){ /* ptcm_command_interface is found */
+			ptcm_ret_code = ptcm_command_interface(PTCM_CMD_INIT_PSRAM, (void *)ptct_base_entry);
+			pr_info("ptcm initialization for core %d with return code %d", get_pcpu_id(), ptcm_ret_code);
+			/* TODO: to handle the return errno gracefully */
+			ASSERT(ptcm_ret_code == PTCM_STATUS_SUCCESS);
+			/* wait until all cores finishes pSRAM initialization*/
+			if (is_bsp){
+				psram_is_initialized = true;
+				pr_info("BSP pSRAM has been initialized\n");
+			}
+			else{
+				while (!psram_is_initialized) {
+					continue;
+				}
 			}
 		}
+		else {
+			ret = -1;
+		}
 	}
+	return ret;
 }
 #else
-void init_psram(__unused bool is_bsp)
+int32_t init_psram(__unused bool is_bsp)
 {
+	return -1;
 }
 #endif

--- a/hypervisor/arch/x86/ptcm.c
+++ b/hypervisor/arch/x86/ptcm.c
@@ -6,7 +6,7 @@
 #include <types.h>
 #include <logmsg.h>
 #include <misc_cfg.h>
-#include <ptct.h>
+#include <ptcm.h>
 
 uint64_t psram_area_bottom = PSRAM_BASE_HPA;
 uint64_t psram_area_top = PSRAM_BASE_HPA;
@@ -99,4 +99,55 @@ static void parse_ptct(void)
 	}
 }
 
+static volatile uint64_t ptcm_command_interface_offset;
+static volatile struct ptct_entry* ptct_base_entry;
+static volatile ptcm_command_abi ptcm_command_interface = NULL;
+static volatile bool psram_is_initialized = false;
+
+void init_psram(bool is_bsp)
+{
+	uint32_t magic,version;
+	int ret;
+
+	if (is_bsp) {
+		parse_ptct();
+		pr_fatal("PTCT is parsed by BSP");
+		ptct_base_entry = (struct ptct_entry*)((uint64_t)get_acpi_tbl(ACPI_SIG_PTCT) + 0x24);
+		pr_fatal("ptct_base_entry is found by BSP at %llx", ptct_base_entry);
+		magic = ((uint32_t *)ptcm_binary.address)[0];
+		version = ((uint32_t *)ptcm_binary.address)[1];
+		ptcm_command_interface_offset =*(uint64_t *)(ptcm_binary.address + 0x8);
+		pr_fatal("ptcm_bin_address:%llx", ptcm_binary.address);
+		pr_fatal("ptcm_command_interface_offset is %llx", ptcm_command_interface_offset);
+		pr_fatal("magic:%x", magic);
+		pr_fatal("version:%x", version);
+
+		ptcm_command_interface = (ptcm_command_abi)(ptcm_binary.address + ptcm_command_interface_offset);
+		pr_fatal("ptcm_command_interface is found at %llx",ptcm_command_interface);
+	} else {
+		//all AP should wait until BSP finishes parsing PTCT and finding the command interface.
+		while (!ptcm_command_interface) {
+			continue;
+		}
+	}
+
+	ret = ptcm_command_interface(PTCM_CMD_INIT_PSRAM, (void *)ptct_base_entry);
+	pr_fatal("PTCM initialization for core %d with return code %d!!!!!!!!!!!!!", get_pcpu_id(), ret);
+	/* TODO: to handle the return errno gracefully */
+	ASSERT(ret == PTCM_STATUS_SUCCESS);
+
+	/* wait until all cores finishes pSRAM initialization*/
+	if (is_bsp){
+		psram_is_initialized = true;
+		pr_fatal("BSP pSRAM has been initialized\n");
+	} else{
+		while (psram_is_initialized) {
+			continue;
+		}
+	}
+}
+#else
+void init_psram(__unused bool is_bsp)
+{
+}
 #endif

--- a/hypervisor/arch/x86/ptcm.c
+++ b/hypervisor/arch/x86/ptcm.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <types.h>
+#include <logmsg.h>
+#include <misc_cfg.h>
+#include <ptct.h>
+
+uint64_t psram_area_bottom = PSRAM_BASE_HPA;
+uint64_t psram_area_top = PSRAM_BASE_HPA;
+
+#ifdef CONFIG_PTCM_ENABLED
+
+struct ptcm_mem_region ptcm_mem_regions[MAX_PCPU_NUM];
+struct ptct_entry_data_ptcm_binary ptcm_binary;
+uint32_t l2_psram_regions_count = 0U;
+uint32_t l3_psram_regions_count = 0U;
+struct ptct_entry_data_psram l2_psram_regions[MAX_L2_PSRAM_REGIONS];
+struct ptct_entry_data_psram l3_psram_regions[MAX_L3_PSRAM_REGIONS];
+
+static void parse_ptct(void)
+{
+	struct ptct_entry *entry;
+	struct ptcm_mem_region *p_mem_region;
+	struct ptct_entry_data_psram *psram_entry;
+	struct ptct_entry_data_ptcm_binary* ptcm_binary_entry;
+	struct acpi_table_ptct* acpi_ptct = ((struct acpi_table_ptct *)get_acpi_tbl(ACPI_SIG_PTCT));
+	pr_fatal("find PTCT subtable in HPA %llx, length: %d", acpi_ptct, acpi_ptct->header.length);
+
+	entry = &acpi_ptct->ptct_first_entry;	//&acpi_ptct->ptct_entries[0];
+	pr_fatal("find PTCT base entry, in HPA %llx", entry);
+
+	while (((uint64_t)entry - (uint64_t)acpi_ptct) < acpi_ptct->header.length) {
+		switch (entry->type) {
+		case PTCT_ENTRY_TYPE_PTCM_BINARY:
+			pr_fatal("PTCT_ENTRY_TYPE_PTCM_BINARY");
+			ptcm_binary_entry = (struct ptct_entry_data_ptcm_binary *)entry->data;
+			ptcm_binary.address = ptcm_binary_entry->address;
+			ptcm_binary.size = ptcm_binary_entry->size;
+			if (psram_area_top < ptcm_binary.address + ptcm_binary.size) {
+				psram_area_top = ptcm_binary.address + ptcm_binary.size;
+			}
+			pr_fatal("find PTCM bin, in HPA %llx, size %llx", ptcm_binary.address, ptcm_binary.size);
+			break;
+		
+		case PTCT_ENTRY_TYPE_PSRAM:
+			pr_fatal("PTCT_ENTRY_TYPE_PSRAM");
+			psram_entry = (struct ptct_entry_data_psram *)entry->data;
+			if (psram_entry->apic_id_0 >= MAX_PCPU_NUM) {
+				break;
+			}
+
+			p_mem_region = &ptcm_mem_regions[psram_entry->apic_id_0];
+			if (psram_entry->cache_level == 3) {
+				if (l3_psram_regions_count >= MAX_L3_PSRAM_REGIONS){
+					pr_fatal("Too many L3 regions!");
+					break;
+				}
+
+				p_mem_region->l3_valid = true;
+				p_mem_region->l3_base = psram_entry->base;
+				p_mem_region->l3_size = psram_entry->size;
+				p_mem_region->l3_ways = psram_entry->ways;
+				p_mem_region->l3_clos[PTCM_CLOS_INDEX_SETUP] = p_mem_region->l3_ways;
+				p_mem_region->l3_clos[PTCM_CLOS_INDEX_LOCK] ^= p_mem_region->l3_ways;
+				if (psram_area_top < p_mem_region->l3_base + p_mem_region->l3_size) {
+					psram_area_top = p_mem_region->l3_base + p_mem_region->l3_size;
+				}
+				l3_psram_regions_count++;
+				pr_fatal("found L3 psram, in HPA %llx, size %llx", p_mem_region->l3_base, p_mem_region->l3_size);
+			} else if (psram_entry->cache_level == 2) {
+				if (l2_psram_regions_count >= MAX_L2_PSRAM_REGIONS){
+					pr_fatal("Too many L2 regions!");
+					break;
+				}
+				p_mem_region->l2_valid = true;
+				p_mem_region->l2_base = psram_entry->base;
+				p_mem_region->l2_size = psram_entry->size;
+				p_mem_region->l2_ways = psram_entry->ways;
+				p_mem_region->l2_clos[PTCM_CLOS_INDEX_SETUP] = p_mem_region->l2_ways;
+				p_mem_region->l2_clos[PTCM_CLOS_INDEX_LOCK] ^= p_mem_region->l2_ways;
+				if (psram_area_top < p_mem_region->l2_base + p_mem_region->l2_size) {
+					psram_area_top = p_mem_region->l2_base + p_mem_region->l2_size;
+				}
+				l2_psram_regions_count++;
+				pr_fatal("found L2 psram, in HPA %llx, size %llx", psram_entry->base, psram_entry->size);
+			}
+			break;
+
+		/* In current phase, we ignore other entries like gt_clos and wrc_close*/
+		default: 
+			break;
+		}
+		/* point to next ptct entry */
+		pr_fatal("%s entry: 0x%lx, size: %d\n", __func__, entry, entry->size);
+		entry = (struct ptct_entry *)((uint64_t)entry + entry->size);
+	}
+}
+
+#endif

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -57,6 +57,7 @@
 #define ACPI_SIG_MCFG            "MCFG" /* Memory Mapped Configuration table */
 #define ACPI_SIG_DSDT            "DSDT" /* Differentiated System Description Table */
 #define ACPI_SIG_TPM2            "TPM2" /* Trusted Platform Module hardware interface table */
+#define ACPI_SIG_PTCT            "PTCT"
 
 struct packed_gas {
 	uint8_t 	space_id;

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -649,6 +649,11 @@ static int32_t add_vm_memory_region(struct acrn_vm *vm, struct acrn_vm *target_v
 			} else {
 				prot |= EPT_UNCACHED;
 			}
+#ifdef CONFIG_PTCM_ENABLED
+			if (hpa == PSRAM_BASE_HPA) {
+				prot |= EPT_WB;
+			}
+#endif
 			/* create gpa to hpa EPT mapping */
 			ept_add_mr(target_vm, pml4_page, hpa,
 					region->gpa, region->size, prot);

--- a/hypervisor/include/arch/x86/ptcm.h
+++ b/hypervisor/include/arch/x86/ptcm.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PTCM_H
+#define PTCM_H
+
+#include <ptct.h>
+
+#define MSABI __attribute__((ms_abi))
+
+typedef int32_t MSABI (*ptcm_command_abi)(uint32_t command, void *command_struct);
+
+#define PTCM_CMD_INIT_PSRAM (int32_t)1U
+#define PTCM_CMD_CPUID (int32_t)2U
+#define PTCM_CMD_RDMSR (int32_t)3U
+#define PTCM_CMD_WRMSR (int32_t)4U
+
+#define PCTM_L2_CLOS_MASK_MAX_NUM 8U
+#define PCTM_L3_CLOS_MASK_MAX_NUM 4U
+
+#define PTCM_STATUS_SUCCESS 0
+#define PTCM_STATUS_FAILURE -1
+
+struct ptcm_info
+{
+    uint32_t version;           // [OUT]
+    uint32_t max_command_index; // [OUT]
+};
+
+struct ptcm_header
+{
+    uint32_t magic;
+    uint32_t version;
+    uint64_t command_interface_offset;
+};
+
+#endif /* PTCM_H */

--- a/hypervisor/include/arch/x86/ptcm.h
+++ b/hypervisor/include/arch/x86/ptcm.h
@@ -18,6 +18,8 @@ typedef int32_t MSABI (*ptcm_command_abi)(uint32_t command, void *command_struct
 #define PTCM_CMD_RDMSR (int32_t)3U
 #define PTCM_CMD_WRMSR (int32_t)4U
 
+#define PTCM_MAGIC 0x5054434dU
+
 #define PCTM_L2_CLOS_MASK_MAX_NUM 8U
 #define PCTM_L3_CLOS_MASK_MAX_NUM 4U
 
@@ -37,4 +39,5 @@ struct ptcm_header
     uint64_t command_interface_offset;
 };
 
+int32_t init_psram(bool is_bsp);
 #endif /* PTCM_H */

--- a/hypervisor/include/arch/x86/ptct.h
+++ b/hypervisor/include/arch/x86/ptct.h
@@ -101,5 +101,4 @@ struct ptcm_mem_region
 
 extern uint64_t psram_area_bottom;
 extern uint64_t psram_area_top;
-void init_psram(bool is_bsp);
 #endif	/* PTCT_H */

--- a/hypervisor/include/arch/x86/ptct.h
+++ b/hypervisor/include/arch/x86/ptct.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PTCT_H
+#define PTCT_H
+
+#include <acpi.h>
+
+#define MAX_L2_PSRAM_REGIONS 4U
+#define MAX_L3_PSRAM_REGIONS 1U
+
+#define PTCT_ENTRY_TYPE_PTCD_LIMIT 1U
+#define PTCT_ENTRY_TYPE_PTCM_BINARY 2U
+#define PTCT_ENTRY_TYPE_WRC_L3_MASKS 3U
+#define PTCT_ENTRY_TYPE_GT_L3_MASKS 4U
+#define PTCT_ENTRY_TYPE_PSRAM 5U
+#define PTCT_ENTRY_TYPE_STREAM_DATAPATH 6U
+#define PTCT_ENTRY_TYPE_TIMEAWARE_SUBSYS 7U
+#define PTCT_ENTRY_TYPE_RT_IOMMU 8U
+#define PTCT_ENTRY_TYPE_MEM_HIERARCHY_LATENCY 9U
+
+#define PSRAM_BASE_HPA 0x40080000U 
+#define PSRAM_BASE_GPA 0x40080000U 
+#define PSRAM_MAX_SIZE 0x00800000U
+
+struct ptct_entry{
+    uint16_t size;
+    uint16_t format;
+    uint32_t type;
+    uint32_t data[64];
+};
+
+struct acpi_table_ptct {
+    struct acpi_table_header header;
+    struct ptct_entry ptct_first_entry;
+};
+
+struct ptct_entry_data_ptcd_limit
+{
+	uint32_t max_ia_l2_clos;
+	uint32_t max_ia_l3_clos;
+	uint32_t max_l2_instances;
+	uint32_t max_gt_clos;
+	uint32_t max_wrc_clos;
+	uint32_t max_tcc_buffers;
+	uint32_t max_tcc_buffers_apic_id;
+	uint32_t max_tcc_streams;
+	uint32_t max_tcc_registers;
+	uint32_t ptcd_limit_reserves_1;
+	uint32_t ptcd_limit_reserves_2;
+};
+
+struct ptct_entry_data_ptcm_binary
+{
+	uint64_t address;
+	uint32_t size;
+};
+
+struct ptct_entry_data_psram
+{
+	uint32_t cache_level;
+	uint64_t base;
+	uint32_t ways;
+	uint32_t size;
+	uint32_t apic_id_0; /*only 1 core is responsible for initialization of this mem region*/
+};
+
+enum ptcm_cache_level
+{
+    PTCM_CACHE_LEVEL_EMPTY = 0,
+    PTCM_CACHE_LEVEL_2 = 2,
+    PTCM_CACHE_LEVEL_3 = 3
+};
+
+enum ptcm_clos_index
+{
+    PTCM_CLOS_INDEX_NOLOCK = 0,
+    PTCM_CLOS_INDEX_LOCK,
+    PTCM_CLOS_INDEX_SETUP,
+    PTCM_CLOS_NUM_OF
+};
+
+struct ptcm_mem_region
+{
+    bool l2_valid;
+    bool l3_valid;
+
+    uint64_t l2_base;
+    uint64_t l2_size;
+    uint32_t l2_ways;
+    uint32_t l2_clos[PTCM_CLOS_NUM_OF];
+
+    uint64_t l3_base;
+    uint32_t l3_size;
+    uint32_t l3_ways;
+    uint32_t l3_clos[PTCM_CLOS_NUM_OF];
+};
+
+extern uint64_t psram_area_bottom;
+extern uint64_t psram_area_top;
+#endif	/* PTCT_H */

--- a/hypervisor/include/arch/x86/ptct.h
+++ b/hypervisor/include/arch/x86/ptct.h
@@ -101,4 +101,5 @@ struct ptcm_mem_region
 
 extern uint64_t psram_area_bottom;
 extern uint64_t psram_area_top;
+void init_psram(bool is_bsp);
 #endif	/* PTCT_H */


### PR DESCRIPTION
We remove the UNCACHED bit for pSRAM EPT memmap segment, otherwise access to pSRAM region may bypass pSRAM.
