### PR TITLE
config-tools: enable "allow_trigger_s5" through launch.xml

### DIFF
--- a/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aaag.xml
+++ b/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aaag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aliaag.xml
+++ b/misc/config_tools/data/apl-mrb/sdc_launch_1uos_aliaag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/apl-mrb/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/apl-mrb/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">IOC</poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/apl-up2-n3350/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/apl-up2-n3350/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/apl-up2/sdc_launch_1uos_aaag.xml
+++ b/misc/config_tools/data/apl-up2/sdc_launch_1uos_aaag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/apl-up2/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/apl-up2/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos">PowerButton</poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -92,6 +94,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -133,6 +136,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -174,6 +178,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -215,6 +220,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/ehl-crb-b/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/generic_board/industry_launch_2uos.xml
+++ b/misc/config_tools/data/generic_board/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc11tnbi5/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc11tnbi5/industry_launch_2uos.xml
@@ -8,6 +8,7 @@
     <vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
     <poweroff_channel desc="the method of power off uos"></poweroff_channel>
     <enable_ptm desc="enable ptm of uos">n</enable_ptm>
+    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
       <pcpu_id/>
@@ -49,6 +50,7 @@
     <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
     <poweroff_channel desc="the method of power off uos"></poweroff_channel>
     <enable_ptm desc="enable ptm of uos">n</enable_ptm>
+    <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
     <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
     <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
       <pcpu_id/>

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc6cayh/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc6cayh/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -51,6 +52,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc6cayh/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc6cayh/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -51,6 +52,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -94,6 +96,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -135,6 +138,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -176,6 +180,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -217,6 +222,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/nuc6cayh/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -92,6 +94,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -133,6 +136,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -174,6 +178,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -215,6 +220,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/nuc7i7dnb/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/tgl-rvp/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/tgl-rvp/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -51,6 +52,7 @@
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
     <enable_ptm desc="enable ptm of uos">n</enable_ptm>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
 		<pcpu_id></pcpu_id>
@@ -92,6 +94,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -133,6 +136,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -174,6 +178,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -215,6 +220,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/tgl-rvp/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -92,6 +94,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -133,6 +136,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -174,6 +178,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -215,6 +220,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/whl-ipc-i5/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid_rt_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_vxworks.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_vxworks.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_waag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_waag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -50,6 +51,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -92,6 +94,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -133,6 +136,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -174,6 +178,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">
@@ -215,6 +220,7 @@
         <vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
         <vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
         <poweroff_channel desc="the method of power off uos" />
+        <allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
         <enable_ptm desc="enable ptm of uos">n</enable_ptm>
         <usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4" />
         <cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_laag.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_laag.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Disable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
+++ b/misc/config_tools/data/whl-ipc-i7/sdc_launch_1uos_zephyr.xml
@@ -7,6 +7,7 @@
 	<vbootloader desc="virtual bootloader method" readonly="true">ovmf</vbootloader>
 	<vuart0 desc="vUART0 which emulated by device model">Enable</vuart0>
 	<poweroff_channel desc="the method of power off uos"></poweroff_channel>
+	<allow_trigger_s5 desc="allow this vm to trigger s5 shutdown flow, this flag works with poweroff_channel 'vuart1(pty)' and 'vuart1(tty)' only.">n</allow_trigger_s5>
 	<enable_ptm desc="enable ptm of uos">n</enable_ptm>
 	<usb_xhci desc="USB xHCI mediator configuration. input format: bus#-port#[:bus#-port#: ...]. e.g.: 1-2:2-4"></usb_xhci>
 	<cpu_affinity desc="List of pCPU that this VM's vCPUs are pinned to.">

--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -585,6 +585,11 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
     # pm_channel set
     if dm['pm_channel'][vmid] and dm['pm_channel'][vmid] != None:
         pm_key = dm['pm_channel'][vmid]
+        pm_vuart = "--pm_notify_channel uart"
+        if vmid in dm["allow_trigger_s5"] and dm["allow_trigger_s5"][vmid] == 'y':
+            pm_vuart = pm_vuart + ",allow_trigger_s5 "
+        else:
+            pm_vuart = pm_vuart + " "
         if pm_key == "vuart1(tty)":
             vuart_base = launch_cfg_lib.get_vuart1_from_scenario(sos_vmid + vmid)
             if vuart_base == "INVALID_COM_BASE":
@@ -592,7 +597,9 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
                 launch_cfg_lib.ERR_LIST[err_key] = "vuart1 of VM{} in scenario file should select 'SOS_COM2_BASE'".format(sos_vmid + vmid)
                 return
             scenario_cfg_lib.get_sos_vuart_settings()
