### PR TITLE
config-tools: guest_flag must be assigned with a valid value

### DIFF
--- a/misc/config_tools/data/apl-mrb/logical_partition.xml
+++ b/misc/config_tools/data/apl-mrb/logical_partition.xml
@@ -64,7 +64,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -126,7 +126,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/apl-up2-n3350/logical_partition.xml
+++ b/misc/config_tools/data/apl-up2-n3350/logical_partition.xml
@@ -64,7 +64,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -124,7 +124,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/apl-up2/logical_partition.xml
+++ b/misc/config_tools/data/apl-up2/logical_partition.xml
@@ -64,7 +64,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -126,7 +126,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/fusa_partition.xml
@@ -71,7 +71,7 @@
         <vm_type>PRE_STD_VM</vm_type>
         <name>ACRN PRE-LAUNCHED VM0</name>
         <guest_flags>
-            <guest_flag></guest_flag>
+            <guest_flag>0</guest_flag>
         </guest_flags>
         <cpu_affinity>
             <pcpu_id>0</pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/logical_partition.xml
+++ b/misc/config_tools/data/ehl-crb-b/logical_partition.xml
@@ -71,7 +71,7 @@
         <vm_type>PRE_STD_VM</vm_type>
         <name>ACRN PRE-LAUNCHED VM0</name>
         <guest_flags>
-            <guest_flag></guest_flag>
+            <guest_flag>0</guest_flag>
         </guest_flags>
         <cpu_affinity>
             <pcpu_id>0</pcpu_id>
@@ -132,7 +132,7 @@
         <vm_type>PRE_STD_VM</vm_type>
         <name>ACRN PRE-LAUNCHED VM1</name>
         <guest_flags>
-            <guest_flag></guest_flag>
+            <guest_flag>0</guest_flag>
         </guest_flags>
         <cpu_affinity>
             <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/generic_board/logical_partition.xml
+++ b/misc/config_tools/data/generic_board/logical_partition.xml
@@ -72,7 +72,7 @@
         <vm_type>PRE_STD_VM</vm_type>
         <name>ACRN PRE-LAUNCHED VM0</name>
         <guest_flags>
-            <guest_flag></guest_flag>
+            <guest_flag>0</guest_flag>
         </guest_flags>
         <cpu_affinity>
             <pcpu_id>0</pcpu_id>
@@ -133,7 +133,7 @@
         <vm_type>PRE_STD_VM</vm_type>
         <name>ACRN PRE-LAUNCHED VM1</name>
         <guest_flags>
-            <guest_flag></guest_flag>
+            <guest_flag>0</guest_flag>
         </guest_flags>
         <cpu_affinity>
             <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/logical_partition.xml
+++ b/misc/config_tools/data/nuc6cayh/logical_partition.xml
@@ -64,7 +64,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -125,7 +125,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/logical_partition.xml
+++ b/misc/config_tools/data/nuc7i7dnb/logical_partition.xml
@@ -60,7 +60,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -123,7 +123,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -57,7 +57,7 @@
     <vm_type>SOS_VM</vm_type>
     <name>ACRN SOS VM</name>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <clos>
       <vcpu_clos>0</vcpu_clos>
@@ -105,7 +105,7 @@
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
       <pcpu_id>0</pcpu_id>
@@ -143,7 +143,7 @@
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
       <pcpu_id>2</pcpu_id>
@@ -181,7 +181,7 @@
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
       <pcpu_id>0</pcpu_id>
@@ -219,7 +219,7 @@
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
       <pcpu_id>0</pcpu_id>
@@ -257,7 +257,7 @@
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
       <pcpu_id>0</pcpu_id>
@@ -295,7 +295,7 @@
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-      <guest_flag></guest_flag>
+      <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
       <pcpu_id>0</pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/logical_partition.xml
+++ b/misc/config_tools/data/tgl-rvp/logical_partition.xml
@@ -60,7 +60,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -121,7 +121,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/logical_partition.xml
+++ b/misc/config_tools/data/whl-ipc-i5/logical_partition.xml
@@ -60,7 +60,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -122,7 +122,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/logical_partition.xml
+++ b/misc/config_tools/data/whl-ipc-i7/logical_partition.xml
@@ -60,7 +60,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM0</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -121,7 +121,7 @@
     <vm_type>PRE_STD_VM</vm_type>
     <name>ACRN PRE-LAUNCHED VM1</name>
     <guest_flags>
-        <guest_flag></guest_flag>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>1</pcpu_id>


### PR DESCRIPTION
commit 873ed752d ("misc: sanity check VM config for nested virtualization")
requires that the guest_flag tag can't be empty, or it fails to build.

This patch changes all instances of "<guest_flag></guest_flag>"
to "<guest_flag>0</guest_flag>".

Tracked-On: #5923
Signed-off-by: Zide Chen <zide.chen@intel.com>