### PR TITLE
DM: gvt: Identical mapping for GPU DSM

### DIFF
--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        6
+#define NUM_E820_ENTRIES        9
 #define LOWRAM_E820_ENTRY       1
-#define HIGHRAM_E820_ENTRY      5
+#define HIGHRAM_E820_ENTRY      6
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {


### PR DESCRIPTION
Windows graphic driver obtains DSM address from in-BAR mmio register
which has passthroughed. Not like the other platforms obtained from
pci configure space register which has virtualized. So TGL has to
keep identical mapping to avoid trap mmio BAR to do the emulation.

To keep simple, this patch hardcode the TGL DSM region in vE820
table, this will cause memory waste here. In the near future, we
need refine the entire vE820 logic as it is hard to maintained
due to many reserved regions have introduced in recently.

Signed-off-by: Sun Peng <peng.p.sun@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>
Tracked-On: #5461