### PR TITLE
hv: Save/restore MSR_IA32_CSTAR during context switch

### DIFF
--- a/hypervisor/arch/x86/guest/vcpu.c
+++ b/hypervisor/arch/x86/guest/vcpu.c
@@ -839,6 +839,7 @@ static void context_switch_out(struct thread_object *prev)
 
 	/* We don't flush TLB as we assume each vcpu has different vpid */
 	ectx->ia32_star = msr_read(MSR_IA32_STAR);
+	ectx->ia32_cstar = msr_read(MSR_IA32_CSTAR);
 	ectx->ia32_lstar = msr_read(MSR_IA32_LSTAR);
 	ectx->ia32_fmask = msr_read(MSR_IA32_FMASK);
 	ectx->ia32_kernel_gs_base = msr_read(MSR_IA32_KERNEL_GS_BASE);
@@ -854,6 +855,7 @@ static void context_switch_in(struct thread_object *next)
 	load_vmcs(vcpu);
 
 	msr_write(MSR_IA32_STAR, ectx->ia32_star);
+	msr_write(MSR_IA32_CSTAR, ectx->ia32_cstar);
 	msr_write(MSR_IA32_LSTAR, ectx->ia32_lstar);
 	msr_write(MSR_IA32_FMASK, ectx->ia32_fmask);
 	msr_write(MSR_IA32_KERNEL_GS_BASE, ectx->ia32_kernel_gs_base);

--- a/hypervisor/include/arch/x86/cpu.h
+++ b/hypervisor/include/arch/x86/cpu.h
@@ -392,6 +392,7 @@ struct ext_context {
 	struct segment_sel gs;
 
 	uint64_t ia32_star;
+	uint64_t ia32_cstar;
 	uint64_t ia32_lstar;
 	uint64_t ia32_fmask;
 	uint64_t ia32_kernel_gs_base;


### PR DESCRIPTION
hv: Save/restore MSR_IA32_CSTAR during context switch
    
Both Windows guest and Linux guest use the MSR MSR_IA32_CSTAR, while
Linux uses it rarely. Now vcpu context switch doesn't save/restore it.
Windows detects the change of the MSR and rises a exception.
    
Do the save/resotre MSR_IA32_CSTAR during context switch.
    
Tracked-On: #5899
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>
