### PR TITLE
PCI vUART Support in HV

### DIFF
--- a/devicemodel/hw/pci/uart.c
+++ b/devicemodel/hw/pci/uart.c
@@ -28,17 +28,25 @@
 
 #include <stdio.h>
 #include <sys/errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/user.h>
 
 #include "pci_core.h"
 #include "uart_core.h"
+#include "dm_string.h"
+#include "vmmapi.h"
 
 /*
  * Pick a PCI vid/did of a chip with a single uart at
  * BAR0, that most versions of FreeBSD can understand:
  * Siig CyberSerial 1-port.
  */
-#define COM_VENDOR	0x131f
-#define COM_DEV		0x2000
+#define COM_VENDOR	0x9710
+#define COM_DEV		0x9900
+
+#define VUART_IDX	"vuart_idx"
 
 static void
 pci_uart_intr_assert(void *arg)
@@ -78,31 +86,79 @@ pci_uart_read(struct vmctx *ctx, int vcpu, struct pci_vdev *dev,
 static int
 pci_uart_init(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
-	pci_emul_alloc_bar(dev, 0, PCIBAR_IO, UART_IO_BAR_SIZE);
-	pci_lintr_request(dev);
+	char *tmp, *val = NULL;
+	bool is_hv_land = false;
+	uint32_t vuart_idx;
+	struct acrn_emul_dev vdev = {};
+	int32_t err = 0;
 
-	/* initialize config space */
-	pci_set_cfgdata16(dev, PCIR_DEVICE, COM_DEV);
-	pci_set_cfgdata16(dev, PCIR_VENDOR, COM_VENDOR);
-	pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_SIMPLECOMM);
-
-	dev->arg = uart_set_backend(pci_uart_intr_assert, pci_uart_intr_deassert, dev, opts);
-	if (dev->arg == NULL) {
-		pr_err("Unable to initialize backend '%s' for "
-		    "pci uart at %d:%d\n", opts, dev->slot, dev->func);
-		return -1;
+	if (opts != NULL) {
+		tmp = val= strdup(opts);
+		if (!tmp) {
+			pr_err("No memory for strdup, can't parse uart args!!!!\n");
+		} else {
+			if (!strncmp(tmp, VUART_IDX, strlen(VUART_IDX))) {
+				 tmp = strsep(&val, ":");
+				 if (!val) {
+					pr_err("pci vuart miss vuart_idx value!!!!\n");
+				 } else {
+					if (dm_strtoui(val, &val, 10, &vuart_idx)) {
+						pr_err("wrong vuart_idx value!!!!\n");
+					} else {
+						is_hv_land = true;
+					}
+				 }
+			}
+		}
 	}
 
-	return 0;
+	if (is_hv_land) {
+		pci_emul_alloc_bar(dev, 0, PCIBAR_MEM32, 256);
+		pci_emul_alloc_bar(dev, 1, PCIBAR_MEM32, PAGE_SIZE);
+		dev->arg = NULL;
+		vdev.dev_id.fields.vendor_id = COM_VENDOR;
+		vdev.dev_id.fields.device_id = COM_DEV;
+		vdev.slot = PCI_BDF(dev->bus, dev->slot, dev->func);
+		vdev.io_addr[0] = pci_get_cfgdata32(dev, PCIR_BAR(0));
+		vdev.io_addr[1] = pci_get_cfgdata32(dev, PCIR_BAR(1));
+		*((uint32_t *)vdev.args) = vuart_idx;
+		err = vm_create_hv_vdev(ctx, &vdev);
+		if (err) {
+			pr_err("HV can't create vuart with vuart_idx=%d\n", vuart_idx);
+		}
+	} else {
+		pci_emul_alloc_bar(dev, 0, PCIBAR_IO, UART_IO_BAR_SIZE);
+		pci_lintr_request(dev);
+
+		/* initialize config space */
+		pci_set_cfgdata16(dev, PCIR_DEVICE, COM_DEV);
+		pci_set_cfgdata16(dev, PCIR_VENDOR, COM_VENDOR);
+		pci_set_cfgdata8(dev, PCIR_CLASS, PCIC_SIMPLECOMM);
+
+		dev->arg = uart_set_backend(pci_uart_intr_assert, pci_uart_intr_deassert, dev, opts);
+		if (dev->arg == NULL) {
+			pr_err("Unable to initialize backend '%s' for "
+			    "pci uart at %d:%d\n", opts, dev->slot, dev->func);
+			err = -1;
+		}
+	}
+
+	return err;
 }
 
 static void
 pci_uart_deinit(struct vmctx *ctx, struct pci_vdev *dev, char *opts)
 {
 	struct uart_vdev *uart = (struct uart_vdev *)dev->arg;
+	struct acrn_emul_dev emul_dev = {};
 
-	if (uart == NULL)
+	if (uart == NULL) {
+		emul_dev.dev_id.fields.vendor_id = COM_VENDOR;
+		emul_dev.dev_id.fields.device_id = COM_DEV;
+		emul_dev.slot = PCI_BDF(dev->bus, dev->slot, dev->func);
+		vm_destroy_hv_vdev(ctx, &emul_dev);
 		return;
+	}
 
 	uart_release_backend(uart, opts);
 }

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -310,6 +310,7 @@ VP_DM_C_SRCS += dm/vpci/vmsi.c
 VP_DM_C_SRCS += dm/vpci/vmsix.c
 VP_DM_C_SRCS += dm/vpci/vmsix_on_msi.c
 VP_DM_C_SRCS += dm/vpci/vsriov.c
+VP_DM_C_SRCS += dm/vpci/vmcs9900.c
 VP_DM_C_SRCS += dm/mmio_dev.c
 VP_DM_C_SRCS += dm/vgpio.c
 VP_DM_C_SRCS += arch/x86/guest/vlapic.c

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -26,6 +26,7 @@
 #include <rdt.h>
 #include <sgx.h>
 #include <uart16550.h>
+#include <vpci.h>
 #include <ivshmem.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -478,7 +478,7 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 		enable_iommu();
 
 		/* Create virtual uart;*/
-		init_vuart(vm, vm_config->vuart);
+		init_legacy_vuarts(vm, vm_config->vuart);
 
 		register_reset_port_handler(vm);
 
@@ -622,7 +622,7 @@ int32_t shutdown_vm(struct acrn_vm *vm)
 
 	ptirq_remove_configured_intx_remappings(vm);
 
-	deinit_vuart(vm);
+	deinit_legacy_vuarts(vm);
 
 	deinit_vpci(vm);
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -21,19 +21,21 @@
 #include <ioapic.h>
 #include <mmio_dev.h>
 #include <ivshmem.h>
+#include <vmcs9900.h>
 
 #define DBG_LEVEL_HYCALL	6U
 
-typedef int32_t (*emul_dev_op) (struct acrn_vm *vm, struct acrn_emul_dev *dev);
+typedef int32_t (*emul_dev_create) (struct acrn_vm *vm, struct acrn_emul_dev *dev);
+typedef int32_t (*emul_dev_destroy) (struct pci_vdev *vdev);
 struct emul_dev_ops {
 	/*
 	 * The low 32 bits represent the vendor id and device id of PCI device,
 	 * and the high 32 bits represent the device number of the legacy device
 	 */
 	uint64_t dev_id;
-	emul_dev_op create;
-	emul_dev_op destroy;
-
+	/* TODO: to re-use vdev_init/vdev_deinit directly in hypercall */
+	emul_dev_create create;
+	emul_dev_destroy destroy;
 };
 
 static struct emul_dev_ops emul_dev_ops_tbl[] = {
@@ -42,6 +44,7 @@ static struct emul_dev_ops emul_dev_ops_tbl[] = {
 #else
 	{(IVSHMEM_VENDOR_ID | (IVSHMEM_DEVICE_ID << 16U)), NULL, NULL},
 #endif
+	{(MCS9900_VENDOR | (MCS9900_DEV << 16U)), create_vmcs9900_vdev, destroy_vmcs9900_vdev},
 };
 
 bool is_hypercall_from_ring0(void)
@@ -1216,16 +1219,30 @@ int32_t hcall_destroy_vdev(struct acrn_vm *vm, struct acrn_vm *target_vm, __unus
 {
 	int32_t ret = -EINVAL;
 	struct acrn_emul_dev dev;
+	struct pci_vdev *vdev;
 	struct emul_dev_ops *op;
+	union pci_bdf bdf;
 
 	/* We should only destroy a device to a post-launched VM at creating or pausing time for safety, not runtime or other cases*/
 	if (is_created_vm(target_vm) || is_paused_vm(target_vm)) {
 		if (copy_from_gpa(vm, &dev, param2, sizeof(dev)) == 0) {
-		op = find_emul_dev_ops(&dev);
-		if ((op != NULL) && (op->destroy != NULL)) {
-			ret = op->destroy(target_vm, &dev);
+			op = find_emul_dev_ops(&dev);
+			if (op != NULL) {
+				bdf.value = (uint16_t) dev.slot;
+				vdev = pci_find_vdev(&vm->vpci, bdf);
+				if (vdev != NULL) {
+					vdev->pci_dev_config->vbdf.value = UNASSIGNED_VBDF;
+					if (op->destroy != NULL) {
+						ret = op->destroy(vdev);
+					} else {
+						ret = 0;
+					}
+				} else {
+					pr_warn("%s, failed to destroy emulated device %x:%x.%x\n",
+						__func__, bdf.bits.b, bdf.bits.d, bdf.bits.f);
+				}
+			}
 		}
-	}
 	} else {
 		pr_err("%s, vm[%d] is not a postlaunched VM, or not in CREATED/PAUSED status to destroy a vdev\n", __func__, target_vm->vm_id);
 	}

--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -394,27 +394,15 @@ int32_t create_ivshmem_vdev(struct acrn_vm *vm, struct acrn_emul_dev *dev)
 	return ret;
 }
 
-/**
- * @pre vm != NULL
- * @pre dev != NULL
- */
-int32_t destroy_ivshmem_vdev(struct acrn_vm *vm, struct acrn_emul_dev *dev)
+int32_t destroy_ivshmem_vdev(struct pci_vdev *vdev)
 {
-	struct pci_vdev *vdev;
-	union pci_bdf bdf;
-	int32_t ret = 0;
+	uint32_t i;
 
-	bdf.value = (uint16_t) dev->slot;
-	vdev = pci_find_vdev(&vm->vpci, bdf);
-	if (vdev != NULL) {
-		vdev->pci_dev_config->vbdf.value = UNASSIGNED_VBDF;
-		(void)memset(vdev->pci_dev_config->vbar_base, 0U, sizeof(vdev->pci_dev_config->vbar_base));
-	} else {
-		pr_warn("%s, failed to destroy ivshmem device %x:%x.%x\n",
-			__func__, bdf.bits.b, bdf.bits.d, bdf.bits.f);
-		ret = -EINVAL;
+	for (i = 0U; i < vdev->nr_bars; i++) {
+		vpci_update_one_vbar(vdev, i, 0U, NULL, ivshmem_vbar_unmap);
 	}
-	return ret;
+
+	return 0;
 }
 
 const struct pci_vdev_ops vpci_ivshmem_ops = {

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <vm.h>
+#include <ept.h>
+#include <vpci.h>
+#include <logmsg.h>
+#include <vmcs9900.h>
+#include "vpci_priv.h"
+
+#define MCS9900_MMIO_BAR        0U
+#define MCS9900_MSIX_BAR        1U
+
+static int32_t read_vmcs9900_cfg(const struct pci_vdev *vdev,
+				       uint32_t offset, uint32_t bytes,
+				       uint32_t * val)
+{
+	if (vbar_access(vdev, offset)) {
+		*val = pci_vdev_read_vbar(vdev, pci_bar_index(offset));
+	} else {
+		*val = pci_vdev_read_vcfg(vdev, offset, bytes);
+	}
+
+	return 0;
+}
+
+static int32_t vmcs9900_mmio_handler(struct io_request *io_req, void *data)
+{
+	struct mmio_request *mmio = &io_req->reqs.mmio;
+	struct pci_vdev *vdev = (struct pci_vdev *)data;
+	struct acrn_vuart *vu = vdev->priv_data;
+	struct pci_vbar *vbar = &vdev->vbars[MCS9900_MMIO_BAR];
+	uint16_t offset;
+
+	offset = mmio->address - vbar->base_gpa;
+
+	if (mmio->direction == REQUEST_READ) {
+		mmio->value = vuart_read_reg(vu, offset);
+	} else {
+		vuart_write_reg(vu, offset, (uint8_t) mmio->value);
+	}
+	return 0;
+}
+
+static void map_vmcs9900_vbar(struct pci_vdev *vdev, uint32_t idx)
+{
+	struct acrn_vuart *vu = vdev->priv_data;
+	struct acrn_vm *vm = vpci2vm(vdev->vpci);
+	struct pci_vbar *vbar = &vdev->vbars[idx];
+
+	if ((idx == MCS9900_MMIO_BAR) && (vbar->base_gpa != 0UL)) {
+		register_mmio_emulation_handler(vm, vmcs9900_mmio_handler,
+			vbar->base_gpa, vbar->base_gpa + vbar->size, vdev, false);
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, vbar->base_gpa, vbar->size);
+		vu->active = true;
+	} else if ((idx == MCS9900_MSIX_BAR) && (vbar->base_gpa != 0UL)) {
+		register_mmio_emulation_handler(vm, vmsix_handle_table_mmio_access, vbar->base_gpa,
+			(vbar->base_gpa + vbar->size), vdev, false);
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, vbar->base_gpa, vbar->size);
+		vdev->msix.mmio_gpa = vbar->base_gpa;
+	}
+
+}
+
+static void unmap_vmcs9900_vbar(struct pci_vdev *vdev, uint32_t idx)
+{
+	struct acrn_vuart *vu = vdev->priv_data;
+	struct acrn_vm *vm = vpci2vm(vdev->vpci);
+	struct pci_vbar *vbar = &vdev->vbars[idx];
+
+	if ((idx == MCS9900_MMIO_BAR) && (vbar->base_gpa != 0UL)) {
+		vu->active = false;
+	}
+	unregister_mmio_emulation_handler(vm, vbar->base_gpa, vbar->base_gpa + vbar->size);
+}
+
+static int32_t write_vmcs9900_cfg(struct pci_vdev *vdev, uint32_t offset,
+					uint32_t bytes, uint32_t val)
+{
+	if (vbar_access(vdev, offset)) {
+		vpci_update_one_vbar(vdev, pci_bar_index(offset), val,
+			map_vmcs9900_vbar, unmap_vmcs9900_vbar);
+	} else if (msixcap_access(vdev, offset)) {
+		write_vmsix_cap_reg(vdev, offset, bytes, val);
+	} else {
+		pci_vdev_write_vcfg(vdev, offset, bytes, val);
+	}
+
+	return 0;
+}
+
+static void init_vmcs9900(struct pci_vdev *vdev)
+{
+	struct acrn_vm_pci_dev_config *pci_cfg = vdev->pci_dev_config;
+	struct acrn_vm *vm = vpci2vm(vdev->vpci);
+	struct pci_vbar *mmio_vbar = &vdev->vbars[MCS9900_MMIO_BAR];
+	struct pci_vbar *msix_vbar = &vdev->vbars[MCS9900_MSIX_BAR];
+	struct acrn_vuart *vu = &vm->vuart[pci_cfg->vuart_idx];
+
+	/* 8250-pci compartiable device */
+	pci_vdev_write_vcfg(vdev, PCIR_VENDOR, 2U, MCS9900_VENDOR);
+	pci_vdev_write_vcfg(vdev, PCIR_DEVICE, 2U, MCS9900_DEV);
+	pci_vdev_write_vcfg(vdev, PCIR_CLASS, 1U, PCIC_SIMPLECOMM);
+	pci_vdev_write_vcfg(vdev, PCIV_SUB_SYSTEM_ID, 2U, 0x1000U);
+	pci_vdev_write_vcfg(vdev, PCIV_SUB_VENDOR_ID, 2U, 0xa000U);
+	pci_vdev_write_vcfg(vdev, PCIR_SUBCLASS, 1U, 0x0U);
+	pci_vdev_write_vcfg(vdev, PCIR_CLASS_CODE, 1U, 0x2U);
+
+	add_vmsix_capability(vdev, 1, MCS9900_MSIX_BAR);
+
+	/* initialize vuart-pci mem bar */
+	mmio_vbar->type = PCIBAR_MEM32;
+	mmio_vbar->size = 0x1000U;
+	mmio_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MMIO_BAR];
+	mmio_vbar->mask = (uint32_t) (~(mmio_vbar->size - 1UL));
+	mmio_vbar->fixed = (uint32_t) (mmio_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+
+	/* initialize vuart-pci msix bar */
+	msix_vbar->type = PCIBAR_MEM32;
+	msix_vbar->size = 0x1000U;
+	msix_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MSIX_BAR];
+	msix_vbar->mask = (uint32_t) (~(msix_vbar->size - 1UL));
+	msix_vbar->fixed = (uint32_t) (msix_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+
+	vdev->nr_bars = 2;
+
+	pci_vdev_write_vbar(vdev, MCS9900_MMIO_BAR, mmio_vbar->base_gpa);
+	pci_vdev_write_vbar(vdev, MCS9900_MSIX_BAR, msix_vbar->base_gpa);
+
+	/* init acrn_vuart */
+	pr_info("init acrn_vuart[%d]", pci_cfg->vuart_idx);
+	vdev->priv_data = vu;
+	init_pci_vuart(vdev);
+
+	vdev->user = vdev;
+}
+
+static void deinit_vmcs9900(struct pci_vdev *vdev)
+{
+	deinit_pci_vuart(vdev);
+	vdev->user = NULL;
+}
+
+const struct pci_vdev_ops vmcs9900_ops = {
+	.init_vdev = init_vmcs9900,
+	.deinit_vdev = deinit_vmcs9900,
+	.write_vdev_cfg = write_vmcs9900_cfg,
+	.read_vdev_cfg = read_vmcs9900_cfg,
+};

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -14,6 +14,23 @@
 #define MCS9900_MMIO_BAR        0U
 #define MCS9900_MSIX_BAR        1U
 
+/*
+ * @pre vdev != NULL
+ */
+void trigger_vmcs9900_msix(struct pci_vdev *vdev)
+{
+	struct acrn_vm *vm = vpci2vm(vdev->vpci);
+	int32_t ret = -1;
+	struct msix_table_entry *entry = &vdev->msix.table_entries[0];
+
+	ret = vlapic_inject_msi(vm, entry->addr, entry->data);
+
+	if (ret != 0) {
+		pr_warn("%2x:%2x.%dfaild injecting msi msi_addr:0x%lx msi_data:0x%x",
+				vdev->bdf.bits.b, vdev->bdf.bits.d, vdev->bdf.bits.f, entry->addr, entry->data);
+	}
+}
+
 static int32_t read_vmcs9900_cfg(const struct pci_vdev *vdev,
 				       uint32_t offset, uint32_t bytes,
 				       uint32_t * val)

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -21,7 +21,7 @@
 
 #define AFFINITY_CPU(n)		(1UL << (n))
 #define MAX_VCPUS_PER_VM	MAX_PCPU_NUM
-#define MAX_VUART_NUM_PER_VM	2U
+#define MAX_VUART_NUM_PER_VM	8U
 #define MAX_VM_OS_NAME_LEN	32U
 #define MAX_MOD_TAG_LEN		32U
 
@@ -152,6 +152,9 @@ struct acrn_vm_pci_dev_config {
 	union pci_bdf vbdf;				/* virtual BDF of PCI device */
 	union pci_bdf pbdf;				/* physical BDF of PCI device */
 	char shm_region_name[32];			/* TODO: combine pbdf and shm_region_name into a union member */
+	/* TODO: All device specific attributions need move to other place */
+	struct target_vuart t_vuart;
+	uint16_t vuart_idx;
 	uint64_t vbar_base[PCI_BAR_COUNT];		/* vbar base address of PCI device, which is power-on default value */
 	struct pci_pdev *pdev;				/* the physical PCI device if it's a PT device */
 	const struct pci_vdev_ops *vdev_ops;		/* operations for PCI CFG read/write */

--- a/hypervisor/include/dm/ivshmem.h
+++ b/hypervisor/include/dm/ivshmem.h
@@ -38,7 +38,7 @@ extern const struct pci_vdev_ops vpci_ivshmem_ops;
 void init_ivshmem_shared_memory(void);
 
 int32_t create_ivshmem_vdev(struct acrn_vm *vm, struct acrn_emul_dev *dev);
-int32_t destroy_ivshmem_vdev(struct acrn_vm *vm, struct acrn_emul_dev *dev);
+int32_t destroy_ivshmem_vdev(struct pci_vdev *vdev);
 #endif /* CONFIG_IVSHMEM_ENABLED */
 
 #endif /* IVSHMEM_H */

--- a/hypervisor/include/dm/vmcs9900.h
+++ b/hypervisor/include/dm/vmcs9900.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef VMCS9900_H
+#define VMCS9900_H
+
+#define MCS9900_VENDOR		0x9710U
+#define MCS9900_DEV		0x9900U
+
+extern const struct pci_vdev_ops vmcs9900_ops;
+
+#endif

--- a/hypervisor/include/dm/vmcs9900.h
+++ b/hypervisor/include/dm/vmcs9900.h
@@ -12,5 +12,7 @@
 
 extern const struct pci_vdev_ops vmcs9900_ops;
 void trigger_vmcs9900_msix(struct pci_vdev *vdev);
+int32_t create_vmcs9900_vdev(struct acrn_vm *vm, struct acrn_emul_dev *dev);
+int32_t destroy_vmcs9900_vdev(struct pci_vdev *vdev);
 
 #endif

--- a/hypervisor/include/dm/vmcs9900.h
+++ b/hypervisor/include/dm/vmcs9900.h
@@ -11,5 +11,6 @@
 #define MCS9900_DEV		0x9900U
 
 extern const struct pci_vdev_ops vmcs9900_ops;
+void trigger_vmcs9900_msix(struct pci_vdev *vdev);
 
 #endif

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -78,11 +78,14 @@ struct acrn_vuart {
 	bool active;
 	struct acrn_vuart *target_vu; /* Pointer to target vuart */
 	struct acrn_vm *vm;
+	struct pci_vdev *vdev;	/* pci vuart */
 	spinlock_t lock;	/* protects all softc elements */
 };
 
-void init_vuart(struct acrn_vm *vm, const struct vuart_config *vu_config);
-void deinit_vuart(struct acrn_vm *vm);
+void init_legacy_vuarts(struct acrn_vm *vm, const struct vuart_config *vu_config);
+void deinit_legacy_vuarts(struct acrn_vm *vm);
+void init_pci_vuart(struct pci_vdev *vdev);
+void deinit_pci_vuart(struct pci_vdev *vdev);
 
 void vuart_putchar(struct acrn_vuart *vu, char ch);
 char vuart_getchar(struct acrn_vuart *vu);

--- a/hypervisor/include/dm/vuart.h
+++ b/hypervisor/include/dm/vuart.h
@@ -89,4 +89,7 @@ char vuart_getchar(struct acrn_vuart *vu);
 void vuart_toggle_intr(const struct acrn_vuart *vu);
 
 bool is_vuart_intx(const struct acrn_vm *vm, uint32_t intx_gsi);
+
+uint8_t vuart_read_reg(struct acrn_vuart *vu, uint16_t offset);
+void vuart_write_reg(struct acrn_vuart *vu, uint16_t offset, uint8_t value);
 #endif /* VUART_H */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -74,6 +74,7 @@
 #define PCIR_STATUS           0x06U
 #define PCIM_STATUS_CAPPRESENT    0x0010U
 #define PCIR_REVID            0x08U
+#define PCIR_CLASS_CODE	      0x09U
 #define PCIR_SUBCLASS         0x0AU
 #define PCIR_CLASS            0x0BU
 #define PCIR_HDRTYPE          0x0EU
@@ -91,6 +92,7 @@
 #define PCIM_BAR_MEM_64       0x04U
 #define PCIM_BAR_MEM_BASE     0xFFFFFFF0U
 #define PCIV_SUB_VENDOR_ID    0x2CU
+#define PCIV_SUB_SYSTEM_ID    0x2EU
 #define PCIR_CAP_PTR          0x34U
 #define PCIR_CAP_PTR_CARDBUS  0x14U
 #define PCI_BASE_ADDRESS_MEM_MASK (~0x0fUL)
@@ -98,6 +100,7 @@
 #define PCIR_INTERRUPT_LINE   0x3cU
 #define PCIR_INTERRUPT_PIN    0x3dU
 
+#define PCIC_SIMPLECOMM       0x07U
 /* config registers for header type 1 (PCI-to-PCI bridge) devices */
 #define PCIR_PRIBUS_1         0x18U
 #define PCIR_SECBUS_1         0x19U

--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -10,6 +10,7 @@
 #include <rdt.h>
 #include <vuart.h>
 #include <ivshmem.h>
+#include <vmcs9900.h>
 #include <vpci.h>
 #include <hv_prebuild.h>
 
@@ -23,6 +24,7 @@ static uint8_t safety_vm_uuid1[16] = SAFETY_VM_UUID1;
 struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 const struct pci_vdev_ops vhostbridge_ops;
 const struct pci_vdev_ops vpci_ivshmem_ops;
+const struct pci_vdev_ops vmcs9900_ops;
 
 #define PLATFORM_CPUS_MASK             ((1UL << MAX_PCPU_NUM) - 1UL)
 


### PR DESCRIPTION
How to use:
Add pci-vuart in vm_config. Because PCI vUART are also virtual pci devices, their config information are in acrn_vm_pci_dev_config, just like that:

struct acrn_vm_pci_dev_config vm0_pci_devs[] = {
           {
                   .emu_type = PCI_DEV_TYPE_HVEMUL,
                   .vbdf.bits = {.b = 0x00U, .d = 0x04U, .f = 0x00U},
                   .vdev_ops = &vmcs9900_ops,
                   .vbar_base[0] = 0x80001000, /*MMIO bar*/
                   .vbar_base[1] = 0x80002000, /*MSIX bar*/
                   .vuart_idx = 2,
                   .t_vuart.vm_id = 1U,
                   .t_vuart.vuart_id = 1U,
           },
        }

If create for post-launched VM, use '-s,<slot>,uart,vuart_idx:<val>' acrn-dm option
