### PR TITLE
config-tools: do not exit when the board inspector runs in hypervisor

### DIFF
--- a/misc/config_tools/board_inspector/cli.py
+++ b/misc/config_tools/board_inspector/cli.py
@@ -11,11 +11,23 @@ import subprocess
 import lxml.etree
 import argparse
 from importlib import import_module
+from cpuparser import parse_cpuid, get_online_cpu_ids
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(script_dir))
 
+def native_check():
+    cpu_ids = get_online_cpu_ids()
+    cpu_id = cpu_ids.pop(0)
+    leaf_1 = parse_cpuid(1, 0, cpu_id)
+    if leaf_1.hypervisor != 0:
+        logging.warning(f"Board inspector is running inside a Virtual Machine (VM). Running ACRN inside a VM is only" \
+        "supported under KVM/QEMU. Unexpected results may occur when deviating from that combination.")
+
 def main(board_name, board_xml, args):
+    # Check if this is native os
+    native_check()
+
     try:
         # First invoke the legacy board parser to create the board XML ...
         legacy_parser = os.path.join(script_dir, "legacy", "board_parser.py")

--- a/misc/config_tools/board_inspector/cpuparser/__init__.py
+++ b/misc/config_tools/board_inspector/cpuparser/__init__.py
@@ -59,3 +59,15 @@ def parse_cpuid(leaf, subleaf, cpu_id):
             return None
     else:
         return None
+
+def get_online_cpu_ids():
+    acc = list()
+    with open("/sys/devices/system/cpu/online", "r") as f:
+        line = f.read().strip()
+        for r in line.split(","):
+            if r.find("-") > 0:
+                first, last = tuple(map(int, r.split("-")))
+                acc.extend(range(first, last + 1))
+            else:
+                acc.append(int(r))
+    return acc

--- a/misc/config_tools/board_inspector/cpuparser/cpuids.py
+++ b/misc/config_tools/board_inspector/cpuparser/cpuids.py
@@ -75,6 +75,7 @@ class LEAF_1(CPUID):
     avx = cpuidfield(ECX, 28, 28)
     f16c = cpuidfield(ECX, 29, 29)
     rdrand = cpuidfield(ECX, 30, 30)
+    hypervisor = cpuidfield(ECX, 31, 31)
 
     fpu = cpuidfield(EDX, 0, 0)
     vme = cpuidfield(EDX, 1, 1)

--- a/misc/config_tools/board_inspector/extractors/10-processors.py
+++ b/misc/config_tools/board_inspector/extractors/10-processors.py
@@ -6,7 +6,7 @@
 import logging
 import lxml.etree
 
-from cpuparser import parse_cpuid
+from cpuparser import parse_cpuid, get_online_cpu_ids
 from extractors.helpers import add_child, get_node
 
 level_types = {
@@ -16,18 +16,6 @@ level_types = {
     4: "tile",
     5: "die",
 }
-
-def get_online_cpu_ids():
-    acc = list()
-    with open("/sys/devices/system/cpu/online", "r") as f:
-        line = f.read().strip()
-        for r in line.split(","):
-            if r.find("-") > 0:
-                first, last = tuple(map(int, r.split("-")))
-                acc.extend(range(first, last + 1))
-            else:
-                acc.append(int(r))
-    return acc
 
 def get_parent(processors_node, topo_level, topo_id):
     n = get_node(processors_node, f"//{topo_level}[@id='{topo_id}']")

--- a/misc/config_tools/board_inspector/legacy/board_parser.py
+++ b/misc/config_tools/board_inspector/legacy/board_parser.py
@@ -30,25 +30,6 @@ def check_permission():
         parser_lib.print_red("You need run this tool with root privileges (sudo)!")
         sys.exit(1)
 
-
-def native_check():
-    """Check if this is natvie os"""
-    cmd = "cpuid -r -l 0x01"
-    res = parser_lib.cmd_execute(cmd)
-    while True:
-        line = parser_lib.decode_stdout(res)
-
-        if line:
-
-            if len(line.split()) <= 2:
-                continue
-
-            reg_value = line.split()[4].split('=')[1]
-            break
-
-    return int(reg_value, 16) & 0x80000000 == 0
-
-
 def vendor_check():
     """Check the CPU vendor"""
     with open("/proc/cpuinfo", 'r') as f_node:
@@ -90,10 +71,6 @@ def check_env():
             if int(version) < 20170122:
                 parser_lib.print_yel("Need CPUID version >= 20170122")
                 sys.exit(1)
-
-    if not native_check():
-        parser_lib.print_red("Please run this tools in a native OS environment!")
-        sys.exit(1)
 
     if os.path.exists(OUTPUT):
         shutil.rmtree(OUTPUT)


### PR DESCRIPTION
While running in a nested environment, such as qemu, parse the board information should be allowed even it is not in a native environment.
Replace the error with warning message and does not exit the program.

Tracked-On: #6208
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>