### PR TITLE
doc/conf.py: enable formatting docs in a PDF file

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -272,7 +272,15 @@ htmlhelp_basename = 'ACRN Project Help'
 
 # -- Options for LaTeX output ---------------------------------------------
 
+latex_engine = "xelatex"
+
 latex_elements = {
+    'fontpkg': r'''
+\setmainfont{DejaVu Serif}
+\setsansfont{DejaVu Sans}
+\setmonofont{DejaVu Sans Mono}
+''',
+
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
@@ -283,7 +291,9 @@ latex_elements = {
 
     # Additional stuff for the LaTeX preamble.
     #
-    # 'preamble': '',
+    'preamble': r'''
+\setcounter{tocdepth}{3}
+''',
 
     # Latex figure (float) alignment
     #


### PR DESCRIPTION
This patch tweaks the settings in doc/conf.py to allow formatting the
documentation to a PDF file by Sphinx. The changes include:

 - Use `xelatex` rather than the default `pdflatex` as the LaTeX engine, as
   `pdflatex` is not that good at formatting non-ascii characters out of
   the box.
 - Use DejaVu fonts (which are available in common Linux distributions) in
   the generated PDF.
 - Restrict the depths of the table of contents to 3.

Signed-off-by: Junjie Mao <junjie.mao@intel.com>