### PR TITLE
HV: cache: Fix page fault by flushing cache for VM trusty RAM in HV

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -447,7 +447,9 @@ void cpu_dead(void)
 		/* clean up native stuff */
 		vmx_off();
 
+		stac();
 		flush_cache_range((void *)get_hv_image_base(), CONFIG_HV_RAM_SIZE);
+		clac();
 
 		/* Set state to show CPU is dead */
 		pcpu_set_current_state(pcpu_id, PCPU_STATE_DEAD);


### PR DESCRIPTION
The accrss right of HV RAM can be changed to PAGE_USER (eg. trusty RAM
of post-launched VM). So before using clflush(or clflushopt) to flush
HV RAM cache, must allow explicit supervisor-mode data accesses to
user-mode pages. Otherwise, it may trigger page fault.

Tracked-On: #6020
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>