### PR TITLE
hv: pgtable: use new algo to calculate PPT/EPT_PD_PAGE_NUM for platform which PAW over 39 bits

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -462,6 +462,11 @@ int32_t detect_hardware_support(void)
 		printf("%s, physical-address width (%d) over maximum physical-address width (%d)\n",
 			__func__, boot_cpu_data.phys_bits, MAXIMUM_PA_WIDTH);
 		ret = -ENODEV;
+	} else if ((boot_cpu_data.phys_bits > 39U) && (!pcpu_has_cap(X86_FEATURE_PAGE1GB) ||
+			!pcpu_has_vmx_ept_cap(VMX_EPT_1GB_PAGE))) {
+		printf("%s, physical-address width %d over 39 bits must support 1GB large page\n",
+			__func__, boot_cpu_data.phys_bits);
+		ret = -ENODEV;
 	} else if (!pcpu_has_cap(X86_FEATURE_INVA_TSC)) {
 		/* check invariant TSC */
 		printf("%s, invariant TSC not supported\n", __func__);

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -22,16 +22,29 @@
 /* EPT address space will not beyond the platform physical address space */
 #define EPT_PML4_PAGE_NUM	PML4_PAGE_NUM(MAX_PHY_ADDRESS_SPACE)
 #define EPT_PDPT_PAGE_NUM	PDPT_PAGE_NUM(MAX_PHY_ADDRESS_SPACE)
-#define EPT_PD_PAGE_NUM	PD_PAGE_NUM(MAX_PHY_ADDRESS_SPACE)
+/* EPT_PD_PAGE_NUM consists of three parts:
+ * 1) DRAM - and low MMIO are contiguous (we could assume this because ve820 was build by us),
+ *            CONFIG_MAX_VM_NUM at most
+ * 2) low MMIO - and DRAM are contiguous, MEM_4G at most
+ * 3) high MMIO - Only PCI BARs're high MMIO (we didn't build the high MMIO EPT mapping
+ *                except writing PCI 64 bits BARs)
+ *
+ * The first two parts may use PD_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + MEM_4G) PD pages
+ * to build EPT mapping at most;
+ * The high MMIO may use (CONFIG_MAX_PCI_DEV_NUM * 6U) PD pages (may plus some PDPT entries
+ * if the high MMIO BAR size is larger than 1GB) to build EPT mapping at most
+ */
+#define EPT_PD_PAGE_NUM	(PD_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + MEM_4G) + \
+			CONFIG_MAX_PCI_DEV_NUM * 6U)
 
 /* EPT_PT_PAGE_NUM consists of three parts:
  * 1) DRAM - and low MMIO are contiguous (we could assume this because ve820 was build by us),
  *            CONFIG_MAX_VM_NUM at most
- * 2) low MMIO - and DRAM are contiguous, (MEM_1G << 2U) at most
+ * 2) low MMIO - and DRAM are contiguous, MEM_4G at most
  * 3) high MMIO - Only PCI BARs're high MMIO (we didn't build the high MMIO EPT mapping
  *                except writing PCI 64 bits BARs)
  *
- * The first two parts may use PT_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + (MEM_1G << 2U)) PT pages
+ * The first two parts may use PT_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + MEM_4G) PT pages
  * to build EPT mapping at most;
  * The high MMIO may use (CONFIG_MAX_PCI_DEV_NUM * 6U) PT pages to build EPT mapping at most:
  * this is because: (a) each 64 bits MMIO BAR may spend one PT page at most to build EPT mapping,
@@ -45,7 +58,7 @@
  *                  (c) The Maximum number of PCI devices for ACRN and the Maximum number of virtual PCI devices
  *                      for VM both are CONFIG_PLATFORM_RAM_SIZE
  */
-#define EPT_PT_PAGE_NUM	(PT_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + (MEM_1G << 2U)) + \
+#define EPT_PT_PAGE_NUM	(PT_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + MEM_4G) + \
 			CONFIG_MAX_PCI_DEV_NUM * 6U)
 
 /* must be a multiple of 64 */

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -45,7 +45,9 @@ static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);
 /* PPT VA and PA are identical mapping */
 #define PPT_PML4_PAGE_NUM	PML4_PAGE_NUM(MAX_PHY_ADDRESS_SPACE)
 #define PPT_PDPT_PAGE_NUM	PDPT_PAGE_NUM(MAX_PHY_ADDRESS_SPACE)
-#define PPT_PD_PAGE_NUM	PD_PAGE_NUM(MAX_PHY_ADDRESS_SPACE)
+/* Please refer to how the EPT_PD_PAGE_NUM was calculated */
+#define PPT_PD_PAGE_NUM	(PD_PAGE_NUM(CONFIG_PLATFORM_RAM_SIZE + (MEM_4G)) + \
+			CONFIG_MAX_PCI_DEV_NUM * 6U)
 #define PPT_PT_PAGE_NUM	0UL	/* not support 4K granularity page mapping */
 /* must be a multiple of 64 */
 #define PPT_PAGE_NUM	(roundup((PPT_PML4_PAGE_NUM + PPT_PDPT_PAGE_NUM + \

--- a/hypervisor/include/arch/x86/page.h
+++ b/hypervisor/include/arch/x86/page.h
@@ -13,7 +13,7 @@
 #define PAGE_SIZE	(1U << PAGE_SHIFT)
 #define PAGE_MASK	0xFFFFFFFFFFFFF000UL
 
-#define MAXIMUM_PA_WIDTH	39U	/* maximum physical-address width */
+#define MAXIMUM_PA_WIDTH	46U	/* maximum physical-address width */
 #define MAX_PHY_ADDRESS_SPACE	(1UL << MAXIMUM_PA_WIDTH)
 
 /* size of the low MMIO address space: 2GB */


### PR DESCRIPTION
1. add assumption "platform which PAW over 39 bits must support 1GB large page"
2. use new algo to calculate PPT/EPT_PD_PAGE_NUM

Tracked-On: #5929
Signed-off-by: Li Fei1 <fei1.li@intel.com>