### PR TITLE
acrn-config: Support pci vuart configuration and generate pci vuart dev information

### DIFF
--- a/misc/acrn-config/board_config/misc_cfg_h.py
+++ b/misc/acrn-config/board_config/misc_cfg_h.py
@@ -109,13 +109,17 @@ def pci_dev_num_per_vm_gen(config):
     shmem_regions = scenario_cfg_lib.get_shmem_regions(ivshmem_region)
     shmem_num = scenario_cfg_lib.get_shmem_num(shmem_regions)
 
+    vuarts = common.get_vuart_info(common.SCENARIO_INFO_FILE)
+    vuarts_num = scenario_cfg_lib.get_vuart_num(vuarts)
+
     for vm_i,vm_type in common.VM_TYPES.items():
         num = 0
         if "POST_LAUNCHED_VM" == scenario_cfg_lib.VM_DB[vm_type]['load_type']:
             shmem_num_i = 0
+            vuart_num = vuarts_num[vm_i]
             if shmem_enabled == 'y' and vm_i in shmem_num.keys():
                 shmem_num_i = shmem_num[vm_i]
-            num = shmem_num_i
+            num = shmem_num_i + vuart_num
         elif "PRE_LAUNCHED_VM" == scenario_cfg_lib.VM_DB[vm_type]['load_type']:
             shmem_num_i = 0
             if shmem_enabled == 'y' and vm_i in shmem_num.keys():
@@ -124,7 +128,7 @@ def pci_dev_num_per_vm_gen(config):
                 # there is only vhostbridge but no passthrough device
                 # remove the count of vhostbridge, check get_pci_num definition
                 pci_dev_num[vm_i] -= 1
-            num = pci_dev_num[vm_i] + shmem_num_i
+            num = pci_dev_num[vm_i] + shmem_num_i + vuarts_num[vm_i]
         elif "SOS_VM" == scenario_cfg_lib.VM_DB[vm_type]['load_type']:
             continue
         if num > 0:

--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -636,6 +636,16 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
             print("   -s {},wdt-i6300esb \\".format(launch_cfg_lib.virtual_dev_slot("wdt-i6300esb")), file=config)
 
     set_dm_pt(names, sel, vmid, config)
+
+    if dm['console_vuart'][vmid] == "Enable":
+        print("   -s {},uart,vuart_idx:0 \\".format(launch_cfg_lib.virtual_dev_slot("console_vuart")), file=config)
+    for vuart_id in dm["communication_vuarts"][vmid]:
+        if not vuart_id:
+            break
+        print("   -s {},uart,vuart_idx:{} \\".format(
+            launch_cfg_lib.virtual_dev_slot("communication_vuart_{}".format(vuart_id)), vuart_id), file=config)
+
+
     print("   $vm_name", file=config)
     print("}", file=config)
 

--- a/misc/acrn-config/launch_config/launch_item.py
+++ b/misc/acrn-config/launch_config/launch_item.py
@@ -34,6 +34,8 @@ class AcrnDmArgs:
             else:
                 self.args["shm_regions"][vmid] = []
         self.args["xhci"] = common.get_leaf_tag_map(self.launch_info, "usb_xhci")
+        self.args["communication_vuarts"] = common.get_leaf_tag_map(self.launch_info, "communication_vuarts", "communication_vuart")
+        self.args["console_vuart"] = common.get_leaf_tag_map(self.launch_info, "console_vuart")
 
     def check_item(self):
         (rootfs, num) = board_cfg_lib.get_rootfs(self.board_info)
@@ -46,6 +48,8 @@ class AcrnDmArgs:
         err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.launch_info, cpu_affinity, "pcpu_id")
         launch_cfg_lib.ERR_LIST.update(err_dic)
         launch_cfg_lib.check_shm_regions(self.args["shm_regions"], self.scenario_info)
+        launch_cfg_lib.check_console_vuart(self.args["console_vuart"],self.args["vuart0"], self.scenario_info)
+        launch_cfg_lib.check_communication_vuart(self.args["communication_vuarts"], self.scenario_info)
 
 
 class AvailablePthru():

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -352,7 +352,7 @@ def get_leaf_tag_map(config_file, branch_tag, tag_str=''):
 
                 # for each 3rd level item
                 for leaf in sub:
-                    if leaf.tag == tag_str and tag_str not in MULTI_ITEM and sub.tag != "vuart":
+                    if leaf.tag == tag_str and tag_str not in MULTI_ITEM and sub.tag not in ["legacy_vuart","vuart"]:
                         if leaf.text == None or not leaf.text:
                             tmp.tag[vm_id] = ''
                         else:
@@ -406,11 +406,11 @@ def get_vuart_info_id(config_file, idx):
         for sub in item:
             tmp_vuart = {}
             for leaf in sub:
-                if sub.tag == "vuart" and int(sub.attrib['id']) == idx:
+                if sub.tag in ["legacy_vuart","vuart"] and int(sub.attrib['id']) == idx:
                     tmp_vuart = get_vuart_id(tmp_vuart, leaf.tag, leaf.text)
 
             # append vuart for each vm
