### PR TITLE
TGL: Fix sos can't boot with 6 pci-vuarts

### DIFF
--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -134,14 +134,14 @@ static void init_vmcs9900(struct pci_vdev *vdev)
 	mmio_vbar->size = 0x1000U;
 	mmio_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MMIO_BAR];
 	mmio_vbar->mask = (uint32_t) (~(mmio_vbar->size - 1UL));
-	mmio_vbar->fixed = (uint32_t) (mmio_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+	mmio_vbar->fixed = 0U;
 
 	/* initialize vuart-pci msix bar */
 	msix_vbar->type = PCIBAR_MEM32;
 	msix_vbar->size = 0x1000U;
 	msix_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MSIX_BAR];
 	msix_vbar->mask = (uint32_t) (~(msix_vbar->size - 1UL));
-	msix_vbar->fixed = (uint32_t) (msix_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+	msix_vbar->fixed = 0U;
 
 	vdev->nr_bars = 2;
 

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -51,7 +51,7 @@
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
         <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">32</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>


### PR DESCRIPTION
Increase CONFIG_MAX_EMULATED_MMIO_REGIONS to 32, for more pci-vuarts.
Each pci-vuart vdev need 2 mmio BARs, if there are 8 pci-vuarts, they
need emulate 16 mmio regions.

But by default CONFIG_MAX_EMULATED_MMIO_REGIONS=16, that is not enough.

Tracked-On: #5491
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>