### PR TITLE
doc: update timer HLD doc after modularization

### DIFF
--- a/doc/developer-guides/hld/hv-timer.rst
+++ b/doc/developer-guides/hld/hv-timer.rst
@@ -33,6 +33,9 @@ Interfaces Design
 .. doxygenfunction:: timer_expired
    :project: Project ACRN
 
+.. doxygenfunction:: timer_is_started
+   :project: Project ACRN
+
 .. doxygenfunction:: add_timer
    :project: Project ACRN
 
@@ -45,6 +48,12 @@ Interfaces Design
 .. doxygenfunction:: calibrate_tsc
    :project: Project ACRN
 
+.. doxygenfunction:: cpu_ticks
+   :project: Project ACRN
+
+.. doxygenfunction:: cpu_tickrate
+   :project: Project ACRN
+
 .. doxygenfunction:: us_to_ticks
    :project: Project ACRN
 
@@ -52,15 +61,6 @@ Interfaces Design
    :project: Project ACRN
 
 .. doxygenfunction:: ticks_to_ms
-   :project: Project ACRN
-
-.. doxygenfunction:: rdtsc
-   :project: Project ACRN
-
-.. doxygenfunction:: get_tsc_khz
-   :project: Project ACRN
-
-.. doxygenfunction:: timer_is_started
    :project: Project ACRN
 
 .. doxygenfunction:: udelay

--- a/hypervisor/include/arch/x86/asm/tsc.h
+++ b/hypervisor/include/arch/x86/asm/tsc.h
@@ -34,6 +34,9 @@ uint32_t get_tsc_khz(void);
 /**
  * @brief Calibrate Time Stamp Counter (TSC) frequency.
  *
+ * @remark Generic time related routines, e.g., cpu_tickrate(), us_to_ticks(),
+ * udelay(), etc., relies on this function being called earlier during system initialization.
+ *
  * @return None
  */
 void calibrate_tsc(void);

--- a/hypervisor/include/common/ticks.h
+++ b/hypervisor/include/common/ticks.h
@@ -14,12 +14,16 @@
 /**
  * @brief Read current CPU tick count.
  *
+ * @remark On x86, this is the Time Stamp Counter (TSC) value of the current logical CPU.
+ *
  * @return CPU ticks
  */
 uint64_t cpu_ticks(void);
 
 /**
  * @brief  Get CPU tick frequency in KHz.
+ *
+ * @remark On x86, this is the Time Stamp Counter (TSC) frequency of the current logical CPU.
  *
  * @return CPU frequency (KHz)
  */


### PR DESCRIPTION
Replace rdstc() and get_tsc_khz() with their architectural agnostic
counterparts cpu_ticks() and cpu_tickrate().

Tracked-On: #5920
Signed-off-by: Yi Liang <yi.liang@intel.com>