### PR TITLE
config_tools/data: cleanup scenario XML files

### DIFF
--- a/misc/config_tools/data/apl-mrb/hybrid.xml
+++ b/misc/config_tools/data/apl-mrb/hybrid.xml
@@ -1,175 +1,176 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-mrb" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS2</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS2</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/mmcblk1p1</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
@@ -178,39 +179,39 @@
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/industry.xml
+++ b/misc/config_tools/data/apl-mrb/industry.xml
@@ -1,110 +1,111 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-mrb" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS2</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS2</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">y</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>y</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-       <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+       <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">s
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>s
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/mmcblk1p1</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
@@ -113,77 +114,77 @@
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/industry.xml
+++ b/misc/config_tools/data/apl-mrb/industry.xml
@@ -100,7 +100,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs>s
+    <pci_devs>
         <pci_dev/>
     </pci_devs>
     <board_private>

--- a/misc/config_tools/data/apl-mrb/logical_partition.xml
+++ b/misc/config_tools/data/apl-mrb/logical_partition.xml
@@ -70,7 +70,7 @@
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos>&gt;
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>

--- a/misc/config_tools/data/apl-mrb/logical_partition.xml
+++ b/misc/config_tools/data/apl-mrb/logical_partition.xml
@@ -1,186 +1,187 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-mrb" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS2</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS2</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">>
+    <clos>&gt;
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw root=/dev/mmcblk1p1 rootwait console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">02:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
+        <pci_dev>02:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</pci_dev>
+    <pci_devs>
+        <pci_dev>00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Marvell Technology Group Ltd. 88W8897 [AVASTAR] 802.11ac Wireless</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/sdc.xml
+++ b/misc/config_tools/data/apl-mrb/sdc.xml
@@ -1,110 +1,111 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-mrb" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS2</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS2</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk1p1</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/mmcblk1p1</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
@@ -113,74 +114,74 @@
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2-n3350/logical_partition.xml
+++ b/misc/config_tools/data/apl-up2-n3350/logical_partition.xml
@@ -1,183 +1,184 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-up2-n3350" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
+        <pci_dev>02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/hybrid.xml
+++ b/misc/config_tools/data/apl-up2/hybrid.xml
@@ -1,175 +1,176 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-up2" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/mmcblk0p3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
@@ -178,39 +179,39 @@
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/industry.xml
+++ b/misc/config_tools/data/apl-up2/industry.xml
@@ -1,110 +1,111 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-up2" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">y</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>y</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/mmcblk0p3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
@@ -113,77 +114,77 @@
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>3</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>1</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/logical_partition.xml
+++ b/misc/config_tools/data/apl-up2/logical_partition.xml
@@ -1,187 +1,188 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-up2" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
+        <pci_dev>02:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 0c)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/sdc.xml
+++ b/misc/config_tools/data/apl-up2/sdc.xml
@@ -1,110 +1,111 @@
+<?xml version="1.0"?>
 <acrn-config board="apl-up2" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/mmcblk0p3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
@@ -113,74 +114,74 @@
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -1,131 +1,132 @@
+<?xml version="1.0"?>
 <acrn-config board="cfl-k700-i7" scenario="hybrid_rt">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/), size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x800000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x800000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x800000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x800000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
-        <UEFI_OS_LOADER_NAME desc="UEFI OS loader name."></UEFI_OS_LOADER_NAME>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
+        <UEFI_OS_LOADER_NAME/>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>PRE_RT_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
         <guest_flag>GUEST_FLAG_RT</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>6</pcpu_id>
         <pcpu_id>7</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x40000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x40000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-	<bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/nvme0n1p3 earlyprintk=serial,ttyS0,115200 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel
+        <name>PREEMPT-RT</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>RT_bzImage</kern_mod>
+        <ramdisk_mod/>
+	<bootargs>rw rootwait root=/dev/nvme0n1p3 earlyprintk=serial,ttyS0,115200 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel
 	log_buf_len=16M consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup
 	idle=poll irqaffinity=0 no_ipi_broadcast=1  reboot=acpi
 	</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-	<pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
-        <pci_dev desc="pci device">09:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</pci_dev>
+    <pci_devs>
+	<pci_dev>00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (7) I219-LM (rev 10)</pci_dev>
+        <pci_dev>09:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">y</TPM2>
+    <mmio_resources>
+        <TPM2>y</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
@@ -134,17 +135,17 @@
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
@@ -153,112 +154,112 @@
         <pcpu_id>5</pcpu_id>
     </cpu_affinity>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check
         hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>4</pcpu_id>
         <pcpu_id>5</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/cfl-k700-i7/industry.xml
+++ b/misc/config_tools/data/cfl-k700-i7/industry.xml
@@ -1,373 +1,374 @@
+<?xml version="1.0"?>
 <acrn-config board="cfl-k700-i7" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor">0x16800000</HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x800000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x800000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE>0x16800000</HV_RAM_SIZE>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x800000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x800000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
