### PR TITLE
acrn-config: fix the logic of get_vuart1_vmid

### DIFF
--- a/misc/acrn-config/library/scenario_cfg_lib.py
+++ b/misc/acrn-config/library/scenario_cfg_lib.py
@@ -576,22 +576,21 @@ def get_vuart1_vmid(vm_vuart1):
     :return: dictionary of vmid:vuart1
     """
     vm_id_dic = {}
+    new_vm_id_dic = {}
     for i in list(common.VM_TYPES.keys()):
         for key in vm_vuart1[i].keys():
             if key == "target_vm_id":
                 vm_id_dic[i] = vm_vuart1[i][key]
 
-    # remove the unavailable vimid:target_vmid from dictonary
+    # remove the unavailable vmid:target_vmid from dictionary
     vmid_list = list(vm_id_dic.keys())
 
     for vmid in vmid_list:
-        new_vmid = vm_id_dic[vmid]
-        if int(new_vmid) in vmid_list and vmid == int(vm_id_dic[int(new_vmid)]):
-            continue
-        else:
-            vm_id_dic.pop(vmid)
+        target_vmid = vm_id_dic[vmid]
+        if int(target_vmid) in vmid_list and vmid == int(vm_id_dic[int(target_vmid)]):
+            new_vm_id_dic[vmid] = target_vmid
 
-    return vm_id_dic
+    return new_vm_id_dic
 
 
 def cpus_assignment(cpus_per_vm, index):


### PR DESCRIPTION
The function validate if the legacy vuart1 and its target_vm_id are
paired. However, it dynamically modifies the tracking list. It would try
to access an invalid keys which has been removed.

Refine the logic to add a valid paired legacy vuart1 to new list.

Tracked-On: #5592
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>