### PR TITLE
doc: specify the version of 'sphinx-tabs' to install

### DIFF
--- a/doc/scripts/requirements.txt
+++ b/doc/scripts/requirements.txt
@@ -3,4 +3,4 @@ sphinx==1.7.7
 docutils==0.14
 sphinx_rtd_theme==0.4.0
 kconfiglib>=10.2
-sphinx-tabs
+sphinx-tabs==1.1.13


### PR DESCRIPTION
Specify the version of 'sphinx-tabs' to be installed in order
to be able to build the documentation. Without this, the latest
is installed but is incompatible with 'sphinx==1.7.7' as specified
in our doc/scripts/requirements' file.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>