### PR TITLE
misc: add more boot arguments for EHL preempt-rt

### DIFF
--- a/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/misc_cfg.h
+++ b/misc/vm_configs/scenarios/hybrid_rt/ehl-crb-b/misc_cfg.h
@@ -84,9 +84,13 @@
 #define VM0_CONFIG_PCI_DEV_NUM	4U
 #define VM2_CONFIG_PCI_DEV_NUM	1U
 
-#define VM0_BOOT_ARGS	"rw rootwait root=/dev/sda3 console=ttyS0 \
-noxsave nohpet no_timer_check ignore_loglevel \
-consoleblank=0 tsc=reliable reboot=acpi"
+#define VM0_BOOT_ARGS	"rw rootwait root=/dev/sda3 no_ipi_broadcast=1 \
+console=ttyS0 noxsave nohpet no_timer_check \
+ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc \
+x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable \
+mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 \
+rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 \
+reboot=acpi"
 
 
 #define VM0_PT_INTX_NUM	0U

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -97,7 +97,7 @@
             <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
             <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
             <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable reboot=acpi</bootargs>
+            <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
         </os_config>
         <legacy_vuart id="0">
             <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>


### PR DESCRIPTION
  some RT related boot arguments are needed for preempt-rt linux.
add them in configure file built in for EHL board.
  for EHL, it is booted with SBL, not like GRUB, extra boot arguments
can be added; so better to be built in.

Tracked-On: #5606
Signed-off-by: Minggui Cao <minggui.cao@intel.com>