### PR TITLE
config-tools: board_info.h and pci_dev.c xfom using xslt 

### DIFF
--- a/hypervisor/scripts/genconf.sh
+++ b/hypervisor/scripts/genconf.sh
@@ -45,11 +45,24 @@ transform() {
     echo "${1} was generated using xsltproc successfully."
 }
 
+transform_board() {
+    echo "Generating ${1}:"
+    xsltproc -o ${out}/boards/${1} --xinclude --xincludestyle ${tool_dir}/xforms/${1}.xsl ${unified_xml}
+    if [ $? -ne 0 ]; then
+        echo "Failed to generate ${1} with xsltproc!"
+        exit 1
+    fi
+    sed -i -e "s/YEAR/$year/" ${out}/boards/${1}
+    echo "${1} was generated using xsltproc successfully."
+}
+
 transform vm_configurations.c
 transform vm_configurations.h
 transform pt_intx.c
 transform ivshmem_cfg.h
 transform misc_cfg.h
+transform pci_dev.c
+transform_board board_info.h
 
 if which clang-format ; then
     find ${out}/scenarios/${scenario} -iname *.h -o -iname *.c \

--- a/misc/config_tools/static_allocators/bdf.py
+++ b/misc/config_tools/static_allocators/bdf.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import sys, os, re
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
+import common, lib.error, lib.lib
+from collections import namedtuple
+
+# Constants for device name prefix
+IVSHMEM = "IVSHMEM"
+VUART = "VUART"
+PTDEV = "PTDEV"
+
+# Exception bdf list
+# Some hardware drivers' bdf is hardcoded, the bdf cannot be changed even it is passtrhough devices.
+HARDCODED_BDF_LIST = ["00:0e.0"]
+
+class BusDevFunc(namedtuple(
+        "BusDevFunc", [
+            "bus",
+            "dev",
+            "func"])):
+
+    PATTERN = re.compile(r"(?P<bus>[0-9a-f]{2}):(?P<dev>[0-9a-f]{2})\.(?P<func>[0-7]{1})")
+
+    @classmethod
+    def from_str(cls, value):
+        if not(isinstance(value, str)):
+            raise ValueError("value must be a str: {}".format(type(value)))
+
+        match = cls.PATTERN.fullmatch(value)
+        if match:
+            return BusDevFunc(
+                bus=int(match.group("bus"), 16),
+                dev=int(match.group("dev"), 16),
+                func=int(match.group("func"), 16))
+        else:
+            raise ValueError("not a bdf: {!r}".format(value))
+
+    def __init__(self, *args, **kwargs):
+        if not (0x00 <= self.bus <= 0xff):
+            raise ValueError(f"Invalid bus number (0x00 ~ 0xff): {self.bus:#04x}")
+        if not (0x00 <= self.dev <= 0x1f):
+            raise ValueError(f"Invalid device number (0x00 ~ 0x1f): {self.dev:#04x}")
+        if not (0x0 <= self.func <= 0x7):
+            raise ValueError(f"Invalid function number (0 ~ 7): {self.func:#x}")
+
+    def __str__(self):
+        return f"{self.bus:02x}:{self.dev:02x}.{self.func:x}"
+
+    def __repr__(self):
+        return "BusDevFunc.from_str({!r})".format(str(self))
+
+def find_unused_bdf(used_bdf):
+    # never assign 0:00.0 to any emulated devices, it's reserved for pci hostbridge
+    for dev in range(0x1, 0x20):
+        bdf = BusDevFunc(bus=0x00, dev=dev, func=0x0)
+        if all((bdf.dev != in_use_bdf.dev for in_use_bdf in used_bdf)):
+            return bdf
+    raise lib.error.ResourceError(f"Cannot find free bdf, used bdf: {sorted(used_bdf)}")
+
+def insert_vuart_to_dev_dict(scenario_etree, devdict, used):
+    console_vuart =  scenario_etree.xpath(f"./console_vuart[base != 'INVALID_PCI_BASE']/@id")
+    communication_vuarts = scenario_etree.xpath(f".//communication_vuart[base != 'INVALID_PCI_BASE']/@id")
+    for vuart_id in console_vuart:
+        free_bdf = find_unused_bdf(used)
+        devdict[f"{VUART}_{vuart_id}"] = free_bdf
+        used.append(free_bdf)
+    for vuart_id in communication_vuarts:
+        free_bdf = find_unused_bdf(used)
+        devdict[f"{VUART}_{vuart_id}"] = free_bdf
+        used.append(free_bdf)
+
+def insert_ivsheme_to_dev_dict(scenario_etree, devdict, vm_id, used):
+    shmem_regions = lib.lib.get_shmem_regions(scenario_etree)
+    if vm_id not in shmem_regions:
+        return
+    shmems = shmem_regions.get(vm_id)
+    for shm in shmems.values():
+        free_bdf = find_unused_bdf(used)
+        devdict[f"{IVSHMEM}_{shm.get('id')}"] = free_bdf
+        used.append(free_bdf)
+
+def insert_pt_devs_to_dev_dict(vm_node_etree, devdict, used):
+    """
+    Assign an unused bdf to each of passtrhough devices.
+    If a passtrhough device's bdf is in the list of HARDCODED_BDF_LIST, this device should apply the same bdf as native one.
+    Calls find_unused_bdf to assign an unused bdf for the rest of passtrhough devices except the ones in HARDCODED_BDF_LIST.
+    """
+    pt_devs = vm_node_etree.xpath(f".//pci_dev/text()")
+    # assign the bdf of the devices in HARDCODED_BDF_LIST
+    for pt_dev in pt_devs:
+        bdf_string = pt_dev.split()[0]
+        if bdf_string in HARDCODED_BDF_LIST:
+            bdf = BusDevFunc.from_str(bdf_string)
+            dev_name = f"{PTDEV}_{bdf.bus:#04x}_{((bdf.dev << 16) | bdf.func):#08x}".upper()
+            devdict[dev_name] = bdf
+            used.append(bdf)
+
+    # remove the pt_dev nodes which are in HARDCODED_BDF_LIST
+    pt_devs = [pt_dev for pt_dev in pt_devs if BusDevFunc.from_str(bdf_string) not in used]
+
+    # call find_unused_bdf to assign an unused bdf for other passthrough devices except the ones in HARDCODED_BDF_LIST
+    for pt_dev in pt_devs:
+        bdf = BusDevFunc.from_str(pt_dev.split()[0])
+        free_bdf = find_unused_bdf(used)
+        dev_name = f"{PTDEV}_{bdf.bus:#04x}_{((bdf.dev << 16) | bdf.func):#08x}".upper()
+        devdict[dev_name] = free_bdf
+        used.append(free_bdf)
+
+def get_devs_bdf_native(board_etree):
+    """
+    Get all pci devices' bdf in native environment.
+    return: list of pci devices' bdf
+    """
+    nodes = board_etree.xpath(f"//bus[@type = 'pci' and @id]/device[@address]")
+    dev_list = []
+    for node in nodes:
+        address = node.get('address')
+        bus = int(common.get_node("../@address", node), 16)
+        dev = int(address, 16) >> 16
+        func = int(address, 16) & 0xffff
+        dev_list.append(BusDevFunc(bus = bus, dev = dev, func = func))
+    return dev_list
+
+def get_devs_bdf_passthrough(scenario_etree):
+    """
+    Get all pre-launched vms' passthrough devices' bdf in native environment.
+    return: list of passtrhough devices' bdf.
+    """
+    dev_list = []
+    for vm_type in lib.lib.PRE_LAUNCHED_VMS_TYPE:
+        pt_devs = scenario_etree.xpath(f"//vm[vm_type = '{vm_type}']/pci_devs/pci_dev/text()")
+        for pt_dev in pt_devs:
+            bdf = BusDevFunc.from_str(pt_dev.split()[0])
+            dev_list.append(bdf)
+    return dev_list
+
+def create_device_node(allocation_etree, vm_id, devdict):
+    for dev in devdict:
+        dev_name = dev
+        bdf = devdict.get(dev)
+        vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
+        if vm_node is None:
+            vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = vm_id)
+        dev_node = common.get_node(f"./device[@name = '{dev_name}']", vm_node)
+        if dev_node is None:
+            dev_node = common.append_node("./device", None, vm_node, name = dev_name)
+        if common.get_node(f"./bus", dev_node) is None:
+            common.append_node(f"./bus",  f"{bdf.bus:#04x}".upper(), dev_node)
+        if common.get_node(f"./dev", dev_node) is None:
+            common.append_node(f"./dev", f"{bdf.dev:#04x}".upper(), dev_node)
+        if common.get_node(f"./func", dev_node) is None:
+            common.append_node(f"./func", f"{bdf.func:#04x}".upper(), dev_node)
+
+def fn(board_etree, scenario_etree, allocation_etree):
+    vm_nodes = scenario_etree.xpath("//vm")
+    for vm_node in vm_nodes:
+        vm_id = vm_node.get('id')
+        devdict = {}
+        used = []
+        vm_type = common.get_node("./vm_type/text()", vm_node)
+        if vm_type is not None and lib.lib.is_post_launched_vm(vm_type):
+            continue
+
+        if vm_type is not None and lib.lib.is_sos_vm(vm_type):
+            native_used = get_devs_bdf_native(board_etree)
+            passthrough_used = get_devs_bdf_passthrough(scenario_etree)
+            used = [bdf for bdf in native_used if bdf not in passthrough_used]
+            if common.get_node("//@board", scenario_etree) == "tgl-rvp":
+                used.append(BusDevFunc(bus = 0, dev = 1, func = 0))
+
+        insert_vuart_to_dev_dict(vm_node, devdict, used)
+        insert_ivsheme_to_dev_dict(scenario_etree, devdict, vm_id, used)
+        insert_pt_devs_to_dev_dict(vm_node, devdict, used)
+        create_device_node(allocation_etree, vm_id, devdict)

