### PR TITLE
config-tools: change default industry kata vm id to 7

### DIFF
--- a/misc/config_tools/config_app/views.py
+++ b/misc/config_tools/config_app/views.py
@@ -973,7 +973,7 @@ def get_generic_scenario_config(scenario_config, add_vm_type=None):
             'SOS_VM': ('industry', 'vm:id=0'),
             'POST_STD_VM': ('industry', 'vm:id=1'),
             'POST_RT_VM': ('industry', 'vm:id=2'),
-            'KATA_VM': ('industry', 'vm:id=1'),
+            'KATA_VM': ('industry', 'vm:id=7'),
             'LAUNCH_POST_STD_VM': ('industry_launch_2uos', 'uos:id=1'),
             'LAUNCH_POST_RT_VM': ('industry_launch_2uos', 'uos:id=2')
         }

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -1,39 +1,36 @@
-<?xml version="1.0"?>
 <acrn-config board="tgl-rvp" scenario="industry">
   <hv>
     <DEBUG_OPTIONS>
-        <RELEASE>n</RELEASE>
-        <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
-        <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
-        <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
-        <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
-        <LOG_DESTINATION>7</LOG_DESTINATION>
-        <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
+      <RELEASE>n</RELEASE>
+      <SERIAL_CONSOLE>/dev/ttyS0</SERIAL_CONSOLE>
+      <MEM_LOGLEVEL>5</MEM_LOGLEVEL>
+      <NPK_LOGLEVEL>5</NPK_LOGLEVEL>
+      <CONSOLE_LOGLEVEL>3</CONSOLE_LOGLEVEL>
+      <LOG_DESTINATION>7</LOG_DESTINATION>
+      <LOG_BUF_SIZE>0x40000</LOG_BUF_SIZE>
     </DEBUG_OPTIONS>
-
     <FEATURES>
-        <RELOC>y</RELOC>
-        <SCHEDULER>SCHED_BVT</SCHEDULER>
-        <MULTIBOOT2>y</MULTIBOOT2>
-        <ENFORCE_TURNOFF_AC>y</ENFORCE_TURNOFF_AC>
-        <RDT>
-            <RDT_ENABLED>n</RDT_ENABLED>
-            <CDP_ENABLED>n</CDP_ENABLED>
-        </RDT>
-        <HYPERV_ENABLED>y</HYPERV_ENABLED>
-        <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
-        <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
-        <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
-        <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
-        <IVSHMEM>
-            <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
-            <IVSHMEM_REGION/>
-        </IVSHMEM>
-        <PSRAM>
-            <PSRAM_ENABLED>n</PSRAM_ENABLED>
-        </PSRAM>
+      <RELOC>y</RELOC>
+      <SCHEDULER>SCHED_BVT</SCHEDULER>
+      <MULTIBOOT2>y</MULTIBOOT2>
+      <ENFORCE_TURNOFF_AC>y</ENFORCE_TURNOFF_AC>
+      <RDT>
+        <RDT_ENABLED>n</RDT_ENABLED>
+        <CDP_ENABLED>n</CDP_ENABLED>
+      </RDT>
+      <HYPERV_ENABLED>y</HYPERV_ENABLED>
+      <IOMMU_ENFORCE_SNP>n</IOMMU_ENFORCE_SNP>
+      <ACPI_PARSE_ENABLED>y</ACPI_PARSE_ENABLED>
+      <L1D_VMENTRY_ENABLED>n</L1D_VMENTRY_ENABLED>
+      <MCE_ON_PSC_DISABLED>n</MCE_ON_PSC_DISABLED>
+      <IVSHMEM>
+        <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
+        <IVSHMEM_REGION></IVSHMEM_REGION>
+      </IVSHMEM>
+      <PSRAM>
+        <PSRAM_ENABLED>n</PSRAM_ENABLED>
+      </PSRAM>
     </FEATURES>
-
     <MEMORY>
         <STACK_SIZE>0x2000</STACK_SIZE>
         <HV_RAM_SIZE/>
