### PR TITLE
hv: hypercalls: refactor permission-checking and dispatching logic

### DIFF
--- a/doc/developer-guides/hld/hld-security.rst
+++ b/doc/developer-guides/hld/hld-security.rst
@@ -599,13 +599,16 @@ As shown in :numref:`security-hir`, there are some restrictions for
 hypercall invocation in the hypervisor design:
 
 #. Hypercalls from ring 1~3 of any guest VM are not allowed. The
-   hypervisor must discard such hypercalls silently. Only ring-0
+   hypervisor must discard such hypercalls and inject ``#GP(0)`` instead. Only ring-0
    hypercalls from the guest VM are handled by the hypervisor.
 #. All the hypercalls (except world\_switch hypercall) must be called
    from the ring-0 driver of the Service VM.
    World\_switch Hypercall is used by the TIPC (Trusty IPC) driver to
    switch guest VM context between secure world and non-secure world.
    Further details will be discussed in the :ref:`secure_trusty` section.
+   When a vCPU issues an unpermitted hypercall, the hypervisor shall either
+   inject ``#UD`` (if the VM cannot issue hypercalls at all) or return ``-EINVAL``
+   (if the VM is allowed to issue hypercalls but not this specific one).
 #. For those hypercalls that may result in data inconsistent intra hypervisor
    when they are executed concurrently, such as ``hcall_create_vm()``
    ``hcll_destroy_vm()`` etc. spinlock is used to ensure these hypercalls

--- a/doc/developer-guides/hld/hv-hypercall.rst
+++ b/doc/developer-guides/hld/hv-hypercall.rst
@@ -11,10 +11,16 @@ power management, and secure world switch.
 
 There are some restrictions for hypercall and upcall:
 
+#. Only specific VMs (currently the Service VM and the VM with trusty enabled)
+   can invoke hypercalls. A VM that cannot invoke hypercalls will get ``#UD``
+   (i.e. invalid opcode exception).
 #. Only ring 0 hypercalls from the guest VM are handled by the hypervisor;
-   otherwise, the hypervisor will inject GP to the Guest VM.
-#. All the hypercalls (except secure world hypercalls) must be called from the Service VM;
-   otherwise, the hypervisor will inject UD to the Guest VM.
+   otherwise, the hypervisor will inject ``#GP(0)`` (i.e. generation protection
+   exception with error code ``0``) to the Guest VM.
+#. Each VM is permitted to invoke a certain subset of hypercalls. Currently a VM
+   with trusty enabled is allowed to invoke trusty hypercalls, and the Service
+   VM is allowed to invoke the other hypercalls. A VM that invokes an
+   unpermitted hypercall will get the return value ``-EINVAL``.
    see :ref:`secure-hypervisor-interface` for a detailed description.
 #. The hypervisor needs to protect the critical resources such as global VM and VCPU structures
    for VM and VCPU management hypercalls.

