### PR TITLE
hv: deny access to HV owned legacy PIO UART from SOS

### DIFF
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -276,3 +276,16 @@ bool is_pci_dbg_uart(union pci_bdf bdf_value)
 
 	return ret;
 }
+
+bool get_pio_dbg_uart_cfg(uint16_t *pio_address, uint32_t *nbytes)
+{
+	bool ret = false;
+
+	if (uart.enabled && (uart.type == PIO)) {
+		*pio_address = uart.port_address;
+		*nbytes = 8U;
+		ret = true;
+	}
+
+	return ret;
+}

--- a/hypervisor/include/debug/uart16550.h
+++ b/hypervisor/include/debug/uart16550.h
@@ -139,5 +139,6 @@ char uart16550_getc(void);
 size_t uart16550_puts(const char *buf, uint32_t len);
 void uart16550_set_property(bool enabled, enum serial_dev_type uart_type, uint64_t base_addr);
 bool is_pci_dbg_uart(union pci_bdf bdf_value);
+bool get_pio_dbg_uart_cfg(uint16_t *pio_address, uint32_t *nbytes);
 
 #endif /* !UART16550_H */

--- a/hypervisor/release/console.c
+++ b/hypervisor/release/console.c
@@ -27,7 +27,6 @@ void suspend_console(void) {}
 void resume_console(void) {}
 
 bool handle_dbg_cmd(__unused const char *cmd, __unused int32_t len) { return false; }
-bool is_pci_dbg_uart(__unused union pci_bdf bdf_value) { return false; }
 
 void shell_init(void) {}
 void shell_kick(void) {}

--- a/hypervisor/release/uart16550.c
+++ b/hypervisor/release/uart16550.c
@@ -8,3 +8,9 @@
 #include <pci.h>
 
 void uart16550_init(__unused bool early_boot) {}
+
+bool is_pci_dbg_uart(__unused union pci_bdf bdf_value) { return false; }
+
+bool get_pio_dbg_uart_cfg(__unused uint64_t *pio_address, __unused uint64_t *nbytes) {
+	return false;
+}


### PR DESCRIPTION
We need to deny accesses from SOS to the HV owned UART device, otherwise
SOS could have direct access to this physical device and mess up the HV
console.

If ACRN debug UART is configured as PIO based, For example,
CONFIG_SERIAL_PIO_BASE is generated from acrn-config tool, or the UART
config is overwritten by hypervisor parameter "uart=port@<port address>",
it could run into problem if ACRN doesn't emulate this UART PIO port
to SOS. For example:

- none of the ACRN emulated vUART devices has same PIO port with the
  port of the debug UART device.
- ACRN emulates PCI vUART for SOS (configure "console_vuart" with
  PCI_VUART in the scenario configuration)

This patch fixes the above issue by masking PIO accesses from SOS.
deny_hv_owned_devices() is moved after setup_io_bitmap() where
vm->arch_vm.io_bitmap is initialized.

Commit 50d852561 ("HV: deny HV owned PCI bar access from SOS") handles
the case that ACRN debug UART is configured as a PCI device. e.g.,
hypervisor parameter "uart=bdf@<BDF value>" is appended.

If the hypervisor debug UART is MMIO based, need to configured it as
a PCI type device, so that it can be hidden from SOS.

Tracked-On: #5923
Signed-off-by: Zide Chen <zide.chen@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>