### PR TITLE
Update hugepage config in SOS Bootargs.

### DIFF
--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -87,6 +87,7 @@
 <xsl:template name="sos_bootargs_diff">
   <xsl:variable name="bootargs" select="normalize-space(vm[acrn:is-sos-vm(vm_type)]/board_private/bootargs[text()])" />
   <xsl:variable name="maxcpunum" select="count(//vm[acrn:is-sos-vm(vm_type)]/cpu_affinity/pcpu_id)" />
+  <xsl:variable name="hugepages" select="round(number(substring-before(//board-data//TOTAL_MEM_INFO, 'kB')) div (1024 * 1024)) - 3" />
   <xsl:variable name="maxcpus">
     <xsl:choose>
       <xsl:when test="$maxcpunum != 0">
@@ -97,7 +98,12 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <xsl:value-of select="acrn:define('SOS_BOOTARGS_DIFF', concat($quot, $bootargs, ' ', $maxcpus, ' ', $quot), '')" />
+  <xsl:variable name="hugepage_kernelstring">
+    <xsl:if test="//board-data//processors//capability[@id='gbyte_pages']">
+      <xsl:value-of select="concat('hugepagesz=1G hugepages=', $hugepages)" />
+    </xsl:if>
+  </xsl:variable>
+  <xsl:value-of select="acrn:define('SOS_BOOTARGS_DIFF', concat($quot, $bootargs, ' ', $maxcpus, ' ', $hugepage_kernelstring, ' ', $quot), '')" />
 </xsl:template>
 
 <xsl:template name="cpu_affinity">


### PR DESCRIPTION
1. HV: refine init_vm_bootargs_info():
    1) The VM load order type condition is not needed, since the function is called only when create SOS VM or pre-launched VM;
    2) Fixed wrong parameter of fill_seed_arg() which introduced by commit 80262f060293d2ba613fa70673ebe794a511ce9c.
    3) More comments on why multiboot string could override the pre-configured VM bootargs and why append multiboot cmdline to SOS VM bootargs;
2. HV: remove SOS kernel hugepage related bootargs: 
    Hypervisor does not need to care about hugepage settings in SOS kernel, user could enable these settings in the scenario config file or GRUB menu.
3. Config_tools: config hugepage in sos kenrel cmdline:
    If there is hugepage support from board xml, config tool will add hugepagesz=1G hugepages=[size] into sos kernel cmdline, the size is calculated by memory size in G reducing 3. The reason for reducing 3 is that it is reserved for SOS VM use.

