### PR TITLE
acrn-config: minor change scenario xml for cfl-k700-i7

### DIFF
--- a/misc/vm_configs/xmls/board-xmls/cfl-k700-i7.xml
+++ b/misc/vm_configs/xmls/board-xmls/cfl-k700-i7.xml
@@ -372,7 +372,7 @@
 	</IOMEM_INFO>
 
 	<BLOCK_DEVICE_INFO>
-	/dev/nvme0n1p2: TYPE="ext4"
+	/dev/nvme0n1p3: TYPE="ext4"
 	/dev/nvme1n1p3: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
 

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
@@ -86,7 +86,7 @@
         <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
         <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
         <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/nvme0n1p2 earlyprintk=serial,ttyS0,115200 console=ttyS0,115200n8 log_buf_len=2M ignore_loglevel noxsave nohpet no_timer_check tsc=reliable</bootargs>
+        <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/nvme0n1p3 earlyprintk=serial,ttyS0,115200 console=ttyS0,115200n8 log_buf_len=2M ignore_loglevel noxsave nohpet no_timer_check tsc=reliable</bootargs>
     </os_config>
     <vuart id="0">
         <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
@@ -102,7 +102,7 @@
     </vuart>
     <pci_devs desc="pci devices list">
 	<pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
-        <pci_dev desc="pci device">01:00.0 Non-Volatile memory controller: Marvell Technology Group Ltd. Device 1160 (rev b0)</pci_dev>
+        <pci_dev desc="pci device">09:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</pci_dev>
     </pci_devs>
     <mmio_resources desc="mmio devices list to passthrough">
         <TPM2 desc="TPM2 device">y</TPM2>
@@ -170,13 +170,11 @@
         <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
-        <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
-        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/industry.xml
@@ -92,7 +92,7 @@
         <pci_dev desc="pci device"></pci_dev>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
+        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
         <bootargs desc="Specify kernel boot arguments">
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000


### PR DESCRIPTION
Changes:
	1. assign 3 CPUs for WaaG on hybrid_rt scenario;
	2. Passthrough NVME@9:0.0 for VM0 on hybrid_rt scenario;
	3. Change rootfs from partition2 to partition3;

Tracked-On: #5390

Signed-off-by: Liang Yi <yi.liang@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>