### PR TITLE
Some minor code refinements

### DIFF
--- a/doc/developer-guides/hld/hv-memmgt.rst
+++ b/doc/developer-guides/hld/hv-memmgt.rst
@@ -440,7 +440,7 @@ EPT
 .. doxygenfunction:: ept_flush_leaf_page
    :project: Project ACRN
 
-.. doxygenfunction:: get_ept_entry
+.. doxygenfunction:: get_eptp
    :project: Project ACRN
 
 .. doxygenfunction:: walk_ept_table

--- a/hypervisor/arch/x86/guest/ept.c
+++ b/hypervisor/arch/x86/guest/ept.c
@@ -234,7 +234,7 @@ uint64_t local_gpa2hpa(struct acrn_vm *vm, uint64_t gpa, uint32_t *size)
 	uint64_t pg_size = 0UL;
 	void *eptp;
 
-	eptp = get_ept_entry(vm);
+	eptp = get_eptp(vm);
 	pgentry = pgtable_lookup_entry((uint64_t *)eptp, gpa, &pg_size, &vm->arch_vm.ept_pgtable);
 	if (pgentry != NULL) {
 		hpa = (((*pgentry & (~EPT_PFN_HIGH_MASK)) & (~(pg_size - 1UL)))
@@ -392,7 +392,7 @@ void ept_flush_leaf_page(uint64_t *pge, uint64_t size)
 /**
  * @pre: vm != NULL.
  */
-void *get_ept_entry(struct acrn_vm *vm)
+void *get_eptp(struct acrn_vm *vm)
 {
 	void *eptp;
 	struct acrn_vcpu *vcpu = vcpu_from_pid(vm, get_pcpu_id());
@@ -416,7 +416,7 @@ void walk_ept_table(struct acrn_vm *vm, pge_handler cb)
 	uint64_t i, j, k, m;
 
 	for (i = 0UL; i < PTRS_PER_PML4E; i++) {
-		pml4e = pml4e_offset((uint64_t *)get_ept_entry(vm), i << PML4E_SHIFT);
+		pml4e = pml4e_offset((uint64_t *)get_eptp(vm), i << PML4E_SHIFT);
 		if (table->pgentry_present(*pml4e) == 0UL) {
 			continue;
 		}

--- a/hypervisor/arch/x86/guest/vept.c
+++ b/hypervisor/arch/x86/guest/vept.c
@@ -258,7 +258,7 @@ static uint64_t generate_shadow_ept_entry(struct acrn_vcpu *vcpu, uint64_t guest
 	 */
 	if (is_leaf_ept_entry(guest_ept_entry, guest_ept_level)) {
 		ASSERT(guest_ept_level == IA32E_PT, "Only support 4K page for guest EPT!");
-		ept_entry = get_leaf_entry((guest_ept_entry & EPT_ENTRY_PFN_MASK), get_ept_entry(vcpu->vm), &ept_level);
+		ept_entry = get_leaf_entry((guest_ept_entry & EPT_ENTRY_PFN_MASK), get_eptp(vcpu->vm), &ept_level);
 		if (ept_entry != 0UL) {
 			/*
 			 * TODO:

--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -16,7 +16,7 @@
 #define E820_TYPE_ACPI_NVS	4U	/* EFI 10 */
 #define E820_TYPE_UNUSABLE	5U	/* EFI 8 */
 
-#define E820_MAX_ENTRIES	32U
+#define E820_MAX_ENTRIES	64U
 
 /** Defines a single entry in an E820 memory map. */
 struct e820_entry {

--- a/hypervisor/include/arch/x86/asm/guest/ept.h
+++ b/hypervisor/include/arch/x86/asm/guest/ept.h
@@ -140,7 +140,7 @@ void ept_flush_leaf_page(uint64_t *pge, uint64_t size);
  * @retval If the current context of vm is SECURE_WORLD, return EPT pointer of
  *            secure world, otherwise return EPT pointer of normal world.
  */
-void *get_ept_entry(struct acrn_vm *vm);
+void *get_eptp(struct acrn_vm *vm);
 
 /**
  * @brief Walking through EPT table


### PR DESCRIPTION
Rename get_ept_entry() to get_eptp().

 vmptrld_vmexit_handler() has a same code snippet with vmclear_vmexit_handler(). Wrap the same code snippet as a static    function clear_vmcs02().
