### PR TITLE
dm: fix fault Injection into VirtIO console backend

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -373,6 +373,7 @@ virtio_vq_enable(struct virtio_base *base)
 	/* Mark queue as allocated after initialization is complete. */
 	mb();
 	vq->flags = VQ_ALLOC;
+	return;
  error:
 	vq->flags = 0;
 	pr_err("%s: vq enable failed\n", __func__);


### PR DESCRIPTION
Add Null pointer check in init vq ring and add vq ring descriptor
check in case cause Nullpointer exception.

Tracked-On: #5355
Signed-off-by: Liu Long <long.liu@intel.com>