-            if tmp_vuart and sub.tag == "vuart":
+            if tmp_vuart and sub.tag in ["legacy_vuart","vuart"]:
                 tmp_tag[vm_id] = tmp_vuart
 
     return tmp_tag

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -21,7 +21,7 @@ PY_CACHES = ["__pycache__", "../board_config/__pycache__", "../scenario_config/_
 GUEST_FLAG = ["0UL", "GUEST_FLAG_SECURE_WORLD_ENABLED", "GUEST_FLAG_LAPIC_PASSTHROUGH",
               "GUEST_FLAG_IO_COMPLETION_POLLING", "GUEST_FLAG_HIDE_MTRR", "GUEST_FLAG_RT"]
 
-MULTI_ITEM = ["guest_flag", "pcpu_id", "vcpu_clos", "input", "block", "network", "pci_dev", "shm_region"]
+MULTI_ITEM = ["guest_flag", "pcpu_id", "vcpu_clos", "input", "block", "network", "pci_dev", "shm_region", "communication_vuart"]
 
 SIZE_K = 1024
 SIZE_M = SIZE_K * 1024
@@ -48,6 +48,7 @@ class MultiItem():
         self.vir_network = []
         self.pci_dev = []
         self.shm_region = []
+        self.communication_vuart = []
 
 class TmpItem():
 
@@ -289,6 +290,10 @@ def get_leaf_value(tmp, tag_str, leaf):
     if leaf.tag == "shm_region" and tag_str == "shm_region":
         tmp.multi.shm_region.append(leaf.text)
 
+    # get communication_vuart for vm
+    if leaf.tag == "communication_vuart" and tag_str == "communication_vuart":
+        tmp.multi.communication_vuart.append(leaf.text)
+
 
 def get_sub_value(tmp, tag_str, vm_id):
 
@@ -323,6 +328,10 @@ def get_sub_value(tmp, tag_str, vm_id):
     # append shm_region for vm
     if tmp.multi.shm_region and tag_str == "shm_region":
         tmp.tag[vm_id] = tmp.multi.shm_region
+
+    # append communication_vuart for vm
+    if tmp.multi.communication_vuart and tag_str == "communication_vuart":
+        tmp.tag[vm_id] = tmp.multi.communication_vuart
 
 
 def get_leaf_tag_map(config_file, branch_tag, tag_str=''):

--- a/misc/acrn-config/library/common.py
+++ b/misc/acrn-config/library/common.py
@@ -36,6 +36,8 @@ LAUNCH_INFO_FILE = ""
 VM_TYPES = {}
 MAX_VM_NUM = 8
 
+MAX_VUART_NUM = 8
+
 class MultiItem():
 
     def __init__(self):

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -634,3 +634,38 @@ def check_shm_regions(launch_shm_regions, scenario_info):
                 ERR_LIST[shm_region_key] = "shm {} should be configured in scenario setting and the size should be decimal" \
                                            "in MB and spaces should not exist.".format(shm_region)
                 return
+
+
+def check_console_vuart(launch_console_vuart, vuart0, scenario_info):
+    vuarts = common.get_vuart_info(scenario_info)
+
+    for uos_id, console_vuart_enable in launch_console_vuart.items():
+        key = 'uos:id={},console_vuart'.format(uos_id)
+        if console_vuart_enable == "Enable" and vuart0[uos_id] == "Enable":
+            ERR_LIST[key] = "vuart0 and console_vuart of uos {} should not be enabled " \
+                 "at the same time".format(uos_id)
+            return
+        if console_vuart_enable == "Enable" and int(uos_id) in vuarts.keys() \
+             and 0 in vuarts[uos_id] and vuarts[uos_id][0]['base'] == "INVALID_PCI_BASE":
+            ERR_LIST[key] = "console_vuart of uos {} should be enabled in scenario setting".format(uos_id)
+            return
+
+
+def check_communication_vuart(launch_communication_vuarts, scenario_info):
+    vuarts = common.get_vuart_info(scenario_info)
+    vuart1_setting = common.get_vuart_info_id(common.SCENARIO_INFO_FILE, 1)
+
+    for uos_id, vuart_list in launch_communication_vuarts.items():
+        vuart_key = 'uos:id={},communication_vuarts,communication_vuart'.format(uos_id)
+        for vuart_id in vuart_list:
+            if not vuart_id:
+                return
+            if int(vuart_id) not in vuarts[uos_id].keys():
+                ERR_LIST[vuart_key] = "communication_vuart {} of uos {} should be configured" \
+                     "in scenario setting.".format(vuart_id, uos_id)
+                return
+            if int(vuart_id) == 1 and vuarts[uos_id][1]['base'] != "INVALID_PCI_BASE":
+                if uos_id in vuart1_setting.keys() and vuart1_setting[uos_id]['base'] != "INVALID_COM_BASE":
+                    ERR_LIST[vuart_key] = "uos {}'s communication_vuart 1 and legacy_vuart 1 should " \
+                        "not be configured at the same time.".format(uos_id)
+                return

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -17,11 +17,15 @@ KERN_TYPE_LIST = ['KERNEL_BZIMAGE', 'KERNEL_ZEPHYR']
 KERN_BOOT_ADDR_LIST = ['0x100000']
 
 VUART_TYPE = ['VUART_LEGACY_PIO', 'VUART_PCI']
+INVALID_COM_BASE = 'INVALID_COM_BASE'
 VUART_BASE = ['SOS_COM1_BASE', 'SOS_COM2_BASE', 'COM1_BASE',
-              'COM2_BASE', 'COM3_BASE', 'COM4_BASE', 'INVALID_COM_BASE']
+              'COM2_BASE', 'COM3_BASE', 'COM4_BASE', INVALID_COM_BASE]
+INVALID_PCI_BASE = 'INVALID_PCI_BASE'
+PCI_VUART = 'PCI_VUART'
+PCI_VUART_BASE = [PCI_VUART, INVALID_PCI_BASE]
 
-AVALIBLE_COM1_BASE = ['INVALID_COM_BASE', 'COM1_BASE']
-AVALIBLE_COM2_BASE = ['INVALID_COM_BASE', 'COM2_BASE']
+AVALIBLE_COM1_BASE = [INVALID_COM_BASE, 'COM1_BASE']
+AVALIBLE_COM2_BASE = [INVALID_COM_BASE, 'COM2_BASE']
 
 VUART_IRQ = ['SOS_COM1_IRQ', 'SOS_COM2_IRQ', 'COM1_IRQ', 'COM2_IRQ', 'COM3_IRQ',
              'COM4_IRQ', 'CONFIG_COM_IRQ', '3', '4', '6', '7']
@@ -63,6 +67,11 @@ VM_DB = {
     'PRE_RT_VM':{'load_type':'PRE_LAUNCHED_VM', 'severity':'SEVERITY_RTVM', 'uuid':UUID_DB['PRE_RT_VM']},
 }
 LOAD_VM_TYPE = list(VM_DB.keys())
+
+# field names
+F_TARGET_VM_ID = 'target_vm_id'
+F_TARGET_UART_ID = 'target_uart_id'
+
 
 def get_pci_devs(pci_items):
 
@@ -654,14 +663,14 @@ def avl_vuart_ui_select(scenario_info):
     for vm_i,vm_type in common.VM_TYPES.items():
 
         if "SOS_VM" == VM_DB[vm_type]['load_type']:
-            key = "vm={},vuart=0,base".format(vm_i)
+            key = "vm={},legacy_vuart=0,base".format(vm_i)
             tmp_vuart[key] = ['SOS_COM1_BASE', 'INVALID_COM_BASE']
-            key = "vm={},vuart=1,base".format(vm_i)
+            key = "vm={},legacy_vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['SOS_COM2_BASE', 'INVALID_COM_BASE']
         else:
