### PR TITLE
Makefile improvements

### DIFF
--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -224,8 +224,8 @@ $(VERSION_H):
 		PATCH=$(DM_BUILD_VERSION);\
 		DAILY_TAG=$(DM_BUILD_TAG);\
 	fi;\
-	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
-	USER=`id -u -n`; \
+	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d %H:%M:%S"); \
+	USER="$${USER:-$$(id -u -n)}"; \
 	echo "/*" > $(VERSION_H); \
 	sed 's/^/ * /' ../LICENSE >> $(VERSION_H);\
 	echo " */" >> $(VERSION_H);\

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -472,10 +472,15 @@ distclean:
 PHONY: (VERSION)
 $(VERSION): $(HV_CONFIG_H)
 	touch $(VERSION)
-	@COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
-	DIRTY=`git diff-index --name-only HEAD`;\
-	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-	DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
+	@if [ "$(BUILD_VERSION)"x = x -o "$(BUILD_TAG)"x = x ];then \
+		COMMIT=`git rev-parse --verify --short HEAD 2>/dev/null`;\
+		DIRTY=`git diff-index --name-only HEAD`;\
+		if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+		DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
+	else \
+		PATCH="$(BUILD_VERSION)"; \
+		DAILY_TAG="$(BUILD_TAG)"; \
+	fi; \
 	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%F %T"); \
 	USER="$${USER:-$$(id -u -n)}"; \
 	if [ x$(CONFIG_RELEASE) = "xy" ];then BUILD_TYPE="REL";else BUILD_TYPE="DBG";fi;\

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -476,8 +476,8 @@ $(VERSION): $(HV_CONFIG_H)
 	DIRTY=`git diff-index --name-only HEAD`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
 	DAILY_TAG=`git tag --merged HEAD|grep "acrn"|tail -n 1`;\
