### PR TITLE
doc: clean legacy software SRAM names

### DIFF
--- a/devicemodel/core/sw_load_common.c
+++ b/devicemodel/core/sw_load_common.c
@@ -224,7 +224,7 @@ acrn_create_e820_table(struct vmctx *ctx, struct e820_entry *e820)
 
 	memcpy(e820, e820_default_entries, sizeof(e820_default_entries));
 
-	/* FIXME: Here wastes 8MB memory if pSRAM is enabled, and 64MB+16KB if
+	/* FIXME: Here wastes 8MB memory if SSRAM is enabled, and 64MB+16KB if
 	 * GPU reserved memory is exist.
 	 *
 	 * Determines the GPU region due to DSM identical mapping.

--- a/doc/developer-guides/hld/hld-devicemodel.rst
+++ b/doc/developer-guides/hld/hld-devicemodel.rst
@@ -60,7 +60,7 @@ options:
                [--vtpm2 sock_path] [--virtio_poll interval] [--mac_seed seed_string]
                [--cpu_affinity pCPUs] [--lapic_pt] [--rtvm] [--windows]
                [--debugexit] [--logger-setting param_setting] [--pm_notify_channel]
-               [--pm_by_vuart vuart_node] [--psram] <vm>
+               [--pm_by_vuart vuart_node] [--ssram] <vm>
        -A: create ACPI tables
        -B: bootargs for kernel
        -E: elf image path
@@ -79,7 +79,7 @@ options:
        --mac_seed: set a platform unique string as a seed for generate mac address
        --vsbl: vsbl file path
        --ovmf: ovmf file path
-       --psram: Enable Pseudo (Software) SRAM passthrough
+       --ssram: Enable Software SRAM
        --cpu_affinity: list of pCPUs assigned to this VM
        --part_info: guest partition info file path
        --enable_trusty: enable trusty for guest

--- a/doc/user-guides/acrn-dm-parameters.rst
+++ b/doc/user-guides/acrn-dm-parameters.rst
@@ -462,9 +462,9 @@ Here are descriptions for each of these ``acrn-dm`` command line parameters:
 
 ----
 
-``--psram``
-   This option enables Pseudo (Software) SRAM passthrough to the VM.
+``--ssram``
+   This option enables Software SRAM passthrough to the VM.
 
    usage::
 
-      --psram
+      --ssram


### PR DESCRIPTION
 psram is legacy name of SSRAM, rename it to ssam

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>