### PR TITLE
Ptcm: Ptcm: Add pSRAM support Part 2

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -145,6 +145,7 @@ usage(int code)
 		"       %*s [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]\n"
 		"       %*s [--vmcfg sub_options] [--dump vm_idx] [--debugexit] \n"
 		"       %*s [--logger-setting param_setting] [--pm_notify_channel]\n"
+		"       %*s [--psram]\n"
 		"       %*s [--pm_by_vuart vuart_node] <vm>\n"
 		"       -A: create ACPI tables\n"
 		"       -B: bootargs for kernel\n"
@@ -167,6 +168,7 @@ usage(int code)
 		"       --dump: show build-in VM configurations\n"
 #endif
 		"       --vsbl: vsbl file path\n"
+		"       --psram: Enable pSRAM passthrough\n"
 		"       --ovmf: ovmf file path\n"
 		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
 		"       --part_info: guest partition info file path\n"
@@ -185,7 +187,7 @@ usage(int code)
 		"       --pm_by_vuart:pty,/run/acrn/vuart_vmname or tty,/dev/ttySn\n"
 		"       --windows: support Oracle virtio-blk, virtio-net and virtio-input devices\n"
 		"            for windows guest with secure boot\n",
-		progname, (int)strnlen(progname, PATH_MAX), "",
+		progname, (int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
 		(int)strnlen(progname, PATH_MAX), "", (int)strnlen(progname, PATH_MAX), "",
@@ -750,6 +752,7 @@ enum {
 	CMD_OPT_VTPM2,
 	CMD_OPT_LAPIC_PT,
 	CMD_OPT_RTVM,
+	CMD_OPT_PSRAM,
 	CMD_OPT_LOGGER_SETTING,
 	CMD_OPT_PM_NOTIFY_CHANNEL,
 	CMD_OPT_PM_BY_VUART,
@@ -791,6 +794,7 @@ static struct option long_options[] = {
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
 	{"lapic_pt",		no_argument,		0, CMD_OPT_LAPIC_PT},
 	{"rtvm",		no_argument,		0, CMD_OPT_RTVM},
+	{"psram",		no_argument,		0, CMD_OPT_PSRAM},
 	{"logger_setting",	required_argument,	0, CMD_OPT_LOGGER_SETTING},
 	{"pm_notify_channel",	required_argument,	0, CMD_OPT_PM_NOTIFY_CHANNEL},
 	{"pm_by_vuart",	required_argument,	0, CMD_OPT_PM_BY_VUART},
@@ -933,6 +937,10 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_RTVM:
 			is_rtvm = true;
+			break;
+		case CMD_OPT_PSRAM:
+			/* TODO: we need to support parameter to specify pSRAM size in the future */
+			pt_ptct = true;
 			break;
 		case CMD_OPT_ACPIDEV_PT:
 			if (parse_pt_acpidev(optarg) != 0)

--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -89,6 +89,7 @@ bool stdio_in_use;
 bool lapic_pt;
 bool is_rtvm;
 bool pt_tpm2;
+bool pt_ptct;
 bool is_winvm;
 bool skip_pci_mem64bar_workaround = false;
 

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -49,6 +49,7 @@ extern char *mac_seed;
 extern bool lapic_pt;
 extern bool is_rtvm;
 extern bool pt_tpm2;
+extern bool pt_ptct;
 extern bool is_winvm;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,

--- a/devicemodel/include/ptct.h
+++ b/devicemodel/include/ptct.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2020 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PTCT_H
+#define PTCT_H
+
+
+/* TODO: Move to high-memory region. */
+#define PSRAM_BASE_HPA	0x40080000UL
+#define PSRAM_BASE_GPA	0x40080000UL
+#define PSRAM_MAX_SIZE	0x00800000UL
+
+#endif  /* PTCT_H */

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        5
+#define NUM_E820_ENTRIES        6
 #define LOWRAM_E820_ENTRY       1
-#define HIGHRAM_E820_ENTRY      4
+#define HIGHRAM_E820_ENTRY      5
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {

--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -276,6 +276,15 @@ config CDP_ENABLED
 	  prioritization of code and data fetches to the L2 or L3 cache in a
 	  software configurable manner, depending on hardware support.
 
+config PSRAM_ENABLED
+	bool "Enable pseudo-SRAM (pSRAM) support"
+	depends on !CDP_ENABLED
+	default n
+	help
+	  This will enable RTVM to make use of pSRAM to improve the performance
+	  of Real-Time applications. pSRAM essentially a block of cache, and is separated via
+	  CAT and protected by some methods.  pSRAM support and CDP support cannot co-exist.
+
 config GPU_SBDF
 	hex "Segment, Bus, Device, and function of the GPU"
 	depends on ACPI_PARSE_ENABLED

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -364,6 +364,11 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 	/* unmap PCIe MMCONFIG region since it's owned by hypervisor */
 	pci_mmcfg = get_mmcfg_region();
 	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, pci_mmcfg->address, get_pci_mmcfg_size(pci_mmcfg));
+
+	/* TODO: remove pSRAM from SOS prevent SOS to use clflush to flush the pSRAM cache.
+	 * If we remove this EPT mapping from the SOS, the ACRN-DM can't do pSRAM EPT mapping
+	 * because the SOS can't get the HPA of this memory region.
+	 */
 }
 
 /* Add EPT mapping of EPC reource for the VM */

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -384,7 +384,7 @@ static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 	struct acrn_vcpu *other;
 
 	/* GUEST_FLAG_RT has not set in post-launched RTVM before it has been created */
-	if ((is_psram_initialized) || (has_rt_vm() == false)) {
+	if ((!is_psram_initialized) && (has_rt_vm() == false)) {
 		cache_flush_invalidate_all();
 	} else {
 		if (is_rt_vm(vcpu->vm)) {

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -22,6 +22,7 @@
 #include <mmio_dev.h>
 #include <ivshmem.h>
 #include <vmcs9900.h>
+#include <ptcm.h>
 
 #define DBG_LEVEL_HYCALL	6U
 
@@ -576,6 +577,16 @@ static int32_t add_vm_memory_region(struct acrn_vm *vm, struct acrn_vm *target_v
 				prot |= EPT_WP;
 			} else {
 				prot |= EPT_UNCACHED;
+			}
+			/* If pSRAM is initialized, and HV received a request to map pSRAM area to guest,
+			 * we should add EPT_WB flag to make pSRAM effective.
+			 * Assumption: SOS must assign the PSRAM area as a whole and as a separate memory
+			 * region whose base address is PSRAM_BASE_HPA
+			 * TODO: We can enforce WB for any region has overlap with pSRAM, for simplicity,
+			 * and leave it to SOS to make sure it won't violate.
+			 */
+			if (hpa == PSRAM_BASE_HPA && is_psram_initialized == true) {
+				prot |= EPT_WB;
 			}
 			/* create gpa to hpa EPT mapping */
 			ept_add_mr(target_vm, pml4_page, hpa,


### PR DESCRIPTION
Add pSRAM support to enable PTCM on pre/post-launched RTVM. This's the Part 2.

v5:

refine ptct e820 add in acrn-dm
other minor refine according to Yu'comments.

v4:

Use bitmap to check whether the pSRAM has initialized on all CPUs.
Change NX page table attribute and flush TLB for all the PTCM binary area.
Fix a bug SOS could wbinvd the pSRAM when the post-launched RTVM hasn't created.
Add Kconfig to configure pSRAM
Other minor code/commit refine.
v3:

detial comment why we could remove wbinvd when guest change CR0.CD
refine init_psram and prase_ptct according Eddie'comments
remove #UD inject for INVD vmexit handle
add limitation now we only support L3 pSRAM and pass through it to one guest
add two TODOs: one for we may use SMP to flush TLB and do pSRAM initialzation on APs,
one for add EPT_WB flag to pSRAM to make pSRAM effective.
Other minor refine, like function/variable rename
NOTO: This serial doesn't add Kconfig to config PTCM. Will add it in v4.

v2:
port pSRAM support from release 2.2 to master

Tracked-On: #5330
Signed-off-by: Qian Wang qian1.wang@intel.com