### PR TITLE
hv: fix potential NULL pointer dereference in 'memcpy_s'

### DIFF
--- a/hypervisor/arch/x86/lib/memory.c
+++ b/hypervisor/arch/x86/lib/memory.c
@@ -53,7 +53,7 @@ int32_t memcpy_s(void *d, size_t dmax, const void *s, size_t slen)
 			memcpy_erms(d, s, slen);
 		}
 		ret = 0;
-	} else {
+	} else if (d != NULL) {
 		(void)memset(d, 0U, dmax);
 	}
 


### PR DESCRIPTION
 'd' should be checked before calling 'memset()'.

Tracked-On: #5398
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>