### PR TITLE
config_tools: remove audio passthru in launch xmls on ehl-crb-b

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
@@ -20,7 +20,7 @@
 	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
-		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
+		<audio desc="vm audio device"></audio>
 		<audio_codec desc="vm audio codec device"></audio_codec>
 		<ipu desc="vm ipu device"></ipu>
 		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_waag.xml
@@ -20,7 +20,7 @@
 	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
-		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
+		<audio desc="vm audio device"></audio>
 		<audio_codec desc="vm audio codec device"></audio_codec>
 		<ipu desc="vm ipu device"></ipu>
 		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
@@ -20,7 +20,7 @@
 	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
-		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
+		<audio desc="vm audio device"></audio>
 		<audio_codec desc="vm audio codec device"></audio_codec>
 		<ipu desc="vm ipu device"></ipu>
 		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
@@ -20,7 +20,7 @@
 	</communication_vuarts>
 	<passthrough_devices>
 		<usb_xdci desc="vm usb_xdci device"></usb_xdci>
-		<audio desc="vm audio device">00:1f.3 Multimedia audio controller: Intel Corporation Device 4b58</audio>
+		<audio desc="vm audio device"></audio>
 		<audio_codec desc="vm audio codec device"></audio_codec>
 		<ipu desc="vm ipu device"></ipu>
 		<ipu_i2c desc="vm ipu_i2c device"></ipu_i2c>


### PR DESCRIPTION
There is no audio device in the default ehl-crb-b.xml, so remove
passthru audio devices from launch xmls on ehl-crb-b.

Tracked-On: #5925

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>