### PR TITLE
Ptcm: Add pSRAM support Part 1

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -212,6 +212,7 @@ ifeq ($(CONFIG_MULTIBOOT2),y)
 BOOT_C_SRCS += boot/multiboot2.c
 endif
 BOOT_C_SRCS += boot/reloc.c
+BOOT_C_SRCS += arch/x86/ptcm.c
 
 # hardware management component
 HW_S_SRCS += arch/x86/idt.S

--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -35,6 +35,7 @@
 #include <host_pm.h>
 #include <pci.h>
 #include <acrn_common.h>
+#include <ptcm.h>
 
 /* Per ACPI spec:
  * There are two fundamental types of ACPI tables:
@@ -129,7 +130,7 @@ static struct acpi_mcfg_allocation *parse_mcfg_allocation_tables(const uint8_t *
 /* put all ACPI fix up code here */
 int32_t acpi_fixup(void)
 {
-	uint8_t *facp_addr = NULL, *facs_addr = NULL, *mcfg_addr = NULL;
+	uint8_t *facp_addr = NULL, *facs_addr = NULL, *mcfg_addr = NULL, *ptct_tbl_addr = NULL;
 	struct acpi_mcfg_allocation *mcfg_table = NULL;
 	int32_t ret = 0;
 	struct acpi_generic_address pm1a_cnt, pm1a_evt;
@@ -166,6 +167,11 @@ int32_t acpi_fixup(void)
 		if (mcfg_table != NULL) {
 			set_mmcfg_region((struct pci_mmcfg_region*)mcfg_table);
 		}
+	}
+
+	ptct_tbl_addr = (uint8_t *)get_acpi_tbl(ACPI_SIG_PTCT);
+	if (ptct_tbl_addr != NULL) {
+		set_ptct_tbl((void *)ptct_tbl_addr);
 	}
 
 	if ((facp_addr == NULL) || (facs_addr == NULL)

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -27,6 +27,7 @@
 #include <sgx.h>
 #include <uart16550.h>
 #include <ivshmem.h>
+#include <ptcm.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
@@ -265,10 +266,14 @@ void init_pcpu_post(uint16_t pcpu_id)
 		}
 
 		ASSERT(get_pcpu_id() == BSP_CPU_ID, "");
+
+		init_psram(true);
 	} else {
 		pr_dbg("Core %hu is up", pcpu_id);
 
 		pr_warn("Skipping VM configuration check which should be done before building HV binary.");
+
+		init_psram(false);
 
 		/* Initialize secondary processor interrupts. */
 		init_interrupt(pcpu_id);

--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -444,6 +444,7 @@ void cpu_dead(void)
 	if (bitmap_test(pcpu_id, &pcpu_active_bitmap)) {
 		/* clean up native stuff */
 		vmx_off();
+		/* TODO: a cpu dead can't effect the RTVM which use pSRAM */
 		cache_flush_invalidate_all();
 
 		/* Set state to show CPU is dead */

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -15,6 +15,7 @@
 #include <vtd.h>
 #include <logmsg.h>
 #include <trace.h>
+#include <ptct.h>
 
 #define DBG_LEVEL_EPT	6U
 
@@ -170,14 +171,52 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t 
  */
 void ept_flush_leaf_page(uint64_t *pge, uint64_t size)
 {
-	uint64_t hpa = INVALID_HPA;
+	uint64_t flush_base_hpa = INVALID_HPA, flush_end_hpa;
 	void *hva = NULL;
+	uint64_t flush_size = size;
 
 	if ((*pge & EPT_MT_MASK) != EPT_UNCACHED) {
-		hpa = (*pge & (~(size - 1UL)));
-		hva = hpa2hva(hpa);
+		flush_base_hpa = (*pge & (~(size - 1UL)));
+		flush_end_hpa = flush_base_hpa + size;
+
+		/* When pSRAM is not intialized, both psram_area_bottom and psram_area_top is 0,
+		 * so the below if/else will have no use
+		 */
+		if (flush_base_hpa < psram_area_bottom) {
+			/* Only flush [flush_base_hpa, psram_area_bottom) and [psram_area_top, flush_base_hpa),
+			 * ignore [psram_area_bottom, psram_area_top)
+			 */
+			if (flush_end_hpa > psram_area_top) {
+				/* Only flush [flush_base_hpa, psram_area_bottom) and [psram_area_top, flush_base_hpa),
+				 * ignore [psram_area_bottom, psram_area_top)
+				 */
+				flush_size = psram_area_bottom - flush_base_hpa;
+				hva = hpa2hva(flush_base_hpa);
+				stac();
+				flush_address_space(hva, flush_size);
+				clac();
+
+				flush_size = flush_end_hpa - psram_area_top;
+				flush_base_hpa = psram_area_top;
+			} else if (flush_end_hpa > psram_area_bottom) {
+				/* Only flush [flush_base_hpa, psram_area_bottom) and
+				 * ignore [psram_area_bottom, flush_end_hpa)
+				 */
+				flush_size = psram_area_bottom - flush_base_hpa;
+			}
+		} else if (flush_base_hpa < psram_area_top) {
+			if (flush_end_hpa <= psram_area_top) {
+				flush_size = 0UL;
+			} else {
+				/* Only flush [psram_area_top, flush_end_hpa) and ignore [flush_base_hpa, psram_area_top) */
+				flush_base_hpa = psram_area_top;
+				flush_size = flush_end_hpa - psram_area_top;
+			}
+		}
+
+		hva = hpa2hva(flush_base_hpa);
 		stac();
-		flush_address_space(hva, size);
+		flush_address_space(hva, flush_size);
 		clac();
 	}
 }

--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -215,7 +215,6 @@ static void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0)
 						 * disabled behavior
 						 */
 						exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL, PAT_ALL_UC_VALUE);
