### PR TITLE
Paging/Memory Modularization - Cache/TLB Part

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -31,6 +31,7 @@
 #include <vpci.h>
 #include <ivshmem.h>
 #include <asm/rtcm.h>
+#include <reloc.h>
 
 #define CPU_UP_TIMEOUT		100U /* millisecond */
 #define CPU_DOWN_TIMEOUT	100U /* millisecond */
@@ -445,8 +446,8 @@ void cpu_dead(void)
 	if (bitmap_test(pcpu_id, &pcpu_active_bitmap)) {
 		/* clean up native stuff */
 		vmx_off();
-		/* TODO: a cpu dead can't effect the RTVM which use Software SRAM */
-		cache_flush_invalidate_all();
+
+		flush_cache_range((void *)get_hv_image_base(), CONFIG_HV_RAM_SIZE);
 
 		/* Set state to show CPU is dead */
 		pcpu_set_current_state(pcpu_id, PCPU_STATE_DEAD);

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -84,7 +84,7 @@ void reserve_buffer_for_ept_pages(void)
 	uint32_t offset = 0U;
 
 	page_base = e820_alloc_memory(TOTAL_EPT_4K_PAGES_SIZE, ~0UL);
-	ppt_clear_user_bit(page_base, TOTAL_EPT_4K_PAGES_SIZE);
+	set_paging_supervisor(page_base, TOTAL_EPT_4K_PAGES_SIZE);
 	for (vm_id = 0U; vm_id < CONFIG_MAX_VM_NUM; vm_id++) {
 		ept_pages[vm_id] = (struct page *)(void *)(page_base + offset);
 		/* assume each VM has same amount of EPT pages */

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -371,7 +371,7 @@ void ept_flush_leaf_page(uint64_t *pge, uint64_t size)
 			 *                            flush [sw_sram_top, end_hpa) in the next if condition
 			 */
 			stac();
-			flush_address_space(hpa2hva(base_hpa), min(end_hpa, sw_sram_bottom) - base_hpa);
+			flush_cache_range(hpa2hva(base_hpa), min(end_hpa, sw_sram_bottom) - base_hpa);
 			clac();
 		}
 
@@ -383,7 +383,7 @@ void ept_flush_leaf_page(uint64_t *pge, uint64_t size)
 			 *                            flush [base_hpa, sw_sram_bottom) in the below if condition
 			 */
 			stac();
-			flush_address_space(hpa2hva(max(base_hpa, sw_sram_top)), end_hpa - max(base_hpa, sw_sram_top));
+			flush_cache_range(hpa2hva(max(base_hpa, sw_sram_top)), end_hpa - max(base_hpa, sw_sram_top));
 			clac();
 		}
 	}

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -409,7 +409,7 @@ static int32_t wbinvd_vmexit_handler(struct acrn_vcpu *vcpu)
 
 	/* GUEST_FLAG_RT has not set in post-launched RTVM before it has been created */
 	if ((!is_software_sram_enabled()) && (!has_rt_vm())) {
-		cache_flush_invalidate_all();
+		flush_invalidate_all_cache();
 	} else {
 		if (is_rt_vm(vcpu->vm)) {
 			walk_ept_table(vcpu->vm, ept_flush_leaf_page);

--- a/hypervisor/arch/x86/ioapic.c
+++ b/hypervisor/arch/x86/ioapic.c
@@ -406,7 +406,7 @@ int32_t init_ioapic_id_info(void)
 		gsi = 0U;
 		for (ioapic_id = 0U; ioapic_id < ioapic_num; ioapic_id++) {
 			addr = map_ioapic(ioapic_array[ioapic_id].addr);
-			ppt_clear_user_bit((uint64_t)addr, PAGE_SIZE);
+			set_paging_supervisor((uint64_t)addr, PAGE_SIZE);
 
 			nr_pins = ioapic_nr_pins(addr);
 			if (nr_pins <= (uint32_t) CONFIG_MAX_IOAPIC_LINES) {

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -347,19 +347,6 @@ void init_paging(void)
 	enable_paging();
 }
 
-/*
- * @pre: addr != NULL  && size != 0
- */
-void flush_address_space(void *addr, uint64_t size)
-{
-	uint64_t n = 0UL;
-
-	while (n < size) {
-		clflushopt((char *)addr + n);
-		n += CACHE_LINE_SIZE;
-	}
-}
-
 void flush_tlb(uint64_t addr)
 {
 	invlpg(addr);
@@ -371,5 +358,24 @@ void flush_tlb_range(uint64_t addr, uint64_t size)
 
 	for (linear_addr = addr; linear_addr < (addr + size); linear_addr += PAGE_SIZE) {
 		invlpg(linear_addr);
+	}
+}
+
+void flush_invalidate_all_cache(void)
+{
+	wbinvd();
+}
+
+void flush_cacheline(const volatile void *p)
+{
+	clflush(p);
+}
+
+void flush_cache_range(const volatile void *p, uint64_t size)
+{
+	uint64_t i;
+
+	for (i = 0UL; i < size; i += CACHE_LINE_SIZE) {
+		clflushopt(p + i);
 	}
 }

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -55,7 +55,7 @@ static uint8_t sanitized_page[PAGE_SIZE] __aligned(PAGE_SIZE);
 static struct page ppt_pages[PPT_PAGE_NUM];
 static uint64_t ppt_page_bitmap[PPT_PAGE_NUM / 64];
 
-/* ppt: pripary page pool */
+/* ppt: primary page pool */
 static struct page_pool ppt_page_pool = {
 	.start_page = ppt_pages,
 	.bitmap_size = PPT_PAGE_NUM / 64,
@@ -237,7 +237,7 @@ void enable_smap(void)
 /*
  * Clean USER bit in page table to update memory pages to be owned by hypervisor.
  */
-void ppt_clear_user_bit(uint64_t base, uint64_t size)
+void set_paging_supervisor(uint64_t base, uint64_t size)
 {
 	uint64_t base_aligned;
 	uint64_t size_aligned;
@@ -251,19 +251,24 @@ void ppt_clear_user_bit(uint64_t base, uint64_t size)
 		round_pde_up(size_aligned), 0UL, PAGE_USER, &ppt_pgtable, MR_MODIFY);
 }
 
-void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add)
+void set_paging_nx(uint64_t base, uint64_t size)
 {
 	uint64_t region_end = base + size;
 	uint64_t base_aligned = round_pde_down(base);
 	uint64_t size_aligned = round_pde_up(region_end - base_aligned);
 
-	if (add) {
-		pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr,
-			base_aligned, size_aligned, PAGE_NX, 0UL, &ppt_pgtable, MR_MODIFY);
-	} else {
-		pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr,
-			base_aligned, size_aligned, 0UL, PAGE_NX, &ppt_pgtable, MR_MODIFY);
-	}
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr,
+		base_aligned, size_aligned, PAGE_NX, 0UL, &ppt_pgtable, MR_MODIFY);
+}
+
+void set_paging_x(uint64_t base, uint64_t size)
+{
+	uint64_t region_end = base + size;
+	uint64_t base_aligned = round_pde_down(base);
+	uint64_t size_aligned = round_pde_up(region_end - base_aligned);
+
+	pgtable_modify_or_del_map((uint64_t *)ppt_mmu_pml4_addr,
+		base_aligned, size_aligned, 0UL, PAGE_NX, &ppt_pgtable, MR_MODIFY);
 }
 
 void init_paging(void)

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -359,3 +359,17 @@ void flush_address_space(void *addr, uint64_t size)
 		n += CACHE_LINE_SIZE;
 	}
 }
