### PR TITLE
hv: rename some software SRAM local names

### DIFF
--- a/hypervisor/include/arch/x86/asm/rtct.h
+++ b/hypervisor/include/arch/x86/asm/rtct.h
@@ -48,7 +48,7 @@ struct rtct_entry_data_rtcm_binary
 	uint32_t size;
 } __packed;
 
-struct rtct_entry_data_software_sram
+struct rtct_entry_data_ssram
 {
 	uint32_t cache_level;
 	uint64_t base;


### PR DESCRIPTION
 For simplification purpose, use 'ssram' instead of
 'software sram' for local names inside rtcm module.

Tracked-On: #6015
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>