### PR TITLE
OVMF release v2.5

### DIFF
--- a/devicemodel/bios/changelog_ovmf.txt
+++ b/devicemodel/bios/changelog_ovmf.txt
@@ -1,3 +1,7 @@
+OVMF release v2.5
+
+- Change 64-bit MMIO BAR window to 256G-512G
+
 OVMF release v2.4
 
 - Ensure successful USB enumeration


### PR DESCRIPTION
- Change 64-bit MMIO BAR window to 256G-512G

The release is the same as 736a03222f5f359aadac9119062ee8255160bad2.
This is just to update the changelog.

Tracked-On: #5913
Signed-off-by: Peter Fang <peter.fang@intel.com>