### PR TITLE
acrn-config: fix the bug of resolved nested mmio address

### DIFF
--- a/misc/acrn-config/board_config/vbar_base_h.py
+++ b/misc/acrn-config/board_config/vbar_base_h.py
@@ -158,6 +158,8 @@ def removed_nested(list1, list2):
     for w1 in resolvedList:
         for w2 in list2:
             if w2.start <= w1.start <= w2.end and w2.start <= w1.end <= w2.end:
+                if w1 not in resolvedList:
+                    continue
                 resolvedList.remove(w1)
     return sorted(resolvedList)
 


### PR DESCRIPTION
Multiple devices could be nested under the same range. Skip remove if
the device is removed already

Tracked-On: #5437
Signed-off-by: Yang,Yu-chu <yu-chu,yang@intel.com>