### PR TITLE
Enhance life mngr makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ BUILD_TAG ?=
 HV_CFG_LOG = $(HV_OUT)/cfg.log
 VM_CONFIGS_DIR = $(T)/misc/config_tools
 
-.PHONY: all hypervisor devicemodel tools doc
+.PHONY: all hypervisor devicemodel tools life_mngr doc
 all: hypervisor devicemodel tools
 	@cat $(HV_CFG_LOG)
 
@@ -120,6 +120,10 @@ tools:
 	mkdir -p $(TOOLS_OUT)
 	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE)
 
+life_mngr:
+	mkdir -p $(TOOLS_OUT)
+	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) life_mngr
+
 doc:
 	$(MAKE) -C $(T)/doc html BUILDDIR=$(DOC_OUT)
 
@@ -129,7 +133,7 @@ clean:
 	$(MAKE) -C $(T)/doc BUILDDIR=$(DOC_OUT) clean
 	rm -rf $(ROOT_OUT)
 
-.PHONY: install
+.PHONY: install life_mngr-install
 install: hypervisor-install devicemodel-install tools-install
 
 hypervisor-install:
@@ -167,3 +171,6 @@ devicemodel-install:
 
 tools-install:
 	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) install
+
+life_mngr-install:
+	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) acrn-life-mngr-install

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -21,9 +21,9 @@ endif
 
 .PHONY: all acrn-manager acrnbridge life_mngr acrn-crashlog acrnlog acrntrace
 ifeq ($(RELEASE),n)
-all: acrn-manager acrnbridge life_mngr acrn-crashlog acrnlog acrntrace
+all: acrn-manager acrnbridge acrn-crashlog acrnlog acrntrace
 else
-all: acrn-manager acrnbridge life_mngr
+all: acrn-manager acrnbridge
 endif
 
 acrn-manager:
@@ -55,10 +55,10 @@ clean:
 
 .PHONY: install
 ifeq ($(RELEASE),n)
-install: acrn-manager-install acrnbridge-install acrn-life-mngr-install acrn-crashlog-install \
+install: acrn-manager-install acrnbridge-install acrn-crashlog-install \
 	acrnlog-install acrntrace-install
 else
-install: acrn-manager-install acrnbridge-install acrn-life-mngr-install
+install: acrn-manager-install acrnbridge-install
 endif
 
 acrn-manager-install:


### PR DESCRIPTION
The Yocto folks are disabling the building of `life_mngr` on the basis it is a component to be run in the User VM. That makes sense to me, if true. Based on that, I have made some modifications to our Makefile to **not** build `life_mngr` by default anymore. I also created a target in the top-level Makefile so it can easily be built on demand from there.

This is sent as a draft PR for now, it should really be sent as a PR after #5810 has been merged... but please take a look at it already today. ;-)