### PR TITLE
acrn-config: update function for xml.etree.ElementTree to compatible …

### DIFF
--- a/misc/acrn-config/acpi_gen/asl_gen.py
+++ b/misc/acrn-config/acpi_gen/asl_gen.py
@@ -423,7 +423,7 @@ def main(args):
                     dict_passthru_devices[vm_id].append(pci_dev_node.text)
             mmio_dev_nodes = vm.find('mmio_resources')
             if mmio_dev_nodes is not None:
-                for mmio_dev_node in mmio_dev_nodes.getchildren():
+                for mmio_dev_node in list(mmio_dev_nodes):
                     if mmio_dev_node is not None and mmio_dev_node.text.strip() == 'y':
                         dict_passthru_devices[vm_id].append(mmio_dev_node.tag)
             dict_vcpu_list[vm_id] = []

--- a/misc/acrn-config/config_app/controller.py
+++ b/misc/acrn-config/config_app/controller.py
@@ -164,7 +164,7 @@ class XmlConfig:
         args = args[:-1]
         dest_node = self._get_dest_node(*args)
         new_node_desc = None
-        for node in dest_node.getchildren():
+        for node in list(dest_node):
             if node.tag == tag:
                 if 'desc' in node.attrib:
                     new_node_desc = node.attrib['desc']

--- a/misc/acrn-config/config_app/templates/launch.html
+++ b/misc/acrn-config/config_app/templates/launch.html
@@ -132,7 +132,7 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
 
     {% if board_info != None and root != None %}
     <table class="table table-hover" id="tab">
-        {% for vm in root.getchildren() %}
+        {% for vm in root|list %}
         <tr>
             <td>
                 <div class="form-group">
@@ -154,8 +154,8 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
                 </div>
             </td>
             <td>
