### PR TITLE
config-tools: add white space between arguments

### DIFF
--- a/misc/config_tools/data/generic_board/generic_code/hybrid/misc_cfg.h
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid/misc_cfg.h
@@ -7,8 +7,8 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define SOS_ROOTFS "root=/dev/sda3"
-#define SOS_CONSOLE "console=ttyS0"
+#define SOS_ROOTFS "root=/dev/sda3 "
+#define SOS_CONSOLE "console=ttyS0 "
 #define SOS_COM1_BASE 0x3F8U
 #define SOS_COM1_IRQ 4U
 #define SOS_COM2_BASE 0x2F8U
@@ -16,7 +16,7 @@
 
 #define SOS_BOOTARGS_DIFF                                                                                              \
 	"rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1 "             \
-	"swiotlb=131072 maxcpus=3"
+	"swiotlb=131072 maxcpus=3 "
 #define VM0_CONFIG_CPU_AFFINITY (AFFINITY_CPU(3U))
 #define SOS_VM_CONFIG_CPU_AFFINITY (AFFINITY_CPU(0U) | AFFINITY_CPU(1U) | AFFINITY_CPU(2U))
 #define VM2_CONFIG_CPU_AFFINITY (AFFINITY_CPU(2U))

--- a/misc/config_tools/data/generic_board/generic_code/hybrid_rt/misc_cfg.h
+++ b/misc/config_tools/data/generic_board/generic_code/hybrid_rt/misc_cfg.h
@@ -7,8 +7,8 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define SOS_ROOTFS "root=/dev/nvme0n1p3"
-#define SOS_CONSOLE "console=ttyS0"
+#define SOS_ROOTFS "root=/dev/nvme0n1p3 "
+#define SOS_CONSOLE "console=ttyS0 "
 #define SOS_COM1_BASE 0x3F8U
 #define SOS_COM1_IRQ 4U
 #define SOS_COM2_BASE 0x2F8U
@@ -16,7 +16,7 @@
 
 #define SOS_BOOTARGS_DIFF                                                                                              \
 	"rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1 "             \
-	"swiotlb=131072 maxcpus=2"
+	"swiotlb=131072 maxcpus=2 "
 #define VM0_CONFIG_CPU_AFFINITY (AFFINITY_CPU(2U) | AFFINITY_CPU(3U))
 #define SOS_VM_CONFIG_CPU_AFFINITY (AFFINITY_CPU(0U) | AFFINITY_CPU(1U))
 #define VM2_CONFIG_CPU_AFFINITY (AFFINITY_CPU(0U) | AFFINITY_CPU(1U))
@@ -58,7 +58,7 @@
 	"rw rootwait root=/dev/sda3 no_ipi_broadcast=1 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel "   \
 	"consoleblank=0 tsc=reliable clocksource=tsc x2apic_phys processor.max_cstate=0 intel_idle.max_cstate=0 "      \
 	"intel_pstate=disable mce=ignore_ce audit=0 isolcpus=nohz,domain,1 nohz_full=1 rcu_nocbs=1 nosoftlockup "      \
-	"idle=poll irqaffinity=0 reboot=acpi"
+	"idle=poll irqaffinity=0 reboot=acpi "
 #define VM0_PT_INTX_NUM 0U
 
 #endif /* MISC_CFG_H */

--- a/misc/config_tools/data/generic_board/generic_code/industry/misc_cfg.h
+++ b/misc/config_tools/data/generic_board/generic_code/industry/misc_cfg.h
@@ -7,8 +7,8 @@
 #ifndef MISC_CFG_H
 #define MISC_CFG_H
 
-#define SOS_ROOTFS "root=/dev/nvme0n1p3"
-#define SOS_CONSOLE "console=ttyS3"
+#define SOS_ROOTFS "root=/dev/nvme0n1p3 "
+#define SOS_CONSOLE "console=ttyS3 "
 #define SOS_COM1_BASE 0x3F8U
 #define SOS_COM1_IRQ 3U
 #define SOS_COM2_BASE 0x2F8U
@@ -16,7 +16,7 @@
 
 #define SOS_BOOTARGS_DIFF                                                                                              \
 	"rw rootwait console=tty0 consoleblank=0 no_timer_check quiet loglevel=3 i915.nuclear_pageflip=1 "             \
