### PR TITLE
[release_2.4 hotfix] dm: bugfix in create_and_inject_vrtct

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -1101,7 +1101,6 @@ int create_and_inject_vrtct(struct vmctx *ctx)
 		.prot = PROT_ALL
 	};
 
-	memmap.gpa = get_software_sram_base_gpa();
 	native_rtct_fd = open(RTCT_NATIVE_FILE_PATH_IN_SOS, O_RDONLY);
 	if (native_rtct_fd < 0) {
 		pr_err("failed to open /sys/firmware/acpi/tables/PTCT !!!!! errno:%d\n", errno);
@@ -1133,6 +1132,7 @@ int create_and_inject_vrtct(struct vmctx *ctx)
 	free(vrtct);
 
 	memmap.hpa = get_software_sram_base_hpa();
+	memmap.gpa = get_software_sram_base_gpa();
 	memmap.len = get_software_sram_size();
 	ioctl(ctx->fd, IC_UNSET_MEMSEG, &memmap);
 	return ioctl(ctx->fd, IC_SET_MEMSEG, &memmap);

--- a/devicemodel/hw/platform/acpi/rtct.c
+++ b/devicemodel/hw/platform/acpi/rtct.c
@@ -283,16 +283,25 @@ static int passthru_rtct_to_guest(struct acpi_table_hdr *vrtct, struct acpi_tabl
 	return  rc;
 }
 
+/*
+ * @pre buid_vrtct(ctx, cfg) != NULL
+ */
 uint64_t get_software_sram_base_hpa(void)
 {
 	return software_sram_base_hpa;
 }
 
+/*
+ * @pre buid_vrtct(ctx, cfg) != NULL
+ */
 uint64_t get_software_sram_base_gpa(void)
 {
 	return software_sram_base_gpa;
 }
 
+/*
+ * @pre buid_vrtct(ctx, cfg) != NULL
+ */
 uint64_t get_software_sram_size(void)
 {
 	return software_sram_size;


### PR DESCRIPTION
 GPA of software SRAM is available only after
 build_vrtct() function is called and the return
 value of it is valid(Not NULL).

 This patch fix bug in create_and_inject_vrtct()
 function which violates above pre-condition when
 calling get_software_sram_base_gpa().

Tracked-On: #5973
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>