### PR TITLE
config-tools: ivshmem support to be shared by multiple vms

### DIFF
--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -130,7 +130,7 @@ Read more about the available scheduling options in :ref:`cpu_sharing`.</xs:docu
 
 <xs:simpleType name="IVSHMEMRegionPattern">
   <xs:restriction base="xs:string">
-    <xs:pattern value="hv:/\w+,\s?\d+\s?,\s?\d\s?:\s?\d\s?" />
+    <xs:pattern value="hv:/\w+,\s?\d+\s?,\s?\d\s?(:\s?\d\s?)+" />
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
Loosen the restriction of IVSHMEM_REGION of xsd validation. An ivshmem
region can be shared by more than two vms.

Tracked-On: #5672
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>