### PR TITLE
Expose hypervisor configuration targets to top-level Makefile and fix bugs in diffconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,16 +63,6 @@ else
   endif
 endif
 
-BOARD ?= kbl-nuc-i7
-
-ifeq ($(BOARD), apl-nuc)
-  override BOARD := nuc6cayh
-else ifeq ($(BOARD), kbl-nuc-i7)
-  override BOARD := nuc7i7dnb
-endif
-
-SCENARIO ?= industry
-
 O ?= build
 ROOT_OUT := $(shell mkdir -p $(O);cd $(O);pwd)
 HV_OUT := $(ROOT_OUT)/hypervisor

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,6 @@ BUILD_TAG ?=
 HV_CFG_LOG = $(HV_OUT)/cfg.log
 VM_CONFIGS_DIR = $(T)/misc/config_tools
 
-export TOOLS_OUT BOARD SCENARIO RELEASE
-
 .PHONY: all hypervisor devicemodel tools doc
 all: hypervisor devicemodel tools
 	@cat $(HV_CFG_LOG)
@@ -105,7 +103,7 @@ hypervisor:
 	@cat $(HV_CFG_LOG)
 
 devicemodel: tools
-	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER) RELEASE=$(RELEASE)
+	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER) TOOLS_OUT=$(TOOLS_OUT) RELEASE=$(RELEASE)
 
 tools:
 	mkdir -p $(TOOLS_OUT)

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,15 @@ else
   endif
 endif
 
+# Backward-compatibility for RELEASE=(0|1)
+ifeq ($(RELEASE),1)
+  override RELEASE := y
+else
+  ifeq ($(RELEASE),0)
+    override RELEASE := n
+  endif
+endif
+
 BOARD ?= kbl-nuc-i7
 
 ifeq ($(BOARD), apl-nuc)

--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,26 @@ define install_acrn_debug
 	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT)/$(1) BOARD=$(1) SCENARIO=$(2) RELEASE=$(RELEASE) install-debug
 endef
 
+HV_MAKEOPTS := -C $(T)/hypervisor BOARD=$(BOARD) SCENARIO=$(SCENARIO) HV_OBJDIR=$(HV_OUT) RELEASE=$(RELEASE)
+
 hypervisor:
-	$(MAKE) -C $(T)/hypervisor BOARD=$(BOARD) SCENARIO=$(SCENARIO) HV_OBJDIR=$(HV_OUT) RELEASE=$(RELEASE)
-	@echo -e "\n\033[47;30mACRN Configuration Summary:\033[0m \nBOARD = $(BOARD)\t SCENARIO = $(SCENARIO)" > $(HV_CFG_LOG); \
-	echo -e "BUILD type = \c" >> $(HV_CFG_LOG); \
-	if [ "$(RELEASE)" = "0" ]; then echo -e "DEBUG" >> $(HV_CFG_LOG); else echo -e "RELEASE" >> $(HV_CFG_LOG); fi; \
-	echo -e "VM configuration is based on:" >> $(HV_CFG_LOG); \
-	echo -e "\tSource code at:\t\t\t$(HV_OUT)/configs" >> $(HV_CFG_LOG);
+	$(MAKE) $(HV_MAKEOPTS)
+	@echo -e "ACRN Configuration Summary:" > $(HV_CFG_LOG)
+	@$(MAKE) showconfig $(HV_MAKEOPTS) -s >> $(HV_CFG_LOG)
 	@cat $(HV_CFG_LOG)
+
+# Targets that manipulate hypervisor configurations
+hvdefconfig:
+	@$(MAKE) defconfig $(HV_MAKEOPTS)
+
+hvshowconfig:
+	@$(MAKE) showconfig $(HV_MAKEOPTS) -s
+
+hvdiffconfig:
+	@$(MAKE) diffconfig $(HV_MAKEOPTS)
+
+hvapplydiffconfig:
+	@$(MAKE) applydiffconfig $(HV_MAKEOPTS) PATCH=$(abspath $(PATCH))
 
 devicemodel: tools
 	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) DM_BUILD_VERSION=$(BUILD_VERSION) DM_BUILD_TAG=$(BUILD_TAG) DM_ASL_COMPILER=$(ASL_COMPILER) TOOLS_OUT=$(TOOLS_OUT) RELEASE=$(RELEASE)
@@ -121,10 +133,10 @@ clean:
 install: hypervisor-install devicemodel-install tools-install
 
 hypervisor-install:
-	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) SCENARIO=$(SCENARIO) RELEASE=$(RELEASE) install
+	$(MAKE) $(HV_MAKEOPTS) install
 
 hypervisor-install-debug:
-	$(MAKE) -C $(T)/hypervisor HV_OBJDIR=$(HV_OUT) BOARD=$(BOARD) SCENARIO=$(SCENARIO) RELEASE=$(RELEASE) install-debug
+	$(MAKE) $(HV_MAKEOPTS) install-debug
 
 kbl-nuc-i7-industry:
 	$(call build_acrn,nuc7i7dnb,industry)

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -11,7 +11,19 @@ DM_BUILD_VERSION ?=
 DM_BUILD_TAG ?=
 
 CC ?= gcc
-RELEASE ?= 0
+
+ifndef RELEASE
+  override RELEASE := n
+else
+  # Backward-compatibility for RELEASE=(0|1)
+  ifeq ($(RELEASE),1)
+    override RELEASE := y
+  else
+    ifeq ($(RELEASE),0)
+      override RELEASE := n
+    endif
+  endif
+endif
 
 CFLAGS := -g -O0 -std=gnu11
 CFLAGS += -D_GNU_SOURCE
