### PR TITLE
config-tools: remove "vuart" poweroff channel from default xml

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_laag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/generic_board/industry_launch_2uos.xml
+++ b/misc/config_tools/data/generic_board/industry_launch_2uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_2uos.xml
@@ -49,7 +49,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_6uos.xml
@@ -49,7 +49,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT arguments. Recommendation is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_laag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -6,7 +6,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
@@ -48,7 +48,7 @@
 	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(tty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -6,7 +6,7 @@
 	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
-	<poweroff_channel desc="the method of power off uos">vuart1(pty)</poweroff_channel>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>


### PR DESCRIPTION
Remove the the vuart1(tty) and vuart1(pty) poweroff channel from default
non-windows uos launch script xmls.

Tracked-On: #5736
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>