### PR TITLE
DM: xHCI: Fix the USB3.2 device recognition problem.

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2088,6 +2088,7 @@ pci_xhci_cmd_address_device(struct pci_xhci_vdev *xdev,
 			UPRINTF(LFTL, "fail to create device for %d-%s\r\n",
 					di->path.bus,
 					usb_dev_path(&di->path));
+			cmderr = XHCI_TRB_ERROR_XACT;
 			goto done;
 		}
 

--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -1067,6 +1067,7 @@ usb_dev_init(void *pdata, char *opt)
 		goto errout;
 
 	switch (desc.bcdUSB) {
+	case 0x320:
 	case 0x310:
 	case 0x300:
 		ver = 3; break;


### PR DESCRIPTION
  The device descriptor describes general information about a device,
the bcdUSB field contains a BCD version number. The version 3.2 is
represented with value of 0x320H. Add the missed BCD version in the
bcdUSB case statement. And modify the return value of address device
command in case create device failed.

Tracked-On: #5712
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>