### PR TITLE
acrn-config: update default pci_dev.c

### DIFF
--- a/misc/vm_configs/scenarios/hybrid/ehl-crb-b/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid/ehl-crb-b/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid/nuc7i7dnb/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i5/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid/whl-ipc-i7/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/hybrid_rt/cfl-k700-i7/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid_rt/cfl-k700-i7/pci_dev.c
@@ -22,6 +22,7 @@
  * TODO: add DEV_PCICOMMON macro to initialize emu_type, vbdf and vdev_ops
  * to simplify the code.
  */
+
 struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
@@ -36,7 +37,7 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_PTDEV,
 		.vbdf.bits = {.b = 0x00U, .d = 0x02U, .f = 0x00U},
-		PTDEV(NON_VOLATILE_MEMORY_CONTROLLER_0),
+		PTDEV(NON_VOLATILE_MEMORY_CONTROLLER_1),
 	},
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
@@ -46,6 +47,8 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 		IVSHMEM_DEVICE_0_VBAR
 	},
 };
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 struct acrn_vm_pci_dev_config vm2_pci_devs[VM2_CONFIG_PCI_DEV_NUM] = {
 	{

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i5/pci_dev.c
@@ -22,6 +22,7 @@
  * TODO: add DEV_PCICOMMON macro to initialize emu_type, vbdf and vdev_ops
  * to simplify the code.
  */
+
 struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
@@ -46,6 +47,8 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 		IVSHMEM_DEVICE_0_VBAR
 	},
 };
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 struct acrn_vm_pci_dev_config vm2_pci_devs[VM2_CONFIG_PCI_DEV_NUM] = {
 	{

--- a/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/pci_dev.c
+++ b/misc/vm_configs/scenarios/hybrid_rt/whl-ipc-i7/pci_dev.c
@@ -22,6 +22,7 @@
  * TODO: add DEV_PCICOMMON macro to initialize emu_type, vbdf and vdev_ops
  * to simplify the code.
  */
+
 struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 	{
 		.emu_type = PCI_DEV_TYPE_HVEMUL,
@@ -46,6 +47,8 @@ struct acrn_vm_pci_dev_config vm0_pci_devs[VM0_CONFIG_PCI_DEV_NUM] = {
 		IVSHMEM_DEVICE_0_VBAR
 	},
 };
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 
 struct acrn_vm_pci_dev_config vm2_pci_devs[VM2_CONFIG_PCI_DEV_NUM] = {
 	{

--- a/misc/vm_configs/scenarios/industry/cfl-k700-i7/pci_dev.c
+++ b/misc/vm_configs/scenarios/industry/cfl-k700-i7/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/industry/ehl-crb-b/pci_dev.c
+++ b/misc/vm_configs/scenarios/industry/ehl-crb-b/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/industry/nuc7i7dnb/pci_dev.c
+++ b/misc/vm_configs/scenarios/industry/nuc7i7dnb/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/industry/whl-ipc-i5/pci_dev.c
+++ b/misc/vm_configs/scenarios/industry/whl-ipc-i5/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];

--- a/misc/vm_configs/scenarios/industry/whl-ipc-i7/pci_dev.c
+++ b/misc/vm_configs/scenarios/industry/whl-ipc-i7/pci_dev.c
@@ -10,3 +10,5 @@
 #include <vbar_base.h>
 #include <mmu.h>
 #include <page.h>
+
+struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];


### PR DESCRIPTION
update all default pci_dev.c under
misc/vm_configs/scenarios/<scenario>/<platform> for non-xml compilation

Tracked-On: #5425
Signed-off-by: Yang Yu-chu <yu-chu.yang@intel.com>