-            print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
+            print("   {} \\".format(pm_vuart + launch_cfg_lib.PM_CHANNEL_DIC[pm_key] + scenario_cfg_lib.SOS_UART1_VALID_NUM), file=config)
+        elif pm_key == "vuart1(pty)":
+            print("   {} \\".format(pm_vuart + launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
         else:
             print("   {} \\".format(launch_cfg_lib.PM_CHANNEL_DIC[pm_key]), file=config)
 

--- a/misc/config_tools/launch_config/launch_cfg_gen.py
+++ b/misc/config_tools/launch_config/launch_cfg_gen.py
@@ -52,7 +52,8 @@ def get_launch_item_values(board_info, scenario_info=None):
     launch_item_values['uos,vuart0'] = launch_cfg_lib.DM_VUART0
     launch_item_values['uos,poweroff_channel'] = launch_cfg_lib.PM_CHANNEL
     launch_item_values["uos,cpu_affinity"] = board_cfg_lib.get_processor_info()
-    launch_item_values['uos,enable_ptm'] = launch_cfg_lib.PTM
+    launch_item_values['uos,enable_ptm'] = launch_cfg_lib.y_n
+    launch_item_values['uos,allow_trigger_s5'] = launch_cfg_lib.y_n
     launch_cfg_lib.set_shm_regions(launch_item_values, scenario_info)
     launch_cfg_lib.set_pci_vuarts(launch_item_values, scenario_info)
 

--- a/misc/config_tools/launch_config/launch_item.py
+++ b/misc/config_tools/launch_config/launch_item.py
@@ -37,6 +37,7 @@ class AcrnDmArgs:
         self.args["communication_vuarts"] = common.get_leaf_tag_map(self.launch_info, "communication_vuarts", "communication_vuart")
         self.args["console_vuart"] = common.get_leaf_tag_map(self.launch_info, "console_vuart")
         self.args["enable_ptm"] = common.get_leaf_tag_map(self.launch_info, "enable_ptm")
+        self.args["allow_trigger_s5"] = common.get_leaf_tag_map(self.launch_info, "allow_trigger_s5")
 
     def check_item(self):
         (rootfs, num) = board_cfg_lib.get_rootfs(self.board_info)
@@ -45,7 +46,8 @@ class AcrnDmArgs:
         launch_cfg_lib.mem_size_check(self.args["mem_size"], "mem_size")
         launch_cfg_lib.args_aval_check(self.args["vbootloader"], "vbootloader", launch_cfg_lib.BOOT_TYPE)
         launch_cfg_lib.args_aval_check(self.args["vuart0"], "vuart0", launch_cfg_lib.DM_VUART0)
-        launch_cfg_lib.args_aval_check(self.args["enable_ptm"], "enable_ptm", launch_cfg_lib.PTM)
+        launch_cfg_lib.args_aval_check(self.args["enable_ptm"], "enable_ptm", launch_cfg_lib.y_n)
+        launch_cfg_lib.args_aval_check(self.args["allow_trigger_s5"], "allow_trigger_s5", launch_cfg_lib.y_n)
         cpu_affinity = launch_cfg_lib.uos_cpu_affinity(self.args["cpu_affinity"])
         err_dic = scenario_cfg_lib.vm_cpu_affinity_check(self.launch_info, cpu_affinity, "pcpu_id")
         launch_cfg_lib.ERR_LIST.update(err_dic)

--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -15,7 +15,7 @@ ERR_LIST = {}
 BOOT_TYPE = ['no', 'vsbl', 'ovmf']
 RTOS_TYPE = ['no', 'Soft RT', 'Hard RT']
 DM_VUART0 = ['Disable', 'Enable']
-PTM = ['y', 'n']
+y_n = ['y', 'n']
 UOS_TYPES = ['CLEARLINUX', 'ANDROID', 'ALIOS', 'PREEMPT-RT LINUX', 'VXWORKS', 'WINDOWS', 'ZEPHYR', 'YOCTO', 'UBUNTU', 'GENERIC LINUX']
 LINUX_LIKE_OS = ['CLEARLINUX', 'PREEMPT-RT LINUX', 'YOCTO', 'UBUNTU', 'GENERIC LINUX']
 
@@ -52,8 +52,8 @@ PM_CHANNEL_DIC = {
     None:'',
     'IOC':'--pm_notify_channel ioc',
     'PowerButton':'--pm_notify_channel power_button',
-    'vuart1(pty)':'--pm_notify_channel uart \\\n   --pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
-    'vuart1(tty)':'--pm_notify_channel uart --pm_by_vuart tty,/dev/',
+    'vuart1(pty)':'--pm_by_vuart pty,/run/acrn/life_mngr_$vm_name \\\n   -l com2,/run/acrn/life_mngr_$vm_name',
+    'vuart1(tty)':'--pm_by_vuart tty,/dev/',
 }
 
 MOUNT_FLAG_DIC = {}
@@ -67,7 +67,7 @@ def usage(file_name):
     print('board_info_file :  file name of the board info')
     print('scenario_info_file :  file name of the scenario info')
     print('launch_info_file :  file name of the launch info')
-    print('uosid :  this is the relateive id for post launch vm in scenario info XML:[1..max post launch vm]')
+    print('uosid :  this is the relative id for post launch vm in scenario info XML:[1..max post launch vm]')
     print('output folder :  path to acrn-hypervisor_folder')
 
 


### PR DESCRIPTION
Add flag "allow_trigger_s5" to launch script xmls. If this flag sets to
'y' and the poweroff_channel sets to "vuart1(pty)" or "vuart1(tty)", the
"allow_trigger_s5" will appends to the end of "--pm_notify_channel
uart".

Tracked-On: #6138
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>