### PR TITLE
[release_2.4] hv: cpu: remove cache_flush_invalidate_all in cpu_dead

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -445,8 +445,8 @@ void cpu_dead(void)
 	if (bitmap_test(pcpu_id, &pcpu_active_bitmap)) {
 		/* clean up native stuff */
 		vmx_off();
-		/* TODO: a cpu dead can't effect the RTVM which use Software SRAM */
-		cache_flush_invalidate_all();
+
+		/* TODO: flush the data segment to the memory when we want to enter S3 */
 
 		/* Set state to show CPU is dead */
 		pcpu_set_current_state(pcpu_id, PCPU_STATE_DEAD);


### PR DESCRIPTION
Before the ACRN HV entered the S3, we would call cache_flush_invalidate_all to
flush all the caches into memory and invalidate the caches on each logical cpu
before we halt the cpu.

This was not a problem before we support pSRAM. Once pSRAM binary code has been
executed on the logical cpu, we could not flush the pSRAM cache into memory then.
Otherwise, the pSRAM cache can't been locked.

This patch removes cache_flush_invalidate_all in cpu_dead since we would not
support to put the ACRN HV into S3. Once we want to support put the ACRN HV into
S3, we would try other ways to flush the data caches in this cpu into memory and
valid whether that way is practical or not.

Signed-off-by: Li Fei1 <fei1.li@intel.com>
Tracked-On: #5806