### PR TITLE
Config_tools: Update get slot logic

### DIFF
--- a/misc/config_tools/data/sample_launch_scripts/nuc/launch_win.sh
+++ b/misc/config_tools/data/sample_launch_scripts/nuc/launch_win.sh
@@ -1,46 +1,109 @@
 #!/bin/bash
-# Copyright (C) 2019 Intel Corporation.
-# SPDX-License-Identifier: BSD-3-Clause
+# board: WHL-IPC-I5, scenario: INDUSTRY, uos: WINDOWS
+# pci devices for passthru
+declare -A passthru_vpid
+declare -A passthru_bdf
 
-function launch_win()
+passthru_vpid=(
+["audio"]="8086 9dc8"
+["gpu"]="8086 3ea0"
+)
+passthru_bdf=(
+["audio"]="0000:00:1f.3"
+["gpu"]="0000:00:02.0"
+)
+
+function tap_net() {
+# create a unique tap device for each VM
+tap=$1
+tap_exist=$(ip a | grep "$tap" | awk '{print $1}')
+if [ "$tap_exist"x != "x" ]; then
+  echo "tap device existed, reuse $tap"
+else
+  ip tuntap add dev $tap mode tap
+fi
+
+# if acrn-br0 exists, add VM's unique tap device under it
+br_exist=$(ip a | grep acrn-br0 | awk '{print $1}')
+if [ "$br_exist"x != "x" -a "$tap_exist"x = "x" ]; then
+  echo "acrn-br0 bridge aleady exists, adding new tap device to it..."
+  ip link set "$tap" master acrn-br0
+  ip link set dev "$tap" down
+  ip link set dev "$tap" up
+fi
+}
+
+function launch_windows()
 {
-vm_name=win_vm$1
+#vm-name used to generate uos-mac address
+mac=$(cat /sys/class/net/e*/address)
+vm_name=post_vm_id$1
+mac_seed=${mac:0:17}-${vm_name}
 
+tap_net tap_WaaG
 #check if the vm is running or not
 vm_ps=$(pgrep -a -f acrn-dm)
-result=$(echo $vm_ps | grep "${vm_name}")
+result=$(echo $vm_ps | grep -w "${vm_name}")
 if [[ "$result" != "" ]]; then
   echo "$vm_name is running, can't create twice!"
   exit
 fi
 
-#for memsize setting
+echo ${passthru_vpid["gpu"]} > /sys/bus/pci/drivers/pci-stub/new_id
+echo ${passthru_bdf["gpu"]} > /sys/bus/pci/devices/${passthru_bdf["gpu"]}/driver/unbind
+echo ${passthru_bdf["gpu"]} > /sys/bus/pci/drivers/pci-stub/bind
+modprobe pci_stub
+kernel_version=$(uname -r)
+audio_module="/usr/lib/modules/$kernel_version/kernel/sound/soc/intel/boards/snd-soc-sst_bxt_sos_tdf8532.ko"
+
+# use the modprobe to force loading snd-soc-skl/sst_bxt_bdf8532
+if [ ! -e $audio_module ]; then
+modprobe -q snd-soc-skl
+modprobe -q snd-soc-sst_bxt_tdf8532
+else
+
+modprobe -q snd_soc_skl
+modprobe -q snd_soc_tdf8532
+modprobe -q snd_soc_sst_bxt_sos_tdf8532
+modprobe -q snd_soc_skl_virtio_be
+fi
+audio_passthrough=0
+
+# Check the device file of /dev/vbs_k_audio to determine the audio mode
+if [ ! -e "/dev/vbs_k_audio" ]; then
+audio_passthrough=1
+fi
+boot_audio_option=""
+if [ $audio_passthrough == 1 ]; then
+    # for audio device
+    echo ${passthru_vpid["audio"]} > /sys/bus/pci/drivers/pci-stub/new_id
+    echo ${passthru_bdf["audio"]} > /sys/bus/pci/devices/${passthru_bdf["audio"]}/driver/unbind
+    echo ${passthru_bdf["audio"]} > /sys/bus/pci/drivers/pci-stub/bind
+
+    boot_audio_option="-s 5,passthru,00/1f/3"
+else
+    boot_audio_option="-s 5,virtio-audio"
+fi
 mem_size=4096M
+#interrupt storm monitor for pass-through devices, params order:
+#threshold/s,probe-period(s),intr-inject-delay-time(ms),delay-duration(ms)
+intr_storm_monitor="--intr_monitor 10000,10,1,100"
 
-acrn-dm -A -m $mem_size -s 0:0,hostbridge -s 1:0,lpc -l com1,stdio \
-  -s 2,pci-gvt -G "$2" \
-  -s 3,virtio-blk,./win10-ltsc.img \
-  -s 4,virtio-net,tap0 \
-  --ovmf /usr/share/acrn/bios/OVMF.fd \
-  --windows \
-  $vm_name
+#logger_setting, format: logger_name,level; like following
+logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
+
+acrn-dm -A -m $mem_size -s 0:0,hostbridge -U d2795438-25d6-11e8-864e-cb7a18b34643 \
+   --windows \
+   $logger_setting \
+   -s 6,virtio-blk,./win10-ltsc.img \
+   -s 7,virtio-net,tap_WaaG \
+   -s 2,passthru,0/2/0,gpu  \
+   --ovmf /usr/share/acrn/bios/OVMF.fd \
+   $intr_storm_monitor \
+   -s 31:0,lpc \
+   -l com1,stdio \
+   $boot_audio_option \
+   $vm_name
 }
