### PR TITLE
Fix: HV: VM OS failed to assign new address to pci-vuart BARs

### DIFF
--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -288,15 +288,12 @@ static int32_t write_ivshmem_vdev_cfg(struct pci_vdev *vdev, uint32_t offset, ui
 static void init_ivshmem_bar(struct pci_vdev *vdev, uint32_t bar_idx)
 {
 	struct pci_vbar *vbar;
-	enum pci_bar_type type;
 	uint64_t addr, mask, size = 0UL;
 	struct acrn_vm_pci_dev_config *dev_config = vdev->pci_dev_config;
 
 	addr = dev_config->vbar_base[bar_idx];
-	type = pci_get_bar_type((uint32_t) addr);
-	mask = (type == PCIBAR_IO_SPACE) ? PCI_BASE_ADDRESS_IO_MASK : PCI_BASE_ADDRESS_MEM_MASK;
+	mask = (is_pci_io_bar((uint32_t)addr)) ? PCI_BASE_ADDRESS_IO_MASK : PCI_BASE_ADDRESS_MEM_MASK;
 	vbar = &vdev->vbars[bar_idx];
-	vbar->type = type;
 	if (bar_idx == IVSHMEM_SHM_BAR) {
 		struct ivshmem_shm_region *region = find_shm_region(dev_config->shm_region_name);
 		if (region != NULL) {
@@ -314,11 +311,11 @@ static void init_ivshmem_bar(struct pci_vdev *vdev, uint32_t bar_idx)
 	if (size != 0UL) {
 		vbar->size = size;
 		vbar->mask = (uint32_t) (~(size - 1UL));
-		vbar->fixed = (uint32_t) (addr & (~mask));
+		vbar->bar_type.bits = (uint32_t) (addr & (~mask));
 		pci_vdev_write_vbar(vdev, bar_idx, (uint32_t) addr);
-		if (type == PCIBAR_MEM64) {
+		if (is_pci_mem64_bar((uint32_t)addr)) {
 			vbar = &vdev->vbars[bar_idx + 1U];
-			vbar->type = PCIBAR_MEM64HI;
+			vbar->is_mem64hi = true;
 			vbar->mask = (uint32_t) ((~(size - 1UL)) >> 32U);
 			pci_vdev_write_vbar(vdev, (bar_idx + 1U), ((uint32_t)(addr >> 32U)));
 		}

--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -130,18 +130,16 @@ static void init_vmcs9900(struct pci_vdev *vdev)
 	add_vmsix_capability(vdev, 1, MCS9900_MSIX_BAR);
 
 	/* initialize vuart-pci mem bar */
-	mmio_vbar->type = PCIBAR_MEM32;
 	mmio_vbar->size = 0x1000U;
 	mmio_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MMIO_BAR];
 	mmio_vbar->mask = (uint32_t) (~(mmio_vbar->size - 1UL));
-	mmio_vbar->fixed = (uint32_t) (mmio_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+	mmio_vbar->bar_type.bits = PCIM_BAR_MEM_32;
 
 	/* initialize vuart-pci msix bar */
-	msix_vbar->type = PCIBAR_MEM32;
 	msix_vbar->size = 0x1000U;
 	msix_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MSIX_BAR];
 	msix_vbar->mask = (uint32_t) (~(msix_vbar->size - 1UL));
-	msix_vbar->fixed = (uint32_t) (msix_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+	msix_vbar->bar_type.bits = PCIM_BAR_MEM_32;
 
 	vdev->nr_bars = 2;
 

--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -83,7 +83,7 @@ void init_vmsix_on_msi(struct pci_vdev *vdev)
 			if (vdev->vbars[i].base_hpa == 0UL){
 				break;
 			}
-			if (vdev->vbars[i].type == PCIBAR_MEM64) {
+			if (is_pci_mem64_bar(vdev->vbars[i].bar_type.bits)) {
 				i++;
 			}
 		}
@@ -106,12 +106,11 @@ void init_vmsix_on_msi(struct pci_vdev *vdev)
 			/* Init PBA table vBAR, offset is 2048 */
 			pci_vdev_write_vcfg(vdev, vdev->msix.capoff + 8U, 4U, 2048U + i);
 
-			vdev->vbars[i].type = PCIBAR_MEM32;
 			vdev->vbars[i].size = 4096U;
 			vdev->vbars[i].base_hpa = 0x0UL;
 			vdev->vbars[i].mask = 0xFFFFF000U & PCI_BASE_ADDRESS_MEM_MASK;
 			/* fixed for memory, 32bit, non-prefetchable */
-			vdev->vbars[i].fixed = 0U;
+			vdev->vbars[i].bar_type.bits = PCIM_BAR_MEM_32;
 
 			/* About MSI-x bar GPA:
 			 * - For Service VM: when first time init, it is programmed as 0, then OS will program

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -780,7 +780,7 @@ void vpci_update_one_vbar(struct pci_vdev *vdev, uint32_t bar_idx, uint32_t val,
 	uint32_t offset = pci_bar_offset(bar_idx);
 	uint32_t update_idx = bar_idx;
 
-	if (vbar->type == PCIBAR_MEM64HI) {
+	if (vbar->is_mem64hi) {
 		update_idx -= 1U;
 	}
 	unmap_cb(vdev, update_idx);

--- a/hypervisor/include/dm/vpci.h
+++ b/hypervisor/include/dm/vpci.h
@@ -38,11 +38,11 @@
 #define VDEV_LIST_HASHSIZE (1U << VDEV_LIST_HASHBITS)
 
 struct pci_vbar {
-	enum pci_bar_type type;
+	bool is_mem64hi;;
 	uint64_t size;		/* BAR size */
 	uint64_t base_gpa;	/* BAR guest physical address */
 	uint64_t base_hpa;	/* BAR host physical address */
-	uint32_t fixed;		/* BAR fix memory type encoding */
+	union pci_bar_type bar_type;
 	uint32_t mask;		/* BAR size mask */
 };
 


### PR DESCRIPTION
When wrong BAR address is set for pci-vuart, OS may assign a
new BAR address to it. Pci-vuart BAR can't be reprogrammed,
for its fixed value.

Remove the fixed value of pci-vuart.

Tracked-On: #5491
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>