-            key = "vm={},vuart=0,base".format(vm_i)
+            key = "vm={},legacy_vuart=0,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM1_BASE']
-            key = "vm={},vuart=1,base".format(vm_i)
+            key = "vm={},legacy_vuart=1,base".format(vm_i)
             tmp_vuart[key] = ['INVALID_COM_BASE', 'COM2_BASE']
 
     return tmp_vuart
@@ -700,23 +709,23 @@ def check_vuart(v0_vuart, v1_vuart):
     for vm_i,vuart_dic in v1_vuart.items():
         # check target vm id
         if 'base' not in vuart_dic.keys():
-            key = "vm:id={},vuart:id=1,base".format(vm_i)
+            key = "vm:id={},legacy_vuart:id=1,base".format(vm_i)
             ERR_LIST[key] = "base should be in xml"
             return
 
         if not vuart_dic['base'] or vuart_dic['base'] not in VUART_BASE:
-            key = "vm:id={},vuart:id=1,base".format(vm_i)
+            key = "vm:id={},legacy_vuart:id=1,base".format(vm_i)
             ERR_LIST[key] = "base should be SOS/COM BASE"
 
         if vuart_dic['base'] == "INVALID_COM_BASE":
             continue
 
         if 'target_vm_id' not in vuart_dic.keys():
-            key = "vm:id={},vuart:id=1,target_vm_id".format(vm_i)
+            key = "vm:id={},legacy_vuart:id=1,target_vm_id".format(vm_i)
             ERR_LIST[key] = "target_vm_id should be in xml"
 
         if not vuart_dic['target_vm_id'] or not vuart_dic['target_vm_id'].isnumeric():
-            key = "vm:id={},vuart:id=1,target_vm_id".format(vm_i)
+            key = "vm:id={},legacy_vuart:id=1,target_vm_id".format(vm_i)
             ERR_LIST[key] = "target_vm_id should be numeric of vm id"
         vm_target_id_dic[vm_i] = vuart_dic['target_vm_id']
 
@@ -725,7 +734,7 @@ def check_vuart(v0_vuart, v1_vuart):
     i = 0
     for vm_i,t_vm_id in vm_target_id_dic.items():
         if t_vm_id.isnumeric() and int(t_vm_id) not in common.VM_TYPES.keys():
-            key = "vm:id={},vuart:id=1,target_vm_id".format(vm_i)
+            key = "vm:id={},legacy_vuart:id=1,target_vm_id".format(vm_i)
             ERR_LIST[key] = "target_vm_id which specified does not exist"
 
         idx = target_id_keys.index(vm_i)
@@ -736,8 +745,309 @@ def check_vuart(v0_vuart, v1_vuart):
                 connect_set = True
 
     if not connect_set and len(target_id_keys) >= 2:
-        key = "vm:id={},vuart:id=1,target_vm_id".format(i)
+        key = "vm:id={},legacy_vuart:id=1,target_vm_id".format(i)
         ERR_LIST[key] = "Creating the wrong configuration for target_vm_id."
