### PR TITLE
Paging/Memory Modularization - e820 Part

### DIFF
--- a/hypervisor/include/arch/x86/e820.h
+++ b/hypervisor/include/arch/x86/e820.h
@@ -44,7 +44,4 @@ uint32_t get_e820_entries_count(void);
 /* get the e802 entiries */
 const struct e820_entry *get_e820_entry(void);
 
-/* get the e820 total memory info */
-const struct mem_range *get_mem_range_info(void);
-
 #endif

--- a/hypervisor/include/arch/x86/mmu.h
+++ b/hypervisor/include/arch/x86/mmu.h
@@ -40,7 +40,8 @@
 #define MEM_1M		(MEM_1K * 1024U)
 #define MEM_2M		(MEM_1M * 2U)
 #define MEM_1G		(MEM_1M * 1024U)
-#define MEM_2G		(1024UL * 1024UL * 1024UL * 2UL)
+#define MEM_2G		(MEM_1G * 2UL)
+#define MEM_4G		(MEM_1G * 4UL)
 
 #ifndef ASSEMBLER
 

--- a/hypervisor/include/arch/x86/pgtable.h
+++ b/hypervisor/include/arch/x86/pgtable.h
@@ -31,6 +31,8 @@
 #define PAGE_CACHE_UC_MINUS	PAGE_PCD
 #define PAGE_CACHE_UC		(PAGE_PCD | PAGE_PWT)
 
+#define PAGE_ATTR_USER		(PAGE_PRESENT | PAGE_RW | PAGE_USER | PAGE_NX)
+
 /**
  * @defgroup ept_mem_access_right EPT Memory Access Right
  *


### PR DESCRIPTION
v2:
1. define a new MACRO PAGE_ATTR_USER
2. use same API to do SOS memory EPT mapping

v1:
For e820 module, we could only provide three APIs:
init_e820 - to initial the e820 table for ACRN hypervisor;
get_e820_entries_count - to get the total number of the e820 entries
get_e820_entry - to get the e802 entiries
to get/set the e820 tables.

However, ACRN doesn't have memory management. There're some usages for
memory allocation. So we add an API e820_alloc_memory to allocate a memory
from e820 table.

Tracked-On: #5830
Signed-off-by: Li Fei1 <fei1.li@intel.com>
Acked-by: eddie Dong <eddie.dong@intel.com>