### PR TITLE
doc: update the content about generating board xml

### DIFF
--- a/doc/tutorials/acrn_configuration_tool.rst
+++ b/doc/tutorials/acrn_configuration_tool.rst
@@ -115,13 +115,13 @@ toolset.
 
       | **Native Linux requirement:**
       | **Release:** Ubuntu 18.04+
-      | **Tools:** cpuid, rdmsr, lspci, dmidecode (optional)
+      | **Tools:** cpuid, rdmsr, lspci, lxml, dmidecode (optional)
       | **Kernel cmdline:** "idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable"
 
-   #. Copy the ``target`` directory into the target file system and then run the
-      ``sudo python3 board_parser.py $(BOARD)`` command.
+   #. Copy the ``board_inspector`` directory into the target file system and then run the
+      ``sudo python3 cli.py $(BOARD)`` command.
    #. A ``$(BOARD).xml`` that includes all needed hardware-specific information
-      is generated in the ``./out/`` directory. Here, ``$(BOARD)`` is the
+      is generated under the current working directory. Here, ``$(BOARD)`` is the
       specified board name.
 
 #. Customize your needs.

--- a/misc/config_tools/board_inspector/README
+++ b/misc/config_tools/board_inspector/README
@@ -1,6 +1,6 @@
 board_parser.py will collect all board related info and then generate a board info file for acrn-config host tool usage.
 
-usage: python3 run.py <board_name> [--out board_info_file]
+usage: python3 cli.py <board_name> [--out board_info_file]
 
 board_name : the name of board that run ACRN hypervisor, like apl-up2/nuc7i7dnb. It will be used as name of the board configurations folder which created by acrn-config host tool.
 board_info_file : (optional) the name of board info file. if it is not specified, a name of <board_name>.xml will be generated under the current working directory by default.
@@ -8,6 +8,6 @@ board_info_file : (optional) the name of board info file. if it is not specified
 Please run this script under native Linux environment with root privilege.
 
 OS requirement:
-	Release:	Ubuntu 18.04+ or ClearLinux 30210+
-	Tools:		cpuid, rdmsr, lspci, dmidecode
+	Release:	Ubuntu 18.04+
+	Tools:		cpuid, rdmsr, lspci, lxml, dmidecode (optional)
 	kernel cmdline: "idle=nomwait intel_idle.max_cstate=0 intel_pstate=disable"


### PR DESCRIPTION
Update the content about getting board xml from native
enviroment in acrn_configuration_tool.rst and README.

Tracked-On: #6134
Signed-off-by: Kunhui Li <kunhuix.li@intel.com>