### PR TITLE
doc: fix breathe config for C vs CPP

### DIFF
--- a/doc/.known-issues/doc/dupdecl.conf
+++ b/doc/.known-issues/doc/dupdecl.conf
@@ -6,5 +6,7 @@
 # Sphinx 2.0
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate declaration, .*
 #
+^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: duplicate C object description.*
+#
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C\+\+ declaration, .*
 ^Declaration is .*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -318,7 +318,21 @@ breathe_projects = {
 	"Project ACRN" : "doxygen/xml",
 }
 breathe_default_project = "Project ACRN"
-breathe_default_members = ('members', 'undoc-members', 'content-only')
+# breathe_default_members = ('members', 'undoc-members', 'content-only')
+breathe_domain_by_extension = {
+   "h": "c",
+   "c": "c",
+}
+
+cpp_id_attributes = [
+    '__syscall', '__deprecated', '__may_alias',
+    '__used', '__unused', '__weak',
+    '__DEPRECATED_MACRO', 'FUNC_NORETURN',
+    '__subsystem',
+]
+c_id_attributes = cpp_id_attributes
+
+
 
 
 # Custom added feature to allow redirecting old URLs (caused by


### PR DESCRIPTION
Breathe and doxygen work best for C++, but we're using C.  This shows up
as API documentaiton having a C++ flavor (modules and classes) instead
of the expected C flavor.  We really need to upgrade the versions of
doxygen and breathe to newer versions, and this configuration tweak
prepares for this.  (It will need CI coordination to update these tools,
but the changes in this PR are compatible with the current older tools.)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>