### PR TITLE
config_tools: update IVSHMEM_SHM_SIZE part for HV_RAM_SIZE calculation

### DIFF
--- a/misc/config_tools/hv_config/board_defconfig.py
+++ b/misc/config_tools/hv_config/board_defconfig.py
@@ -81,7 +81,7 @@ def get_memory(hv_info, config):
                 except Exception as e:
                     print(e)
 
-    hv_ram_size += total_shm_size
+    hv_ram_size += 2 * max(total_shm_size, 0x200000)
     if hv_ram_size > HV_RAM_SIZE_MAX:
         common.print_red("requested RAM size should be smaller then {}".format(HV_RAM_SIZE_MAX), err=True)
         err_dic["board config: total vm number error"] = \

--- a/misc/config_tools/static_allocators/hv_ram.py
+++ b/misc/config_tools/static_allocators/hv_ram.py
@@ -40,7 +40,7 @@ def fn(board_etree, scenario_etree, allocation_etree):
                     total_shm_size += int_size
                 except Exception as e:
                     print(e)
-    hv_ram_size += total_shm_size
+    hv_ram_size += 2 * max(total_shm_size, 0x200000)
     assert(hv_ram_size <= HV_RAM_SIZE_MAX)
 
     # reseve 16M memory for hv sbuf, ramoops, etc.


### PR DESCRIPTION
add 2 * max (IVSHMEM_SHM_SIZE, 2M) in HV_RAM_SIZE calculation to
avoid ram overflow caused by additional memory usage for shared
memory alignment.

Tracked-On: #5955

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>
Reviewed-by: Victor Sun <victor.sun@intel.com>