### PR TITLE
acrn-config: config the entry number of vcpu_clos same as that of pcp…

### DIFF
--- a/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-mrb/hybrid.xml
@@ -128,7 +128,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/apl-up2/hybrid.xml
@@ -128,7 +128,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/cfl-k700-i7/hybrid_rt.xml
@@ -125,7 +125,7 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid.xml
@@ -76,9 +76,6 @@
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <mmio_resources desc="MMIO resources.">
-            <p2sb>n</p2sb>
-        </mmio_resources>
         <pt_intx desc="pt intx mapping.">
         </pt_intx>
         <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
@@ -128,6 +125,7 @@
         </pci_devs>
         <mmio_resources desc="mmio devices list to passthrough">
             <TPM2 desc="TPM2 device">n</TPM2>
+            <p2sb>n</p2sb>
         </mmio_resources>
     </vm>
     <vm id="1">
@@ -141,7 +139,9 @@
             <pcpu_id>1</pcpu_id>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
+            <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt.xml
@@ -81,6 +81,7 @@
         </cpu_affinity>
         <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
             <vcpu_clos>0</vcpu_clos>
+            <vcpu_clos>0</vcpu_clos>
         </clos>
         <epc_section configurable="0" desc="epc section">
             <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -137,7 +138,8 @@
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>

--- a/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/vm_configs/xmls/config-xmls/ehl-crb-b/hybrid_rt_fusa.xml
@@ -80,6 +80,7 @@
         </cpu_affinity>
         <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
             <vcpu_clos>0</vcpu_clos>
+            <vcpu_clos>0</vcpu_clos>
         </clos>
         <epc_section configurable="0" desc="epc section">
             <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -140,7 +141,8 @@
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+            <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid.xml
@@ -126,7 +126,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/generic/hybrid_rt.xml
@@ -126,7 +126,8 @@
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc6cayh/hybrid.xml
@@ -128,7 +128,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/nuc7i7dnb/hybrid.xml
@@ -124,7 +124,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
+++ b/misc/vm_configs/xmls/config-xmls/qemu/sdc.xml
@@ -114,7 +114,7 @@
     <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section configurable="0" desc="epc section">

--- a/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
+++ b/misc/vm_configs/xmls/config-xmls/template/SOS_VM.xml
@@ -8,7 +8,7 @@
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
         <pcpu_id></pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid.xml
@@ -124,7 +124,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/tgl-rvp/hybrid_rt.xml
@@ -71,6 +71,7 @@
     </cpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
         <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section configurable="0" desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -126,7 +127,8 @@
     <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid.xml
@@ -124,7 +124,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i5/hybrid_rt.xml
@@ -68,6 +68,7 @@
     </cpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
         <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section configurable="0" desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -127,7 +128,8 @@
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid.xml
@@ -124,7 +124,9 @@
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>

--- a/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/vm_configs/xmls/config-xmls/whl-ipc-i7/hybrid_rt.xml
@@ -68,6 +68,7 @@
     </cpu_affinity>
     <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
         <vcpu_clos>0</vcpu_clos>
+        <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section configurable="0" desc="epc section">
         <base desc="SGX EPC section base, must be page aligned">0</base>
@@ -127,7 +128,8 @@
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>


### PR DESCRIPTION
…u_id

configure the entry number of vcpu_clos same as the entry number
of pcpu_id to avoid sanity check error.

Tracked-On: #5600
Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>