### PR TITLE
config-tools: fix the regular expression of ivshmem region name

### DIFF
--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -129,7 +129,7 @@ its size, and the VM IDs that can access it, such as ``hv:/shm_region_0, 2, 0:2`
 See :ref:`ivshmem-hv` for more information.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">
-    <xs:pattern value="|hv:/\w+,\s?\d+\s?,\s?\d\s?(:\s?\d\s?)+" />
+    <xs:pattern value="|((hv)|(dm)):/\w+,\s?\d+\s?,\s?\d\s?(:\s?\d\s?)+" />
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
The ivshmem region name format is not ristricted to start with "hv".
Loosen the schema validation so that the region name can start with "hv" or "dm".

Tracked-On: #6009
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>