### PR TITLE
Support OVMF split images

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -81,6 +81,8 @@ char *vmname;
 char *guest_uuid_str;
 char *vsbl_file_name;
 char *ovmf_file_name;
+char *ovmf_code_file_name;
+char *ovmf_vars_file_name;
 char *kernel_file_name;
 char *elf_file_name;
 uint8_t trusty_enabled;
@@ -230,10 +232,7 @@ virtio_uses_msix(void)
 size_t
 high_bios_size(void)
 {
-	size_t size = 0;
-
-	if (ovmf_file_name)
-		size = ovmf_image_size();
+	size_t size = ovmf_image_size();
 
 	return roundup2(size, 2 * MB);
 }

--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -260,7 +260,7 @@ acrn_sw_load(struct vmctx *ctx)
 {
 	if (vsbl_file_name)
 		return acrn_sw_load_vsbl(ctx);
-	else if (ovmf_file_name)
+	else if ((ovmf_file_name != NULL) ^ (ovmf_code_file_name && ovmf_vars_file_name))
 		return acrn_sw_load_ovmf(ctx);
 	else if (kernel_file_name)
 		return acrn_sw_load_bzimage(ctx);

--- a/devicemodel/core/sw_load_ovmf.c
+++ b/devicemodel/core/sw_load_ovmf.c
@@ -28,6 +28,10 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 
 #include "dm.h"
 #include "vmmapi.h"
@@ -55,95 +59,212 @@
 /* ovmf real entry is reset vector, which is (OVMF_TOP - 16) */
 #define OVMF_TOP(ctx)		(4*GB)
 
-/* ovmf NV storage begins at offset 0 */
-#define OVMF_NVSTORAGE_OFFSET (OVMF_TOP(ctx) - ovmf_size)
-
 /* ovmf image size limit */
 #define OVMF_SZ_LIMIT		(2*MB)
 
+/* ovmf split images size limit */
+#define OVMF_VARS_SZ_LIMIT	(128*KB)
+#define OVMF_CODE_SZ_LIMIT	(OVMF_SZ_LIMIT - OVMF_VARS_SZ_LIMIT)
+
+/* ovmf NV storage begins at offset 0 */
+#define OVMF_NVSTORAGE_OFFSET	(OVMF_TOP(ctx) - ovmf_image_size())
+
 /* ovmf NV storage size */
-#define OVMF_NVSTORAGE_SZ	(128*KB)
+#define OVMF_NVSTORAGE_SZ	(ovmf_file_name ? OVMF_VARS_SZ_LIMIT : ovmf_vars_size)
 
 /* located in the ROM area */
 #define OVMF_E820_BASE		0x000EF000UL
 
 static char ovmf_path[STR_LEN];
+static char ovmf_code_path[STR_LEN];
+static char ovmf_vars_path[STR_LEN];
 static size_t ovmf_size;
-bool writeback_nv_storage;
+static size_t ovmf_code_size;
+static size_t ovmf_vars_size;
+static char *mmap_vars;
+static bool writeback_nv_storage;
 
 extern int init_cmos_vrpmb(struct vmctx *ctx);
 
 size_t
 ovmf_image_size(void)
 {
-	return ovmf_size;
+	size_t size = 0;
+
+	if (ovmf_file_name)
+		size = ovmf_size;
+	else if (ovmf_code_file_name && ovmf_vars_file_name)
+		size = ovmf_code_size + ovmf_vars_size;
+
+	return size;
 }
 
 int
 acrn_parse_ovmf(char *arg)
 {
 	int error = -1;
-	char *str, *cp, *token = NULL;
-	size_t len = strnlen(arg, STR_LEN);
+	char *str, *cp, *token;
 
-	str = strdup(arg);
-	if (len < STR_LEN) {
-		cp = str;
-		token = strsep(&cp, ",");
-		while (token != NULL) {
-			if (strcmp(token, "w") == 0) {
+	if (strnlen(arg, STR_LEN) < STR_LEN) {
+		str = cp = strdup(arg);
+
+		while ((token = strsep(&cp, ",")) != NULL) {
+			if (!strcmp(token, "w")) {
 				writeback_nv_storage = true;
+			} else if (!strncmp(token, "code=", sizeof("code=") - 1)) {
+				token += sizeof("code=") - 1;
+				strncpy(ovmf_code_path, token, sizeof(ovmf_code_path));
+				if (check_image(ovmf_code_path, OVMF_CODE_SZ_LIMIT,
+						&ovmf_code_size) != 0)
+					break;
+				ovmf_code_file_name = ovmf_code_path;
+				pr_notice("SW_LOAD: get ovmf code path %s, size 0x%lx\n",
+					ovmf_code_path, ovmf_code_size);
+			} else if (!strncmp(token, "vars=", sizeof("vars=") - 1)) {
+				token += sizeof("vars=") - 1;
+				strncpy(ovmf_vars_path, token, sizeof(ovmf_vars_path));
+				if (check_image(ovmf_vars_path, OVMF_VARS_SZ_LIMIT,
+						&ovmf_vars_size) != 0)
+					break;
+				ovmf_vars_file_name = ovmf_vars_path;
+				pr_notice("SW_LOAD: get ovmf vars path %s, size 0x%lx\n",
+					ovmf_vars_path, ovmf_vars_size);
 			} else {
-				len = strnlen(token, STR_LEN);
-				strncpy(ovmf_path, token, len + 1);
+				strncpy(ovmf_path, token, sizeof(ovmf_path));
 				if (check_image(ovmf_path, OVMF_SZ_LIMIT, &ovmf_size) != 0)
 					break;
 				ovmf_file_name = ovmf_path;
 				pr_notice("SW_LOAD: get ovmf path %s, size 0x%lx\n",
 					ovmf_path, ovmf_size);
-				error = 0;
 			}
-			token = strsep(&cp, ",");
 		}
+		free(str);
 	}
-	free(str);
+
+	if ((ovmf_file_name != NULL) ^ (ovmf_code_file_name && ovmf_vars_file_name))
+		error = 0;
+
 	return error;
 }
 
 static int
 acrn_prepare_ovmf(struct vmctx *ctx)
 {
+	int i, flags, fd;
+	char *path, *addr;
+	size_t size, size_limit, cur_size, read;
+	struct flock fl;
 	FILE *fp;
-	size_t read;
 
-	fp = fopen(ovmf_path, "r");
-	if (fp == NULL) {
-		pr_err("SW_LOAD ERR: could not open ovmf file: %s\n",
-			ovmf_path);
-		return -1;
+	if (ovmf_file_name) {
+		path = ovmf_file_name;
+		size = ovmf_size;
+		size_limit = OVMF_SZ_LIMIT;
+	} else {
+		path = ovmf_vars_file_name;
+		size = ovmf_vars_size;
+		size_limit = OVMF_VARS_SZ_LIMIT;
 	}
 
-	fseek(fp, 0, SEEK_END);
+	flags = writeback_nv_storage ? O_RDWR : O_RDONLY;
+	addr = ctx->baseaddr + OVMF_TOP(ctx) - ovmf_image_size();
 
-	if (ftell(fp) != ovmf_size) {
-		pr_err("SW_LOAD ERR: ovmf file changed\n");
+	for (i = 0; i < 2; i++) {
+		fd = open(path, flags);
+
+		if (fd == -1) {
+			pr_err("SW_LOAD ERR: could not open ovmf file: %s (%s)\n",
+				path, strerror(errno));
+			return -1;
+		}
+
+		/* acquire read lock over the entire file */
+		memset(&fl, 0, sizeof(fl));
+		fl.l_type = F_RDLCK;
+		fl.l_whence = SEEK_SET;
+		fl.l_start = 0;
+		fl.l_len = 0;
+
+		if (fcntl(fd, F_SETLK, &fl)) {
+			pr_err("SW_LOAD ERR: could not fcntl(F_RDLCK) "
+				"ovmf file: %s (%s)\n",
+				path, strerror(errno));
+			close(fd);
+			return -1;
+		}
+
+		if (check_image(path, size_limit, &cur_size) != 0) {
+			close(fd);
+			return -1;
+		}
+
+		if (cur_size != size) {
+			pr_err("SW_LOAD ERR: ovmf file %s changed\n", path);
+			close(fd);
+			return -1;
+		}
+
+		if (flags == O_RDWR) {
+			/* upgrade to write lock */
+			memset(&fl, 0, sizeof(fl));
+			fl.l_type = F_WRLCK;
+			fl.l_whence = SEEK_SET;
+			fl.l_start = 0;
+			fl.l_len = OVMF_NVSTORAGE_SZ;
+
+			if (fcntl(fd, F_SETLK, &fl)) {
+				pr_err("SW_LOAD ERR: could not fcntl(F_WRLCK) "
+					"ovmf file: %s (%s)\n",
+					path, strerror(errno));
+				close(fd);
+				return -1;
+			}
+
+			mmap_vars = mmap(NULL, OVMF_NVSTORAGE_SZ, PROT_WRITE,
+					MAP_SHARED, fd, 0);
+
+			if (mmap_vars == MAP_FAILED) {
+				pr_err("SW_LOAD ERR: could not mmap "
+					"ovmf file: %s (%s)\n",
+					path, strerror(errno));
+				close(fd);
+				return -1;
+			}
+		}
+
+		fp = fdopen(fd, "r");
+
+		if (fp == NULL) {
+			pr_err("SW_LOAD ERR: could not fdopen "
+				"ovmf file: %s (%s)\n",
+				path, strerror(errno));
+			close(fd);
+			return -1;
+		}
+
+		fseek(fp, 0, SEEK_SET);
+		read = fread(addr, sizeof(char), size, fp);
 		fclose(fp);
-		return -1;
+
+		if (read < size) {
+			pr_err("SW_LOAD ERR: could not read whole partition blob %s\n",
+				path);
+			return -1;
+		}
+
+		pr_info("SW_LOAD: partition blob %s size 0x%lx copied to addr %p\n",
+			path, size, addr);
+
+		if (!ovmf_file_name) {
+			addr += size;
+			path = ovmf_code_file_name;
+			size = ovmf_code_size;
+			size_limit = OVMF_CODE_SZ_LIMIT;
+			flags = O_RDONLY;
+		} else
+			break;
 	}
 
-	fseek(fp, 0, SEEK_SET);
-	read = fread(ctx->baseaddr + OVMF_TOP(ctx) - ovmf_size,
-		sizeof(char), ovmf_size, fp);
-
-	if (read < ovmf_size) {
-		pr_err("SW_LOAD ERR: could not read whole partition blob\n");
-		fclose(fp);
-		return -1;
-	}
-
-	fclose(fp);
-	pr_info("SW_LOAD: partition blob %s size %lu copy to guest 0x%lx\n",
-		ovmf_path, ovmf_size, OVMF_TOP(ctx) - ovmf_size);
 	return 0;
 }
 
@@ -192,7 +313,8 @@ acrn_sw_load_ovmf(struct vmctx *ctx)
 	return 0;
 }
 
-/* The NV data section is the first 128KB in the OVMF image. At runtime,
+/*
+ * The NV data section is the first 128KB in the OVMF image. At runtime,
  * it's copied into guest memory and behave as RAM to OVMF. It can be
  * accessed and updated by OVMF. To preserve NV section (referred to
  * as Non-Volatile Data Store section in the OVMF spec), we're flushing
@@ -202,41 +324,61 @@ acrn_sw_load_ovmf(struct vmctx *ctx)
 int
 acrn_writeback_ovmf_nvstorage(struct vmctx *ctx)
 {
-	FILE *fp;
-	size_t write;
+	int i, fd, ret = 0;
+	char *path;
+	struct flock fl;
 
 	if (!writeback_nv_storage)
 		return 0;
 
-	fp = fopen(ovmf_path, "r+");
-	if (fp == NULL) {
-		pr_err("OVMF_WRITEBACK ERR: could not open ovmf file: %s\n",
-			ovmf_path);
-		return -1;
+	memcpy(mmap_vars, ctx->baseaddr + OVMF_NVSTORAGE_OFFSET,
+		OVMF_NVSTORAGE_SZ);
+
+	if (munmap(mmap_vars, OVMF_NVSTORAGE_SZ)) {
+		pr_err("SW_LOAD ERR: could not munmap (%s)\n",
+			strerror(errno));
+		ret = -1;
 	}
 
-	fseek(fp, 0, SEEK_END);
+	mmap_vars = NULL;
 
-	if (ftell(fp) != ovmf_size) {
-		pr_err("SW_LOAD ERR: ovmf file changed\n");
-		fclose(fp);
-		return -1;
+	path = ovmf_file_name ? ovmf_file_name : ovmf_vars_file_name;
+	pr_info("OVMF_WRITEBACK: OVMF has been written back "
+		"to partition blob %s size 0x%lx @ gpa %p\n",
+		path, OVMF_NVSTORAGE_SZ, (void *)OVMF_NVSTORAGE_OFFSET);
+
+	for (i = 0; i < 2; i++) {
+		fd = open(path, O_RDONLY);
+
+		if (fd == -1) {
+			pr_err("SW_LOAD ERR: could not open ovmf file: %s (%s)\n",
+				path, strerror(errno));
+			ret = -1;
+			goto next;
+		}
+
+		/* unlock the entire file */
+		memset(&fl, 0, sizeof(fl));
+		fl.l_type = F_UNLCK;
+		fl.l_whence = SEEK_SET;
+		fl.l_start = 0;
+		fl.l_len = 0;
+
+		if (fcntl(fd, F_SETLK, &fl)) {
+			pr_err("SW_LOAD ERR: could not fcntl(F_UNLCK) "
+				"ovmf file: %s (%s)\n",
+				path, strerror(errno));
+			ret = -1;
+		}
+
+		close(fd);
+
+next:
+		if (!ovmf_file_name)
+			path = ovmf_code_file_name;
+		else
+			break;
 	}
 
-	fseek(fp, 0, SEEK_SET);
-	write = fwrite(ctx->baseaddr + OVMF_NVSTORAGE_OFFSET,
-		sizeof(char), OVMF_NVSTORAGE_SZ, fp);
-
-	if (write < OVMF_NVSTORAGE_SZ) {
-		pr_err("OVMF_WRITEBACK ERR: could not write back OVMF\n");
-		fclose(fp);
-		return -1;
-	}
-
-	fclose(fp);
-	pr_info("OVMF_WRITEBACK: OVMF has been written back \
-		to partition blob %s size %lu from guest 0x%lx\n",
-		ovmf_path, OVMF_NVSTORAGE_SZ, OVMF_NVSTORAGE_OFFSET);
-
-	return 0;
+	return ret;
 }

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -41,6 +41,8 @@ extern char *guest_uuid_str;
 extern uint8_t trusty_enabled;
 extern char *vsbl_file_name;
 extern char *ovmf_file_name;
+extern char *ovmf_code_file_name;
+extern char *ovmf_vars_file_name;
 extern char *kernel_file_name;
 extern char *elf_file_name;
 extern char *vmname;

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -55,7 +55,6 @@ struct e820_entry {
 
 extern const struct e820_entry e820_default_entries[NUM_E820_ENTRIES];
 extern int with_bootargs;
-extern bool writeback_nv_storage;
 
 size_t ovmf_image_size(void);
 

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -236,6 +236,7 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
        uses ``/usr/share/acrn/bios/VSBL.bin`` as the vSBL image
 
    * - :kbd:`--ovmf [w,]<ovmf_file_path>`
+       :kbd:`--ovmf [w,]code=<ovmf_code_file>,vars=<ovmf_vars_file>`
      - Open Virtual Machine Firmware (OVMF) is an EDK II based project to enable
        UEFI support for Virtual Machines.
 
@@ -249,14 +250,24 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
        uses ``/usr/share/acrn/bios/OVMF.fd`` as the OVMF image
 
-       ACRN supports option "w" of OVMF. To preserve any change of OVMF NV data
-       store section, using this option to enable NV data store section writeback.
+       ACRN also supports using OVMF split images; ``OVMF_CODE.fd`` that contains
+       the OVMF firmware executable and ``OVMF_VARS.fd`` that contains the NV
+       data store.
+
+       usage::
+
+          --ovmf code=/usr/share/acrn/bios/OVMF_CODE.fd,vars=/usr/share/acrn/bios/OVMF_VARS.fd
+
+       ACRN supports the option "w" for OVMF. To preserve all changes in OVMF's
+       NV data store section, use this option to enable writeback mode.
+
+       Writeback mode is only enabled for the ``OVMF_VARS.fd`` file in case of
+       OVMF split images, the firmware executable (``OVMF_CODE.fd``) remains
+       read-only.
 
        usage::
 
           --ovmf w,/usr/share/acrn/bios/OVMF.fd
-
-
 
    * - :kbd:`--cpu_affinity <list of pCPUs>`
      - list of pCPUs assigned to this VM.


### PR DESCRIPTION
In addition to a single OVMF image (OVMF.fd), split images (OVMF_CODE.fd, OVMF_VARS.fd) can be used to facilitate VM management.

From the OVMF Whitepaper:

> The variable store and the firmware executable are also available in the build output as separate files entitled: "OVMF_VARS.fd" and "OVMF_CODE.fd". This enables central management and updates of the firmware executable, while each virtual machine can retain its own variable store.