### PR TITLE
Makefile: add pre-requisite before building the hypervisor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endef
 
 HV_MAKEOPTS := -C $(T)/hypervisor BOARD=$(BOARD) SCENARIO=$(SCENARIO) HV_OBJDIR=$(HV_OUT) RELEASE=$(RELEASE)
 
-hypervisor:
+hypervisor: hvdefconfig
 	$(MAKE) $(HV_MAKEOPTS)
 	@echo -e "ACRN Configuration Summary:" > $(HV_CFG_LOG)
 	@$(MAKE) showconfig $(HV_MAKEOPTS) -s >> $(HV_CFG_LOG)


### PR DESCRIPTION
Add the 'hvdefconfig' as a pre-requisite before building the hypervisor.
This solves the problem when using multiple parallel threads (i.e.
"make -j2").

Tracked-On: #5874
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>