### PR TITLE
config-tools: replace "PTDEV_HI_MMIO_START" with "HI_MMIO_START"

### DIFF
--- a/misc/config_tools/board_config/vbar_base_h.py
+++ b/misc/config_tools/board_config/vbar_base_h.py
@@ -117,7 +117,7 @@ def write_vbar(i_cnt, bdf, pci_bar_dic, bar_attr, \
             bar_num += 1
             bar_val = pci_bar_dic[bdf][bar_i].addr
             if pci_bar_dic[bdf][bar_i].remapped:
-                ptdev_mmio_str = 'PTDEV_HI_MMIO_START + '
+                ptdev_mmio_str = 'HI_MMIO_START + '
 
             if bar_num == bar_len:
                 if bar_len == 1:

--- a/misc/config_tools/data/generic_board/generic_code/hybrid/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/vbar_base.h
@@ -8,7 +8,7 @@
 #define VBAR_BASE_H_
 
 #define VGA_COMPATIBLE_CONTROLLER_0_VBAR              .vbar_base[0] = 0x82000000UL, \
-                                                      .vbar_base[2] = PTDEV_HI_MMIO_START + 0x0UL
+                                                      .vbar_base[2] = HI_MMIO_START + 0x0UL
 
 #define SYSTEM_PERIPHERAL_0_VBAR                      .vbar_base[0] = 0x834e4000UL
 

--- a/misc/config_tools/data/generic_board/generic_code/hybrid_rt/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid_rt/vbar_base.h
@@ -12,7 +12,7 @@
                                                       .vbar_base[2] = 0x8020000cUL
 
 #define VGA_COMPATIBLE_CONTROLLER_0_VBAR              .vbar_base[0] = 0x82000000UL, \
-                                                      .vbar_base[2] = PTDEV_HI_MMIO_START + 0x0UL
+                                                      .vbar_base[2] = HI_MMIO_START + 0x0UL
 
 #define SYSTEM_PERIPHERAL_0_VBAR                      .vbar_base[0] = 0x834e4000UL
 

--- a/misc/config_tools/data/generic_board/generic_code/industry/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/industry/vbar_base.h
@@ -8,7 +8,7 @@
 #define VBAR_BASE_H_
 
 #define VGA_COMPATIBLE_CONTROLLER_0_VBAR              .vbar_base[0] = 0x82000000UL, \
-                                                      .vbar_base[2] = PTDEV_HI_MMIO_START + 0x0UL
+                                                      .vbar_base[2] = HI_MMIO_START + 0x0UL
 
 #define SYSTEM_PERIPHERAL_0_VBAR                      .vbar_base[0] = 0x834e4000UL
 

--- a/misc/config_tools/data/generic_board/generic_code/logical_partition/vbar_base.h
+++ b/misc/config_tools/data/generic_board/generic_code/logical_partition/vbar_base.h
@@ -8,7 +8,7 @@
 #define VBAR_BASE_H_
 
 #define VGA_COMPATIBLE_CONTROLLER_0_VBAR              .vbar_base[0] = 0x82000000UL, \
-                                                      .vbar_base[2] = PTDEV_HI_MMIO_START + 0x0UL
+                                                      .vbar_base[2] = HI_MMIO_START + 0x0UL
 
 #define SYSTEM_PERIPHERAL_0_VBAR                      .vbar_base[0] = 0x834e4000UL
 


### PR DESCRIPTION
"PTDEV_HI_MMIO_START" is removed by the commit
8d9f12f3b737394fbad6247d57155b0455429d15.

Replace "PTDEV_HI_MMIO_START" with "HI_MMIO_START".

Tracked-On: #5693
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>