### PR TITLE
[release_v2.5] hv: update RTCT ACPI table detecting

### DIFF
--- a/hypervisor/acpi_parser/acpi_ext.c
+++ b/hypervisor/acpi_parser/acpi_ext.c
@@ -170,6 +170,10 @@ int32_t acpi_fixup(void)
 	}
 
 	rtct_tbl_addr = (uint8_t *)get_acpi_tbl(ACPI_SIG_RTCT);
+	if (rtct_tbl_addr == NULL) {
+		rtct_tbl_addr = (uint8_t *)get_acpi_tbl(ACPI_SIG_RTCT_V2);
+	}
+
 	if (rtct_tbl_addr != NULL) {
 		set_rtct_tbl((void *)rtct_tbl_addr);
 	}

--- a/hypervisor/arch/x86/rtcm.c
+++ b/hypervisor/arch/x86/rtcm.c
@@ -149,7 +149,8 @@ bool init_software_sram(bool is_bsp)
 			header = hpa2hva(rtcm_binary->address);
 			pr_info("rtcm_bin_address:%llx, rtcm magic:%x, rtcm version:%x",
 				rtcm_binary->address, header->magic, header->version);
-			ASSERT(header->magic == RTCM_MAGIC, "Incorrect RTCM magic!");
+			ASSERT(((header->magic == RTCM_MAGIC) || (header->magic == RTCM_MAGIC_V2)),
+				"Wrong RTCM magic!");
 
 			/* Flush the TLB, so that BSP/AP can execute the RTCM ABI */
 			flush_tlb_range((uint64_t)hpa2hva(rtcm_binary->address), rtcm_binary->size);

--- a/hypervisor/boot/include/acpi.h
+++ b/hypervisor/boot/include/acpi.h
@@ -58,6 +58,7 @@
 #define ACPI_SIG_DSDT            "DSDT" /* Differentiated System Description Table */
 #define ACPI_SIG_TPM2            "TPM2" /* Trusted Platform Module hardware interface table */
 #define ACPI_SIG_RTCT            "PTCT" /* Platform Tuning Configuration Table (Real-Time Configuration Table) */
+#define ACPI_SIG_RTCT_V2         "RTCT" /* Platform Tuning Configuration Table (Real-Time Configuration Table) V2 */
 
 struct packed_gas {
 	uint8_t 	space_id;

--- a/hypervisor/include/arch/x86/asm/rtcm.h
+++ b/hypervisor/include/arch/x86/asm/rtcm.h
@@ -19,6 +19,7 @@ typedef int32_t MSABI(*rtcm_abi_func)(uint32_t command, void *command_struct);
 #define RTCM_CMD_WRMSR			(int32_t)4U
 
 #define RTCM_MAGIC 0x5054434dU
+#define RTCM_MAGIC_V2 0x5254434dU
 
 struct rtcm_header {
 	uint32_t magic;


### PR DESCRIPTION
 Signature of RTCT ACPI table maybe "PTCT"(v1) or "RTCT"(v2).
 and the MAGIC number in CRL header is also changed from "PTCM"
 to "RTCM".

 This patch refine the code to detect RTCT table for both
 v1 and v2.

Tracked-On: #6020
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>