### PR TITLE
build: fix dm and acrn_crashlog build error with gcc-11

### DIFF
--- a/devicemodel/core/mevent.c
+++ b/devicemodel/core/mevent.c
@@ -112,7 +112,7 @@ mevent_pipe_read(int fd, enum ev_type type, void *param)
 int
 mevent_notify(void)
 {
-	char c;
+	char c = 0;
 
 	/*
 	 * If calling from outside the i/o thread, write a byte on the

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/include/probeutils.h
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/include/probeutils.h
@@ -38,8 +38,8 @@ enum key_type {
 	KEY_LONG,
 };
 
-int get_uptime_string(char newuptime[24], int *hours);
-int get_current_time_long(char buf[32]);
+int get_uptime_string(char *newuptime, int *hours);
+int get_current_time_long(char *buf);
 unsigned long long get_uptime(void);
 char *generate_event_id(const char *seed1, size_t slen1, const char *seed2,
 			size_t slen2, enum key_type type);


### PR DESCRIPTION
Unify two functions definitions/declarifications:
  Update the parameters from char array to char pointer.
to fix the build issue:
  probeutils.c:61:29: error: argument 1 of type 'char *' declared
  as a pointer [-Werror=array-parameter=]

Initialize local variable "c" to fix build issue:
  core/mevent.c:122:21: error: 'c' may be used uninitialized
  [-Werror=maybe-uninitialized]

Tracked-On: #5993
Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>