### PR TITLE
Makefile: make internal comment in doc Makefile silent

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -68,7 +68,7 @@ singlehtml: doxy content kconfig
 
 clean:
 	rm -fr $(BUILDDIR)
-	# Keeping these temporarily, but no longer strictly needed.
+	@# Keeping these temporarily, but no longer strictly needed.
 	rm -fr doxygen
 	rm -fr misc
 	rm -fr reference/kconfig/*.rst


### PR DESCRIPTION
There is a comment in the doc/Makefile that is beinhg spit out
when calling 'make clean'. This is harmless but can be confusing
to users so let's make it silent.

Tracked-On: #5669
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>