-						cache_flush_invalidate_all();
 					} else {
 						/* Restore IA32_PAT to enable cache again */
 						exec_vmwrite64(VMX_GUEST_IA32_PAT_FULL,

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -18,6 +18,7 @@
 #include <vtd.h>
 #include <vcpuid.h>
 #include <trace.h>
+#include <ptcm.h>
 
 /*
  * According to "SDM APPENDIX C VMX BASIC EXIT REASONS",
@@ -382,7 +383,8 @@ static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 	uint16_t i;
 	struct acrn_vcpu *other;
 
-	if (has_rt_vm() == false) {
+	/* GUEST_FLAG_RT has not set in post-launched RTVM before it has been created */
+	if ((is_psram_initialized) || (has_rt_vm() == false)) {
 		cache_flush_invalidate_all();
 	} else {
 		if (is_rt_vm(vcpu->vm)) {

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -384,7 +384,7 @@ int32_t init_ioapic_id_info(void)
 		gsi = 0U;
 		for (ioapic_id = 0U; ioapic_id < ioapic_num; ioapic_id++) {
 			addr = map_ioapic(ioapic_array[ioapic_id].addr);
-			hv_access_memory_region_update((uint64_t)addr, PAGE_SIZE);
+			ppt_clear_user_bit((uint64_t)addr, PAGE_SIZE);
 
 			nr_pins = ioapic_nr_pins(addr);
 			if (nr_pins <= (uint32_t) CONFIG_MAX_IOAPIC_LINES) {

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -210,6 +210,21 @@ void hv_access_memory_region_update(uint64_t base, uint64_t size)
 		round_pde_up(size_aligned), 0UL, PAGE_USER, &ppt_mem_ops, MR_MODIFY);
 }
 
+void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add)
+{
+	uint64_t region_end = base + size;
+	uint64_t base_aligned = round_pde_down(base);
+	uint64_t size_aligned = round_pde_up(region_end - base_aligned);
+
+	if (add) {
+		mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr,
+			base_aligned, size_aligned, PAGE_NX, 0UL, &ppt_mem_ops, MR_MODIFY);
+	} else {
+		mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr,
+			base_aligned, size_aligned, 0UL, PAGE_NX, &ppt_mem_ops, MR_MODIFY);
+	}
+}
+
 void init_paging(void)
 {
 	uint64_t hv_hva;

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -194,9 +194,9 @@ void enable_smap(void)
 }
 
 /*
- * Update memory pages to be owned by hypervisor.
+ * Clean USER bit in page table to update memory pages to be owned by hypervisor.
  */
-void hv_access_memory_region_update(uint64_t base, uint64_t size)
+void ppt_clear_user_bit(uint64_t base, uint64_t size)
 {
 	uint64_t base_aligned;
 	uint64_t size_aligned;

--- a/hypervisor/arch/x86/page.c
+++ b/hypervisor/arch/x86/page.c
@@ -136,7 +136,7 @@ void reserve_buffer_for_ept_pages(void)
 	struct acrn_vm_config *vm_config;
 
 	pt_base = e820_alloc_memory(TOTAL_EPT_4K_PAGES_SIZE, ~0UL);
-	hv_access_memory_region_update(pt_base, TOTAL_EPT_4K_PAGES_SIZE);
+	ppt_clear_user_bit(pt_base, TOTAL_EPT_4K_PAGES_SIZE);
 	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
 		vm_config = get_vm_config(vm_id);
 		ept_pages_info[vm_id].ept.nworld_pt_base = (struct page *)(void *)(pt_base + offset);

--- a/hypervisor/arch/x86/ptcm.c
+++ b/hypervisor/arch/x86/ptcm.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <types.h>
+#include <bits.h>
+#include <logmsg.h>
+#include <misc_cfg.h>
+#include <mmu.h>
+#include <ptcm.h>
+
+
+/* is_psram_initialized is used to tell whether psram is successfully initialized for all cores */
+volatile bool is_psram_initialized = false;
+
+#ifdef CONFIG_PSRAM_ENABLED
+
+static struct ptct_entry_data_ptcm_binary *ptcm_binary = NULL;
+
+static struct acpi_table_header *acpi_ptct_tbl = NULL;
+
+static inline void *get_ptct_address()
+{
+	return (void *)acpi_ptct_tbl + sizeof(*acpi_ptct_tbl);
+}
+
+static void parse_ptct(void)
+{
+	/* TODO: Will add in the next patch */
+}
+
+/*
+ * Function to initialize pSRAM. Both BSP and APs shall call this function to
+ * make sure pSRAM is initialized, which is required by PTCM.
+ * BSP:
+ *	To parse PTCT and find the entry of PTCM command function
+ * AP:
+ *	Wait until BSP has done the parsing work, then call the PTCM ABI.
+ *
+ * Synchronization of AP and BSP is ensured, both inside and outside PTCM.
+ * BSP shall be the last to finish the call.
+ */
+void init_psram(bool is_bsp)
+{
+	int32_t ptcm_ret_code;
+	struct ptcm_header *header;
+	ptcm_abi_func ptcm_command_func = NULL;
+	static uint64_t init_psram_cpus_mask = (1UL << BSP_CPU_ID);
+
+	/*
+	 * When we shut down an RTVM, its pCPUs will be re-initialized
+	 * we must ensure init_psram() will only be executed at the first time when a pcpu is booted
+	 * That's why we add "!is_psram_initialized" as an condition.
+	 */
+	if (!is_psram_initialized && (acpi_ptct_tbl != NULL)) {
+		if (is_bsp) {
+			parse_ptct();
+			bitmap_clear_lock(get_pcpu_id(), &init_psram_cpus_mask);
+		}
+
+		wait_sync_change(&init_psram_cpus_mask, 0UL);
+		pr_info("PTCT is parsed by BSP");
+		header = hpa2hva(ptcm_binary->address);
+		pr_info("ptcm_bin_address:%llx, ptcm magic:%x, ptcm version:%x",
+			ptcm_binary->address, header->magic, header->version);
+		ASSERT(header->magic == PTCM_MAGIC, "Incorrect PTCM magic!");
+
+		ptcm_command_func = (ptcm_abi_func)(hpa2hva(ptcm_binary->address) + header->command_offset);
+		pr_info("ptcm command function is found at %llx",ptcm_command_func);
+		ptcm_ret_code = ptcm_command_func(PTCM_CMD_INIT_PSRAM, get_ptct_address());
+		pr_info("ptcm initialization return %d", ptcm_ret_code);
+		/* return 0 for success, -1 for failure */
+		ASSERT(ptcm_ret_code == 0);
+
+		bitmap_set_lock(get_pcpu_id(), &init_psram_cpus_mask);
+		wait_sync_change(&init_psram_cpus_mask, ALL_CPUS_MASK);
+
+		if (is_bsp) {
+			is_psram_initialized = true;
+			pr_info("BSP pSRAM has been initialized\n");
+		}
+	}
+}
+#else
+void init_psram(__unused bool is_bsp)
+{
+}
+#endif

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -209,7 +209,7 @@ static int32_t register_hrhd_units(void)
 		drhd_rt->drhd = &platform_dmar_info->drhd_units[i];
 		drhd_rt->dmar_irq = IRQ_INVALID;
 
-		hv_access_memory_region_update(drhd_rt->drhd->reg_base_addr, PAGE_SIZE);
+		ppt_clear_user_bit(drhd_rt->drhd->reg_base_addr, PAGE_SIZE);
 
 		ret = dmar_register_hrhd(drhd_rt);
 		if (ret != 0) {

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -57,6 +57,7 @@
 #define ACPI_SIG_MCFG            "MCFG" /* Memory Mapped Configuration table */
 #define ACPI_SIG_DSDT            "DSDT" /* Differentiated System Description Table */
 #define ACPI_SIG_TPM2            "TPM2" /* Trusted Platform Module hardware interface table */
+#define ACPI_SIG_PTCT            "PTCT" /* Platform Tuning Configuration Table (Real-Time Configuration Table) */
 
 struct packed_gas {
 	uint8_t 	space_id;

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -104,7 +104,7 @@ void npk_log_setup(struct hv_npk_log_param *param)
 				for (i = 0U; i < pcpu_nums; i++) {
 					per_cpu(npk_log_ref, i) = 0U;
 				}
-				hv_access_memory_region_update(base,
+				ppt_clear_user_bit(base,
 					pcpu_nums * (HV_NPK_LOG_REF_MASK + 1U)
 					* sizeof(struct npk_chan));
 			}

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -139,7 +139,7 @@ void uart16550_init(bool early_boot)
 			mmio_base_va = hpa2hva(hva2hpa_early(uart.mmio.pci.cached_mmio_base_va));
 		}
 		if (mmio_base_va != NULL) {
-			hv_access_memory_region_update((uint64_t)mmio_base_va, PDE_SIZE);
+			ppt_clear_user_bit((uint64_t)mmio_base_va, PDE_SIZE);
 		}
 		return;
 	}

--- a/hypervisor/dm/vgpio.c
+++ b/hypervisor/dm/vgpio.c
@@ -142,7 +142,7 @@ void register_vgpio_handler(struct acrn_vm *vm, const struct acrn_mmiodev *mmiod
 	base_hpa    = mmiodev->base_hpa + (P2SB_BASE_GPIO_PORT_ID << P2SB_PORTID_SHIFT);
 
 	/* emulate MMIO access to the GPIO private configuration space registers */
-	hv_access_memory_region_update((uint64_t)hpa2hva(base_hpa), gpio_pcr_sz);
+	ppt_clear_user_bit((uint64_t)hpa2hva(base_hpa), gpio_pcr_sz);
 	register_mmio_emulation_handler(vm, vgpio_mmio_handler, gpa_start, gpa_end, (void *)vm, false);
 	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, gpa_start, gpio_pcr_sz);
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -635,7 +635,7 @@ void init_pci_pdev_list(void)
 	uint16_t bus;
 	bool was_visited = false;
 
-	hv_access_memory_region_update(phys_pci_mmcfg.address, get_pci_mmcfg_size(&phys_pci_mmcfg));
+	ppt_clear_user_bit(phys_pci_mmcfg.address, get_pci_mmcfg_size(&phys_pci_mmcfg));
 
 	pci_parse_iommu_devscopes(&bdfs_from_drhds, &drhd_idx_pci_all);
 

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -113,7 +113,7 @@ void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base,
 		uint64_t size, uint64_t prot, const struct memory_ops *mem_ops);
 void mmu_modify_or_del(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr, const struct memory_ops *mem_ops, uint32_t type);
-void hv_access_memory_region_update(uint64_t base, uint64_t size);
+void ppt_clear_user_bit(uint64_t base, uint64_t size);
 void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add);
 
 /**

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -114,6 +114,7 @@ void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base,
 void mmu_modify_or_del(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr, const struct memory_ops *mem_ops, uint32_t type);
 void hv_access_memory_region_update(uint64_t base, uint64_t size);
+void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add);
 
 /**
  * @brief Specified signle VPID flush
@@ -149,6 +150,11 @@ void flush_address_space(void *addr, uint64_t size);
  * @return None
  */
 void invept(const void *eptp);
