### PR TITLE
Always enable PTM on PTM root capable root port

### DIFF
--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -136,8 +136,9 @@
 /* PTM Definitions */
 #define PCI_PTM_CAP_LEN				0x04U
 #define PCIR_PTM_CAP				0x04U
-#define PCIR_PTM_CTRL				0x08U
 #define PCIM_PTM_CAP_ROOT_CAPABLE	0x4U
+#define PCIM_PTM_GRANULARITY_MASK	0xFF00
+#define PCIR_PTM_CTRL				0x08U
 #define PCIM_PTM_CTRL_ENABLED		0x1U
 #define PCIM_PTM_CTRL_ROOT_SELECTED	0x2U
 
@@ -186,6 +187,13 @@
 #define PCIR_PCIE_DEVCTRL     0x08U
 #define PCIM_PCIE_FLRCAP      (0x1U << 28U)
 #define PCIM_PCIE_FLR         (0x1U << 15U)
+
+/* PCI Express Device Type definitions */
+#define PCIER_FLAGS                    0x2
+#define PCIEM_FLAGS_TYPE               0x00F0
+#define PCIEM_TYPE_ENDPOINT            0x0000
+#define PCIEM_TYPE_ROOTPORT            0x0004
+#define PCIEM_TYPE_ROOT_INT_EP         0x0009
 
 #define PCIR_PCIE_DEVCAP2     0x24U
 #define PCIM_PCIE_DEVCAP2_ARI (0x1U << 5U)


### PR DESCRIPTION
This patch includes 2 parts:
hv: during pci init, hv enables PTM on PTM root capable root port.
dm: add a sanity check whether PTM is enabled before launch guest