### PR TITLE
Fix: HV: VM OS failed to assign new address to pci-vuart BARs

### DIFF
--- a/hypervisor/dm/vpci/vmcs9900.c
+++ b/hypervisor/dm/vpci/vmcs9900.c
@@ -134,14 +134,14 @@ static void init_vmcs9900(struct pci_vdev *vdev)
 	mmio_vbar->size = 0x1000U;
 	mmio_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MMIO_BAR];
 	mmio_vbar->mask = (uint32_t) (~(mmio_vbar->size - 1UL));
-	mmio_vbar->fixed = (uint32_t) (mmio_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+	mmio_vbar->fixed = 0U;
 
 	/* initialize vuart-pci msix bar */
 	msix_vbar->type = PCIBAR_MEM32;
 	msix_vbar->size = 0x1000U;
 	msix_vbar->base_gpa = pci_cfg->vbar_base[MCS9900_MSIX_BAR];
 	msix_vbar->mask = (uint32_t) (~(msix_vbar->size - 1UL));
-	msix_vbar->fixed = (uint32_t) (msix_vbar->base_gpa & PCI_BASE_ADDRESS_MEM_MASK);
+	msix_vbar->fixed = 0U;
 
 	vdev->nr_bars = 2;
 


### PR DESCRIPTION
When wrong BAR address is set for pci-vuart, OS may assign a
new BAR address to it. Pci-vuart BAR can't be reprogrammed,
for its fixed value.

Remove the fixed value of pci-vuart.

Tracked-On: #5491
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>