### PR TITLE
doc: add sphinx-generated index to leftnav

### DIFF
--- a/doc/genindex.rst
+++ b/doc/genindex.rst
@@ -1,0 +1,8 @@
+.. Place holder Index. The sphinx-generated genindex.html will overwrite
+   this placeholder when the website is created, but his file will give us
+   something we can add to the TOC.  Technically this isn't advised, but
+   works.
+
+Index
+#####
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -84,6 +84,7 @@ license.
    asa
    FAQ <faq>
    glossary
+   genindex
 
 .. _BSD 3-clause license:
    https://github.com/projectacrn/acrn-hypervisor/blob/master/LICENSE


### PR DESCRIPTION
Sphinx generates a full-site index (headings, terms, function names,
etc.) but we haven't been linking to it.  This is a tricky way to get
the site index added to the left nav that appears to work, by creating a
genindex.rst that we can link to in the site toctree so it shows up in
the leftnav, but the generated genindex.html for the dummy genindex.rst
will be overwritten by the sphinx created genindex.html with the
full-site index.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>