### PR TITLE
hv: fix nr_bars for hv-land ivshmem devices

### DIFF
--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -340,7 +340,7 @@ static void init_ivshmem_vdev(struct pci_vdev *vdev)
 	add_vmsix_capability(vdev, MAX_IVSHMEM_MSIX_TBL_ENTRY_NUM, IVSHMEM_MSIX_BAR);
 
 	/* initialize ivshmem bars */
-	vdev->nr_bars = 3U;
+	vdev->nr_bars = 4U;
 	init_ivshmem_bar(vdev, IVSHMEM_MMIO_BAR);
 	init_ivshmem_bar(vdev, IVSHMEM_MSIX_BAR);
 	init_ivshmem_bar(vdev, IVSHMEM_SHM_BAR);


### PR DESCRIPTION
 Memory BAR of ivshmem device is 64-bit, 2 BAR registers
 are used, counting in one 32-bit MMIO bar and and one
 32-bit vMSIX table bar, number of bars "nr_bars" shall
 be 4 instead of 3.

Tracked-On: #5490
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>