### PR TITLE
doc: fix layout of release notes after title case fix

### DIFF
--- a/doc/release_notes/release_notes_0.7.rst
+++ b/doc/release_notes/release_notes_0.7.rst
@@ -121,6 +121,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the unrecognized device after booting.
 
+-----
 
 :acrn-issue:`1991` - Input not accepted in UART Console for corner case
    Input is useless in UART Console for a corner case, demonstrated with these steps:
@@ -135,6 +136,7 @@ Known Issues
 
    **Workaround:** Enter other keys before typing :kbd:`Enter`.
 
+-----
 
 :acrn-issue:`1996` - There is an error log when using ``acrnd&`` to boot UOS
    An error log is printed when starting ``acrnd`` as a background job
@@ -148,6 +150,7 @@ Known Issues
 
    **Workaround:** None.
 
+-----
 
 :acrn-issue:`2267` - [APLUP2][LaaG] LaaG can't detect 4k monitor
    After launching UOS on APL UP2 , 4k monitor cannot be detected.
@@ -156,6 +159,7 @@ Known Issues
 
    **Workaround:** Use a monitor with less than 4k resolution.
 
+-----
 
 :acrn-issue:`2278` - [KBLNUC] Cx/Px is not supported on KBLNUC
    C states and P states are not supported on KBL NUC.
@@ -165,6 +169,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2279` - [APLNUC] After exiting UOS with mediator
    Usb_KeyBoard and Mouse, SOS cannot use the USB keyboard and mouse.
@@ -184,6 +189,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the USB keyboard and mouse after exiting UOS.
 
+-----
 
 :acrn-issue:`2522` - [NUC7i7BNH] After starting IAS in SOS, there is no display
    On NUC7i7BNH, after starting IAS in SOS, there is no display if the monitor is
@@ -193,6 +199,7 @@ Known Issues
 
    **Workaround:** None.
 
+-----
 
 :acrn-issue:`2523` - UOS monitor does not display when using IAS
    There is no UOS display after starting IAS weston.
@@ -213,6 +220,7 @@ Known Issues
 
    The issue will be fixed in the next release.
 
+-----
 
 :acrn-issue:`2524` - [UP2][SBL] Launching UOS hangs while weston is running in SOS
    When using weston in SOS, it will hang during the UOS launch.
@@ -231,6 +239,7 @@ Known Issues
 
    The issue will be fixed in the next release.
 
+-----
 
 :acrn-issue:`2527` - [KBLNUC][HV]System will crash when run ``crashme`` (SOS/UOS)
    System will crash after a few minutes running stress test ``crashme`` tool in SOS/UOS.
@@ -239,6 +248,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2526` - Hypervisor crash when booting UOS with acrnlog running with mem loglevel=6
    If we use ``loglevel 3 6`` to change the mem loglevel to 6, we may hit a page fault in HV.
@@ -247,6 +257,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2753` - UOS cannot resume after suspend by pressing power key
    UOS cannot resume after suspend by pressing power key

--- a/doc/release_notes/release_notes_0.8.rst
+++ b/doc/release_notes/release_notes_0.8.rst
@@ -114,6 +114,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the unrecognized device after booting.
 
+-----
 
 :acrn-issue:`1991` - Input not accepted in UART Console for corner case
    Input is useless in UART Console for a corner case, demonstrated with these steps:
@@ -128,6 +129,7 @@ Known Issues
 
    **Workaround:** Enter other keys before typing :kbd:`Enter`.
 
+-----
 
 :acrn-issue:`2267` - [APLUP2][LaaG] LaaG can't detect 4k monitor
    After launching UOS on APL UP2 , 4k monitor cannot be detected.
@@ -136,6 +138,7 @@ Known Issues
 
    **Workaround:** Use a monitor with less than 4k resolution.
 
+-----
 
 :acrn-issue:`2278` - [KBLNUC] Cx/Px is not supported on KBLNUC
    C states and P states are not supported on KBL NUC.
@@ -145,6 +148,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2279` - [APLNUC] After exiting UOS, SOS can't use USB keyboard and mouse
    After exiting UOS with mediator
@@ -165,6 +169,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the USB keyboard and mouse after exiting UOS.
 
+-----
 
 :acrn-issue:`2527` - System will crash after a few minutes running stress test ``crashme`` tool in SOS/UOS.
    System stress test may cause a system crash.
@@ -173,6 +178,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2526` - Hypervisor crash when booting UOS with acrnlog running with mem loglevel=6
    If we use ``loglevel 3 6`` to change the mem loglevel to 6, we may hit a page fault in HV.
@@ -181,6 +187,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2753` - UOS cannot resume after suspend by pressing power key
    UOS cannot resume after suspend by pressing power key

--- a/doc/release_notes/release_notes_1.0.rst
+++ b/doc/release_notes/release_notes_1.0.rst
@@ -390,6 +390,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the unrecognized device after booting.
 
+-----
 
 :acrn-issue:`1991` - Input not accepted in UART Console for corner case
    Input is useless in UART Console for a corner case, demonstrated with these steps:
@@ -404,6 +405,7 @@ Known Issues
 
    **Workaround:** Enter other keys before typing :kbd:`Enter`.
 
+-----
 
 :acrn-issue:`2267` - [APLUP2][LaaG] LaaG can't detect 4k monitor
    After launching UOS on APL UP2 , 4k monitor cannot be detected.
@@ -412,6 +414,7 @@ Known Issues
 
    **Workaround:** Use a monitor with less than 4k resolution.
 
+-----
 
 :acrn-issue:`2278` - [KBLNUC] Cx/Px is not supported on KBLNUC
    C states and P states are not supported on KBL NUC.
