### PR TITLE
dm: return error if PTM is not enabled on physical root port

### DIFF
--- a/devicemodel/hw/pci/ptm.c
+++ b/devicemodel/hw/pci/ptm.c
@@ -181,12 +181,15 @@ int ptm_probe(struct vmctx *ctx, struct passthru_dev *ptdev, int *vrp_sec_bus)
 		/* hv is responsible to ensure that PTM is enabled on hw root port if
 		 * root port is PTM root-capable.  If PTM root is not enabled already in physical
 		 * root port before guest launch, guest OS can only enable it in root port's virtual
-		 * config space and PTM may not function as desired.
+		 * config space and PTM may not function as desired so we are not going to allow user
+		 * to enable PTM on pass-thru device.
 		 */
 		cap = get_ptm_reg_value(rp, PCIR_PTM_CTRL);
 		if (!(cap & PCIM_PTM_CTRL_ENABLE) || !(cap & PCIM_PTM_CTRL_ROOT_SELECT)) {
 			pr_err("%s Warning: guest is not allowed to enable PTM on root port %x:%x.%x.\n",
 				__func__, rp->bus, rp->dev, rp->func);
+
+			return -EINVAL;
 		}
 
 		rp_ptm_offset = pci_find_ext_cap(rp, PCIZ_PTM);


### PR DESCRIPTION
Cherry-pick the changes from master to release 2.5 since my last patch
is merged already.

hv is responsible to ensure PTM is always enabled on hw root port if
that root port is PTM root-capable.  If PTM root is not enabled already in physical
root port before guest launch, guest OS can only enable it in root port's virtual
config space and PTM may not function as desired so we would rather not
to allow user to enable PTM on pass-thru device in this case.
Also revisit a few comments to add assumption that acrn only support a
simple PTM hierarch emulation i.e., EP (ptm requestor) is directly connected
to root port (ptm root), or ptm requestor is rcie).

V4:
 - Change behavior from V3: When users tries to enable PTM while PTM root is not enabled on
physical root port, allow user to launch VM and pass thru the device
with no PTM support.
V3:
 - When users tries to enable PTM while PTM root is not enabled on
physical root port, allow user to launch VM and enable PTM in virtual
root port.  This is not going to enable PTM on physical root port.

Tracked-On: #5915
Signed-off-by: Rong Liu <rong.l.liu@intel.com>
Acked-by: Jason Chen <jason.cj.chen@intel.com>