### PR TITLE
doc: fix config option display

### DIFF
--- a/doc/scripts/configdoc.xsl
+++ b/doc/scripts/configdoc.xsl
@@ -84,6 +84,15 @@
        </xsl:if>
       </xsl:when>
       <xsl:otherwise>
+       <!-- Write a section header for elements with a simple type -->
+       <xsl:if test="$level = 3">
+         <xsl:call-template name="section-header">
+           <xsl:with-param name="title" select="concat($prefix, @name)"/>
+           <xsl:with-param name="label" select="concat($prefix, @name)"/>
+           <xsl:with-param name="level" select="$level"/>
+         </xsl:call-template>
+       </xsl:if>
+
        <xsl:call-template name="option-header">
          <xsl:with-param name="label" select="concat($prefix, @name)"/>
        </xsl:call-template>


### PR DESCRIPTION
Seperate options with simple types with a heading so they don't get
hidden under the previous options that are part of a complex type.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>