### PR TITLE
Fix: HV: keep reshuffling on VBARs

### DIFF
--- a/hypervisor/dm/vpci/vdev.c
+++ b/hypervisor/dm/vpci/vdev.c
@@ -115,10 +115,10 @@ static void pci_vdev_update_vbar_base(struct pci_vdev *vdev, uint32_t idx)
 	vbar = &vdev->vbars[idx];
 	offset = pci_bar_offset(idx);
 	lo = pci_vdev_read_vcfg(vdev, offset, 4U);
-	if (((is_pci_io_bar(vbar->bar_type.bits) || is_pci_mem32_bar(vbar->bar_type.bits) || is_pci_mem64_bar(vbar->bar_type.bits) || vbar->is_mem64hi)) && (lo != ~0U)) {
+	if ((!is_pci_reserved_bar(vbar)) && (lo != ~0U)) {
 		base = lo & vbar->mask;
 
-		if (is_pci_mem64_bar(vbar->bar_type.bits)) {
+		if (is_pci_mem64lo_bar(vbar)) {
 			vbar = &vdev->vbars[idx + 1U];
 			hi = pci_vdev_read_vcfg(vdev, (offset + 4U), 4U);
 			if (hi != ~0U) {
@@ -128,12 +128,14 @@ static void pci_vdev_update_vbar_base(struct pci_vdev *vdev, uint32_t idx)
 				base = 0UL;
 			}
 		}
-		if (is_pci_io_bar(vbar->bar_type.bits)) {
-			base &= 0xffffUL;
-		}
+	} else if (is_pci_io_bar(vbar)) {
+		/* Because guest driver may write to upper 16-bits of PIO BAR and expect that should have no effect,
+		 * SO PIO BAR base may bigger than 0xffff after calculation, should mask the upper 16-bits.
+		 */
+		base &= 0xffffUL;
 	}
 
-	if ((base != 0UL) && !ept_is_mr_valid(vpci2vm(vdev->vpci), base, vdev->vbars[idx].size)) {
+	if (is_pci_mem_bar(vbar) && (base != 0UL) && !ept_is_mr_valid(vpci2vm(vdev->vpci), base, vdev->vbars[idx].size)) {
 		pr_warn("%s, %x:%x.%x set invalid bar[%d] base: 0x%lx, size: 0x%lx\n", __func__,
 			vdev->bdf.bits.b, vdev->bdf.bits.d, vdev->bdf.bits.f, idx, base, vdev->vbars[idx].size);
 		base = 0UL;	/* 0UL means invalid GPA, so that EPT won't map */
@@ -150,13 +152,17 @@ void pci_vdev_write_vbar(struct pci_vdev *vdev, uint32_t idx, uint32_t val)
 
 	vbar = &vdev->vbars[idx];
 	bar = val & vbar->mask;
-	bar |= vbar->bar_type.bits;
-	offset = pci_bar_offset(idx);
-	pci_vdev_write_vcfg(vdev, offset, 4U, bar);
-
 	if (vbar->is_mem64hi) {
 		update_idx -= 1U;
+	} else {
+		if (is_pci_io_bar(vbar)) {
+			bar |= (vbar->bar_type.bits & (~PCI_BASE_ADDRESS_IO_MASK));
+		} else {
+			bar |= (vbar->bar_type.bits & (~PCI_BASE_ADDRESS_MEM_MASK));
+		}
 	}
+	offset = pci_bar_offset(idx);
+	pci_vdev_write_vcfg(vdev, offset, 4U, bar);
 
 	pci_vdev_update_vbar_base(vdev, update_idx);
 }

--- a/hypervisor/dm/vpci/vmsix_on_msi.c
+++ b/hypervisor/dm/vpci/vmsix_on_msi.c
@@ -83,7 +83,7 @@ void init_vmsix_on_msi(struct pci_vdev *vdev)
 			if (vdev->vbars[i].base_hpa == 0UL){
 				break;
 			}
-			if (is_pci_mem64_bar(vdev->vbars[i].bar_type.bits)) {
+			if (is_pci_mem64lo_bar(&vdev->vbars[i])) {
 				i++;
 			}
 		}

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -203,16 +203,22 @@ union pci_bdf {
 	} fields;
 };
 
+/*
+ * The next data structure is to reflect the format of PCI BAR base on the PCI sepc.
+ */
+
 union pci_bar_type {
 	uint32_t bits;
 	struct {
-		uint8_t indicator :1;   /* BITs[0], mapped to I/O space if read as 1 */
-		uint8_t reserved :1;    /* BITs[1], reserved */
+		uint32_t indicator :1;               /* BITs[0], mapped to I/O space if read as 1 */
+		uint32_t reserved :1;               /* BITs[1], reserved and must be "0" per spec. */
+		uint32_t reserved2 : 30;
 	} io_space;
 	struct {
-		uint8_t indicator :1;   /* BITs[0], mapped to memory space if read as 0 */
-		uint8_t mem_type :2;    /* BITs[1:2], 32-bit address if read as 00b, 64-bit address as 01b */
-		uint8_t prefetchable :1;        /* BITs[3], set to 1b if the data is prefetchable and set to 0b otherwise */
+		uint32_t indicator :1;               /* BITs[0], mapped to memory space if read as 0 */
+		uint32_t mem_type :2;            /* BITs[1:2], 32-bit address if read as 00b, 64-bit address as 01b */
+		uint32_t prefetchable :1;        /* BITs[3], set to 1b if the data is prefetchable and set to 0b otherwise */
+		uint32_t reserved2 : 28;
 	} mem_space;
 };
 
@@ -307,34 +313,6 @@ static inline bool is_bar_offset(uint32_t nr_bars, uint32_t offset)
 	}
 
 	return ret;
-}
-
-static inline bool is_pci_io_bar(uint32_t val)
-{
-	union pci_bar_type bar_type = {.bits = val};
-
-	return (bar_type.io_space.indicator == 1U);
-}
-
-static inline bool is_pci_mem_bar(uint32_t val)
-{
-	union pci_bar_type bar_type = {.bits = val};
-
-	return ((bar_type.mem_space.indicator == 0U));
-}
-
-static inline bool is_pci_mem32_bar(uint32_t val)
-{
-	union pci_bar_type bar_type = {.bits = val};
-
-	return (is_pci_mem_bar(val) && (bar_type.mem_space.mem_type == 0U));
-}
-
-static inline bool is_pci_mem64_bar(uint32_t val)
-{
-	union pci_bar_type bar_type = {.bits = val};
-
-	return (is_pci_mem_bar(val) && (bar_type.mem_space.mem_type == 2U));
 }
 
 static inline bool bdf_is_equal(union pci_bdf a, union pci_bdf b)


### PR DESCRIPTION
The commit 'Fix: HV: VM OS failed to assign new address to pci-vuart
BARs' need more reshuffle.

Tracked-On: #5491
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>
Signed-off-by: Eddie Dong <eddie.dong@intel.com>