### PR TITLE
doc: update acpica-unix version to latest (20210105)

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -79,9 +79,9 @@ ACRN.
           xsltproc
 
      $ sudo pip3 install lxml xmlschema
-     $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
-     $ tar zxvf acpica-unix-20191018.tar.gz
-     $ cd acpica-unix-20191018
+     $ wget https://acpica.org/sites/acpica/files/acpica-unix-20210105.tar.gz
+     $ tar zxvf acpica-unix-20210105.tar.gz
+     $ cd acpica-unix-20210105
      $ make clean && make iasl
      $ sudo cp ./generate/unix/bin/iasl /usr/sbin/
 

--- a/doc/getting-started/roscube/roscube-gsg.rst
+++ b/doc/getting-started/roscube/roscube-gsg.rst
@@ -410,9 +410,9 @@ the User VM.
    .. code-block:: bash
 
      cd /tmp
-     wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
-     tar zxvf acpica-unix-20191018.tar.gz
-     cd acpica-unix-20191018
+     wget https://acpica.org/sites/acpica/files/acpica-unix-20210105.tar.gz
+     tar zxvf acpica-unix-20210105.tar.gz
+     cd acpica-unix-20210105
      make clean && make iasl
      sudo cp ./generate/unix/bin/iasl /usr/sbin/
 

--- a/doc/getting-started/rt_industry_ubuntu.rst
+++ b/doc/getting-started/rt_industry_ubuntu.rst
@@ -176,15 +176,11 @@ Build the ACRN Hypervisor on Ubuntu
    .. code-block:: none
 
       $ cd /home/acrn/work
-      $ wget https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
-      $ tar zxvf acpica-unix-20191018.tar.gz
-      $ cd acpica-unix-20191018
+      $ wget https://acpica.org/sites/acpica/files/acpica-unix-20210105.tar.gz
+      $ tar zxvf acpica-unix-20210105.tar.gz
+      $ cd acpica-unix-20210105
       $ make clean && make iasl
       $ sudo cp ./generate/unix/bin/iasl /usr/sbin/
-
-   .. note:: While there are newer versions of software available from
-      the `ACPICA downloads site <https://acpica.org/downloads>`_, this
-      20191018 version has been verified to work.
 
 #. Get the ACRN source code:
 


### PR DESCRIPTION
Update the ACPI Component Architecture package (acpica-unix) to
the latest version available as of today: 20210105

Tracked-On: #5553
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>