+
+
+def get_legacy_vuart1_target_dict(legacy_vuart1):
+    vuart1_target_dict = {}
+    vuart1_visited = {}
+    for vm_i, vuart_dict in legacy_vuart1.items():
+        vuart_base = vuart_dict.get('base')
+        if vuart_base not in VUART_BASE:
+            continue
+        if vuart_base == INVALID_COM_BASE:
+            continue
+
+        try:
+            key = "vm:id={},legacy_vuart:id=1,target_vm_id".format(vm_i)
+            target_vm_id = get_target_vm_id(vuart_dict, vm_i)
+            err_key = "vm:id={},legacy_vuart:id=1,target_uart_id".format(vm_i)
+            target_uart_id = get_target_uart_id(vuart_dict)
+        except XmlError as exc:
+            ERR_LIST[err_key] = str(exc)
+            return vuart1_target_dict, vuart1_visited
+
+        if vm_i not in vuart1_target_dict:
+            vuart1_target_dict[vm_i] = (target_vm_id, target_uart_id)
+        else:
+            raise ValueError('vm id {} has more than one legacy vuart 1'.format(vm_i))
+
+        if vm_i not in vuart1_visited:
+            vuart1_visited[vm_i] = -1
+        else:
+            raise ValueError('vm id {} has more than one legacy vuart 1'.format(vm_i))
+
+    return vuart1_target_dict, vuart1_visited
+
+
+class InvalidError(Exception):
+    pass
+
+class LegacyVuartError(Exception):
+    pass
+
+class PciVuartError(Exception):
+    pass
+
+class TargetError(Exception):
+    pass
+class XmlError(Exception):
+    pass
+
+def check_vuart_id(vuart_id):
+    if not isinstance(vuart_id, int):
+        raise ValueError('vuart_id must be int: {}, {!r}'.format(type(vuart_id), vuart_id))
+
+
+def check_vuart_id_count(vm_pci_vuarts, legacy_vuart0, legacy_vuart1):
+    vuart_cnt = 0
+    for vuart_id in vm_pci_vuarts:
+        pci_vuart_base = vm_pci_vuarts.get(vuart_id, {}).get('base')
+        if pci_vuart_base == PCI_VUART:
+            vuart_cnt += 1
+
+    legacy_vuart_base0 = legacy_vuart0.get('base')
+    if legacy_vuart_base0 != INVALID_COM_BASE:
+        vuart_cnt += 1
+
+    legacy_vuart_base1 = legacy_vuart1.get('base')
+    if legacy_vuart_base1 != INVALID_COM_BASE:
+        vuart_cnt += 1
+
+    if vuart_cnt > common.MAX_VUART_NUM:
+        raise XmlError("enables more than {} vuarts, total number: {}".format(common.MAX_VUART_NUM, vuart_cnt))
+
+
+def check_against_coexistence(vm_pci_vuarts, vm_legacy_vuart, legacy_vuart_idx):
+    pci_vuart_base = vm_pci_vuarts.get(legacy_vuart_idx, {}).get('base')
+    legacy_base = vm_legacy_vuart.get('base')
+    if legacy_base not in VUART_BASE:
+        raise LegacyVuartError('legacy vuart base should be one of {}'.format(", ".join(VUART_BASE)))
+    if legacy_base == INVALID_COM_BASE:
+        return
+    if pci_vuart_base not in PCI_VUART_BASE:
+        raise PciVuartError('pci vuart base should be one of {}, last call: {!r}'.format(", ".join(PCI_VUART_BASE), pci_vuart_base))
+    if pci_vuart_base == INVALID_PCI_BASE:
+        return
+    raise PciVuartError('cannot enable legacy vuart {} and this vuart {} at the same time' \
+                    .format(legacy_vuart_idx, legacy_vuart_idx))
+
+
+def check_pci_vuart_base(pci_vuart):
+    if not isinstance(pci_vuart, dict):
+        raise TypeError('pci_vuart should be a dict: {}, {!r}'.format(type(pci_vuart), pci_vuart))
+    if 'base' not in pci_vuart:
+        raise ValueError('base should be in vuart: keys_found={}'.format(pci_vuart.keys()))
+
+    pci_vuart_base_str = pci_vuart['base']
+    if pci_vuart_base_str not in PCI_VUART_BASE:
+        raise ValueError("base should be one of {}, last called:  {!r}".format(", ".join(PCI_VUART_BASE), pci_vuart_base_str))
+    if pci_vuart_base_str == INVALID_PCI_BASE:
+        raise InvalidError
+
+
+def get_target_vm_id(vuart, vm_id):
+    if not isinstance(vuart, dict):
+        raise TypeError('vuart should be a dict: {}, {!r}'.format(type(vuart), vuart))
+    if not isinstance(vm_id, int):
+        raise TypeError('vm_id should be an int: {}, {!r}'.format(type(vm_id), vm_id))
+    if F_TARGET_VM_ID not in vuart:
+        raise ValueError('target_vm_id should be in vuart: keys_found={}'.format(vuart.keys()))
+
+    try:
+        target_vm_id_str = vuart.get(F_TARGET_VM_ID)
+        target_vm_id = int(target_vm_id_str)
+    except (TypeError, ValueError):
+        raise XmlError(
+            "target_vm_id should be present and numeric: {!r}".format(
+                target_vm_id_str))
+
+    if target_vm_id not in common.VM_TYPES:
+        raise XmlError(
+            'invalid target_vm_id: target_vm_id={!r}, vm_ids={}'.format(
+                target_vm_id, common.VM_TYPES.keys()))
+
+    if target_vm_id == vm_id:
+        raise XmlError(
+            "cannot connect to itself, target_vm_id: {}".format(vm_id))
+    return target_vm_id
+
+
+def get_target_uart_id(vuart):
+    if not isinstance(vuart, dict):
+        raise TypeError('vuart should be a dict: {}, {!r}'.format(type(vuart), vuart))
+    if F_TARGET_UART_ID not in vuart:
+        raise ValueError('target_uart_id should be in vuart: keys_found={}'.format(vuart.keys()))
+
+    try:
+        target_uart_id_str = vuart.get(F_TARGET_UART_ID)
+        target_uart_id = int(target_uart_id_str)
+    except (TypeError, ValueError):
+        raise XmlError(
+            "target_uart_id_str should be present and numeric: {!r}".format(
+                target_uart_id_str))
+    if target_uart_id == 0:
+        raise XmlError("cannot connect to any type of vuart 0")
+    return target_uart_id
+
+
+def check_pci_vuart(pci_vuarts, legacy_vuart0, legacy_vuart1):
+
+    vm_target_dict = {}
+    vm_visited = {}
+
+    for vm_id, vm_pci_vuarts in pci_vuarts.items():
+
+        try:
+            vuart_id = 0
+            check_against_coexistence(vm_pci_vuarts, legacy_vuart0.get(vm_id), vuart_id)
+            vuart_id = 1
+            check_against_coexistence(vm_pci_vuarts, legacy_vuart1.get(vm_id), vuart_id)
+            key = "vm:id={}".format(vm_id)
+            check_vuart_id_count(vm_pci_vuarts, legacy_vuart0.get(vm_id), legacy_vuart1.get(vm_id))
+        except XmlError as exc:
+            ERR_LIST[key] = str(exc)
+            return
+        except LegacyVuartError as exc:
+            key = "vm:id={},legacy_vuart:id={},base".format(vm_id, vuart_id)
+            ERR_LIST[key] = str(exc)
+            return
+        except PciVuartError as exc:
+            err_key = (
+                "vm:id={},console_vuart:id={},base".format(vm_id, vuart_id)
+                if vuart_id == 0
+                else "vm:id={},communication_vuart:id={},base".format(vm_id, vuart_id)
+                )
+            ERR_LIST[err_key] = str(exc)
+            return
+
+        for vuart_id, pci_vuart in vm_pci_vuarts.items():
+
+            check_vuart_id(vuart_id)
+
+            err_key = (
+                "vm:id={},console_vuart:id={},base".format(vm_id, vuart_id)
+                if vuart_id == 0
+                else "vm:id={},communication_vuart:id={},base".format(vm_id, vuart_id)
+                )
+            key = err_key
+
+            try:
+                check_pci_vuart_base(pci_vuart)
+            except ValueError as exc:
+                ERR_LIST[err_key] = str(exc)
+                return
+            except InvalidError:
+                continue
+
+            if vuart_id == 0:
+                continue
+
+            try:
+                err_key = "vm:id={},communication_vuart:id={},target_vm_id".format(vm_id, vuart_id)
+                target_vm_id = get_target_vm_id(pci_vuart, vm_id)
+                err_key = "vm:id={},communication_vuart:id={},target_uart_id".format(vm_id, vuart_id)
+                target_uart_id = get_target_uart_id(pci_vuart)
+            except XmlError as exc:
+                ERR_LIST[err_key] = str(exc)
+                return
+
+            if vm_id not in vm_target_dict:
+                vm_target_dict[vm_id] = {}
+            if vuart_id in vm_target_dict[vm_id]:
+                raise ValueError('Duplicated vm id {} and vuart id {}'.format(vm_id, vuart_id))
+            else:
+                vm_target_dict[vm_id][vuart_id] = (target_vm_id, target_uart_id)
+
+            if vm_id not in vm_visited:
+                vm_visited[vm_id] = {}
+            if vuart_id in vm_visited[vm_id]:
+                raise ValueError('vuart {} of vm {} is duplicated'.format(vuart_id, vm_id))
+            else:
+                vm_visited[vm_id][vuart_id] = -1
+
+
+    legacy_vuart1_target_dict, legacy_vuart1_visited = get_legacy_vuart1_target_dict(legacy_vuart1)
+
+    for vm_id, target in legacy_vuart1_target_dict.items():
+        try:
+            err_key = "vm:id={},legacy_vuart:id=1,target_vm_id".format(vm_id)
+            target_vm_id = int(target[0])
+            is_target_vm_available(target_vm_id, vm_visited, legacy_vuart1_visited)
+            err_key = "vm:id={},legacy_vuart:id=1,target_uart_id".format(vm_id)
+            target_uart_id = int(target[1])
+            check_target_connection(vm_id, target_vm_id, target_uart_id, vm_visited, legacy_vuart1_visited)
+        except TargetError as exc:
+            ERR_LIST[err_key] = str(exc)
+            continue
+
+    for vm_id, target_list in vm_target_dict.items():
+        for vuart_id, target in target_list.items():
+            try:
+                err_key = "vm:id={},communication_vuart:id={},target_vm_id".format(vm_id, vuart_id)
+                target_vm_id = int(target[0])
+                is_target_vm_available(target_vm_id, vm_visited, legacy_vuart1_visited)
+                err_key = "vm:id={},communication_vuart:id={},target_uart_id".format(vm_id, vuart_id)
+                target_uart_id = int(target[1])
+                check_target_connection(vm_id, target_vm_id, target_uart_id, vm_visited, legacy_vuart1_visited)
+            except TargetError as exc:
+                ERR_LIST[err_key] = str(exc)
+                continue
+
+
+def is_target_vm_available(target_vm_id, vm_visited, legacy_vuart1_visited):
+    if not isinstance(target_vm_id, int):
+        raise TypeError('target_vm_id should be an int: {}, {!r}'.format(type(target_vm_id), target_vm_id))
+    if not isinstance(vm_visited, dict):
+        raise TypeError('vm_visited should be a dict: {}, {!r}'.format(type(vm_visited), vm_visited))
+    if not isinstance(legacy_vuart1_visited, dict):
+        raise TypeError('legacy_vuart1_visited should be a dict: {}, {!r}' \
+                 .format(type(legacy_vuart1_visited), legacy_vuart1_visited))
+
+    if target_vm_id not in common.VM_TYPES:
+        raise TargetError("target vm {} is not present".format(target_vm_id))
+    if target_vm_id in vm_visited:
+        pass
+    elif target_vm_id in legacy_vuart1_visited:
+        pass
+    else:
+        raise TargetError("target vm {} disables legacy vuart 1 and all communication vuarts"\
+                         .format(target_vm_id))
+
+
+def check_target_connection(vm_id, target_vm_id, target_uart_id, vm_visited, legacy_vuart1_visited):
+    if not isinstance(vm_visited, dict):
+        raise TypeError('vm_visited should be a dict: {}, {!r}'.format(type(vm_visited), vm_visited))
+    if not isinstance(legacy_vuart1_visited, dict):
+        raise TypeError('legacy_vuart1_visited should be a dict: {}, {!r}' \
+                 .format(type(legacy_vuart1_visited), legacy_vuart1_visited))
+    if not isinstance(target_vm_id, int):
+        raise TypeError('vm_id should be an int: {}, {!r}'.format(type(vm_id), vm_id))
+    if not isinstance(target_vm_id, int):
+        raise TypeError('target_vm_id should be an int: {}, {!r}'.format(type(target_vm_id), target_vm_id))
+    if not isinstance(target_uart_id, int):
+        raise TypeError('target_uart_id should be an int: {}, {!r}'.format(type(target_uart_id), target_uart_id))
+
+    if target_uart_id == 0:
+        raise TargetError("cannot connect to any type of vuart 0")
+
+    if vm_visited.get(target_vm_id) and target_uart_id in vm_visited[target_vm_id]:
+        connected_vm = vm_visited[target_vm_id][target_uart_id]
+        if  connected_vm > -1:
+            raise TargetError("target vm{} : vuart{} is connected to vm {}" \
+                             .format(target_vm_id, target_uart_id, connected_vm))
+        else:
+            vm_visited[target_vm_id][target_uart_id] = vm_id
+    elif target_uart_id == 1 and target_vm_id in legacy_vuart1_visited:
+        connected_vm = legacy_vuart1_visited[target_vm_id]
+        if  connected_vm > -1:
+            raise TargetError("target vm{} : vuart{} is connected to vm {}" \
+                             .format(target_vm_id, target_uart_id, connected_vm))
+        else:
+            legacy_vuart1_visited[target_vm_id] = vm_id
+    else:
+        raise TargetError("target vm{}'s vuart{} is not present".format(target_vm_id ,target_uart_id))
 
 
 def vcpu_clos_check(cpus_per_vm, clos_per_vm, prime_item, item):

