### PR TITLE
doc: fix misspellings in config option doc

### DIFF
--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -9,6 +9,9 @@
   <xsl:variable name="newline" select="'&#xa;'"/>
   <xsl:variable name="section_adornment" select="'#*=-%+@`'"/>
 
+  <xsl:variable name="vLower" select= "'abcdefghijklmnopqrstuvwxyz'"/>
+  <xsl:variable name="vUpper" select= "'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
   <!--
       Visitors of XSD elements
   -->
@@ -96,7 +99,7 @@
          </xsl:when>
          <xsl:when test="starts-with($ty, 'xs:')">
            <xsl:text>   - </xsl:text>
-           <xsl:value-of select="substring($ty, 4)"/>
+           <xsl:value-of select="concat(translate(substring($ty, 4,1), $vLower, $vUpper), substring($ty,5))"/>
            <xsl:value-of select="$newline"/>
          </xsl:when>
          <xsl:otherwise>

--- a/misc/config_tools/schema/VMtypes.xsd
+++ b/misc/config_tools/schema/VMtypes.xsd
@@ -345,7 +345,7 @@ to the pre-launched VM.</xs:documentation>
   <xs:sequence>
     <xs:element name="pci_dev" type="xs:string" maxOccurs="unbounded">
       <xs:annotation>
-        <xs:documentation>A passthrough pci device.</xs:documentation>
+        <xs:documentation>A passthrough PCI device.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:sequence>
@@ -355,7 +355,7 @@ to the pre-launched VM.</xs:documentation>
   <xs:sequence>
     <xs:element name="rootfs" type="xs:string" default="/dev/nvme0n1p3">
       <xs:annotation>
-        <xs:documentation>rootfs for the Linux kernel.</xs:documentation>
+        <xs:documentation>Rootfs for the Linux kernel.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="bootargs" type="xs:string">

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -53,9 +53,9 @@ written to the serial console.</xs:documentation>
         <xs:documentation>Bitmap indicating the destination of log messages.
 There are three log destinations available:
 
