### PR TITLE
misc: efi-stub: Set MOR bit before jumping to hypervisor

### DIFF
--- a/misc/efi-stub/boot.h
+++ b/misc/efi-stub/boot.h
@@ -59,6 +59,13 @@
 
 #define UEFI_BOOT_LOADER_NAME "ACRN UEFI loader"
 
+#define EFI_VAR_MORCTL_NAME                    L"MemoryOverwriteRequestControl"
+#define EFI_VAR_MORCTL_GUID \
+       {  0xe20939be, 0x32d4, 0x41be, { 0xa1, 0x50, 0x89, 0x7f, 0x85, 0xd4, 0x98, 0x29 } }
+#define EFI_VAR_MORCTLLOCK_NAME                L"MemoryOverwriteRequestControlLock"
+#define EFI_VAR_MORCTLLOCK_GUID \
+       {  0xBB983CCF, 0x151D, 0x40E1, { 0xA0, 0x7B, 0x4A, 0x17, 0xBE, 0x16, 0x82, 0x92 } }
+
 #define ALIGN_UP(addr, align) \
 	(((addr) + (typeof (addr)) (align) - 1) & ~((typeof (addr)) (align) - 1))
 

--- a/misc/efi-stub/efilinux.h
+++ b/misc/efi-stub/efilinux.h
@@ -51,6 +51,7 @@
 
 extern EFI_SYSTEM_TABLE *sys_table;
 extern EFI_BOOT_SERVICES *boot;
+extern EFI_RUNTIME_SERVICES *runtime;
 
 extern EFI_STATUS
 emalloc_reserved_aligned(EFI_PHYSICAL_ADDRESS *addr, UINTN size, UINTN align,
@@ -221,6 +222,16 @@ static inline EFI_STATUS emalloc_fixed_addr(EFI_PHYSICAL_ADDRESS *addr,
 	*addr = fixed_addr;
 	return allocate_pages(AllocateAddress, EfiReservedMemoryType,
 		EFI_SIZE_TO_PAGES(size), addr);
+}
+
+static inline EFI_STATUS get_variable(const CHAR16 *name, EFI_GUID *guid, UINT32 *attrs, UINTN *size, void *data)
+{
+	return uefi_call_wrapper(runtime->GetVariable, 5, name, guid, attrs, size, data);
+}
+
+static inline EFI_STATUS set_variable(const CHAR16 *name, EFI_GUID *guid, UINT32 attrs, UINTN size, void *data)
+{
+	return uefi_call_wrapper(runtime->SetVariable, 5, name, guid, attrs, size, data);
 }
 
 /**


### PR DESCRIPTION
This patch sets the MemoryOverwriteRequestControl (MORCtrl for short)
EFI variable before jumping to hypervisor.

Setting variable MemoryOverwriteRequestControlLock (MORCtrlLock for
short) can also be enabled by manually adding -DMORCTRL_LOCK_ENABLED to
CFLAGS.

Setting MORCtrl indicates to the platform firmware that memory be
cleared upon system reset. Setting MORCtrlLock for the first time will
render both MORCtrl and MORCtrlLock to read-only, until next reset.

Tracked-On: #6097 
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>