### PR TITLE
dm: iasl warning message fix

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1677,7 +1677,6 @@ pci_bus_write_dsdt(int bus)
 	dsdt_line("  Device (PCI%01X)", bus);
 	dsdt_line("  {");
 	dsdt_line("    Name (_HID, EisaId (\"PNP0A03\"))");
-	dsdt_line("    Name (_ADR, Zero)");
 
 	dsdt_line("    Method (_BBN, 0, NotSerialized)");
 	dsdt_line("    {");

--- a/devicemodel/hw/platform/acpi/acpi_pm.c
+++ b/devicemodel/hw/platform/acpi/acpi_pm.c
@@ -324,8 +324,11 @@ void pm_write_dsdt(struct vmctx *ctx, int ncpu)
 	dsdt_line("  Scope (_PR)");
 	dsdt_line("  {");
 	for (i = 0; i < ncpu; i++) {
-		dsdt_line("    Processor (CPU%d, 0x%02X, 0x00000000, 0x00) {}",
-					i, i);
+		dsdt_line("    Device (CPU%d)", i);
+		dsdt_line("    {");
+		dsdt_line("        Name (_HID, \"ACPI0007\")");
+		dsdt_line("        Name (_UID, 0x%02X)", i);
+		dsdt_line("    }");
 	}
 	dsdt_line("  }");
 	dsdt_line("");


### PR DESCRIPTION
Per ACPI 6.x chapter 6.1, "A device object must contain either an _HID object
or an _ADR object, but should not contain both."
Remove this object otherwise iasl would complain
"Warning  3073 -   Multiple types ^  (Device object requires either a _HID or _ADR, but not both)"
when launch post-launched VM in devicemodel.

Per ACPI 6.x chapter 19.6.109, the Processor Operator is deprecated.
Replace it with Device Operator, otherwise the iasl would complain
    "Warning  3168 -             Legacy Processor() keyword detected. Use Device() keyword instead."
when launch post-launched VM in devicemodel.

Tracked-On: #5719

Signed-off-by: Victor Sun <victor.sun@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>
