### PR TITLE
dm: virtio_console: read only when the virtqueue is ready.

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -461,7 +461,7 @@ virtio_console_backend_read(int fd __attribute__((unused)),
 	port = be->port;
 	vq = virtio_console_port_to_vq(port, true);
 
-	if (!be->open || !port->rx_ready) {
+	if (!be->open || !port->rx_ready || !vq_ring_ready(vq)) {
 		len = read(be->fd, dummybuf, sizeof(dummybuf));
 		if (len == 0)
 			goto close;


### PR DESCRIPTION
The read should not continue if the virtqueue is not ready.

Tracked-On: #5544
Signed-off-by: Jie Deng <jie.deng@intel.com>