### PR TITLE
hv: bugfix for hv-emulated device de-init -v2.3

### DIFF
--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -1241,7 +1241,7 @@ int32_t hcall_destroy_vdev(struct acrn_vm *vm, struct acrn_vm *target_vm, __unus
 			op = find_emul_dev_ops(&dev);
 			if (op != NULL) {
 				bdf.value = (uint16_t) dev.slot;
-				vdev = pci_find_vdev(&vm->vpci, bdf);
+				vdev = pci_find_vdev(&target_vm->vpci, bdf);
 				if (vdev != NULL) {
 					vdev->pci_dev_config->vbdf.value = UNASSIGNED_VBDF;
 					if (op->destroy != NULL) {

--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -18,7 +18,10 @@
 #define	IVSHMEM_CLASS		0x05U
 #define	IVSHMEM_REV		0x01U
 
-/* ivshmem device supports bar0, bar1 and bar2 */
+/*
+ * ivshmem device supports bar0, bar1 and bar2,
+ * indexes of them shall begin with 0 and be continuous.
+ */
 #define IVSHMEM_MMIO_BAR	0U
 #define IVSHMEM_MSIX_BAR	1U
 #define IVSHMEM_SHM_BAR	2U
@@ -337,7 +340,7 @@ static void init_ivshmem_vdev(struct pci_vdev *vdev)
 	add_vmsix_capability(vdev, MAX_IVSHMEM_MSIX_TBL_ENTRY_NUM, IVSHMEM_MSIX_BAR);
 
 	/* initialize ivshmem bars */
-	vdev->nr_bars = PCI_BAR_COUNT;
+	vdev->nr_bars = 3U;
 	init_ivshmem_bar(vdev, IVSHMEM_MMIO_BAR);
 	init_ivshmem_bar(vdev, IVSHMEM_MSIX_BAR);
 	init_ivshmem_bar(vdev, IVSHMEM_SHM_BAR);

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -773,6 +773,9 @@ int32_t vpci_deassign_pcidev(struct acrn_vm *tgt_vm, struct acrn_assign_pcidev *
 	return ret;
 }
 
+/*
+ * @pre unmap_cb != NULL
+ */
 void vpci_update_one_vbar(struct pci_vdev *vdev, uint32_t bar_idx, uint32_t val,
 		map_pcibar map_cb, unmap_pcibar unmap_cb)
 {
@@ -786,7 +789,9 @@ void vpci_update_one_vbar(struct pci_vdev *vdev, uint32_t bar_idx, uint32_t val,
 	unmap_cb(vdev, update_idx);
 	if (val != ~0U) {
 		pci_vdev_write_vbar(vdev, bar_idx, val);
-		map_cb(vdev, update_idx);
+		if (map_cb != NULL) {
+			map_cb(vdev, update_idx);
+		}
 	} else {
 		pci_vdev_write_vcfg(vdev, offset, 4U, val);
 		vdev->vbars[update_idx].base_gpa = 0UL;


### PR DESCRIPTION
This patch is ported from mainline for 2.3 branch 


- fix bug in 'hcall_destroy_vdev()', the availability of
   vpci device shall be checked on 'target_vm".

 - refine 'vpci_update_one_vbar()' to avoid potential NULL
   pointer access.

Tracked-On: #5508
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>