--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -195,7 +195,7 @@ def get_pci_dev_num_per_vm():
                 # there is only vhostbridge but no passthrough device
                 # remove the count of vhostbridge, check get_pci_num definition
                 pci_dev_num[vm_i] -= 1
-            pci_dev_num_per_vm[vm_i] = pci_dev_num[vm_i] + shmem_num_i+ vuarts_num[vm_i]
+            pci_dev_num_per_vm[vm_i] = pci_dev_num[vm_i] + shmem_num_i + vuarts_num[vm_i]
         elif "SOS_VM" == VM_DB[vm_type]['load_type']:
             shmem_num_i = 0
             if shmem_enabled == 'y' and vm_i in shmem_num.keys():

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -117,6 +117,7 @@ class VuartInfo:
     """ This is Abstract of class of vm vuart setting """
     v0_vuart = {}
     v1_vuart = {}
+    pci_vuarts = {}
 
     def __init__(self, scenario_file):
         self.scenario_info = scenario_file
@@ -132,6 +133,7 @@ class VuartInfo:
         """
         self.v0_vuart = common.get_vuart_info_id(self.scenario_info, 0)
         self.v1_vuart = common.get_vuart_info_id(self.scenario_info, 1)
+        self.pci_vuarts = common.get_vuart_info(self.scenario_info)
 
     def check_item(self):
         """
@@ -140,6 +142,7 @@ class VuartInfo:
         """
         scenario_cfg_lib.check_board_private_info()
         scenario_cfg_lib.check_vuart(self.v0_vuart, self.v1_vuart)
+        scenario_cfg_lib.check_pci_vuart(self.pci_vuarts, self.v0_vuart, self.v1_vuart)
 
 class MemInfo:
     """ This is Abstract of class of memory setting information """

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -45,6 +45,8 @@ def get_post_vm_type(vm_type, vm_i):
 
 
 def vuart0_output(i, vm_type, vm_info, config):
+    if vm_info.vuart.v0_vuart[i]['base'] == "INVALID_COM_BASE":
+        return
     """
     This is generate vuart 0 setting
     :param i: vm id number