--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -1,13 +1,284 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-import sys, os
+import sys, os, re
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
-import common
+import common, lib.error, lib.lib
+from collections import namedtuple
+
+# VMSIX devices list
+TSN_DEVS = [("0x8086", "0x4b30"), ("0x8086", "0x4b31"), ("0x8086", "0x4b32"), ("0x8086", "0x4ba0"),
+            ("0x8086", "0x4ba1"), ("0x8086", "0x4ba2"), ("0x8086", "0x4bb0"), ("0x8086", "0x4bb1"),
+            ("0x8086", "0x4bb2"), ("0x8086", "0xa0ac"), ("0x8086", "0x43ac"), ("0x8086", "0x43a2")]
+GPIO_DEVS = [("0x8086", "0x4b88"), ("0x8086", "0x4b89")]
+
+KNOWN_CAPS_PCI_DEVS_DB = {
+    "VMSIX": TSN_DEVS + GPIO_DEVS,
+}
+
+# Constants for device name prefix
+IVSHMEM = "IVSHMEM"
+VUART = "VUART"
+PTDEV = "PTDEV"
+
+# A bar in pci hole must be above this threshold
+# A bar's address below this threshold is for special purpose and should be preserved
+PCI_HOLE_THRESHOLD = 0x100000
+
+# Common memory size units
+SIZE_K = 1024
+SIZE_M = SIZE_K * 1024
+SIZE_G = SIZE_M * 1024
+
+# Bar base alignment constant
+VBAR_ALIGNMENT = 4 * SIZE_K
+
+# Memory bar bits
+PREFETCHABLE_BIT = 0x8
+MEMORY_BAR_LOCATABLE_64BITS = 0x4
+
+# Pre-launched VM MMIO windows constant
+PRE_LAUNCHED_VM_LOW_MEM_START = 2 * SIZE_G
+PRE_LAUNCHED_VM_LOW_MEM_END = 3.5 * SIZE_G
+PRE_LAUNCHED_VM_HIGH_MEM_START = 256 * SIZE_G
+PRE_LAUNCHED_VM_HIGH_MEM_END = 512 * SIZE_G
+
+# Constants for ivshmem
+BAR0_SHEMEM_SIZE = 4 * SIZE_K
+BAR1_SHEMEM_SIZE = 4 * SIZE_K
+BAR2_SHEMEM_ALIGNMENT = 2 * common.SIZE_M
+
+# Constants for pci vuart
+PCI_VUART_VBAR0_SIZE = 4 * SIZE_K
+PCI_VUART_VBAR1_SIZE = 4 * SIZE_K
+
+# Constants for vmsix bar
+VMSIX_VBAR_SIZE = 4 * SIZE_K
+
+class MmioWindow(namedtuple(
+        "MmioWindow", [
+            "start",
+            "end"])):
+
+    PATTERN = re.compile(r"\s*(?P<start>[0-9a-f]+)-(?P<end>[0-9a-f]+) ")
+
+    @classmethod
+    def from_str(cls, value):
+        if not isinstance(value, str):
+            raise ValueError("value must be a str: {}".format(type(value)))
+
+        match = cls.PATTERN.fullmatch(value)
+        if match:
+            return MmioWindow(
+                start=int(match.group("start"), 16),
+                end=int(match.group("end"), 16))
+        else:
+            raise ValueError("not an mmio window: {!r}".format(value))
+
+    def overlaps(self, other):
+        if not isinstance(other, MmioWindow):
+            raise TypeError('overlaps() other must be an MmioWindow: {}'.format(type(other)))
+        if other.end < self.start:
+            return False
+        if self.end < other.start:
+            return False
+        return True
+
+def insert_vuart_to_dev_dict(scenario_etree, devdict_32bits):
+    console_vuart =  scenario_etree.xpath(f"./console_vuart[base != 'INVALID_PCI_BASE']/@id")
+    communication_vuarts = scenario_etree.xpath(f".//communication_vuart[base != 'INVALID_PCI_BASE']/@id")
+    for vuart_id in console_vuart:
+        devdict_32bits[(f"{VUART}_{vuart_id}", "bar0")] = PCI_VUART_VBAR0_SIZE
+        devdict_32bits[(f"{VUART}_{vuart_id}", "bar1")] = PCI_VUART_VBAR1_SIZE
+    for vuart_id in communication_vuarts:
+        devdict_32bits[(f"{VUART}_{vuart_id}", "bar0")] = PCI_VUART_VBAR0_SIZE
+        devdict_32bits[(f"{VUART}_{vuart_id}", "bar1")] = PCI_VUART_VBAR1_SIZE
+
+def insert_ivsheme_to_dev_dict(scenario_etree, devdict_32bits, devdict_64bits, vm_id):
+    shmem_regions = lib.lib.get_shmem_regions(scenario_etree)
+    if vm_id not in shmem_regions:
+        return
+    shmems = shmem_regions.get(vm_id)
+    for shm in shmems.values():
+        try:
+            int_size = int(shm.get('size')) * SIZE_M
+        except:
+            continue
+        idx = shm.get('id')
+        devdict_32bits[(f"{IVSHMEM}_{idx}", "bar0")] = BAR0_SHEMEM_SIZE
+        devdict_32bits[(f"{IVSHMEM}_{idx}", "bar1")] = BAR1_SHEMEM_SIZE
+        devdict_64bits[(f"{IVSHMEM}_{idx}", "bar2")] = int_size
+
+def insert_pt_devs_to_dev_dict(board_etree, vm_node_etree, devdict_32bits, devdict_64bits):
+    pt_devs = vm_node_etree.xpath(f".//pci_dev/text()")
+    for pt_dev in pt_devs:
+        bdf = pt_dev.split()[0]
+        bus = int(bdf.split(':')[0], 16)
+        dev = int(bdf.split(":")[1].split('.')[0], 16)
+        func = int(bdf.split(":")[1].split('.')[1], 16)
+        pt_dev_node = common.get_node(f"//bus[@type = 'pci' and @address = '{hex(bus)}']/device[@address = '{hex((dev << 16) | func)}']", board_etree)
+        if pt_dev_node is not None:
+            insert_vmsix_to_dev_dict(pt_dev_node, devdict_32bits)
+            pt_dev_resources = pt_dev_node.xpath(".//resource[@type = 'memory' and @len != '0x0' and @id and @width]")
+            for pt_dev_resource in pt_dev_resources:
+                if int(pt_dev_resource.get('min'), 16) < PCI_HOLE_THRESHOLD:
+                    continue
+                dev_name = f"{PTDEV}_{bus:#04x}_{((dev << 16) | func):#08x}".upper()
+                bar_len = pt_dev_resource.get('len')
+                bar_region = pt_dev_resource.get('id')
+                bar_width = pt_dev_resource.get('width')
+                if bar_width == "32":
+                    devdict_32bits[(f"{dev_name}", f"{bar_region}")] = int(bar_len, 16)
+                else:
+                    devdict_64bits[(f"{dev_name}", f"{bar_region}")] = int(bar_len, 16)
+
+def insert_vmsix_to_dev_dict(pt_dev_node, devdict):
+    vendor = common.get_node("./vendor/text()", pt_dev_node)
+    identifier = common.get_node("./identifier/text()", pt_dev_node)
+    if vendor is None or identifier is None:
+        return
+
+    if (vendor, identifier) in KNOWN_CAPS_PCI_DEVS_DB.get('VMSIX'):
+        bar_regions = pt_dev_node.xpath(".//resource[@type = 'memory' and @width]")
+        bar_32bits = [bar_region.get('id') for bar_region in bar_regions if bar_region.get('width') == '32']
+        bar_32bits_idx_list = [int(bar.split('bar')[-1]) for bar in bar_32bits]
+        bar_64bits = [bar_region.get('id') for bar_region in bar_regions if bar_region.get('width') == '64']
+        bar_64bits_idx_list_1 = [int(bar.split('bar')[-1]) for bar in bar_64bits]
+        bar_64bits_idx_list_2 = [idx + 1 for idx in bar_64bits_idx_list_1]
+        used_bar_index = set(bar_32bits_idx_list + bar_64bits_idx_list_1 + bar_64bits_idx_list_2)
+        unused_bar_index = [i for i in range(6) if i not in used_bar_index]
+        try:
+            next_bar_region = unused_bar_index.pop()
+        except IndexError:
+            raise lib.error.ResourceError(f"Cannot allocate a bar index for vmsix supported device: {vendor}:{identifier}, used bar idx list: {used_bar_index}")
+        address = common.get_node("./@address", pt_dev_node)
+        bus = common.get_node(f"../@address", pt_dev_node)
+        if bus is not None and address is not None:
+            dev_name = f"{PTDEV}_{int(bus, 16):#04x}_{int(address, 16):#08x}".upper()
+            devdict[(f"{dev_name}", f"bar{next_bar_region}")] = VMSIX_VBAR_SIZE
+
+def get_devs_mem_native(board_etree, mems):
+    nodes = board_etree.xpath(f"//resource[@type = 'memory' and @len != '0x0' and @id and @width]")
+    dev_list = []
+    for node in nodes:
+        start = node.get('min')
+        end = node.get('max')
+        if start is not None and end is not None:
+            window = MmioWindow(int(start, 16), int(end, 16))
+            for mem in mems:
+                if window.start >= mem.start and window.end <= mem.end:
+                    dev_list.append(window)
+                    break
+    return sorted(dev_list)
+
+def get_devs_mem_passthrough(board_etree, scenario_etree):
+    """
+    Get all pre-launched vms' passthrough devices' mmio windows in native environment.
+    return: list of passtrhough devices' mmio windows.
+    """
+    dev_list = []
+    for vm_type in lib.lib.PRE_LAUNCHED_VMS_TYPE:
+        pt_devs = scenario_etree.xpath(f"//vm[vm_type = '{vm_type}']/pci_devs/pci_dev/text()")
+        for pt_dev in pt_devs:
+            bdf = pt_dev.split()[0]
+            bus = int(bdf.split(':')[0], 16)
+            dev = int(bdf.split(":")[1].split('.')[0], 16)
+            func = int(bdf.split(":")[1].split('.')[1], 16)
+            resources = board_etree.xpath(f"//bus[@address = '{hex(bus)}']/device[@address = '{hex((dev << 16) | func)}'] \
+                            /resource[@type = 'memory' and @len != '0x0' and @width]")
+            for resource in resources:
+                start = resource.get('min')
+                end = resource.get('max')
+                dev_list.append(MmioWindow(int(start, 16), int(end, 16)))
+    return dev_list
+
+def get_pci_hole_native(board_etree):
+    resources = board_etree.xpath(f"//bus[@type = 'pci']/device[@address]/resource[@type = 'memory' and @len != '0x0']")
+    resources_hostbridge =  board_etree.xpath("//bus[@address = '0x0']/resource[@type = 'memory' and @len != '0x0' and not(@id) and not(@width)]")
+    low_mem = set()
+    high_mem = set()
+    for resource_hostbridge in resources_hostbridge:
+        start = resource_hostbridge.get('min')
+        end = resource_hostbridge.get('max')
+        if start is not None and end is not None and int(start, 16) >= PCI_HOLE_THRESHOLD:
+            for resource in resources:
+                resource_start = int(resource.get('min'), 16)
+                resource_end = int(resource.get('max'), 16)
+                if resource_start >= int(start, 16) and resource_end <= int(end, 16):
+                    if resource_end < 4 * SIZE_G:
+                        low_mem.add(MmioWindow(int(start, 16), int(end, 16)))
+                        break
+                    else:
+                        high_mem.add(MmioWindow(int(start, 16), int(end, 16)))
+                        break
+    return list(sorted(low_mem)), list(sorted(high_mem))
+
+def create_device_node(allocation_etree, vm_id, devdict):
+    for dev in devdict:
+        dev_name = dev[0]
+        bar_region = dev[1].split('bar')[-1]
+        bar_base = devdict.get(dev)
+
+        vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
+        if vm_node is None:
+            vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = vm_id)
+        dev_node = common.get_node(f"./device[@name = '{dev_name}']", vm_node)
+        if dev_node is None:
+            dev_node = common.append_node("./device", None, vm_node, name = dev_name)
+        if common.get_node(f"./bar[@id='{bar_region}']", dev_node) is None:
+            common.append_node(f"./bar", hex(bar_base), dev_node, id = bar_region)
+        if IVSHMEM in dev_name and bar_region == '2':
+            common.update_text(f"./bar[@id = '2']", hex(bar_base | PREFETCHABLE_BIT | MEMORY_BAR_LOCATABLE_64BITS), dev_node, True)
+
+def create_native_pci_hole_node(allocation_etree, low_mem, high_mem):
+    common.append_node("/acrn-config/hv/MMIO/MMIO32_START", hex(low_mem[0].start).upper(), allocation_etree)
+    common.append_node("/acrn-config/hv/MMIO/MMIO32_END", hex(low_mem[0].end + 1).upper(), allocation_etree)
+    if len(high_mem):
+        common.append_node("/acrn-config/hv/MMIO/MMIO64_START", hex(high_mem[0].start).upper(), allocation_etree)
+        common.append_node("/acrn-config/hv/MMIO/MMIO64_END", hex(high_mem[0].end + 1).upper(), allocation_etree)
+        common.append_node("/acrn-config/hv/MMIO/HI_MMIO_START", hex(high_mem[0].start).upper(), allocation_etree)
+        common.append_node("/acrn-config/hv/MMIO/HI_MMIO_END", hex(high_mem[0].end + 1).upper(), allocation_etree)
+    else:
+        common.append_node("/acrn-config/hv/MMIO/MMIO64_START", "~0".upper(), allocation_etree)
+        common.append_node("/acrn-config/hv/MMIO/MMIO64_END", "~0", allocation_etree)
+        common.append_node("/acrn-config/hv/MMIO/HI_MMIO_START", "~0".upper(), allocation_etree)
+        common.append_node("/acrn-config/hv/MMIO/HI_MMIO_END", "0", allocation_etree)
+
+def get_free_mmio(windowslist, used, size):
+    if not size:
+        raise ValueError(f"allocate size cannot be: {size}")
+    if not windowslist:
+        raise ValueError(f"No mmio range is specified:{windowslist}")
+
+    alignment = max(VBAR_ALIGNMENT, size)
+    for w in windowslist:
+        new_w_start = common.round_up(w.start, alignment)
+        window = MmioWindow(start = new_w_start, end = new_w_start + size - 1)
+        for u in used:
+            if window.overlaps(u):
+                new_u_end = common.round_up(u.end + 1, alignment)
+                window = MmioWindow(start = new_u_end, end = new_u_end + size - 1)
+                continue
+        if window.overlaps(w):
+            return window
+    raise lib.error.ResourceError(f"Not enough mmio window for a device size: {size}, free mmio windows: {windowslist}, used mmio windos{used}")
+
+def alloc_mmio(mems, devdict, used_mem):
+    devdict_list = sorted(devdict.items(), key = lambda t : t[1], reverse = True)
+    devdict_base = {}
+    for dev_bar in devdict_list:
+        bar_name = dev_bar[0]
+        bar_length = dev_bar[1]
+        bar_window = get_free_mmio(mems, used_mem, bar_length)
+        bar_end_addr = bar_window.start + bar_length - 1
+        used_mem.append(MmioWindow(bar_window.start, bar_end_addr))
+        used_mem.sort()
+        devdict_base[bar_name] = bar_window.start
+    return devdict_base
 
 def allocate_ssram_region(board_etree, scenario_etree, allocation_etree):
     # Guest physical address of the SW SRAM allocated to a pre-launched VM