-        <UEFI_OS_LOADER_NAME desc="UEFI OS loader name.">\\EFI\\BOOT\\bootx64.efi</UEFI_OS_LOADER_NAME>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
+        <UEFI_OS_LOADER_NAME>\\EFI\\BOOT\\bootx64.efi</UEFI_OS_LOADER_NAME>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
@@ -1,188 +1,188 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="fusa_partition">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:1</IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:1</IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-            <guest_flag />
+        <vm_type>SAFETY_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
+            <guest_flag/>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments"></bootargs>
-            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+            <name>Zephyr</name>
+            <kern_type>KERNEL_ZEPHYR</kern_type>
+            <kern_mod>Zephyr_RawImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs/>
+            <kern_load_addr>0x8000</kern_load_addr>
+            <kern_entry_addr>0x8000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-        <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>PRE_RT_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM1</name>
+        <guest_flags>
             <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
             <guest_flag>GUEST_FLAG_RT</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x120000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-            <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
+            <name>PREEMPT-RT</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>RT_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
+        <pci_devs>
+            <pci_dev>00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid.xml
@@ -1,225 +1,225 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="hybrid">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SAFETY_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <pt_intx desc="pt intx mapping.">
+        <pt_intx>
         </pt_intx>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+            <name>Zephyr</name>
+            <kern_type>KERNEL_ZEPHYR</kern_type>
+            <kern_mod>Zephyr_RawImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>reboot=acpi</bootargs>
+            <kern_load_addr>0x8000</kern_load_addr>
+            <kern_entry_addr>0x8000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
             <p2sb>n</p2sb>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+            <start_hpa>0</start_hpa>
+            <size>CONFIG_SOS_RAM_SIZE</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/sda3</rootfs>
+            <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
@@ -1,261 +1,261 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="hybrid_rt">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
-            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name."></UEFI_OS_LOADER_NAME>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME/>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>PRE_RT_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
             <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
             <guest_flag>GUEST_FLAG_RT</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x40000000</size>
-            <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x40000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
+            <name>PREEMPT-RT</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>RT_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
-            <pci_dev desc="pci device">00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
+        <pci_devs>
+            <pci_dev>00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
+            <pci_dev>00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">y</TPM2>
+        <mmio_resources>
+            <TPM2>y</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+            <start_hpa>0</start_hpa>
+            <size>CONFIG_SOS_RAM_SIZE</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/nvme0n1p3</rootfs>
+            <bootargs>
             rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
             i915.nuclear_pageflip=1 swiotlb=131072
             </bootargs>
         </board_private>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
     <vm id="3">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
@@ -1,226 +1,226 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="hybrid_rt_fusa">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
-            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name."></UEFI_OS_LOADER_NAME>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME/>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>PRE_RT_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
             <guest_flag>GUEST_FLAG_RT</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0xC0000000</size>
-            <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0xC0000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda2 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable reboot=acpi</bootargs>
+            <name>PREEMPT-RT</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>RT_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>rw rootwait root=/dev/sda2 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable reboot=acpi</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
-            <pci_dev desc="pci device">00:1a.3 Non-VGA unclassified device [0000]: Intel Corporation Device 4b4a</pci_dev>
+        <pci_devs>
+            <pci_dev>00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
+            <pci_dev>00:1a.3 Non-VGA unclassified device [0000]: Intel Corporation Device 4b4a</pci_dev>
         </pci_devs>
-        <mmio_resources desc="MMIO resources.">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
             <p2sb>true</p2sb>
         </mmio_resources>
-        <pt_intx desc="pt intx mapping.">
+        <pt_intx>
             (14, 0)
         </pt_intx>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+            <start_hpa>0</start_hpa>
+            <size>CONFIG_SOS_RAM_SIZE</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/mmcblk0p3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/mmcblk0p3</rootfs>
+            <bootargs>
             rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
             i915.nuclear_pageflip=1 swiotlb=131072 modprobe.blacklist=pinctrl_elkhartlake,intel_ehl_gpio
             </bootargs>
         </board_private>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
@@ -125,7 +125,7 @@
         </pci_devs>
         <mmio_resources>
             <TPM2>n</TPM2>
-            <p2sb>true</p2sb>
+            <p2sb>y</p2sb>
         </mmio_resources>
         <pt_intx>
             (14, 0)

--- a/misc/config_tools/data/ehl-crb-b/industry.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry.xml
@@ -1,384 +1,384 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="industry">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS3</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">y</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>y</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+            <start_hpa>0</start_hpa>
+            <size>0x20000000</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>2</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/nvme0n1p3</rootfs>
+            <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_RT_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/logical_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/logical_partition.xml
@@ -1,194 +1,194 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="logical_partition">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-            <guest_flag />
-            <guest_flag />
+        <vm_type>PRE_STD_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
+            <guest_flag/>
+            <guest_flag/>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">
+            <name>YOCTO</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-        <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-            <guest_flag></guest_flag>
+        <vm_type>PRE_STD_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM1</name>
+        <guest_flags>
+            <guest_flag/>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x120000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-            <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">
+            <name>YOCTO</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/sdc.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc.xml
@@ -1,190 +1,190 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="ehl-crb-b" scenario="sdc">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+            <start_hpa>0</start_hpa>
+            <size>CONFIG_SOS_RAM_SIZE</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/sda3</rootfs>
+            <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
-    <vm configurable="1" desc="specific for Kata" id="2">
-        <vm_type desc="Specify the VM type" readonly="true">KATA_VM</vm_type>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <vm id="2">
+        <vm_type>KATA_VM</vm_type>
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic/hybrid.xml
+++ b/misc/config_tools/data/generic/hybrid.xml
@@ -1,225 +1,225 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="generic" scenario="hybrid">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SAFETY_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <pt_intx desc="pt intx mapping.">
+        <pt_intx>
         </pt_intx>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-            <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-            <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+            <name>Zephyr</name>
