### PR TITLE
update zephyr entry point address on ehl-crb-b

### DIFF
--- a/hypervisor/boot/guest/vboot_info.c
+++ b/hypervisor/boot/guest/vboot_info.c
@@ -225,7 +225,10 @@ static int32_t init_vm_sw_load(struct acrn_vm *vm, const struct acrn_multiboot_i
 	}
 
 	if (ret == 0) {
-		init_vm_bootargs_info(vm, mbi);
+		/* Currently VM bootargs only support Linux kernel bzImage format */
+		if (vm->sw.kernel_type == KERNEL_BZIMAGE) {
+			init_vm_bootargs_info(vm, mbi);
+		}
 		/* check whether there is a ramdisk module */
 		mod = get_mod_by_tag(mbi, vm_config->os_config.ramdisk_mod_tag);
 		if (mod != NULL) {

--- a/hypervisor/common/vm_load.c
+++ b/hypervisor/common/vm_load.c
@@ -212,7 +212,7 @@ int32_t vm_sw_loader(struct acrn_vm *vm)
 			ramdisk_info->size);
 	}
 	/* Copy Guest OS bootargs to its load location */
-	if (bootargs_info->size != 0U) {
+	if ((bootargs_info->size != 0U) && (bootargs_info->load_addr != NULL)) {
 		(void)copy_to_gpa(vm, bootargs_info->src_addr,
 			(uint64_t)bootargs_info->load_addr,
 			(strnlen_s((char *)bootargs_info->src_addr, MAX_BOOTARGS_SIZE) + 1U));

--- a/misc/config_tools/acpi_gen/asl_gen.py
+++ b/misc/config_tools/acpi_gen/asl_gen.py
@@ -446,9 +446,9 @@ def main(args):
         PASSTHROUGH_PTCT = False
 
     kern_args = common.get_leaf_tag_map(scenario, "os_config", "bootargs")
-    vm_type = common.get_leaf_tag_map(scenario, "vm_type")
+    kern_type = common.get_leaf_tag_map(scenario, "os_config", "kern_type")
     for vm_id, passthru_devices in dict_passthru_devices.items():
-        if kern_args[int(vm_id)].find('reboot=acpi') == -1 and vm_type[int(vm_id)] not in ['SAFETY_VM']:
+        if kern_args[int(vm_id)].find('reboot=acpi') == -1 and kern_type[int(vm_id)] in ['KERNEL_BZIMAGE']:
             emsg = "you need to specify 'reboot=acpi' in scenario file's bootargs for VM{}".format(vm_id)
             print(emsg)
             err_dic['vm,bootargs'] = emsg

--- a/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS>
             <RELEASE>n</RELEASE>
-            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
@@ -95,8 +95,8 @@
             <kern_mod>Zephyr_RawImage</kern_mod>
             <ramdisk_mod/>
             <bootargs/>
-            <kern_load_addr>0x8000</kern_load_addr>
-            <kern_entry_addr>0x8000</kern_entry_addr>
+            <kern_load_addr>0x1000</kern_load_addr>
+            <kern_entry_addr>0x1000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
             <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/ehl-crb-b/hybrid.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS>
             <RELEASE>n</RELEASE>
-            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
@@ -96,9 +96,9 @@
             <kern_type>KERNEL_ZEPHYR</kern_type>
             <kern_mod>Zephyr_RawImage</kern_mod>
             <ramdisk_mod/>
-            <bootargs>reboot=acpi</bootargs>
-            <kern_load_addr>0x8000</kern_load_addr>
-            <kern_entry_addr>0x8000</kern_entry_addr>
+            <bootargs></bootargs>
+            <kern_load_addr>0x1000</kern_load_addr>
+            <kern_entry_addr>0x1000</kern_entry_addr>
         </os_config>
         <legacy_vuart id="0">
             <type>VUART_LEGACY_PIO</type>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS>
             <RELEASE>n</RELEASE>
-            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS>
             <RELEASE>n</RELEASE>
-            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>

--- a/misc/config_tools/data/ehl-crb-b/logical_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/logical_partition.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS>
             <RELEASE>n</RELEASE>
-            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>

--- a/misc/config_tools/data/ehl-crb-b/sdc.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc.xml
@@ -3,7 +3,7 @@
     <hv>
         <DEBUG_OPTIONS>
             <RELEASE>n</RELEASE>
-            <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+            <SERIAL_CONSOLE>/dev/ttyS3</SERIAL_CONSOLE>
             <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
             <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
             <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>


### PR DESCRIPTION
config_tools: update zephyr entry point address on ehl-crb-b to work with zephyr 2.5
config_tools: update condition for bootargs error check only when kernel type is KERNEL_BZIMAGE.
HV: init VM bootargs only for LaaG
Currently the VM bootargs load address is hard-coded at 8KB right before
kernel load address, this should work for Linux kernel only since Linux
kernel is guaranteed to be loadered high than GPA 8K so its load address
would never be overflowed, other OS like Zephyr has no such assumption.

Tracked-on: #5689
