### PR TITLE
config-tools: enable PTM through config-tools

### DIFF
--- a/misc/config_tools/data/adl-rvp/industry.xml
+++ b/misc/config_tools/data/adl-rvp/industry.xml
@@ -125,7 +125,6 @@
         <base>0</base>
         <size>0</size>
     </epc_section>
-
     <legacy_vuart id="0">
         <type>VUART_LEGACY_PIO</type>
         <base>COM1_BASE</base>
@@ -146,6 +145,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
@@ -184,6 +184,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -230,6 +231,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
     <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -276,6 +278,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -322,6 +325,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -368,6 +372,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -411,6 +416,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/hybrid.xml
+++ b/misc/config_tools/data/apl-mrb/hybrid.xml
@@ -212,5 +212,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/industry.xml
+++ b/misc/config_tools/data/apl-mrb/industry.xml
@@ -186,5 +186,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/sdc.xml
+++ b/misc/config_tools/data/apl-mrb/sdc.xml
@@ -149,6 +149,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -182,5 +183,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/apl-mrb/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/apl-up2/hybrid.xml
+++ b/misc/config_tools/data/apl-up2/hybrid.xml
@@ -212,5 +212,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/industry.xml
+++ b/misc/config_tools/data/apl-up2/industry.xml
@@ -148,6 +148,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
@@ -186,5 +187,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/sdc.xml
+++ b/misc/config_tools/data/apl-up2/sdc.xml
@@ -149,6 +149,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -182,5 +183,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/config_tools/data/apl-up2/sdc_launch_1uos_aaag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/apl-up2/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -222,6 +222,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -260,5 +261,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/cfl-k700-i7/industry.xml
+++ b/misc/config_tools/data/cfl-k700-i7/industry.xml
@@ -183,6 +183,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -221,6 +222,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -259,6 +261,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -297,6 +300,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -335,6 +339,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -370,5 +375,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid.xml
@@ -220,5 +220,6 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
@@ -223,6 +223,7 @@
             <target_vm_id>0</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
     <vm id="3">
         <vm_type>POST_STD_VM</vm_type>
@@ -259,5 +260,6 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_fusa.xml
@@ -221,5 +221,6 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry.xml
@@ -196,6 +196,7 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -234,6 +235,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -272,6 +274,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -310,6 +313,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -348,6 +352,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -383,5 +388,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -90,6 +92,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -130,6 +133,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -170,6 +174,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -210,6 +215,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />

--- a/misc/config_tools/data/ehl-crb-b/sdc.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc.xml
@@ -185,5 +185,6 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/generic_board/hybrid.xml
+++ b/misc/config_tools/data/generic_board/hybrid.xml
@@ -221,5 +221,6 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic_board/hybrid_rt.xml
+++ b/misc/config_tools/data/generic_board/hybrid_rt.xml
@@ -221,6 +221,7 @@
             <target_vm_id>0</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
     <vm id="3">
         <vm_type>POST_STD_VM</vm_type>
@@ -257,5 +258,6 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic_board/industry.xml
+++ b/misc/config_tools/data/generic_board/industry.xml
@@ -156,6 +156,7 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
     </vm>
     <vm id="2">
         <vm_type>POST_RT_VM</vm_type>
@@ -194,6 +195,7 @@
             <target_vm_id>1</target_vm_id>
             <target_uart_id>1</target_uart_id>
         </communication_vuart>
+        <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -232,6 +234,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -270,6 +273,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -308,6 +312,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -346,6 +351,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -381,5 +387,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/generic_board/industry_launch_2uos.xml
+++ b/misc/config_tools/data/generic_board/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/hybrid.xml
+++ b/misc/config_tools/data/nuc6cayh/hybrid.xml
@@ -210,5 +210,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/industry.xml
+++ b/misc/config_tools/data/nuc6cayh/industry.xml
@@ -147,6 +147,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
@@ -185,6 +186,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -223,6 +225,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -261,6 +264,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -299,6 +303,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -337,6 +342,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -372,5 +378,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -92,6 +94,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -132,6 +135,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -172,6 +176,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -212,6 +217,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />

--- a/misc/config_tools/data/nuc6cayh/sdc.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc.xml
@@ -148,6 +148,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -181,5 +182,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/hybrid.xml
+++ b/misc/config_tools/data/nuc7i7dnb/hybrid.xml
@@ -206,5 +206,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry.xml
@@ -182,6 +182,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -220,6 +221,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -258,6 +260,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -296,6 +299,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -334,6 +338,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -369,5 +374,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -90,6 +92,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -130,6 +133,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -170,6 +174,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -210,6 +215,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />

