### PR TITLE
dm: validate inputs in vq_endchains

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio.c
+++ b/devicemodel/hw/pci/virtio/virtio.c
@@ -647,6 +647,9 @@ vq_endchains(struct virtio_vq_info *vq, int used_all_avail)
 	uint16_t event_idx, new_idx, old_idx;
 	int intr;
 
+	if (!vq || !vq->used)
+		return;
+
 	/*
 	 * Interrupt generation: if we're using EVENT_IDX,
 	 * interrupt if we've crossed the event threshold.


### PR DESCRIPTION
 inputs shall be validated to avoid NULL pointer access.

Tracked-On: #6129
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>