### PR TITLE
hv: fix some minor bug 

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -402,6 +402,10 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 			case 0x10U:
 			/* Intel Processor Trace */
 			case 0x14U:
+			/* PCONFIG */
+			case 0x1bU:
+			/* V2 Extended Topology Enumeration Leaf */
+			case 0x1fU:
 				break;
 			default:
 				init_vcpuid_entry(i, 0U, 0U, &entry);

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -119,6 +119,7 @@ uint64_t prepare_trampoline(void)
 			(size_t)size);
 	update_trampoline_code_refs(dest_pa);
 
+	cpu_memory_barrier();
 	for (i = 0UL; i < size; i = i + CACHE_LINE_SIZE) {
 		clflush(hpa2hva(dest_pa + i));
 	}


### PR DESCRIPTION
v2:
1. hide new cpuid 0x1f

v1:
1. Use MFENCE to enforce fast string operations was done
2.  Hide CPUID.1b and Use CPUID.0b to emulate CPUID.1f
 
Tracked-On: #5929
Signed-off-by: Li Fei1 <fei1.li@intel.com>