### PR TITLE
Fix the bug that pci passthru ethernet failed to get ip address

### DIFF
--- a/hypervisor/include/arch/x86/asm/vm_config.h
+++ b/hypervisor/include/arch/x86/asm/vm_config.h
@@ -154,6 +154,7 @@ struct acrn_vm_pci_dev_config {
 	struct target_vuart t_vuart;
 	uint16_t vuart_idx;
 	uint16_t vrp_sec_bus;			/* use virtual root port's secondary bus as unique identification */
+	uint8_t vrp_max_payload;		/* vrp's dev cap's max payload */
 	uint64_t vbar_base[PCI_BAR_COUNT];		/* vbar base address of PCI device, which is power-on default value */
 	struct pci_pdev *pdev;				/* the physical PCI device if it's a PT device */
 	const struct pci_vdev_ops *vdev_ops;		/* operations for PCI CFG read/write */

--- a/hypervisor/include/hw/pci.h
+++ b/hypervisor/include/hw/pci.h
@@ -185,6 +185,7 @@
 #define PCIY_PCIE             0x10U
 #define PCIR_PCIE_DEVCAP      0x04U
 #define PCIR_PCIE_DEVCTRL     0x08U
+#define PCIM_PCIE_DEV_CTRL_MAX_PAYLOAD    0x00E0U
 #define PCIM_PCIE_FLRCAP      (0x1U << 28U)
 #define PCIM_PCIE_FLR         (0x1U << 15U)
 

--- a/hypervisor/include/public/acrn_common.h
+++ b/hypervisor/include/public/acrn_common.h
@@ -672,6 +672,7 @@ struct acrn_intr_monitor {
 struct vrp_config
 {
 	uint16_t phy_bdf;
+	uint8_t max_payload; /* dev cap's max payload */
 	uint8_t primary_bus;
 	uint8_t secondary_bus;
 	uint8_t subordinate_bus;


### PR DESCRIPTION
Root cause:  vrp accidentally changed passthru device's max payload which doesn't match its backend's max payload.  This match causes tx/rv to fail on ethernet card.

Fix: Set vrp's max payload to match hardware value