+            <kern_type>KERNEL_ZEPHYR</kern_type>
+            <kern_mod>Zephyr_RawImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>reboot=acpi</bootargs>
+            <kern_load_addr>0x8000</kern_load_addr>
+            <kern_entry_addr>0x8000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
             <p2sb>n</p2sb>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+            <start_hpa>0</start_hpa>
+            <size>CONFIG_SOS_RAM_SIZE</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/sda3</rootfs>
+            <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic/hybrid_rt.xml
+++ b/misc/config_tools/data/generic/hybrid_rt.xml
@@ -1,261 +1,261 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="generic" scenario="hybrid_rt">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
-            <UEFI_OS_LOADER_NAME desc="UEFI OS loader name."></UEFI_OS_LOADER_NAME>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
+            <UEFI_OS_LOADER_NAME/>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>PRE_RT_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
             <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
             <guest_flag>GUEST_FLAG_RT</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x40000000</size>
-            <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x40000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
+            <name>PREEMPT-RT</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>RT_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 reboot=acpi </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
-            <pci_dev desc="pci device">00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
+        <pci_devs>
+            <pci_dev>00:17.0 SATA controller: Intel Corporation Device 4b63</pci_dev>
+            <pci_dev>00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">y</TPM2>
+        <mmio_resources>
+            <TPM2>y</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+            <start_hpa>0</start_hpa>
+            <size>CONFIG_SOS_RAM_SIZE</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/nvme0n1p3</rootfs>
+            <bootargs>
             rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
             i915.nuclear_pageflip=1 swiotlb=131072
             </bootargs>
         </board_private>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
     <vm id="3">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>0</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic/industry.xml
+++ b/misc/config_tools/data/generic/industry.xml
@@ -1,384 +1,384 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="generic" scenario="industry">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS3</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">y</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>y</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">256</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>256</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>SOS_VM</vm_type>
+        <name>ACRN SOS VM</name>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
         <memory>
-            <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-            <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+            <start_hpa>0</start_hpa>
+            <size>0x20000000</size>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-            <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+            <name>ACRN Service OS</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>SOS_VM_BOOTARGS</bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM1_BASE</base>
+            <irq>SOS_COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>SOS_COM2_BASE</base>
+            <irq>SOS_COM2_IRQ</irq>
+            <target_vm_id>2</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs configurable="0" desc="pci devices list">
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
         </pci_devs>
         <board_private>
-            <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-            <bootargs desc="Specify kernel boot arguments">
+            <rootfs>/dev/nvme0n1p3</rootfs>
+            <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 swiotlb=131072
         </bootargs>
         </board_private>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_STD_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>1</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>INVALID_COM_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
     </vm>
     <vm id="2">
-        <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+        <vm_type>POST_RT_VM</vm_type>
+        <guest_flags>
             <guest_flag>0</guest_flag>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+        <cpu_affinity>
             <pcpu_id>2</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic/logical_partition.xml
+++ b/misc/config_tools/data/generic/logical_partition.xml
@@ -1,194 +1,194 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <acrn-config board="generic" scenario="logical_partition">
     <hv>
-        <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-            <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-            <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-            <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-            <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-            <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-            <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-            <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+        <DEBUG_OPTIONS>
+            <RELEASE>n</RELEASE>
+            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+            <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+            <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+            <LOG_DESTINATION>7</LOG_DESTINATION>
+            <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
         </DEBUG_OPTIONS>
         <FEATURES>
-            <RELOC desc="Enable hypervisor relocation">y</RELOC>
-            <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-            <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-            <RDT desc="Intel RDT (Resource Director Technology).">
-                <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-                <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
-                <CLOS_MASK desc="Cache Capacity Bitmask">0xfff</CLOS_MASK>
+            <RELOC>y</RELOC>
+            <SCHEDULER>SCHED_BVT</SCHEDULER>
+            <MULTIBOOT2>y</MULTIBOOT2>
+            <RDT>
+                <RDT_ENABLED>n</RDT_ENABLED>
+                <CDP_ENABLED>n</CDP_ENABLED>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
+                <CLOS_MASK>0xfff</CLOS_MASK>
             </RDT>
