### PR TITLE
hv: coding style clean-up related to Boolean

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -931,7 +931,7 @@ bool has_rt_vm(void)
 		}
 	}
 
-	return ((vm_id == CONFIG_MAX_VM_NUM) ? false : true);
+	return (vm_id != CONFIG_MAX_VM_NUM);
 }
 
 void make_shutdown_vm_request(uint16_t pcpu_id)

--- a/hypervisor/arch/x86/irq.c
+++ b/hypervisor/arch/x86/irq.c
@@ -261,7 +261,7 @@ void set_irq_trigger_mode(uint32_t irq, bool is_level_triggered)
 	if (irq < NR_IRQS) {
 		desc = &irq_desc_array[irq];
 		spinlock_irqsave_obtain(&desc->lock, &rflags);
-		if (is_level_triggered == true) {
+		if (is_level_triggered) {
 			desc->flags |= IRQF_LEVEL;
 		} else {
 			desc->flags &= ~IRQF_LEVEL;

--- a/hypervisor/arch/x86/rdt.c
+++ b/hypervisor/arch/x86/rdt.c
@@ -102,7 +102,7 @@ static void init_mba_capability(int res)
 	 */
 	cpuid_subleaf(CPUID_RDT_ALLOCATION, res_cap_info[res].res_id, &eax, &ebx, &ecx, &edx);
 	res_cap_info[res].res.membw.mba_max = (uint16_t)((eax & 0xfffU) + 1U);
-	res_cap_info[res].res.membw.delay_linear = ((ecx & 0x4U) != 0U) ? true : false;
+	res_cap_info[res].res.membw.delay_linear = ((ecx & 0x4U) != 0U);
 	res_cap_info[res].clos_max = (uint16_t)(edx & 0xffffU) + 1U;
 }
 

--- a/hypervisor/common/hypercall.c
+++ b/hypervisor/common/hypercall.c
@@ -586,7 +586,7 @@ static int32_t add_vm_memory_region(struct acrn_vm *vm, struct acrn_vm *target_v
 			 * TODO: We can enforce WB for any region has overlap with pSRAM, for simplicity,
 			 * and leave it to SOS to make sure it won't violate.
 			 */
-			if (hpa == PSRAM_BASE_HPA && is_psram_initialized == true) {
+			if ((hpa == PSRAM_BASE_HPA) && is_psram_initialized) {
 				prot |= EPT_WB;
 			}
 			/* create gpa to hpa EPT mapping */

--- a/hypervisor/debug/dbg_cmd.c
+++ b/hypervisor/debug/dbg_cmd.c
@@ -58,5 +58,5 @@ bool handle_dbg_cmd(const char *cmd, int32_t len)
 		}
 	}
 
-	return i < ARRAY_SIZE(cmd_list)? true : false;
+	return (i < ARRAY_SIZE(cmd_list));
 }

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -295,7 +295,7 @@ void write_sriov_cap_reg(struct pci_vdev *vdev, uint32_t offset, uint32_t bytes,
 		if (reg == PCIR_SRIOV_CONTROL) {
 			bool enable;
 
-			enable = (((val & PCIM_SRIOV_VF_ENABLE) != 0U) ? true : false);
+			enable = ((val & PCIM_SRIOV_VF_ENABLE) != 0U);
 			if (enable != is_vf_enabled(vdev)) {
 				if (enable) {
 					/*


### PR DESCRIPTION
While following two styles are both correct, the 2nd one is simpler.
	bool is_level_triggered;
	1. if (is_level_triggered == true) {...}
	2. if (is_level_triggered) {...}

This patch cleans up the style in hypervisor.

Tracked-On: #861
Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>