### PR TITLE
doc: add the iasl dependence

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -88,7 +88,8 @@ Install the necessary tools for the following systems:
      $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
      $ tar zxvf acpica-unix-20191018.tar.gz
      $ cd acpica-unix-20191018
-     $ make clean && make iasl && make install
+     $ make clean && make iasl
+     $ sudo cp ./generate/unix/bin/iasl /usr/sbin/
 
   .. note::
      ACRN requires ``gcc`` version 7.3.* (or higher) and ``binutils`` version

--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -79,8 +79,16 @@ Install the necessary tools for the following systems:
           libblkid-dev \
           e2fslibs-dev \
           pkg-config \
-          libnuma-dev
+          libnuma-dev \
+          liblz4-tool \
+          flex \
+          bison
+
      $ sudo pip3 install kconfiglib
+     $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
+     $ tar zxvf acpica-unix-20191018.tar.gz
+     $ cd acpica-unix-20191018
+     $ make clean && make iasl && make install
 
   .. note::
      ACRN requires ``gcc`` version 7.3.* (or higher) and ``binutils`` version

--- a/doc/getting-started/rt_industry_ubuntu.rst
+++ b/doc/getting-started/rt_industry_ubuntu.rst
@@ -154,10 +154,8 @@ Build the ACRN Hypervisor on Ubuntu
         bison
 
       $ sudo pip3 install kconfiglib
-      $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
-      $ tar zxvf acpica-unix-20191018.tar.gz
-      $ cd acpica-unix-20191018
-      $ make clean && make iasl && make install
+
+   Follow the `Install IASL in Ubuntu for User VM launch`_ section to install ``iasl``.
 
 #. Get the ACRN source code:
 
@@ -317,14 +315,11 @@ The User VM will be launched by OVMF, so copy it to the specific folder:
 Install IASL in Ubuntu for User VM launch
 -----------------------------------------
 
-ACRN uses ``iasl`` to parse **User VM ACPI** information. The original ``iasl``
-in Ubuntu 18.04 is too old to match with ``acrn-dm``; update it using the
-following steps:
+ACRN uses ``iasl`` to parse **User VM ACPI** information. or to generate
+ACPI binary for pre-launched VMs.
 
 .. code-block:: none
 
-   $ sudo -E apt-get install iasl
-   $ cd /home/acrn/work
    $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
    $ tar zxvf acpica-unix-20191018.tar.gz
    $ cd acpica-unix-20191018

--- a/doc/getting-started/rt_industry_ubuntu.rst
+++ b/doc/getting-started/rt_industry_ubuntu.rst
@@ -154,6 +154,10 @@ Build the ACRN Hypervisor on Ubuntu
         bison
 
       $ sudo pip3 install kconfiglib
+      $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
+      $ tar zxvf acpica-unix-20191018.tar.gz
+      $ cd acpica-unix-20191018
+      $ make clean && make iasl && make install
 
 #. Get the ACRN source code:
 


### PR DESCRIPTION
From V2.2, we use the iasl tool to compile offline ACPI binary for pre-launched VMs while building ACRN,
so we need to install the iasl tool in the ACRN building environment. This doc is to describe how
to install the iasl tool and specify the version of iasl at the chapter Install build tools and dependencies.

Tracked-On: #5350

Signed-off-by: Shixiong Zhang <shixiongx.zhang@intel.com>