### PR TITLE
Paging/Memory Modularization, Part 1 - PageTable

### DIFF
--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -222,7 +222,7 @@ uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 	void *eptp;
 
 	eptp = get_ept_entry(vm);
-	pgentry = lookup_address((uint64_t *)eptp, gpa, &pg_size, &vm->arch_vm.ept_pgtable);
+	pgentry = pgtable_lookup_entry((uint64_t *)eptp, gpa, &pg_size, &vm->arch_vm.ept_pgtable);
 	if (pgentry != NULL) {
 		hpa = (((*pgentry & (~EPT_PFN_HIGH_MASK)) & (~(pg_size - 1UL)))
 				| (gpa & (pg_size - 1UL)));

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -294,7 +294,7 @@ void ept_add_mr(struct acrn_vm *vm, uint64_t *pml4_page,
 
 	spinlock_obtain(&vm->ept_lock);
 
-	mmu_add(pml4_page, hpa, gpa, size, prot, &vm->arch_vm.ept_pgtable);
+	pgtable_add_map(pml4_page, hpa, gpa, size, prot, &vm->arch_vm.ept_pgtable);
 
 	spinlock_release(&vm->ept_lock);
 
@@ -311,7 +311,7 @@ void ept_modify_mr(struct acrn_vm *vm, uint64_t *pml4_page,
 
 	spinlock_obtain(&vm->ept_lock);
 
-	mmu_modify_or_del(pml4_page, gpa, size, local_prot, prot_clr, &(vm->arch_vm.ept_pgtable), MR_MODIFY);
+	pgtable_modify_or_del_map(pml4_page, gpa, size, local_prot, prot_clr, &(vm->arch_vm.ept_pgtable), MR_MODIFY);
 
 	spinlock_release(&vm->ept_lock);
 
@@ -326,7 +326,7 @@ void ept_del_mr(struct acrn_vm *vm, uint64_t *pml4_page, uint64_t gpa, uint64_t 
 
 	spinlock_obtain(&vm->ept_lock);
 
-	mmu_modify_or_del(pml4_page, gpa, size, 0UL, 0UL, &vm->arch_vm.ept_pgtable, MR_DEL);
+	pgtable_modify_or_del_map(pml4_page, gpa, size, 0UL, 0UL, &(vm->arch_vm.ept_pgtable), MR_DEL);
 
 	spinlock_release(&vm->ept_lock);
 

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -446,8 +446,3 @@ void walk_ept_table(struct acrn_vm *vm, pge_handler cb)
 		}
 	}
 }
-
-struct page *alloc_ept_page(struct acrn_vm *vm)
-{
-	return alloc_page(vm->arch_vm.ept_pgtable.pool);
-}

--- a/hypervisor/arch/x86/guest/trusty.c
+++ b/hypervisor/arch/x86/guest/trusty.c
@@ -90,8 +90,6 @@ void destroy_secure_world(struct acrn_vm *vm, bool need_clr_mem)
 		}
 
 		ept_del_mr(vm, vm->arch_vm.sworld_eptp, gpa_uos, size);
-		/* sanitize trusty ept page-structures */
-		sanitize_pte((uint64_t *)vm->arch_vm.sworld_eptp, &vm->arch_vm.ept_pgtable);
 		vm->arch_vm.sworld_eptp = NULL;
 
 		/* Restore memory to guest normal world */

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -504,7 +504,6 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 
 	init_ept_pgtable(&vm->arch_vm.ept_pgtable, vm->vm_id);
 	vm->arch_vm.nworld_eptp = pgtable_create_root(&vm->arch_vm.ept_pgtable);
-	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp, &vm->arch_vm.ept_pgtable);
 
 	(void)memcpy_s(&vm->uuid[0], sizeof(vm->uuid),
 		&vm_config->uuid[0], sizeof(vm_config->uuid));

--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -503,7 +503,7 @@ int32_t create_vm(uint16_t vm_id, uint64_t pcpu_bitmap, struct acrn_vm_config *v
 	vm->hw.created_vcpus = 0U;
 
 	init_ept_pgtable(&vm->arch_vm.ept_pgtable, vm->vm_id);
-	vm->arch_vm.nworld_eptp = alloc_ept_page(vm);
+	vm->arch_vm.nworld_eptp = pgtable_create_root(&vm->arch_vm.ept_pgtable);
 	sanitize_pte((uint64_t *)vm->arch_vm.nworld_eptp, &vm->arch_vm.ept_pgtable);
 
 	(void)memcpy_s(&vm->uuid[0], sizeof(vm->uuid),

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -307,7 +307,7 @@ void init_paging(void)
 	}
 
 	/* Allocate memory for Hypervisor PML4 table */
-	ppt_mmu_pml4_addr = alloc_page(ppt_pgtable.pool);
+	ppt_mmu_pml4_addr = pgtable_create_root(&ppt_pgtable);
 
 	/* Map all memory regions to UC attribute */
 	pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, 0UL, 0UL, high64_max_ram - 0UL, attr_uc, &ppt_pgtable);

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -263,7 +263,7 @@ void ppt_clear_user_bit(uint64_t base, uint64_t size)
 	base_aligned = round_pde_down(base);
 	size_aligned = region_end - base_aligned;
 
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, base_aligned,
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, base_aligned,
 		round_pde_up(size_aligned), 0UL, PAGE_USER, &ppt_pgtable, MR_MODIFY);
 }
 
