### PR TITLE
doc: more prep for upgrading doc build tools

### DIFF
--- a/doc/.known-issues/doc/dupdecl.conf
+++ b/doc/.known-issues/doc/dupdecl.conf
@@ -5,3 +5,6 @@
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration.
 # Sphinx 2.0
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration, .*
+#
+^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C\+\+ declaration, .*
+^Declaration is .*

--- a/doc/.known-issues/doc/kerneldoc.conf
+++ b/doc/.known-issues/doc/kerneldoc.conf
@@ -1,0 +1,8 @@
+#
+# Kerneldoc (vbs.h)
+#
+#
+^(?P<filename>[-._/\w]+/acrn-kernel/include/linux/vbs/vbs.h):(?P<lineno>[0-9]+): WARNING: Error in declarator or parameters
+^Invalid C declaration:.*
+^  long virtio_.*
+^[- \t]*\^

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -144,7 +144,7 @@ Glossary of Terms
       Pre-launched VMs are started by the ACRN hypervisor before the
       Service VM is launched. (See :term:`Post-launched VM`)
 
-   Post-Launched VM
+   Post-launched VM
       Post-Launched VMs are launched and configured by the Service VM.
       (See :term:`Pre-launched VM`)
 
@@ -176,9 +176,9 @@ Glossary of Terms
       soft real-time workloads (or applications) much more efficiently
       than the typical User VM through the use of a passthrough interrupt
       controller, polling-mode Virtio, Intel RDT allocation features (CAT,
-      MBA), and I/O prioritization.  RTVMs are typically a :term:`pre-launched VM`.
-      A non-:term:`safety VM` with real-time requirements is a
-      :term:`post-launched VM`.
+      MBA), and I/O prioritization.  RTVMs are typically a :term:`Pre-launched VM`.
+      A non-:term:`Safety VM` with real-time requirements is a
+      :term:`Post-launched VM`.
 
    Safety VM
       A special VM with dedicated hardware resources, running in


### PR DESCRIPTION
Preparing for upgrading to newer versions of doc building tools
including sphing, doxygen, breathe, docutils, etc.  This PR's changes
still work find with the older tool versions, but should eliminate
issues found while moving to newer tool versions (later).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>