### PR TITLE
doc: update debian ISO image version number

### DIFF
--- a/doc/tutorials/running_deb_as_serv_vm.rst
+++ b/doc/tutorials/running_deb_as_serv_vm.rst
@@ -21,6 +21,11 @@ Use the following instructions to install Debian.
   <https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/>`_.
   Select and download **debian-10.1.0-amd64-netinst.iso** (scroll down to
   the bottom of the page).
+
+  .. note::  These instructions were validated with the
+     debian_10.1.0 ISO image. A newer Debian 10 version
+     should still work as expected.
+
 - Follow the `Debian installation guide
   <https://www.debian.org/releases/stable/amd64/index.en.html>`_ to
   install it on your board; we are using a Kaby Lake Intel NUC (NUC7i7DNHE)


### PR DESCRIPTION
Documentation mentions a specific Debian 10 ISO image version that no
longer exists.  Update to indiate we validated with debian_10.1.0 but
newer versions should also work.

Tracked-On: #5408

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>