### PR TITLE
doc: fix misspelling in hv-dev-passthrough

### DIFF
--- a/doc/developer-guides/hld/hv-dev-passthrough.rst
+++ b/doc/developer-guides/hld/hv-dev-passthrough.rst
@@ -316,7 +316,7 @@ Table Entry (or RTE). The hypervisor then invokes the IOAPIC emulation
 handler (refer to :ref:`hld-io-emulation` for details on I/O emulation) which
 calls APIs to set up a remapping for the to-be-unmasked interrupt.
 
-Remapping of (virtual) PIC interrupts are set up in a similar sequence:
+Remapping of (virtual) MSI interrupts are set up in a similar sequence:
 
 .. figure:: images/passthru-image98.png
    :align: center


### PR DESCRIPTION
Tracked-On: #5647

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>