### PR TITLE
hv: mmu: remove duplicated efer.nxe enable

### DIFF
--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -159,14 +159,6 @@ void enable_paging(void)
 {
 	uint64_t tmp64 = 0UL;
 
-	/*
-	 * Enable MSR IA32_EFER.NXE bit,to prevent
-	 * instruction fetching from pages with XD bit set.
-	 */
-	tmp64 = msr_read(MSR_IA32_EFER);
-	tmp64 |= MSR_IA32_EFER_NXE_BIT;
-	msr_write(MSR_IA32_EFER, tmp64);
-
 	/* Enable Write Protect, inhibiting writing to read-only pages */
 	CPU_CR_READ(cr0, &tmp64);
 	CPU_CR_WRITE(cr0, tmp64 | CR0_WP);


### PR DESCRIPTION
Remove duplicated efer.nxe enable in enable_paging:
1. EFER.NXE is enabled in boot ASM code
2. If IA32_EFER.NXE = 0 and the P flag of a PDE or a PTE is 1,
the XD flag (bit 63) is reserved.

Tracked-On: #4550
Signed-off-by: Li Fei1 <fei1.li@intel.com>