-	TIME=`date "+%F %T"`;\
-	USER=`id -u -n`; \
+	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%F %T"); \
+	USER="$${USER:-$$(id -u -n)}"; \
 	if [ x$(CONFIG_RELEASE) = "xy" ];then BUILD_TYPE="REL";else BUILD_TYPE="DBG";fi;\
 	echo "/*" > $(VERSION); \
 	sed 's/^/ * /' ../LICENSE >> $(VERSION); \

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
@@ -66,8 +66,8 @@ $(VERSION_H):
 	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
 	DIRTY=`git diff --name-only $(CURDIR)`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
-	USER=`id -u -n`; \
+	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d %H:%M:%S"); \
+	USER="$${USER:-$$(id -u -n)}"; \
 	cat $(CURDIR)/../license_header > $(VERSION_H);\
 	echo "#define AP_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
 	echo "#define AP_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\

--- a/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
+++ b/misc/debug_tools/acrn_crashlog/acrnprobe/Makefile
@@ -63,9 +63,13 @@ $(VERSION_H):
 		mkdir -p $(BUILDDIR)/include/acrnprobe ; \
 	fi
 	touch $(VERSION_H)
-	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
-	DIRTY=`git diff --name-only $(CURDIR)`;\
-	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+	@if [ "$(BUILD_VERSION)"x = x ];then \
+		COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
+		DIRTY=`git diff --name-only $(CURDIR)`;\
+		if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+	else \
+		PATCH="$(BUILD_VERSION)"; \
+	fi; \
 	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d %H:%M:%S"); \
 	USER="$${USER:-$$(id -u -n)}"; \
 	cat $(CURDIR)/../license_header > $(VERSION_H);\

--- a/misc/debug_tools/acrn_crashlog/usercrash/Makefile
+++ b/misc/debug_tools/acrn_crashlog/usercrash/Makefile
@@ -45,8 +45,8 @@ $(VERSION_H):
 	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
 	DIRTY=`git diff --name-only $(CURDIR)`;\
 	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
-	TIME=`date "+%Y-%m-%d %H:%M:%S"`;\
-	USER=`id -u -n`; \
+	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d %H:%M:%S"); \
+	USER="$${USER:-$$(id -u -n)}"; \
 	cat $(CURDIR)/../license_header > $(VERSION_H);\
 	echo "#define UC_MAJOR_VERSION $(MAJOR_VERSION)" >> $(VERSION_H);\
 	echo "#define UC_MINOR_VERSION $(MINOR_VERSION)" >> $(VERSION_H);\

--- a/misc/debug_tools/acrn_crashlog/usercrash/Makefile
+++ b/misc/debug_tools/acrn_crashlog/usercrash/Makefile
@@ -42,9 +42,13 @@ $(VERSION_H):
 		mkdir -p $(BUILDDIR)/include/usercrash ; \
 	fi
 	touch $(VERSION_H)
-	@COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
-	DIRTY=`git diff --name-only $(CURDIR)`;\
-	if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+	@if [ "$(BUILD_VERSION)"x = x ];then \
+		COMMIT=`git log -1 --pretty=format:%h . 2>/dev/null`;\
+		DIRTY=`git diff --name-only $(CURDIR)`;\
+		if [ -n "$$DIRTY" ];then PATCH="$$COMMIT-dirty";else PATCH="$$COMMIT";fi;\
+	else \
+		PATCH="$(BUILD_VERSION)"; \
+	fi; \
 	TIME=$$(date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d %H:%M:%S"); \
 	USER="$${USER:-$$(id -u -n)}"; \
 	cat $(CURDIR)/../license_header > $(VERSION_H);\

--- a/misc/services/life_mngr/Makefile
+++ b/misc/services/life_mngr/Makefile
@@ -37,12 +37,24 @@ LIFEMNGR_LDFLAGS += -Wl,-z,relro,-z,now
 LIFEMNGR_LDFLAGS += -pie
 LIFEMNGR_LDFLAGS += $(LDFLAGS)
 
-all:
+# set cross compiler for Windows
+MINGWIN_CC := x86_64-w64-mingw32-gcc
+
+all: all-linux all-win
+
+all-linux:
 	$(CC) -g life_mngr.c -o $(OUT_DIR)/life_mngr -lpthread $(LIFEMNGR_CFLAGS) $(LIFEMNGR_LDFLAGS)
 	cp life_mngr.service $(OUT_DIR)/life_mngr.service
 
-	-x86_64-w64-mingw32-gcc -g life_mngr_win.c -o $(OUT_DIR)/life_mngr_win.exe -Wall -O2 $(LDFLAGS)
+# only build for Windows if cross compiler is installed
+ifneq ($(shell which $(MINGWIN_CC)),)
+all-win:
+	$(MINGWIN_CC) -g life_mngr_win.c -o $(OUT_DIR)/life_mngr_win.exe -Wall -O2 $(LDFLAGS)
 	cp COPYING.MinGW-w64-runtime.txt $(OUT_DIR)/COPYING.MinGW-w64-runtime.txt
+else
+all-win:
+	@echo "WARN: $(MINGWIN_CC) not installed, skipping life_mngr_win.exe" >&2
+endif
 
 clean:
 	rm -f $(OUT_DIR)/life_mngr
@@ -55,3 +67,4 @@ endif
 install:
 	install -d $(DESTDIR)/usr/bin
 	install -t $(DESTDIR)/usr/bin $(OUT_DIR)/life_mngr
+	install -p -D -m 0644 $(OUT_DIR)/life_mngr.service $(DESTDIR)$(systemd_unitdir)/system/


### PR DESCRIPTION
This patch series contains some changes for ACRN makefiles and relates to build reproducibility required for generating reliably reproducible packages on a build system like Debian packaging. Furthermore I added a first split up of the windows and linux build of life_mngr:
 * Makefile: Make builds reproducible
 * Makefile: honor BUILD_VERSION and BUILD_TAG
 * Makefile: lifemngr: split linux and windows build

Otherwise there is no impact on the build system.

The patches are already used for quite a while within my ACRN fork for Debian packaging and were affirmed by @NanlinXie and her team. 