-- bit 0 enables the serial console (``0x1``),
-- bit 1 enables the Service VM log (``0x2``), and
-- bit 2 enables the NPK log (``0x4``).
+- Bit 0 enables the serial console (``0x1``),
+- Bit 1 enables the Service VM log (``0x2``), and
+- Bit 2 enables the NPK log (``0x4``).
 
 For example, a value of ``3`` enables only the
 serial console and Service VM logs. Effective only in debug builds (when
@@ -63,7 +63,7 @@ serial console and Service VM logs. Effective only in debug builds (when
       </xs:annotation>
     <xs:simpleType>
       <xs:annotation>
-        <xs:documentation>integer value from 0 to 7.</xs:documentation>
+        <xs:documentation>Integer value from 0 to 7.</xs:documentation>
       </xs:annotation>
       <xs:restriction base="xs:integer">
         <xs:minInclusive value="0" />
@@ -74,7 +74,7 @@ serial console and Service VM logs. Effective only in debug builds (when
     <xs:element name="LOG_BUF_SIZE" type="HexFormat" default="0x40000">
       <xs:annotation>
         <xs:documentation>Capacity (in bytes) of logbuf for each
-physical cpu, for example, ``0x40000``.</xs:documentation>
+physical CPU, for example, ``0x40000``.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
@@ -222,7 +222,7 @@ initialization.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
          <xs:annotation>
-           <xs:documentation>integer from 1 to 10.</xs:documentation>
+           <xs:documentation>Integer from 1 to 10.</xs:documentation>
          </xs:annotation>
         <xs:restriction base="xs:integer">
           <xs:minInclusive value="1" />
@@ -241,7 +241,7 @@ initialization.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
          <xs:annotation>
-           <xs:documentation>integer from 1 to 1024.</xs:documentation>
+           <xs:documentation>Integer from 1 to 1024.</xs:documentation>
          </xs:annotation>
         <xs:restriction base="xs:integer">
           <xs:minInclusive value="1" />
@@ -255,7 +255,7 @@ initialization.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
          <xs:annotation>
-           <xs:documentation>integer from 1 to 120.</xs:documentation>
+           <xs:documentation>Integer from 1 to 120.</xs:documentation>
          </xs:annotation>
         <xs:restriction base="xs:integer">
           <xs:minInclusive value="1" />
@@ -275,7 +275,7 @@ devices.</xs:documentation>
         </xs:annotation>
       <xs:simpleType>
         <xs:annotation>
-          <xs:documentation>integer value from 1 to 2048.</xs:documentation>
+          <xs:documentation>Integer value from 1 to 2048.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:integer">
           <xs:minInclusive value="1" />
@@ -289,7 +289,7 @@ devices.</xs:documentation>
         </xs:annotation>
       <xs:simpleType>
         <xs:annotation>
-          <xs:documentation>integer value from 1 to 128.</xs:documentation>
+          <xs:documentation>Integer value from 1 to 128.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:integer">
           <xs:minInclusive value="1" />

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -3,7 +3,7 @@
 
 <xs:simpleType name="Boolean">
   <xs:annotation>
-    <xs:documentation>A boolean value, written as ``y`` or ``n``.</xs:documentation>
+    <xs:documentation>A Boolean value, written as ``y`` or ``n``.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:enumeration value="y" />
@@ -13,7 +13,7 @@
 
 <xs:simpleType name="HexFormat">
   <xs:annotation>
-    <xs:documentation>An integer value in hexadecimal format.</xs:documentation>
+    <xs:documentation>An Integer value in hexadecimal format.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
     <xs:pattern value="0[Xx][0-9A-Fa-f]+|0" />
@@ -28,21 +28,21 @@
 
 <xs:simpleType name="HVRamSizeType">
   <xs:annotation>
-    <xs:documentation>Either empty, or an integer value in hexadecimal format.</xs:documentation>
+    <xs:documentation>Either empty, or an Integer value in hexadecimal format.</xs:documentation>
   </xs:annotation>
   <xs:union memberTypes="None HexFormat" />
 </xs:simpleType>
 
 <xs:simpleType name="HVRamStartType">
   <xs:annotation>
-    <xs:documentation>Either empty, or an integer value in hexadecimal format.</xs:documentation>
+    <xs:documentation>Either empty, or an Integer value in hexadecimal format.</xs:documentation>
   </xs:annotation>
   <xs:union memberTypes="None HexFormat" />
 </xs:simpleType>
 
 <xs:simpleType name="MaxMsixTableNumType">
   <xs:annotation>
-    <xs:documentation>integer from 1 to 2048.</xs:documentation>
+    <xs:documentation>Integer from 1 to 2048.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:integer">
     <xs:minInclusive value="1" />
@@ -52,7 +52,7 @@
 
 <xs:simpleType name="MaxMsixTableSizeType">
   <xs:annotation>
-    <xs:documentation>Either empty, or an integer value between 1 and 2048.</xs:documentation>
+    <xs:documentation>Either empty, or an Integer value between 1 and 2048.</xs:documentation>
   </xs:annotation>
   <xs:union memberTypes="None MaxMsixTableNumType" />
 </xs:simpleType>
@@ -65,14 +65,14 @@
 
 <xs:simpleType name="MemorySizeType">
   <xs:annotation>
-    <xs:documentation>An integer value in hexadecimal format.</xs:documentation>
+    <xs:documentation>An Integer value in hexadecimal format.</xs:documentation>
   </xs:annotation>
   <xs:union memberTypes="SOSRamSize HexFormat" />
 </xs:simpleType>
 
 <xs:simpleType name="LogLevelType">
   <xs:annotation>
-    <xs:documentation>An integer from 0 to 7 representing log message
+    <xs:documentation>An Integer from 0 to 7 representing log message
 severity and intent:
 
 - 1 (LOG_FATAL) system is unusable


### PR DESCRIPTION
Some terms in the config option docs (e.g, Integer, Boolean) are being
flagged by one of our spell checking tools.  Let's make it happy.

Tracked-On: #5692

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>