### PR TITLE
DM: xHCI: Check trb pointer before use it

### DIFF
--- a/devicemodel/hw/pci/xhci.c
+++ b/devicemodel/hw/pci/xhci.c
@@ -2627,6 +2627,10 @@ pci_xhci_complete_commands(struct pci_xhci_vdev *xdev)
 	trb = xdev->opregs.cr_p;
 	ccs = xdev->opregs.crcr & XHCI_CRCR_LO_RCS;
 	crcr = xdev->opregs.crcr & ~0xF;
+	if (!trb) {
+		UPRINTF(LDBG, "Get the invalid guest address!\r\n");
+		goto out;
+	}
 
 	while (1) {
 		xdev->opregs.cr_p = trb;
@@ -2759,6 +2763,7 @@ pci_xhci_complete_commands(struct pci_xhci_vdev *xdev)
 		}
 	}
 
+out:
 	xdev->opregs.crcr = crcr | (xdev->opregs.crcr & XHCI_CRCR_LO_CA) | ccs;
 	xdev->opregs.crcr &= ~XHCI_CRCR_LO_CRR;
 	return 0;


### PR DESCRIPTION
The trb pointer may be NULL when get the address from user space, add
the pointer check before use the trb.

Tracked-On: #6172
Signed-off-by: Liu Long <long.liu@intel.com>
Reviewed-by: Shuo A Liu <shuo.a.liu@intel.com>
Acked-by: Yu Wang <yu1.wang@intel.com>