### PR TITLE
hv: update RTCT parser to support RTCT version 2

### DIFF
--- a/hypervisor/include/arch/x86/asm/rtct.h
+++ b/hypervisor/include/arch/x86/asm/rtct.h
@@ -21,6 +21,17 @@
 #define RTCT_ENTRY_TYPE_RT_IOMMU		8U
 #define RTCT_ENTRY_TYPE_MEM_HIERARCHY_LATENCY	9U
 
+#define	RTCT_V2_COMPATIBILITY	0U
+#define	RTCT_V2_RTCD_LIMIT	1U
+#define	RTCT_V2_CRL_BINARY	2U
+#define	RTCT_V2_IA_WAYMASK	3U
+#define	RTCT_V2_WRC_WAYMASK	4U
+#define	RTCT_V2_GT_WAYMASK	5U
+#define	RTCT_V2_SSRAM_WAYMASK	6U
+#define	RTCT_V2_SSRAM	7U
+#define	RTCT_V2_MEMORY_HIERARCHY_LATENCY	8U
+#define	RTCT_V2_ERROR_LOG_ADDRESS	9U
+
 #if !defined(PRE_RTVM_SW_SRAM_ENABLED)
 /*
  * PRE_RTVM_SW_SRAM_BASE_GPA is for Prelaunch VM only and
@@ -42,6 +53,13 @@ struct rtct_entry {
 	 uint32_t data[64];
 } __packed;
 
+struct rtct_entry_data_compatibility {
+	uint32_t rtct_ver_major;
+	uint32_t rtct_ver_minor;
+	uint32_t rtcd_ver_major;
+	uint32_t rtcd_ver_minor;
+} __packed;
+
 struct rtct_entry_data_rtcm_binary
 {
 	uint64_t address;
@@ -55,6 +73,14 @@ struct rtct_entry_data_ssram
 	uint32_t ways;
 	uint32_t size;
 	uint32_t apic_id_0; /*only the first core is responsible for initialization of L3 mem region*/
+} __packed;
+
+struct rtct_entry_data_ssram_v2 {
+	uint32_t cache_level;
+	uint32_t cache_id;
+	uint64_t base;
+	uint32_t size;
+	uint32_t shared;
 } __packed;
 
 uint64_t get_software_sram_base(void);


### PR DESCRIPTION
  RTCT has been updated to version 2,
  this patch update hypervisor RTCT parseer to support
  both version 1 and version 2 of RTCT.

Tracked-On: #6020
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>
Reviewed-by: Jason CJ Chen <jason.cj.chen@intel.com>