### PR TITLE
Use physical APIC IDs as vLAPIC IDs for pre-launched and post-launched VMs

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -712,7 +712,7 @@ vm_irqfd(struct vmctx *ctx, struct acrn_irqfd *args)
 }
 
 int
-vm_get_config(struct vmctx *ctx, struct acrn_vm_config *vm_cfg)
+vm_get_config(struct vmctx *ctx, struct acrn_vm_config *vm_cfg, struct platform_info *plat_info)
 {
 #define VM_CFG_BUFF_SIZE 0x8000
 	int i, err = 0;
@@ -751,6 +751,9 @@ vm_get_config(struct vmctx *ctx, struct acrn_vm_config *vm_cfg)
 	}
 
 	memcpy((void *)vm_cfg, (void *)pcfg, sizeof(struct acrn_vm_config));
+	if (plat_info != NULL) {
+		memcpy((void *)plat_info, (void *)&platform_info, sizeof(struct platform_info));
+	}
 
 exit:
 	free(configs_buff);

--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -753,6 +753,8 @@ vm_get_config(struct vmctx *ctx, struct acrn_vm_config *vm_cfg, struct platform_
 	memcpy((void *)vm_cfg, (void *)pcfg, sizeof(struct acrn_vm_config));
 	if (plat_info != NULL) {
 		memcpy((void *)plat_info, (void *)&platform_info, sizeof(struct platform_info));
+		pr_info("%s, l2_cat_shift=%u, l3_cat_shift=%u\n",
+			__func__, platform_info.l2_cat_shift, platform_info.l3_cat_shift);
 	}
 
 exit:

--- a/devicemodel/hw/platform/acpi/rtct.c
+++ b/devicemodel/hw/platform/acpi/rtct.c
@@ -337,7 +337,7 @@ uint8_t *build_vrtct(struct vmctx *ctx, void *cfg)
 	vrtct->length = sizeof(struct acpi_table_hdr);
 	vrtct->checksum = 0;
 
-	if (vm_get_config(ctx, &vm_cfg)) {
+	if (vm_get_config(ctx, &vm_cfg, NULL)) {
 		pr_err("%s, get VM configuration fail.\n", __func__);
 		goto error;
 	}

--- a/devicemodel/include/acpi.h
+++ b/devicemodel/include/acpi.h
@@ -29,6 +29,8 @@
 #ifndef _ACPI_H_
 #define _ACPI_H_
 
+#include "vhm_ioctl_defs.h"
+
 #define	SCI_INT			9
 
 #define	SMI_CMD			0xb2
@@ -82,5 +84,8 @@ void	pm_backto_wakeup(struct vmctx *ctx);
 void	inject_power_button_event(struct vmctx *ctx);
 void	power_button_init(struct vmctx *ctx);
 void	power_button_deinit(struct vmctx *ctx);
+
+int pcpuid_from_vcpuid(uint64_t guest_pcpu_bitmask, int vcpu_id);
+int lapicid_from_pcpuid(struct platform_info *plat_info, int pcpu_id);
 
 #endif /* _ACPI_H_ */

--- a/devicemodel/include/public/vhm_ioctl_defs.h
+++ b/devicemodel/include/public/vhm_ioctl_defs.h
@@ -329,8 +329,25 @@ struct platform_info {
 	/** version of this structure */
 	uint16_t version;
 
-	/** Align the size of version & hardware info to 128Bytes. */
-	uint8_t reserved0[124];
+	uint32_t l2_cat_shift;
+	uint32_t l3_cat_shift;
+
+	#define MAX_PLATFORM_LAPIC_IDS 64U
+	/** pLAPIC ID list */
+	uint8_t lapic_ids[MAX_PLATFORM_LAPIC_IDS];
+
+	/**
+	 * sizeof(uint8_t reserved0[]) + sizeof(l2_cat_shift)
+	 * + sizeof(l3_cat_shift) + sizeof(uint8_t lapic_ids[]) = 124
+	 *
+	 * Note:
+	 * 1. DM needs to use the same logic as hypervisor to calculate vLAPIC IDs
+	 * based on physical APIC IDs and CPU affinity setting.
+	 *
+	 * 2. Can only support at most 116 cores. And it assumes LAPIC ID is 8bits
+	 * (X2APIC mode supports 32 bits)
+	 */
+	uint8_t reserved0[116U - MAX_PLATFORM_LAPIC_IDS];
 
 	/** Configuration Information */
 	/** Maximum vCPU number for one VM. */

--- a/devicemodel/include/vmmapi.h
+++ b/devicemodel/include/vmmapi.h
@@ -151,5 +151,5 @@ void	vm_reset_watchdog(struct vmctx *ctx);
 
 int	vm_ioeventfd(struct vmctx *ctx, struct acrn_ioeventfd *args);
 int	vm_irqfd(struct vmctx *ctx, struct acrn_irqfd *args);
-int	vm_get_config(struct vmctx *ctx, struct acrn_vm_config *vm_cfg);
+int	vm_get_config(struct vmctx *ctx, struct acrn_vm_config *vm_cfg, struct platform_info *plat_info);
 #endif	/* _VMMAPI_H_ */

--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -523,37 +523,10 @@ static void guest_cpuid_01h(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx
 
 static void guest_cpuid_0bh(struct acrn_vcpu *vcpu, uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)
 {
-	uint32_t leaf = 0x0bU;
-	uint32_t subleaf = *ecx;
+	/* Forward host cpu topology to the guest, guest will know the native platform information such as host cpu topology here */
+	cpuid_subleaf(0x0BU, *ecx, eax, ebx, ecx, edx);
 
 	/* Patching X2APIC */
-	if (is_sos_vm(vcpu->vm)) {
-		cpuid_subleaf(leaf, subleaf, eax, ebx, ecx, edx);
-	} else {
-		*ecx = subleaf & 0xFFU;
-		/* No HT emulation for UOS */
-		switch (subleaf) {
-		case 0U:
-			*eax = 0U;
-			*ebx = 1U;
-			*ecx |= (1U << 8U);
-		break;
-		case 1U:
-			if (vcpu->vm->hw.created_vcpus == 1U) {
-				*eax = 0U;
-			} else {
-				*eax = (uint32_t)fls32(vcpu->vm->hw.created_vcpus - 1U) + 1U;
-			}
-			*ebx = vcpu->vm->hw.created_vcpus;
-			*ecx |= (2U << 8U);
-		break;
-		default:
-			*eax = 0U;
-			*ebx = 0U;
-			*ecx |= (0U << 8U);
-		break;
-		}
-	}
 	*edx = vlapic_get_apicid(vcpu_vlapic(vcpu));
 }
 

--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2200,16 +2200,8 @@ void vlapic_create(struct acrn_vcpu *vcpu, uint16_t pcpu_id)
 
 	vlapic_init_timer(vlapic);
 
-	if (is_sos_vm(vcpu->vm)) {
-		/*
-		 * For SOS_VM type, pLAPIC IDs need to be used because
-		 * host ACPI tables are passthru to SOS.
-		 * Get APIC ID sequence format from cpu_storage
-		 */
-		vlapic->vapic_id = per_cpu(lapic_id, pcpu_id);
-	} else {
-		vlapic->vapic_id = (uint32_t)vcpu->vcpu_id;
-	}
+	/* Set vLAPIC ID to be same as pLAPIC ID */
+	vlapic->vapic_id = per_cpu(lapic_id, pcpu_id);
 
 	dev_dbg(DBG_LEVEL_VLAPIC, "vlapic APIC ID : 0x%04x", vlapic->vapic_id);
 }

--- a/hypervisor/include/public/acrn_hv_defs.h
+++ b/hypervisor/include/public/acrn_hv_defs.h
@@ -390,8 +390,25 @@ struct hc_platform_info {
 	/** version of this structure */
 	uint16_t version;
 
-	/** Align the size of version & hardware info to 128Bytes. */
-	uint8_t reserved0[124];
+	uint32_t l2_cat_shift;
+	uint32_t l3_cat_shift;
+
+	#define MAX_PLATFORM_LAPIC_IDS 64U
+	/** pLAPIC ID list */
+	uint8_t lapic_ids[MAX_PLATFORM_LAPIC_IDS];
+
+	/**
+	 * sizeof(uint8_t reserved0[]) + sizeof(l2_cat_shift)
+	 * + sizeof(l3_cat_shift) + sizeof(uint8_t lapic_ids[]) = 124
+	 *
+	 * Note:
+	 * 1. DM needs to use the same logic as hypervisor to calculate vLAPIC IDs
+	 * based on physical APIC IDs and CPU affinity setting.
+	 *
+	 * 2. Can only support at most 116 cores. And it assumes LAPIC ID is 8bits
+	 * (X2APIC mode supports 32 bits)
+	 */
+	uint8_t reserved0[116U - MAX_PLATFORM_LAPIC_IDS];
 
 	/** Configuration Information */
 	/** Maximum vCPU number for one VM. */


### PR DESCRIPTION
This pull request introduces the support to use physical APIC IDs as vLAPIC IDs for
pre-launched and post-launched VMs, as an attempt to reproduce the host CPU/cache
topology in pre-launched and post-launched VMs.

Tracked-On: #6020
Signed-off-by: dongshen <dongsheng.x.zhang@intel.com>