### PR TITLE
config_tools: add psram config in launch config

### DIFF
--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -613,6 +613,15 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     # shm regions args set
     shm_arg_set(dm, vmid, config)
 
+    # psram set
+    psram_enabled = 'n'
+    try:
+        psram_enabled = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "PSRAM", "PSRAM_ENABLED")
+    except:
+        pass
+    if uos_type == "PREEMPT-RT LINUX" and psram_enabled == 'y':
+        print("   --psram \\", file=config)
+
     for value in sel.bdf.values():
         if value[vmid]:
             print("   $intr_storm_monitor \\", file=config)


### PR DESCRIPTION
add "--psram" in acrn dm arguments in launch scripts
when PSRAM_ENABLED=y and the VM is post-launched RTVM.

Tracked-On: #5649

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Acked-by: Victor Sun <victor.sun@intel.com>