### PR TITLE
doc: bring back prev/next buttons

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,7 +166,7 @@ else:
         'analytics_id': '',
         'logo_only': False,
         'display_version': True,
-        'prev_next_buttons_location': 'None',
+        #'prev_next_buttons_location': 'None',
         # Toc options
         'collapse_navigation': False,
         'sticky_navigation': True,


### PR DESCRIPTION
Some ACRN docs (in particular the HLD) has content nested more than the
4 levels shown in the sidebar navigation.  So when looking at those
documents, it's hard to get to next chapter.  Bring back the
previous/next links to fix this situation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>