### PR TITLE
config-tool: rename PSRARM to SSRAM

### DIFF
--- a/hypervisor/arch/x86/Kconfig
+++ b/hypervisor/arch/x86/Kconfig
@@ -260,7 +260,7 @@ config CDP_ENABLED
 	  prioritization of code and data fetches to the L2 or L3 cache in a
 	  software configurable manner, depending on hardware support.
 
-config PSRAM_ENABLED
+config SSRAM_ENABLED
 	bool "Enable Software SRAM support"
 	depends on !CDP_ENABLED
 	default n

--- a/misc/config_tools/acpi_gen/asl_gen.py
+++ b/misc/config_tools/acpi_gen/asl_gen.py
@@ -434,7 +434,7 @@ def main(args):
     PASSTHROUGH_PTCT = False
     PRELAUNCHED_RTVM_ID = None
     try:
-        if scenario_root.find('hv/FEATURES/PSRAM/PSRAM_ENABLED').text.strip() == 'y':
+        if scenario_root.find('hv/FEATURES/SSRAM/SSRAM_ENABLED').text.strip() == 'y':
             PASSTHROUGH_PTCT = True
         for vm in scenario_root.findall('vm'):
             vm_id = vm.attrib['id']

--- a/misc/config_tools/board_config/misc_cfg_h.py
+++ b/misc/config_tools/board_config/misc_cfg_h.py
@@ -191,7 +191,7 @@ def swsram_base_gpa_gen(config):
 
     """
     scenario_etree = lxml.etree.parse(common.SCENARIO_INFO_FILE)
-    enabled = scenario_etree.xpath("//PSRAM_ENABLED")
+    enabled = scenario_etree.xpath("//SSRAM_ENABLED")
     if enabled and enabled[0].text == "y":
         pre_rt_vms = scenario_etree.xpath("//vm/vm_type[text() ='PRE_RT_VM']")
         if pre_rt_vms:

--- a/misc/config_tools/board_inspector/legacy/rtct.py
+++ b/misc/config_tools/board_inspector/legacy/rtct.py
@@ -8,7 +8,7 @@ from acpiparser import parse_rtct
 import acpiparser.rtct
 import parser_lib
 
-def dump_psram(config):
+def dump_ssram(config):
     print("\t<RTCT>", file=config)
 
     rtct = None
@@ -40,4 +40,4 @@ def generate_info(board_info):
     :param board_info: this is the file which stores the hardware board information
     """
     with open(board_info, 'a+') as config:
-        dump_psram(config)
+        dump_ssram(config)

--- a/misc/config_tools/config_app/templates/scenario.html
+++ b/misc/config_tools/config_app/templates/scenario.html
@@ -204,7 +204,7 @@ the source files will be generated into default path and overwirte the previous 
                             {% for sub_elem in elem|list %}
                                 {% set sub_elem_text = sub_elem.text if sub_elem.text != None else '' %}
 
-                                {% if sub_elem.tag in ['RDT', 'IVSHMEM', 'PSRAM'] %}
+                                {% if sub_elem.tag in ['RDT', 'IVSHMEM', 'SSRAM'] %}
                                     {% for sub_elem_2 in sub_elem|list %}
                                     {% set sub_elem_2_text = sub_elem_2.text if sub_elem_2.text != None else '' %}
                                     {% if ','.join([vm.tag, elem.tag, sub_elem.tag, sub_elem_2.tag]) in scenario_item_values %}

--- a/misc/config_tools/data/adl-rvp/industry.xml
+++ b/misc/config_tools/data/adl-rvp/industry.xml
@@ -30,9 +30,9 @@
             <IVSHMEM_ENABLED>n</IVSHMEM_ENABLED>
             <IVSHMEM_REGION/>
         </IVSHMEM>
-        <PSRAM>
-            <PSRAM_ENABLED>n</PSRAM_ENABLED>
-        </PSRAM>
+        <SSRAM>
+            <SSRAM_ENABLED>n</SSRAM_ENABLED>
+        </SSRAM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
@@ -45,9 +45,9 @@
                 <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
                 <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
             </IVSHMEM>
-            <PSRAM>
-                <PSRAM_ENABLED>n</PSRAM_ENABLED>
-            </PSRAM>
+            <SSRAM>
+                <SSRAM_ENABLED>n</SSRAM_ENABLED>
+            </SSRAM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE>0x2000</STACK_SIZE>

--- a/misc/config_tools/data/ehl-crb-b/industry.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry.xml
@@ -45,9 +45,9 @@
                 <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
                 <IVSHMEM_REGION>hv:/shm_region_0, 2, 2:3</IVSHMEM_REGION>
             </IVSHMEM>
-            <PSRAM>
-                <PSRAM_ENABLED>n</PSRAM_ENABLED>
-            </PSRAM>
+            <SSRAM>
+                <SSRAM_ENABLED>n</SSRAM_ENABLED>
+            </SSRAM>
         </FEATURES>
         <MEMORY>
             <STACK_SIZE>0x2000</STACK_SIZE>

