### PR TITLE
config-tools: modify sample launch scripts

### DIFF
--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (C) 2019 Intel Corporation.
 # SPDX-License-Identifier: BSD-3-Clause
-# This is an example of launch script for KBL NUC7i7DNH, may need to revise for other platform.
+# This is an example, if use different HW,the script must be adapted to match the BDF on the actual HW platform
 
 # pci devices for passthru
 declare -A passthru_vpid
@@ -39,9 +39,6 @@ echo ${passthru_vpid["nvme"]} > /sys/bus/pci/drivers/pci-stub/new_id
 echo ${passthru_bdf["nvme"]} > /sys/bus/pci/devices/${passthru_bdf["nvme"]}/driver/unbind
 echo ${passthru_bdf["nvme"]} > /sys/bus/pci/drivers/pci-stub/bind
 
-# for pm setting
-pm_channel="--pm_notify_channel uart "
-pm_by_vuart="--pm_by_vuart tty,/dev/ttyS1"
 
 
 /usr/bin/acrn-dm -A -m $mem_size -s 0:0,hostbridge \
@@ -51,7 +48,6 @@ pm_by_vuart="--pm_by_vuart tty,/dev/ttyS1"
    -U 495ae2e5-2603-4d64-af76-d4bc5a8ec0e5 \
    -s 2,passthru,02/0/0 \
    -s 3,virtio-console,@stdio:stdio_port \
-   $pm_channel $pm_by_vuart \
    --ovmf /usr/share/acrn/bios/OVMF.fd \
    hard_rtvm
 

--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh
@@ -94,10 +94,6 @@ fi
 #logger_setting, format: logger_name,level; like following
 logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
 
-#for pm by vuart setting
-pm_channel="--pm_notify_channel uart "
-pm_by_vuart="--pm_by_vuart pty,/run/acrn/life_mngr_"$vm_name
-pm_vuart_node=" -s 1:0,lpc -l com2,/run/acrn/life_mngr_"$vm_name
 
 #for memsize setting
 mem_size=2048M
@@ -110,7 +106,6 @@ acrn-dm -A -m $mem_size -s 0:0,hostbridge \
   -s 4,virtio-net,tap0 \
   -s 7,virtio-rnd \
   --ovmf /usr/share/acrn/bios/OVMF.fd \
-  $pm_channel $pm_by_vuart $pm_vuart_node \
   $logger_setting \
   --mac_seed $mac_seed \
   $vm_name


### PR DESCRIPTION
Remove the Power Management ('pm') parameters from the sample launch scripts,
and update the comments, At most one VM is allowed to use "--pm_notify_channel uart"
at a time, since only one socket connection to SOS life_mngr is allowed.
Remove it by default and allow user to add on demand

Tracked-On: #5736
Signed-off-by: li shuang <shuangx.li@intel.com>