### PR TITLE
config_tools: add sanity check for PSRAM and RDT

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -150,6 +150,7 @@ Machine Check Error on Page Size Change.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
+  <xs:assert test="not (RDT/RDT_ENABLED = 'y' and PSRAM/PSRAM_ENABLED = 'y')"/>
 </xs:complexType>
 
 <xs:complexType name="MemoryOptionsType">


### PR DESCRIPTION
RDT_ENABLED and PSRAM_ENABLED should not by y simultaneously.

Tracked-On: #5649

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>