### PR TITLE
hv: Enlarge E820_MAX_ENTRIES to 64

### DIFF
--- a/hypervisor/include/arch/x86/asm/e820.h
+++ b/hypervisor/include/arch/x86/asm/e820.h
@@ -16,7 +16,7 @@
 #define E820_TYPE_ACPI_NVS	4U	/* EFI 10 */
 #define E820_TYPE_UNUSABLE	5U	/* EFI 8 */
 
-#define E820_MAX_ENTRIES	32U
+#define E820_MAX_ENTRIES	64U
 
 /** Defines a single entry in an E820 memory map. */
 struct e820_entry {


### PR DESCRIPTION
e820_alloc_memory() splits one E820 entry into two entries. With vEPT
enabled, e820_alloc_memory() is called one more. On some platforms, the
e820 entries might exceed 32.

Enlarge E820_MAX_ENTRIES to 64. Please note, it must be less than 128
due to constrain of zeropage. Linux kernel defines it as 128.

Tracked-On: #7198
Signed-off-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>