### PR TITLE
config-tools: refine get_pt_intx_table and check_pt_intx

### DIFF
--- a/misc/config_tools/library/common.py
+++ b/misc/config_tools/library/common.py
@@ -656,9 +656,6 @@ def get_pt_intx_table(config_file):
         #extract the phys_gsi and virt_gsi pairs between parenthesis to a list
         s = re.findall(r'\(([^)]+)', s)
 
-        phys_gsi[vm_i] = [];
-        virt_gsi[vm_i] = [];
-
         for part in s:
             if not part: continue
             assert ',' in part, "you need to use ',' to separate phys_gsi and virt_gsi!"
@@ -667,6 +664,9 @@ def get_pt_intx_table(config_file):
             assert a and b, "you need to specify both phys_gsi and virt_gsi!"
             a, b = str2int(a), str2int(b)
 
+            if vm_i not in phys_gsi and vm_i not in virt_gsi:
+                phys_gsi[vm_i] = []
+                virt_gsi[vm_i] = []
             phys_gsi[vm_i].append(a)
             virt_gsi[vm_i].append(b)
 

--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -1215,6 +1215,9 @@ def check_pt_intx(phys_gsi, virt_gsi):
     if not phys_gsi and not virt_gsi:
         return
 
+    if len(phys_gsi) == 0 and len(virt_gsi) == 0:
+        return
+
     if not board_cfg_lib.is_matched_board(('ehl-crb-b','generic_board')):
         ERR_LIST["pt_intx"] = "only board ehl-crb-b/generic_board is supported"
         return


### PR DESCRIPTION
Refine get_pt_intx_table. The method parse the <pt_inx> of scenario and
append the pair of phys_gsi and virt_gsi if there is any.

Refine check_pt_intx. Add a condition that the method returns if the
phys_gsi and virt_gsi are empty dictionary.

Tracked-On: #6178
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>