@@ -274,10 +274,10 @@ void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add)
 	uint64_t size_aligned = round_pde_up(region_end - base_aligned);
 
 	if (add) {
-		mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr,
+		pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr,
 			base_aligned, size_aligned, PAGE_NX, 0UL, &ppt_pgtable, MR_MODIFY);
 	} else {
-		mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr,
+		pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr,
 			base_aligned, size_aligned, 0UL, PAGE_NX, &ppt_pgtable, MR_MODIFY);
 	}
 }
@@ -310,7 +310,7 @@ void init_paging(void)
 	ppt_mmu_pml4_addr = alloc_page(ppt_pgtable.pool);
 
 	/* Map all memory regions to UC attribute */
-	mmu_add((uint64_t *)ppt_mmu_pml4_addr, 0UL, 0UL, high64_max_ram - 0UL, attr_uc, &ppt_pgtable);
+	pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, 0UL, 0UL, high64_max_ram - 0UL, attr_uc, &ppt_pgtable);
 
 	/* Modify WB attribute for E820_TYPE_RAM */
 	for (i = 0U; i < entries_count; i++) {
@@ -325,10 +325,10 @@ void init_paging(void)
 		}
 	}
 
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, 0UL, round_pde_up(low32_max_ram),
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, 0UL, round_pde_up(low32_max_ram),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK, &ppt_pgtable, MR_MODIFY);
 
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (1UL << 32U), high64_max_ram - (1UL << 32U),
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, (1UL << 32U), high64_max_ram - (1UL << 32U),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK, &ppt_pgtable, MR_MODIFY);
 
 	/*
@@ -339,7 +339,7 @@ void init_paging(void)
 	 * simply treat the return value of get_hv_image_base() as HPA.
 	 */
 	hv_hva = get_hv_image_base();
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, hv_hva & PDE_MASK,
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, hv_hva & PDE_MASK,
 			CONFIG_HV_RAM_SIZE + (((hv_hva & (PDE_SIZE - 1UL)) != 0UL) ? PDE_SIZE : 0UL),
 			PAGE_CACHE_WB, PAGE_CACHE_MASK | PAGE_USER, &ppt_pgtable, MR_MODIFY);
 
@@ -347,11 +347,11 @@ void init_paging(void)
 	 * remove 'NX' bit for pages that contain hv code section, as by default XD bit is set for
 	 * all pages, including pages for guests.
 	 */
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, round_pde_down(hv_hva),
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, round_pde_down(hv_hva),
 			round_pde_up((uint64_t)&ld_text_end) - round_pde_down(hv_hva), 0UL,
 			PAGE_NX, &ppt_pgtable, MR_MODIFY);
 #if (SOS_VM_NUM == 1)
-	mmu_modify_or_del((uint64_t *)ppt_mmu_pml4_addr, (uint64_t)get_sworld_memory_base(),
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr, (uint64_t)get_sworld_memory_base(),
 			TRUSTY_RAM_SIZE * MAX_POST_VM_NUM, PAGE_USER, 0UL, &ppt_pgtable, MR_MODIFY);
 #endif
 
