### PR TITLE
Hv ivshmem barsize

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -26,6 +26,7 @@
  * $FreeBSD$
  */
 
+#include <sys/user.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -564,6 +565,13 @@ pci_emul_alloc_resource(uint64_t *baseptr, uint64_t limit, uint64_t size,
 		return -1;
 	}
 
+	/* PCI spec said that BAR base should be naturally aligned. On ACRN
+	 * if the bar size < PAGE_SIZE, BAR base should be aligned with
+	 * PAGE_SIZE. This is because the minimal size that EPT can map/unmap
+	 * is PAGE_SIZE.
+	 */
+	if (size < PAGE_SIZE)
+		size = PAGE_SIZE;
 	base = roundup2(*baseptr, size);
 
 	/* TODO:Currently, we only reserve gvt mmio regions,

--- a/hypervisor/dm/vpci/ivshmem.c
+++ b/hypervisor/dm/vpci/ivshmem.c
@@ -26,7 +26,7 @@
 #define IVSHMEM_MSIX_BAR	1U
 #define IVSHMEM_SHM_BAR	2U
 
-#define IVSHMEM_MMIO_BAR_SIZE 4096UL
+#define IVSHMEM_MMIO_BAR_SIZE 256UL
 
 /* The device-specific registers of ivshmem device */
 #define	IVSHMEM_IRQ_MASK_REG	0x0U
@@ -261,7 +261,7 @@ static void ivshmem_vbar_map(struct pci_vdev *vdev, uint32_t idx)
 		(void)memset(&ivs_dev->mmio, 0U, sizeof(ivs_dev->mmio));
 		register_mmio_emulation_handler(vm, ivshmem_mmio_handler, vbar->base_gpa,
 				(vbar->base_gpa + vbar->size), vdev, false);
-		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, vbar->base_gpa, vbar->size);
+		ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, vbar->base_gpa, round_page_up(vbar->size));
 	} else if ((idx == IVSHMEM_MSIX_BAR) && (vbar->base_gpa != 0UL)) {
 		register_mmio_emulation_handler(vm, vmsix_handle_table_mmio_access, vbar->base_gpa,
 			(vbar->base_gpa + vbar->size), vdev, false);


### PR DESCRIPTION
Ivshmem spec says that BAR0 size should be 256 bytes. Windows ivshmem driver will check BAR0 size, if it is not 256 windows will refuse to load the driver. These two patches fixed this issue with the following
changes:

- In hv the BAR0 size is changed to 256 according to ivshmem spec.
  Reviewed-by: Fei Li <fei1.li@intel.com>
  Acked-by: Eddie Dong <eddie.dong@intel.com>

- In dm BAR base addr is aligned to 4K at least to satisfy EPT mapping.
  Reviewed-by: Fei Li <fei1.li@intel.com>
  Acked-by: Yu Wang <yu1.wang@intel.com>