@@ -41,186 +38,330 @@
         <LOW_RAM_SIZE>0x00010000</LOW_RAM_SIZE>
         <PLATFORM_RAM_SIZE>0x480000000</PLATFORM_RAM_SIZE>
     </MEMORY>
-
     <CAPACITIES>
-        <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
-        <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
-        <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
-        <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
-        <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
-        <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
-        <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
-        <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
+      <IOMMU_BUS_NUM>0x100</IOMMU_BUS_NUM>
+      <MAX_IR_ENTRIES>256</MAX_IR_ENTRIES>
+      <MAX_IOAPIC_NUM>1</MAX_IOAPIC_NUM>
+      <MAX_PCI_DEV_NUM>96</MAX_PCI_DEV_NUM>
+      <MAX_IOAPIC_LINES>120</MAX_IOAPIC_LINES>
+      <MAX_PT_IRQ_ENTRIES>64</MAX_PT_IRQ_ENTRIES>
+      <MAX_MSIX_TABLE_NUM>64</MAX_MSIX_TABLE_NUM>
+      <MAX_EMULATED_MMIO>16</MAX_EMULATED_MMIO>
     </CAPACITIES>
-
     <MISC_CFG>
-        <GPU_SBDF>0x00000010</GPU_SBDF>
+      <GPU_SBDF>0x00000010</GPU_SBDF>
     </MISC_CFG>
   </hv>
-
   <vm id="0">
     <vm_type>SOS_VM</vm_type>
     <name>ACRN SOS VM</name>
     <guest_flags>
-        <guest_flag/>
+      <guest_flag></guest_flag>
     </guest_flags>
     <clos>
-        <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
     </clos>
     <memory>
-        <start_hpa>0</start_hpa>
-        <size>0x20000000</size>
+      <start_hpa>0</start_hpa>
+      <size>0x20000000</size>
     </memory>
     <os_config>
-        <name>ACRN Service OS</name>
-        <kern_type>KERNEL_BZIMAGE</kern_type>
-        <kern_mod>Linux_bzImage</kern_mod>
-        <ramdisk_mod/>
-        <bootargs>SOS_VM_BOOTARGS</bootargs>
+      <name>ACRN Service OS</name>
+      <kern_type>KERNEL_BZIMAGE</kern_type>
+      <kern_mod>Linux_bzImage</kern_mod>
+      <ramdisk_mod></ramdisk_mod>
+      <bootargs>SOS_VM_BOOTARGS</bootargs>
     </os_config>
     <legacy_vuart id="0">
-        <type>VUART_LEGACY_PIO</type>
-        <base>SOS_COM1_BASE</base>
-        <irq>SOS_COM1_IRQ</irq>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SOS_COM1_BASE</base>
+      <irq>SOS_COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>SOS_COM2_BASE</base>
-        <irq>SOS_COM2_IRQ</irq>
-        <target_vm_id>2</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>SOS_COM2_BASE</base>
+      <irq>SOS_COM2_IRQ</irq>
+      <target_vm_id>2</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base>INVALID_PCI_BASE</base>
+      <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base>INVALID_PCI_BASE</base>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </communication_vuart>
     <pci_devs>
-        <pci_dev/>
+      <pci_dev></pci_dev>
     </pci_devs>
     <board_private>
-        <rootfs>/dev/nvme0n1p3</rootfs>
-        <bootargs>        rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1
+      <rootfs>/dev/nvme0n1p3</rootfs>
+      <bootargs>        rw rootwait console=ttyS0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1
     </bootargs>
     </board_private>
   </vm>
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-        <guest_flag/>
+      <guest_flag></guest_flag>
     </guest_flags>
     <cpu_affinity>
-        <pcpu_id>0</pcpu_id>
-        <pcpu_id>1</pcpu_id>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
     </cpu_affinity>
     <clos>
-        <vcpu_clos>0</vcpu_clos>
-        <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section>
-        <base>0</base>
-        <size>0</size>
+      <base>0</base>
+      <size>0</size>
     </epc_section>
-
     <legacy_vuart id="0">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM1_BASE</base>
