### PR TITLE
Vmsix vbar gpa

### DIFF
--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -115,14 +115,11 @@ void init_vmsix_on_msi(struct pci_vdev *vdev)
 
 			/* About MSI-x bar GPA:
 			 * - For Service VM: when first time init, it is programmed as 0, then OS will program
-			 * the value later and the value is stored in  vdev->vbars[MSI-X_BAR_ID].base_gpa.
-			 * When the device is assigned to UOS and then assgined back to SOS, the stored base
-			 * GPA will be used.
+			 *   the value later.
 			 * - For Post-launched VM: The GPA is assigned by device model.
 			 * - For Pre-launched VM: Not supported yet.
 			 */
-			vdev->msix.mmio_gpa = vdev->vbars[i].base_gpa;
-			vdev_pt_write_vbar(vdev, i, (uint32_t)(vdev->vbars[i].base_gpa & 0xFFFFFFFFUL));
+			pci_vdev_write_vbar(vdev, i, (uint32_t)vdev->vbars[i].base_gpa);
 		}
 	}
 }

--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -117,9 +117,12 @@ void init_vmsix_on_msi(struct pci_vdev *vdev)
 			 * - For Service VM: when first time init, it is programmed as 0, then OS will program
 			 *   the value later.
 			 * - For Post-launched VM: The GPA is assigned by device model.
-			 * - For Pre-launched VM: Not supported yet.
+			 * - For Pre-launched VM: The GPA is assigned by acrn-config tool.
 			 */
-			pci_vdev_write_vbar(vdev, i, (uint32_t)vdev->vbars[i].base_gpa);
+			if (is_prelaunched_vm(vpci2vm(vdev->vpci))) {
+				vdev->vbars[i].base_gpa = vdev->pci_dev_config->vbar_base[i];
+				pci_vdev_write_vbar(vdev, i, (uint32_t)vdev->vbars[i].base_gpa);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Currently vmsix over msi is not working for pre-launched VM. The reason is the Bar GPA is invalid. acrn-config is enhanced to calcuate/allocate a valid MMIO region for the vmsix Bar. This patch is used to assign the GPA generated by acrn-config to vmsix Bar when vdev init.

This patch also refines the code in init_vmsix_on_msi to use pci_vdev_write_vbar instead of vdev_pt_write_vbar because no mapping/ unmapping needs to be done when vdev init.

Tracked-On: #5316
Signed-off-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
