### PR TITLE
hv: two minor refine for PSCMCE

### DIFF
--- a/hypervisor/arch/x86/guest/vmx_io.c
+++ b/hypervisor/arch/x86/guest/vmx_io.c
@@ -113,6 +113,7 @@ int32_t ept_violation_vmexit_handler(struct acrn_vcpu *vcpu)
 
 	/*caused by instruction fetch */
 	if ((exit_qual & 0x4UL) != 0UL) {
+		/* TODO: check wehther the gpa is not a MMIO address. */
 		if (vcpu->arch.cur_context == NORMAL_WORLD) {
 			ept_modify_mr(vcpu->vm, (uint64_t *)vcpu->vm->arch_vm.nworld_eptp,
 				gpa & PAGE_MASK, PAGE_SIZE, EPT_EXE, 0UL);

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -309,6 +309,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 	uint64_t vaddr = vaddr_start;
 	uint64_t paddr = paddr_start;
 	uint64_t index = pde_index(vaddr);
+	uint64_t local_prot = prot;
 
 	dev_dbg(DBG_LEVEL_MMU, "%s, paddr: 0x%lx, vaddr: [0x%lx - 0x%lx]\n",
 		__func__, paddr, vaddr, vaddr_end);
@@ -324,8 +325,8 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 					mem_aligned_check(paddr, PDE_SIZE) &&
 					mem_aligned_check(vaddr, PDE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {
-					mem_ops->tweak_exe_right(&prot);
-					set_pgentry(pde, paddr | (prot | PAGE_PSE), mem_ops);
+					mem_ops->tweak_exe_right(&local_prot);
+					set_pgentry(pde, paddr | (local_prot | PAGE_PSE), mem_ops);
 					if (vaddr_next < vaddr_end) {
 						paddr += (vaddr_next - vaddr);
 						vaddr = vaddr_next;
@@ -358,6 +359,7 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 	uint64_t vaddr = vaddr_start;
 	uint64_t paddr = paddr_start;
 	uint64_t index = pdpte_index(vaddr);
+	uint64_t local_prot = prot;
 
 	dev_dbg(DBG_LEVEL_MMU, "%s, paddr: 0x%lx, vaddr: [0x%lx - 0x%lx]\n", __func__, paddr, vaddr, vaddr_end);
 	for (; index < PTRS_PER_PDPTE; index++) {
@@ -372,8 +374,8 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 					mem_aligned_check(paddr, PDPTE_SIZE) &&
 					mem_aligned_check(vaddr, PDPTE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {
-					mem_ops->tweak_exe_right(&prot);
-					set_pgentry(pdpte, paddr | (prot | PAGE_PSE), mem_ops);
+					mem_ops->tweak_exe_right(&local_prot);
+					set_pgentry(pdpte, paddr | (local_prot | PAGE_PSE), mem_ops);
 					if (vaddr_next < vaddr_end) {
 						paddr += (vaddr_next - vaddr);
 						vaddr = vaddr_next;

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -321,7 +321,7 @@ static void add_pde(const uint64_t *pdpte, uint64_t paddr_start, uint64_t vaddr_
 			pr_fatal("%s, pde 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			if (mem_ops->pgentry_present(*pde) == 0UL) {
-				if (mem_ops->large_page_support(IA32E_PD) &&
+				if (mem_ops->large_page_support(IA32E_PD, prot) &&
 					mem_aligned_check(paddr, PDE_SIZE) &&
 					mem_aligned_check(vaddr, PDE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {
@@ -370,7 +370,7 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
 			pr_fatal("%s, pdpte 0x%lx is already present!\n", __func__, vaddr);
 		} else {
 			if (mem_ops->pgentry_present(*pdpte) == 0UL) {
-				if (mem_ops->large_page_support(IA32E_PDPT) &&
+				if (mem_ops->large_page_support(IA32E_PDPT, prot) &&
 					mem_aligned_check(paddr, PDPTE_SIZE) &&
 					mem_aligned_check(vaddr, PDPTE_SIZE) &&
 					(vaddr_next <= vaddr_end)) {

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -68,7 +68,7 @@ struct page_pool {
 
 struct memory_ops {
 	struct page_pool *pool;
-	bool (*large_page_support)(enum _page_table_level level);
+	bool (*large_page_support)(enum _page_table_level level, uint64_t prot);
 	uint64_t (*get_default_access_right)(void);
 	uint64_t (*pgentry_present)(uint64_t pte);
 	void (*clflush_pagewalk)(const void *p);


### PR DESCRIPTION
v3:
abandon "2. only recover execution right when EPT violation for PSCMCE" in v1

v2:
refine the comments

v1:
1. only treak execution right for large pages
2. only recover execution right when EPT violation for PSCMCE
3. RTVM: build 4KB page mapping in EPT for code pages, use large page mapping for data pages

Tracked-On: #5788