-            <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-            <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-            <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-            <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-            <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-            <IVSHMEM desc="IVSHMEM configuration">
-                <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-                <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+            <HYPERV_ENABLED>y</HYPERV_ENABLED>
+            <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+            <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+            <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+            <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+            <IVSHMEM>
+                <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+                <IVSHMEM_REGION/>
             </IVSHMEM>
         </FEATURES>
         <MEMORY>
-            <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-            <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor" />
-            <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor." />
-            <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-            <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-            <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-            <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+            <STACK_SIZE>0x2000</STACK_SIZE>
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
+            <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+            <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+            <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+            <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
         </MEMORY>
-        <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-            <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-            <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-            <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-            <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-            <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-            <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-            <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-            <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+        <CAPACITIES>
+            <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+            <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+            <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+            <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+            <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+            <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+            <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+            <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
         </CAPACITIES>
         <MISC_CFG>
-            <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+            <GPU_SBDF>0x00000010</GPU_SBDF>
         </MISC_CFG>
     </hv>
     <vm id="0">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-        <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-            <guest_flag />
-            <guest_flag />
+        <vm_type>PRE_STD_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM0</name>
+        <guest_flags>
+            <guest_flag/>
+            <guest_flag/>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>0</pcpu_id>
             <pcpu_id>2</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x100000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-            <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">
+            <name>YOCTO</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">
-        <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-        <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-        <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-            <guest_flag></guest_flag>
+        <vm_type>PRE_STD_VM</vm_type>
+        <name>ACRN PRE-LAUNCHED VM1</name>
+        <guest_flags>
+            <guest_flag/>
         </guest_flags>
-        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+        <cpu_affinity>
             <pcpu_id>1</pcpu_id>
             <pcpu_id>3</pcpu_id>
         </cpu_affinity>
-        <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+        <clos>
             <vcpu_clos>0</vcpu_clos>
             <vcpu_clos>0</vcpu_clos>
         </clos>
-        <epc_section configurable="0" desc="epc section">
-            <base desc="SGX EPC section base, must be page aligned">0</base>
-            <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+        <epc_section>
+            <base>0</base>
+            <size>0</size>
         </epc_section>
         <memory>
-            <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-            <size desc="The memory size in Bytes for the VM">0x20000000</size>
-            <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-            <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+            <start_hpa>0x120000000</start_hpa>
+            <size>0x20000000</size>
+            <start_hpa2>0x0</start_hpa2>
+            <size_hpa2>0x0</size_hpa2>
         </memory>
         <os_config>
-            <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-            <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-            <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-            <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline." />
-            <bootargs desc="Specify kernel boot arguments">
+            <name>YOCTO</name>
+            <kern_type>KERNEL_BZIMAGE</kern_type>
+            <kern_mod>Linux_bzImage</kern_mod>
+            <ramdisk_mod/>
+            <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
         </os_config>
         <legacy_vuart id="0">
-            <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-            <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM1_BASE</base>
+            <irq>COM1_IRQ</irq>
         </legacy_vuart>
         <legacy_vuart id="1">
-            <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-            <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-            <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-            <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-            <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+            <type>VUART_LEGACY_PIO</type>
+            <base>COM2_BASE</base>
+            <irq>COM2_IRQ</irq>
+            <target_vm_id>0</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </legacy_vuart>
         <console_vuart id="0">
-            <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+            <base>INVALID_PCI_BASE</base>
         </console_vuart>
         <communication_vuart id="1">
-            <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-            <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-            <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+            <base>INVALID_PCI_BASE</base>
+            <target_vm_id>1</target_vm_id>
+            <target_uart_id>1</target_uart_id>
         </communication_vuart>
-        <pci_devs desc="pci devices list">
-            <pci_dev desc="pci device" />
-            <pci_dev desc="pci device" />
+        <pci_devs>
+            <pci_dev/>
+            <pci_dev/>
         </pci_devs>
-        <mmio_resources desc="mmio devices list to passthrough">
-            <TPM2 desc="TPM2 device">n</TPM2>
+        <mmio_resources>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/hybrid.xml
+++ b/misc/config_tools/data/nuc6cayh/hybrid.xml
@@ -1,214 +1,215 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc6cayh" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/industry.xml
+++ b/misc/config_tools/data/nuc6cayh/industry.xml
@@ -1,375 +1,376 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc6cayh" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-	<RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">y</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+	<RDT>
+            <RDT_ENABLED>y</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
 	</RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/logical_partition.xml
