### PR TITLE
release_2.5: hv: vlapic: a minor refine about vlapic_x2apic_pt_icr_access

### DIFF
--- a/hypervisor/arch/x86/guest/vlapic.c
+++ b/hypervisor/arch/x86/guest/vlapic.c
@@ -2054,8 +2054,8 @@ vlapic_x2apic_pt_icr_access(struct acrn_vcpu *vcpu, uint64_t val)
 	phys = ((icr_low & APIC_DESTMODE_LOG) == 0UL);
 	shorthand = icr_low & APIC_DEST_MASK;
 
-	if (vlapic_mode != VM_VLAPIC_X2APIC) {
-		pr_err("Only works on VM_VLAPIC_X2APIC mode\n");
+	if ((vlapic_mode != VM_VLAPIC_X2APIC) && !phys) {
+		pr_err("Only Physical Destination Mode could work on non-VM_VLAPIC_X2APIC mode\n");
 		ret = -1;
 	} else {
 		dmask = vlapic_calc_dest(vcpu, shorthand, (dest == 0xffffffffU), dest, phys, false);


### PR DESCRIPTION
In physical destination mode, the destination processor is specified by its
local APIC ID. When a CPU switch xAPIC Mode to x2APIC Mode or vice versa,
the local APIC ID is not changed. So a vcpu in x2APIC Mode could use physical
Destination Mode to send an IPI to another vcpu in xAPIC Mode by writing ICR.

This patch adds support for a vCPU A could write ICR to send IPI to another
vCPU B which is in different APIC mode.

Tracked-On: #5923
Signed-off-by: Li Fei1 <fei1.li@intel.com>