### PR TITLE
acrn-config: removed_nested returns None instead return Error

### DIFF
--- a/misc/acrn-config/board_config/vbar_base_h.py
+++ b/misc/acrn-config/board_config/vbar_base_h.py
@@ -235,7 +235,7 @@ def get_mmio_windows_with_key(keywords):
 
 def removed_nested(list1, list2):
     if not list1 or not list2:
-        raise ValueError("Invalid inputs: None, list1 is {}, \list2 is {}".format (list1, list2))
+        return list1
 
     resolvedList = list1[:]
     for w1 in resolvedList:
@@ -265,6 +265,10 @@ def merged_windows(windowslist):
 
 
 def get_free_mmio(windowslist, used, size):
+    if not size:
+        raise ValueError("allocate size cannot be {}".format(size))
+    if not windowslist:
+        raise ValueError("No mmio range is specified:{}".format(windowslist))
     for w in windowslist:
         window = MmioWindow(start=w.start, end=w.start+size-1)
         for u in used:


### PR DESCRIPTION
qemu xml has no devices list. Tool will receive the empty devices list while parsing the "platform" xml. Remove the error of resolved nested mmio address window that the input couldn't be None. Simply return an None list.

Tracked-On:#5454
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>