### PR TITLE
DM: gvt: Identical mapping for GPU DSM refine to support EHL/TGL

### DIFF
--- a/devicemodel/hw/pci/core.c
+++ b/devicemodel/hw/pci/core.c
@@ -1387,7 +1387,7 @@ init_pci(struct vmctx *ctx)
 	uint64_t bus0_memlimit;
 
 	pci_emul_iobase = PCI_EMUL_IOBASE;
-	pci_emul_membase32 = vm_get_lowmem_limit(ctx);
+	pci_emul_membase32 = PCI_EMUL_MEMBASE32;
 	pci_emul_membase64 = PCI_EMUL_MEMBASE64;
 
 	create_gsi_sharing_groups();

--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -49,7 +49,7 @@
 #define	PCI_EMUL_MEMLIMIT64	0x140000000UL	/* 5GB */
 
 #define SOFTWARE_SRAM_MAX_SIZE	0x00800000UL
-#define SOFTWARE_SRAM_BASE_GPA	(PCI_EMUL_MEMBASE32 - SOFTWARE_SRAM_MAX_SIZE)
+#define SOFTWARE_SRAM_BASE_GPA	0x50000000UL
 
 /* Currently,only gvt need reserved bar regions,
  * so just hardcode REGION_NUMS=5 here

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,7 +1066,7 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
-#define INTEL_ELKHARTLAKE		0x4551
+#define INTEL_ELKHARTLAKE		0x4571
 #define INTEL_TIGERLAKE		0x9a49
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
 #define PCIR_GEN11_BDSM_DW0		0xC0

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        9
+#define NUM_E820_ENTRIES        5
 #define LOWRAM_E820_ENTRY       1
-#define HIGHRAM_E820_ENTRY      6
+#define HIGHRAM_E820_ENTRY      4
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {


### PR DESCRIPTION
Windows graphic driver obtains DSM address from in-BAR mmio register
which has passthroughed. Not like the other platforms obtained from
pci configure space register which has virtualized. GPU GuC must use
WOPCM in DSM, besides, Windows OS wants to manage DSM also. These two
reason force acrn has to keep identical mapping to avoid trap mmio
BAR to do the emulation.

To keep simple, this patch reserve a big address range hole for DSM
& opregion of gpu in vE820 table, this will cause memory waste here.
In the near future, we need refine the entire vE820 logic as it is
hard to maintained due to many reserved regions have introduced in
recently.

Tracked-On: #5880
Signed-off-by: Peng Sun <peng.p.sun@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>