### PR TITLE
hv: nested virtualization part 4 - master

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -281,6 +281,7 @@ VP_BASE_C_SRCS += arch/x86/guest/hyperv.c
 endif
 ifeq ($(CONFIG_NVMX_ENABLED),y)
 VP_BASE_C_SRCS += arch/x86/guest/nested.c
+VP_BASE_C_SRCS += arch/x86/guest/vept.c
 endif
 VP_BASE_C_SRCS += boot/guest/vboot_info.c
 VP_BASE_C_SRCS += common/hv_main.c

--- a/hypervisor/arch/x86/guest/vept.c
+++ b/hypervisor/arch/x86/guest/vept.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <types.h>
+#include <logmsg.h>
+#include <asm/mmu.h>
+#include <asm/guest/vcpu.h>
+#include <asm/guest/vm.h>
+#include <asm/guest/vmexit.h>
+#include <asm/guest/ept.h>
+#include <asm/guest/nested.h>
+
+/**
+ * @pre vcpu != NULL
+ */
+int32_t invept_vmexit_handler(struct acrn_vcpu *vcpu)
+{
+	struct invept_desc operand_gla_ept;
+	uint64_t type;
+
+	if (check_vmx_permission(vcpu)) {
+		type = get_invvpid_ept_operands(vcpu, (void *)&operand_gla_ept, sizeof(operand_gla_ept));
+
+		if (type > INVEPT_TYPE_ALL_CONTEXTS) {
+			nested_vmx_result(VMfailValid, VMXERR_INVEPT_INVVPID_INVALID_OPERAND);
+		} else {
+			operand_gla_ept.eptp = gpa2hpa(vcpu->vm, operand_gla_ept.eptp);
+			asm_invept(type, operand_gla_ept);
+			nested_vmx_result(VMsucceed, 0);
+		}
+	}
+
+	return 0;
+}

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -78,13 +78,13 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_VMCALL] = {
 		.handler = vmcall_vmexit_handler},
-	[VMX_EXIT_REASON_VMLAUNCH] = {
-		.handler = undefined_vmexit_handler},
 	[VMX_EXIT_REASON_VMPTRST] = {
+		.handler = undefined_vmexit_handler},
+#ifndef CONFIG_NVMX_ENABLED
+	[VMX_EXIT_REASON_VMLAUNCH] = {
 		.handler = undefined_vmexit_handler},
 	[VMX_EXIT_REASON_VMRESUME] = {
 		.handler = undefined_vmexit_handler},
-#ifndef CONFIG_NVMX_ENABLED
 	[VMX_EXIT_REASON_VMCLEAR] = {
 		.handler = undefined_vmexit_handler},
 	[VMX_EXIT_REASON_VMPTRLD] = {
@@ -98,6 +98,10 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 	[VMX_EXIT_REASON_VMXON] = {
 		.handler = undefined_vmexit_handler},
 #else
+	[VMX_EXIT_REASON_VMLAUNCH] = {
+		.handler = vmlaunch_vmexit_handler},
+	[VMX_EXIT_REASON_VMRESUME] = {
+		.handler = vmresume_vmexit_handler},
 	[VMX_EXIT_REASON_VMCLEAR] = {
 		.handler = vmclear_vmexit_handler,
 		.need_exit_qualification = 1},

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -16,6 +16,7 @@
 #include <asm/guest/vmx_io.h>
 #include <asm/guest/splitlock.h>
 #include <asm/guest/ept.h>
+#include <asm/guest/vept.h>
 #include <asm/vtd.h>
 #include <asm/cpuid.h>
 #include <asm/guest/vcpuid.h>
@@ -97,6 +98,10 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 		.handler = undefined_vmexit_handler},
 	[VMX_EXIT_REASON_VMXON] = {
 		.handler = undefined_vmexit_handler},
+	[VMX_EXIT_REASON_INVEPT] = {
+		.handler = undefined_vmexit_handler},
+	[VMX_EXIT_REASON_INVVPID] = {
+		.handler = undefined_vmexit_handler},
 #else
 	[VMX_EXIT_REASON_VMLAUNCH] = {
 		.handler = vmlaunch_vmexit_handler},
