### PR TITLE
Makefile: automatically determine the location of 'iasl'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ BUILD_VERSION ?=
 BUILD_TAG ?=
 HV_CFG_LOG = $(HV_OUT)/cfg.log
 VM_CONFIGS_DIR = $(T)/misc/config_tools
+ASL_COMPILER ?= $(shell which iasl)
 
 .PHONY: all hypervisor devicemodel tools doc
 all: hypervisor devicemodel tools


### PR DESCRIPTION
The 'iasl' binary (from the acpica) package can be installed in
different locations depending on the distribution. By default,
we look for it under '/usr/sbin/'. But it is also often found
under '/usr/bin'. This can be overwritten by setting the ASL_COMPILER
flag when compiling ACRN.

This patch goes one step further and automatically determine where
'iasl' is on the development system if the ASL_COMPILER variable
has not been set already.

Tracked-On: #5854
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>