### PR TITLE
ACRN: DM: Free the console in the unify API

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -1020,24 +1020,13 @@ virtio_console_destroy(struct virtio_console *console)
 static void
 virtio_console_teardown_backend(void *param)
 {
-	struct virtio_console *console = NULL;
 	struct virtio_console_backend *be;
 
 	be = (struct virtio_console_backend *)param;
 	if (!be)
 		return;
 
-	if (be->port)
-		console = be->port->console;
-
 	virtio_console_close_backend(be);
-
-	if (console) {
-		console->ref_count--;
-		/* free virtio_console if this is the last backend */
-		if (console->ref_count == 0)
-			virtio_console_destroy(console);
-	}
 }
 
 static int


### PR DESCRIPTION
Use the teardown API as the unify free console API in virtio console,
in case the console have already been freed by deinit when the teardwon
API is called.

Tracked-On: #6157
Signed-off-by: Liu Long <long.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>