### PR TITLE
hv: Fix incorrect struct definition for ir_bits

### DIFF
--- a/hypervisor/include/arch/x86/apicreg.h
+++ b/hypervisor/include/arch/x86/apicreg.h
@@ -213,6 +213,7 @@ union ioapic_rte {
 		uint32_t vector:8;
 		uint32_t constant:3;
 		uint32_t intr_index_high:1;
+		uint32_t delivery_status:1;
 		uint32_t intr_polarity:1;
 		uint32_t remote_irr:1;
 		uint32_t trigger_mode:1;


### PR DESCRIPTION
Fixing an incorrect struct definition for ir_bits in ioapic_rte. Since bits after
the delivery status in the lower 32 bits are not touched by code,
this has never showed up as an issue. And the higher 32 bits in the RTE
are aligned by the compiler.

Tracked-On: #5773
Signed-off-by: Sainath Grandhi <sainath.grandhi@intel.com>