@@ -118,6 +123,12 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 		.handler = vmxoff_vmexit_handler},
 	[VMX_EXIT_REASON_VMXON] = {
 		.handler = vmxon_vmexit_handler,
+		.need_exit_qualification = 1},
+	[VMX_EXIT_REASON_INVEPT] = {
+		.handler = invept_vmexit_handler,
+		.need_exit_qualification = 1},
+	[VMX_EXIT_REASON_INVVPID] = {
+		.handler = invvpid_vmexit_handler,
 		.need_exit_qualification = 1},
 #endif
 	[VMX_EXIT_REASON_CR_ACCESS] = {
@@ -165,14 +176,10 @@ static const struct vm_exit_dispatch dispatch_table[NR_VMX_EXIT_REASONS] = {
 	[VMX_EXIT_REASON_EPT_MISCONFIGURATION] = {
 		.handler = ept_misconfig_vmexit_handler,
 		.need_exit_qualification = 1},
-	[VMX_EXIT_REASON_INVEPT] = {
-		.handler = undefined_vmexit_handler},
 	[VMX_EXIT_REASON_RDTSCP] = {
 		.handler = unhandled_vmexit_handler},
 	[VMX_EXIT_REASON_VMX_PREEMPTION_TIMER_EXPIRED] = {
 		.handler = unhandled_vmexit_handler},
-	[VMX_EXIT_REASON_INVVPID] = {
-		.handler = undefined_vmexit_handler},
 	[VMX_EXIT_REASON_WBINVD] = {
 		.handler = wbinvd_vmexit_handler},
 	[VMX_EXIT_REASON_XSETBV] = {

--- a/hypervisor/arch/x86/guest/vmexit.c
+++ b/hypervisor/arch/x86/guest/vmexit.c
@@ -216,6 +216,8 @@ int32_t vmexit_handler(struct acrn_vcpu *vcpu)
 	if (get_pcpu_id() != pcpuid_from_vcpu(vcpu)) {
 		pr_fatal("vcpu is not running on its pcpu!");
 		ret = -EINVAL;
+	} else if (is_vcpu_in_l2_guest(vcpu)) {
+		ret = nested_vmexit_handler(vcpu);
 	} else {
 		/* Obtain interrupt info */
 		vcpu->arch.idt_vectoring_info = exec_vmread32(VMX_IDT_VEC_INFO_FIELD);

--- a/hypervisor/include/arch/x86/asm/guest/nested.h
+++ b/hypervisor/include/arch/x86/asm/guest/nested.h
@@ -84,6 +84,9 @@ union value_64 {
 
 /* refer to ISDM: Table 30-1. VM-Instruction Error Numbers */
 #define VMXERR_VMCLEAR_VMXON_POINTER		(3)
+#define VMXERR_VMLAUNCH_NONCLEAR_VMCS		(4)
+#define VMXERR_VMRESUME_NONLAUNCHED_VMCS	(5)
+#define VMXERR_VMRESUME_AFTER_VMXOFF		(6)
 #define VMXERR_VMPTRLD_INVALID_ADDRESS		(9)
 #define VMXERR_VMPTRLD_INCORRECT_VMCS_REVISION_ID (10)
 #define VMXERR_VMPTRLD_VMXON_POINTER		(11)
@@ -317,6 +320,8 @@ int32_t vmptrld_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmclear_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmread_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmwrite_vmexit_handler(struct acrn_vcpu *vcpu);
+int32_t vmresume_vmexit_handler(struct acrn_vcpu *vcpu);
+int32_t vmlaunch_vmexit_handler(struct acrn_vcpu *vcpu);
 
 #ifdef CONFIG_NVMX_ENABLED
 struct acrn_nested {
@@ -327,8 +332,10 @@ struct acrn_nested {
 	uint64_t current_vmcs12_ptr;	/* GPA */
 	uint64_t vmxon_ptr;		/* GPA */
 	bool vmxon;		/* To indicate if vCPU entered VMX operation */
+	bool in_l2_guest;	/* To indicate if vCPU is currently in Guest mode (from L1's perspective) */
 	bool host_state_dirty;	/* To indicate need to merge VMCS12 host-state fields to VMCS01 */
 	bool gpa_field_dirty;
+	bool control_field_dirty;	/* for VM-execution, VM-exit, VM-entry control fields */
 } __aligned(PAGE_SIZE);
 
 void init_nested_vmx(__unused struct acrn_vm *vm);

--- a/hypervisor/include/arch/x86/asm/guest/nested.h
+++ b/hypervisor/include/arch/x86/asm/guest/nested.h
@@ -317,6 +317,7 @@ enum VMXResult {
 void nested_vmx_result(enum VMXResult, int error_number);
 int64_t get_invvpid_ept_operands(struct acrn_vcpu *vcpu, void *desc, size_t size);
 bool check_vmx_permission(struct acrn_vcpu *vcpu);
+int32_t nested_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmxon_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmxoff_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmptrld_vmexit_handler(struct acrn_vcpu *vcpu);
@@ -343,6 +344,7 @@ struct acrn_nested {
 } __aligned(PAGE_SIZE);
 
 void init_nested_vmx(__unused struct acrn_vm *vm);
+bool is_vcpu_in_l2_guest(struct acrn_vcpu *vcpu);
 bool is_vmx_msr(uint32_t msr);
 void init_vmx_msrs(struct acrn_vcpu *vcpu);
 int32_t read_vmx_msr(__unused struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *val);
@@ -350,6 +352,10 @@ int32_t read_vmx_msr(__unused struct acrn_vcpu *vcpu, uint32_t msr, uint64_t *va
 struct acrn_nested {};
 
 static inline void init_nested_vmx(__unused struct acrn_vm *vm) {}
+static inline bool is_vcpu_in_l2_guest(__unused struct acrn_vcpu *vcpu) {
+	return false;
+}
+
 static inline bool is_vmx_msr(__unused uint32_t msr)
 {
 	/*

--- a/hypervisor/include/arch/x86/asm/guest/nested.h
+++ b/hypervisor/include/arch/x86/asm/guest/nested.h
@@ -93,6 +93,7 @@ union value_64 {
 #define VMXERR_UNSUPPORTED_COMPONENT		(12)
 #define VMXERR_VMWRITE_RO_COMPONENT		(13)
 #define VMXERR_VMXON_IN_VMX_ROOT_OPERATION	(15)
+#define VMXERR_INVEPT_INVVPID_INVALID_OPERAND	(28)
 
 /*
  * This VMCS12 revision id is chosen arbitrarily.
@@ -314,6 +315,8 @@ enum VMXResult {
 	VMfailInvalid,
 };
 void nested_vmx_result(enum VMXResult, int error_number);
+int64_t get_invvpid_ept_operands(struct acrn_vcpu *vcpu, void *desc, size_t size);
+bool check_vmx_permission(struct acrn_vcpu *vcpu);
 int32_t vmxon_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmxoff_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmptrld_vmexit_handler(struct acrn_vcpu *vcpu);
@@ -322,6 +325,7 @@ int32_t vmread_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmwrite_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmresume_vmexit_handler(struct acrn_vcpu *vcpu);
 int32_t vmlaunch_vmexit_handler(struct acrn_vcpu *vcpu);
+int32_t invvpid_vmexit_handler(struct acrn_vcpu *vcpu);
 
 #ifdef CONFIG_NVMX_ENABLED
 struct acrn_nested {

--- a/hypervisor/include/arch/x86/asm/guest/vept.h
+++ b/hypervisor/include/arch/x86/asm/guest/vept.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef VEPT_H
+#define VEPT_H
+
+#ifdef CONFIG_NVMX_ENABLED
+int32_t invept_vmexit_handler(struct acrn_vcpu *vcpu);
+#endif /* CONFIG_NVMX_ENABLED */
+#endif /* VEPT_H */


### PR DESCRIPTION
After these patches are merged, it's supposed that it can enable nVMX on SOS without vEPT support.