### PR TITLE
config_tools: update clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,6 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:


### PR DESCRIPTION
Remove the AlwaysBreakTemplateDeclarations setting in clang-format file
to fix the issue about "make defconfig".

Tracked-On: #6199

Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>