--- a/misc/config_tools/data/nuc7i7dnb/sdc.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc.xml
@@ -143,6 +143,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -176,5 +177,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/hybrid.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid.xml
@@ -205,5 +205,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid_rt.xml
@@ -214,6 +214,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -250,5 +251,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/industry.xml
+++ b/misc/config_tools/data/tgl-rvp/industry.xml
@@ -139,6 +139,7 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
@@ -177,6 +178,7 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -215,6 +217,7 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -253,6 +256,7 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -291,6 +295,7 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -329,6 +334,7 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -364,5 +370,6 @@
       <target_vm_id>1</target_vm_id>
       <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+    <enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -90,6 +92,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -130,6 +133,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -170,6 +174,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -210,6 +215,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />

--- a/misc/config_tools/data/tgl-rvp/sdc.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc.xml
@@ -142,6 +142,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -175,5 +176,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid.xml
@@ -206,5 +206,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -211,6 +211,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -247,5 +248,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry.xml
@@ -182,6 +182,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -220,6 +221,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -258,6 +260,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -296,6 +299,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -334,6 +338,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -369,5 +374,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -90,6 +92,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -130,6 +133,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -170,6 +174,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -210,6 +215,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />

--- a/misc/config_tools/data/whl-ipc-i5/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc.xml
@@ -143,6 +143,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -176,5 +177,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -7,13 +7,13 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
-	</shm_regions>
 	</shm_regions>
 	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
 	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -7,13 +7,13 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
 	</cpu_affinity>
 	<shm_regions desc="List of shared memory regions for inter-VM communication.">
 		<shm_region desc="configure the shm regions for current VM, for example hv:/sharename,2"></shm_region>
-	</shm_regions>
 	</shm_regions>
 	<console_vuart desc="A PCI based console vuart which is emulated by device model">Disable</console_vuart>
 	<communication_vuarts desc="List of PCI based communication vuarts which are emulated by device model">

--- a/misc/config_tools/data/whl-ipc-i7/hybrid.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid.xml
@@ -206,5 +206,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid_rt.xml
@@ -211,6 +211,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -247,5 +248,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry.xml
@@ -144,6 +144,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>POST_RT_VM</vm_type>
@@ -182,6 +183,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="3">
     <vm_type>POST_STD_VM</vm_type>
@@ -220,6 +222,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
@@ -258,6 +261,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="5">
     <vm_type>POST_STD_VM</vm_type>
@@ -296,6 +300,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="6">
     <vm_type>POST_STD_VM</vm_type>
@@ -334,6 +339,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="7">
     <vm_type>KATA_VM</vm_type>
@@ -369,5 +375,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -49,6 +50,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -90,6 +92,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -130,6 +133,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -170,6 +174,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />
@@ -210,6 +215,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
             <pcpu_id />

--- a/misc/config_tools/data/whl-ipc-i7/sdc.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc.xml
@@ -147,6 +147,7 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
   <vm id="2">
     <vm_type>KATA_VM</vm_type>
@@ -180,5 +181,6 @@
         <target_vm_id>1</target_vm_id>
         <target_uart_id>1</target_uart_id>
     </communication_vuart>
+    <PTM>n</PTM>
   </vm>
 </acrn-config>

--- a/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -411,7 +411,7 @@ def launch_end(names, args, virt_io, vmid, config):
     uos_launch(names, args, virt_io, vmid, config)
 
 
-def set_dm_pt(names, sel, vmid, config):
+def set_dm_pt(names, sel, vmid, config, dm):
 
     uos_type = names['uos_types'][vmid]
 
@@ -449,8 +449,12 @@ def set_dm_pt(names, sel, vmid, config):
         print("   $boot_ipu_option      \\", file=config)
 
     if sel.bdf['ethernet'][vmid] and sel.slot['ethernet'][vmid]:
-        print("   -s {},passthru,{}/{}/{} \\".format(sel.slot["ethernet"][vmid], sel.bdf["ethernet"][vmid][0:2], \
-            sel.bdf["ethernet"][vmid][3:5], sel.bdf["ethernet"][vmid][6:7]), file=config)
+        if vmid in dm["enable_ptm"] and dm["enable_ptm"][vmid] == 'y':
+            print("   -s {},passthru,{}/{}/{},enable_ptm \\".format(sel.slot["ethernet"][vmid], sel.bdf["ethernet"][vmid][0:2], \
+                sel.bdf["ethernet"][vmid][3:5], sel.bdf["ethernet"][vmid][6:7]), file=config)
+        else:
+            print("   -s {},passthru,{}/{}/{} \\".format(sel.slot["ethernet"][vmid], sel.bdf["ethernet"][vmid][0:2], \
+                sel.bdf["ethernet"][vmid][3:5], sel.bdf["ethernet"][vmid][6:7]), file=config)
 
     if sel.bdf['sata'] and sel.slot["sata"][vmid]:
         print("   -s {},passthru,{}/{}/{} \\".format(sel.slot["sata"][vmid], sel.bdf["sata"][vmid][0:2], \
@@ -642,7 +646,7 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
         if not is_nuc_whl_linux(names, vmid):
             print("   -s {},wdt-i6300esb \\".format(launch_cfg_lib.virtual_dev_slot("wdt-i6300esb")), file=config)
 
-    set_dm_pt(names, sel, vmid, config)
+    set_dm_pt(names, sel, vmid, config, dm)
 
     if dm['console_vuart'][vmid] == "Enable":
         print("   -s {},uart,vuart_idx:0 \\".format(launch_cfg_lib.virtual_dev_slot("console_vuart")), file=config)

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -52,6 +52,7 @@ def get_launch_item_values(board_info, scenario_info=None):
     launch_item_values['uos,vuart0'] = launch_cfg_lib.DM_VUART0
     launch_item_values['uos,poweroff_channel'] = launch_cfg_lib.PM_CHANNEL
     launch_item_values["uos,cpu_affinity"] = board_cfg_lib.get_processor_info()
+    launch_item_values['uos,enable_ptm'] = launch_cfg_lib.PTM
     launch_cfg_lib.set_shm_regions(launch_item_values, scenario_info)
     launch_cfg_lib.set_pci_vuarts(launch_item_values, scenario_info)
 

--- a/misc/config_tools/launch_config/launch_item.py
+++ b/misc/config_tools/launch_config/launch_item.py
@@ -36,6 +36,7 @@ class AcrnDmArgs:
         self.args["xhci"] = common.get_leaf_tag_map(self.launch_info, "usb_xhci")
         self.args["communication_vuarts"] = common.get_leaf_tag_map(self.launch_info, "communication_vuarts", "communication_vuart")
         self.args["console_vuart"] = common.get_leaf_tag_map(self.launch_info, "console_vuart")
+        self.args["enable_ptm"] = common.get_leaf_tag_map(self.launch_info, "enable_ptm")
 
     def check_item(self):
         (rootfs, num) = board_cfg_lib.get_rootfs(self.board_info)
@@ -44,12 +45,14 @@ class AcrnDmArgs:
         launch_cfg_lib.mem_size_check(self.args["mem_size"], "mem_size")
         launch_cfg_lib.args_aval_check(self.args["vbootloader"], "vbootloader", launch_cfg_lib.BOOT_TYPE)
         launch_cfg_lib.args_aval_check(self.args["vuart0"], "vuart0", launch_cfg_lib.DM_VUART0)
+        launch_cfg_lib.args_aval_check(self.args["enable_ptm"], "enable_ptm", launch_cfg_lib.PTM)
         cpu_affinity = launch_cfg_lib.uos_cpu_affinity(self.args["cpu_affinity"])
         err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.launch_info, cpu_affinity, "pcpu_id")
         launch_cfg_lib.ERR_LIST.update(err_dic)
         launch_cfg_lib.check_shm_regions(self.args["shm_regions"], self.scenario_info)
         launch_cfg_lib.check_console_vuart(self.args["console_vuart"],self.args["vuart0"], self.scenario_info)
         launch_cfg_lib.check_communication_vuart(self.args["communication_vuarts"], self.scenario_info)
+        launch_cfg_lib.check_enable_ptm(self.args["enable_ptm"], self.scenario_info)
 
 
 class AvailablePthru():

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -8,11 +8,14 @@ import getopt
 import common
 import board_cfg_lib
 import scenario_cfg_lib
+import lxml
+import lxml.etree
 
 ERR_LIST = {}
 BOOT_TYPE = ['no', 'vsbl', 'ovmf']
 RTOS_TYPE = ['no', 'Soft RT', 'Hard RT']
 DM_VUART0 = ['Disable', 'Enable']
+PTM = ['y', 'n']
 UOS_TYPES = ['CLEARLINUX', 'ANDROID', 'ALIOS', 'PREEMPT-RT LINUX', 'VXWORKS', 'WINDOWS', 'ZEPHYR', 'YOCTO', 'UBUNTU', 'GENERIC LINUX']
 LINUX_LIKE_OS = ['CLEARLINUX', 'PREEMPT-RT LINUX', 'YOCTO', 'UBUNTU', 'GENERIC LINUX']
 
@@ -669,3 +672,11 @@ def check_communication_vuart(launch_communication_vuarts, scenario_info):
                     ERR_LIST[vuart_key] = "uos {}'s communication_vuart 1 and legacy_vuart 1 should " \
                         "not be configured at the same time.".format(uos_id)
                 return
+
+def check_enable_ptm(launch_enable_ptm, scenario_info):
+    scenario_etree = lxml.etree.parse(scenario_info)
+    enable_ptm_vm_list = scenario_etree.xpath("//vm[PTM = 'y']/@id")
+    for uos_id, enable_ptm in launch_enable_ptm.items():
+        key = 'uos:id={},enable_ptm'.format(uos_id)
+        if enable_ptm == 'y' and str(uos_id) not in enable_ptm_vm_list:
+            ERR_LIST[key] = "PTM of uos:{} set to 'n' in scenario xml".format(uos_id)

--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -420,6 +420,11 @@ its ``id`` attribute. When it is enabled, specify which target VM's vUART the cu
       </xs:annotation>
     </xs:element>
     <xs:element name="board_private" type="BoardPrivateConfiguration" minOccurs="0" />
+    <xs:element name="PTM" type="Boolean" default="n" minOccurs="0">
+      <xs:annotation>
+        <xs:documentation>Enable and disable PTM(Precision Timing Measurement) feature.</xs:documentation>
+      </xs:annotation>
+    </xs:element>
   </xs:all>
   <xs:attribute name="id" type="xs:integer" />
 

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -311,12 +311,25 @@
       <xsl:variable name="communication_vuart" select="count(./communication_vuart/base[text() = 'PCI_VUART'])" />
       <xsl:variable name="pci_devs" select="count(./pci_devs/pci_dev[text() != ''])" />
       <xsl:variable name="pci_hostbridge" select="1" />
+      <xsl:variable name="virtual_root_port">
+        <xsl:choose>
+          <xsl:when test="./PTM = 'y'">
+            <xsl:value-of select="1" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="0" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
       <xsl:if test="acrn:is-pre-launched-vm($vmtype)">
         <xsl:if test="$ivshmem + $console_vuart + $communication_vuart + $pci_devs > 0">
           <func:result select="$ivshmem + $console_vuart + $communication_vuart + $pci_devs + $pci_hostbridge" />
         </xsl:if>
       </xsl:if>
-      <xsl:if test="acrn:is-post-launched-vm($vmtype) or acrn:is-sos-vm($vmtype)">
+      <xsl:if test="acrn:is-post-launched-vm($vmtype)">
+        <func:result select="$ivshmem + $console_vuart + $communication_vuart + $virtual_root_port" />
+      </xsl:if>
+      <xsl:if test="acrn:is-sos-vm($vmtype)">
         <func:result select="$ivshmem + $console_vuart + $communication_vuart" />
       </xsl:if>
     </xsl:for-each>

--- a/misc/config_tools/xforms/pci_dev.c.xsl
+++ b/misc/config_tools/xforms/pci_dev.c.xsl
@@ -48,6 +48,9 @@
     <xsl:apply-templates select="console_vuart" />
     <xsl:apply-templates select="communication_vuart" />
     <xsl:apply-templates select="pci_devs" />
+    <xsl:if test="acrn:is-post-launched-vm(vm_type)">
+      <xsl:apply-templates select="PTM" />
+    </xsl:if>
 
     <xsl:if test="acrn:is-sos-vm(vm_type) or acrn:pci-dev-num(@id)">
       <xsl:value-of select="$end_of_array_initializer" />
@@ -162,6 +165,17 @@
         <xsl:value-of select="$newline" />
       </xsl:if>
     </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="PTM">
+    <xsl:if test="text() = 'y'">
+      <xsl:text>{</xsl:text>
+      <xsl:value-of select="$newline" />
+      <xsl:value-of select="acrn:initializer('vbdf.value', 'UNASSIGNED_VBDF', '')" />
+      <xsl:value-of select="acrn:initializer('vrp_sec_bus', '1', '')" />
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
+    </xsl:if>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Configure PTM in post-launched VM using <PTM> element. If the //vm/PTM
sets to 'y', pci_dev.c.xsl appends the virtual root port to
corresponding struct acrn_vm_pci_dev_config of that VM. Currently it
supports only post-launched VMs.

Configure enable_ptm for dm argument. If a uos/enable_ptm with uos id
= 'vm_id 'sets to 'y' and the vm/PTM with the same vm_id sets to 'y',
append an "enable_ptm" flag to the end of passthrough ethernet devices.
Currently there is only ethernet card can support the "enable_ptm"flag.

For the schema validation, the <PTM> can only be ['y', 'n'].

For the launched script validation, the <enable_ptm> can only be ['y',
'n']. If the <enable_ptm> sets to 'y' but the corresponding <PTM> sets
to 'n', the launch script will fail to generate.