@@ -100,6 +102,8 @@ def vuart1_output(i, vm_type, vuart1_vmid_dic, vm_info, config):
     :return: None
     """
     vuart_enable = vuart_map_enable(vm_info)
+    if vm_info.vuart.v1_vuart[i]['base'] == "INVALID_COM_BASE":
+        return
     # vuart1:   {vmid:target_vmid}
     print("\t\t.vuart[1] = {", file=config)
     print("\t\t\t.type = {0},".format(vm_info.vuart.v1_vuart[i]['type']), file=config)
@@ -122,6 +126,7 @@ def vuart1_output(i, vm_type, vuart1_vmid_dic, vm_info, config):
                 vm_info.vuart.v1_vuart[i]['target_vm_id']), file=config)
             print("\t\t\t.t_vuart.vuart_id = {0}U,".format(
                 vm_info.vuart.v1_vuart[i]['target_uart_id']), file=config)
+    print("\t\t},", file=config)
 
 def vuart_output(vm_type, i, vm_info, config):
     """
@@ -136,7 +141,6 @@ def vuart_output(vm_type, i, vm_info, config):
 
     vuart0_output(i, vm_type, vm_info, config)
     vuart1_output(i, vm_type, vuart1_vmid_dic, vm_info, config)
-    print("\t\t},", file=config)
 
 
 def is_need_epc(epc_section, i, config):

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -92,7 +92,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -144,7 +144,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -90,18 +90,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -134,18 +134,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -174,17 +174,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -102,6 +102,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -146,6 +154,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -186,5 +202,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">s
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -119,18 +119,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -149,17 +149,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/industry.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">s
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -131,6 +139,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -161,5 +177,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -104,6 +104,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -158,6 +166,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -92,18 +92,18 @@
         rw root=/dev/mmcblk1p1 rootwait console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -146,18 +146,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/logical_partition.xml
@@ -94,7 +94,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -156,7 +156,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -133,6 +141,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -158,5 +174,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -121,18 +121,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -146,17 +146,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -93,7 +93,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -153,7 +153,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -91,18 +91,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
@@ -143,18 +143,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/logical_partition.xml
@@ -103,6 +103,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
@@ -155,6 +163,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -144,7 +144,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -90,18 +90,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -134,18 +134,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -174,17 +174,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -102,6 +102,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -146,6 +154,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -186,5 +202,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -131,6 +139,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -161,5 +177,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/industry.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -119,18 +119,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -149,17 +149,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -95,7 +95,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -157,7 +157,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -105,6 +105,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
@@ -159,6 +167,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/logical_partition.xml
@@ -93,18 +93,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
@@ -147,18 +147,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -133,6 +141,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -158,5 +174,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -121,18 +121,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -146,17 +146,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_aaag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device">00:15.1 USB controller: Intel Corporation Device 5aaa (rev 0b)</usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
@@ -100,6 +100,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
 	<pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
         <pci_dev desc="pci device">09:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</pci_dev>
@@ -153,6 +161,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -195,6 +211,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -225,5 +249,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
@@ -88,18 +88,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/nvme0n1p3 earlyprintk=serial,ttyS0,115200 console=ttyS0,115200n8 log_buf_len=2M ignore_loglevel noxsave nohpet no_timer_check tsc=reliable</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
 	<pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
         <pci_dev desc="pci device">09:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</pci_dev>
@@ -141,18 +141,18 @@
         <pcpu_id>4</pcpu_id>
         <pcpu_id>5</pcpu_id>
     </cpu_affinity>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -183,18 +183,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -213,17 +213,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
@@ -151,7 +151,7 @@
     </cpu_affinity>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
@@ -88,6 +88,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -128,6 +136,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -158,6 +174,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -188,6 +212,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -218,6 +250,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -248,6 +288,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -278,6 +326,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -305,5 +361,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
@@ -76,18 +76,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -116,18 +116,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -146,18 +146,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -176,18 +176,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -206,18 +206,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -236,18 +236,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -266,18 +266,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -293,17 +293,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
@@ -78,7 +78,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -103,18 +103,18 @@
             <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
             <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -147,18 +147,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -185,17 +185,17 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -115,6 +115,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -159,6 +167,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -197,5 +213,13 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -157,7 +157,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -111,6 +111,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
             <pci_dev desc="pci device">00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
@@ -155,6 +163,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -195,6 +211,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
     <vm id="3">
         <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -223,5 +247,13 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -153,7 +153,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -99,18 +99,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
             <pci_dev desc="pci device">00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
@@ -143,18 +143,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -183,18 +183,18 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
     <vm id="3">
         <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -211,17 +211,17 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
@@ -98,18 +98,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda2 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
             <pci_dev desc="pci device">00:1a.3 Non-VGA unclassified device [0000]: Intel Corporation Device 4b4a</pci_dev>
@@ -146,18 +146,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -184,17 +184,17 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
@@ -156,7 +156,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
@@ -110,6 +110,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
             <pci_dev desc="pci device">00:1a.3 Non-VGA unclassified device [0000]: Intel Corporation Device 4b4a</pci_dev>
@@ -158,6 +166,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -196,5 +212,13 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -87,18 +87,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -127,18 +127,18 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
     <vm id="2">
         <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -157,18 +157,18 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -187,18 +187,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -217,18 +217,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -247,18 +247,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -277,18 +277,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -304,17 +304,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -99,6 +99,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -139,6 +147,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
     <vm id="2">
         <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -169,6 +185,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -199,6 +223,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -229,6 +261,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -259,6 +299,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -289,6 +337,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -316,5 +372,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry.xml
@@ -89,7 +89,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_vxworks.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/industry_launch_6uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>
@@ -89,6 +97,10 @@
 	    <shm_regions desc="List of shared memory regions for inter-VM communication.">
 		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -125,6 +137,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
 		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -161,6 +177,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -197,6 +217,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -103,7 +103,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
@@ -165,7 +165,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -113,6 +113,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
             <pci_dev desc="pci device" />
@@ -167,6 +175,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
             <pci_dev desc="pci device" />

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/logical_partition.xml
@@ -101,18 +101,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
             <pci_dev desc="pci device" />
