### PR TITLE
DM: samples: Enable VxWorks as normal VM by default

### DIFF
--- a/misc/vm_configs/sample_launch_scripts/nuc/launch_vxworks.sh
+++ b/misc/vm_configs/sample_launch_scripts/nuc/launch_vxworks.sh
@@ -18,17 +18,21 @@ fi
 mem_size=2048M
 
 # Note:
-#      For RTVM with lapic_pt, we only support virtio devices with polling mode enabled for both
-#      front-end and back-end. The virtio devices with polling mode are not supported by VxWorks
-#      offically now and we are working on upstream the front-end drivers.
-#      OVMF console is not available with default parameters.
-
+#      Here we just launch VxWorks as a normal vm without lapic pt. If you want try it
+#      with lapic pt, you should add the following options and make sure the front-end virtio-console
+#      driver use polling mode (This feature is not supported by VxWorks offically now and should
+#      be implemented it by youself).
+#
+#      --lapic_pt \
+#      --virtio_poll 1000000 \
+#      -U $rtvm_uuid \
+#
+#      Once the front-end polling mode virtio-console get supported by VxWorks offically, we will
+#      set the lapic_pt option as default.
 acrn-dm -A -m $mem_size -s 0:0,hostbridge \
   -s 5,virtio-console,@stdio:stdio_port \
   -s 3,virtio-blk,./VxWorks.img \
-  --virtio_poll 1000000 \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
-  --lapic_pt \
   $vm_name
 }
 


### PR DESCRIPTION
This patch basically reverts commit 22f24c229b48a98e70572e7e25b1de2077fbd198
since virtio polling mode is still not ready in VxWorks official build.

	commit 22f24c229b48a98e70572e7e25b1de2077fbd198
	Author: Kaige Fu <kaige.fu@intel.com>
	Date:   Thu Jun 13 09:24:07 2019 +0000

	    DM: Samples: Enable VxWorks as hard-rt VM

	    This patch adds --lapic_pt option to launch VxWorks as hard-rt VM.

End user could enable VxWorks as hard-rt VM with acrn-config tool, or add
below acrn-dm parameters in launch script:

	" --lapic_pt \
	  --virtio_poll 1000000 \
	  -U $rtvm_uuid"

Tracked-On: #3069

Signed-off-by: Victor Sun <victor.sun@intel.com>