--- a/hypervisor/common/trusty_hypercall.c
+++ b/hypervisor/common/trusty_hypercall.c
@@ -24,7 +24,8 @@
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_world_switch(struct acrn_vcpu *vcpu)
+int32_t hcall_world_switch(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
+		__unused uint64_t param1, __unused uint64_t param2)
 {
 	int32_t next_world_id = !(vcpu->arch.cur_context);
 	int32_t ret = -EPERM;
@@ -46,12 +47,12 @@ int32_t hcall_world_switch(struct acrn_vcpu *vcpu)
  * * The hypervisor needs to save current vCPU contexts (Normal World)
  *
  * @param vcpu Pointer to vCPU data structure
- * @param param guest physical address. This gpa points to
- *              trusty_boot_param structure
+ * @param param1 guest physical address. This gpa points to trusty_boot_param structure
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
+int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
+		uint64_t param1, __unused uint64_t param2)
 {
 	int32_t ret = -EFAULT;
 
@@ -60,7 +61,7 @@ int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
 		&& (vcpu->arch.cur_context == NORMAL_WORLD)) {
 		struct trusty_boot_param boot_param;
 
-		if (copy_from_gpa(vcpu->vm, &boot_param, param, sizeof(boot_param)) == 0) {
+		if (copy_from_gpa(vcpu->vm, &boot_param, param1, sizeof(boot_param)) == 0) {
 			if (initialize_trusty(vcpu, &boot_param)) {
 				vcpu->vm->sworld_control.flag.active = 1UL;
 				ret = 0;
@@ -80,7 +81,8 @@ int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param)
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu)
+int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
+		__unused uint64_t param1, __unused uint64_t param2)
 {
 	struct acrn_vm *vm = vcpu->vm;
 	int32_t ret = -EINVAL;

--- a/hypervisor/debug/hypercall.c
+++ b/hypervisor/debug/hypercall.c
@@ -17,16 +17,18 @@
 /**
  * @brief Execute profiling operation
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param param1 profiling command to be executed
  * @param param2 guest physical address. This gpa points to
  *             data structure required by each command
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_profiling_ops(struct acrn_vm *vm, __unused struct acrn_vm *target_vm, uint64_t param1, uint64_t param2)
+int32_t hcall_profiling_ops(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
+		uint64_t param1, uint64_t param2)
 {
+	struct acrn_vm *vm = vcpu->vm;
 	int32_t ret;
 	uint64_t cmd = param1;
 
@@ -70,16 +72,17 @@ int32_t hcall_profiling_ops(struct acrn_vm *vm, __unused struct acrn_vm *target_
 /**
  * @brief Setup a share buffer for a VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param param1 guest physical address. This gpa points to
  *              struct sbuf_setup_param
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_setup_sbuf(struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+int32_t hcall_setup_sbuf(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		uint64_t param1, __unused uint64_t param2)
 {
+	struct acrn_vm *vm = vcpu->vm;
 	struct sbuf_setup_param ssp;
 	uint64_t *hva;
 
@@ -97,18 +100,19 @@ int32_t hcall_setup_sbuf(struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
 }
 
 /**
-  * @brief Setup the hypervisor NPK log.
-  *
-  * @param vm Pointer to VM data structure
-  * @param param1 guest physical address. This gpa points to
-  *              struct hv_npk_log_param
-  *
-  * @pre Pointer vm shall point to SOS_VM
-  * @return 0 on success, non-zero on error.
-  */
-int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+ * @brief Setup the hypervisor NPK log.
+ *
+ * @param vcpu Pointer to vCPU that initiates the hypercall
+ * @param param1 guest physical address. This gpa points to
+ *              struct hv_npk_log_param
+ *
+ * @pre is_sos_vm(vcpu->vm)
+ * @return 0 on success, non-zero on error.
+ */
+int32_t hcall_setup_hv_npk_log(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		uint64_t param1, __unused uint64_t param2)
 {
+	struct acrn_vm *vm = vcpu->vm;
 	struct hv_npk_log_param npk_param;
 
 	if (copy_from_gpa(vm, &npk_param, param1, sizeof(npk_param)) != 0) {
@@ -123,16 +127,16 @@ int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, __unused struct acrn_vm *targ
 /**
  * @brief Get hardware related info
  *
- * @param vm Pointer to vm data structure
- * @param param Guest physical address pointing to struct acrn_hw_info
+ * @param vcpu Pointer to vCPU that initiates the hypercall
+ * @param param1 Guest physical address pointing to struct acrn_hw_info
  *
- * @pre vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @pre param1 shall be a valid physical address
  *
  * @retval 0 on success
  * @retval -1 in case of error
  */
-int32_t hcall_get_hw_info(struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+int32_t hcall_get_hw_info(struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		uint64_t param1, __unused uint64_t param2)
 {
 	struct acrn_hw_info hw_info;
@@ -140,5 +144,5 @@ int32_t hcall_get_hw_info(struct acrn_vm *vm, __unused struct acrn_vm *target_vm
 	(void)memset((void *)&hw_info, 0U, sizeof(hw_info));
 
 	hw_info.cpu_num = get_pcpu_nums();
-	return copy_to_gpa(vm, &hw_info, param1, sizeof(hw_info));
+	return copy_to_gpa(vcpu->vm, &hw_info, param1, sizeof(hw_info));
 }

--- a/hypervisor/include/common/hypercall.h
+++ b/hypervisor/include/common/hypercall.h
@@ -27,31 +27,31 @@ bool is_hypercall_from_ring0(void);
  *
  * The function offline specific vcpu from SOS.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm not used
  * @param param1 lapic id of the vcpu which wants to offline
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_sos_offline_cpu(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_sos_offline_cpu(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Get hypervisor api version
  *
  * The function only return api version information when VM is SOS_VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm not used
  * @param param1 guest physical memory address. The api version returned
  *              will be copied to this gpa
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_get_api_version(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_get_api_version(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Get basic platform information.
@@ -59,15 +59,15 @@ int32_t hcall_get_api_version(struct acrn_vm *vm, struct acrn_vm *target_vm, uin
  * The function returns basic hardware or configuration information
  * for the current platform.
  *
- * @param vm Pointer to VM data structure.
+ * @param vcpu Pointer to vCPU that initiates the hypercall.
  * @param target_vm not used
  * @param param1 GPA pointer to struct hc_platform_info.
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, -1 in case of error.
  */
-int32_t hcall_get_platform_info(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_get_platform_info(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief create virtual machine
@@ -76,16 +76,16 @@ int32_t hcall_get_platform_info(struct acrn_vm *vm, struct acrn_vm *target_vm, u
  * limitation for calling times of this function, will add MAX_VM_NUM
  * support later.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 guest physical memory address. This gpa points to
  *              struct acrn_create_vm
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_create_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_create_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief destroy virtual machine
@@ -93,14 +93,14 @@ int32_t hcall_create_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t 
  * Destroy a virtual machine, it will pause target VM then shutdown it.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm not used
+ * @param vcpu not used
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_destroy_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_destroy_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief reset virtual machine
@@ -110,14 +110,14 @@ int32_t hcall_destroy_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t
  * each vcpu state and do some initialization for guest.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm not used
+ * @param vcpu not used
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_reset_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_reset_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief start virtual machine
@@ -126,14 +126,14 @@ int32_t hcall_reset_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t p
  * The function will return -1 if the target VM does not exist or the
  * IOReq buffer page for the VM is not ready.
  *
- * @param vm not used
+ * @param vcpu not used
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_start_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_start_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief pause virtual machine
@@ -142,14 +142,14 @@ int32_t hcall_start_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t p
  * will return 0 directly for success.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm not used
+ * @param vcpu not used
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_pause_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_pause_vm(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief set vcpu regs
@@ -158,7 +158,7 @@ int32_t hcall_pause_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t p
  * it's only applied to BSP. AP always uses fixed init regs.
  * The function will return -1 if the targat VM or BSP doesn't exist.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to
@@ -166,7 +166,7 @@ int32_t hcall_pause_vm(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t p
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_set_vcpu_regs(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief set or clear IRQ line
@@ -175,15 +175,15 @@ int32_t hcall_set_vcpu_regs(struct acrn_vm *vm, struct acrn_vm *target_vm, uint6
  * or IOAPIC, normally it triggers an edge IRQ.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 info for irqline
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_irqline(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_set_irqline(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief inject MSI interrupt
@@ -191,15 +191,15 @@ int32_t hcall_set_irqline(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_
  * Inject a MSI interrupt for a VM.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to struct acrn_msi_entry
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_inject_msi(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_inject_msi(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief set ioreq shared buffer
@@ -207,16 +207,16 @@ int32_t hcall_inject_msi(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t
  * Set the ioreq share buffer for a VM.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to
  *              struct acrn_set_ioreq_buffer
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_set_ioreq_buffer(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief notify request done
@@ -224,42 +224,43 @@ int32_t hcall_set_ioreq_buffer(struct acrn_vm *vm, struct acrn_vm *target_vm, ui
  * Notify the requestor VCPU for the completion of an ioreq.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm not used
+ * @param vcpu not used
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 vcpu ID of the requestor
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_notify_ioreq_finish(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_notify_ioreq_finish(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief setup ept memory mapping for multi regions
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 guest physical address. This gpa points to
  *              struct set_memmaps
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_vm_memory_regions(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_set_vm_memory_regions(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
+		uint64_t param1, uint64_t param2);
 
 /**
  * @brief change guest memory page write permission
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to
  *              struct wp_data
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_write_protect_page(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_write_protect_page(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief translate guest physical address to host physical address
@@ -267,154 +268,155 @@ int32_t hcall_write_protect_page(struct acrn_vm *vm, struct acrn_vm *target_vm, 
  * Translate guest physical address to host physical address for a VM.
  * The function will return -1 if the target VM does not exist.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to struct vm_gpa2hpa
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_gpa_to_hpa(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_gpa_to_hpa(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Assign one PCI dev to VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_assign_pcidev including assign PCI device info
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_assign_pcidev(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_assign_pcidev(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Deassign one PCI dev to VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_assign_pcidev including deassign PCI device info
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_deassign_pcidev(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_deassign_pcidev(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Assign one MMIO dev to VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_mmiodev including assign MMIO device info
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_assign_mmiodev(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_assign_mmiodev(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Deassign one MMIO dev to VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_mmiodev including deassign MMIO device info
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_deassign_mmiodev(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_deassign_mmiodev(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Add an emulated device in hypervisor.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_emul_dev including information about PCI or legacy devices
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_add_vdev(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_add_vdev(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Remove an emulated device in hypervisor.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_emul_dev including information about PCI or legacy devices
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_remove_vdev(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_remove_vdev(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Set interrupt mapping info of ptdev.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              hc_ptdev_irq including intr remapping info
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_ptdev_intr_info(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_set_ptdev_intr_info(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Clear interrupt mapping info of ptdev.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              hc_ptdev_irq including intr remapping info
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_reset_ptdev_intr_info(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_reset_ptdev_intr_info(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
+		uint64_t param1, uint64_t param2);
 
 /**
  * @brief Get VCPU Power state.
  *
- * @param vm pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 cmd to show get which VCPU power state data
  * @param param2 VCPU power state data
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_get_cpu_pm_state(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_get_cpu_pm_state(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Get VCPU a VM's interrupt count data.
  *
- * @param vm pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm Pointer to target VM data structure
  * @param param1 not used
  * @param param2 guest physical address. This gpa points to data structure of
  *              acrn_intr_monitor
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_vm_intr_monitor(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @defgroup trusty_hypercall Trusty Hypercalls
@@ -436,11 +438,14 @@ int32_t hcall_vm_intr_monitor(struct acrn_vm *vm, struct acrn_vm *target_vm, uin
  *     vCPU contexts
  *
  * @param vcpu Pointer to VCPU data structure
+ * @param target_vm not used
+ * @param param1 not used
+ * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
 
-int32_t hcall_world_switch(struct acrn_vcpu *vcpu);
+int32_t hcall_world_switch(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Initialize environment for Trusty-OS on a vCPU.
@@ -451,21 +456,27 @@ int32_t hcall_world_switch(struct acrn_vcpu *vcpu);
  * * The hypervisor needs to save current vCPU contexts (Normal World)
  *
  * @param vcpu Pointer to vCPU data structure
- * @param param guest physical address. This gpa points to
- *              trusty_boot_param structure
+ * @param target_vm not used
+ * @param param1 guest physical address. This gpa points to
+ *               trusty_boot_param structure
+ * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, uint64_t param);
+int32_t hcall_initialize_trusty(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Save/Restore Context of Secure World.
  *
  * @param vcpu Pointer to VCPU data structure
+ * @param target_vm not used
+ * @param param1 not used
+ * @param param2 not used
  *
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu);
+int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm,
+		uint64_t param1, uint64_t param2);
 
 /**
  * @}
@@ -479,48 +490,48 @@ int32_t hcall_save_restore_sworld_ctx(struct acrn_vcpu *vcpu);
  * not called, the hypervisor will use the default notifier vector(0xF7)
  * to notify the SOS kernel.
  *
- * @param vm not used
+ * @param vcpu not used
  * @param target_vm not used
  * @param param1 the expected notifier vector from guest
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_set_callback_vector(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_set_callback_vector(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Setup a share buffer for a VM.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm not used
  * @param param1 guest physical address. This gpa points to
  *              struct sbuf_setup_param
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_setup_sbuf(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_setup_sbuf(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Setup the hypervisor NPK log.
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm not used
  * @param param1 guest physical address. This gpa points to
  *              struct hv_npk_log_param
  * @param param2 not used
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_setup_hv_npk_log(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Get hardware related info
  *
- * @param vm Pointer to vm data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm not used
  * @param param1 Guest physical address pointing to struct acrn_hw_info
  * @param param2 not used
@@ -531,23 +542,23 @@ int32_t hcall_setup_hv_npk_log(struct acrn_vm *vm, struct acrn_vm *target_vm, ui
  * @retval 0 on success
  * @retval -1 in case of error
  */
-int32_t hcall_get_hw_info(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_get_hw_info(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
 /**
  * @brief Execute profiling operation
  *
- * @param vm Pointer to VM data structure
+ * @param vcpu Pointer to vCPU that initiates the hypercall
  * @param target_vm not used
  * @param param1 profiling command to be executed
  * @param param2 guest physical address. This gpa points to
  *             data structure required by each command
  *
- * @pre Pointer vm shall point to SOS_VM
+ * @pre is_sos_vm(vcpu->vm)
  * @return 0 on success, non-zero on error.
  */
-int32_t hcall_profiling_ops(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_profiling_ops(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 
-int32_t hcall_create_vcpu(struct acrn_vm *vm, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
+int32_t hcall_create_vcpu(struct acrn_vcpu *vcpu, struct acrn_vm *target_vm, uint64_t param1, uint64_t param2);
 /**
  * @}
  */

--- a/hypervisor/release/hypercall.c
+++ b/hypervisor/release/hypercall.c
@@ -8,25 +8,25 @@
 #include <errno.h>
 #include <asm/guest/vm.h>
 
-int32_t hcall_setup_sbuf(__unused struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+int32_t hcall_setup_sbuf(__unused struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		__unused uint64_t param1, __unused uint64_t param2)
 {
 	return -EPERM;
 }
 
-int32_t hcall_setup_hv_npk_log(__unused struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+int32_t hcall_setup_hv_npk_log(__unused struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		__unused uint64_t param1, __unused uint64_t param2)
 {
 	return -EPERM;
 }
 
-int32_t hcall_get_hw_info(__unused struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+int32_t hcall_get_hw_info(__unused struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		__unused uint64_t param1, __unused uint64_t param2)
 {
 	return -EPERM;
 }
 
-int32_t hcall_profiling_ops(__unused struct acrn_vm *vm, __unused struct acrn_vm *target_vm,
+int32_t hcall_profiling_ops(__unused struct acrn_vcpu *vcpu, __unused struct acrn_vm *target_vm,
 		__unused uint64_t param1, __unused uint64_t param2)
 {
 	return -EPERM;


### PR DESCRIPTION
The current permission-checking and dispatching mechanism of hypercalls is
not unified because:

  1. Some hypercalls require the exact vCPU initiating the call, while the
     others only need to know the VM.
  2. Different hypercalls have different permission requirements: the
     trusty-related ones are enabled by a guest flag, while the others
     require the initiating VM to be the Service OS.

Without a unified logic it could be hard to scale when more kinds of
hypercalls are added later.

The objectives of this patch are as follows.

  1. All hypercalls have the same prototype and are dispatched by a unified
     logic.
  2. Permissions are checked by a unified logic without consulting the
     hypercall ID.

To achieve the first objective, this patch modifies the type of the first
parameter of hcall_* functions (which are the callbacks implementing the
hypercalls) from `struct acrn_vm *` to `struct acrn_vcpu *`. The
doxygen-style documentations are updated accordingly.

To achieve the second objective, this patch adds to `struct hc_dispatch` a
`permission_flags` field which specifies the guest flags that must ALL be
set for a VM to be able to invoke the hypercall. The default value (which
is 0UL) indicates that this hypercall is for SOS only. Currently only the
`permission_flag` of trusty-related hypercalls have the non-zero value
GUEST_FLAG_SECURE_WORLD_ENABLED.

With `permission_flag`, the permission checking logic of hypercalls is
unified as follows.

  1. General checks
     i. If the VM is neither SOS nor having any guest flag that allows
        certain hypercalls, it gets #UD upon executing the `vmcall`
        instruction.
    ii. If the VM is allowed to execute the `vmcall` instruction, but
        attempts to execute it in ring 1, 2 or 3, the VM gets #GP(0).
  2. Hypercall-specific checks
     i. If the hypercall is for SOS (i.e. `permission_flag` is 0), the
        initiating VM must be SOS and the specified target VM cannot be a
        pre-launched VM. Otherwise the hypercall returns -EINVAL without
        further actions.
    ii. If the hypercall requires certain guest flags, the initiating VM
        must have all the required flags. Otherwise the hypercall returns
        -EINVAL without further actions.
   iii. A hypercall with an unknown hypercall ID makes the hypercall
        returns -EINVAL without further actions.

The logic above is different from the current implementation in the
following aspects.

  1. A pre-launched VM now gets #UD (rather than #GP(0)) when it attempts
     to execute `vmcall` in ring 1, 2 or 3.
  2. A pre-launched VM now gets #UD (rather than the return value -EPERM)
     when it attempts to execute a trusty hypercall in ring 0.
  3. The SOS now gets the return value -EINVAL (rather than -EPERM) when it
     attempts to invoke a trusty hypercall.
  4. A post-launched VM with trusty support now gets the return value
     -EINVAL (rather than #UD) when it attempts to invoke a non-trusty
     hypercall or an invalid hypercall.

v1 -> v2:
 - Update documentation that describe hypercall behavior.

Tracked-On: #5924
Signed-off-by: Junjie Mao <junjie.mao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>