### PR TITLE
hv: ptirq: Shouldn't change sid if intx irq mapping was added

### DIFF
--- a/hypervisor/arch/x86/guest/assign.c
+++ b/hypervisor/arch/x86/guest/assign.c
@@ -706,14 +706,23 @@ int32_t ptirq_intx_pin_remap(struct acrn_vm *vm, uint32_t virt_gsi, enum intx_ct
 
 					entry = find_ptirq_entry(PTDEV_INTR_INTX, &alt_virt_sid, vm);
 					if (entry != NULL) {
-						entry->virt_sid.value = virt_sid.value;
-						dev_dbg(DBG_LEVEL_IRQ,
-								"IOAPIC gsi=%hhu pirq=%u vgsi=%d switch from %s to %s for vm%d",
+						uint32_t phys_gsi = virt_gsi;
+
+						remove_intx_remapping(vm, alt_virt_sid.intx_id.gsi,
+							alt_virt_sid.intx_id.ctlr);
+						entry = add_intx_remapping(vm, virt_gsi, phys_gsi, vgsi_ctlr);
+						if (entry == NULL) {
+							pr_err("%s, add intx remapping failed", __func__);
+							status = -ENODEV;
+						} else {
+							dev_dbg(DBG_LEVEL_IRQ,
+								"IOAPIC gsi=%hhu pirq=%u vgsi=%d from %s to %s for vm%d",
 								entry->phys_sid.intx_id.gsi,
 								entry->allocated_pirq, entry->virt_sid.intx_id.gsi,
 								(vgsi_ctlr == INTX_CTLR_IOAPIC) ? "vPIC" : "vIOAPIC",
 								(vgsi_ctlr == INTX_CTLR_IOAPIC) ? "vIOPIC" : "vPIC",
 								entry->vm->vm_id);
+						}
 					}
 				}
 


### PR DESCRIPTION
Now, we use hash table to maintain intx irq mapping by using
the key generated from sid. So once the entry is added,we can
not update source ide any more. Otherwise, we can't locate the
entry with the key generated from new source ide.

For source id change, remove_remapping/add_remapping is used
instead of update source id directly if entry was added already.

Tracked-On: #5640
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>