+++ b/misc/config_tools/data/nuc6cayh/logical_partition.xml
@@ -1,186 +1,187 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc6cayh" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:12.0 SATA controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series SATA AHCI Controller (rev 0b)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
-        <pci_dev desc="pci device">02:00.0 Network controller: Intel Corporation Device 24fb (rev 10)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:15.0 USB controller: Intel Corporation Celeron N3350/Pentium N4200/Atom E3900 Series USB xHCI (rev 0b)</pci_dev>
+        <pci_dev>02:00.0 Network controller: Intel Corporation Device 24fb (rev 10)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/sdc.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc.xml
@@ -1,185 +1,186 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc6cayh" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/hybrid.xml
+++ b/misc/config_tools/data/nuc7i7dnb/hybrid.xml
@@ -1,210 +1,211 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc7i7dnb" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/industry.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry.xml
@@ -1,372 +1,373 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc7i7dnb" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/logical_partition.xml
+++ b/misc/config_tools/data/nuc7i7dnb/logical_partition.xml
@@ -1,185 +1,186 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc7i7dnb" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_dev_num configurable="0" desc="pci devices number">VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Sunrise Point-LP SATA Controller [AHCI mode] (rev 21)</pci_dev>
-        <pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</pci_dev>
+    <pci_dev_num>VM0_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Sunrise Point-LP SATA Controller [AHCI mode] (rev 21)</pci_dev>
+        <pci_dev>00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection I219-LM (rev 21)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_dev_num configurable="0" desc="pci devices number">VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Sunrise Point-LP USB 3.0 xHCI Controller (rev 21)</pci_dev>
-        <pci_dev desc="pci device">01:00.0 Network controller: Intel Corporation Wireless 8265 / 8275 (rev 78)</pci_dev>
+    <pci_dev_num>VM1_CONFIG_PCI_DEV_NUM</pci_dev_num>
+    <pci_devs>
+        <pci_dev>00:14.0 USB controller: Intel Corporation Sunrise Point-LP USB 3.0 xHCI Controller (rev 21)</pci_dev>
+        <pci_dev>01:00.0 Network controller: Intel Corporation Wireless 8265 / 8275 (rev 78)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/sdc.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc.xml
@@ -1,180 +1,181 @@
+<?xml version="1.0"?>
 <acrn-config board="nuc7i7dnb" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/qemu/sdc.xml
+++ b/misc/config_tools/data/qemu/sdc.xml
@@ -1,145 +1,146 @@
+<?xml version="1.0"?>
 <acrn-config board="qemu" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor">0x07800000</HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor.">0x11000000</HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x20000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x100000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x100000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE>0x07800000</HV_RAM_SIZE>
+        <HV_RAM_START>0x11000000</HV_RAM_START>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x20000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x100000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x100000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">16</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>16</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/vda1</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/vda1</rootfs>
+        <bootargs>
         earlyprintk=serial,ttyS0,115200n8 rw rootwait console=tty0 consoleblank=0 no_timer_check ignore_loglevel
         ignore_loglevel no_timer_check intel_iommu=off tsc=reliable hvlog=2M@0x1FE00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/hybrid.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid.xml
@@ -1,209 +1,210 @@
+<?xml version="1.0"?>
 <acrn-config board="tgl-rvp" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
@@ -1,254 +1,255 @@
+<?xml version="1.0"?>
 <acrn-config board="tgl-rvp" scenario="hybrid_rt">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
-        <PSRAM desc="Pseudo SRAM configuration.">
-            <PSRAM_ENABLED desc="Enable PTCM (Platform Tuning Configuration Manager).">n</PSRAM_ENABLED>
+        <PSRAM>
+            <PSRAM_ENABLED>n</PSRAM_ENABLED>
         </PSRAM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">32</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>32</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>PRE_RT_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
         <guest_flag>GUEST_FLAG_RT</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x40000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x40000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-	<bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        <name>PREEMPT-RT</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>RT_bzImage</kern_mod>
+        <ramdisk_mod/>
+	<bootargs>rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
 	clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 no_ipi_broadcast=1
 	reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
-        <pci_dev desc="pci device">00:1e.4 Ethernet controller: Intel Corporation Device a0ac (rev 20)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
+        <pci_dev>00:1e.4 Ethernet controller: Intel Corporation Device a0ac (rev 20)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">y</TPM2>
+    <mmio_resources>
+        <TPM2>y</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=ttyS0,115200n8 ignore_loglevel no_timer_check
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -1,222 +1,223 @@
+<?xml version="1.0"?>
 <acrn-config board="tgl-rvp" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag />
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">        rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>        rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1
     </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag />
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="vCPU affinity map. Each vCPU will pin to the selected pCPU ID. Please make sure each vCPU pin to different pCPU.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
 
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 

--- a/misc/config_tools/data/tgl-rvp/logical_partition.xml
+++ b/misc/config_tools/data/tgl-rvp/logical_partition.xml
@@ -1,181 +1,182 @@
+<?xml version="1.0"?>
 <acrn-config board="tgl-rvp" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
-        <pci_dev desc="pci device">00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V (rev 20)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</pci_dev>
+        <pci_dev>00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V (rev 20)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/sdc.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc.xml
@@ -1,179 +1,180 @@
+<?xml version="1.0"?>
 <acrn-config board="tgl-rvp" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x480000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x480000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x480000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -1,210 +1,211 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i5" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -1,251 +1,252 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i5" scenario="hybrid_rt">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>PRE_RT_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
         <guest_flag>GUEST_FLAG_RT</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x40000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x40000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-	<bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        <name>PREEMPT-RT</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>RT_bzImage</kern_mod>
+        <ramdisk_mod/>
+	<bootargs>rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
 	clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 no_ipi_broadcast=1
 	reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">y</TPM2>
