### PR TITLE
hv: remove vm_lock in hcall_destroy_vm()

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -256,12 +256,10 @@ int32_t hcall_destroy_vm(__unused struct acrn_vm *vm, struct acrn_vm *target_vm,
 {
 	int32_t ret = -1;
 
-	get_vm_lock(target_vm);
 	if (is_paused_vm(target_vm)) {
 		/* TODO: check target_vm guest_flags */
 		ret = shutdown_vm(target_vm);
 	}
-	put_vm_lock(target_vm);
 
 	return ret;
 }


### PR DESCRIPTION
Hypercall handlers for post-launched VMs automatically grab the vm_lock
in dispatch_sos_hypercall(). Remove the use of vm_lock inside the
handler.

Tracked-On: #5411
Signed-off-by: Peter Fang <peter.fang@intel.com>