### PR TITLE
Makefile: fix build issues due to reorg of misc/

### DIFF
--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -56,9 +56,9 @@ define determine_config =
 ifneq ($($(1)),)
   ifneq ($(realpath $($(1))),)
     override $(1)_FILE := $($(1))
-    override $(1) := $$(shell xmllint --xpath 'string(/config_tools/@$(shell echo $(1) | tr A-Z a-z))' $$($(1)_FILE))
+    override $(1) := $$(shell xmllint --xpath 'string(/acrn-config/@$(shell echo $(1) | tr A-Z a-z))' $$($(1)_FILE))
   else
-    override $(1)_FILE := $(HV_PREDEFINED_$(1)_DIR)/$$($(1)).xml
+    override $(1)_FILE := $(HV_PREDEFINED_DATA_DIR)/$$(BOARD)/$$($(1)).xml
     ifeq ($$(realpath $$($(1)_FILE)),)
       $$(error $(1) = '$($(1))' is neither path to a file nor name of a predefined board)
     endif
@@ -76,7 +76,7 @@ else
   else
     override $(1) := $(2)
   endif
-  override $(1)_FILE := $(HV_PREDEFINED_$(1)_DIR)/$$($(1)).xml
+  override $(1)_FILE := $(HV_PREDEFINED_DATA_DIR)/$$(BOARD)/$$($(1)).xml
 endif
 endef
 
@@ -107,14 +107,10 @@ endif
 endef
 
 # Paths to the inputs
-#
-# Note: BOARD may not be defined at this point. Thus, HV_PREDEFINED_SCENARIO_DIR is defined using '=' rather than ':='
-# so that the variable will only be expanded when used.
 HV_BOARD_XML := $(HV_OBJDIR)/.board.xml
 HV_SCENARIO_XML := $(HV_OBJDIR)/.scenario.xml
 HV_UNIFIED_XML_IN := $(BASEDIR)/scripts/makefile/unified.xml.in
-HV_PREDEFINED_BOARD_DIR := $(realpath $(BASEDIR)/../misc/config_tools/data)/$(BOARD)
-HV_PREDEFINED_SCENARIO_DIR = $(realpath $(BASEDIR)/../misc/config_tools/data)/$(BOARD)
+HV_PREDEFINED_DATA_DIR := $(realpath $(BASEDIR)/../misc/config_tools/data)
 HV_CONFIG_TOOL_DIR := $(realpath $(BASEDIR)/../misc/config_tools)
 HV_CONFIG_XFORM_DIR := $(HV_CONFIG_TOOL_DIR)/xforms
 


### PR DESCRIPTION
This patch fixes the following issues that break the build system:

 1. The tag of the root nodes of board/scenario XML files are still acrn-config,
     not config_tools. This patch reverts the XPATH that refers to these nodes.

 2. HV_PREDEFINED_BOARD_DIR now also relies on BOARD which may not be
    available at the time the variable is defined. As both board and
    scenario XML files are placed under the same directory, this patch
    refines the path calculation logic to get rid of mixing variables of
    the different flavors.

Tracked-On: #5644
Fixes: 97c9b2403036 ("acrn-config: Reorg config tool folder")
Signed-off-by: Junjie Mao <junjie.mao@intel.com>