### PR TITLE
dm: Add PCI IDS for EHL/TGL/ADL in GPU passthrough

### DIFF
--- a/devicemodel/hw/pci/passthrough.c
+++ b/devicemodel/hw/pci/passthrough.c
@@ -438,8 +438,34 @@ passthru_gpu_dsm_opregion(struct vmctx *ctx, struct passthru_dev *ptdev,
 	gpu_opregion_hpa = opregion_phys & PCIM_ASLS_OPREGION_MASK;
 
 	switch (device) {
-	case INTEL_ELKHARTLAKE:
-	case INTEL_TIGERLAKE:
+	/* ElkhartLake */
+	case 0x4500:
+	case 0x4541:
+	case 0x4551:
+	case 0x4571:
+	/* TigerLake */
+	case 0x9a40:
+	case 0x9a49:
+	case 0x9a59:
+	case 0x9a60:
+	case 0x9a68:
+	case 0x9a70:
+	case 0x9a78:
+	case 0x9ac0:
+	case 0x9ac9:
+	case 0x9ad9:
+	case 0x9af8:
+	/* AlderLake */
+	case 0x4680:
+	case 0x4681:
+	case 0x4682:
+	case 0x4683:
+	case 0x4690:
+	case 0x4691:
+	case 0x4692:
+	case 0x4693:
+	case 0x4698:
+	case 0x4699:
 		/* BDSM register has 64 bits.
 		 * bits 63:20 contains the base address of stolen memory
 		 */

--- a/devicemodel/include/pcireg.h
+++ b/devicemodel/include/pcireg.h
@@ -1066,8 +1066,6 @@
 #define	PCIM_OSC_CTL_PCIE_CAP_STRUCT	0x10 /* Various Capability Structures */
 
 /* Graphics definitions */
-#define INTEL_ELKHARTLAKE		0x4571
-#define INTEL_TIGERLAKE			0x9a49
 #define PCIR_BDSM			0x5C /* BDSM graphics base data of stolen memory register */
 #define PCIR_GEN11_BDSM_DW0		0xC0
 #define PCIR_GEN11_BDSM_DW1		0xC4


### PR DESCRIPTION
Add PCI IDS for ElkhartLake/TigerLake/AlderLake in GPU DSM and OpRegion
passthrough.

Tracked-On: #6270
Signed-off-by: Sun Peng <peng.p.sun@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>