### PR TITLE
config_tools: addSW SRAM config

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
@@ -43,6 +43,9 @@
                 <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
                 <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
             </IVSHMEM>
+            <PSRAM>
+                <PSRAM_ENABLED>n</PSRAM_ENABLED>
+            </PSRAM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE>0x2000</STACK_SIZE>

--- a/misc/config_tools/data/ehl-crb-b/industry.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry.xml
@@ -43,6 +43,9 @@
                 <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
                 <IVSHMEM_REGION/>
             </IVSHMEM>
+            <PSRAM>
+                <PSRAM_ENABLED>n</PSRAM_ENABLED>
+            </PSRAM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE>0x2000</STACK_SIZE>

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -28,6 +28,9 @@
             <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
             <IVSHMEM_REGION/>
         </IVSHMEM>
+        <PSRAM>
+            <PSRAM_ENABLED>n</PSRAM_ENABLED>
+        </PSRAM>
     </FEATURES>
 
     <MEMORY>


### PR DESCRIPTION
add SW SRAM config for hybrid_rt and industry scenarios on tgl-rvp
and ehl-crb-b boards.

Tracked-On: #5649

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>