### PR TITLE
acrn-config: enable 32bit Zephyr on ehl-crb-b

### DIFF
--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
             <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
@@ -101,8 +101,8 @@
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs desc="Specify kernel boot arguments"></bootargs>
-            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x100000</kern_load_addr>
+            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x100000</kern_entry_addr>
         </os_config>
         <vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>


### PR DESCRIPTION
Currently we have problem to enable 64bit Zephyr as pre-launched VM,
so fall back to support 32bit Zephyr image on hybrid scenario.

Tracked-On: #5352

Signed-off-by: Victor Sun <victor.sun@intel.com>