-        <irq>COM1_IRQ</irq>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base>INVALID_PCI_BASE</base>
+      <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base>INVALID_PCI_BASE</base>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
     <guest_flags>
-        <guest_flag>0</guest_flag>
+      <guest_flag></guest_flag>
     </guest_flags>
     <cpu_affinity>
-        <pcpu_id>2</pcpu_id>
-        <pcpu_id>3</pcpu_id>
+      <pcpu_id>2</pcpu_id>
+      <pcpu_id>3</pcpu_id>
     </cpu_affinity>
     <clos>
-        <vcpu_clos>0</vcpu_clos>
-        <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section>
-        <base>0</base>
-        <size>0</size>
+      <base>0</base>
+      <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM1_BASE</base>
-        <irq>COM1_IRQ</irq>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM2_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM2_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base>INVALID_PCI_BASE</base>
+      <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base>INVALID_PCI_BASE</base>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-        <guest_flag>0</guest_flag>
+      <guest_flag></guest_flag>
     </guest_flags>
     <cpu_affinity>
-        <pcpu_id>0</pcpu_id>
-        <pcpu_id>1</pcpu_id>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
     </cpu_affinity>
     <clos>
-        <vcpu_clos>0</vcpu_clos>
-        <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
     </clos>
     <epc_section>
-        <base>0</base>
-        <size>0</size>
+      <base>0</base>
+      <size>0</size>
     </epc_section>
     <legacy_vuart id="0">
-        <type>VUART_LEGACY_PIO</type>
-        <base>COM1_BASE</base>
-        <irq>COM1_IRQ</irq>
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
     </legacy_vuart>
     <legacy_vuart id="1">
-        <type>VUART_LEGACY_PIO</type>
-        <base>INVALID_COM_BASE</base>
-        <irq>COM2_IRQ</irq>
-        <target_vm_id>0</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </legacy_vuart>
     <console_vuart id="0">
-        <base>INVALID_PCI_BASE</base>
+      <base>INVALID_PCI_BASE</base>
     </console_vuart>
     <communication_vuart id="1">
-        <base>INVALID_PCI_BASE</base>
-        <target_vm_id>1</target_vm_id>
-        <target_uart_id>1</target_uart_id>
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
     </communication_vuart>
   </vm>