@@ -155,18 +155,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs desc="pci devices list">
             <pci_dev desc="pci device" />
             <pci_dev desc="pci device" />

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -87,18 +87,18 @@
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
             <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
         </os_config>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -125,18 +125,18 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
     <vm configurable="1" desc="specific for Kata" id="2">
         <vm_type desc="Specify the VM type" readonly="true">KATA_VM</vm_type>
@@ -150,17 +150,17 @@
             <base desc="SGX EPC section base, must be page aligned">0</base>
             <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
         </epc_section>
-        <vuart id="0">
+        <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
             <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-        </vuart>
-        <vuart id="1">
+        </legacy_vuart>
+        <legacy_vuart id="1">
             <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
             <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
             <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-        </vuart>
+        </legacy_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -89,7 +89,7 @@
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
             <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc.xml
@@ -99,6 +99,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
         <pci_devs configurable="0" desc="pci devices list">
             <pci_dev desc="pci device" />
         </pci_devs>
@@ -137,6 +145,14 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
     <vm configurable="1" desc="specific for Kata" id="2">
         <vm_type desc="Specify the VM type" readonly="true">KATA_VM</vm_type>
@@ -162,5 +178,13 @@
             <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
             <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
         </legacy_vuart>
+        <console_vuart id="0">
+            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        </console_vuart>
+        <communication_vuart id="1">
+            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/sdc_launch_1uos_zephyr.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -142,7 +142,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -88,18 +88,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -132,18 +132,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -170,17 +170,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -100,6 +100,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -144,6 +152,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -182,5 +198,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_launch_1uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_launch_1uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -102,6 +102,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -145,6 +153,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -183,6 +199,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -211,5 +235,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -90,18 +90,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -133,18 +133,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -171,18 +171,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -199,17 +199,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -143,7 +143,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/generic/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry.xml
@@ -89,6 +89,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -157,5 +173,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry.xml
@@ -79,7 +79,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/generic/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry.xml
@@ -77,18 +77,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -145,17 +145,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/industry_launch_1uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry_launch_1uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/generic/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>
@@ -51,6 +55,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
@@ -91,18 +91,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
@@ -145,18 +145,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
@@ -93,7 +93,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -155,7 +155,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/logical_partition.xml
@@ -103,6 +103,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
@@ -157,6 +165,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
@@ -77,18 +77,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -140,17 +140,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
@@ -79,7 +79,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." >SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/sdc.xml
@@ -89,6 +89,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -152,5 +168,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/generic/sdc_launch_1uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/sdc_launch_1uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -102,6 +102,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -146,6 +154,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -184,5 +200,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -144,7 +144,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -90,18 +90,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -134,18 +134,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -172,17 +172,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
@@ -130,6 +138,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -160,6 +176,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -190,6 +214,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -220,6 +252,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -250,6 +290,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -280,6 +328,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -307,5 +363,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
@@ -118,18 +118,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -148,18 +148,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -178,18 +178,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -208,18 +208,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -238,18 +238,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -268,18 +268,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -295,17 +295,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -53,6 +57,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/industry_launch_6uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+    <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+    <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+        <communication_vuart></communication_vuart>
+    </communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -53,6 +57,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+    <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+    <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+        <communication_vuart></communication_vuart>
+    </communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
@@ -91,6 +99,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -127,6 +139,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -163,6 +179,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -199,6 +219,10 @@
 	    <shm_regions desc="List of shared memory regions for inter-VM communication.">
 		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -105,6 +105,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)</pci_dev>
@@ -159,6 +167,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Network controller: Intel Corporation Device 24fb (rev 10)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -95,7 +95,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -157,7 +157,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/logical_partition.xml
@@ -93,18 +93,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)</pci_dev>
@@ -147,18 +147,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
         <pci_dev desc="pci device">02:00.0 Network controller: Intel Corporation Device 24fb (rev 10)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
@@ -132,6 +140,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -157,5 +173,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>
@@ -120,18 +120,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -145,17 +145,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -86,18 +86,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -130,18 +130,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -168,17 +168,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -98,6 +98,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -142,6 +150,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -180,5 +196,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -140,7 +140,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)</audio>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -145,18 +145,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -175,18 +175,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -205,18 +205,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -235,18 +235,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -265,18 +265,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -292,17 +292,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -157,6 +173,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -187,6 +211,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -217,6 +249,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -247,6 +287,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -277,6 +325,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -304,5 +360,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)</audio>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/industry_launch_6uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>
@@ -89,6 +97,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -125,6 +137,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -161,6 +177,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -197,6 +217,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -91,7 +91,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -154,7 +154,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -89,18 +89,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_dev_num configurable="0" desc="pci devices number">VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Sunrise Point-LP SATA Controller [AHCI mode] (rev 21)</pci_dev>
@@ -144,18 +144,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_dev_num configurable="0" desc="pci devices number">VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Sunrise Point-LP USB 3.0 xHCI Controller (rev 21)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/logical_partition.xml
@@ -101,6 +101,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_dev_num configurable="0" desc="pci devices number">VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Sunrise Point-LP SATA Controller [AHCI mode] (rev 21)</pci_dev>
@@ -156,6 +164,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_dev_num configurable="0" desc="pci devices number">VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Sunrise Point-LP USB 3.0 xHCI Controller (rev 21)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -140,17 +140,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -152,5 +168,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -113,17 +113,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -125,5 +133,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/KATA_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/KATA_VM.xml
@@ -23,5 +23,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/KATA_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/KATA_VM.xml
@@ -11,17 +11,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_RT_VM.xml
@@ -14,6 +14,10 @@
 		<shm_regions desc="List of shared memory regions for inter-VM communication.">
 			<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 		</shm_regions>
+		<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+		<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+			<communication_vuart></communication_vuart>
+		</communication_vuarts>
 
 		<passthrough_devices>
 			<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/LAUNCH_POST_STD_VM.xml
@@ -14,6 +14,10 @@
 		<shm_regions desc="List of shared memory regions for inter-VM communication.">
 			<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 		</shm_regions>
+		<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+		<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+			<communication_vuart></communication_vuart>
+		</communication_vuarts>
 
 		<passthrough_devices>
 			<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/template/POST_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/POST_RT_VM.xml
