### PR TITLE
Correctly handle EAGAIN in pm_vuart when listening

### DIFF
--- a/misc/life_mngr/life_mngr.c
+++ b/misc/life_mngr/life_mngr.c
@@ -179,10 +179,10 @@ void *sos_socket_thread(void *arg)
 	}
 
 	while (1) {
-		memset(buf, 0, BUFF_SIZE);
+		memset(buf, 0, sizeof(buf));
 
 		/* Here assume the socket communication is reliable, no need to try */
-		num = read(connect_fd, buf, sizeof(SHUTDOWN_CMD));
+		num = read(connect_fd, buf, sizeof(buf));
 		if (num == -1) {
 			LOG_PRINTF("read error on a socket(fd = 0x%x)\n", connect_fd);
 			close(connect_fd);


### PR DESCRIPTION
pm_vuart stops listening and relays the message right away if it encounters EAGAIN during read(). This causes the messages relayed to be fragmented.

Only relay the message when it encounters a null character or a newline character, or when the buffer is full.

Tracked-On: #5429
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>