### PR TITLE
dm: rb: only free rb_entry when we remove this entry from the rb tree

### DIFF
--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -248,12 +248,12 @@ unregister_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 			/* flush Per-VM cache */
 			if (mmio_hint == entry)
 				mmio_hint = NULL;
+
+			if (entry)
+				free(entry);
 		}
 	}
 	pthread_rwlock_unlock(&mmio_rwlock);
-
-	if (entry)
-		free(entry);
 
 	return err;
 }


### PR DESCRIPTION
Only free rb_entry when we remove this entry from the rb tree, otherwise, a
page fault would trigger when next rb itreation would access the freed rb_entry.

Tracked-On: #6056
Signed-off-by: Li Fei1 <fei1.li@intel.com>