+
+static inline void invlpg(unsigned long addr)
+{
+	asm volatile("invlpg (%0)" ::"r" (addr) : "memory");
+}
 
 static inline void cache_flush_invalidate_all(void)
 {

--- a/hypervisor/include/arch/x86/ptcm.h
+++ b/hypervisor/include/arch/x86/ptcm.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PTCM_H
+#define PTCM_H
+
+#include <ptct.h>
+
+#define MSABI __attribute__((ms_abi))
+
+typedef int32_t MSABI (*ptcm_abi_func)(uint32_t command, void *command_struct);
+
+#define PTCM_CMD_INIT_PSRAM	(int32_t)1U
+#define PTCM_CMD_CPUID		(int32_t)2U
+#define PTCM_CMD_RDMSR		(int32_t)3U
+#define PTCM_CMD_WRMSR		(int32_t)4U
+
+#define PTCM_MAGIC 0x5054434dU
+
+struct ptcm_header {
+	uint32_t magic;
+	uint32_t version;
+	uint64_t command_offset;
+} __packed;
+
+extern volatile bool is_psram_initialized;
+void init_psram(bool is_bsp);
+#endif /* PTCM_H */

--- a/hypervisor/include/arch/x86/ptcm.h
+++ b/hypervisor/include/arch/x86/ptcm.h
@@ -28,4 +28,5 @@ struct ptcm_header {
 
 extern volatile bool is_psram_initialized;
 void init_psram(bool is_bsp);
+void set_ptct_tbl(void *ptct_tbl_addr);
 #endif /* PTCM_H */

--- a/hypervisor/include/arch/x86/ptct.h
+++ b/hypervisor/include/arch/x86/ptct.h
@@ -10,11 +10,44 @@
 #include <acpi.h>
 
 
+#define PTCT_ENTRY_TYPE_PTCD_LIMIT		1U
+#define PTCT_ENTRY_TYPE_PTCM_BINARY		2U
+#define PTCT_ENTRY_TYPE_WRC_L3_MASKS		3U
+#define PTCT_ENTRY_TYPE_GT_L3_MASKS		4U
+#define PTCT_ENTRY_TYPE_PSRAM			5U
+#define PTCT_ENTRY_TYPE_STREAM_DATAPATH		6U
+#define PTCT_ENTRY_TYPE_TIMEAWARE_SUBSYS	7U
+#define PTCT_ENTRY_TYPE_RT_IOMMU		8U
+#define PTCT_ENTRY_TYPE_MEM_HIERARCHY_LATENCY	9U
+
+#define PSRAM_BASE_HPA 0x40080000U
+#define PSRAM_BASE_GPA 0x40080000U
+#define PSRAM_MAX_SIZE 0x00800000U
+
+struct ptct_entry{
+	 uint16_t size;
+	 uint16_t format;
+	 uint32_t type;
+	 uint32_t data[64];
+} __packed;
+
 struct ptct_entry_data_ptcm_binary
 {
 	uint64_t address;
 	uint32_t size;
 } __packed;
 
+struct ptct_entry_data_psram
+{
+	uint32_t cache_level;
+	uint64_t base;
+	uint32_t ways;
+	uint32_t size;
+	uint32_t apic_id_0; /*only the first core is responsible for initialization of L3 mem region*/
+} __packed;
+
+
+extern uint64_t psram_area_bottom;
+extern uint64_t psram_area_top;
 
 #endif /* PTCT_H */

--- a/hypervisor/include/arch/x86/ptct.h
+++ b/hypervisor/include/arch/x86/ptct.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PTCT_H
+#define PTCT_H
+
+#include <acpi.h>
+
+
+struct ptct_entry_data_ptcm_binary
+{
+	uint64_t address;
+	uint32_t size;
+} __packed;
+
+
+#endif /* PTCT_H */


### PR DESCRIPTION
Add pSRAM support in the HV part to initialize pSRAM on all cores. This's the Part 1.
Part 2 will PR later which is used to enable PTCM on pre/post-launched RTVM.

v5:
1. refine global ptcm_command_func
2. remove unnecessary assignment when parse PTCT ACPI Table.

v4:
1. Use bitmap to check whether the pSRAM has initialized on all CPUs.
2. Change NX page table attribute and flush TLB for all the PTCM binary area.
3. Fix a bug SOS could wbinvd the pSRAM when the post-launched RTVM hasn't created.
4. Add Kconfig to configure pSRAM
5. Other minor code/commit refine.

v3:
  1. detial comment why we could remove wbinvd when guest change CR0.CD
  2. refine init_psram and prase_ptct according Eddie'comments
  3. remove #UD inject for INVD vmexit handle
  4. add limitation now we only support L3 pSRAM and pass through it to one guest
  5. add two TODOs: one for we may use SMP to flush TLB and do pSRAM initialzation on APs,
                        one for add EPT_WB flag to pSRAM to make pSRAM effective.
  6. Other minor refine, like function/variable rename

NOTO: This serial doesn't add Kconfig to config PTCM. Will add it in v4.


v2:
  port pSRAM support from release 2.2 to master

Tracked-On: #5330 
Signed-off-by: Qian Wang <qian1.wang@intel.com>

