### PR TITLE
DM: xHCI: Implement the USB PLS Machine flow spec.

### DIFF
--- a/devicemodel/hw/platform/usb_pmapper.c
+++ b/devicemodel/hw/platform/usb_pmapper.c
@@ -730,6 +730,7 @@ int
 usb_dev_reset(void *pdata)
 {
 	struct usb_dev *udev;
+	int rc = 0;
 
 	udev = pdata;
 
@@ -737,7 +738,12 @@ usb_dev_reset(void *pdata)
 	libusb_reset_device(udev->handle);
 	usb_dev_reset_ep(udev);
 	usb_dev_update_ep(udev);
-	return 0;
+	rc = libusb_reset_device(udev->handle);
+	if (!rc) {
+		usb_dev_reset_ep(udev);
+		usb_dev_update_ep(udev);
+	}
+	return rc;
 }
 
 int


### PR DESCRIPTION
From the Figure 11-10. Downstream Facing Hub Port State Machine the
device connect status should be disabled and the PLS should be polling
for USB2.0, when the device be connected, then the xHCD send the port
reset, for acrn we use libusb_reset_device to emulate the bus reset
action.

Tracked-On: #5795
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>