### PR TITLE
Add support to assign 3rd non-contiguous HPA regions for logical partition scenario

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -221,6 +221,7 @@ static inline uint16_t get_configured_bsp_pcpu_id(const struct acrn_vm_config *v
 static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_vm_config *vm_config)
 {
 	bool is_hpa1 = true;
+	bool is_hpa2 = true;
 	uint64_t base_hpa = vm_config->memory.start_hpa;
 	uint64_t remaining_hpa_size = vm_config->memory.size;
 	uint32_t i;
@@ -245,6 +246,7 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 			/* Do EPT mapping for GPAs that are backed by physical memory */
 			if ((entry->type == E820_TYPE_RAM) || (entry->type == E820_TYPE_ACPI_RECLAIM)
 					|| (entry->type == E820_TYPE_ACPI_NVS)) {
+
 				ept_add_mr(vm, (uint64_t *)vm->arch_vm.nworld_eptp, base_hpa, entry->baseaddr,
 					entry->length, EPT_RWX | EPT_WB);
 				base_hpa += entry->length;
@@ -262,10 +264,16 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 			pr_warn("%s: HPA size incorrectly configured in v820\n", __func__);
 		}
 
-		if ((remaining_hpa_size == 0UL) && (is_hpa1)) {
-			is_hpa1 = false;
-			base_hpa = vm_config->memory.start_hpa2;
-			remaining_hpa_size = vm_config->memory.size_hpa2;
+		if (remaining_hpa_size == 0UL) {
+			if (is_hpa1) {
+				is_hpa1 = false;
+				base_hpa = vm_config->memory.start_hpa2;
+				remaining_hpa_size = vm_config->memory.size_hpa2;
+			} else if (is_hpa2) {
+				is_hpa2 = false;
+				base_hpa = vm_config->memory.start_hpa3;
+				remaining_hpa_size = vm_config->memory.size_hpa3;
+			}
 		}
 	}
 

--- a/hypervisor/include/arch/x86/vm_config.h
+++ b/hypervisor/include/arch/x86/vm_config.h
@@ -94,6 +94,10 @@ struct acrn_vm_mem_config {
 	uint64_t start_hpa2;	/* Start of second HPA for non-contiguous allocations in VM memory configuration,
 				   for pre-launched VMs only */
 	uint64_t size_hpa2;	/* Size of second HPA for non-contiguous allocations in VM memory configuration */
+
+	uint64_t start_hpa3;	/* Start of third HPA for non-contiguous allocations in VM memory configuration,
+				   for pre-launched VMs only */
+	uint64_t size_hpa3;	/* Size of third HPA for non-contiguous allocations in VM memory configuration */
 };
 
 struct target_vuart {

--- a/misc/acrn-config/scenario_config/scenario_item.py
+++ b/misc/acrn-config/scenario_config/scenario_item.py
@@ -150,6 +150,8 @@ class MemInfo:
     mem_size = {}
     mem_start_hpa2 = {}
     mem_size_hpa2 = {}
+    mem_start_hpa3 = {}
+    mem_size_hpa3 = {}
 
     def __init__(self, scenario_file):
         self.scenario_info = scenario_file
@@ -167,6 +169,10 @@ class MemInfo:
             self.scenario_info, "memory", "start_hpa2")
         self.mem_size_hpa2 = common.get_leaf_tag_map(
             self.scenario_info, "memory", "size_hpa2")
+        self.mem_start_hpa3 = common.get_leaf_tag_map(
+            self.scenario_info, "memory", "start_hpa3")
+        self.mem_size_hpa3 = common.get_leaf_tag_map(
+            self.scenario_info, "memory", "size_hpa3")
 
     def check_item(self):
         """
@@ -177,6 +183,8 @@ class MemInfo:
         scenario_cfg_lib.mem_size_check(self.mem_size, "memory", "size")
         scenario_cfg_lib.mem_start_hpa_check(self.mem_start_hpa2, "memory", "start_hpa2")
         scenario_cfg_lib.mem_size_check(self.mem_size_hpa2, "memory", "size_hpa2")
+        scenario_cfg_lib.mem_start_hpa_check(self.mem_start_hpa3, "memory", "start_hpa3")
+        scenario_cfg_lib.mem_size_check(self.mem_size_hpa3, "memory", "size_hpa3")
 
 
 class CfgPci:

--- a/misc/acrn-config/scenario_config/vm_configurations_c.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_c.py
@@ -304,6 +304,8 @@ def gen_pre_launch_vm(vm_type, vm_i, scenario_items, config):
     print("\t\t\t.size = VM{0}_CONFIG_MEM_SIZE,".format(vm_i), file=config)
     print("\t\t\t.start_hpa2 = VM{0}_CONFIG_MEM_START_HPA2,".format(vm_i), file=config)
     print("\t\t\t.size_hpa2 = VM{0}_CONFIG_MEM_SIZE_HPA2,".format(vm_i), file=config)
+    print("\t\t\t.start_hpa3 = VM{0}_CONFIG_MEM_START_HPA3,".format(vm_i), file=config)
+    print("\t\t\t.size_hpa3 = VM{0}_CONFIG_MEM_SIZE_HPA3,".format(vm_i), file=config)
     print("\t\t},", file=config)
     is_need_epc(vm_info.epc_section, vm_i, config)
     print("\t\t.os_config = {", file=config)

--- a/misc/acrn-config/scenario_config/vm_configurations_h.py
+++ b/misc/acrn-config/scenario_config/vm_configurations_h.py
@@ -57,6 +57,13 @@ def gen_pre_launch_vm(scenario_items, config):
             print("#define VM{0}_CONFIG_MEM_SIZE_HPA2        {1}UL".format(
                 vm_i, vm_info.mem_info.mem_size_hpa2[vm_i]), file=config)
 
+        start_hpa3 = vm_info.mem_info.mem_start_hpa3.get(vm_i, '0')
+        size_hpa3 = vm_info.mem_info.mem_size_hpa3.get(vm_i, '0')
+        print("#define VM{0}_CONFIG_MEM_START_HPA3       {1}UL".format(
+            vm_i, start_hpa3), file=config)
+        print("#define VM{0}_CONFIG_MEM_SIZE_HPA3        {1}UL".format(
+            vm_i, size_hpa3), file=config)
+
         print("", file=config)
         vm_i += 1
 


### PR DESCRIPTION
This patch is specifically for ANL only, as currently only ANL is using HPA2/HPA3.

Currently acrn supports 2 non-contiguous HPA regions (HPA1 and HPA2), extend
the code to support 3rd non-contiguous HPA region (HPA3) for logical partition scenario
(hybrid scenario is not supported).

To keep things simple, current design has the following assumptions for
ve820 and ept mapping:

HPA2 will always be placed after HPA1
HPA3 will always be placed after HPA2
HPA1/HPA2/HPA3 don’t share a single ve820 entry.
(Create multiple entries if needed but not shared)

 Tracked-On: #6145