### PR TITLE
config-tools: remove "--pm_notify_channel uart" of waag

### DIFF
--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -581,6 +581,12 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     # pm_channel set
     if dm['pm_channel'][vmid] and dm['pm_channel'][vmid] != None:
         pm_key = dm['pm_channel'][vmid]
+        pm_arg = ""
+        if uos_type == "WINDOWS":
+           pm_arg = launch_cfg_lib.WINDOWS_PM_CHANNEL_DIC[pm_key]
+        else:
+           pm_arg = launch_cfg_lib.PM_CHANNEL_DIC[pm_key]
+
         if pm_key == "vuart1(tty)":
             vuart_base = launch_cfg_lib.get_vuart1_from_scenario(sos_vmid + vmid)
             if vuart_base == "INVALID_COM_BASE":
@@ -588,9 +594,9 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
                 launch_cfg_lib.ERR_LIST[err_key] = "vuart1 of VM{} in scenario file should select 'SOS_COM2_BASE'".format(sos_vmid + vmid)
                 return
             scenario_cfg_lib.get_sos_vuart_settings()
-            print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
+            print("   {} \\".format(pm_arg + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
         else:
-            print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
+            print("   {} \\".format(pm_arg), file=config)
 
     # set logger_setting for all VMs
     print("   $logger_setting \\", file=config)

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -44,12 +44,20 @@ PT_SLOT = {
 
 
 PM_CHANNEL = ['', 'IOC', 'PowerButton', 'vuart1(pty)', 'vuart1(tty)']
-PM_CHANNEL_DIC = {
+WINDOWS_PM_CHANNEL_DIC = {
     None:'',
     'IOC':'--pm_notify_channel ioc',
     'PowerButton':'--pm_notify_channel power_button',
     'vuart1(pty)':'--pm_notify_channel uart \\\n   --pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
     'vuart1(tty)':'--pm_notify_channel uart --pm_by_vuart tty,/dev/',
+}
+
+PM_CHANNEL_DIC = {
+    None:'',
+    'IOC':'--pm_notify_channel ioc',
+    'PowerButton':'--pm_notify_channel power_button',
+    'vuart1(pty)':'--pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
+    'vuart1(tty)':'--pm_by_vuart tty,/dev/',
 }
 
 MOUNT_FLAG_DIC = {}


### PR DESCRIPTION
"--pm_notify_channel uart" is no longer needed for waag which using uart
as powerbutton, remove this command argument from uos launch script
generating process.

Tracked-On: #5736
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>