### PR TITLE
doc: tweak doc config for v2.3 for CI tool mismatch

### DIFF
--- a/doc/.known-issues/doc/dupdecl.conf
+++ b/doc/.known-issues/doc/dupdecl.conf
@@ -10,5 +10,5 @@
 #
 ^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: duplicate C object description.*
 #
-^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C\+\+ declaration, .*
+^(?P<filename>[-._/\w]+/hld/[-._/\w]+.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C[\+]* declaration, .*
 ^Declaration is .*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -228,10 +228,23 @@ numfig_format = {'figure': 'Figure %s', 'table': 'Table %s', 'code-block': 'Code
 html_static_path = ['static']
 
 def setup(app):
-   app.add_stylesheet("acrn-custom.css")
-   app.add_javascript("https://www.googletagmanager.com/gtag/js?id=UA-831873-64")
-   # note more GA tag manager calls are in acrn-custom.js
-   app.add_javascript("acrn-custom.js")
+   import sphinx
+
+   # add_stylesheet and add_javascript were deprecated in Sphinx 4.0
+   # so we'll need to tweak the configuration for CI systems using
+   # a newer Sphinx version than originally used for that ACRN release.
+
+   if float(sphinx.__version__[0:3]) < 3.0:
+      app.add_stylesheet("acrn-custom.css")
+      app.add_javascript("https://www.googletagmanager.com/gtag/js?id=UA-831873-64")
+      # note more GA tag manager calls are in acrn-custom.js
+      app.add_javascript("acrn-custom.js")
+   else:
+      app.add_css_file("acrn-custom.css")
+      app.add_js_file("https://www.googletagmanager.com/gtag/js?id=UA-831873-64")
+      # note more GA tag manager calls are in acrn-custom.js
+      app.add_js_file("acrn-custom.js")
+
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -304,7 +317,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'Project ACRN', u'Project ACRN Documentation',
-     author, 'Project ACRN', 
+     author, 'Project ACRN',
      'IoT-Optimized Hypervisor for Intel Architecture',
      'Miscellaneous'),
 ]


### PR DESCRIPTION
All releases of ACRN use the same CI docker image for testing the
documentation build. This creates a problem because some features used
in older ACRN releases are deprecated or behave differently with newer
versions of Sphinx and other tools.  Add a check for the Sphinx version
to account for this, and update the .known-issues patterns for duplicate
declarations.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>