### PR TITLE
Disable AC for split-lock by default

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -354,7 +354,7 @@ config MCE_ON_PSC_WORKAROUND_DISABLED
 
 config ENFORCE_TURNOFF_AC
 	bool "Force to disable #AC for Split-locked Access"
-	default n
+	default y
 	help
 	  If CPU has #AC for split-locked access, HV enable it and VMs can't disable.
 	  Set this to enforce turn off that #AC, for community developer only.


### PR DESCRIPTION
    hv: disable AC for split-lock by default.
    This patch disables the AC for split-lock check. Only for 2.3.
    Tracked-On: #4765
