### PR TITLE
doc: update doc build instructions

### DIFF
--- a/doc/tutorials/docbuild.rst
+++ b/doc/tutorials/docbuild.rst
@@ -131,11 +131,12 @@ and these other tools:
 * sphinx                    version: 3.2.1
 * docutils                  version: 0.16
 * sphinx-rtd-theme          version: 0.5.0
-* kconfiglib                version: 14.1.0
 * sphinx-tabs               version: 1.3.0
 * doxygen                   version: 1.8.13
 
-Depending on your Linux version, install the needed tools.
+Depending on your Linux version, install the needed tools. You may get a
+different (newer) version of doxygen noted above that may also work.
+
 For Ubuntu use:
 
   .. code-block:: bash


### PR DESCRIPTION
We've validated doc build tool versions, so let's make sure those are
the versions the instructions say to install.  The version of doxygen
you get when you use ``sudo apt install doxygen`` may get a newer
version that may still work so let's tell them that.

Also, we no longer use kconfig files in the document build process, so
remove mentioning that in the build documentation.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>