### PR TITLE
hv: remove the hardcoding of Software SRAM GPA base

### DIFF
--- a/hypervisor/arch/x86/guest/ve820.c
+++ b/hypervisor/arch/x86/guest/ve820.c
@@ -14,7 +14,6 @@
 
 #define ENTRY_HPA1_LOW_PART1	2U
 #define ENTRY_HPA1_LOW_PART2	4U
-#define ENTRY_SOFTWARE_SRAM	3U
 #define ENTRY_HPA1_HI		8U
 
 static struct e820_entry sos_vm_e820[E820_MAX_ENTRIES];
@@ -136,17 +135,17 @@ static const struct e820_entry pre_ve820_template[E820_MAX_ENTRIES] = {
 	/* Software SRAM segment splits the lowmem into two parts */
 	{	/* part1 of lowmem of hpa1*/
 		.baseaddr = MEM_1M,		/* 1MB */
-		.length   = SOFTWARE_SRAM_BASE_GPA - MEM_1M,
+		.length   = PRE_RTVM_SW_SRAM_BASE_GPA - MEM_1M,
 		.type     = E820_TYPE_RAM
 	},
 	{	/* Software SRAM */
-		.baseaddr = SOFTWARE_SRAM_BASE_GPA,
-		.length   = SOFTWARE_SRAM_MAX_SIZE,
+		.baseaddr = PRE_RTVM_SW_SRAM_BASE_GPA,
+		.length   = PRE_RTVM_SW_SRAM_MAX_SIZE,
 		.type     = E820_TYPE_RESERVED
 	},
 	{	/* part2 of lowmem of hpa1*/
-		.baseaddr = SOFTWARE_SRAM_BASE_GPA + SOFTWARE_SRAM_MAX_SIZE,
-		.length   = MEM_2G - MEM_1M - (SOFTWARE_SRAM_BASE_GPA + SOFTWARE_SRAM_MAX_SIZE),
+		.baseaddr = PRE_RTVM_SW_SRAM_BASE_GPA + PRE_RTVM_SW_SRAM_MAX_SIZE,
+		.length   = MEM_2G - MEM_1M - (PRE_RTVM_SW_SRAM_BASE_GPA + PRE_RTVM_SW_SRAM_MAX_SIZE),
 		.type     = E820_TYPE_RAM
 	},
 	{	/* ACPI Reclaim */
@@ -194,14 +193,14 @@ static inline uint64_t add_ram_entry(struct e820_entry *entry, uint64_t gpa, uin
  *   entry6: ACPI NVS from 0x7fff0000 to 0x7fffffff
  *   entry7: reserved for 32bit PCI hole from 0x80000000 to 0xffffffff
  *   (entry8): usable for
- *            a) hpa1_hi, if hpa1 > 2GB - SOFTWARE_SRAM_MAX_SIZE
- *            b) hpa2, if (hpa1 + hpa2) < 2GB - SOFTWARE_SRAM_MAX_SIZE
+ *            a) hpa1_hi, if hpa1 > 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE
+ *            b) hpa2, if (hpa1 + hpa2) < 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE
  *            c) hpa2_lo,
- *               if hpa1 < 2GB - SOFTWARE_SRAM_MAX_SIZE and (hpa1 + hpa2) > 2GB - SOFTWARE_SRAM_MAX_SIZE
+ *               if hpa1 < 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE and (hpa1 + hpa2) > 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE
  *   (entry9): usable for
- *            a) hpa2, if hpa1 > 2GB - SOFTWARE_SRAM_MAX_SIZE
+ *            a) hpa2, if hpa1 > 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE
  *            b) hpa2_hi,
