### PR TITLE
doc: update breadcrumb to include release version

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -1,0 +1,14 @@
+{% extends "!breadcrumbs.html" %}
+{% block breadcrumbs %}
+  <!-- {{ docs_title }} -->
+  {# parameterize default name "Docs" in breadcrumb via docs_title in conf.py #}
+  {% if not docs_title %}
+  {% set docs_title = "Docs" %}
+  {% endif %}
+
+  <li><a href="{{ pathto(master_doc) }}">{{ docs_title }}</a> &raquo;</li>
+  {% for doc in parents %}
+     <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
+  {% endfor %}
+  <li>{{ title }}</li>
+{% endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,13 +1,4 @@
 {% extends "!layout.html" %}
-{% block document %}
-  {% if is_release %}
-    <div class="wy-alert wy-alert-danger">
-      The <a href="/{{ pagename }}.html">latest development version</a>
-      of this page may be more current than this released {{ version }} version.
-    </div>
-  {% endif %}
-  {{ super() }}
-{% endblock %}
 {% block menu %}
   {% include "aversions.html" %}
   {{ super() }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,7 +76,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'Project ACRN™'
 copyright = u'2020, Project ACRN'
-author = u'Project ARCN developers'
+author = u'Project ACRN developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -109,7 +109,7 @@ try:
               break
 finally:
     if version_major and version_minor :
-        version = release = "v " + str(version_major) + '.' + str(version_minor)
+        version = release = str(version_major) + '.' + str(version_minor)
         if version_rc :
           version = release = version + version_rc
     else:
@@ -177,17 +177,25 @@ else:
 # Here's where we (manually) list the document versions maintained on
 # the published doc website.  On a daily basis we publish to the
 # /latest folder but when releases are made, we publish to a /<relnum>
-# folder (specified via RELEASE=name on the make command).
+# folder (specified via the VERSION file as processed earlier or
+# overridden on the make command line with RELEASE=name.
 
 if tags.has('release'):
+   is_release = True
+   docs_title = '%s' %(version)
    current_version = version
    if RELEASE:
-      version = current_version = RELEASE
+      version = release = current_version = RELEASE
+      docs_title = '%s' %(version)
 else:
    version = current_version = "latest"
+   is_release = False
+   docs_title = 'Latest'
 
 html_context = {
    'current_version': current_version,
+   'docs_title': docs_title,
+   'is_release': is_release,
    'versions': ( ("latest", "/latest/"),
                  ("2.2", "/2.2/"),
                  ("2.1", "/2.1/"),


### PR DESCRIPTION
As a DX improvement in the documentation, include the release version
(or Latest) in the breadcrumb header on every page.  This can help
readers know which release version documentation they're using.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>