### PR TITLE
doc: update Kconfig options documentation

### DIFF
--- a/doc/developer-guides/hld/hld-trace-log.rst
+++ b/doc/developer-guides/hld/hld-trace-log.rst
@@ -161,10 +161,10 @@ system:
   can allocate and set up sbuf
 
 There are 6 different loglevels, as shown below. The specified
-severity loglevel is stored in ``mem_loglevel``, initialized
-by :option:`CONFIG_MEM_LOGLEVEL_DEFAULT`. The loglevel can
-be set to a new value
-at runtime via hypervisor shell command "loglevel".
+severity loglevel is stored in ``mem_loglevel``, initialized by
+:option:`CONFIG_MEM_LOGLEVEL_DEFAULT <Kconfig CONFIG_MEM_LOGLEVEL_DEFAULT>`.
+The loglevel can be set to a new value at runtime via hypervisor shell
+command "loglevel".
 
 .. code-block:: c
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -26,10 +26,10 @@ It's important that the ACRN Kconfig settings are aligned with the physical memo
 on your platform. Check the documentation for these option settings for
 details:
 
-* :option:`CONFIG_PLATFORM_RAM_SIZE`
-* :option:`CONFIG_SOS_RAM_SIZE`
-* :option:`CONFIG_UOS_RAM_SIZE`
-* :option:`CONFIG_HV_RAM_SIZE`
+* :option:`CONFIG_PLATFORM_RAM_SIZE <Kconfig CONFIG_PLATFORM_RAM_SIZE>`
+* :option:`CONFIG_SOS_RAM_SIZE <Kconfig CONFIG_SOS_RAM_SIZE>`
+* :option:`CONFIG_UOS_RAM_SIZE <Kconfig CONFIG_UOS_RAM_SIZE>`
+* :option:`CONFIG_HV_RAM_SIZE <Kconfig CONFIG_HV_RAM_SIZE>`
 
 For example, if the Intel NUC's physical memory size is 32G, you may follow these steps
 to make the new UEFI ACRN hypervisor, and then deploy it onto the Intel NUC to boot

--- a/doc/scripts/genrest.py
+++ b/doc/scripts/genrest.py
@@ -23,7 +23,7 @@ def rst_link(sc):
         if sc.nodes:
             # The "\ " avoids RST issues for !CONFIG_FOO -- see
             # http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#character-level-inline-markup
-            return r"\ :option:`{0} <CONFIG_{0}>`".format(sc.name)
+            return r"\ :option:`{0} <Kconfig CONFIG_{0}>`".format(sc.name)
 
     elif isinstance(sc, kconfiglib.Choice):
         # Choices appear as dependencies of choice symbols.
@@ -50,8 +50,8 @@ def expr_str(expr):
 
 INDEX_RST_HEADER = """.. _configuration:
 
-Configuration Symbol Reference
-##############################
+Kconfig Configuration Symbol Reference
+######################################
 
 Introduction
 ************
@@ -100,7 +100,8 @@ def write_kconfig_rst():
         # Add an index entry for the symbol that links to its RST file. Also
         # list its prompt(s), if any. (A symbol can have multiple prompts if it
         # has multiple definitions.)
-        index_rst += "   * - :option:`CONFIG_{}`\n     - {}\n".format(
+        index_rst += "   * - :option:`CONFIG_{} <Kconfig CONFIG_{}>`\n     - {}\n".format(
+            sym.name,
             sym.name,
             " / ".join(node.prompt[0]
                        for node in sym.nodes if node.prompt))
@@ -149,6 +150,7 @@ def sym_header_rst(sym):
     #   to be poorly documented at the moment.
     return ":orphan:\n\n" \
            ".. title:: {0}\n\n" \
+           ".. program:: Kconfig\n\n" \
            ".. option:: CONFIG_{0}\n\n" \
            "{1}\n\n" \
            "Type: ``{2}``\n\n" \

--- a/doc/tutorials/rtvm_performance_tips.rst
+++ b/doc/tutorials/rtvm_performance_tips.rst
@@ -190,7 +190,8 @@ Tip: Disable the software workaround for Machine Check Error on Page Size Change
    Change is conditionally applied to the models that may be affected by the
    issue. However, the software workaround has a negative impact on
    performance. If all guest OS kernels are trusted, the
-   :option:`CONFIG_MCE_ON_PSC_WORKAROUND_DISABLED` option could be set for performance.
+   :option:`CONFIG_MCE_ON_PSC_WORKAROUND_DISABLED <Kconfig CONFIG_MCE_ON_PSC_WORKAROUND_DISABLED>`
+   option could be set for performance.
 
 .. note::
    The tips for preempt-RT Linux are mostly applicable to the Linux-based RTOS as well, such as Xenomai.

--- a/doc/user-guides/kernel-parameters.rst
+++ b/doc/user-guides/kernel-parameters.rst
@@ -207,7 +207,8 @@ relevant for configuring or debugging ACRN-based systems.
        from the guest VM.
 
        If hypervisor relocation is disabled, verify that
-       :option:`CONFIG_HV_RAM_START` and :option:`CONFIG_HV_RAM_SIZE`
+       :option:`CONFIG_HV_RAM_START <Kconfig CONFIG_HV_RAM_START>`
+       and :option:`CONFIG_HV_RAM_SIZE <Kconfig CONFIG_HV_RAM_SIZE>`
        does not overlap with the hypervisor's reserved buffer space allocated
        in the Service VM. Service VM GPA and HPA are a 1:1 mapping.
 


### PR DESCRIPTION
Kconfig options documentation used a linking capability (:option:) but
did it in an unnamed domain that would complicate use of this capability
for other domains (such as the configuration tool options).

Create the Kconfig options in a new Kconfig domain (done in the genrest.py
script) and update references to specify this domain in the
documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>