### PR TITLE
Config_tools: Update Hybrid Cores

### DIFF
--- a/misc/config_tools/schema/checks/pre_launched_vm_support.xsd
+++ b/misc/config_tools/schema/checks/pre_launched_vm_support.xsd
@@ -25,7 +25,7 @@ To fix this error, you can
   <xs:assert test="every $vm in vm satisfies
 		   every $cpu in $vm/cpu_affinity/pcpu_id satisfies
 		   processors//thread[cpu_id = $cpu]/core_type = processors//thread[cpu_id = $vm/cpu_affinity/pcpu_id[1]]/core_type">
-    <xs:annotation acrn:severity="warning">
+    <xs:annotation acrn:severity="error">
       <xs:documentation>The physical CPUs allocated to the same VM shall have the same core types.
 
 On platforms having both big and little cores, the current design of ACRN only allows allocating the same type of cores


### PR DESCRIPTION
Update the severity from "warning" to "error" for hybrid cores check.

Tracked-On: #5918
Reviewed-by: Junjie Mao <junjie.mao@intel.com>
Signed-off-by: Kunhui Li <kunhuix.li@intel.com>