### PR TITLE
dm: fix typo error to pass through TPM device

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -785,7 +785,7 @@ static struct option long_options[] = {
 	{"mac_seed",		required_argument,	0, CMD_OPT_MAC_SEED},
 	{"debugexit",		no_argument,		0, CMD_OPT_DEBUGEXIT},
 	{"intr_monitor",	required_argument,	0, CMD_OPT_INTR_MONITOR},
-	{"apcidev_pt",		required_argument,	0, CMD_OPT_ACPIDEV_PT},
+	{"acpidev_pt",		required_argument,	0, CMD_OPT_ACPIDEV_PT},
 	{"mmiodev_pt",		required_argument,	0, CMD_OPT_MMIODEV_PT},
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
 	{"lapic_pt",		no_argument,		0, CMD_OPT_LAPIC_PT},


### PR DESCRIPTION
Fix typo error "--apicdev_pt HID" to pass through a TPM device. Fix it to
"--acpidev_pt HID"

Tracked-On: #5401
Signed-off-by: Li Fei1 <fei1.li@intel.com>