-	"swiotlb=131072 maxcpus=4"
+	"swiotlb=131072 maxcpus=4 "
 #define SOS_VM_CONFIG_CPU_AFFINITY (AFFINITY_CPU(0U) | AFFINITY_CPU(1U) | AFFINITY_CPU(2U) | AFFINITY_CPU(3U))
 #define VM1_CONFIG_CPU_AFFINITY (AFFINITY_CPU(0U) | AFFINITY_CPU(1U))
 #define VM2_CONFIG_CPU_AFFINITY (AFFINITY_CPU(2U) | AFFINITY_CPU(3U))

--- a/misc/config_tools/data/generic_board/generic_code/logical_partition/misc_cfg.h
+++ b/misc/config_tools/data/generic_board/generic_code/logical_partition/misc_cfg.h
@@ -38,10 +38,10 @@
 
 #define VM0_BOOT_ARGS                                                                                                  \
 	"rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M "      \
-	"consoleblank=0 tsc=reliable reboot=acpi"
+	"consoleblank=0 tsc=reliable reboot=acpi "
 #define VM1_BOOT_ARGS                                                                                                  \
 	"rw rootwait root=/dev/sda3 console=ttyS0 noxsave nohpet no_timer_check ignore_loglevel log_buf_len=16M "      \
-	"consoleblank=0 tsc=reliable reboot=acpi"
+	"consoleblank=0 tsc=reliable reboot=acpi "
 #define VM0_PT_INTX_NUM 0U
 
 #endif /* MISC_CFG_H */

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -41,7 +41,7 @@
   </xsl:template>
 
 <xsl:template name="sos_rootfs">
-  <xsl:value-of select="acrn:define('SOS_ROOTFS', concat($quot, 'root=', vm/board_private/rootfs[text()], $quot), '')" />
+  <xsl:value-of select="acrn:define('SOS_ROOTFS', concat($quot, 'root=', vm/board_private/rootfs[text()], ' ', $quot), '')" />
 </xsl:template>
 
 <xsl:template name="sos_serial_console">
@@ -52,10 +52,10 @@
     </xsl:if>
     <xsl:if test="$consoleport != ''">
       <xsl:if test="contains($consoleport, '/')">
-        <xsl:value-of select="concat($quot, 'console=', substring-after(substring-after($consoleport,'/'), '/'), $quot)" />
+        <xsl:value-of select="concat($quot, 'console=', substring-after(substring-after($consoleport,'/'), '/'), ' ', $quot)" />
       </xsl:if>
       <xsl:if test="not(contains($consoleport, '/'))">
-        <xsl:value-of select="concat($quot, 'console=', $consoleport, $quot)" />
+        <xsl:value-of select="concat($quot, 'console=', $consoleport, ' ', $quot)" />
       </xsl:if>
     </xsl:if>
   </xsl:variable>
@@ -97,7 +97,7 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <xsl:value-of select="acrn:define('SOS_BOOTARGS_DIFF', concat($quot, $bootargs, ' ', $maxcpus, $quot), '')" />
+  <xsl:value-of select="acrn:define('SOS_BOOTARGS_DIFF', concat($quot, $bootargs, ' ', $maxcpus, ' ', $quot), '')" />
 </xsl:template>
 
 <xsl:template name="cpu_affinity">
@@ -196,7 +196,7 @@
     <xsl:if test="acrn:is-pre-launched-vm(vm_type)">
     <xsl:variable name="bootargs" select="normalize-space(os_config/bootargs)" />
       <xsl:if test="$bootargs">
-        <xsl:value-of select="acrn:define(concat('VM', @id, '_BOOT_ARGS'), concat($quot, $bootargs, $quot), '')" />
+        <xsl:value-of select="acrn:define(concat('VM', @id, '_BOOT_ARGS'), concat($quot, $bootargs, ' ', $quot), '')" />
       </xsl:if>
     </xsl:if>
   </xsl:for-each>


### PR DESCRIPTION
The macro definition SOS_VM_BOOTARGS in vm_configurations.h calls
macros SOS_ROOTFS, SOS_CONSOLE and SOS_BOOTARGS_DIFF which is defined in
misc_cfg.h and parsed from scenario.xmls.

Add a whitespace in the end of the argument macros to prevent arguments
are concatenated in a single line.

Tracked-On: #5998
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>