### PR TITLE
DM: Add the return value check in case cause Null pointer exception

### DIFF
--- a/devicemodel/core/pm_vuart.c
+++ b/devicemodel/core/pm_vuart.c
@@ -23,6 +23,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <termios.h>
+#include <errno.h>
 
 #include "vmmapi.h"
 #include "monitor.h"
@@ -188,6 +189,10 @@ int parse_pm_by_vuart(const char *opts)
 	char *str, *cpy, *type;
 
 	str = cpy = strdup(opts);
+	if (!str) {
+		pr_err("Function strdup return %d in %s line %d!\n", errno, __func__, __LINE__);
+		return error;
+	}
 	type = strsep(&str, ",");
 
 	if (type != NULL) {

--- a/devicemodel/hw/pci/ahci.c
+++ b/devicemodel/hw/pci/ahci.c
@@ -786,6 +786,10 @@ read_prdt(struct ahci_port *p, int slot, uint8_t *cfis,
 
 		dbcsz = (prdt->dbc & DBCMASK) + 1;
 		ptr = paddr_guest2host(ahci_ctx(p->ahci_dev), prdt->dba, dbcsz);
+		if (!ptr) {
+			WPRINTF("%s:%d invalid gpa 0x%x!\n", __func__, __LINE__, prdt->dba);
+			continue;
+		}
 		sublen = MIN(len, dbcsz);
 		memcpy(to, ptr, sublen);
 		len -= sublen;
@@ -905,6 +909,10 @@ write_prdt(struct ahci_port *p, int slot, uint8_t *cfis,
 
 		dbcsz = (prdt->dbc & DBCMASK) + 1;
 		ptr = paddr_guest2host(ahci_ctx(p->ahci_dev), prdt->dba, dbcsz);
+		if (!ptr) {
+			WPRINTF("%s:%d invalid gpa 0x%x!\n", __func__, __LINE__, prdt->dba);
+			continue;
+		}
 		sublen = MIN(len, dbcsz);
 		memcpy(ptr, from, sublen);
 		len -= sublen;
@@ -1812,6 +1820,10 @@ ahci_handle_slot(struct ahci_port *p, int slot)
 #endif
 	cfis = paddr_guest2host(ahci_ctx(ahci_dev), hdr->ctba,
 			0x80 + hdr->prdtl * sizeof(struct ahci_prdt_entry));
+	if (!cfis) {
+		WPRINTF("%s:%d invalid gpa 0x%x!\n", __func__, __LINE__, hdr->ctba);
+		return;
+	}
 #ifdef AHCI_DEBUG
 	prdt = (struct ahci_prdt_entry *)(cfis + 0x80);
 


### PR DESCRIPTION
  paddr_guest2host may return NULL, this patch checks the return value
to avoid null pointer dereference.

Tracked-On: #5514
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>