### PR TITLE
doc: fix doc reference using symbolic link

### DIFF
--- a/doc/tutorials/enable_s5.rst
+++ b/doc/tutorials/enable_s5.rst
@@ -92,9 +92,9 @@ Enable S5
 The procedure for enabling S5 is specific to the particular OS:
 
 * For Linux (LaaG) or Windows (WaaG), refer to the following configurations in the
-  ``devicemodel/samples/nuc/launch_uos.sh`` launch script for ``acrn-dm``.
+  ``misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh`` launch script for ``acrn-dm``.
 
-  .. literalinclude:: ../../../../devicemodel/samples/nuc/launch_uos.sh
+  .. literalinclude:: ../../../../misc/config_tools/data/sample_launch_scripts/nuc/launch_uos.sh
      :name: laag-waag-script
      :caption: LaaG/WaaG launch script
      :linenos:
@@ -102,9 +102,9 @@ The procedure for enabling S5 is specific to the particular OS:
      :emphasize-lines: 2-4,17
      :language: bash
 
-* For RT-Linux, refer to the ``devicemodel/samples/nuc/launch_hard_rt_vm.sh`` script:
+* For RT-Linux, refer to the ``misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh`` script:
 
-  .. literalinclude:: ../../../../devicemodel/samples/nuc/launch_hard_rt_vm.sh
+  .. literalinclude:: ../../../../misc/config_tools/data/sample_launch_scripts/nuc/launch_hard_rt_vm.sh
      :name: rt-script
      :caption: RT-Linux launch script
      :linenos:


### PR DESCRIPTION
enable_s5.rst has a couple of literalinclude directives referencing
sample scripts that were moved and now go through a symbolic link to the
new folder.  Symbolic links don't work on Windows, so change the
references in enable_s5.rst to not go through the symbolic link.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>