### PR TITLE
[release_2.5] dm: remove redundant null check in unregister_mem_init

### DIFF
--- a/devicemodel/core/mem.c
+++ b/devicemodel/core/mem.c
@@ -249,8 +249,7 @@ unregister_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 			if (mmio_hint == entry)
 				mmio_hint = NULL;
 
-			if (entry)
-				free(entry);
+			free(entry);
 		}
 	}
 	pthread_rwlock_unlock(&mmio_rwlock);


### PR DESCRIPTION
  return value 'err' of mmio_rb_lookup() being 0 ensures
  'entry' is not NULL, hence checking it before 'free(entry)'
  is unnecessary.

Tracked-On: #6157
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>