### PR TITLE
doc: update CODEOWNERS for tech docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 Makefile                                 @terryzouhao @NanlinXie
 /hypervisor/                             @anthonyzxu @dongyaozu
 /devicemodel/                            @anthonyzxu @ywan170
-/doc/                                    @dbkinder @deb-intel @NanlinXie
+/doc/                                    @dbkinder @fitchbe @NanlinXie
 /misc/debug_tools/acrn_crashlog/         @chengangc @dizhang417
 /misc/debug_tools/acrn_log/              @ywan170 @shuox
 /misc/debug_tools/acrn_trace/            @ywan170 @shuox
@@ -27,4 +27,4 @@ Makefile                                 @terryzouhao @NanlinXie
 /misc/packaging/                         @terryzouhao @NanlinXie
 /misc/hv_prebuild/                       @terryzouhao @NanlinXie
 
-*.rst                                    @dbkinder @deb-intel @NanlinXie
+*.rst                                    @dbkinder @fitchbe @NanlinXie


### PR DESCRIPTION
Replace Deb (deb-intel) with Ben (fitchbe)for technical writer/reviewer

Tracked-On: #5581

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>