### PR TITLE
hv: remove UNCACHED for pSRAM EPT memmap segment

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -21,6 +21,7 @@
 #include <ioapic.h>
 #include <mmio_dev.h>
 #include <ivshmem.h>
+#include <ptcm.h>
 
 #define DBG_LEVEL_HYCALL	6U
 
@@ -649,6 +650,11 @@ static int32_t add_vm_memory_region(struct acrn_vm *vm, struct acrn_vm *target_v
 			} else {
 				prot |= EPT_UNCACHED;
 			}
+#ifdef CONFIG_PTCM_ENABLED
+			if (hpa == PSRAM_BASE_HPA) {
+				prot |= EPT_WB;
+			}
+#endif
 			/* create gpa to hpa EPT mapping */
 			ept_add_mr(target_vm, pml4_page, hpa,
 					region->gpa, region->size, prot);


### PR DESCRIPTION
We remove the UNCACHED bit for pSRAM EPT memmap segment, otherwise access to pSRAM region may bypass pSRAM.