--- a/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
@@ -30,9 +30,9 @@
             <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
             <IVSHMEM_REGION>hv:/shm_region_0, 2, 0:2</IVSHMEM_REGION>
         </IVSHMEM>
-        <PSRAM>
-            <PSRAM_ENABLED>n</PSRAM_ENABLED>
-        </PSRAM>
+        <SSRAM>
+            <SSRAM_ENABLED>n</SSRAM_ENABLED>
+        </SSRAM>
     </FEATURES>
 
     <MEMORY>

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -28,9 +28,9 @@
         <IVSHMEM_ENABLED>y</IVSHMEM_ENABLED>
         <IVSHMEM_REGION>hv:/shm_region_0, 2, 2:3</IVSHMEM_REGION>
       </IVSHMEM>
-      <PSRAM>
-        <PSRAM_ENABLED>n</PSRAM_ENABLED>
-      </PSRAM>
+      <SSRAM>
+        <SSRAM_ENABLED>n</SSRAM_ENABLED>
+      </SSRAM>
     </FEATURES>
     <MEMORY>
         <STACK_SIZE>0x2000</STACK_SIZE>

--- a/misc/config_tools/hv_config/board_defconfig.py
+++ b/misc/config_tools/hv_config/board_defconfig.py
@@ -158,8 +158,8 @@ def get_features(hv_info, config):
     print("CONFIG_ACPI_PARSE_ENABLED={}".format(hv_info.features.acpi_parse_enabled), file=config)
     print("CONFIG_L1D_FLUSH_VMENTRY_ENABLED={}".format(hv_info.features.l1d_flush_vmentry_enabled), file=config)
     print("CONFIG_MCE_ON_PSC_WORKAROUND_DISABLED={}".format(hv_info.features.mce_on_psc_workaround_disabled), file=config)
-    if hv_info.features.psram_enabled in ['y', 'n']:
-        print("CONFIG_PSRAM_ENABLED={}".format(hv_info.features.psram_enabled), file=config)
+    if hv_info.features.ssram_enabled in ['y', 'n']:
+        print("CONFIG_SSRAM_ENABLED={}".format(hv_info.features.ssram_enabled), file=config)
 
 
 def get_capacities(hv_info, config):

--- a/misc/config_tools/hv_config/hv_item.py
+++ b/misc/config_tools/hv_config/hv_item.py
@@ -109,7 +109,7 @@ class Features:
         self.acpi_parse_enabled = ''
         self.l1d_flush_vmentry_enabled = ''
         self.mce_on_psc_workaround_disabled = ''
-        self.psram_enabled = ''
+        self.ssram_enabled = ''
 
     def get_info(self):
         self.multiboot2 = common.get_hv_item_tag(self.hv_file, "FEATURES", "MULTIBOOT2")
@@ -124,7 +124,7 @@ class Features:
         self.l1d_flush_vmentry_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "L1D_VMENTRY_ENABLED")
         self.mce_on_psc_workaround_disabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "MCE_ON_PSC_DISABLED")
         self.iommu_enforce_snp = common.get_hv_item_tag(self.hv_file, "FEATURES", "IOMMU_ENFORCE_SNP")
-        self.psram_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "PSRAM", "PSRAM_ENABLED")
+        self.ssram_enabled = common.get_hv_item_tag(self.hv_file, "FEATURES", "SSRAM", "SSRAM_ENABLED")
 
     def check_item(self):
         hv_cfg_lib.ny_support_check(self.multiboot2, "FEATURES", "MULTIBOOT2")
@@ -139,8 +139,8 @@ class Features:
         hv_cfg_lib.ny_support_check(self.l1d_flush_vmentry_enabled, "FEATURES", "L1D_VMENTRY_ENABLED")
         hv_cfg_lib.ny_support_check(self.mce_on_psc_workaround_disabled, "FEATURES", "MCE_ON_PSC_DISABLED")
         hv_cfg_lib.ny_support_check(self.iommu_enforce_snp, "FEATURES", "IOMMU_ENFORCE_SNP")
-        # hv_cfg_lib.ny_support_check(self.psram_enabled, "FEATURES", "PSRAM", "PSRAM_ENABLED")
-        hv_cfg_lib.hv_psram_check(self.psram_enabled, self.cdp_enabled, "FEATURES", "PSRAM", "PSRAM_ENABLED")
+        # hv_cfg_lib.ny_support_check(self.ssram_enabled, "FEATURES", "SSRAM", "SSRAM_ENABLED")
+        hv_cfg_lib.hv_ssram_check(self.ssram_enabled, self.cdp_enabled, "FEATURES", "SSRAM", "SSRAM_ENABLED")
 
 
 class Memory:

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -613,14 +613,14 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     # shm regions args set
     shm_arg_set(dm, vmid, config)
 
-    # psram set
-    psram_enabled = 'n'
+    # ssram set
+    ssram_enabled = 'n'
     try:
