### PR TITLE
doc: automate copyright year footer

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,8 @@
 #
 import os
 import sys
+from datetime import datetime
+
 sys.path.insert(0, os.path.abspath('.'))
 
 RELEASE = ""
@@ -75,7 +77,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Project ACRN™'
-copyright = u'2020, Project ACRN'
+copyright = u'2018-' + str(datetime.now().year) + u', Project ACRN'
 author = u'Project ACRN developers'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Automatically update the copyright year on the page footers to be
2018-[current_year] when generating documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>