### PR TITLE
acrn-config: fix the wrong vuart name in launch script

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -587,8 +587,10 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
                 err_key = "uos:id={}:poweroff_channel".format(vmid)
                 launch_cfg_lib.ERR_LIST[err_key] = "vuart1 of VM{} in scenario file should select 'SOS_COM2_BASE'".format(sos_vmid + vmid)
                 return
-        scenario_cfg_lib.get_sos_vuart_settings()
-        print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
+            scenario_cfg_lib.get_sos_vuart_settings()
+            print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
+        else:
+            print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
 
     # set logger_setting for all VMs
     print("   $logger_setting \\", file=config)


### PR DESCRIPTION
when fix the issue of _PM_SystemS5 with life_mngr fail,
the vuart1(tty) item was devided into two parts, the last
part "/dev/tty*" which need to get will be added to the
end, so it should be handled singly, but it will be added
to other item too, such as vuart1(pty).

Tracked-On:#5366

Signed-off-by: Shixiong Zhang <shixiongx.zhang@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>