+
+void flush_tlb(uint64_t addr)
+{
+	invlpg(addr);
+}
+
+void flush_tlb_range(uint64_t addr, uint64_t size)
+{
+	uint64_t linear_addr;
+
+	for (linear_addr = addr; linear_addr < (addr + size); linear_addr += PAGE_SIZE) {
+		invlpg(linear_addr);
+	}
+}

--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -24,11 +24,6 @@ static struct rtct_entry_data_rtcm_binary *rtcm_binary = NULL;
 
 static struct acpi_table_header *acpi_rtct_tbl = NULL;
 
-static inline void rtcm_set_nx(bool add)
-{
-	ppt_set_nx_bit((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size, add);
-}
-
 static inline void rtcm_flush_binary_tlb(void)
 {
 	uint64_t linear_addr, start_addr = (uint64_t)hpa2hva(rtcm_binary->address);
@@ -125,7 +120,7 @@ bool init_software_sram(bool is_bsp)
 			parse_rtct();
 			if (rtcm_binary != NULL) {
 				/* Clear the NX bit of PTCM area */
-				rtcm_set_nx(false);
+				set_paging_x((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size);
 			}
 			bitmap_clear_lock(get_pcpu_id(), &init_sw_sram_cpus_mask);
 		}
@@ -148,7 +143,7 @@ bool init_software_sram(bool is_bsp)
 
 			if (is_bsp) {
 				/* Restore the NX bit of RTCM area in page table */
-				rtcm_set_nx(true);
+				set_paging_nx((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size);
 			}
 
 			bitmap_set_lock(get_pcpu_id(), &init_sw_sram_cpus_mask);

--- a/hypervisor/arch/x86/trampoline.c
+++ b/hypervisor/arch/x86/trampoline.c
@@ -107,7 +107,7 @@ static void update_trampoline_code_refs(uint64_t dest_pa)
 
 uint64_t prepare_trampoline(void)
 {
-	uint64_t size, dest_pa, i;
+	uint64_t size, dest_pa;
 
 	size = (uint64_t)(&ld_trampoline_end - &ld_trampoline_start);
 	dest_pa = e820_alloc_memory(CONFIG_LOW_RAM_SIZE, MEM_1M);
@@ -120,9 +120,7 @@ uint64_t prepare_trampoline(void)
 	update_trampoline_code_refs(dest_pa);
 
 	cpu_memory_barrier();
-	for (i = 0UL; i < size; i = i + CACHE_LINE_SIZE) {
-		clflush(hpa2hva(dest_pa + i));
-	}
+	flush_cache_range(hpa2hva(dest_pa), size);
 
 	trampoline_start16_paddr = dest_pa;
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -264,13 +264,9 @@ static inline void dmar_wait_completion(const struct dmar_drhd_rt *dmar_unit, ui
  */
 void iommu_flush_cache(const void *p, uint32_t size)
 {
-	uint32_t i;
-
 	/* if vtd support page-walk coherency, no need to flush cacheline */
 	if (!iommu_page_walk_coherent) {
-		for (i = 0U; i < size; i += CACHE_LINE_SIZE) {
-			clflush((const char *)p + i);
-		}
+		flush_cache_range(p, size);
 	}
 }
 

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -10,8 +10,7 @@
 #include <errno.h>
 #include <asm/lib/bits.h>
 #include <asm/lib/spinlock.h>
-#include <asm/page.h>
-#include <asm/pgtable.h>
+#include <asm/cpu_caps.h>
 #include <irq.h>
 #include <asm/irq.h>
 #include <asm/io.h>

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -210,7 +210,7 @@ static int32_t register_hrhd_units(void)
 		drhd_rt->drhd = &platform_dmar_info->drhd_units[i];
 		drhd_rt->dmar_irq = IRQ_INVALID;
 
-		ppt_clear_user_bit(drhd_rt->drhd->reg_base_addr, PAGE_SIZE);
+		set_paging_supervisor(drhd_rt->drhd->reg_base_addr, PAGE_SIZE);
 
 		ret = dmar_register_hrhd(drhd_rt);
 		if (ret != 0) {

--- a/hypervisor/debug/dump.c
+++ b/hypervisor/debug/dump.c
@@ -255,7 +255,7 @@ void dump_exception(struct intr_excp_ctx *ctx, uint16_t pcpu_id)
 
 	/* Save registers*/
 	crash_ctx = ctx;
-	cache_flush_invalidate_all();
+	flush_invalidate_all_cache();
 
 	/* Release lock to let other CPUs handle exception */
 	spinlock_release(&exception_spinlock);

--- a/hypervisor/debug/npk_log.c
+++ b/hypervisor/debug/npk_log.c
@@ -104,7 +104,7 @@ void npk_log_setup(struct hv_npk_log_param *param)
 				for (i = 0U; i < pcpu_nums; i++) {
 					per_cpu(npk_log_ref, i) = 0U;
 				}
-				ppt_clear_user_bit(base,
+				set_paging_supervisor(base,
 					pcpu_nums * (HV_NPK_LOG_REF_MASK + 1U)
 					* sizeof(struct npk_chan));
 			}

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -7,9 +7,9 @@
 #include <types.h>
 #include <asm/lib/spinlock.h>
 #include <pci.h>
-#include <asm/pgtable.h>
 #include <uart16550.h>
 #include <asm/io.h>
+#include <asm/cpu.h>
 #include <asm/mmu.h>
 
 #define MAX_BDF_LEN 8

--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -133,7 +133,7 @@ void uart16550_init(bool early_boot)
 		if (uart.type == MMIO) {
 			mmio_base_va = hpa2hva(hva2hpa_early(uart.mmio_base_vaddr));
 			if (mmio_base_va != NULL) {
-				ppt_clear_user_bit((uint64_t)mmio_base_va, PDE_SIZE);
+				set_paging_supervisor((uint64_t)mmio_base_va, PDE_SIZE);
 			}
 		}
 		return;

--- a/hypervisor/dm/vgpio.c
+++ b/hypervisor/dm/vgpio.c
@@ -142,7 +142,7 @@ void register_vgpio_handler(struct acrn_vm *vm, const struct acrn_mmiodev *mmiod
 	base_hpa    = mmiodev->base_hpa + (P2SB_BASE_GPIO_PORT_ID << P2SB_PORTID_SHIFT);
 
 	/* emulate MMIO access to the GPIO private configuration space registers */
-	ppt_clear_user_bit((uint64_t)hpa2hva(base_hpa), gpio_pcr_sz);
+	set_paging_supervisor((uint64_t)hpa2hva(base_hpa), gpio_pcr_sz);
 	register_mmio_emulation_handler(vm, vgpio_mmio_handler, gpa_start, gpa_end, (void *)vm, false);
 	ept_del_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, gpa_start, gpio_pcr_sz);
 }

--- a/hypervisor/hw/pci.c
+++ b/hypervisor/hw/pci.c
@@ -652,7 +652,7 @@ void init_pci_pdev_list(void)
 	uint16_t bus;
 	bool was_visited = false;
 
-	ppt_clear_user_bit(phys_pci_mmcfg.address, get_pci_mmcfg_size(&phys_pci_mmcfg));
+	set_paging_supervisor(phys_pci_mmcfg.address, get_pci_mmcfg_size(&phys_pci_mmcfg));
 
 	pci_parse_iommu_devscopes(&bdfs_from_drhds, &drhd_idx_pci_all);
 

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -551,7 +551,7 @@ static inline void invlpg(unsigned long addr)
 	asm volatile("invlpg (%0)" ::"r" (addr) : "memory");
 }
 
-static inline void cache_flush_invalidate_all(void)
+static inline void wbinvd(void)
 {
 	asm volatile ("   wbinvd\n" : : : "memory");
 }

--- a/hypervisor/include/arch/x86/asm/cpu.h
+++ b/hypervisor/include/arch/x86/asm/cpu.h
@@ -546,6 +546,26 @@ static inline void cpu_memory_barrier(void)
 	asm volatile ("mfence\n" : : : "memory");
 }
 
+static inline void invlpg(unsigned long addr)
+{
+	asm volatile("invlpg (%0)" ::"r" (addr) : "memory");
+}
+
+static inline void cache_flush_invalidate_all(void)
+{
+	asm volatile ("   wbinvd\n" : : : "memory");
+}
+
+static inline void clflush(const volatile void *p)
+{
+	asm volatile ("clflush (%0)" :: "r"(p));
+}
+
+static inline void clflushopt(const volatile void *p)
+{
+	asm volatile ("clflushopt (%0)" :: "r"(p));
+}
+
 /* Write the task register */
 #define CPU_LTR_EXECUTE(ltr_ptr)                            \
 {                                                           \

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -130,17 +130,6 @@ void flush_vpid_single(uint16_t vpid);
 void flush_vpid_global(void);
 
 /**
- * @brief Flush address space
- *
- * @param[in] addr the specified virtual address
- *
- * @param[in] size the specified size to flush
- *
- * @return None
- */
-void flush_address_space(void *addr, uint64_t size);
-
-/**
  * @brief Guest-physical mappings and combined mappings invalidation
  *
  * @param[in] eptp the pointer that points the eptp
@@ -160,6 +149,10 @@ static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)
  */
 void flush_tlb(uint64_t addr);
 void flush_tlb_range(uint64_t addr, uint64_t size);
+
+void flush_invalidate_all_cache(void);
+void flush_cacheline(const volatile void *p);
+void flush_cache_range(const volatile void *p, uint64_t size);
 
 /**
  * @}

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -45,10 +45,8 @@
 
 #ifndef ASSEMBLER
 
-#include <asm/cpu.h>
 #include <asm/page.h>
 #include <asm/pgtable.h>
-#include <asm/cpu_caps.h>
 
 /* Define cache line size (in bytes) */
 #define CACHE_LINE_SIZE		64U
@@ -150,26 +148,6 @@ void flush_address_space(void *addr, uint64_t size);
  * @return None
  */
 void invept(const void *eptp);
-
-static inline void invlpg(unsigned long addr)
-{
-	asm volatile("invlpg (%0)" ::"r" (addr) : "memory");
-}
-
-static inline void cache_flush_invalidate_all(void)
-{
-	asm volatile ("   wbinvd\n" : : : "memory");
-}
-
-static inline void clflush(const volatile void *p)
-{
-	asm volatile ("clflush (%0)" :: "r"(p));
-}
-
-static inline void clflushopt(const volatile void *p)
-{
-	asm volatile ("clflushopt (%0)" :: "r"(p));
-}
 
 /* get PDPT address from CR3 vaule in PAE mode */
 static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -155,6 +155,12 @@ static inline uint64_t get_pae_pdpt_addr(uint64_t cr3)
 	return (cr3 & 0xFFFFFFE0UL);
 }
 
+/*
+ * flush TLB only for the specified page with the address
+ */
+void flush_tlb(uint64_t addr);
+void flush_tlb_range(uint64_t addr, uint64_t size);
+
 /**
  * @}
  */

--- a/hypervisor/include/arch/x86/asm/mmu.h
+++ b/hypervisor/include/arch/x86/asm/mmu.h
@@ -108,8 +108,13 @@ void enable_smap(void);
  * @return None
  */
 void init_paging(void);
-void ppt_clear_user_bit(uint64_t base, uint64_t size);
-void ppt_set_nx_bit(uint64_t base, uint64_t size, bool add);
+
+/*
+ * set paging attribute for primary page tables
+ */
+void set_paging_supervisor(uint64_t base, uint64_t size);
+void set_paging_x(uint64_t base, uint64_t size);
+void set_paging_nx(uint64_t base, uint64_t size);
 
 /**
  * @brief Specified signle VPID flush


### PR DESCRIPTION
Wrap common APIs for Cache/TLB Part

For Cache, ACRN provides three APIs:
    - flush_invalidate_all_cache
    - flush_cacheline
    - flush_cache_range

For TLB, ACRN provides two APIs:
    - flush_tlb
    - flush_tlb_range

This patch also remove ppt_set/clear_(attribute) to set_paging_(attribute)

Tracked-On: #5830
Signed-off-by: Li Fei1 <fei1.li@intel.com>
