### PR TITLE
misc: adjust compiler options for gcc-10

### DIFF
--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -21,7 +21,6 @@ static uint8_t rtvm_uuids[][16] = {
 static uint8_t safety_vm_uuid1[16] = SAFETY_VM_UUID1;
 
 /* sanity check for below structs is not needed, so use a empty struct instead */
-struct acrn_vm_pci_dev_config sos_pci_devs[CONFIG_MAX_PCI_DEV_NUM];
 const struct pci_vdev_ops vhostbridge_ops;
 const struct pci_vdev_ops vpci_ivshmem_ops;
 const struct pci_vdev_ops vmcs9900_ops;

--- a/misc/tools/acrn-crashlog/acrnprobe/Makefile
+++ b/misc/tools/acrn-crashlog/acrnprobe/Makefile
@@ -9,6 +9,7 @@ INCLUDE		+= -I $(CURDIR)/include -I $(SYSROOT)/usr/include/libxml2
 INCLUDE		+= -I $(BUILDDIR)/include/acrnprobe
 CFLAGS 		+= $(INCLUDE)
 CFLAGS 		+= -fdata-sections
+CFLAGS 		+= -fcommon
 
 LDFLAGS 	+= $(LIBS) -Wl,--gc-sections
 


### PR DESCRIPTION
The latest gcc 10.x changes the default to '-fno-common'. This causes a couple
of build failures in ACRN. This patch changes the default behaviour to
'-fcommon'.

More details on that change can be found here:
https://gcc.gnu.org/gcc-10/porting_to.html

Tracked-On: #5553
Tracked-On: #5549
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>