### PR TITLE
config_tools: add RTCT table support in pre-launched VMs

### DIFF
--- a/misc/config_tools/acpi_gen/acpi_const.py
+++ b/misc/config_tools/acpi_gen/acpi_const.py
@@ -15,7 +15,7 @@ TEMPLATE_ACPI_PATH = os.path.join(VM_CONFIGS_PATH, 'acpi_template', 'template')
 
 ACPI_TABLE_LIST = [('rsdp.asl', 'rsdp.aml'), ('xsdt.asl', 'xsdt.aml'), ('facp.asl', 'facp.aml'),
                    ('mcfg.asl', 'mcfg.aml'), ('apic.asl', 'apic.aml'), ('tpm2.asl', 'tpm2.aml'),
-                   ('dsdt.asl', 'dsdt.aml'), ('PTCT', 'ptct.aml')]
+                   ('dsdt.asl', 'dsdt.aml'), ('PTCT', 'ptct.aml'), ('RTCT', 'rtct.aml')]
 
 ACPI_BASE = 0x7ff00000
 
@@ -25,7 +25,7 @@ ACPI_FADT_ADDR_OFFSET = 0x100       # (268 bytes)
 ACPI_DSDT_ADDR_OFFSET = 0x240       # (variable)
 ACPI_MCFG_ADDR_OFFSET = 0x440       # (60 bytes)
 ACPI_MADT_ADDR_OFFSET = 0x480       # (depends on #CPUs)
-ACPI_PTCT_ADDR_OFFSET = 0xF00
+ACPI_RTCT_ADDR_OFFSET = 0xF00
 ACPI_TPM2_ADDR_OFFSET = 0x1100      # (52 bytes)
 
 ACPI_RSDP_ADDR = (ACPI_BASE + ACPI_RSDP_ADDR_OFFSET)
@@ -35,7 +35,7 @@ ACPI_MCFG_ADDR = (ACPI_BASE + ACPI_MCFG_ADDR_OFFSET)
 ACPI_MADT_ADDR = (ACPI_BASE + ACPI_MADT_ADDR_OFFSET)
 ACPI_TPM2_ADDR = (ACPI_BASE + ACPI_TPM2_ADDR_OFFSET)
 ACPI_DSDT_ADDR = (ACPI_BASE + ACPI_DSDT_ADDR_OFFSET)
-ACPI_PTCT_ADDR = (ACPI_BASE + ACPI_PTCT_ADDR_OFFSET)
+ACPI_RTCT_ADDR = (ACPI_BASE + ACPI_RTCT_ADDR_OFFSET)
 ACPI_FACS_ADDR = 0x0
 
 VIRT_PCI_MMCFG_BASE = 0xE0000000
@@ -50,4 +50,4 @@ TSN_DEVICE_LIST = ['8086:4ba0',
                    '8086:4bb0',
                    '8086:4b32']
 
-PTCT = 'PTCT'
+RTCT = ['RTCT', 'PTCT']

--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -33,8 +33,12 @@ def asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path):
                         os.remove(os.path.join(dest_vm_acpi_path, acpi_table[1]))
                     rmsg = 'failed to compile {}'.format(acpi_table[0])
                     break
-        elif acpi_table[0] == PTCT:
-            if PTCT in os.listdir(dest_vm_acpi_path):
+        elif acpi_table[0] == 'PTCT':
+            if 'PTCT' in os.listdir(dest_vm_acpi_path):
+                shutil.copyfile(os.path.join(dest_vm_acpi_path, acpi_table[0]),
+                                os.path.join(dest_vm_acpi_bin_path, acpi_table[1]))
+        elif acpi_table[0] == 'RTCT':
+            if 'RTCT' in os.listdir(dest_vm_acpi_path):
                 shutil.copyfile(os.path.join(dest_vm_acpi_path, acpi_table[0]),
                                 os.path.join(dest_vm_acpi_bin_path, acpi_table[1]))
         else:
@@ -96,9 +100,13 @@ def aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, acpi_bin_name):
         with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[6][1]), 'rb') as asl:
             acpi_bin.write(asl.read())
 
-        if PTCT in os.listdir(dest_vm_acpi_path):
-            acpi_bin.seek(ACPI_PTCT_ADDR_OFFSET)
+        if 'PTCT' in os.listdir(dest_vm_acpi_path):
+            acpi_bin.seek(ACPI_RTCT_ADDR_OFFSET)
             with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[7][1]), 'rb') as asl:
+                acpi_bin.write(asl.read())
+        elif 'RTCT' in os.listdir(dest_vm_acpi_path):
+            acpi_bin.seek(ACPI_RTCT_ADDR_OFFSET)
+            with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[8][1]), 'rb') as asl:
                 acpi_bin.write(asl.read())
 
         acpi_bin.seek(0xfffff)


### PR DESCRIPTION
add RTCT table integrated with ACPI binary for pre-launched
VMs.

Tracked-On: #6025

Signed-off-by: Shuang Zheng <shuang.zheng@intel.com>