### PR TITLE
[release_2.5] DM v2.5 bugfix create and inject vrtct

### DIFF
--- a/devicemodel/hw/platform/acpi/acpi.c
+++ b/devicemodel/hw/platform/acpi/acpi.c
@@ -1198,6 +1198,7 @@ int create_and_inject_vrtct(struct vmctx *ctx)
 	rc = read(native_rtct_fd, buf, native_rtct_len);
 	if (rc < native_rtct_len) {
 		pr_err("Native RTCT is not fully read into buf!!!");
+		free(buf);
 		return -1;
 	}
 	close(native_rtct_fd);


### PR DESCRIPTION
 return with error when read native RTCT done induces
 memory leakage pointered by 'buf'.

Tracked-On: #6157
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>