-        psram_enabled = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "PSRAM", "PSRAM_ENABLED")
+        ssram_enabled = common.get_hv_item_tag(common.SCENARIO_INFO_FILE, "FEATURES", "SSRAM", "SSRAM_ENABLED")
     except:
         pass
-    if uos_type == "PREEMPT-RT LINUX" and psram_enabled == 'y':
-        print("   --psram \\", file=config)
+    if uos_type == "PREEMPT-RT LINUX" and ssram_enabled == 'y':
+        print("   --ssram \\", file=config)
 
     for value in sel.bdf.values():
         if value[vmid]:

--- a/misc/config_tools/library/hv_cfg_lib.py
+++ b/misc/config_tools/library/hv_cfg_lib.py
@@ -233,8 +233,8 @@ def max_msix_table_num_check(max_msix_table_num, cap_str, max_msi_num_str):
         range_check(native_max_msix_num, "In board xml", max_msi_num_str, RANGE_DB['MSIX_TABLE_NUM'])
 
 
-def hv_psram_check(psram_enabled, cpd_enabled, feature, tag, leaf):
+def hv_ssram_check(ssram_enabled, cpd_enabled, feature, tag, leaf):
     key = 'hv,{},{},{}'.format(feature, tag, leaf)
-    if psram_enabled == 'y' and cpd_enabled == 'y':
-        ERR_LIST[key] = "PSRAM_ENABLED should not be y when CDP_ENABLED is y."
+    if ssram_enabled == 'y' and cpd_enabled == 'y':
+        ERR_LIST[key] = "SSRAM_ENABLED should not be y when CDP_ENABLED is y."
         return

--- a/misc/config_tools/scenario_config/scenario_cfg_gen.py
+++ b/misc/config_tools/scenario_config/scenario_cfg_gen.py
@@ -90,7 +90,7 @@ def get_scenario_item_values(board_info, scenario_info):
     scenario_item_values["hv,FEATURES,MCE_ON_PSC_DISABLED"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,FEATURES,IOMMU_ENFORCE_SNP"] = hv_cfg_lib.N_Y
     scenario_item_values["hv,FEATURES,IVSHMEM,IVSHMEM_ENABLED"] = hv_cfg_lib.N_Y
-    scenario_item_values["hv,FEATURES,PSRAM,PSRAM_ENABLED"] = hv_cfg_lib.N_Y
+    scenario_item_values["hv,FEATURES,SSRAM,SSRAM_ENABLED"] = hv_cfg_lib.N_Y
 
     scenario_cfg_lib.ERR_LIST.update(hv_cfg_lib.ERR_LIST)
     return scenario_item_values

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -156,13 +156,13 @@ Machine Check Error on Page Size Change.</xs:documentation>
         <xs:documentation>Enable Inter-VM Shared memory feature.</xs:documentation>
       </xs:annotation>
     </xs:element>
-    <xs:element name="PSRAM" minOccurs="0" type="PSRAMInfo">
+    <xs:element name="SSRAM" minOccurs="0" type="SSRAMInfo">
       <xs:annotation>
         <xs:documentation>Pseudo SRAM configuration.</xs:documentation>
       </xs:annotation>
     </xs:element>
   </xs:all>
-  <xs:assert test="not (RDT/RDT_ENABLED = 'y' and PSRAM/PSRAM_ENABLED = 'y')"/>
+  <xs:assert test="not (RDT/RDT_ENABLED = 'y' and SSRAM/SSRAM_ENABLED = 'y')"/>
   <xs:assert test="not (NVMX_ENABLED = 'y' and not (SCHEDULER = 'SCHED_NOOP'))"/>
 </xs:complexType>
 

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -189,9 +189,9 @@ are allowed. The value will be ignored when hardware does not support RDT.</xs:d
   </xs:sequence>
 </xs:complexType>
 
-<xs:complexType name="PSRAMInfo">
+<xs:complexType name="SSRAMInfo">
   <xs:sequence>
-    <xs:element name="PSRAM_ENABLED" type="Boolean" default="n">
+    <xs:element name="SSRAM_ENABLED" type="Boolean" default="n">
       <xs:annotation>
         <xs:documentation>Enable PTCM (Platform Tuning Configuration
 Manager).</xs:documentation>

--- a/misc/config_tools/xforms/config_common.xsl
+++ b/misc/config_tools/xforms/config_common.xsl
@@ -114,8 +114,8 @@
     </xsl:call-template>
 
     <xsl:call-template name="boolean-by-key-value">
-      <xsl:with-param name="key" select="'PSRAM_ENABLED'" />
-      <xsl:with-param name="value" select="PSRAM/PSRAM_ENABLED" />
+      <xsl:with-param name="key" select="'SSRAM_ENABLED'" />
+      <xsl:with-param name="value" select="SSRAM/SSRAM_ENABLED" />
     </xsl:call-template>
 
     <xsl:call-template name="boolean-by-key-value">


### PR DESCRIPTION
  'psram' and 'PSARM' are legacy names and replaced
  with 'ssram' and 'SSRAM' respectively.

Tracked-On: #6012
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>