### PR TITLE
doc: prep for upgrading doc build tools

### DIFF
--- a/doc/.known-issues/doc/dupdecl.conf
+++ b/doc/.known-issues/doc/dupdecl.conf
@@ -10,5 +10,5 @@
 #
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: duplicate C object description.*
 #
-^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C\+\+ declaration, .*
+^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C[\+]* declaration, .*
 ^Declaration is .*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -231,10 +231,18 @@ numfig_format = {'figure': 'Figure %s', 'table': 'Table %s', 'code-block': 'Code
 html_static_path = ['static']
 
 def setup(app):
-   app.add_stylesheet("acrn-custom.css")
-   app.add_javascript("https://www.googletagmanager.com/gtag/js?id=UA-831873-64")
-   # note more GA tag manager calls are in acrn-custom.js
-   app.add_javascript("acrn-custom.js")
+   import sphinx
+
+   if float(sphinx.__version__[0:3]) < 3.0:
+      app.add_stylesheet("acrn-custom.css")
+      app.add_javascript("https://www.googletagmanager.com/gtag/js?id=UA-831873-64")
+      # note more GA tag manager calls are in acrn-custom.js
+      app.add_javascript("acrn-custom.js")
+   else:
+      app.add_css_file("acrn-custom.css")
+      app.add_js_file("https://www.googletagmanager.com/gtag/js?id=UA-831873-64")
+      # note more GA tag manager calls are in acrn-custom.js
+      app.add_js_file("acrn-custom.js")
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
Update known-issues list to eliminate known warnings for duplicate
declaration warnings because of breathe/sphinx upgrades.

Update conf.py to check sphinx version and use appropriate way to
include extra javascript and css files depending on the version.

Both of these changes will allow the old and new doc tools to not show
unanticipated warnings or errors and allow for a smooth upgrade to the
CI system (and contributors local doc builds).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>