### PR TITLE
Allow only one active SOS life_mngr socket

### DIFF
--- a/devicemodel/include/pm_vuart.h
+++ b/devicemodel/include/pm_vuart.h
@@ -12,7 +12,7 @@
 #define	__PM_VUART__
 
 int parse_pm_by_vuart(const char *opts);
-void pm_by_vuart_init(struct vmctx *ctx);
+int pm_by_vuart_init(struct vmctx *ctx);
 void pm_by_vuart_deinit(struct vmctx *ctx);
 
 #endif


### PR DESCRIPTION
At most one VM is allowed to use "--pm_notify_channel uart" at a time, since only one socket connection to SOS life_mngr is allowed.

Monitor the listening socket in SOS life_mngr and close any additional connections after a socket connection is established. Identify a closed socket connection to SOS life_mngr as a failure in dm and fail gracefully.

Tracked-On: #5736
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>