### PR TITLE
doc: add note to emphasize the need to use --windows for WaaG

### DIFF
--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -456,6 +456,10 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
       --windows
 
+   .. note::
+      This option is mandatory for running Windows in a User VM. If it is
+      not used, Windows will not recognize the virtual disk.
+
 ----
 
 ``--psram``


### PR DESCRIPTION
Add a note to the "Device Model Parameters" document to emphasize
the need to use the '--windows' parameter to use Windows-as-a-Guest
(WaaG), else Windows will not recognize the virtual disk it has
been assigned.

Tracked-On: #5962
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>