### PR TITLE
dm: virtio-gpio: avoid flood messages in virtio_irq_evt_notify

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_gpio.c
+++ b/devicemodel/hw/pci/virtio/virtio_gpio.c
@@ -1221,7 +1221,7 @@ static void
 virtio_irq_evt_notify(void *vdev, struct virtio_vq_info *vq)
 {
 	/* The front-end driver does not make a kick, just avoid warning */
-	WPRINTF(("%s", "virtio gpio irq_evt_notify\n"));
+	DPRINTF(("%s", "virtio gpio irq_evt_notify\n"));
 }
 
 static void


### PR DESCRIPTION
To avoid flood messages in virtio_irq_evt_notify.
Tracked-On: #5635