+    <mmio_resources>
+        <TPM2>y</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/industry.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry.xml
@@ -1,372 +1,373 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i5" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/logical_partition.xml
+++ b/misc/config_tools/data/whl-ipc-i5/logical_partition.xml
@@ -1,183 +1,184 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i5" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
         reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
-        <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
+        <pci_dev>04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -1,180 +1,181 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i5" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid.xml
@@ -1,210 +1,211 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i7" scenario="hybrid">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SAFETY_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SAFETY_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">Zephyr</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_ZEPHYR</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Zephyr_RawImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">reboot=acpi</bootargs>
-        <kern_load_addr desc="The loading address in host memory for the VM kernel">0x8000</kern_load_addr>
-        <kern_entry_addr desc="The entry address in host memory for the VM kernel">0x8000</kern_entry_addr>
+        <name>Zephyr</name>
+        <kern_type>KERNEL_ZEPHYR</kern_type>
+        <kern_mod>Zephyr_RawImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>reboot=acpi</bootargs>
+        <kern_load_addr>0x8000</kern_load_addr>
+        <kern_entry_addr>0x8000</kern_entry_addr>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid_rt.xml
@@ -1,251 +1,252 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i7" scenario="hybrid_rt">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">y</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2">hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_RT_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>PRE_RT_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
         <guest_flag>GUEST_FLAG_LAPIC_PASSTHROUGH</guest_flag>
         <guest_flag>GUEST_FLAG_RT</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x40000000</size>
-        <start_hpa2 configurable="0" desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 configurable="0" desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x40000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">PREEMPT-RT</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">RT_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-	<bootargs desc="Specify kernel boot arguments">rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
+        <name>PREEMPT-RT</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>RT_bzImage</kern_mod>
+        <ramdisk_mod/>
+	<bootargs>rw rootwait root=/dev/sda3 rootfstype=ext4 console=ttyS0,115200 console=tty0 rw nohpet console=hvc0 no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable
 	clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup idle=poll irqaffinity=0 no_ipi_broadcast=1
 	reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">y</TPM2>
+    <mmio_resources>
+        <TPM2>y</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/nvme0n1p3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/nvme0n1p3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/industry.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry.xml
@@ -1,372 +1,373 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i7" scenario="industry">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">0x20000000</size>
+        <start_hpa>0</start_hpa>
+        <size>0x20000000</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">2</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM2_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>2</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
-    <vm_type desc="Specify the VM type" readonly="true">POST_RT_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_RT_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>2</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="4">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="5">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="6">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="7" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>1</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/logical_partition.xml
+++ b/misc/config_tools/data/whl-ipc-i7/logical_partition.xml
@@ -1,182 +1,183 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i7" scenario="logical_partition">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE configurable="0" desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN PRE-LAUNCHED VM0</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM0</name>
+    <guest_flags>
+        <guest_flag/>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>0</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x100000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x100000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
-        <pci_dev desc="pci device">03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)</pci_dev>
+        <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">PRE_STD_VM</vm_type>
-    <name desc="vm_name">ACRN PRE-LAUNCHED VM1</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
-        <guest_flag></guest_flag>
+    <vm_type>PRE_STD_VM</vm_type>
+    <name>ACRN PRE-LAUNCHED VM1</name>
+    <guest_flags>
+        <guest_flag/>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <memory>
-        <start_hpa desc="The start physical address in host for the VM">0x120000000</start_hpa>
-        <size desc="The memory size in Bytes for the VM">0x20000000</size>
-        <start_hpa2 desc="Start of second HPA for non-contiguous allocations in host for the VM">0x0</start_hpa2>
-        <size_hpa2 desc="Memory size of second HPA for non-contiguous allocations in Bytes for the VM">0x0</size_hpa2>
+        <start_hpa>0x120000000</start_hpa>
+        <size>0x20000000</size>
+        <start_hpa2>0x0</start_hpa2>
+        <size_hpa2>0x0</size_hpa2>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">YOCTO</name>
-        <kern_type desc="kernel name">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs desc="Specify kernel boot arguments">
+        <name>YOCTO</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>
         rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
         consoleblank=0 tsc=reliable reboot=acpi
         </bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM1_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">COM2_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>COM2_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs desc="pci devices list">
-        <pci_dev desc="pci device">00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
-        <pci_dev desc="pci device">04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
+    <pci_devs>
+        <pci_dev>00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)</pci_dev>
+        <pci_dev>04:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
-    <mmio_resources desc="mmio devices list to passthrough">
-        <TPM2 desc="TPM2 device">n</TPM2>
+    <mmio_resources>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc.xml
@@ -1,184 +1,185 @@
+<?xml version="1.0"?>
 <acrn-config board="whl-ipc-i7" scenario="sdc">
   <hv>
