### PR TITLE
config-tools: fix "is_tpm_passthru" always return "False"

### DIFF
--- a/misc/config_tools/library/board_cfg_lib.py
+++ b/misc/config_tools/library/board_cfg_lib.py
@@ -612,8 +612,8 @@ def is_tpm_passthru():
 
     tpm_passthru = False
     (_, board) = common.get_board_name()
-    tpm2_passthru_enabled = common.get_leaf_tag_map_bool(common.SCENARIO_INFO_FILE, "mmio_resources", "TPM2")
-    if board in TPM_PASSTHRU_BOARD and tpm2_passthru_enabled and tpm2_passthru_enabled == 'y':
+    tpm2_passthru_enabled = common.get_leaf_tag_map(common.SCENARIO_INFO_FILE, "mmio_resources", "TPM2")
+    if board in TPM_PASSTHRU_BOARD and tpm2_passthru_enabled and 'y' in tpm2_passthru_enabled.values():
         tpm_passthru = True
 
     return tpm_passthru


### PR DESCRIPTION
"is_tpm_passthru" would always return "False" with the existing logic.

1. Replace "get_leaf_tag_map_bool" with "get_leaf_tag_map". Instead returning a dictrionary with boolean diction values, just get the string value.
2. Return "True" if any vm has enabled the passtrhough tpm with option "y".

Tracked-On: #5710
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>