### PR TITLE
doc: add 'libxml2-utils' to the list of build dependencies

### DIFF
--- a/doc/getting-started/building-from-source.rst
+++ b/doc/getting-started/building-from-source.rst
@@ -66,6 +66,7 @@ ACRN.
           libsystemd-dev \
           libevent-dev \
           libxml2-dev \
+          libxml2-utils \
           libusb-1.0-0-dev \
           python3 \
           python3-pip \

--- a/doc/getting-started/roscube/roscube-gsg.rst
+++ b/doc/getting-started/roscube/roscube-gsg.rst
@@ -92,7 +92,7 @@ Set Up Environment
 
      sudo apt update
      sudo apt install -y gcc git make gnu-efi libssl-dev libpciaccess-dev \
-       uuid-dev libsystemd-dev libevent-dev libxml2-dev \
+       uuid-dev libsystemd-dev libevent-dev libxml2-dev libxml2-utils \
        libusb-1.0-0-dev python3 python3-pip libblkid-dev \
        e2fslibs-dev pkg-config libnuma-dev liblz4-tool flex bison
      sudo pip3 install kconfiglib

--- a/doc/getting-started/rt_industry_ubuntu.rst
+++ b/doc/getting-started/rt_industry_ubuntu.rst
@@ -152,6 +152,7 @@ Build the ACRN Hypervisor on Ubuntu
         libsystemd-dev \
         libevent-dev \
         libxml2-dev \
+        libxml2-utils \
         libusb-1.0-0-dev \
         python3 \
         python3-pip \


### PR DESCRIPTION
The ACRN buid system uses 'xmllint' which is provided by the 'libxml2-utils'
package on Ubuntu. This patch adds it to the list of build and development
packages to be installed on the build system to succesfully build ACRN.

Tracked-On: #5861
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>