### PR TITLE
DM: gvt: Identical mapping for GPU DSM refine to support EHL/TGL

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -1095,13 +1095,13 @@ int create_and_inject_vrtct(struct vmctx *ctx)
 	uint8_t *vrtct;
 	struct vm_memmap memmap = {
 		.type = VM_MMIO,
-		.gpa = SOFTWARE_SRAM_BASE_GPA,
 		/* HPA base and size of Software SRAM shall be parsed from vRTCT. */
 		.hpa = 0,
 		.len = 0,
 		.prot = PROT_ALL
 	};
 
+	memmap.gpa = get_software_sram_base_gpa();
 	native_rtct_fd = open(RTCT_NATIVE_FILE_PATH_IN_SOS, O_RDONLY);
 	if (native_rtct_fd < 0) {
 		pr_err("failed to open /sys/firmware/acpi/tables/PTCT !!!!! errno:%d\n", errno);

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,8 +1066,8 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
-#define INTEL_ELKHARTLAKE		0x4551
-#define INTEL_TIGERLAKE		0x9a49
+#define INTEL_ELKHARTLAKE		0x4571
+#define INTEL_TIGERLAKE			0x9a49
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
 #define PCIR_GEN11_BDSM_DW0		0xC0
 #define PCIR_GEN11_BDSM_DW1		0xC4

--- a/devicemodel/include/sw_load.h
+++ b/devicemodel/include/sw_load.h
@@ -39,9 +39,9 @@
 #define E820_TYPE_ACPI_NVS      4U   /* EFI 10 */
 #define E820_TYPE_UNUSABLE      5U   /* EFI 8 */
 
-#define NUM_E820_ENTRIES        9
-#define LOWRAM_E820_ENTRY       1
-#define HIGHRAM_E820_ENTRY      6
+#define NUM_E820_ENTRIES	7
+#define LOWRAM_E820_ENTRY	1
+#define HIGHRAM_E820_ENTRY	6
 
 /* Defines a single entry in an E820 memory map. */
 struct e820_entry {


### PR DESCRIPTION
Windows graphic driver obtains DSM address from in-BAR mmio register
which has passthroughed. Not like the other platforms obtained from
pci configure space register which has virtualized. GPU GuC must use
WOPCM in DSM, besides, Windows OS wants to manage DSM also. These two
reason force acrn has to keep identical mapping to avoid trap mmio
BAR to do the emulation.

Tracked-On: #5880
Signed-off-by: Peng Sun <peng.p.sun@intel.com>