### PR TITLE
Add default hybrid rt xml

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -551,8 +551,8 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     boot_image_type(dm, vmid, config)
 
     # uuid get
-    scenario_uuid = launch_cfg_lib.get_scenario_uuid(vmid)
     sos_vmid = launch_cfg_lib.get_sos_vmid()
+    scenario_uuid = launch_cfg_lib.get_scenario_uuid(vmid, sos_vmid)
 
     # clearlinux/android/alios
     print('acrn-dm -A -m $mem_size -s 0:0,hostbridge -U {} \\'.format(scenario_uuid), file=config)

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -214,11 +214,12 @@ def get_vm_uuid_idx(vm_type, uosid):
     return i_cnt
 
 
-def get_scenario_uuid(uosid):
+def get_scenario_uuid(uosid, sos_vmid):
     # {id_num:uuid} (id_num:0~max)
     scenario_uuid = ''
-    i_cnt = get_vm_uuid_idx(common.VM_TYPES[uosid], uosid)
-    scenario_uuid = scenario_cfg_lib.VM_DB[common.VM_TYPES[uosid]]['uuid'][i_cnt]
+    vm_id = uosid + sos_vmid
+    i_cnt = get_vm_uuid_idx(common.VM_TYPES[vm_id], vm_id)
+    scenario_uuid = scenario_cfg_lib.VM_DB[common.VM_TYPES[vm_id]]['uuid'][i_cnt]
     return scenario_uuid
 
 

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
@@ -1,0 +1,39 @@
+<acrn-config board="ehl-crb-b" scenario="hybrid_rt" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	</shm_regions>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
@@ -1,0 +1,39 @@
+<acrn-config board="nuc7i7dnb" scenario="hybrid_rt" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	</shm_regions>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
@@ -1,0 +1,39 @@
+<acrn-config board="tgl-rvp" scenario="hybrid_rt" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	</shm_regions>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device a0c8 (rev 10)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
@@ -1,0 +1,39 @@
+<acrn-config board="whl-ipc-i5" scenario="hybrid_rt" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	</shm_regions>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+</acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
@@ -1,0 +1,39 @@
+<acrn-config board="whl-ipc-i7" scenario="hybrid_rt" uos_launcher="1">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
+	</shm_regions>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+</acrn-config>


### PR DESCRIPTION
acrn-config: Provide post launch xml for hybrid scenario

There is no default xml for hybrid_rt to to generate the
script of posted launch WaaG.

Tracked-On: #5336
Acked-by: Victor Sun <victor.sun@intel.com>