### PR TITLE
config_tools: add passthru devices for logical partition scenario on ehl

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/logical_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/logical_partition.xml
@@ -123,8 +123,8 @@
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
         <pci_devs>
-            <pci_dev/>
-            <pci_dev/>
+            <pci_dev>00:17.0 SATA controller: Intel Corporation Device 4b63 (rev 10)</pci_dev>
+            <pci_dev>00:1d.1 Ethernet controller: Intel Corporation Device 4ba0 (rev 10)</pci_dev>
         </pci_devs>
         <mmio_resources>
             <TPM2>n</TPM2>
@@ -185,8 +185,7 @@
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
         <pci_devs>
-            <pci_dev/>
-            <pci_dev/>
+            <pci_dev>00:14.0 USB controller: Intel Corporation Device 4b7d (rev 10)</pci_dev>
         </pci_devs>
         <mmio_resources>
             <TPM2>n</TPM2>


### PR DESCRIPTION
add passthru devices for logical partition scenario on ehl.

Tracked-On: #5665

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>