@@ -421,6 +424,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2279` - [APLNUC] After exiting UOS, SOS can't use USB keyboard and mouse
    After exiting UOS with mediator
@@ -441,6 +445,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the USB keyboard and mouse after exiting UOS.
 
+-----
 
 :acrn-issue:`2527` - System will crash after a few minutes running stress test ``crashme`` tool in SOS/UOS.
    System stress test may cause a system crash.
@@ -449,6 +454,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2526` - Hypervisor crash when booting UOS with acrnlog running with mem loglevel=6
    If we use ``loglevel 3 6`` to change the mem loglevel to 6, we may hit a page fault in HV.
@@ -457,6 +463,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2753` - UOS cannot resume after suspend by pressing power key
    UOS cannot resume after suspend by pressing power key
@@ -465,6 +472,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2974` - Launching Zephyr RTOS as a real-time UOS takes too long
     Launching Zephyr RTOS as a real-time UOS takes too long
@@ -480,6 +488,7 @@ Known Issues
 
     **Workaround:** None
 
+-----
 
 Change Log
 **********

--- a/doc/release_notes/release_notes_1.1.rst
+++ b/doc/release_notes/release_notes_1.1.rst
@@ -132,6 +132,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the unrecognized device after booting.
 
+-----
 
 :acrn-issue:`1991` - Input not accepted in UART Console for corner case
    Input is useless in UART Console for a corner case, demonstrated with these steps:
@@ -146,6 +147,7 @@ Known Issues
 
    **Workaround:** Enter other keys before typing :kbd:`Enter`.
 
+-----
 
 :acrn-issue:`2267` - [APLUP2][LaaG] LaaG can't detect 4k monitor
    After launching UOS on APL UP2 , 4k monitor cannot be detected.
@@ -154,6 +156,7 @@ Known Issues
 
    **Workaround:** Use a monitor with less than 4k resolution.
 
+-----
 
 :acrn-issue:`2279` - [APLNUC] After exiting UOS, SOS can't use USB keyboard and mouse
    After exiting UOS with mediator Usb_KeyBoard and Mouse, SOS cannot use the USB keyboard and mouse.
@@ -173,6 +176,7 @@ Known Issues
 
    **Workaround:** Unplug and plug-in the USB keyboard and mouse after exiting UOS.
 
+-----
 
 :acrn-issue:`2753` - UOS cannot resume after suspend by pressing power key
    UOS cannot resume after suspend by pressing power key
@@ -181,6 +185,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`2974` - Launching Zephyr RTOS as a real-time UOS takes too long
    Launching Zephyr RTOS as a real-time UOS takes too long
@@ -199,6 +204,7 @@ Known Issues
 
    **Workaround:** A different version of Grub is known to work correctly
 
+-----
 
 :acrn-issue:`3268` - dm: add virtio-rnd device to command line
    LaaG's network is unreachable with UOS kernel
@@ -216,6 +222,7 @@ Known Issues
 
    **Workaround:** Add ``-s 7,virtio-rnd \`` to the launch_uos.sh script
 
+-----
 
 :acrn-issue:`3280` - AcrnGT holding forcewake lock causes high CPU usage in gvt workload thread.
    The i915 forcewake mechanism is to keep the GPU from its low power state, in
@@ -226,6 +233,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 :acrn-issue:`3279` - AcrnGT causes display flicker in some situations.
    In current scaler ownership assignment logic, there's an issue that when SOS disables a plane,
@@ -236,6 +244,7 @@ Known Issues
 
    **Workaround:** None
 
+-----
 
 Change Log
 **********

--- a/doc/release_notes/release_notes_1.2.rst
+++ b/doc/release_notes/release_notes_1.2.rst
@@ -105,6 +105,7 @@ Known Issues
 
    **Workaround:** Issue resolved on ACRN tag: ``acrn-2019w33.1-140000p``
 
+-----
 
 :acrn-issue:`3520` - bundle of "VGPU unconformance guest" messages observed for "gvt" in SOS console while using UOS
    After the need_force_wake is not removed in course of submitting VGPU workload,
@@ -117,6 +118,7 @@ Known Issues
 
    **Workaround:** Need to rebuild and apply the latest Service VM kernel from the ``acrn-kernel`` source code.
 
+-----
 
 :acrn-issue:`3533` - NUC hang while repeating the cold boot
    NUC will hang while repeating cold boot operation.
@@ -132,6 +134,7 @@ Known Issues
 
    **Workaround:** Need to rebuild and apply the latest Service VM kernel from the ``acrn-kernel`` source code.
 
+-----
 
 :acrn-issue:`3576` - Expand default memory from 2G to 4G for WaaG
 
@@ -139,21 +142,25 @@ Known Issues
 
    **Workaround:** Issue resolved on ACRN tag: ``acrn-2019w33.1-140000p``
 
+-----
 
 :acrn-issue:`3609` - Sometimes fail to boot os while repeating the cold boot operation
 
    **Workaround:** Please refer the PR information in this git issue
 
+-----
 
 :acrn-issue:`3610` - LaaG hang while run some workloads loop with zephyr idle
 
    **Workaround:** Revert commit ``bbb891728d82834ec450f6a61792f715f4ec3013`` from the kernel
 
+-----
 
 :acrn-issue:`3611` - OVMF launch UOS fail for Hybrid and industry scenario
 
    **Workaround:** Please refer the PR information in this git issue
 
+-----
 
 
 Change Log


### PR DESCRIPTION
Horizontal lines were incorrectly removed during the processing for
using title case on all headings.  Put them back.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>