### PR TITLE
TGL: Fix sos can't boot with 6 pci-vuarts

### DIFF
--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -51,7 +51,7 @@
         <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
         <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
         <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">32</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>


### PR DESCRIPTION
Increase CONFIG_MAX_EMULATED_MMIO_REGIONS to 32, for more pci-vuarts.
Each pci-vuart vdev need 2 mmio BARs, if there are 8 pci-vuarts, they
need emulate 16 mmio regions.

But by default CONFIG_MAX_EMULATED_MMIO_REGIONS=16, that is not enough.

Tracked-On: #5491
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>