@@ -360,7 +360,7 @@ void init_paging(void)
 	 */
 
 	if ((HI_MMIO_START != ~0UL) && (HI_MMIO_END != 0UL)) {
-		mmu_add((uint64_t *)ppt_mmu_pml4_addr, HI_MMIO_START, HI_MMIO_START,
+		pgtable_add_map((uint64_t *)ppt_mmu_pml4_addr, HI_MMIO_START, HI_MMIO_START,
 			(HI_MMIO_END - HI_MMIO_START), attr_uc, &ppt_pgtable);
 	}
 

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -244,7 +244,7 @@ static void modify_or_del_pdpte(const uint64_t *pml4e, uint64_t vaddr_start, uin
  * type: MR_DEL
  * delete [vaddr_base, vaddr_base + size ) memory region page table mapping.
  */
-void mmu_modify_or_del(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
+void pgtable_modify_or_del_map(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
 		uint64_t prot_set, uint64_t prot_clr, const struct pgtable *table, uint32_t type)
 {
 	uint64_t vaddr = round_page_up(vaddr_base);
@@ -402,8 +402,8 @@ static void add_pdpte(const uint64_t *pml4e, uint64_t paddr_start, uint64_t vadd
  * add [vaddr_base, vaddr_base + size ) memory region page table mapping.
  * @pre: the prot should set before call this function.
  */
-void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base, uint64_t size, uint64_t prot,
-		const struct pgtable *table)
+void pgtable_add_map(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base,
+		uint64_t size, uint64_t prot, const struct pgtable *table)
 {
 	uint64_t vaddr, vaddr_next, vaddr_end;
 	uint64_t paddr;

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -485,7 +485,7 @@ void *pgtable_create_trusty_root(const struct pgtable *table,
 /**
  * @pre (pml4_page != NULL) && (pg_size != NULL)
  */
-const uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr, uint64_t *pg_size, const struct pgtable *table)
+const uint64_t *pgtable_lookup_entry(uint64_t *pml4_page, uint64_t addr, uint64_t *pg_size, const struct pgtable *table)
 {
 	const uint64_t *pret = NULL;
 	bool present = true;

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -430,6 +430,11 @@ void pgtable_add_map(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_ba
 	}
 }
 
+void *pgtable_create_root(const struct pgtable *table)
+{
+	return (uint64_t *)alloc_page(table->pool);
+}
+
 /**
  * @pre (pml4_page != NULL) && (pg_size != NULL)
  */

--- a/hypervisor/arch/x86/pagetable.c
+++ b/hypervisor/arch/x86/pagetable.c
@@ -435,6 +435,53 @@ void *pgtable_create_root(const struct pgtable *table)
 	return (uint64_t *)alloc_page(table->pool);
 }
 
+void *pgtable_create_trusty_root(const struct pgtable *table,
+	void *nworld_pml4_page, uint64_t prot_table_present, uint64_t prot_clr)
+{
+	uint16_t i;
+	uint64_t pdpte, *dest_pdpte_p, *src_pdpte_p;
+	uint64_t nworld_pml4e, sworld_pml4e;
+	void *sub_table_addr, *pml4_base;
+
+	/* Copy PDPT entries from Normal world to Secure world
+	 * Secure world can access Normal World's memory,
+	 * but Normal World can not access Secure World's memory.
+	 * The PML4/PDPT for Secure world are separated from
+	 * Normal World.PD/PT are shared in both Secure world's EPT
+	 * and Normal World's EPT
+	 */
+	pml4_base = alloc_page(table->pool);
+	sanitize_pte((uint64_t *)pml4_base, table);
+
+	/* The trusty memory is remapped to guest physical address
+	 * of gpa_rebased to gpa_rebased + size
+	 */
+	sub_table_addr = alloc_page(table->pool);
+	sworld_pml4e = hva2hpa(sub_table_addr) | prot_table_present;
+	set_pgentry((uint64_t *)pml4_base, sworld_pml4e, table);
+
+	nworld_pml4e = get_pgentry((uint64_t *)nworld_pml4_page);
+
+	/*
+	 * copy PTPDEs from normal world EPT to secure world EPT,
+	 * and remove execute access attribute in these entries
+	 */
+	dest_pdpte_p = pml4e_page_vaddr(sworld_pml4e);
+	src_pdpte_p = pml4e_page_vaddr(nworld_pml4e);
+	for (i = 0U; i < (uint16_t)(PTRS_PER_PDPTE - 1UL); i++) {
+		pdpte = get_pgentry(src_pdpte_p);
+		if ((pdpte & prot_table_present) != 0UL) {
+			pdpte &= ~prot_clr;
+			set_pgentry(dest_pdpte_p, pdpte, table);
+		}
+		src_pdpte_p++;
+		dest_pdpte_p++;
+	}
+
+	return pml4_base;
+}
+
+
 /**
  * @pre (pml4_page != NULL) && (pg_size != NULL)
  */

--- a/hypervisor/include/arch/x86/guest/ept.h
+++ b/hypervisor/include/arch/x86/guest/ept.h
@@ -164,16 +164,6 @@ void walk_ept_table(struct acrn_vm *vm, pge_handler cb);
  */
 int32_t ept_misconfig_vmexit_handler(__unused struct acrn_vcpu *vcpu);
 
-/**
- * @brief allocate a page from the VM's EPT pagetable page pool
- *
- * @param[in] vm the pointer that points to VM data structure
- *
- * @retval a page pointer if there's available used pages in the VM's EPT
- *         pagetable page pool, null otherwise.
- */
-struct page *alloc_ept_page(struct acrn_vm *vm);
-
 void init_ept_pgtable(struct pgtable *table, uint16_t vm_id);
 void reserve_buffer_for_ept_pages(void);
 #endif /* EPT_H */

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -81,8 +81,6 @@ static inline uint64_t round_pde_down(uint64_t val)
 #define PAGE_SIZE_2M	MEM_2M
 #define PAGE_SIZE_1G	MEM_1G
 
-void sanitize_pte_entry(uint64_t *ptep, const struct pgtable *table);
-void sanitize_pte(uint64_t *pt_page, const struct pgtable *table);
 /**
  * @brief MMU paging enable
  *

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -109,10 +109,6 @@ void enable_smap(void);
  * @return None
  */
 void init_paging(void);
-void mmu_add(uint64_t *pml4_page, uint64_t paddr_base, uint64_t vaddr_base,
-		uint64_t size, uint64_t prot, const struct pgtable *table);
-void mmu_modify_or_del(uint64_t *pml4_page, uint64_t vaddr_base, uint64_t size,
-		uint64_t prot_set, uint64_t prot_clr, const struct pgtable *table, uint32_t type);
 void ppt_clear_user_bit(uint64_t base, uint64_t size);
 void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add);
 

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -310,7 +310,7 @@ void *pgtable_create_trusty_root(const struct pgtable *table,
 /**
  *@pre (pml4_page != NULL) && (pg_size != NULL)
  */
-const uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
+const uint64_t *pgtable_lookup_entry(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, const struct pgtable *table);
 
 void pgtable_add_map(uint64_t *pml4_page, uint64_t paddr_base,

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -304,6 +304,7 @@ static inline uint64_t pdpte_large(uint64_t pdpte)
 	return pdpte & PAGE_PSE;
 }
 
+void *pgtable_create_root(const struct pgtable *table);
 /**
  *@pre (pml4_page != NULL) && (pg_size != NULL)
  */

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -305,6 +305,8 @@ static inline uint64_t pdpte_large(uint64_t pdpte)
 }
 
 void *pgtable_create_root(const struct pgtable *table);
+void *pgtable_create_trusty_root(const struct pgtable *table,
+	void *nworld_pml4_page, uint64_t prot_table_present, uint64_t prot_clr);
 /**
  *@pre (pml4_page != NULL) && (pg_size != NULL)
  */

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -310,6 +310,12 @@ static inline uint64_t pdpte_large(uint64_t pdpte)
 const uint64_t *lookup_address(uint64_t *pml4_page, uint64_t addr,
 		uint64_t *pg_size, const struct pgtable *table);
 
+void pgtable_add_map(uint64_t *pml4_page, uint64_t paddr_base,
+		uint64_t vaddr_base, uint64_t size,
+		uint64_t prot, const struct pgtable *table);
+void pgtable_modify_or_del_map(uint64_t *pml4_page, uint64_t vaddr_base,
+		uint64_t size, uint64_t prot_set, uint64_t prot_clr,
+		const struct pgtable *table, uint32_t type);
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -304,6 +304,8 @@ static inline uint64_t pdpte_large(uint64_t pdpte)
 	return pdpte & PAGE_PSE;
 }
 
+void init_sanitized_page(uint64_t *sanitized_page, uint64_t hpa);
+
 void *pgtable_create_root(const struct pgtable *table);
 void *pgtable_create_trusty_root(const struct pgtable *table,
 	void *nworld_pml4_page, uint64_t prot_table_present, uint64_t prot_clr);


### PR DESCRIPTION
This patch series reshuffle pagetable module. The goal is to provides the
stable interfaces and data structure for this module. For PageTable, we should
provide interfaces to add/modify/del Page Table Mapping; we also need to provide
interfaces to create the root page table entry and to lookup a page table entry.

The page table date structure:
struct pgtable {
        uint64_t flags;
        uint64_t default_access_right;
        struct page_pool *pool;
        bool (*large_page_support)(enum _page_table_level level, uint64_t prot);
        uint64_t (*pgentry_present)(uint64_t pte);
        void (*tweak_exe_right)(uint64_t *entry);
        void (*recover_exe_right)(uint64_t *entry);
};

The page table external interfaces:
 ----------
 | paging |
 ----------
     |
     | pgtable_create_root
     | pgtable_create_trusty_root
     | pgtable_add_map                      ------------        alloc_page               -------------
     |-------------------------------------> |  pgtable | ------------------------> | page pool |
     | pgtable_modify_or_del_map            ------------         free_page               -------------
     | pgtable_lookup_entry
     |
 ---------
 |  EPT  |
 ---------


TODO:
1. remove clflush_pagewalk API once Cache module has been reshuffled.
2. pgtable only provides these six external interfaces listed above once EPT module has been reshuffled.

v2:
1. move sanitize_pte into pagetable.c
2. rename mmu_modify_or_del to pgtable_modify_or_del_map
3. refine pgtable_create_trusty_root

Tracked-On: #5830
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Reviewed-by: Jason Chen CJ <jason.cj.chen@intel.com>