@@ -29,3 +300,43 @@ def allocate_ssram_region(board_etree, scenario_etree, allocation_etree):
 
 def fn(board_etree, scenario_etree, allocation_etree):
     allocate_ssram_region(board_etree, scenario_etree, allocation_etree)
+
+    native_low_mem, native_high_mem = get_pci_hole_native(board_etree)
+    create_native_pci_hole_node(allocation_etree, native_low_mem, native_high_mem)
+
+    vm_nodes = scenario_etree.xpath("//vm")
+    for vm_node in vm_nodes:
+        vm_id = vm_node.get('id')
+
+        devdict_32bits = {}
+        devdict_64bits = {}
+        insert_vuart_to_dev_dict(vm_node, devdict_32bits)
+        insert_ivsheme_to_dev_dict(scenario_etree, devdict_32bits, devdict_64bits, vm_id)
+        insert_pt_devs_to_dev_dict(board_etree, vm_node, devdict_32bits, devdict_64bits)
+
+        low_mem = []
+        high_mem = []
+        used_low_mem = []
+        used_high_mem = []
+
+        vm_type = common.get_node("./vm_type/text()", vm_node)
+        if vm_type is not None and lib.lib.is_pre_launched_vm(vm_type):
+            low_mem = [MmioWindow(start = PRE_LAUNCHED_VM_LOW_MEM_START, end = PRE_LAUNCHED_VM_LOW_MEM_END - 1)]
+            high_mem = [MmioWindow(start = PRE_LAUNCHED_VM_HIGH_MEM_START, end = PRE_LAUNCHED_VM_HIGH_MEM_END - 1)]
+        elif vm_type is not None and lib.lib.is_sos_vm(vm_type):
+            low_mem = native_low_mem
+            high_mem = native_high_mem
+            mem_passthrough = get_devs_mem_passthrough(board_etree, scenario_etree)
+            used_low_mem_native = get_devs_mem_native(board_etree, low_mem)
+            used_high_mem_native = get_devs_mem_native(board_etree, high_mem)
+            # release the passthrough devices mmio windows from SOS
+            used_low_mem = [mem for mem in used_low_mem_native if mem not in mem_passthrough]
+            used_high_mem = [mem for mem in used_high_mem_native if mem not in mem_passthrough]
+        else:
+            # fall into else when the vm_type is post-launched vm, no mmio allocation is needed
+            continue
+
+        devdict_base_32_bits = alloc_mmio(low_mem, devdict_32bits, used_low_mem)
+        devdict_base_64_bits = alloc_mmio(low_mem + high_mem, devdict_64bits, used_low_mem + used_high_mem)
+        create_device_node(allocation_etree, vm_id, devdict_base_32_bits)
+        create_device_node(allocation_etree, vm_id, devdict_base_64_bits)

