### PR TITLE
config_tools: fix VM boot issue for fusa_partition scenario

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
@@ -46,8 +46,8 @@
         </FEATURES>
         <MEMORY>
             <STACK_SIZE>0x2000</STACK_SIZE>
-            <HV_RAM_SIZE />
-            <HV_RAM_START />
+            <HV_RAM_SIZE/>
+            <HV_RAM_START/>
             <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
             <UOS_RAM_SIZE>0x200000000</UOS_RAM_SIZE>
             <SOS_RAM_SIZE>0x400000000</SOS_RAM_SIZE>
@@ -71,8 +71,7 @@
         <vm_type>PRE_STD_VM</vm_type>
         <name>ACRN PRE-LAUNCHED VM0</name>
         <guest_flags>
-            <guest_flag />
-            <guest_flag />
+            <guest_flag/>
         </guest_flags>
         <cpu_affinity>
             <pcpu_id>0</pcpu_id>
@@ -88,7 +87,7 @@
         </epc_section>
         <memory>
             <start_hpa>0x100000000</start_hpa>
-            <size>0x80000000</size>
+            <size>0x20000000</size>
             <start_hpa2>0x0</start_hpa2>
             <size_hpa2>0x0</size_hpa2>
         </memory>
@@ -96,8 +95,8 @@
             <name>Zephyr</name>
             <kern_type>KERNEL_ZEPHYR</kern_type>
             <kern_mod>Zephyr_RawImage</kern_mod>
-            <ramdisk_mod />
-            <bootargs>reboot=acpi</bootargs>
+            <ramdisk_mod/>
+            <bootargs/>
             <kern_load_addr>0x1000</kern_load_addr>
             <kern_entry_addr>0x1000</kern_entry_addr>
         </os_config>
@@ -158,12 +157,12 @@
         <os_config>
             <name>YOCTO</name>
             <kern_type>KERNEL_BZIMAGE</kern_type>
-            <kern_mod>Linux_bzImage</kern_mod>
-            <ramdisk_mod />
+            <kern_mod>RT_bzImage</kern_mod>
+            <ramdisk_mod/>
             <bootargs>
-        rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
-        consoleblank=0 tsc=reliable reboot=acpi
-        </bootargs>
+            rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M
+            consoleblank=0 tsc=reliable reboot=acpi
+            </bootargs>
         </os_config>
         <legacy_vuart id="0">
             <type>VUART_LEGACY_PIO</type>


### PR DESCRIPTION
update kern_mod to RT_bzImage in VM1, update memory size of
VM0 to avoid memory conflict.

Tracked-On: #5665

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>