+launch_windows 1
 
-# offline SOS CPUs except BSP before launch UOS
-for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
-        online=`cat $i/online`
-        idx=`echo $i | tr -cd "[1-99]"`
-        echo cpu$idx online=$online
-        if [ "$online" = "1" ]; then
-                echo 0 > $i/online
-		# during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
-		while [ "$online" = "1" ]; do
-			sleep 1
-			echo 0 > $i/online
-			online=`cat $i/online`
-		done
-                echo $idx > /sys/class/vhm/acrn_vhm/offline_cpu
-        fi
-done
-
-launch_win 1 "64 448 8"

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -632,7 +632,7 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
             break
 
     if uos_type != "PREEMPT-RT LINUX":
-        print("   -s 1:0,lpc \\", file=config)
+        print("   -s 31:0,lpc \\", file=config)
 
     # redirect console
     if dm['vuart0'][vmid] == "Enable":

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -40,9 +40,10 @@ PASSTHRU_DEVS = ['usb_xdci', 'ipu', 'ipu_i2c', 'cse', 'audio', 'sata',
 
 PT_SLOT = {
         "hostbridge":0,
-        "lpc":1,
+        "isa":1,
         "pci-gvt":2,
         "virtio-blk":3,
+        "lpc":31,
     }
 
 
@@ -423,17 +424,8 @@ def get_slot(bdf_list, dev):
         if not bdf_list[p_id]:
             slot_list[p_id] = ''
         else:
-            bus = int(bdf_list[p_id][0:2], 16)
-            slot = int(bdf_list[p_id][3:5], 16)
-            fun = int(bdf_list[p_id][6:7], 16)
-            slot_fun = str(bus) + ":" +  str(slot) + ":" + str(fun)
-            if bus != 0:
-                slot_fun = virtual_dev_slot(dev)
-                PT_SLOT[dev] = slot_fun
-            else:
-                # add already used slot for pass-throught devices to avoid conflict with virtio devices
-                PT_SLOT[dev] = slot
-
+            slot_fun = virtual_dev_slot(dev)
+            PT_SLOT[dev] = slot_fun
             slot_list[p_id] = slot_fun
 
     return slot_list


### PR DESCRIPTION
Modify the initial value of PT_SLOT variable and
update the get slot logic that all device call the virtual_dev_slot function to get slot number directly.
Copy the launch_uos_id1.sh to launch_win.sh.

Tracked-On: #6072
Signed-off-by: Kunhui Li <kunhuix.li@intel.com>