@@ -26,5 +26,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/POST_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/POST_RT_VM.xml
@@ -14,17 +14,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/POST_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/POST_STD_VM.xml
@@ -26,5 +26,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/POST_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/POST_STD_VM.xml
@@ -14,17 +14,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/template/PRE_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/PRE_RT_VM.xml
@@ -41,6 +41,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/template/PRE_RT_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/PRE_RT_VM.xml
@@ -29,18 +29,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/template/PRE_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/PRE_STD_VM.xml
@@ -30,7 +30,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/template/PRE_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/PRE_STD_VM.xml
@@ -40,6 +40,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/template/PRE_STD_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/PRE_STD_VM.xml
@@ -28,18 +28,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments"></bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
         <pci_dev desc="pci device"></pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/template/SAFETY_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/SAFETY_VM.xml
@@ -42,6 +42,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/template/SAFETY_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/SAFETY_VM.xml
@@ -30,18 +30,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel"></kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel"></kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
@@ -24,7 +24,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
@@ -22,18 +22,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
@@ -34,6 +34,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -86,18 +86,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -130,18 +130,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -167,17 +167,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -98,6 +98,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -142,6 +150,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -179,5 +195,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -140,7 +140,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -144,7 +144,7 @@
     </cpu_affinity>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -90,18 +90,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 earlyprintk=serial,ttyS0,115200 console=ttyS0,115200n8 log_buf_len=2M ignore_loglevel noxsave nohpet no_timer_check tsc=reliable</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
         <pci_dev desc="pci device">00:1e.4 Ethernet controller: Intel Corporation Device a0ac (rev 20)</pci_dev>
@@ -134,18 +134,18 @@
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -174,18 +174,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -202,17 +202,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -102,6 +102,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
         <pci_dev desc="pci device">00:1e.4 Ethernet controller: Intel Corporation Device a0ac (rev 20)</pci_dev>
@@ -146,6 +154,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -186,6 +202,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -214,5 +238,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device a0c8 (rev 10)</audio>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -126,6 +134,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -156,6 +172,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -186,6 +210,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -114,18 +114,18 @@
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
 
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -144,18 +144,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -174,18 +174,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device a0c8 (rev 10)</audio>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -91,7 +91,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -153,7 +153,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -89,18 +89,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
         <pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V (rev 20)</pci_dev>
@@ -143,18 +143,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/logical_partition.xml
@@ -101,6 +101,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
         <pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V (rev 20)</pci_dev>
@@ -155,6 +163,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
     </pci_devs>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -126,6 +134,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -151,5 +167,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -114,18 +114,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -139,17 +139,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/sdc_launch_1uos_zephyr.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -86,18 +86,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -130,18 +130,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -168,17 +168,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -98,6 +98,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -142,6 +150,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -180,5 +196,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -140,7 +140,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -86,18 +86,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -130,18 +130,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -170,18 +170,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -198,17 +198,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -98,6 +98,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -142,6 +150,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -182,6 +198,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -210,5 +234,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -140,7 +140,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -145,18 +145,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -175,18 +175,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -205,18 +205,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -235,18 +235,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -265,18 +265,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -292,17 +292,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -157,6 +173,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -187,6 +211,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -217,6 +249,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -247,6 +287,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -277,6 +325,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -304,5 +360,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/industry_launch_6uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>
@@ -89,6 +97,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -125,6 +137,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -161,6 +177,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
 		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	    </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -197,6 +217,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -89,18 +89,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -143,18 +143,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
         <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -91,7 +91,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -153,7 +153,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/logical_partition.xml
@@ -101,6 +101,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -155,6 +163,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
         <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -140,17 +140,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -152,5 +168,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -14,6 +14,11 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -14,6 +14,11 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -86,18 +86,18 @@
         <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
         <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -130,18 +130,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -168,17 +168,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -98,6 +98,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -142,6 +150,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -180,5 +196,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -140,7 +140,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -86,18 +86,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -130,18 +130,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -170,18 +170,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -198,17 +198,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -98,6 +98,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -142,6 +150,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -182,6 +198,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -210,5 +234,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -140,7 +140,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memrory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, formated as hv:/shm_region_0,2097152"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -75,18 +75,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -115,18 +115,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -145,18 +145,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -175,18 +175,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -205,18 +205,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -235,18 +235,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -265,18 +265,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -292,17 +292,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -77,7 +77,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry.xml
@@ -87,6 +87,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -127,6 +135,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
@@ -157,6 +173,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -187,6 +211,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="4">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -217,6 +249,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="5">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -247,6 +287,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="6">
     <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
@@ -277,6 +325,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="7" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -304,5 +360,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_2uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_6uos.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/industry_launch_6uos.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+    <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+    <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+        <communication_vuart></communication_vuart>
+    </communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device">00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)</audio>
@@ -52,6 +56,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+    <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+    <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+        <communication_vuart></communication_vuart>
+    </communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
 		<audio desc="vm audio device"></audio>
@@ -89,6 +97,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -125,6 +137,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -161,6 +177,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />
@@ -197,6 +217,10 @@
         <shm_regions desc="List of shared memory regions for inter-VM communication.">
             <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
         </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
         <passthrough_devices>
             <usb_xdci desc="vm usb_xdci device" />
             <audio desc="vm audio device" />

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -89,18 +89,18 @@
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -143,18 +143,18 @@
         consoleblank=0 tsc=reliable
         </bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
         <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -91,7 +91,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
@@ -153,7 +153,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/logical_partition.xml
@@ -101,6 +101,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
         <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
@@ -155,6 +163,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs desc="pci devices list">
         <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
         <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -81,7 +81,7 @@
     </os_config>
     <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
+        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -79,18 +79,18 @@
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
         <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address." readonly="true">SOS_COM1_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -119,18 +119,18 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -144,17 +144,17 @@
         <base desc="SGX EPC section base, must be page aligned">0</base>
         <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
     </epc_section>
-    <vuart id="0">
+    <legacy_vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
-    </vuart>
-    <vuart id="1">
+    </legacy_vuart>
+    <legacy_vuart id="1">
         <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
         <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
         <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
-    </vuart>
+    </legacy_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc.xml
@@ -91,6 +91,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
     <pci_devs configurable="0" desc="pci devices list">
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
@@ -131,6 +139,14 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
   <vm id="2" configurable="1" desc="specific for Kata">
     <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
@@ -156,5 +172,13 @@
         <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
         <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
     </legacy_vuart>
+    <console_vuart id="0">
+        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
+        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+    </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -14,6 +14,10 @@
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
 	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
 
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>


### PR DESCRIPTION
- assign vbar and vbdf to pci vuart
- insert vuart pci dev to pci_dev.c
- update vm_configurations.c and misc_cfg.h accordinly
- sanity check of configuration error

Tracked-On: #5425
Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>