--- a/misc/config_tools/static_allocators/lib/lib.py
+++ b/misc/config_tools/static_allocators/lib/lib.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 Intel Corporation. All rights reserved.
+# Copyright (C) 2021 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -8,7 +8,11 @@
 
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'library'))
-import common, board_cfg_lib, scenario_cfg_lib
+import common, board_cfg_lib
+
+PRE_LAUNCHED_VMS_TYPE = ["SAFETY_VM", "PRE_RT_VM", "PRE_STD_VM"]
+POST_LAUNCHED_VMS_TYPE = ["POST_STD_VM", "POST_RT_VM", "KATA_VM"]
+SOS_VM_TYPE = ["SOS_VM"]
 
 def parse_hv_console(scenario_etree):
     """
@@ -47,3 +51,41 @@ def get_native_ttys():
             tmp_dic['irq'] = int(ttys_irq)
             native_ttys[tty] = tmp_dic
     return native_ttys
+
+def get_shmem_regions(etree):
+    ivshmem_enabled = common.get_node("//IVSHMEM_ENABLED/text()", etree)
+    if ivshmem_enabled == 'n':
+        return {}
+
+    # <IVSHMEM_REGION> format is shm_name, shm_size, VM IDs
+    # example: hv:/shm_region_0, 2, 0:2
+    ivshmem_regions = etree.xpath("//IVSHMEM_REGION")
+    shmem_regions = {}
+    for idx in range(len(ivshmem_regions)):
+        shm_string = ivshmem_regions[idx].text
+        if shm_string is None:
+            continue
+        shm_string_list = shm_string.split(',')
+        shm_name = shm_string_list[0].strip()
+        shm_size = shm_string_list[1].strip()
+        vmid_list = [vm_id.strip() for vm_id in shm_string_list[2].split(':')]
+        for vm_id in vmid_list:
+            if vm_id not in shmem_regions:
+                shmem_regions[vm_id] = {}
+            shmem_regions[vm_id][shm_name] = {'id' : str(idx), 'size' : shm_size}
+    return shmem_regions
+
+def is_pre_launched_vm(vm_type):
+    if vm_type in PRE_LAUNCHED_VMS_TYPE:
+        return True
+    return False
+
+def is_post_launched_vm(vm_type):
+    if vm_type in POST_LAUNCHED_VMS_TYPE:
+        return True
+    return False
+
+def is_sos_vm(vm_type):
+    if vm_type in SOS_VM_TYPE:
+        return True
+    return False

--- a/misc/config_tools/xforms/board_info.h.xsl
+++ b/misc/config_tools/xforms/board_info.h.xsl
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xi="http://www.w3.org/2003/XInclude"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:dyn="http://exslt.org/dynamic"
+    xmlns:math="http://exslt.org/math"
+    xmlns:acrn="http://projectacrn.org">
+  <xsl:include href="lib.xsl" />
+  <xsl:output method="text" />
+
+  <xsl:template match="/acrn-offline-data">
+    <!-- Declaration of license -->
+    <xsl:value-of select="$license" />
+
+    <!-- Header include guard -->
+    <xsl:value-of select="acrn:include-guard('BOARD_INFO_H')" />
+
+    <xsl:apply-templates select="config-data/acrn-config" />
+    <xsl:apply-templates select="board-data/acrn-config" />
+    <xsl:apply-templates select="allocation-data/acrn-config" />
+
+    <xsl:value-of select="acrn:include-guard-end('BOARD_INFO_H')" />
+  </xsl:template>
+
+  <xsl:template match="config-data/acrn-config">
+    <xsl:if test="count(//p2sb[text() = 'y'])">
+      <xsl:call-template name="p2sb" />
+    </xsl:if>
+    <xsl:call-template name="MAX_HIDDEN_PDEVS_NUM" />
+  </xsl:template>
+
+  <xsl:template match="board-data/acrn-config">
+    <xsl:call-template name="MAX_PCPU_NUM" />
+    <xsl:call-template name="MAX_VMSIX_ON_MSI_PDEVS_NUM" />
+  </xsl:template>
+
+  <xsl:template match="allocation-data/acrn-config">
+    <xsl:apply-templates select="hv/MMIO" />
+  </xsl:template>
+
+  <xsl:template name="p2sb">
+    <xsl:value-of select="acrn:define('P2SB_VGPIO_DM_ENABLED', '', '')" />
+    <xsl:value-of select="acrn:define('P2SB_BAR_ADDR', '0xFD000000', 'UL')" />
+    <xsl:value-of select="acrn:define('P2SB_BAR_ADDR_GPA', '0xFD000000', 'UL')" />
+    <xsl:value-of select="acrn:define('P2SB_BAR_SIZE', '0x1000000', 'UL')" />
+    <xsl:value-of select="acrn:define('P2SB_BASE_GPIO_PORT_ID', '0x69', 'U')" />
+    <xsl:value-of select="acrn:define('P2SB_MAX_GPIO_COMMUNITIES', '0x6', 'U')" />
+  </xsl:template>
+
+  <xsl:template name="MAX_HIDDEN_PDEVS_NUM">
+    <xsl:value-of select="acrn:define('MAX_HIDDEN_PDEVS_NUM', acrn:get-hidden-device-num(), 'U')" />
+  </xsl:template>
+
+  <xsl:template name="MAX_PCPU_NUM">
+    <xsl:value-of select="acrn:define('MAX_PCPU_NUM', count(//processors/die/core/thread), 'U')" />
+  </xsl:template>
+
+  <xsl:template name="MAX_VMSIX_ON_MSI_PDEVS_NUM">
+    <xsl:value-of select="acrn:define('MAX_VMSIX_ON_MSI_PDEVS_NUM', sum(dyn:map(//device, 'acrn:is-vmsix-supported-device(./vendor, ./identifier)')), 'U')" />
+  </xsl:template>
+
+  <xsl:template match="MMIO">
+    <xsl:value-of select="acrn:define('MMIO32_START', //MMIO32_START, 'UL')" />
+    <xsl:value-of select="acrn:define('MMIO32_END', //MMIO32_END, 'UL')" />
+    <xsl:value-of select="acrn:define('MMIO64_START', //MMIO64_START, 'UL')" />
+    <xsl:value-of select="acrn:define('MMIO64_END', //MMIO64_END, 'UL')" />
+    <xsl:value-of select="acrn:define('HI_MMIO_START', //HI_MMIO_START, 'UL')" />
+    <xsl:value-of select="acrn:define('HI_MMIO_END', //HI_MMIO_END, 'UL')" />
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/misc/config_tools/xforms/pci_dev.c.xsl
+++ b/misc/config_tools/xforms/pci_dev.c.xsl
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='utf-8'?>
+
+<!-- Copyright (C) 2021 Intel Corporation. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xi="http://www.w3.org/2003/XInclude"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:dyn="http://exslt.org/dynamic"
+    xmlns:math="http://exslt.org/math"
+    xmlns:acrn="http://projectacrn.org">
+  <xsl:include href="lib.xsl" />
+  <xsl:output method="text" />
+
+  <xsl:template match="/acrn-offline-data">
+    <!-- Declaration of license -->
+    <xsl:value-of select="$license" />
+
+    <!-- Included headers -->
+    <xsl:value-of select="acrn:include('asm/vm_config.h')" />
+    <xsl:value-of select="acrn:include('vpci.h')" />
+    <xsl:value-of select="acrn:include('asm/mmu.h')" />
+    <xsl:value-of select="acrn:include('asm/page.h')" />
+    <xsl:value-of select="acrn:include('vmcs9900.h')" />
+    <xsl:value-of select="acrn:include('ivshmem_cfg.h')" />
+
+    <xsl:value-of select="acrn:define('INVALID_PCI_BASE', '0', 'U')" />
+
+    <xsl:apply-templates select="config-data/acrn-config/vm" />
+  </xsl:template>
+
+  <xsl:template match="config-data/acrn-config/vm">
+    <!-- Initializer of a acrn_vm_pci_dev_config instance -->
+    <xsl:choose>
+      <xsl:when test="acrn:is-sos-vm(vm_type)">
+        <xsl:value-of select="acrn:array-initializer('struct acrn_vm_pci_dev_config', 'sos_pci_devs', 'CONFIG_MAX_PCI_DEV_NUM')" />
+      </xsl:when>
+      <xsl:when test="acrn:pci-dev-num(@id)">
+        <xsl:value-of select="acrn:array-initializer('struct acrn_vm_pci_dev_config', concat('vm', @id, '_pci_devs'), concat('VM', @id, '_CONFIG_PCI_DEV_NUM'))" />
+      </xsl:when>
+    </xsl:choose>
+
+    <xsl:if test="acrn:is-pre-launched-vm(vm_type) and acrn:pci-dev-num(@id)">
+      <xsl:call-template name="virtual_pci_hostbridge" />
+    </xsl:if>
+    <xsl:call-template name="ivshmem_shm_mem" />
+    <xsl:apply-templates select="console_vuart" />
+    <xsl:apply-templates select="communication_vuart" />
+    <xsl:apply-templates select="pci_devs" />
+
+    <xsl:if test="acrn:is-sos-vm(vm_type) or acrn:pci-dev-num(@id)">
+      <xsl:value-of select="$end_of_array_initializer" />
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="virtual_pci_hostbridge">
+    <xsl:text>{</xsl:text>
+    <xsl:value-of select="$newline" />
+      <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
+      <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vhostbridge_ops', '')" />
+      <xsl:value-of select="acrn:initializer('vbdf.bits', '{.b = 0x00U, .d = 0x00U, .f = 0x00U}', '')" />
+    <xsl:text>},</xsl:text>
+    <xsl:value-of select="$newline" />
+  </xsl:template>
+
+  <xsl:template match="console_vuart">
+    <xsl:if test="base != 'INVALID_PCI_BASE'">
+      <xsl:variable name="vm_id" select="../@id" />
+      <xsl:variable name="dev_name" select="concat('VUART_', @id)" />
+      <xsl:text>{</xsl:text>
+      <xsl:value-of select="$newline" />
+        <xsl:value-of select="acrn:initializer('vuart_idx', @id, '')" />
+        <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
+        <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vmcs9900_ops', '')" />
+        <xsl:choose>
+          <xsl:when test="acrn:is-post-launched-vm(../vm_type)">
+            <xsl:value-of select="acrn:initializer('vbar_base[0]', 'INVALID_PCI_BASE', '')" />
+            <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:for-each select="//vm[@id = $vm_id]/device[@name = $dev_name]/bar">
+              <xsl:value-of select="acrn:initializer(concat('vbar_base[', @id,']'), concat(text(), 'UL'), '')" />
+            </xsl:for-each>
+            <xsl:value-of select="acrn:initializer('vbdf.bits', acrn:get-vbdf(../@id, $dev_name), '')" />
+          </xsl:otherwise>
+        </xsl:choose>
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="communication_vuart">
+    <xsl:if test="base != 'INVALID_PCI_BASE'">
+      <xsl:variable name="vm_id" select="../@id" />
+      <xsl:variable name="dev_name" select="concat('VUART_', @id)" />
+      <xsl:text>{</xsl:text>
+      <xsl:value-of select="$newline" />
+      <xsl:value-of select="acrn:initializer('vuart_idx', @id, '')" />
+      <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
+      <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vmcs9900_ops', '')" />
+      <xsl:choose>
+        <xsl:when test="acrn:is-post-launched-vm(../vm_type)">
+          <xsl:value-of select="acrn:initializer('vbar_base[0]', 'INVALID_PCI_BASE', '')" />
+          <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="//vm[@id = $vm_id]/device[@name = $dev_name]/bar">
+            <xsl:value-of select="acrn:initializer(concat('vbar_base[', @id,']'), concat(text(), 'UL'), '')" />
+          </xsl:for-each>
+          <xsl:value-of select="acrn:initializer('vbdf.bits', acrn:get-vbdf(../@id, $dev_name), '')" />
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:value-of select="acrn:initializer('t_vuart.vm_id', target_vm_id, '')" />
+      <xsl:value-of select="acrn:initializer('t_vuart.vuart_id', target_uart_id, '')" />
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="pci_devs">
+    <xsl:variable name="vm_id" select="../@id" />
+    <xsl:for-each select="pci_dev/text()">
+      <xsl:text>{</xsl:text>
+      <xsl:value-of select="$newline" />
+      <xsl:variable name="devname_suffix" select="acrn:ptdev-name-suffix(.)" />
+      <xsl:variable name="dev_name" select="concat('PTDEV_', $devname_suffix)" />
+      <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_PTDEV', '')" />
+      <xsl:value-of select="acrn:initializer('vbdf.bits', acrn:get-vbdf($vm_id, $dev_name), '')" />
+      <xsl:value-of select="acrn:initializer('pbdf.bits', acrn:get-pbdf(.), '')" />
+      <xsl:for-each select="//device[@name = $dev_name]/bar">
+        <xsl:value-of select="acrn:initializer(concat('vbar_base[', @id,']'), concat(text(), 'UL'), '')" />
+      </xsl:for-each>
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="ivshmem_shm_mem">
+    <xsl:variable name="vm_id" select="@id" />
+    <xsl:variable name="vm_type" select="vm_type" />
+    <xsl:for-each select="//hv/FEATURES/IVSHMEM/IVSHMEM_REGION/text()">
+      <xsl:if test="contains(substring-after(substring-after(current(), ','), ','), $vm_id)">
+        <xsl:variable name="dev_name" select="concat('IVSHMEM_', position() - 1)" />
+        <xsl:text>{</xsl:text>
+        <xsl:value-of select="$newline" />
+        <xsl:value-of select="acrn:initializer('emu_type', 'PCI_DEV_TYPE_HVEMUL', '')" />
+        <xsl:value-of select="acrn:initializer('vdev_ops', '&amp;vpci_ivshmem_ops', '')" />
+        <xsl:choose>
+          <xsl:when test="acrn:is-post-launched-vm($vm_type)">
+            <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="acrn:initializer('vbdf.bits', acrn:get-vbdf($vm_id, $dev_name), '')" />
+            <xsl:for-each select="//vm[@id = $vm_id]/device[@name = $dev_name]/bar">
+              <xsl:value-of select="acrn:initializer(concat('vbar_base[', @id,']'), concat(text(), 'UL'), '')" />
+            </xsl:for-each>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:value-of select="acrn:initializer('shm_region_name', concat('IVSHMEM_SHM_REGION_', position() - 1), '')" />
+        <xsl:text>},</xsl:text>
+        <xsl:value-of select="$newline" />
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Generate board_info.h and pci_dev.c based on the new board.xml and integrated to acrn project compilation.

Two static allocators are added: mmio.py and bdf.py. Those allocate free mmio windows and bdf to emulated vuarts, inter-vm shared memory and passthrough devices