### PR TITLE
doc: fix formatting in windows as UOS doc

### DIFF
--- a/doc/tutorials/using_windows_as_uos.rst
+++ b/doc/tutorials/using_windows_as_uos.rst
@@ -139,9 +139,9 @@ Install Windows 10 by GVT-d
 
    .. code-block:: bash
 
-   cd /home/acrn/work/
-   sudo chmod +x install_win.sh
-   sudo ./install_win.sh
+      cd /home/acrn/work/
+      sudo chmod +x install_win.sh
+      sudo ./install_win.sh
 
 When you see the UEFI shell, input **exit**.
 
@@ -223,15 +223,15 @@ Boot Windows on ACRN with a default configuration
 
    .. code-block:: bash
 
-   -s 5,ahci,cd:./windows.iso \
-   -s 6,ahci,cd:./winvirtio.iso \
+      -s 5,ahci,cd:./windows.iso \
+      -s 6,ahci,cd:./winvirtio.iso \
 
 #. Lauch WaaG
 
    .. code-block:: bash
 
-   cd /home/acrn/work/
-   sudo ./launch_win.sh
+      cd /home/acrn/work/
+      sudo ./launch_win.sh
 
 The WaaG desktop displays on the monitor.
 


### PR DESCRIPTION
code-block content wasn't indented in a recent change so wasn't included
in the code-block formatting

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>