### PR TITLE
hv: VMPTRLD and VMCLEAR VMCS with the common APIs

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -545,7 +545,6 @@ static void init_exit_ctrl(const struct acrn_vcpu *vcpu)
 void init_vmcs(struct acrn_vcpu *vcpu)
 {
 	uint64_t vmx_rev_id;
-	uint64_t vmcs_pa;
 	void **vmcs_ptr = &get_cpu_var(vmcs_run);
 
 	/* Log message */
@@ -556,11 +555,10 @@ void init_vmcs(struct acrn_vcpu *vcpu)
 	(void)memcpy_s(vcpu->arch.vmcs, 4U, (void *)&vmx_rev_id, 4U);
 
 	/* Execute VMCLEAR VMCS of this vcpu */
-	vmcs_pa = hva2hpa(vcpu->arch.vmcs);
-	exec_vmclear((void *)&vmcs_pa);
+	clear_va_vmcs(vcpu->arch.vmcs);
 
 	/* Load VMCS pointer */
-	exec_vmptrld((void *)&vmcs_pa);
+	load_va_vmcs(vcpu->arch.vmcs);
 	*vmcs_ptr = (void *)vcpu->arch.vmcs;
 
 	/* Initialize the Virtual Machine Control Structure (VMCS) */
@@ -577,12 +575,10 @@ void init_vmcs(struct acrn_vcpu *vcpu)
  */
 void load_vmcs(const struct acrn_vcpu *vcpu)
 {
-	uint64_t vmcs_pa;
 	void **vmcs_ptr = &get_cpu_var(vmcs_run);
 
 	if (vcpu->launched && (*vmcs_ptr != (void *)vcpu->arch.vmcs)) {
-		vmcs_pa = hva2hpa(vcpu->arch.vmcs);
-		exec_vmptrld((void *)&vmcs_pa);
+		load_va_vmcs(vcpu->arch.vmcs);
 		*vmcs_ptr = (void *)vcpu->arch.vmcs;
 	}
 }

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -139,10 +139,7 @@ void vmx_off(void)
 	void **vmcs_ptr = &get_cpu_var(vmcs_run);
 
 	if (*vmcs_ptr != NULL) {
-		uint64_t vmcs_pa;
-
-		vmcs_pa = hva2hpa(*vmcs_ptr);
-		exec_vmclear((void *)&vmcs_pa);
+		clear_va_vmcs(*vmcs_ptr);
 		*vmcs_ptr = NULL;
 	}
 


### PR DESCRIPTION
Remove the direct calls to exec_vmptrld() or exec_vmclear(), and replace
with the wrapper APIs load_va_vmcs() and clear_va_vmcs().

Tracked-On: #5923
Signed-off-by: Zide Chen <zide.chen@intel.com>