### PR TITLE
config-tools: validate the scenario against schema

### DIFF
--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -16,6 +16,7 @@ import lxml
 ACRN_CONFIG_TARGET = ''
 SOURCE_ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../')
 HV_LICENSE_FILE = SOURCE_ROOT_DIR + 'misc/config_tools/library/hypervisor_license'
+SCENARIO_SCHEMA_FILE = SOURCE_ROOT_DIR + 'misc/config_tools/schema/config.xsd'
 
 
 PY_CACHES = ["__pycache__", "../board_config/__pycache__", "../scenario_config/__pycache__"]

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import copy
+import lxml.etree as etree
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'hv_config'))
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'acpi_gen'))
@@ -91,6 +92,26 @@ def get_scenario_item_values(board_info, scenario_info):
 
 
 def validate_scenario_setting(board_info, scenario_info):
+    """
+    Validate settings in scenario xml if there is scenario schema
+    :param xsd_doc: scenario schema
+    :param scenario_info: scenario file
+    """
+    try:
+        import xmlschema
+
+        # XMLSchema does not process XInclude. Use lxml to expand the schema which is feed to XMLSchema as a string.
+        xsd_doc = SCENARIO_SCHEMA_FILE
+        xsd_doc.xinclude()
+        my_schema = xmlschema.XMLSchema11(etree.tostring(xsd_doc, encoding="unicode"))
+
+        it = my_schema.iter_errors(scenario_info)
+        for idx, validation_error in enumerate(it, start=1):
+            print(f'[{idx}] path: {validation_error.path} | reason: {validation_error.reason}')
+            print(validation_error)
+    except:
+        pass
+
     """
     Validate settings in scenario xml
     :param board_info: board file

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -132,7 +132,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
 
 <xs:simpleType name="IVSHMEMRegionPattern">
   <xs:restriction base="xs:string">
-    <xs:pattern value="hv:/\w+,\s?\d,\s?\s?\d:\s?\d\s?" />
+    <xs:pattern value="hv:/\w+,\s?\d+\s?,\s?\d\s?:\s?\d\s?" />
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
Try validate the scenario xml against schema if the config.xsd exsists.

Fix the regular expression pattern of IVSHMEM_REGION string validation.

Tracked-On: #5672
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>