### PR TITLE
dm: update acrn-dm built-in list and description of args

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -143,8 +143,8 @@ usage(int code)
 		"       %*s [--part_info part_info_name] [--enable_trusty] [--intr_monitor param_setting]\n"
 		"       %*s [--acpidev_pt HID] [--mmiodev_pt MMIO_Regions]\n"
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
-		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--debugexit] \n"
-		"       %*s [--logger-setting param_setting] [--pm_notify_channel]\n"
+		"       %*s [--cpu_affinity pCPUs] [--lapic_pt] [--rtvm] [--windows]\n"
+		"       %*s [--debugexit] [--logger-setting param_setting] [--pm_notify_channel]\n"
 		"       %*s [--psram]\n"
 		"       %*s [--pm_by_vuart vuart_node] <vm>\n"
 		"       -A: create ACPI tables\n"
@@ -163,10 +163,6 @@ usage(int code)
 		"       -W: force virtio to use single-vector MSI\n"
 		"       -Y: disable MPtable generation\n"
 		"       --mac_seed: set a platform unique string as a seed for generate mac address\n"
-#ifdef CONFIG_VM_CFG
-		"       --vmcfg: build-in VM configurations\n"
-		"       --dump: show build-in VM configurations\n"
-#endif
 		"       --vsbl: vsbl file path\n"
 		"       --psram: Enable pSRAM passthrough\n"
 		"       --ovmf: ovmf file path\n"


### PR DESCRIPTION
Update and light clean-up of the buit-in list of arguments from 'acrn-dm'
* Added options in the top part (list with no explanation)
* A couple of typos fixed
* A couple of options put inside an '#ifdef' statement

Tracked-On: #5445
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>