### PR TITLE
hv: hypercall: prevent sos can touch hv/pre-launched VM resource

### DIFF
--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -51,6 +51,7 @@ void set_rtct_tbl(void *rtct_tbl_addr)
 }
 
 /*
+ *@pre the PSRAM region is separate and never mixed with normal DRAM
  *@pre acpi_rtct_tbl != NULL
  */
 static void parse_rtct(void)

--- a/hypervisor/include/arch/x86/guest/ept.h
+++ b/hypervisor/include/arch/x86/guest/ept.h
@@ -19,16 +19,29 @@ typedef void (*pge_handler)(uint64_t *pgentry, uint64_t size);
 #define INVALID_GPA	(0x1UL << 52U)
 /* External Interfaces */
 /**
- * @brief Check guest-physical memory region mapping valid
+ * @brief Check whether pagetable pages is reserved enough for the GPA range or not
  *
  * @param[in] vm the pointer that points to VM data structure
  * @param[in] base The specified start guest physical address of guest
  *                physical memory region
  * @param[in] size The size of guest physical memory region
  *
- * @retval true if the guest-physical memory region mapping valid, false otherwise.
+ * @retval true if pagetable pages is reserved enough for the GPA range, false otherwise.
  */
 bool ept_is_mr_valid(const struct acrn_vm *vm, uint64_t base, uint64_t size);
+
+/**
+ * @brief Check if the GPA range is guest valid GPA or not
+ *
+ * @param[in] vm the pointer that points to VM data structure
+ * @param[in] base The specified start guest physical address of guest
+ *                physical memory region
+ * @param[in] size The size of guest physical memory region
+ *
+ * @retval true if the GPA range is guest valid GPA, false otherwise.
+ */
+bool ept_is_valid_mr(struct acrn_vm *vm, uint64_t base, uint64_t size);
+
 /**
  * @brief EPT page tables destroy
  *


### PR DESCRIPTION
Current implementation, SOS may allocate the memory region belonging to
hypervisor/pre-launched VM to a post-launched VM. Because it only verifies
the start address rather than the entire memory region.

This patch verifies the validity of the entire memory region before
allocating to a post-launched VM so that the specified memory can only
be allocated to a post-launched VM if the entire memory region is mapped
in SOS’s EPT.

Tracked-On: #5555
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Reviewed-by: Yonghua Huang  <yonghua.huang@intel.com>