### PR TITLE
support deny access pdev resource from SOS

### DIFF
--- a/hypervisor/arch/x86/configs/pci_dev.c
+++ b/hypervisor/arch/x86/configs/pci_dev.c
@@ -64,7 +64,21 @@ struct acrn_vm_pci_dev_config *init_one_dev_config(struct pci_pdev *pdev)
 			}
 
 			dev_config = &vm_config->pci_devs[vm_config->pci_dev_num];
-			dev_config->emu_type = PCI_DEV_TYPE_PTDEV;
+			if (is_hv_owned_pdev(pdev->bdf)) {
+				/* SOS need to emulate the type1 pdevs owned by HV */
+				dev_config->emu_type = PCI_DEV_TYPE_SOSEMUL;
+				if (is_bridge(pdev)) {
+					dev_config->vdev_ops = &vpci_bridge_ops;
+				} else if (is_host_bridge(pdev)) {
+					dev_config->vdev_ops = &vhostbridge_ops;
+				} else {
+					/* May have type0 device, E.g. debug pci uart */
+					break;
+				}
+			} else {
+				dev_config->emu_type = PCI_DEV_TYPE_PTDEV;
+			}
+
 			dev_config->vbdf.value = pdev->bdf.value;
 			dev_config->pbdf.value = pdev->bdf.value;
 			dev_config->pdev = pdev;

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -332,6 +332,17 @@ static void deny_pdevs(struct acrn_vm *sos, struct acrn_vm_pci_dev_config *pci_d
 	}
 }
 
+static void deny_hv_owned_devices(struct acrn_vm *sos)
+{
+	uint32_t i;
+
+	const struct pci_pdev **hv_owned = get_hv_owned_pdevs();
+
+	for (i = 0U; i < get_hv_owned_pdev_num(); i++) {
+		deny_pci_bar_access(sos, hv_owned[i]);
+	}
+}
+
 /**
  * @param[inout] vm pointer to a vm descriptor
  *
@@ -409,6 +420,8 @@ static void prepare_sos_vm_memmap(struct acrn_vm *vm)
 			(void)deassign_mmio_dev(vm, &vm_config->mmiodevs[i]);
 		}
 	}
+
+	deny_hv_owned_devices(vm);
 
 	/* unmap AP trampoline code for security
 	 * This buffer is guaranteed to be page aligned.

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -625,18 +625,7 @@ struct pci_vdev *vpci_init_vdev(struct acrn_vpci *vpci, struct acrn_vm_pci_dev_c
 	if (dev_config->vdev_ops != NULL) {
 		vdev->vdev_ops = dev_config->vdev_ops;
 	} else {
-		if (get_highest_severity_vm(false) == vpci2vm(vpci)) {
-			vdev->vdev_ops = &pci_pt_dev_ops;
-		} else {
-			if (is_bridge(vdev->pdev)) {
-				vdev->vdev_ops = &vpci_bridge_ops;
-			} else if (is_host_bridge(vdev->pdev)) {
-				vdev->vdev_ops = &vhostbridge_ops;
-			} else {
-				vdev->vdev_ops = &pci_pt_dev_ops;
-			}
-		}
-
+		vdev->vdev_ops = &pci_pt_dev_ops;
 		ASSERT(dev_config->emu_type == PCI_DEV_TYPE_PTDEV,
 			"Only PCI_DEV_TYPE_PTDEV could not configure vdev_ops");
 		ASSERT(dev_config->pdev != NULL, "PCI PTDev is not present on platform!");

--- a/hypervisor/dm/vpci/vsriov.c
+++ b/hypervisor/dm/vpci/vsriov.c
@@ -90,7 +90,7 @@ static void create_vf(struct pci_vdev *pf_vdev, union pci_bdf vf_bdf, uint16_t v
 	 * Per VT-d 8.3.3, the VFs are under the scope of the same
 	 * remapping unit as the associated PF when SRIOV is enabled.
 	 */
-	vf_pdev = init_pdev(vf_bdf.value, pf_vdev->pdev->drhd_index);
+	vf_pdev = pci_init_pdev(vf_bdf, pf_vdev->pdev->drhd_index);
 	if (vf_pdev != NULL) {
 		struct acrn_vm_pci_dev_config *dev_cfg;
 

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -246,6 +246,14 @@ struct pci_sriov_cap {
 	bool hide_sriov;
 };
 
+/* PCI BAR size is detected at run time. We don't want to re-detect it to avoid malfunction of
+ * the device. We have record physical bar values, we need to record size_mask.
+ */
+struct pci_bar_resource {
+	uint32_t phy_bar;	/* the origional raw data read from physical BAR */
+	uint32_t size_mask;	/* read value of physical BAR after write 0xffffffff */
+};
+
 struct pci_pdev {
 	uint8_t hdr_type;
 	uint8_t base_class;
@@ -259,7 +267,7 @@ struct pci_pdev {
 
 	/* The bar info of the physical PCI device. */
 	uint32_t nr_bars; /* 6 for normal device, 2 for bridge, 1 for cardbus */
-	uint32_t bars[PCI_STD_NUM_BARS];
+	struct pci_bar_resource bars[PCI_STD_NUM_BARS];	/* For common bar resource recording */
 
 	/* The bus/device/function triple of the physical PCI device. */
 	union pci_bdf bdf;
@@ -384,4 +392,5 @@ bool pdev_need_bar_restore(const struct pci_pdev *pdev);
 void pdev_restore_bar(const struct pci_pdev *pdev);
 void pci_switch_to_mmio_cfg_ops(void);
 void reserve_vmsix_on_msi_irtes(struct pci_pdev *pdev);
+
 #endif /* PCI_H_ */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -338,11 +338,14 @@ void set_mmcfg_region(struct pci_mmcfg_region *region);
 #endif
 struct pci_mmcfg_region *get_mmcfg_region(void);
 
-struct pci_pdev *init_pdev(uint16_t pbdf, uint32_t drhd_index);
+struct pci_pdev *pci_init_pdev(union pci_bdf pbdf, uint32_t drhd_index);
 uint32_t pci_pdev_read_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes);
 void pci_pdev_write_cfg(union pci_bdf bdf, uint32_t offset, uint32_t bytes, uint32_t val);
 void enable_disable_pci_intx(union pci_bdf bdf, bool enable);
 
+bool is_hv_owned_pdev(union pci_bdf pbdf);
+uint32_t get_hv_owned_pdev_num(void);
+const struct pci_pdev **get_hv_owned_pdevs(void);
 /*
  * @brief Walks the PCI heirarchy and initializes array of pci_pdev structs
  * Uses DRHD info from ACPI DMAR tables to cover the endpoints and

--- a/misc/hv_prebuild/vm_cfg_checks.c
+++ b/misc/hv_prebuild/vm_cfg_checks.c
@@ -130,7 +130,13 @@ bool sanitize_vm_config(void)
 			} else if (is_safety_vm_uuid(vm_config->uuid) && (vm_config->severity != (uint8_t)SEVERITY_SAFETY_VM)) {
 				ret = false;
 			} else {
-				/* nothing to do here */
+#if (SOS_VM_NUM == 1U)
+				if (vm_config->severity <= SEVERITY_SOS) {
+				/* If there are both SOS and Pre-launched VM, make sure pre-launched VM has higher severity than SOS */
+					printf("%s: pre-launched vm doesn't has higher severity than SOS \n", __func__);
+					ret = false;
+				}
+#endif
 			}
 			break;
 		case SOS_VM:


### PR DESCRIPTION
For pdev owned by HV, or passthrough to pre-launched VM. Deny access
their mmio/pio resource from SOS.