### PR TITLE
cleanup vpci structure when shutdown_vm

### DIFF
--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -274,6 +274,7 @@ void deinit_vpci(struct acrn_vm *vm)
 	}
 
 	ptdev_release_all_entries(vm);
+	(void)memset(&vm->vpci, 0U, sizeof(struct acrn_vpci));
 
 	/* Free iommu */
 	destroy_iommu_domain(vm->iommu);


### PR DESCRIPTION
cleanup vpci structure when shutdown_vm to avoid use uninitialized data
after reboot.

Tracked-On: #4958
Signed-off-by: Mingqiang Chi <mingqiang.chi@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>