### PR TITLE
acrn-config: remove PSRAM_PASSTHROUGH_PRE_RTVM in PSRAM config

### DIFF
--- a/misc/acrn-config/acpi_gen/asl_gen.py
+++ b/misc/acrn-config/acpi_gen/asl_gen.py
@@ -461,8 +461,7 @@ def main(args):
     PASSTHROUGH_PTCT = False
     PRELAUNCHED_RTVM_ID = None
     try:
-        if scenario_root.find('hv/FEATURES/PSRAM/PSRAM_ENABLED').text.strip() == 'y' \
-                and scenario_root.find('hv/FEATURES/PSRAM/PSRAM_PASSTHROUGH_PRE_RTVM').text.strip() == 'y':
+        if scenario_root.find('hv/FEATURES/PSRAM/PSRAM_ENABLED').text.strip() == 'y':
             PASSTHROUGH_PTCT = True
         for vm in scenario_root.findall('vm'):
             vm_id = vm.attrib['id']

--- a/misc/acrn-config/hv_config/board_defconfig.py
+++ b/misc/acrn-config/hv_config/board_defconfig.py
@@ -179,8 +179,6 @@ def get_features(hv_info, config):
     print("CONFIG_MCE_ON_PSC_WORKAROUND_DISABLED={}".format(hv_info.features.mce_on_psc_workaround_disabled), file=config)
     if hv_info.features.psram_enabled in ['y', 'n']:
         print("CONFIG_PSRAM_ENABLED={}".format(hv_info.features.psram_enabled), file=config)
-    if hv_info.features.psram_enabled in ['y', 'n']:
-        print("CONFIG_PSRAM_PRE_RTVM_ENABLED={}".format(hv_info.features.psram_passthrough_pre_rtvm), file=config)
 
 
 def get_capacities(hv_info, config):

--- a/misc/acrn-config/hv_config/hv_item.py
+++ b/misc/acrn-config/hv_config/hv_item.py
@@ -110,7 +110,6 @@ class Features:
         self.l1d_flush_vmentry_enabled = ''
         self.mce_on_psc_workaround_disabled = ''
         self.psram_enabled = ''
-        self.psram_passthrough_pre_rtvm = ''
 
     def get_info(self):
         self.multiboot2 = common.get_hv_item_tag(self.hv_file, "FEATURES", "MULTIBOOT2")
@@ -126,7 +125,6 @@ class Features:
         self.mce_on_psc_workaround_disabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "MCE_ON_PSC_DISABLED")
         self.iommu_enforce_snp = common.get_hv_item_tag(self.hv_file, "FEATURES", "IOMMU_ENFORCE_SNP")
         self.psram_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "PSRAM", "PSRAM_ENABLED")
-        self.psram_passthrough_pre_rtvm = common.get_hv_item_tag(self.hv_file, "FEATURES", "PSRAM", "PSRAM_PASSTHROUGH_PRE_RTVM")
 
     def check_item(self):
         hv_cfg_lib.ny_support_check(self.multiboot2, "FEATURES", "MULTIBOOT2")
@@ -142,11 +140,7 @@ class Features:
         hv_cfg_lib.ny_support_check(self.mce_on_psc_workaround_disabled, "FEATURES", "MCE_ON_PSC_DISABLED")
         hv_cfg_lib.ny_support_check(self.iommu_enforce_snp, "FEATURES", "IOMMU_ENFORCE_SNP")
         # hv_cfg_lib.ny_support_check(self.psram_enabled, "FEATURES", "PSRAM", "PSRAM_ENABLED")
-        # hv_cfg_lib.ny_support_check(self.psram_passthrough_pre_rtvm,
-        #                                                "FEATURES", "PSRAM", "PSRAM_PASSTHROUGH_PRE_RTVM")
         hv_cfg_lib.hv_psram_check(self.psram_enabled, self.cdp_enabled, "FEATURES", "PSRAM", "PSRAM_ENABLED")
-        hv_cfg_lib.hv_psram_passthrough_pre_rtvm_check(self.psram_passthrough_pre_rtvm, self.psram_enabled,
-                                                       "FEATURES", "PSRAM", "PSRAM_PASSTHROUGH_PRE_RTVM")
 
 
 class Memory:

--- a/misc/acrn-config/library/hv_cfg_lib.py
+++ b/misc/acrn-config/library/hv_cfg_lib.py
@@ -238,10 +238,3 @@ def hv_psram_check(psram_enabled, cpd_enabled, feature, tag, leaf):
     if psram_enabled == 'y' and cpd_enabled == 'y':
         ERR_LIST[key] = "PSRAM_ENABLED should not be y when CDP_ENABLED is y."
         return
-
-
-def hv_psram_passthrough_pre_rtvm_check(psram_passthrough_pre_rtvm, psram_enabled, feature, tag, leaf):
-    key = 'hv,{},{},{}'.format(feature, tag, leaf)
-    if psram_enabled == 'n' and psram_passthrough_pre_rtvm == 'y':
-        ERR_LIST[key] = "{} should not be y when {} is n.".format(leaf, tag)
-        return

--- a/misc/acrn-config/scenario_config/scenario_cfg_gen.py
+++ b/misc/acrn-config/scenario_config/scenario_cfg_gen.py
@@ -85,7 +85,6 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["hv,FEATURES,IOMMU_ENFORCE_SNP"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,FEATURES,IVSHMEM,IVSHMEM_ENABLED"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,FEATURES,PSRAM,PSRAM_ENABLED"] = hv_cfg_lib.N_Y
-    scenario_item_values["hv,FEATURES,PSRAM,PSRAM_PASSTHROUGH_PRE_RTVM"] = hv_cfg_lib.N_Y
 
     scenario_cfg_lib.ERR_LIST.update(hv_cfg_lib.ERR_LIST)
     return scenario_item_values

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -31,7 +31,6 @@
         </IVSHMEM>
         <PSRAM desc="Pseudo SRAM configuration.">
             <PSRAM_ENABLED desc="Enable PTCM (Platform Tuning Configuration Manager).">n</PSRAM_ENABLED>
-            <PSRAM_PASSTHROUGH_PRE_RTVM desc="Pass through PSRAM to Pre-launched RTVM.">n</PSRAM_PASSTHROUGH_PRE_RTVM>
         </PSRAM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/template/HV.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/HV.xml
@@ -31,7 +31,6 @@
         </IVSHMEM>
         <PSRAM desc="Pseudo SRAM configuration.">
             <PSRAM_ENABLED desc="Enable PTCM (Platform Tuning Configuration Manager).">n</PSRAM_ENABLED>
-            <PSRAM_PASSTHROUGH_PRE_RTVM desc="Pass through PSRAM to Pre-launched RTVM.">n</PSRAM_PASSTHROUGH_PRE_RTVM>
         </PSRAM>
     </FEATURES>
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -28,8 +28,7 @@
             <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
         <PSRAM desc="Pseudo SRAM configuration.">
-            <PSRAM_ENABLED desc="Enable PTCM (Platform Tuning Configuration Manager).">y</PSRAM_ENABLED>
-            <PSRAM_PASSTHROUGH_PRE_RTVM desc="Pass through PSRAM to Pre-launched RTVM.">y</PSRAM_PASSTHROUGH_PRE_RTVM>
+            <PSRAM_ENABLED desc="Enable PTCM (Platform Tuning Configuration Manager).">n</PSRAM_ENABLED>
         </PSRAM>
     </FEATURES>
 


### PR DESCRIPTION
remove PSRAM_PASSTHROUGH_PRE_RTVM config which is not used in
PSRAM config.

Tracked-On: #5418

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>