### PR TITLE
release2.5:DM: change 32-bit mmio limit to 3.5G

### DIFF
--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -41,7 +41,7 @@
 #define	PCI_BDF(b, d, f) (((b & 0xFF) << 8) | ((d & 0x1F) << 3) | ((f & 0x7)))
 
 #define	PCI_EMUL_MEMBASE32	0x80000000UL	/* 2GB */
-#define	PCI_EMUL_MEMLIMIT32	0xC0000000UL	/* 3GB */
+#define	PCI_EMUL_MEMLIMIT32	0xE0000000UL	/* 3.5GB */
 
 #define	PCI_EMUL_ECFG_BASE	0xE0000000UL	/* 3.5GB */
 


### PR DESCRIPTION
VM 32-bit mmio window is 2G~3.5G

Tracked-On: #6011
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>