### PR TITLE
acrn-config: remove obsolete kernel parameters from APL configurations

### DIFF
--- a/misc/config_tools/data/apl-mrb/hybrid.xml
+++ b/misc/config_tools/data/apl-mrb/hybrid.xml
@@ -172,9 +172,9 @@
         <rootfs>/dev/mmcblk1p1</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
-        reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
+        reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/apl-mrb/industry.xml
+++ b/misc/config_tools/data/apl-mrb/industry.xml
@@ -107,9 +107,9 @@
         <rootfs>/dev/mmcblk1p1</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
-        reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
+        reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/apl-mrb/sdc.xml
+++ b/misc/config_tools/data/apl-mrb/sdc.xml
@@ -107,9 +107,9 @@
         <rootfs>/dev/mmcblk1p1</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
-        reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_initial_modeset=1 i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
+        reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 video=DP-1:d video=DP-2:d cma=64M@0- panic_print=0x1f
         </bootargs>
     </board_private>
   </vm>

--- a/misc/config_tools/data/apl-up2/hybrid.xml
+++ b/misc/config_tools/data/apl-up2/hybrid.xml
@@ -172,7 +172,7 @@
         <rootfs>/dev/mmcblk0p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01070F i915.domain_plane_owners=0x011100001111 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>

--- a/misc/config_tools/data/apl-up2/industry.xml
+++ b/misc/config_tools/data/apl-up2/industry.xml
@@ -107,7 +107,7 @@
         <rootfs>/dev/mmcblk0p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>

--- a/misc/config_tools/data/apl-up2/sdc.xml
+++ b/misc/config_tools/data/apl-up2/sdc.xml
@@ -107,7 +107,7 @@
         <rootfs>/dev/mmcblk0p3</rootfs>
         <bootargs>
         rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3
-        i915.nuclear_pageflip=1 i915.avail_planes_per_pipe=0x01010F i915.domain_plane_owners=0x011111110000 i915.enable_gvt=1
+        i915.nuclear_pageflip=1 i915.enable_gvt=1
         hvlog=2M@0xe00000 memmap=0x600000$0xa00000 ramoops.mem_address=0xa00000 ramoops.mem_size=0x400000 ramoops.console_size=0x200000
         reboot_panic=p,w module_blacklist=dwc3_pci i915.enable_guc=0x02 cma=64M@0-
         </bootargs>


### PR DESCRIPTION
Remove obsolete kernel (i915) parameters from the Apollo Lake (APL)
board configurations.

Tracked-On: #5236
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>