### PR TITLE
dm: add allow_trigger_s5 mode to pm_notify_channel uart

### DIFF
--- a/devicemodel/include/pm.h
+++ b/devicemodel/include/pm.h
@@ -5,9 +5,10 @@
 #ifndef	_DM_INCLUDE_PM_
 #define	_DM_INCLUDE_PM_
 
-#define	PWR_EVENT_NOTIFY_IOC	0x1
-#define	PWR_EVENT_NOTIFY_PWR_BT	0x2
-#define	PWR_EVENT_NOTIFY_UART	0x3
+#define	PWR_EVENT_NOTIFY_IOC			0x1
+#define	PWR_EVENT_NOTIFY_PWR_BT			0x2
+#define	PWR_EVENT_NOTIFY_UART			0x3
+#define	PWR_EVENT_NOTIFY_UART_TRIG_PLAT_S5	0x4
 
 int wait_for_resume(struct vmctx *ctx);
 int vm_resume(struct vmctx *ctx);

--- a/devicemodel/include/pm_vuart.h
+++ b/devicemodel/include/pm_vuart.h
@@ -12,7 +12,7 @@
 #define	__PM_VUART__
 
 int parse_pm_by_vuart(const char *opts);
-int pm_by_vuart_init(struct vmctx *ctx);
+int pm_by_vuart_init(struct vmctx *ctx, bool trigger_s5);
 void pm_by_vuart_deinit(struct vmctx *ctx);
 
 #endif


### PR DESCRIPTION
A user can use "--pm_notify_channel uart,allow_trigger_s5" to indicate
the User VM is allowed to trigger system S5.

"--pm_notify_channel uart" means a vuart channel will be created in the
User VM to allow communication with the VM's life_mngr. The Service VM
can then initiate S5 in the guest via its dm's monitor interface. The
additional option, "allow_trigger_s5", will create a socket connection
with the Service VM's life_mngr, allowing this VM to initiate system S5.

v1 -> v2:
- rename pm_notify_channel type to PWR_EVENT_NOTIFY_UART_TRIG_PLAT_S5

Tracked-On: #6034
Signed-off-by: Peter Fang <peter.fang@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>