-    <DEBUG_OPTIONS desc="Debug options for ACRN hypervisor, only valid on debug version">
-        <RELEASE desc="Release build. 'y' for Release, 'n' for Debug.">n</RELEASE>
-        <SERIAL_CONSOLE desc="The serial device which is used for hypervisor debug, only valid on Debug version.">/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL desc="Default loglevel in memory">5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL desc="Default loglevel for the hypervisor NPK log">5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL desc="Default loglevel on the serial console">3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION desc="Bitmap of consoles where logs are printed.">7</LOG_DESTINATION>
-        <LOG_BUF_SIZE desc="Capacity of logbuf for each physical cpu.">0x40000</LOG_BUF_SIZE>
+    <DEBUG_OPTIONS>
+        <RELEASE>n</RELEASE>
+        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+        <LOG_DESTINATION>7</LOG_DESTINATION>
+        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
 
     <FEATURES>
-        <RELOC desc="Enable hypervisor relocation">y</RELOC>
-        <SCHEDULER desc="The CPU scheduler to be used by the hypervisor.">SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2 desc="Support boot ACRN from multiboot2 protocol.">y</MULTIBOOT2>
-        <RDT desc="Intel RDT (Resource Director Technology).">
-            <RDT_ENABLED desc="Enable RDT">n</RDT_ENABLED>
-            <CDP_ENABLED desc="CDP (Code and Data Prioritization). CDP is an extension of CAT.">n</CDP_ENABLED>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
-            <CLOS_MASK desc="Cache Capacity Bitmask">0xff</CLOS_MASK>
+        <RELOC>y</RELOC>
+        <SCHEDULER>SCHED_BVT</SCHEDULER>
+        <MULTIBOOT2>y</MULTIBOOT2>
+        <RDT>
+            <RDT_ENABLED>n</RDT_ENABLED>
+            <CDP_ENABLED>n</CDP_ENABLED>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
+            <CLOS_MASK>0xff</CLOS_MASK>
         </RDT>
-        <HYPERV_ENABLED desc="Enable Hyper-V enlightenment">y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP desc="IOMMU enforce snoop behavior of DMA operation.">n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED desc="Enable ACPI runtime parsing.">y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED desc="Enable L1 cache flush before VM entry.">n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED desc="Force to disable software workaround for Machine Check Error on Page Size Change.">n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM desc="IVSHMEM configuration">
-            <IVSHMEM_ENABLED desc="Enable Share Memory between VMs by IVSHMEM.">n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION desc="the shared memory region name (starting with hv:/, size (in MB), and IDs of all VMs (separated by a colon) sharing this region, for example hv:/sharename,2,0:2"></IVSHMEM_REGION>
+        <HYPERV_ENABLED>y</HYPERV_ENABLED>
+        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+        <IVSHMEM>
+            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+            <IVSHMEM_REGION/>
         </IVSHMEM>
     </FEATURES>
 
     <MEMORY>
-        <STACK_SIZE desc="Capacity of one stack, in bytes.">0x2000</STACK_SIZE>
-        <HV_RAM_SIZE desc="Size of the RAM region used by the hypervisor"></HV_RAM_SIZE>
-        <HV_RAM_START desc="2M-aligned Start physical address of the RAM region used by the hypervisor."></HV_RAM_START>
-        <LOW_RAM_SIZE desc="Size of the low RAM region">0x00010000</LOW_RAM_SIZE>
-        <UOS_RAM_SIZE desc="Size of the User OS (UOS) RAM.">0x200000000</UOS_RAM_SIZE>
-        <SOS_RAM_SIZE desc="Size of the Service OS (SOS) RAM.">0x400000000</SOS_RAM_SIZE>
-        <PLATFORM_RAM_SIZE desc="Size of the physical platform RAM">0x400000000</PLATFORM_RAM_SIZE>
+        <STACK_SIZE>0x2000</STACK_SIZE>
+        <HV_RAM_SIZE/>
+        <HV_RAM_START/>
+        <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
+        <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
+        <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
+        <PLATFORM_RAM_SIZE>0x400000000</PLATFORM_RAM_SIZE>
     </MEMORY>
 
-    <CAPACITIES desc="Capacity limits for static assigned data struct or maximum supported resouce">
-        <IOMMU_BUS_NUM desc="Highest PCI bus ID used during IOMMU initialization.">0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES desc="Maximum number of Interrupt Remapping Entries.">256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM desc="Maximum number of IO-APICs.">1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM desc="Maximum number of PCI devices.">96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES desc="Maximum number of interrupt lines per IOAPIC.">120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES desc="Maximum number of interrupt source for PT devices.">64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM desc="Maximum number of MSI-X tables per device. Please leave it blank if not sure.">64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO desc="Maximum number of emulated MMIO regions.">16</MAX_EMULATED_MMIO>
+    <CAPACITIES>
+        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
 
     <MISC_CFG>
-        <GPU_SBDF desc="Segment, Bus, Device, and function of the GPU.">0x00000010</GPU_SBDF>
+        <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
 
   <vm id="0">
