### PR TITLE
Add null-ptr check and prevent WBINVD after pSRAM is initialized.

### DIFF
--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -150,9 +150,11 @@ void flush_address_space(void *addr, uint64_t size);
  */
 void invept(const void *eptp);
 
+extern volatile bool psram_is_initialized;
 static inline void cache_flush_invalidate_all(void)
 {
-	asm volatile ("   wbinvd\n" : : : "memory");
+	if (psram_is_initialized == false)
+		asm volatile ("   wbinvd\n" : : : "memory");
 }
 
 static inline void clflush(const volatile void *p)

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -150,6 +150,9 @@ void flush_address_space(void *addr, uint64_t size);
  */
 void invept(const void *eptp);
 
+/* FIX-ME:
+ * this is an workaround for pSRAM protection. We should implement full emulation for WBINVD
+ */
 extern volatile bool psram_is_initialized;
 static inline void cache_flush_invalidate_all(void)
 {


### PR DESCRIPTION
1. Add null-ptr check for security
2. prevent WBINVD after pSRAM is initialized.