### PR TITLE
Fix: do not need to hide IO 0x3f8 for SOS on EHL

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -420,7 +420,6 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 	struct acrn_vm *vm = NULL;
 	int32_t status = 0;
 	uint16_t pcpu_id;
-	struct vm_io_range vu_range = {};
 
 	/* Allocate memory for virtual machine */
 	vm = &vm_array[vm_id];
@@ -494,7 +493,9 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 		enable_iommu();
 
 		/* Create virtual uart;*/
+#ifdef		CONFIG_SERIAL_PIO_BASE
 		if (is_sos_vm(vm)) {
+			struct vm_io_range vu_range = {};
 			/* Legacy vuart[0] will take CONFIG_SERIAL_PIO_BASE, as SOS_COM1_BASE
 			 * If has no legacy vuart[0], SOS will access to CONFIG_SERIAL_PIO_BASE,
 			 * SOS need to trap for CONFIG_SERIAL_PIO_BASE too, without legacy vuart[0].
@@ -504,6 +505,7 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 			vu_range.len = 8U;
 			register_pio_emulation_handler(vm, UART_PIO_IDX0, &vu_range, NULL, NULL);
 		}
+#endif
 		init_legacy_vuarts(vm, vm_config->vuart);
 
 		register_reset_port_handler(vm);


### PR DESCRIPTION
when HW platform like EHL use mmio type serial, do not need to hide
serial IO port for SOS

Tracked-On: #5498
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>