-    <vm_type desc="Specify the VM type" readonly="true">SOS_VM</vm_type>
-    <name desc="Specify the VM name which will be shown in hypervisor console command: vm_list.">ACRN SOS VM</name>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>SOS_VM</vm_type>
+    <name>ACRN SOS VM</name>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <clos configurable="0" desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa configurable="0" desc="The start physical address in host for the VM">0</start_hpa>
-        <size configurable="0" desc="The memory size in Bytes for the VM">CONFIG_SOS_RAM_SIZE</size>
+        <start_hpa>0</start_hpa>
+        <size>CONFIG_SOS_RAM_SIZE</size>
     </memory>
     <os_config>
-        <name desc="Specify the OS name of VM, currently it is not referenced by hypervisor code.">ACRN Service OS</name>
-        <kern_type desc="Specify the kernel image type so that hypervisor could load it correctly. Currently support KERNEL_BZIMAGE and KERNEL_ZEPHYR.">KERNEL_BZIMAGE</kern_type>
-        <kern_mod desc="The tag for kernel image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline.">Linux_bzImage</kern_mod>
-        <ramdisk_mod desc="The tag for ramdisk image which act as multiboot module, it must exactly match the module tag in GRUB multiboot cmdline."></ramdisk_mod>
-        <bootargs configurable="0" desc="Specify kernel boot arguments">SOS_VM_BOOTARGS</bootargs>
+        <name>ACRN Service OS</name>
+        <kern_type>KERNEL_BZIMAGE</kern_type>
+        <kern_mod>Linux_bzImage</kern_mod>
+        <ramdisk_mod/>
+        <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">SOS_COM1_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">SOS_COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>SOS_COM1_BASE</base>
+        <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">SOS_COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>SOS_COM2_IRQ</irq>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
-    <pci_devs configurable="0" desc="pci devices list">
-        <pci_dev desc="pci device"></pci_dev>
+    <pci_devs>
+        <pci_dev/>
     </pci_devs>
     <board_private>
-        <rootfs desc="rootfs for Linux kernel">/dev/sda3</rootfs>
-        <bootargs desc="Specify kernel boot arguments">
+        <rootfs>/dev/sda3</rootfs>
+        <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
         i915.nuclear_pageflip=1 hvlog=2M@0xe00000 memmap=0x200000$0xe00000
         </bootargs>
     </board_private>
   </vm>
   <vm id="1">
-    <vm_type desc="Specify the VM type" readonly="true">POST_STD_VM</vm_type>
-    <guest_flags desc="Select all applicable flags for the VM" multiselect="true">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
         <guest_flag>0</guest_flag>
     </guest_flags>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+    <cpu_affinity>
         <pcpu_id>1</pcpu_id>
         <pcpu_id>2</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">1</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-  <vm id="2" configurable="1" desc="specific for Kata">
-    <vm_type readonly="true" desc="Specify the VM type">KATA_VM</vm_type>
-    <cpu_affinity desc="List of pCPU: the guest VM is allowed to create vCPU from all or a subset of this list.">
+  <vm id="2">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
         <pcpu_id>3</pcpu_id>
     </cpu_affinity>
-    <clos desc="Class of Service for Cache Allocation Technology. Please refer SDM 17.19.2 for details and use with caution.">
+    <clos>
         <vcpu_clos>0</vcpu_clos>
     </clos>
-    <epc_section configurable="0" desc="epc section">
-        <base desc="SGX EPC section base, must be page aligned">0</base>
-        <size desc="SGX EPC section size in Bytes, must be page aligned">0</size>
+    <epc_section>
+        <base>0</base>
+        <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type configurable="0" desc="vCOM1 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART0 (A.K.A COM1) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM1 irq">COM1_IRQ</irq>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type configurable="0" desc="vCOM2 type">VUART_LEGACY_PIO</type>
-        <base configurable="0" desc="vUART1 (A.K.A COM2) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_COM_BASE</base>
-        <irq configurable="0" desc="vCOM2 irq">COM2_IRQ</irq>
-        <target_vm_id desc="COM2 is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">0</target_vm_id>
-        <target_uart_id configurable="0" desc="target vUART ID that vCOM2 connect to">0</target_uart_id>
+        <type>VUART_LEGACY_PIO</type>
+        <base>INVALID_COM_BASE</base>
+        <irq>COM2_IRQ</irq>
+        <target_vm_id>0</target_vm_id>
+        <target_uart_id>0</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base desc="Console vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
+        <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base desc="Communicatin vuart (PCI based) enabling switch. Enable by exposing its base address, disable by returning invalid base address.">INVALID_PCI_BASE</base>
-        <target_vm_id desc="This vuart is used for VM communications. When it is enabled, please specify which target VM that current VM connect to.">1</target_vm_id>
-        <target_uart_id desc="target vUART ID that this vuart connects to">1</target_uart_id>
+        <base>INVALID_PCI_BASE</base>
+        <target_vm_id>1</target_vm_id>
+        <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
 </acrn-config>


### PR DESCRIPTION
With a schema of scenario XML files introduced, we can now remove the (duplicated) description attributes in these files, systematically check whether these files are well-formed and fix any issue detected.

This PR contains two patches, one cleaning up the unnecessary attributes and the other fixes violations of the schema.