### PR TITLE
doc: correct typo (missing space)

### DIFF
--- a/doc/tutorials/running_ubun_as_user_vm.rst
+++ b/doc/tutorials/running_ubun_as_user_vm.rst
@@ -59,7 +59,7 @@ Hardware Configurations
 Validated Versions
 ==================
 
--  **Ubuntuversion:** 18.04
+-  **Ubuntu version:** 18.04
 -  **ACRN hypervisor tag:** v2.2
 -  **Service VM Kernel version:** v2.2
 


### PR DESCRIPTION
Add missing space in the document describing how to use Ubuntu as a User VM OS.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>