### PR TITLE
config_tools: is_tpm_passthru is checked by scenario config

### DIFF
--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -612,7 +612,8 @@ def is_tpm_passthru():
 
     tpm_passthru = False
     (_, board) = common.get_board_name()
-    if board in TPM_PASSTHRU_BOARD:
+    tpm2_passthru_enabled = common.get_leaf_tag_map_bool(common.SCENARIO_INFO_FILE, "mmio_resources", "TPM2")
+    if board in TPM_PASSTHRU_BOARD and tpm2_passthru_enabled and tpm2_passthru_enabled == 'y':
         tpm_passthru = True
 
     return tpm_passthru


### PR DESCRIPTION
add check for is_tpm_passthru by tpm config from scenario
config.

Tracked-On: #5710

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>