### PR TITLE
hv: vmexit: refine xsetbv_vmexit_handler API

### DIFF
--- a/hypervisor/arch/x86/guest/virtual_cr.c
+++ b/hypervisor/arch/x86/guest/virtual_cr.c
@@ -202,7 +202,7 @@ static void vmx_write_cr0(struct acrn_vcpu *vcpu, uint64_t cr0)
 			/* do nothing */
 		}
 
-		if (err_found == false) {
+		if (!err_found) {
 			/* If CR0.CD or CR0.NW get cr0_changed_bits */
 			if ((cr0_changed_bits & (CR0_CD | CR0_NW)) != 0UL) {
 				/* No action if only CR0.NW is cr0_changed_bits */
@@ -295,7 +295,7 @@ static bool is_cr4_write_valid(struct acrn_vcpu *vcpu, uint64_t cr4)
  *   - OSXMMEXCPT (10) Flexible to guest
  *   - VMXE (13) Trapped to hide from guest
  *   - SMXE (14) must always be 0 => must lead to a VM exit
- *   - PCIDE (17) Flexible tol guest
+ *   - PCIDE (17) Flexible to guest
  *   - OSXSAVE (18) Flexible to guest
  *   - XSAVE (19) Flexible to guest
  *         We always keep align with physical cpu. So it's flexible to
@@ -323,12 +323,12 @@ static void vmx_write_cr4(struct acrn_vcpu *vcpu, uint64_t cr4)
 					vcpu_inject_gp(vcpu, 0U);
 				}
 			}
-			if (err_found == false) {
+			if (!err_found) {
 				vcpu_make_request(vcpu, ACRN_REQUEST_EPT_FLUSH);
 			}
 		}
 
-		if ((err_found == false) && (((cr4 ^ old_cr4) & CR4_PCIDE) != 0UL)) {
+		if (!err_found && (((cr4 ^ old_cr4) & CR4_PCIDE) != 0UL)) {
 			/* MOV to CR4 causes a general-protection exception (#GP) if it would change
 			 * CR4.PCIDE from 0 to 1 and either IA32_EFER.LMA = 0 or CR3[11:0] != 000H
 			 */
@@ -352,7 +352,7 @@ static void vmx_write_cr4(struct acrn_vcpu *vcpu, uint64_t cr4)
 			}
 		}
 
-		if (err_found == false) {
+		if (!err_found) {
 			/* Clear forced off bits */
 			cr4_shadow = cr4 & ~CR4_MCE;
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -730,7 +730,7 @@ vlapic_write_lvt(struct acrn_vlapic *vlapic, uint32_t offset)
 		/* No action required. */
 	}
 
-	if (error == false) {
+	if (!error) {
 		*lvtptr = val;
 		idx = lvt_off_to_idx(offset);
 		vlapic->lvt_last[idx] = val;
@@ -883,7 +883,7 @@ vlapic_trigger_lvt(struct acrn_vlapic *vlapic, uint32_t lvt_index)
 	uint32_t lvt;
 	int32_t ret = 0;
 
-	if (vlapic_enabled(vlapic) == false) {
+	if (!vlapic_enabled(vlapic)) {
 		struct acrn_vcpu *vcpu = vlapic2vcpu(vlapic);
 		/*
 		 * When the local APIC is global/hardware disabled,
@@ -2095,7 +2095,7 @@ vlapic_x2apic_pt_icr_access(struct acrn_vm *vm, uint64_t val)
 	phys = ((icr_low & APIC_DESTMODE_LOG) == 0UL);
 	shorthand = icr_low & APIC_DEST_MASK;
 
-	if ((phys == false) || (shorthand  != APIC_DEST_DESTFLD)) {
+	if (!phys || (shorthand  != APIC_DEST_DESTFLD)) {
 		pr_err("Logical destination mode or shorthands \
 				not supported in ICR forpartition mode\n");
 		/*
@@ -2280,7 +2280,7 @@ apicv_set_intr_ready(struct acrn_vlapic *vlapic, uint32_t vector)
 	pid = get_pi_desc(vlapic2vcpu(vlapic));
 	idx = vector >> 6U;
 	if (!bitmap_test_and_set_lock((uint16_t)(vector & 0x3fU), &pid->pir[idx])) {
-		notify = (bitmap_test_and_set_lock(POSTED_INTR_ON, &pid->control.value) == false);
+		notify = !bitmap_test_and_set_lock(POSTED_INTR_ON, &pid->control.value);
 	}
 	return notify;
 }

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -386,7 +386,7 @@ static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 	struct acrn_vcpu *other;
 
 	/* GUEST_FLAG_RT has not set in post-launched RTVM before it has been created */
-	if ((!is_psram_initialized) && (has_rt_vm() == false)) {
+	if ((!is_psram_initialized) && (!has_rt_vm())) {
 		cache_flush_invalidate_all();
 	} else {
 		if (is_rt_vm(vcpu->vm)) {

--- a/hypervisor/arch/x86/seed/seed.c
+++ b/hypervisor/arch/x86/seed/seed.c
@@ -239,7 +239,7 @@ void init_seed(void)
 	}
 
 	/* Failed to parse seed from Bootloader, using dummy seed */
-	if (status == false) {
+	if (!status) {
 		g_phy_seed.num_seeds = 1U;
 		(void)memset(&g_phy_seed.seed_list[0], 0xA5U, sizeof(g_phy_seed.seed_list));
 	}


### PR DESCRIPTION
From SDM Vol.2C - XSETBV instruction description,
If CR4.OSXSAVE[bit 18] = 0,
execute "XSETBV" instruction will generate #UD exception.

From SDM Vol.3C 25.1.1,#UD exception has priority over VM exits,
So if vCPU execute "XSETBV" instruction when CR4.OSXSAVE[bit 18] = 0,
VM exits won't happen.

While hv inject #GP if vCPU execute "XSETBV" instruction
when CR4.OSXSAVE[bit 18] = 0.
It's a wrong behavior, this patch will fix the bug.

Tracked-On: #4020

Signed-off-by: Junming Liu <junming.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>