-
+  <vm id="4">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
+      <guest_flag></guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+  </vm>
+  <vm id="5">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
+      <guest_flag></guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+  </vm>
+  <vm id="6">
+    <vm_type>POST_STD_VM</vm_type>
+    <guest_flags>
+      <guest_flag></guest_flag>
+    </guest_flags>
+    <cpu_affinity>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>COM1_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+  </vm>
+  <vm id="7">
+    <vm_type>KATA_VM</vm_type>
+    <cpu_affinity>
+      <pcpu_id>0</pcpu_id>
+      <pcpu_id>1</pcpu_id>
+    </cpu_affinity>
+    <clos>
+      <vcpu_clos>0</vcpu_clos>
+      <vcpu_clos>0</vcpu_clos>
+    </clos>
+    <epc_section>
+      <base>0</base>
+      <size>0</size>
+    </epc_section>
+    <legacy_vuart id="0">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM1_IRQ</irq>
+    </legacy_vuart>
+    <legacy_vuart id="1">
+      <type>VUART_LEGACY_PIO</type>
+      <base>INVALID_COM_BASE</base>
+      <irq>COM2_IRQ</irq>
+      <target_vm_id>0</target_vm_id>
+      <target_uart_id>0</target_uart_id>
+    </legacy_vuart>
+    <console_vuart id="0">
+      <base>INVALID_PCI_BASE</base>
+    </console_vuart>
+    <communication_vuart id="1">
+      <base>INVALID_PCI_BASE</base>
+      <target_vm_id>1</target_vm_id>
+      <target_uart_id>1</target_uart_id>
+    </communication_vuart>
+  </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
@@ -1,0 +1,245 @@
+<acrn-config board="tgl-rvp" scenario="industry" uos_launcher="6">
+    <uos id="1">
+	<uos_type desc="UOS type">WINDOWS</uos_type>
+	<rtos_type desc="UOS Realtime capability">no</rtos_type>
+	<mem_size desc="UOS memory size in MByte">4096</mem_size>
+	<gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT.">gvtd</gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
+	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">WaaG</network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./win10-ltsc.img</block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]"></console>
+	</virtio_devices>
+    </uos>
+
+    <uos id="2">
+	<uos_type desc="UOS type">PREEMPT-RT LINUX</uos_type>
+	<rtos_type desc="UOS Realtime capability">Hard RT</rtos_type>
+	<mem_size desc="UOS memory size in MByte">1024</mem_size>
+	<gvt_args configurable="0" desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
+	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+		<pcpu_id></pcpu_id>
+	</cpu_affinity>
+	<shm_regions desc="List of shared memory regions for inter-VM communication.">
+		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
+	</shm_regions>
+	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+		<communication_vuart></communication_vuart>
+	</communication_vuarts>
+	<passthrough_devices>
+		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
+		<audio desc="vm audio device"></audio>
+		<audio_codec desc="vm audio codec device"></audio_codec>
+		<ipu desc="vm ipu device"></ipu>
+		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>
+		<cse desc="vm cse device"></cse>
+		<wifi desc="vm wifi device"></wifi>
+		<bluetooth desc="vm bluetooth"></bluetooth>
+		<sd_card desc="vm sd card device"></sd_card>
+		<ethernet desc="vm ethernet device"></ethernet>
+		<sata desc="vm sata device"></sata>
+		<nvme desc="vm nvme device"></nvme>
+	</passthrough_devices>
+
+	<virtio_devices>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<input desc="virtio input device"></input>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
+	</virtio_devices>
+    </uos>
+    <uos id="3">
+        <uos_type desc="UOS type">YOCTO</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+	    <shm_regions desc="List of shared memory regions for inter-VM communication.">
+		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
+	    </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="4">
+        <uos_type desc="UOS type">YOCTO</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+		    <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
+	    </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="5">
+        <uos_type desc="UOS type">YOCTO</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
+        </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+    <uos id="6">
+        <uos_type desc="UOS type">YOCTO</uos_type>
+        <rtos_type desc="UOS Realtime capability">no</rtos_type>
+        <mem_size desc="UOS memory size in MByte">512</mem_size>
+        <gvt_args desc="GVT settings. Set it to gvtd for GVTd, otherwise is GVTg arguments. The recommendation arguments for GVTg is 64 448 8. Leave it blank to disable GVT."></gvt_args>
+        <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
+        <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
+        <poweroff_channel desc="the method of power off uos" />
+        <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
+        <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
+            <pcpu_id />
+        </cpu_affinity>
+        <shm_regions desc="List of shared memory regions for inter-VM communication.">
+            <shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
+        </shm_regions>
+        <console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
+        <communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">
+            <communication_vuart></communication_vuart>
+        </communication_vuarts>
+        <passthrough_devices>
+            <usb_xdci desc="vm usb_xdci device" />
+            <audio desc="vm audio device" />
+            <audio_codec desc="vm audio codec device" />
+            <ipu desc="vm ipu device" />
+            <ipu_i2c desc="vm ipu_i2c device" />
+            <cse desc="vm cse device" />
+            <wifi desc="vm wifi device" />
+            <bluetooth desc="vm bluetooth" />
+            <sd_card desc="vm sd card device" />
+            <ethernet desc="vm ethernet device" />
+            <sata desc="vm sata device" />
+            <nvme desc="vm nvme device" />
+        </passthrough_devices>
+        <virtio_devices>
+            <console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]" />
+            <network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]." />
+            <input desc="virtio input device" />
+            <block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img" />
+        </virtio_devices>
+    </uos>
+</acrn-config>


### PR DESCRIPTION
fail to create kata vm type in industry scenario due to
the default vm id value is 1. Meanwhile set the max user
vm to 7 in tgl-rvp industry xml.

Tracked-On: #5932
Signed-off-by: lirui34 <ruix.li@intel.com>