### PR TITLE
HV: Fix mistake use stac() & clac()

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -450,9 +450,9 @@ void cpu_dead(void)
 		/* clean up native stuff */
 		vmx_off();
 
-		clac();
-		flush_cache_range((void *)get_hv_image_base(), CONFIG_HV_RAM_SIZE);
 		stac();
+		flush_cache_range((void *)get_hv_image_base(), CONFIG_HV_RAM_SIZE);
+		clac();
 
 		/* Set state to show CPU is dead */
 		pcpu_set_current_state(pcpu_id, PCPU_STATE_DEAD);


### PR DESCRIPTION
The commit 2ab70f43e5ff682382d2f30fcb0d582a9f4e501d
HV: cache: Fix page fault by flushing cache for VM trusty RAM in HV

It is wrong in using stac()/clac()

Tracked-On: #6020
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>