@@ -52,7 +64,7 @@ endif
 endif
 endif
 
-ifeq ($(RELEASE),0)
+ifeq ($(RELEASE),n)
 CFLAGS += -DDM_DEBUG
 else
 LDFLAGS += -s

--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -141,6 +141,13 @@ ifdef RELEASE
   endif
 endif
 
+# Backward-compatibility for BOARD=apl-nuc or BOARD=kbl-nuc
+ifeq ($(BOARD), apl-nuc)
+  override BOARD := nuc6cayh
+else ifeq ($(BOARD), kbl-nuc-i7)
+  override BOARD := nuc7i7dnb
+endif
+
 ifeq ($(findstring $(MAKECMDGOALS),distclean),)
 -include $(HV_CONFIG_MK)
 endif
@@ -181,7 +188,7 @@ endif
 
 $(eval $(call determine_config,BOARD,nuc7i7dnb))
 $(eval $(call determine_config,SCENARIO,industry))
-$(eval $(call determine_build_type,y))
+$(eval $(call determine_build_type,n))
 
 $(HV_BOARD_XML):
 	@if [ ! -f $(HV_BOARD_XML) ]; then \

--- a/hypervisor/scripts/makefile/config.mk
+++ b/hypervisor/scripts/makefile/config.mk
@@ -99,9 +99,9 @@ ifdef RELEASE
   endif
 else
   ifdef CONFIG_RELEASE
-    RELEASE := $(CONFIG_RELEASE)
+    override RELEASE := $(CONFIG_RELEASE)
   else
-    RELEASE := $(1)
+    override RELEASE := $(1)
   endif
 endif
 endef

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -1,9 +1,21 @@
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
-RELEASE ?= 0
+
+ifndef RELEASE
+  override RELEASE := n
+else
+  # Backward-compatibility for RELEASE=(0|1)
+  ifeq ($(RELEASE),1)
+    override RELEASE := y
+  else
+    ifeq ($(RELEASE),0)
+      override RELEASE := n
+    endif
+  endif
+endif
 
 .PHONY: all acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
-ifeq ($(RELEASE),0)
+ifeq ($(RELEASE),n)
 all: acrn-crashlog acrnlog acrn-manager acrntrace acrnbridge life_mngr
 else
 all: acrn-manager acrnbridge life_mngr
@@ -37,7 +49,7 @@ clean:
 	rm -rf $(OUT_DIR)
 
 .PHONY: install
-ifeq ($(RELEASE),0)
+ifeq ($(RELEASE),n)
 install: acrn-crashlog-install acrnlog-install acrn-manager-install acrntrace-install acrnbridge-install \
 	acrn-life-mngr-install
 else

--- a/misc/debug_tools/acrn_crashlog/Makefile
+++ b/misc/debug_tools/acrn_crashlog/Makefile
@@ -9,9 +9,21 @@ OUT_DIR 	?= $(BASEDIR)
 BUILDDIR	:= $(OUT_DIR)/acrn-crashlog
 CC		?= gcc
 RM		= rm
-RELEASE 	?= 0
 
-ifeq ($(RELEASE),0)
+ifndef RELEASE
+  override RELEASE := n
+else
+  # Backward-compatibility for RELEASE=(0|1)
+  ifeq ($(RELEASE),1)
+    override RELEASE := y
+  else
+    ifeq ($(RELEASE),0)
+      override RELEASE := n
+    endif
+  endif
+endif
+
+ifeq ($(RELEASE),n)
 CFLAGS	+= -DDEBUG_ACRN_CRASHLOG
 endif
 

--- a/misc/services/acrn_manager/Makefile
+++ b/misc/services/acrn_manager/Makefile
@@ -3,7 +3,19 @@ include ../../../paths.make
 T := $(CURDIR)
 OUT_DIR ?= $(shell mkdir -p $(T)/build;cd $(T)/build;pwd)
 CC ?= gcc
-RELEASE ?= 0
+
+ifndef RELEASE
+  override RELEASE := n
+else
+  # Backward-compatibility for RELEASE=(0|1)
+  ifeq ($(RELEASE),1)
+    override RELEASE := y
+  else
+    ifeq ($(RELEASE),0)
+      override RELEASE := n
+    endif
+  endif
+endif
 
 MANAGER_CFLAGS := -g -O0 -std=gnu11
 MANAGER_CFLAGS += -D_GNU_SOURCE
@@ -50,7 +62,7 @@ endif
 endif
 endif
 
-ifeq ($(RELEASE),0)
+ifeq ($(RELEASE),n)
 MANAGER_CFLAGS += -g -DMNGR_DEBUG
 else
 MANAGER_LDFLAGS += -s


### PR DESCRIPTION
Motivated by the review of #5753, the issue #5772 and some offline-reported bugs, this patch series tries aligning the functionality and terminology used in top-level Makefile and component-wise ones. The major changes are as follows.

 - Use `y` and `n` as the preferred values of `RELEASE`. The old values `0` and `1` can still be used for backward compatibility. (fixes #5772)
 - Allow the top-level Makefile to recognize the `BOARD` and `SCENARIO` settings of a build directory. This allows commands like below to work.
 - The top-level Makefile can now invoke the hypervisor configuration-related targets as `hvshowconfig`, `hvdiffconfig` and `hvapplydiffconfig`. The `hv` prefix is added to highlight that they only apply to hypervisor configurations, not configurations to every component.
 - Fixes broken `diffconfig`
 - Fixes `applydiffconfig` when a patch is specified by multiple times

The changes also impact the offline patches in meta-acrn. Refer to intel/meta-acrn#308 for the corresponding changes required there.