### PR TITLE
hv: add missing arch specific path for included pre_cpu.h

### DIFF
--- a/hypervisor/common/sched_iorr.c
+++ b/hypervisor/common/sched_iorr.c
@@ -5,7 +5,7 @@
  */
 
 #include <list.h>
-#include <per_cpu.h>
+#include <x86/per_cpu.h>
 #include <schedule.h>
 
 #define CONFIG_SLICE_MS 10UL

--- a/hypervisor/common/sched_noop.c
+++ b/hypervisor/common/sched_noop.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <per_cpu.h>
+#include <x86/per_cpu.h>
 #include <schedule.h>
 
 static int32_t sched_noop_init(struct sched_control *ctl)


### PR DESCRIPTION
Tracked-On: #5825
Signed-off-by: Zide Chen <zide.chen@intel.com>