- *               if hpa1 < 2GB - SOFTWARE_SRAM_MAX_SIZE and (hpa1 + hpa2) > 2GB - SOFTWARE_SRAM_MAX_SIZE
+ *               if hpa1 < 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE and (hpa1 + hpa2) > 2GB - PRE_RTVM_SW_SRAM_MAX_SIZE
  */
 
 /*
@@ -218,8 +217,8 @@ void create_prelaunched_vm_e820(struct acrn_vm *vm)
 	struct acrn_vm_config *vm_config = get_vm_config(vm->vm_id);
 	uint64_t gpa_start = 0x100000000UL;
 	uint64_t hpa1_hi_size, hpa2_lo_size;
-	uint64_t lowmem_max_length = MEM_2G - SOFTWARE_SRAM_MAX_SIZE;
-	uint64_t hpa1_part1_max_length = SOFTWARE_SRAM_BASE_GPA - MEM_1M;
+	uint64_t lowmem_max_length = MEM_2G - PRE_RTVM_SW_SRAM_MAX_SIZE;
+	uint64_t hpa1_part1_max_length = PRE_RTVM_SW_SRAM_BASE_GPA - MEM_1M;
 	uint64_t remaining_hpa2_size = vm_config->memory.size_hpa2;
 	uint32_t entry_idx = ENTRY_HPA1_HI;
 
@@ -244,7 +243,7 @@ void create_prelaunched_vm_e820(struct acrn_vm *vm)
 	} else {
 		/* Otherwise, part2 is not empty. */
 		vm->e820_entries[ENTRY_HPA1_LOW_PART2].length =
-			vm_config->memory.size - SOFTWARE_SRAM_BASE_GPA - MEM_1M;
+			vm_config->memory.size - PRE_RTVM_SW_SRAM_BASE_GPA - MEM_1M;
 		/* need to set gpa_start for hpa2 */
 	}
 

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -231,11 +231,11 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 		if (entry->length == 0UL) {
 			continue;
 		} else {
-			if (is_sw_sram_initialized && (entry->baseaddr == SOFTWARE_SRAM_BASE_GPA) &&
+			if (is_sw_sram_initialized && (entry->baseaddr == PRE_RTVM_SW_SRAM_BASE_GPA) &&
 				((vm_config->guest_flags & GUEST_FLAG_RT) != 0U)){
 				/* pass through Software SRAM to pre-RTVM */
 				ept_add_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp,
-					get_software_sram_base(), SOFTWARE_SRAM_BASE_GPA,
+					get_software_sram_base(), PRE_RTVM_SW_SRAM_BASE_GPA,
 					get_software_sram_size(), EPT_RWX | EPT_WB);
 				continue;
 			}

--- a/hypervisor/include/arch/x86/rtct.h
+++ b/hypervisor/include/arch/x86/rtct.h
@@ -9,6 +9,7 @@
 
 #include <acpi.h>
 
+#include "misc_cfg.h"
 
 #define RTCT_ENTRY_TYPE_RTCD_LIMIT		1U
 #define RTCT_ENTRY_TYPE_RTCM_BINARY		2U
@@ -20,8 +21,19 @@
 #define RTCT_ENTRY_TYPE_RT_IOMMU		8U
 #define RTCT_ENTRY_TYPE_MEM_HIERARCHY_LATENCY	9U
 
-#define SOFTWARE_SRAM_BASE_GPA 0x40080000U
-#define SOFTWARE_SRAM_MAX_SIZE 0x00800000U
+#if !defined(PRE_RTVM_SW_SRAM_BASE_GPA)
+/*
+ * PRE_RTVM_SW_SRAM_BASE_GPA is for Prelaunch VM only and
+ * is configured by config tool on platform that Software SRAM is detected.
+ *
+ * For cases that Software SRAM is not detected, we still hardcode a dummy
+ * placeholder entry in vE820 table of Prelaunch VM to unify the logic
+ * to initialize the vE820.
+ */
+#define PRE_RTVM_SW_SRAM_BASE_GPA 0x40080000U
+#endif
+
+#define PRE_RTVM_SW_SRAM_MAX_SIZE  0x00800000U
 
 struct rtct_entry {
 	 uint16_t size;


### PR DESCRIPTION
 Currently, we hardcode the GPA base of Software SRAM
 to an address that is derived from TGL platform,
 as this GPA is identical with HPA for Pre-launch VM,
 This hardcoded address may not work on other platforms
 if the HPA bases of Software SRAM are different.

 Now, Offline tool configures above GPA based on the
 detection of Software SRAM on specific platform.

 This patch removes the hardcoding GPA of Software SRAM,
 and also renames MACRO 'SOFTWARE_SRAM_BASE_GPA' to
 'PRE_RTVM_SW_SRAM_BASE_GPA' to avoid confusing, as it
 is for Prelaunch VM only.

Tracked-On: #5649
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>