### PR TITLE
doc: fix rendering of rightwards arrows

### DIFF
--- a/doc/substitutions.txt
+++ b/doc/substitutions.txt
@@ -20,3 +20,4 @@
 .. |check|  unicode:: U+02714 .. HEAVY CHECK MARK
    :rtrim:
 .. |oplus|  unicode:: U+02295 .. CIRCLED PLUS SIGN
+.. |rarr|   unicode:: U+02192 .. RIGHTWARDS ARROW

--- a/doc/tutorials/gpu-passthru.rst
+++ b/doc/tutorials/gpu-passthru.rst
@@ -46,25 +46,25 @@ BIOS Settings
 Kaby Lake Platform
 ==================
 
-* Set **IGD Minimum Memory** to **64MB** in **Devices** &rarr;
-  **Video** &rarr; **IGD Minimum Memory**.
+* Set **IGD Minimum Memory** to **64MB** in **Devices** |rarr|
+  **Video** |rarr| **IGD Minimum Memory**.
 
 Whiskey Lake Platform
 =====================
 
-* Set **PM Support**  to **Enabled** in **Chipset** &rarr; **System
-  Agent (SA) Configuration** &rarr; **Graphics Configuration** &rarr;
+* Set **PM Support**  to **Enabled** in **Chipset** |rarr| **System
+  Agent (SA) Configuration** |rarr| **Graphics Configuration** |rarr|
   **PM support**.
-* Set **DVMT Pre-Allocated** to **64MB** in **Chipset** &rarr;
+* Set **DVMT Pre-Allocated** to **64MB** in **Chipset** |rarr|
   **System Agent (SA) Configuration**
-  &rarr; **Graphics Configuration** &rarr; **DVMT Pre-Allocated**.
+  |rarr| **Graphics Configuration** |rarr| **DVMT Pre-Allocated**.
 
 Elkhart Lake Platform
 =====================
 
 * Set **DMVT Pre-Allocated** to **64MB** in **Intel Advanced Menu**
-  &rarr; **System Agent(SA) Configuration** &rarr;
-  **Graphics Configuration** &rarr; **DMVT Pre-Allocated**.
+  |rarr| **System Agent(SA) Configuration** |rarr|
+  **Graphics Configuration** |rarr| **DMVT Pre-Allocated**.
 
 Passthrough the GPU to Guest
 ****************************


### PR DESCRIPTION
The "Enable GVT-d in ACRN" tutorial includes a number of rightwards
arrows. The source text used the "&rarr;" symbol for this but this
is not valid in ReST files. We add a substitution for this and use it
in the tutorial instead.

Tracked-On: #5769
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>