### PR TITLE
dm: clean legacy software SRAM names

### DIFF
--- a/devicemodel/core/main.c
+++ b/devicemodel/core/main.c
@@ -91,7 +91,7 @@ bool stdio_in_use;
 bool lapic_pt;
 bool is_rtvm;
 bool pt_tpm2;
-bool pt_ptct;
+bool pt_rtct;
 bool is_winvm;
 bool skip_pci_mem64bar_workaround = false;
 
@@ -148,7 +148,7 @@ usage(int code)
 		"       %*s [--cpu_affinity pCPUs] [--lapic_pt] [--rtvm] [--windows]\n"
 		"       %*s [--debugexit] [--logger_setting param_setting]\n"
 		"       %*s [--pm_notify_channel] [--pm_by_vuart vuart_node]\n"
-		"       %*s [--psram] <vm>\n"
+		"       %*s [--ssram] <vm>\n"
 		"       -A: create ACPI tables\n"
 		"       -B: bootargs for kernel\n"
 		"       -E: elf image path\n"
@@ -167,7 +167,7 @@ usage(int code)
 		"       --mac_seed: set a platform unique string as a seed for generate mac address\n"
 		"       --vsbl: vsbl file path\n"
 		"       --ovmf: ovmf file path\n"
-		"       --psram: Enable Software SRAM passthrough\n"
+		"       --ssram: Enable Software SRAM passthrough\n"
 		"       --cpu_affinity: list of pCPUs assigned to this VM\n"
 		"       --part_info: guest partition info file path\n"
 		"       --enable_trusty: enable trusty for guest\n"
@@ -796,7 +796,7 @@ static struct option long_options[] = {
 	{"vtpm2",		required_argument,	0, CMD_OPT_VTPM2},
 	{"lapic_pt",		no_argument,		0, CMD_OPT_LAPIC_PT},
 	{"rtvm",		no_argument,		0, CMD_OPT_RTVM},
-	{"psram",		no_argument,		0, CMD_OPT_SOFTWARE_SRAM},
+	{"ssram",		no_argument,		0, CMD_OPT_SOFTWARE_SRAM},
 	{"logger_setting",	required_argument,	0, CMD_OPT_LOGGER_SETTING},
 	{"pm_notify_channel",	required_argument,	0, CMD_OPT_PM_NOTIFY_CHANNEL},
 	{"pm_by_vuart",	required_argument,	0, CMD_OPT_PM_BY_VUART},
@@ -942,7 +942,7 @@ main(int argc, char *argv[])
 			break;
 		case CMD_OPT_SOFTWARE_SRAM:
 			/* TODO: we need to support parameter to specify Software SRAM size in the future */
-			pt_ptct = true;
+			pt_rtct = true;
 			break;
 		case CMD_OPT_ACPIDEV_PT:
 			if (parse_pt_acpidev(optarg) != 0)

--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -192,7 +192,7 @@ basl_fwrite_rsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
-	if (pt_ptct) {
+	if (pt_rtct) {
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : %08X\n", num++,
 			    basl_acpi_base + RTCT_OFFSET);
 	}
@@ -239,7 +239,7 @@ basl_fwrite_xsdt(FILE *fp, struct vmctx *ctx)
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
 		    basl_acpi_base + TPM2_OFFSET);
 
-	if (pt_ptct) {
+	if (pt_rtct) {
 		EFPRINTF(fp, "[0004]\t\tACPI Table Address %u : 00000000%08X\n", num++,
 			    basl_acpi_base + RTCT_OFFSET);
 	}
@@ -1208,7 +1208,7 @@ acpi_build(struct vmctx *ctx, int ncpu)
 		i++;
 	}
 
-	if (pt_ptct) {
+	if (pt_rtct) {
 		create_and_inject_vrtct(ctx);
 	}
 

--- a/devicemodel/include/dm.h
+++ b/devicemodel/include/dm.h
@@ -51,7 +51,7 @@ extern char *mac_seed;
 extern bool lapic_pt;
 extern bool is_rtvm;
 extern bool pt_tpm2;
-extern bool pt_ptct;
+extern bool pt_rtct;
 extern bool is_winvm;
 
 int vmexit_task_switch(struct vmctx *ctx, struct vhm_request *vhm_req,

--- a/devicemodel/include/rtct.h
+++ b/devicemodel/include/rtct.h
@@ -11,7 +11,7 @@
 #define RTCT_ENTRY_TYPE_PTCM_BINARY		2U
 #define RTCT_ENTRY_TYPE_WRC_L3_MASKS		3U
 #define RTCT_ENTRY_TYPE_GT_L3_MASKS		4U
-#define RTCT_ENTRY_TYPE_PSRAM			5U
+#define RTCT_ENTRY_TYPE_SSRAM			5U
 #define RTCT_ENTRY_TYPE_STREAM_DATAPATH		6U
 #define RTCT_ENTRY_TYPE_TIMEAWARE_SUBSYS	7U
 #define RTCT_ENTRY_TYPE_RT_IOMMU		8U
@@ -24,7 +24,7 @@ struct rtct_entry {
 	uint32_t data[64];
 } __packed;
 
-struct rtct_entry_data_psram {
+struct rtct_entry_data_ssram {
 	uint32_t cache_level;
 	uint64_t base;
 	uint32_t ways;


### PR DESCRIPTION
Remove below legacy SSRAM names:

  psram -> ssram
  ptct -> rtct

Tracked-On: #6015
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>