### PR TITLE
hv: bugfix in min() and max() MACROs

### DIFF
--- a/hypervisor/include/lib/util.h
+++ b/hypervisor/include/lib/util.h
@@ -18,9 +18,9 @@
 /** Roundup (x) to (y) aligned **/
 #define roundup(x, y)  (((x) + ((y) - 1UL)) & (~((y) - 1UL)))
 
-#define min(x, y)	((x) < (y)) ? (x) : (y)
+#define min(x, y)	(((x) < (y)) ? (x) : (y))
 
-#define max(x, y)	((x) < (y)) ? (y) : (x)
+#define max(x, y)	(((x) < (y)) ? (y) : (x))
 
 /** Replaces 'x' by the string "x". */
 #define STRINGIFY(x) #x


### PR DESCRIPTION
 These two MACROs shall be wrapped as a single
 value respectively, hence brackets should be used.

Tracked-On: #5951
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>