### PR TITLE
dm: fix compilation issue with gcc10

### DIFF
--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -58,7 +58,7 @@ struct acpi_table_hdr {
 	char                    asl_compiler_id[4];
 	/* ASL compiler version */
 	uint32_t                asl_compiler_revision;
-} __packed;
+} __attribute__((packed));
 
 /* All dynamic table entry no. */
 #define NHLT_ENTRY_NO		8


### PR DESCRIPTION
Fix compilation issue when using gcc 10.x due to the "__packed"
attribute in acpi.h. Explicitly changing that to __attribute__((packed))
fixes the compilation error.

Tracked-On: #5671
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>