### PR TITLE
config-tools: fix guest_flag issue in config xml for adl

### DIFF
--- a/misc/config_tools/data/adl-rvp/industry.xml
+++ b/misc/config_tools/data/adl-rvp/industry.xml
@@ -63,7 +63,7 @@
     <vm_type>SOS_VM</vm_type>
     <name>ACRN SOS VM</name>
     <guest_flags>
-        <guest_flag/>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <clos>
         <vcpu_clos>0</vcpu_clos>
@@ -111,7 +111,7 @@
   <vm id="1">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
-        <guest_flag/>
+        <guest_flag>0</guest_flag>
     </guest_flags>
     <cpu_affinity>
         <pcpu_id>0</pcpu_id>
@@ -233,7 +233,7 @@
     </communication_vuart>
     <PTM>n</PTM>
   </vm>
-    <vm id="4">
+  <vm id="4">
     <vm_type>POST_STD_VM</vm_type>
     <guest_flags>
         <guest_flag>0</guest_flag>


### PR DESCRIPTION
commit 873ed75 ("misc: sanity check VM config for nested virtualization")
requires that the guest_flag tag can't be empty, or it will fail to build.

This patch changes adl instances of "<guest_flag></guest_flag>" to
"<guest_flag>0</guest_flag>".

Tracked-On: #5923
Signed-off-by: Jiang, Yanting <yanting.jiang@intel.com>