### PR TITLE
acrn-config: remove hardcoded device in launch script

### DIFF
--- a/misc/acrn-config/launch_config/com.py
+++ b/misc/acrn-config/launch_config/com.py
@@ -626,8 +626,6 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
         print("   -l com1,stdio \\", file=config)
 
     if launch_cfg_lib.is_linux_like(uos_type) or uos_type in ("ANDROID", "ALIOS"):
-        if uos_type != "PREEMPT-RT LINUX":
-            print("   -s {},virtio-hyper_dmabuf \\".format(launch_cfg_lib.virtual_dev_slot("virtio-hyper_dmabuf")), file=config)
         if board_name == "apl-mrb":
             print("   -i /run/acrn/ioc_$vm_name,0x20 \\", file=config)
             print("   -l com2,/run/acrn/ioc_$vm_name \\", file=config)


### PR DESCRIPTION
The "virtio-hyper_dmabuf" is no longer needed for PREEMPT-RT LINUX.
Remove it from launch script.

Tracked-On: #5565
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>