-            {% for elem in vm.getchildren() %}
-                {% if elem.getchildren() == [] and ('configurable' not in elem.attrib or elem.attrib['configurable'] !=
+            {% for elem in vm|list %}
+                {% if elem|list == [] and ('configurable' not in elem.attrib or elem.attrib['configurable'] !=
                 '0') %}
                 <div class="form-group">
                     <label class="col-sm-1 control-label" data-toggle="tooltip"
@@ -204,11 +204,11 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
                     {% endif %}
                     <p id="{{'uos:id='+vm.attrib['id']+','+elem.tag}}_err" class="col-sm-3"></p>
                 </div>
-                {% elif elem.getchildren() != [] %}
+                {% elif elem|list != [] %}
                     {% if 'multiselect' not in elem.attrib or elem.attrib['multiselect'] != 'true' %}
                         {% set first_multi_child = {'block': 0, 'network': 0, 'input': 0, 'pcpu_id': 0, 'shm_region': 0,
                         'passthrough_devices': 0, 'virtio_devices': 0, 'communication_vuart': 0} %}
-                        {% for sub_elem in elem.getchildren() %}
+                        {% for sub_elem in elem|list %}
                             {% set sub_elem_text = '' if sub_elem.text == None else sub_elem.text %}
                             {% if 'configurable' not in sub_elem.attrib or sub_elem.attrib['configurable'] != '0' %}
                             <div class="form-group">
@@ -366,12 +366,12 @@ the launch scripts will be generated into misc/acrn-config/xmls/config-xmls/[boa
                             {% endif %}
                             {% if ','.join(['uos', elem.tag]) not in launch_item_values %}
                                 {% set x=1 %}
-                                {% for sub_elem in elem.getchildren() %}
+                                {% for sub_elem in elem|list %}
                                     <option value="{{sub_elem.text}}" selected="selected">{{sub_elem.text}}</option>
                                 {% endfor %}
                             {% else %}
                                 {% set selected_list = [] %}
-                                {% for sub_elem in elem.getchildren() %}
+                                {% for sub_elem in elem|list %}
                                     {% do selected_list.append(sub_elem.text) %}
                                 {% endfor %}
                                 {% for item_value in launch_item_values[','.join(['uos', elem.tag])] %}

--- a/misc/acrn-config/config_app/templates/scenario.html
+++ b/misc/acrn-config/config_app/templates/scenario.html
@@ -126,7 +126,7 @@ the source files will be generated into default path and overwirte the previous 
     {% if board_info != None and root != None and scenario_item_values %}
     <table class="table table-hover" id="tab">
         {% set vm_kata = [] %}
-        {% for vm in root.getchildren() %}
+        {% for vm in root|list %}
             {% if 'desc' in vm.attrib and vm.attrib['desc'] == 'specific for Kata'  %}
                 {% do vm_kata.append(1) %}
             {% endif %}
@@ -165,9 +165,9 @@ the source files will be generated into default path and overwirte the previous 
                     {% endif %}
                 </td>
                 <td>
-                {% for elem in vm.getchildren() %}
+                {% for elem in vm|list %}
                     {% set elem_text = elem.text if elem.text != None else '' %}
-                    {% if elem.getchildren() == [] and ('configurable' not in elem.attrib or elem.attrib['configurable']
+                    {% if elem|list == [] and ('configurable' not in elem.attrib or elem.attrib['configurable']
                     != '0')%}
                     <div class="form-group">
                         <label class="col-sm-1 control-label" data-toggle="tooltip"
@@ -206,15 +206,15 @@ the source files will be generated into default path and overwirte the previous 
                         {% endif %}
                         <p id="{{vm_type+','+elem.tag}}_err" class="col-sm-3"></p>
                     </div>
-                    {% elif elem.getchildren() != [] and ('configurable' not in elem.attrib or elem.attrib['configurable']
+                    {% elif elem|list != [] and ('configurable' not in elem.attrib or elem.attrib['configurable']
                     != '0')%}
                         {% if 'multiselect' not in elem.attrib or elem.attrib['multiselect'] != 'true' %}
                             {% set first_child = [] %}
-                            {% for sub_elem in elem.getchildren() %}
+                            {% for sub_elem in elem|list %}
                                 {% set sub_elem_text = sub_elem.text if sub_elem.text != None else '' %}
 
                                 {% if sub_elem.tag in ['RDT', 'IVSHMEM', 'PSRAM'] %}
-                                    {% for sub_elem_2 in sub_elem.getchildren() %}
+                                    {% for sub_elem_2 in sub_elem|list %}
                                     {% set sub_elem_2_text = sub_elem_2.text if sub_elem_2.text != None else '' %}
                                     {% if ','.join([vm.tag, elem.tag, sub_elem.tag, sub_elem_2.tag]) in scenario_item_values %}
                                     <div class="form-group">
@@ -464,12 +464,12 @@ the source files will be generated into default path and overwirte the previous 
                                     {% endif %}
                                     {% if ','.join([vm.tag, elem.tag]) not in scenario_item_values %}
                                         {% set x=1 %}
-                                        {% for sub_elem in elem.getchildren() %}
+                                        {% for sub_elem in elem|list %}
                                         <option value="{{sub_elem.text}}" selected="selected">{{sub_elem.text}}</option>
                                         {% endfor %}
                                     {% else %}
                                         {% set selected_list = [] %}
-                                        {% for sub_elem in elem.getchildren() %}
+                                        {% for sub_elem in elem|list %}
                                         {% do selected_list.append(sub_elem.text) %}
                                         {% endfor %}
                                         {% for item_value in scenario_item_values[','.join([vm.tag, elem.tag])] %}

--- a/misc/acrn-config/config_app/views.py
+++ b/misc/acrn-config/config_app/views.py
@@ -170,9 +170,9 @@ def save_scenario():
     old_scenario_name = scenario_config_data['old_scenario_name']
     scenario_config.set_curr(old_scenario_name)
 
-    for vm in scenario_config.get_curr_root().getchildren():
+    for vm in list(scenario_config.get_curr_root()):
         if vm.tag == 'vm':
-            for elem in vm.getchildren():
+            for elem in list(vm):
                 if elem.tag in ['communication_vuart', 'console_vuart']:
                     vuart_key = vm.tag+':id='+vm.attrib['id']+','+elem.tag + ':id='+elem.attrib['id']
                     delete_flag = True
@@ -200,7 +200,7 @@ def save_scenario():
                     communication_vuart_i_item = copy.deepcopy(communication_vuart_1_item)
                     communication_vuart_i_item.attrib['id'] = communication_vuart_id
                     curr_index = 0
-                    elem_list = scenario_config.get_curr_elem(key.split(',')[0]).getchildren()
+                    elem_list = list(scenario_config.get_curr_elem(key.split(',')[0]))
                     for elem in reversed(elem_list):
                         curr_index += 1
                         if elem.tag in ['communication_vuart', 'console_vuart']:
@@ -221,7 +221,7 @@ def save_scenario():
             assign_vm_id(scenario_config)
         elif generator == 'add_vm_kata':
             vm_list = []
-            for vm in scenario_config.get_curr_root().getchildren():
+            for vm in list(scenario_config.get_curr_root()):
                 if vm.tag == 'vm':
                     vm_list.append(vm.attrib['id'])
             if len(vm_list) >= MAX_VM_NUM:
@@ -232,7 +232,7 @@ def save_scenario():
             generic_scenario_config = get_generic_scenario_config(scenario_config)
             generic_scenario_config_root = generic_scenario_config.get_curr_root()
             elem_kata = None
-            for vm in generic_scenario_config_root.getchildren():
+            for vm in list(generic_scenario_config_root):
                 if 'desc' in vm.attrib and vm.attrib['desc'] == 'specific for Kata':
                     elem_kata = vm
                     break
@@ -241,7 +241,7 @@ def save_scenario():
             assign_vm_id(scenario_config)
         elif generator.startswith('add_vm:'):
             vm_list = []
-            for vm in scenario_config.get_curr_root().getchildren():
+            for vm in list(scenario_config.get_curr_root()):
                 if vm.tag == 'vm':
                     vm_list.append(vm.attrib['id'])
             if len(vm_list) >= MAX_VM_NUM:
@@ -260,7 +260,7 @@ def save_scenario():
                     if curr_vm_id == vm_list[i]:
                         curr_vm_index = i + 2
                         break
-            for vm in generic_scenario_config_root.getchildren():
+            for vm in list(generic_scenario_config_root):
                 if vm.tag == 'vm':
                     for i in range(0, MAX_VM_NUM):
                         if str(i) not in vm_list:
@@ -346,7 +346,7 @@ def save_launch():
     if generator is not None:
         if generator.startswith('add_vm:'):
             vm_list = []
-            for vm in launch_config.get_curr_root().getchildren():
+            for vm in list(launch_config.get_curr_root()):
                 if vm.tag == 'uos':
                     vm_list.append(vm.attrib['id'])
             if len(vm_list) >= MAX_VM_NUM:
@@ -380,7 +380,7 @@ def save_launch():
                     if curr_vm_id == vm_list[i]:
                         curr_vm_index = i + 1
                         break
-            for vm in generic_scenario_config_root.getchildren():
+            for vm in list(generic_scenario_config_root):
                 if vm.tag == 'uos':
                     for i in range(1, MAX_VM_NUM):
                         if str(i) not in vm_list:
@@ -397,7 +397,7 @@ def save_launch():
     launch_config.set_curr_attr('scenario', scenario_name)
     launch_config.set_curr_attr('board', current_app.config.get('BOARD_TYPE'))
 
-    launch_config.set_curr_attr('uos_launcher', str(len(launch_config.get_curr_root().getchildren())))
+    launch_config.set_curr_attr('uos_launcher', str(len(list(launch_config.get_curr_root()))))
 
     tmp_launch_file = os.path.join(current_app.config.get('CONFIG_PATH'), xml_configs[1],
                                    'user_defined',
@@ -608,10 +608,11 @@ def generate_src():
         scenario_setting_xml = os.path.join(current_app.config.get('CONFIG_PATH'), board_type,
                                             'user_defined', scenario_setting + '.xml')
 
-        try:
+        # try:
+        if True:
             from launch_config.launch_cfg_gen import ui_entry_api
             error_list = ui_entry_api(board_info_xml, scenario_setting_xml, launch_setting_xml, src_path)
-        except Exception as error:
+        # except Exception as error:
             status = 'fail'
             error_list = {'launch setting error': str(error)}
     else:
@@ -877,7 +878,7 @@ def get_post_launch_vms():
     launch_config = xml_configs[3]
     launch_config.set_curr(launch_name)
     if launch_config is not None and launch_config.get_curr_root() is not None:
-        for uos in launch_config.get_curr_root().getchildren():
+        for uos in list(launch_config.get_curr_root()):
             if 'id' in uos.attrib:
                 uos_id_list.append(int(uos.attrib['id'])-1)
 
@@ -914,10 +915,10 @@ def get_post_launch_vm_list(scenario_name):
     scenario_config.set_curr(scenario_name)
     vm_list = []
     if scenario_config is not None and scenario_config.get_curr_root() is not None:
-        for vm in scenario_config.get_curr_root().getchildren():
+        for vm in list(scenario_config.get_curr_root()):
             if vm.tag == 'vm' and 'id' in vm.attrib:
                 vm_id = vm.attrib['id']
-                for item in vm.getchildren():
+                for item in list(vm):
                     if item.tag == 'vm_type' and item.text in ['POST_STD_VM', 'POST_RT_VM']:
                         vm_list.append((vm_id, item.text))
                         break
@@ -1026,7 +1027,7 @@ def get_board_info(board_info):
     if board_config is not None:
         board_info_root = board_config.get_curr_root()
         if board_info_root:
-            for item in board_info_root.getchildren():
+            for item in list(board_info_root):
                 if item.tag == 'BIOS_INFO':
                     for line in item.text.split('\n'):
                         if line.strip() != '':
@@ -1096,7 +1097,7 @@ def get_board_rdt_res_clos_max(board_file_name):
     if board_config is not None:
         board_info_root = board_config.get_curr_root()
         if board_info_root:
-            for item in board_info_root.getchildren():
+            for item in list(board_info_root):
                 if item.tag == 'CLOS_INFO':
                     for line in item.text.split('\n'):
                         line = line.strip()
@@ -1136,9 +1137,9 @@ def assign_vm_id(scenario_config):
     sos_vm_num = 0
     post_launched_vm_num = 0
 
-    for vm in root.getchildren():
+    for vm in list(root):
         if vm.tag == 'vm':
-            for item in vm.getchildren():
+            for item in list(vm):
                 if item.tag == 'vm_type':
                     if item.text in ['PRE_STD_VM', 'SAFETY_VM', 'PRE_RT_VM']:
                         pre_launched_vm_num += 1
@@ -1150,9 +1151,9 @@ def assign_vm_id(scenario_config):
     pre_launched_vm_index = 0
     sos_vm_index = pre_launched_vm_num
     post_launched_vm_index = pre_launched_vm_num + sos_vm_num
-    for vm in root.getchildren():
+    for vm in list(root):
         if vm.tag == 'vm':
-            for item in vm.getchildren():
+            for item in list(vm):
                 if item.tag == 'vm_type':
                     if item.text in ['PRE_STD_VM', 'SAFETY_VM', 'PRE_RT_VM']:
                         vm.attrib['id'] = str(pre_launched_vm_index)

--- a/misc/acrn-config/library/launch_cfg_lib.py
+++ b/misc/acrn-config/library/launch_cfg_lib.py
@@ -607,13 +607,13 @@ def set_pci_vuarts(launch_item_values, scenario_info):
         for vm_id, vm_type in vm_types.items():
             if vm_type in ['SOS_VM']:
                 sos_vm_id = vm_id
-        for vm in common.get_config_root(scenario_info).getchildren():
+        for vm in list(common.get_config_root(scenario_info)):
             if vm.tag == 'vm' and scenario_cfg_lib.VM_DB[vm_types[int(vm.attrib['id'])]]['load_type'] == 'POST_LAUNCHED_VM':
                 uos_id = int(vm.attrib['id']) - sos_vm_id
                 pci_vuart_key = 'uos:id={},communication_vuarts,communication_vuart'.format(uos_id)
-                for elem in vm.getchildren():
+                for elem in list(vm):
                     if elem.tag == 'communication_vuart':
-                        for sub_elem in elem.getchildren():
+                        for sub_elem in list(elem):
                             if sub_elem.tag == 'base' and sub_elem.text == 'PCI_VUART':
                                 if pci_vuart_key not in launch_item_values.keys():
                                     launch_item_values[pci_vuart_key] = ['', elem.attrib['id']]


### PR DESCRIPTION
…with python3.9

The function getchildren() is removed from xml.etree.ElementTree.Element
on python3.9, update the function to list() to make config tool
compatible with python3.9.

Tracked-On: #5570

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>