### PR TITLE
config_tools: update board xml files for MAX_MSIX_TABLE_NUM fix

### DIFF
--- a/misc/config_tools/data/adl-rvp/adl-rvp.xml
+++ b/misc/config_tools/data/adl-rvp/adl-rvp.xml
@@ -16,8 +16,8 @@
 	00:02.0 VGA compatible controller: Intel Corporation Device 46a0
 	Region 0: Memory at 607d000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at 4000000000 (64-bit, prefetchable) [size=256M]
-	Region 0: Memory at 0000000000000000 (64-bit, non-prefetchable)
-	Region 2: Memory at 0000000000000000 (64-bit, prefetchable)
+	Region 0: Memory at 0000004010000000 (64-bit, non-prefetchable)
+	Region 2: Memory at 0000004020000000 (64-bit, prefetchable)
 	00:04.0 Signal processing controller: Intel Corporation Device 461d
 	Region 0: Memory at 607e480000 (64-bit, non-prefetchable) [disabled] [size=128K]
 	00:05.0 Multimedia controller: Intel Corporation Device 465d
@@ -53,32 +53,32 @@
 	Region 0: Memory at 607e4d8000 (64-bit, non-prefetchable) [disabled] [size=16K]
 	Region 2: Memory at 607e4e4000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:15.0 Serial bus controller [0c80]: Intel Corporation Device 51e8
-	Region 0: Memory at 4010000000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	Region 0: Memory at 4017000000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:15.1 Serial bus controller [0c80]: Intel Corporation Device 51e9
-	Region 0: Memory at 4010001000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	Region 0: Memory at 4017001000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:16.0 Communication controller: Intel Corporation Device 51e0
 	Region 0: Memory at 607e4e1000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:17.0 SATA controller: Intel Corporation Device 51d3
-	Region 0: Memory at 88320000 (32-bit, non-prefetchable) [size=8K]
-	Region 1: Memory at 88324000 (32-bit, non-prefetchable) [size=256]
-	Region 5: Memory at 88323000 (32-bit, non-prefetchable) [size=2K]
+	Region 0: Memory at 86320000 (32-bit, non-prefetchable) [size=8K]
+	Region 1: Memory at 86324000 (32-bit, non-prefetchable) [size=256]
+	Region 5: Memory at 86323000 (32-bit, non-prefetchable) [size=2K]
 	00:19.0 Serial bus controller [0c80]: Intel Corporation Device 51c5
-	Region 0: Memory at 4010002000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	Region 0: Memory at 4017002000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:19.1 Serial bus controller [0c80]: Intel Corporation Device 51c6
-	Region 0: Memory at 4010003000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	Region 0: Memory at 4017003000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:1e.0 Communication controller: Intel Corporation Device 51a8
-	Region 0: Memory at 4010004000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	Region 0: Memory at 4017004000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:1e.3 Serial bus controller [0c80]: Intel Corporation Device 51ab
-	Region 0: Memory at 4010005000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	Region 0: Memory at 4017005000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:1f.0 ISA bridge: Intel Corporation Device 5181
 	00:1f.4 SMBus: Intel Corporation Device 51a3
 	Region 0: Memory at 607e4dc000 (64-bit, non-prefetchable) [disabled] [size=256]
 	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 51a4
-	Region 0: Memory at 50400000 (32-bit, non-prefetchable) [size=4K]
-	00:1f.6 Ethernet controller: Intel Corporation Device 1a1f
-	Region 0: Memory at 88300000 (32-bit, non-prefetchable) [size=128K]
+	Region 0: Memory at 4f800000 (32-bit, non-prefetchable) [size=4K]
+	00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (16) I219-V
+	Region 0: Memory at 86300000 (32-bit, non-prefetchable) [size=128K]
 	01:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)
-	Region 0: Memory at 88200000 (64-bit, non-prefetchable) [size=16K]
+	Region 0: Memory at 86200000 (64-bit, non-prefetchable) [size=16K]
 	</PCI_DEVICE>
   <PCI_VID_PID>
 	00:00.0 0600: 8086:4601
@@ -115,8 +115,8 @@
 	01:00.0 0108: 126f:2263 (rev 03)
 	</PCI_VID_PID>
   <WAKE_VECTOR_INFO>
-	#define WAKE_VECTOR_32          0x46A6900CUL
-	#define WAKE_VECTOR_64          0x46A69018UL
+	#define WAKE_VECTOR_32          0x45A6600CUL
+	#define WAKE_VECTOR_64          0x45A66018UL
 	</WAKE_VECTOR_INFO>
   <RESET_REGISTER_INFO>
 	#define RESET_REGISTER_ADDRESS  0xCF9UL
@@ -202,13 +202,12 @@
 	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x1819UL}, 0x03U, 0x418U, 0x00U},	/* C3 */
 	</CX_INFO>
   <PX_INFO>
-	{0x1131UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001800UL, 0x001800UL},	/* P0 */
-	{0x1130UL, 0x00UL, 0x0AUL, 0x0AUL, 0x002C00UL, 0x002C00UL},	/* P1 */
-	{0xC80UL, 0x00UL, 0x0AUL, 0x0AUL, 0x002000UL, 0x002000UL},	/* P2 */
-	{0x4B0UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000C00UL, 0x000C00UL},	/* P3 */
-	{0x3E8UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000A00UL, 0x000A00UL},	/* P4 */
-	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P5 */
-	{0x188UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000300UL, 0x000300UL},	/* P6 */
+	{0x321UL, 0x00UL, 0x0AUL, 0x0AUL, 0x001800UL, 0x001800UL},	/* P0 */
+	{0x320UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000800UL, 0x000800UL},	/* P1 */
+	{0x2BCUL, 0x00UL, 0x0AUL, 0x0AUL, 0x000700UL, 0x000700UL},	/* P2 */
+	{0x258UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000600UL, 0x000600UL},	/* P3 */
+	{0x1F4UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000500UL, 0x000500UL},	/* P4 */
+	{0x190UL, 0x00UL, 0x0AUL, 0x0AUL, 0x000400UL, 0x000400UL},	/* P5 */
 	</PX_INFO>
   <MMCFG_BASE_INFO>
 	/* PCI mmcfg base of MCFG */
@@ -225,35 +224,33 @@
 	0009f000-000fffff : Reserved
 	  000a0000-000bffff : PCI Bus 0000:00
 	  000f0000-000fffff : System ROM
-	00100000-40b31fff : System RAM
-	40b32000-40b32fff : Reserved
-	40b33000-43691fff : System RAM
-	43692000-46a00fff : Reserved
-	  443b7000-443c6fff : pnp 00:05
-	46a01000-46ae8fff : ACPI Non-volatile Storage
-	46ae9000-46bfefff : ACPI Tables
-	46bff000-46bfffff : System RAM
-	46c00000-491fffff : Reserved
-	49e00000-503fffff : Reserved
-	50400000-bfffffff : PCI Bus 0000:00
-	  50400000-50400fff : 0000:00:1f.5
-	  52000000-5e1fffff : PCI Bus 0000:80
-	  60000000-6c1fffff : PCI Bus 0000:56
-	  6e000000-7a1fffff : PCI Bus 0000:2c
-	  7c000000-881fffff : PCI Bus 0000:02
-	  88200000-882fffff : PCI Bus 0000:01
-	    88200000-88203fff : 0000:01:00.0
-	      88200000-88203fff : nvme
-	  88300000-8831ffff : 0000:00:1f.6
-	    88300000-8831ffff : e1000e
-	  88320000-88321fff : 0000:00:17.0
-	    88320000-88321fff : ahci
-	  88323000-883237ff : 0000:00:17.0
-	    88323000-883237ff : ahci
-	  88324000-883240ff : 0000:00:17.0
-	    88324000-883240ff : ahci
+	00100000-3fb2efff : System RAM
+	3fb2f000-3fb2ffff : Reserved
+	3fb30000-4268efff : System RAM
+	4268f000-459fdfff : Reserved
+	459fe000-45ae5fff : ACPI Non-volatile Storage
+	45ae6000-45bfefff : ACPI Tables
+	45bff000-45bfffff : System RAM
+	45c00000-47ffffff : Reserved
+	48c00000-4f7fffff : Reserved
+	4f800000-bfffffff : PCI Bus 0000:00
+	  4f800000-4f800fff : 0000:00:1f.5
+	  50000000-5c1fffff : PCI Bus 0000:80
+	  5e000000-6a1fffff : PCI Bus 0000:56
+	  6c000000-781fffff : PCI Bus 0000:2c
+	  7a000000-861fffff : PCI Bus 0000:02
+	  86200000-862fffff : PCI Bus 0000:01
+	    86200000-86203fff : 0000:01:00.0
+	      86200000-86203fff : nvme
+	  86300000-8631ffff : 0000:00:1f.6
+	    86300000-8631ffff : e1000e
+	  86320000-86321fff : 0000:00:17.0
+	    86320000-86321fff : ahci
+	  86323000-863237ff : 0000:00:17.0
+	    86323000-863237ff : ahci
+	  86324000-863240ff : 0000:00:17.0
+	    86324000-863240ff : ahci
 	c0000000-cfffffff : PCI MMCONFIG 0000 [bus 00-ff]
-	  c0000000-cfffffff : pnp 00:05
 	fd690000-fd69ffff : INTC1055:00
 	fd6a0000-fd6affff : INTC1055:00
 	fd6d0000-fd6dffff : INTC1055:00
@@ -265,6 +262,7 @@
 	  fed00000-fed003ff : PNP0103:00
 	fed20000-fed7ffff : Reserved
 	  fed40000-fed44fff : INTC6001:00
+	    fed40000-fed44fff : INTC6001:00
 	fed90000-fed90fff : dmar0
 	fed91000-fed91fff : dmar2
 	fed92000-fed92fff : dmar1
@@ -274,20 +272,22 @@
 	fee00000-feefffff : pnp 00:05
 	  fee00000-fee00fff : Local APIC
 	ff000000-ffffffff : Reserved
-	100000000-4afbfffff : System RAM
-	  1e7400000-1e80010d6 : Kernel code
-	  1e8200000-1e8524fff : Kernel rodata
-	  1e8600000-1e87a09bf : Kernel data
-	  1e8cb0000-1e8dfffff : Kernel bss
-	4afc00000-4afffffff : RAM buffer
+	100000000-4b07fffff : System RAM
+	  171c00000-172a00db6 : Kernel code
+	  172c00000-17313afff : Kernel rodata
+	  173200000-173480cbf : Kernel data
+	  173737000-173bfffff : Kernel bss
+	4b0800000-4b3ffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
-	  4010000000-4010000fff : 0000:00:15.0
-	  4010001000-4010001fff : 0000:00:15.1
-	  4010002000-4010002fff : 0000:00:19.0
-	  4010003000-4010003fff : 0000:00:19.1
-	  4010004000-4010004fff : 0000:00:1e.0
-	  4010005000-4010005fff : 0000:00:1e.3
+	  4010000000-4016ffffff : 0000:00:02.0
+	  4017000000-4017000fff : 0000:00:15.0
+	  4017001000-4017001fff : 0000:00:15.1
+	  4017002000-4017002fff : 0000:00:19.0
+	  4017003000-4017003fff : 0000:00:19.1
+	  4017004000-4017004fff : 0000:00:1e.0
+	  4017005000-4017005fff : 0000:00:1e.3
+	  4020000000-40ffffffff : 0000:00:02.0
 	  6000000000-601bffffff : PCI Bus 0000:02
 	  6020000000-603bffffff : PCI Bus 0000:2c
 	  6040000000-605bffffff : PCI Bus 0000:56
@@ -316,10 +316,9 @@
 	  607e4e9000-607e4e9fff : 0000:00:08.0
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
+	/dev/sdb3: TYPE="ext4"
 	/dev/nvme0n1p3: TYPE="ext4"
 	/dev/sda3: TYPE="ext4"
-	/dev/sdb2: TYPE="ext4"
-	/dev/sdb3: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
@@ -328,7 +327,7 @@
 	3, 5, 6, 7, 10, 11, 12, 13, 14, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	16191052 kB
+	16181832 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9
@@ -1078,9 +1077,9 @@
   </caches>
   <memory>
     <range start="0x0000000000000000" end="0x000000000009efff" size="651264"/>
-    <range start="0x0000000000100000" end="0x0000000043691fff" size="1129914368"/>
-    <range start="0x0000000046bff000" end="0x0000000046bfffff" size="4096"/>
-    <range start="0x0000000100000000" end="0x00000004afbfffff" size="15833497600"/>
+    <range start="0x0000000000100000" end="0x000000004268efff" size="1113124864"/>
+    <range start="0x0000000045bff000" end="0x0000000045bfffff" size="4096"/>
+    <range start="0x0000000100000000" end="0x00000004b07fffff" size="15846080512"/>
   </memory>
   <devices>
     <bus type="pci" address="0x0" id="0x4601" description="Host bridge: Intel Corporation">
@@ -1090,7 +1089,7 @@
       <subsystem_identifier>0x7270</subsystem_identifier>
       <class>0x060000</class>
       <resource type="memory" min="0xa0000" max="0xbffff" len="0x20000"/>
-      <resource type="memory" min="0x50400000" max="0xbfffffff" len="0x6fc00000"/>
+      <resource type="memory" min="0x4f800000" max="0xbfffffff" len="0x70800000"/>
       <resource type="memory" min="0x4000000000" max="0x7fffffffff" len="0x4000000000"/>
       <capability id="Vendor-Specific"/>
       <device address="0x20000" id="0x46a0" description="VGA compatible controller: Intel Corporation">
@@ -1105,6 +1104,7 @@
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="per-vector masking"/>
         </capability>
         <capability id="Power Management"/>
@@ -1120,7 +1120,9 @@
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x118000</class>
         <resource type="memory" min="0x607e480000" max="0x607e49ffff" len="0x20000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1138,9 +1140,11 @@
         <vendor>0x8086</vendor>
         <identifier>0x464d</identifier>
         <class>0x060400</class>
-        <resource type="memory" min="0x88200000" max="0x882fffff" len="0x100000"/>
+        <resource type="memory" min="0x86200000" max="0x862fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1160,17 +1164,22 @@
             <subsystem_vendor>0x126f</subsystem_vendor>
             <subsystem_identifier>0x2263</subsystem_identifier>
             <class>0x010802</class>
-            <resource type="memory" min="0x88200000" max="0x88203fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
+            <resource type="memory" min="0x86200000" max="0x86203fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -1183,9 +1192,10 @@
         <identifier>0x466e</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
-        <resource type="memory" min="0x7c000000" max="0x881fffff" len="0xc200000"/>
+        <resource type="memory" min="0x7a000000" max="0x861fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
@@ -1204,9 +1214,10 @@
         <identifier>0x463f</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x5000" max="0x5fff" len="0x1000"/>
-        <resource type="memory" min="0x6e000000" max="0x7a1fffff" len="0xc200000"/>
+        <resource type="memory" min="0x6c000000" max="0x781fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
@@ -1225,9 +1236,10 @@
         <identifier>0x462f</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x6000" max="0x6fff" len="0x1000"/>
-        <resource type="memory" min="0x60000000" max="0x6c1fffff" len="0xc200000"/>
+        <resource type="memory" min="0x5e000000" max="0x6a1fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
@@ -1246,9 +1258,10 @@
         <identifier>0x461f</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x7000" max="0x7fff" len="0x1000"/>
-        <resource type="memory" min="0x52000000" max="0x5e1fffff" len="0xc200000"/>
+        <resource type="memory" min="0x50000000" max="0x5c1fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
@@ -1269,7 +1282,9 @@
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x088000</class>
         <resource type="memory" min="0x607e4e9000" max="0x607e4e9fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Vendor-Specific"/>
         <capability id="Power Management"/>
         <capability id="Conventional PCI Advanced Features"/>
@@ -1296,9 +1311,8 @@
         <resource type="memory" min="0x607e4c0000" max="0x607e4cffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -1325,9 +1339,16 @@
         <resource type="memory" min="0x607e4e7000" max="0x607e4e7fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>4</table_bir>
+          <table_offset>0xfa20000</table_offset>
+          <pba_bir>0</pba_bir>
+          <pba_offset>0x2000000</pba_offset>
+        </capability>
       </device>
       <device address="0xd0003" id="0x466d" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
@@ -1339,9 +1360,16 @@
         <resource type="memory" min="0x607e4e6000" max="0x607e4e6fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>4</table_bir>
+          <table_offset>0xfa20000</table_offset>
+          <pba_bir>0</pba_bir>
+          <pba_offset>0x2000000</pba_offset>
+        </capability>
       </device>
       <device address="0x120000" id="0x51fc" description="Serial controller: Intel Corporation">
         <vendor>0x8086</vendor>
@@ -1362,9 +1390,8 @@
         <resource type="memory" min="0x607e4a0000" max="0x607e4affff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -1397,7 +1424,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x4010000000" max="0x4010000fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x4017000000" max="0x4017000fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1407,7 +1434,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x4010001000" max="0x4010001fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x4017001000" max="0x4017001fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1420,6 +1447,7 @@
         <resource type="memory" min="0x607e4e1000" max="0x607e4e1fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -1433,10 +1461,12 @@
         <resource type="io_port" min="0x3060" max="0x307f" len="0x20" id="bar4"/>
         <resource type="io_port" min="0x3080" max="0x3087" len="0x8" id="bar2"/>
         <resource type="io_port" min="0x3088" max="0x308b" len="0x4" id="bar3"/>
-        <resource type="memory" min="0x88320000" max="0x88321fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
-        <resource type="memory" min="0x88323000" max="0x883237ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
-        <resource type="memory" min="0x88324000" max="0x883240ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <resource type="memory" min="0x86320000" max="0x86321fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x86323000" max="0x863237ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x86324000" max="0x863240ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
@@ -1446,7 +1476,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x4010002000" max="0x4010002fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x4017002000" max="0x4017002fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1456,7 +1486,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x4010003000" max="0x4010003fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x4017003000" max="0x4017003fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1466,7 +1496,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x078000</class>
-        <resource type="memory" min="0x4010004000" max="0x4010004fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x4017004000" max="0x4017004fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1476,7 +1506,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x4010005000" max="0x4010005fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x4017005000" max="0x4017005fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1502,21 +1532,21 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x50400000" max="0x50400fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x4f800000" max="0x4f800fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
       </device>
-      <device address="0x1f0006" id="0x1a1f" description="Ethernet controller: Intel Corporation">
+      <device address="0x1f0006" id="0x1a1f" description="Ethernet controller: Intel Corporation Ethernet Connection (16) I219-V">
         <vendor>0x8086</vendor>
         <identifier>0x1a1f</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x0000</subsystem_identifier>
         <class>0x020000</class>
-        <resource type="memory" min="0x88300000" max="0x8831ffff" len="0x20000" id="bar0" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x86300000" max="0x8631ffff" len="0x20000" id="bar0" width="32" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
     </bus>
   </devices>
 </acrn-config>
-

--- a/misc/config_tools/data/cfl-k700-i7/cfl-k700-i7.xml
+++ b/misc/config_tools/data/cfl-k700-i7/cfl-k700-i7.xml
@@ -209,11 +209,11 @@
 	0009f000-000fffff : Reserved
 	  000a0000-000bffff : PCI Bus 0000:00
 	  000f0000-000fffff : System ROM
-	00100000-6f298017 : System RAM
-	6f298018-6f2a8057 : System RAM
-	6f2a8058-76be6fff : System RAM
-	76be7000-76c99fff : Reserved
-	76c9a000-8738dfff : System RAM
+	00100000-6f17c017 : System RAM
+	6f17c018-6f18c057 : System RAM
+	6f18c058-76bd5fff : System RAM
+	76bd6000-76c88fff : Reserved
+	76c89000-8738dfff : System RAM
 	8738e000-8878dfff : Reserved
 	8878e000-89b8dfff : ACPI Non-volatile Storage
 	89b8e000-89c0dfff : ACPI Tables
@@ -302,10 +302,10 @@
 	  fee00000-fee00fff : Reserved
 	ff600000-ffffffff : Reserved
 	100000000-86c7fffff : System RAM
-	  57ca00000-57d6010d6 : Kernel code
-	  57d800000-57db24fff : Kernel rodata
-	  57dc00000-57dda09bf : Kernel data
-	  57e2b0000-57e3fffff : Kernel bss
+	  818600000-8192010d6 : Kernel code
+	  819400000-819724fff : Kernel rodata
+	  819800000-8199a09bf : Kernel data
+	  819eb0000-819ffffff : Kernel bss
 	86c800000-86fffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
@@ -336,8 +336,10 @@
 	  600110d000-600110dfff : 0000:00:08.0
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
-	/dev/nvme1n1p3: TYPE="ext4"
+	/dev/nvme1n1p2: TYPE="ext4"
+	/dev/nvme1n1p4: TYPE="ext4"
 	/dev/nvme0n1p3: TYPE="ext4"
+	/dev/nvme0n1p4: TYPE="ext4"
 	/dev/sda2: TYPE="ext4"
 	/dev/sda3: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
@@ -385,6 +387,7 @@
       <capability id="movbe"/>
       <capability id="popcnt"/>
       <capability id="tsc_deadline"/>
+      <capability id="aes"/>
       <capability id="xsave"/>
       <capability id="avx"/>
       <capability id="f16c"/>
@@ -962,7 +965,9 @@
         <resource type="memory" min="0x6000000000" max="0x6000ffffff" len="0x1000000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="PASID"/>
         <capability id="ATS"/>
@@ -975,7 +980,9 @@
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x088000</class>
         <resource type="memory" min="0x600110d000" max="0x600110dfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Conventional PCI Advanced Features"/>
       </device>
@@ -987,7 +994,9 @@
         <class>0x118000</class>
         <resource type="memory" min="0x600110c000" max="0x600110cfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
       </device>
       <device address="0x140000" id="0xa36d" description="USB controller: Intel Corporation Cannon Lake PCH USB 3.1 xHCI Host Controller">
         <vendor>0x8086</vendor>
@@ -998,9 +1007,8 @@
         <resource type="memory" min="0x90020000" max="0x9002ffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -1047,7 +1055,9 @@
         <resource type="memory" min="0x90030000" max="0x90031fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
         <resource type="memory" min="0x90033000" max="0x900337ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
         <resource type="memory" min="0x90034000" max="0x900340ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
@@ -1057,7 +1067,9 @@
         <class>0x060400</class>
         <resource type="memory" min="0x8ff00000" max="0x8fffffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1076,14 +1088,19 @@
             <resource type="memory" min="0x8ff00000" max="0x8ff03fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -1098,7 +1115,9 @@
         <resource type="io_port" min="0x5000" max="0x8fff" len="0x4000"/>
         <resource type="memory" min="0x8fb00000" max="0x8fefffff" len="0x400000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1152,10 +1171,17 @@
                     <resource type="memory" min="0x8fe80000" max="0x8fe83fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
                     <capability id="Power Management"/>
                     <capability id="MSI">
+                      <count>1</count>
                       <capability id="64-bit address"/>
                       <capability id="per-vector masking"/>
                     </capability>
-                    <capability id="MSI-X"/>
+                    <capability id="MSI-X">
+                      <table_size>5</table_size>
+                      <table_bir>7</table_bir>
+                      <table_offset>0x30000</table_offset>
+                      <pba_bir>1</pba_bir>
+                      <pba_offset>0x0</pba_offset>
+                    </capability>
                     <capability id="PCI Express"/>
                     <capability id="Advanced Error Reporting"/>
                     <capability id="Device Serial Number"/>
@@ -1190,10 +1216,17 @@
                     <resource type="memory" min="0x8fd80000" max="0x8fd83fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
                     <capability id="Power Management"/>
                     <capability id="MSI">
+                      <count>1</count>
                       <capability id="64-bit address"/>
                       <capability id="per-vector masking"/>
                     </capability>
-                    <capability id="MSI-X"/>
+                    <capability id="MSI-X">
+                      <table_size>5</table_size>
+                      <table_bir>7</table_bir>
+                      <table_offset>0x30000</table_offset>
+                      <pba_bir>1</pba_bir>
+                      <pba_offset>0x0</pba_offset>
+                    </capability>
                     <capability id="PCI Express"/>
                     <capability id="Advanced Error Reporting"/>
                     <capability id="Device Serial Number"/>
@@ -1228,10 +1261,17 @@
                     <resource type="memory" min="0x8fc80000" max="0x8fc83fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
                     <capability id="Power Management"/>
                     <capability id="MSI">
+                      <count>1</count>
                       <capability id="64-bit address"/>
                       <capability id="per-vector masking"/>
                     </capability>
-                    <capability id="MSI-X"/>
+                    <capability id="MSI-X">
+                      <table_size>5</table_size>
+                      <table_bir>7</table_bir>
+                      <table_offset>0x30000</table_offset>
+                      <pba_bir>1</pba_bir>
+                      <pba_offset>0x0</pba_offset>
+                    </capability>
                     <capability id="PCI Express"/>
                     <capability id="Advanced Error Reporting"/>
                     <capability id="Device Serial Number"/>
@@ -1266,10 +1306,17 @@
                     <resource type="memory" min="0x8fb80000" max="0x8fb83fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
                     <capability id="Power Management"/>
                     <capability id="MSI">
+                      <count>1</count>
                       <capability id="64-bit address"/>
                       <capability id="per-vector masking"/>
                     </capability>
-                    <capability id="MSI-X"/>
+                    <capability id="MSI-X">
+                      <table_size>5</table_size>
+                      <table_bir>7</table_bir>
+                      <table_offset>0x30000</table_offset>
+                      <pba_bir>1</pba_bir>
+                      <pba_offset>0x0</pba_offset>
+                    </capability>
                     <capability id="PCI Express"/>
                     <capability id="Advanced Error Reporting"/>
                     <capability id="Device Serial Number"/>
@@ -1302,7 +1349,9 @@
         <class>0x060400</class>
         <resource type="memory" min="0x8fa00000" max="0x8fafffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1321,10 +1370,17 @@
             <resource type="memory" min="0x8fa00000" max="0x8fa03fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>32</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x10000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -1338,7 +1394,9 @@
         <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
         <resource type="memory" min="0x8f900000" max="0x8f9fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1359,10 +1417,17 @@
             <resource type="memory" min="0x8f980000" max="0x8f983fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -1377,7 +1442,9 @@
         <resource type="io_port" min="0x3000" max="0x3fff" len="0x1000"/>
         <resource type="memory" min="0x8f800000" max="0x8f8fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1398,10 +1465,17 @@
             <resource type="memory" min="0x8f880000" max="0x8f883fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -1437,6 +1511,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
@@ -1466,10 +1541,10 @@
         <resource type="memory" min="0x90000000" max="0x9001ffff" len="0x20000" id="bar0" width="32" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
     </bus>
   </devices>
 </acrn-config>
-

--- a/misc/config_tools/data/ehl-crb-b/ehl-crb-b.xml
+++ b/misc/config_tools/data/ehl-crb-b/ehl-crb-b.xml
@@ -2,8 +2,8 @@
   <BIOS_INFO>
 	BIOS Information
 	Vendor: Intel Corporation
-	Version: SB_EHL.001.000.005.000.008.00008.D-DE6BC238D41D2E2F-dirty
-	Release Date: Mar  2 2021
+	Version: SB_EHL.001.000.005.000.008.00018.D-2BD67C90F42587C7-dirty
+	Release Date: Jan 11 2021
 	BIOS Revision: 0.1
 	</BIOS_INFO>
   <BASE_BOARD_INFO>
@@ -18,65 +18,69 @@
 	Region 0: Memory at 80000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at 90000000 (64-bit, prefetchable) [size=256M]
 	00:08.0 System peripheral: Intel Corporation Device 4511 (rev 01)
-	Region 0: Memory at 825ea000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826ee000 (64-bit, non-prefetchable) [size=4K]
 	00:09.0 Non-Essential Instrumentation [1300]: Intel Corporation Device 4529 (rev 01)
-	Region 0: Memory at 82400000 (64-bit, non-prefetchable) [size=1M]
+	Region 0: Memory at 82500000 (64-bit, non-prefetchable) [size=1M]
 	Region 2: Memory at 81800000 (64-bit, non-prefetchable) [size=8M]
-	Region 4: Memory at 825e9000 (64-bit, non-prefetchable) [size=1K]
+	Region 4: Memory at 826ed000 (64-bit, non-prefetchable) [size=1K]
 	00:10.0 Serial bus controller [0c80]: Intel Corporation Device 4b44 (rev 10)
-	Region 0: Memory at 825e8000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826ec000 (64-bit, non-prefetchable) [size=4K]
 	00:10.1 Serial bus controller [0c80]: Intel Corporation Device 4b45 (rev 10)
-	Region 0: Memory at 825e7000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826eb000 (64-bit, non-prefetchable) [size=4K]
 	00:10.5 Host bridge: Intel Corporation Device 4b2f (rev 10)
 	00:14.0 USB controller: Intel Corporation Device 4b7d (rev 10)
-	Region 0: Memory at 825c0000 (64-bit, non-prefetchable) [size=64K]
+	Region 0: Memory at 826c0000 (64-bit, non-prefetchable) [size=64K]
 	00:14.2 RAM memory: Intel Corporation Device 4b7f (rev 10)
-	Region 0: Memory at 825d0000 (64-bit, non-prefetchable) [size=16K]
-	Region 2: Memory at 825e6000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826d4000 (64-bit, non-prefetchable) [size=16K]
+	Region 2: Memory at 826ea000 (64-bit, non-prefetchable) [size=4K]
 	00:15.0 Serial bus controller [0c80]: Intel Corporation Device 4b78 (rev 10)
-	Region 0: Memory at 825e5000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e9000 (64-bit, non-prefetchable) [size=4K]
 	00:15.2 Serial bus controller [0c80]: Intel Corporation Device 4b7a (rev 10)
-	Region 0: Memory at 825e4000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e8000 (64-bit, non-prefetchable) [size=4K]
 	00:15.3 Serial bus controller [0c80]: Intel Corporation Device 4b7b (rev 10)
-	Region 0: Memory at 825e3000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e7000 (64-bit, non-prefetchable) [size=4K]
 	00:16.0 Communication controller: Intel Corporation Device 4b70 (rev 10)
-	Region 0: Memory at 825e2000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e6000 (64-bit, non-prefetchable) [size=4K]
 	00:17.0 SATA controller: Intel Corporation Device 4b63 (rev 10)
-	Region 0: Memory at 825d6000 (32-bit, non-prefetchable) [size=8K]
-	Region 1: Memory at 825e1000 (32-bit, non-prefetchable) [size=256]
-	Region 5: Memory at 825e0000 (32-bit, non-prefetchable) [size=2K]
+	Region 0: Memory at 826da000 (32-bit, non-prefetchable) [size=8K]
+	Region 1: Memory at 826e5000 (32-bit, non-prefetchable) [size=256]
+	Region 5: Memory at 826e4000 (32-bit, non-prefetchable) [size=2K]
 	00:19.0 Serial bus controller [0c80]: Intel Corporation Device 4b4b (rev 10)
-	Region 0: Memory at 825df000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e3000 (64-bit, non-prefetchable) [size=4K]
 	00:1a.0 SD Host controller: Intel Corporation Device 4b47 (rev 10)
-	Region 0: Memory at 825de000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e2000 (64-bit, non-prefetchable) [size=4K]
 	00:1a.1 SD Host controller: Intel Corporation Device 4b48 (rev 10)
-	Region 0: Memory at 825dd000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e1000 (64-bit, non-prefetchable) [size=4K]
 	00:1a.3 Non-VGA unclassified device: Intel Corporation Device 4b4a (rev 10)
-	Region 0: Memory at 82580000 (64-bit, non-prefetchable) [size=256K]
+	Region 0: Memory at 82680000 (64-bit, non-prefetchable) [size=256K]
 	00:1c.0 PCI bridge: Intel Corporation Device 4b38 (rev 10)
+	00:1c.4 PCI bridge: Intel Corporation Device 4b3c (rev 10)
 	00:1d.0 System peripheral: Intel Corporation Device 4bb3 (rev 10)
 	Region 0: Memory at 82000000 (64-bit, non-prefetchable) [size=2M]
 	00:1d.1 Ethernet controller: Intel Corporation Device 4ba0 (rev 10)
-	Region 0: Memory at 82600000 (64-bit, non-prefetchable) [size=256K]
+	Region 0: Memory at 82700000 (64-bit, non-prefetchable) [size=256K]
 	00:1d.2 Ethernet controller: Intel Corporation Device 4bb0 (rev 10)
-	Region 0: Memory at 82640000 (64-bit, non-prefetchable) [size=256K]
+	Region 0: Memory at 82740000 (64-bit, non-prefetchable) [size=256K]
 	00:1e.0 Communication controller: Intel Corporation Device 4b28 (rev 10)
-	Region 0: Memory at 825dc000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826e0000 (64-bit, non-prefetchable) [size=4K]
 	00:1e.1 Communication controller: Intel Corporation Device 4b29 (rev 10)
-	Region 0: Memory at 825db000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 826df000 (64-bit, non-prefetchable) [size=4K]
 	00:1e.4 Ethernet controller: Intel Corporation Device 4b32 (rev 10)
-	Region 0: Memory at 82502000 (64-bit, non-prefetchable) [size=8K]
-	Region 2: Memory at 825da000 (64-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 82602000 (64-bit, non-prefetchable) [size=8K]
+	Region 2: Memory at 826de000 (64-bit, non-prefetchable) [size=4K]
 	00:1f.0 ISA bridge: Intel Corporation Device 4b00 (rev 10)
+	00:1f.3 Audio device: Intel Corporation Device 4b58 (rev 10)
+	Region 0: Memory at 826d0000 (64-bit, non-prefetchable) [size=16K]
+	Region 4: Memory at 82300000 (64-bit, non-prefetchable) [size=1M]
 	00:1f.4 SMBus: Intel Corporation Device 4b23 (rev 10)
-	Region 0: Memory at 825d9000 (64-bit, non-prefetchable) [size=256]
+	Region 0: Memory at 826dd000 (64-bit, non-prefetchable) [size=256]
 	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 4b24 (rev 10)
-	Region 0: Memory at 82501000 (32-bit, non-prefetchable) [size=4K]
+	Region 0: Memory at 82601000 (32-bit, non-prefetchable) [size=4K]
 	00:1f.7 Non-Essential Instrumentation [1300]: Intel Corporation Device 4b26 (rev 10)
 	Region 0: Memory at 82200000 (64-bit, non-prefetchable) [size=1M]
 	Region 2: Memory at 81000000 (64-bit, non-prefetchable) [size=8M]
-	01:00.0 Non-Volatile memory controller: Intel Corporation SSD Pro 7600p/760p/E 6100p Series (rev 03)
-	Region 0: Memory at 82300000 (64-bit, non-prefetchable) [size=16K]
+	01:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)
+	Region 0: Memory at 82400000 (64-bit, non-prefetchable) [size=16K]
 	</PCI_DEVICE>
   <PCI_VID_PID>
 	00:00.0 0600: 8086:4532 (rev 01)
@@ -98,6 +102,7 @@
 	00:1a.1 0805: 8086:4b48 (rev 10)
 	00:1a.3 0000: 8086:4b4a (rev 10)
 	00:1c.0 0604: 8086:4b38 (rev 10)
+	00:1c.4 0604: 8086:4b3c (rev 10)
 	00:1d.0 0880: 8086:4bb3 (rev 10)
 	00:1d.1 0200: 8086:4ba0 (rev 10)
 	00:1d.2 0200: 8086:4bb0 (rev 10)
@@ -105,14 +110,15 @@
 	00:1e.1 0780: 8086:4b29 (rev 10)
 	00:1e.4 0200: 8086:4b32 (rev 10)
 	00:1f.0 0601: 8086:4b00 (rev 10)
+	00:1f.3 0403: 8086:4b58 (rev 10)
 	00:1f.4 0c05: 8086:4b23 (rev 10)
 	00:1f.5 0c80: 8086:4b24 (rev 10)
 	00:1f.7 1300: 8086:4b26 (rev 10)
-	01:00.0 0108: 8086:f1a6 (rev 03)
+	01:00.0 0108: 126f:2263 (rev 03)
 	</PCI_VID_PID>
   <WAKE_VECTOR_INFO>
-	#define WAKE_VECTOR_32          0x786E02FCUL
-	#define WAKE_VECTOR_64          0x786E0308UL
+	#define WAKE_VECTOR_32          0x768542FCUL
+	#define WAKE_VECTOR_64          0x76854308UL
 	</WAKE_VECTOR_INFO>
   <RESET_REGISTER_INFO>
 	#define RESET_REGISTER_ADDRESS  0xCF9UL
@@ -183,10 +189,13 @@
 	"Intel Atom(R) Processor x6427FE @ 1.90GHz"
 	</CPU_BRAND>
   <CX_INFO>
-	/* Cx data is not available */
+	{{SPACE_FFixedHW, 0x00U, 0x00U, 0x00U, 0x00UL}, 0x01U, 0x01U, 0x00U},	/* C1 */
+	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x1816UL}, 0x02U, 0xFDU, 0x00U},	/* C2 */
+	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x1819UL}, 0x03U, 0x418U, 0x00U},	/* C3 */
 	</CX_INFO>
   <PX_INFO>
-	/* Px data is not available */
+	{0x76DUL, 0x00UL, 0x0AUL, 0x0AUL, 0x001300UL, 0x001300UL},	/* P0 */
+	{0x76CUL, 0x00UL, 0x0AUL, 0x0AUL, 0x001300UL, 0x001300UL},	/* P1 */
 	</PX_INFO>
   <MMCFG_BASE_INFO>
 	/* PCI mmcfg base of MCFG */
@@ -208,14 +217,13 @@
 	  000e8000-000ebfff : PCI Bus 0000:00
 	  000ec000-000effff : PCI Bus 0000:00
 	  000f0000-000fffff : System ROM
-	00100000-781dffff : System RAM
-	  67400000-682011b0 : Kernel code
-	  682011b1-6899c3ff : Kernel data
-	  6934d000-699fffff : Kernel bss
-	781e0000-786dffff : Reserved
-	786e0000-78747fff : ACPI Tables
-	78748000-7874ffff : ACPI Non-volatile Storage
-	78750000-7fbfffff : Reserved
+	00100000-3fffffff : System RAM
+	40000000-40087fff : Reserved
+	40088000-76353fff : System RAM
+	76354000-76853fff : Reserved
+	76854000-768bbfff : ACPI Tables
+	768bc000-768c3fff : ACPI Non-volatile Storage
+	768c4000-7fbfffff : Reserved
 	  7c000000-7fbfffff : Graphics Stolen Memory
 	80000000-bfffffff : PCI Bus 0000:00
 	  80000000-80ffffff : 0000:00:02.0
@@ -227,93 +235,97 @@
 	    82000000-821fffff : intel_ish_ipc
 	  82200000-822fffff : 0000:00:1f.7
 	    82200000-822fffff : intel_th_pci
-	  82300000-823fffff : PCI Bus 0000:01
-	    82300000-82303fff : 0000:01:00.0
-	      82300000-82303fff : nvme
-	  82400000-824fffff : 0000:00:09.0
-	    82400000-824fffff : intel_th_pci
-	  82500200-82500203 : INTC1033:02
-	  82500204-82500207 : INTC1033:02
-	  82501000-82501fff : 0000:00:1f.5
-	    82501000-82501fff : 0000:00:1f.5 0000:00:1f.5
-	  82502000-82503fff : 0000:00:1e.4
-	    82502000-82503fff : 0000:00:1e.4
-	  82540200-82540203 : INTC1033:01
-	  82540204-82540207 : INTC1033:01
-	  82580000-825bffff : 0000:00:1a.3
-	  825c0000-825cffff : 0000:00:14.0
-	    825c0000-825cffff : xhci-hcd
-	  825d0000-825d3fff : 0000:00:14.2
-	  825d4200-825d4203 : INTC1033:00
-	  825d4204-825d4207 : INTC1033:00
-	  825d6000-825d7fff : 0000:00:17.0
-	    825d6000-825d7fff : ahci
-	  825d9000-825d90ff : 0000:00:1f.4
-	  825da000-825dafff : 0000:00:1e.4
-	  825db000-825dbfff : 0000:00:1e.1
-	    825db000-825db1ff : lpss_dev
-	      825db000-825db01f : serial
-	    825db200-825db2ff : lpss_priv
-	    825db800-825dbfff : idma64.6
-	      825db800-825dbfff : idma64.6 idma64.6
-	  825dc000-825dcfff : 0000:00:1e.0
-	    825dc000-825dc1ff : lpss_dev
-	      825dc000-825dc01f : serial
-	    825dc200-825dc2ff : lpss_priv
-	    825dc800-825dcfff : idma64.5
-	      825dc800-825dcfff : idma64.5 idma64.5
-	  825dd000-825ddfff : 0000:00:1a.1
-	    825dd000-825ddfff : mmc1
-	  825de000-825defff : 0000:00:1a.0
-	    825de000-825defff : mmc0
-	  825df000-825dffff : 0000:00:19.0
-	    825df000-825df1ff : lpss_dev
-	      825df000-825df1ff : i2c_designware.4 lpss_dev
-	    825df200-825df2ff : lpss_priv
-	    825df800-825dffff : idma64.4
-	      825df800-825dffff : idma64.4 idma64.4
-	  825e0000-825e07ff : 0000:00:17.0
-	    825e0000-825e07ff : ahci
-	  825e1000-825e10ff : 0000:00:17.0
-	    825e1000-825e10ff : ahci
-	  825e2000-825e2fff : 0000:00:16.0
-	    825e2000-825e2fff : mei_me
-	  825e3000-825e3fff : 0000:00:15.3
-	    825e3000-825e31ff : lpss_dev
-	      825e3000-825e31ff : i2c_designware.3 lpss_dev
-	    825e3200-825e32ff : lpss_priv
-	    825e3800-825e3fff : idma64.3
-	      825e3800-825e3fff : idma64.3 idma64.3
-	  825e4000-825e4fff : 0000:00:15.2
-	    825e4000-825e41ff : lpss_dev
-	      825e4000-825e41ff : i2c_designware.2 lpss_dev
-	    825e4200-825e42ff : lpss_priv
-	    825e4800-825e4fff : idma64.2
-	      825e4800-825e4fff : idma64.2 idma64.2
-	  825e5000-825e5fff : 0000:00:15.0
-	    825e5000-825e51ff : lpss_dev
-	      825e5000-825e51ff : i2c_designware.1 lpss_dev
-	    825e5200-825e52ff : lpss_priv
-	    825e5800-825e5fff : idma64.1
-	      825e5800-825e5fff : idma64.1 idma64.1
-	  825e6000-825e6fff : 0000:00:14.2
-	  825e7000-825e7fff : 0000:00:10.1
-	    825e7000-825e71ff : lpss_dev
-	      825e7000-825e71ff : i2c_designware.0 lpss_dev
-	    825e7200-825e72ff : lpss_priv
-	  825e8000-825e8fff : 0000:00:10.0
-	  825e9000-825e93ff : 0000:00:09.0
-	    825e9000-825e93ff : intel_th_pci
-	  825ea000-825eafff : 0000:00:08.0
-	    825ea000-825eafff : gna
-	  82600000-8263ffff : 0000:00:1d.1
-	    82600000-8263ffff : 0000:00:1d.1
-	  82640000-8267ffff : 0000:00:1d.2
-	    82640000-8267ffff : 0000:00:1d.2
+	  82300000-823fffff : 0000:00:1f.3
+	    82300000-823fffff : ICH HD audio
+	  82400000-824fffff : PCI Bus 0000:01
+	    82400000-82403fff : 0000:01:00.0
+	      82400000-82403fff : nvme
+	  82500000-825fffff : 0000:00:09.0
+	    82500000-825fffff : intel_th_pci
+	  82600200-82600203 : INTC1033:02
+	  82600204-82600207 : INTC1033:02
+	  82601000-82601fff : 0000:00:1f.5
+	    82601000-82601fff : 0000:00:1f.5 0000:00:1f.5
+	  82602000-82603fff : 0000:00:1e.4
+	    82602000-82603fff : 0000:00:1e.4
+	  82640200-82640203 : INTC1033:01
+	  82640204-82640207 : INTC1033:01
+	  82680000-826bffff : 0000:00:1a.3
+	  826c0000-826cffff : 0000:00:14.0
+	    826c0000-826cffff : xhci-hcd
+	  826d0000-826d3fff : 0000:00:1f.3
+	    826d0000-826d3fff : ICH HD audio
+	  826d4000-826d7fff : 0000:00:14.2
+	  826d8200-826d8203 : INTC1033:00
+	  826d8204-826d8207 : INTC1033:00
+	  826da000-826dbfff : 0000:00:17.0
+	    826da000-826dbfff : ahci
+	  826dd000-826dd0ff : 0000:00:1f.4
+	  826de000-826defff : 0000:00:1e.4
+	  826df000-826dffff : 0000:00:1e.1
+	    826df000-826df1ff : lpss_dev
+	      826df000-826df01f : serial
+	    826df200-826df2ff : lpss_priv
+	    826df800-826dffff : idma64.6
+	      826df800-826dffff : idma64.6 idma64.6
+	  826e0000-826e0fff : 0000:00:1e.0
+	    826e0000-826e01ff : lpss_dev
+	      826e0000-826e001f : serial
+	    826e0200-826e02ff : lpss_priv
+	    826e0800-826e0fff : idma64.5
+	      826e0800-826e0fff : idma64.5 idma64.5
+	  826e1000-826e1fff : 0000:00:1a.1
+	    826e1000-826e1fff : mmc1
+	  826e2000-826e2fff : 0000:00:1a.0
+	    826e2000-826e2fff : mmc0
+	  826e3000-826e3fff : 0000:00:19.0
+	    826e3000-826e31ff : lpss_dev
+	      826e3000-826e31ff : i2c_designware.4 lpss_dev
+	    826e3200-826e32ff : lpss_priv
+	    826e3800-826e3fff : idma64.4
+	      826e3800-826e3fff : idma64.4 idma64.4
+	  826e4000-826e47ff : 0000:00:17.0
+	    826e4000-826e47ff : ahci
+	  826e5000-826e50ff : 0000:00:17.0
+	    826e5000-826e50ff : ahci
+	  826e6000-826e6fff : 0000:00:16.0
+	    826e6000-826e6fff : mei_me
+	  826e7000-826e7fff : 0000:00:15.3
+	    826e7000-826e71ff : lpss_dev
+	      826e7000-826e71ff : i2c_designware.3 lpss_dev
+	    826e7200-826e72ff : lpss_priv
+	    826e7800-826e7fff : idma64.3
+	      826e7800-826e7fff : idma64.3 idma64.3
+	  826e8000-826e8fff : 0000:00:15.2
+	    826e8000-826e81ff : lpss_dev
+	      826e8000-826e81ff : i2c_designware.2 lpss_dev
+	    826e8200-826e82ff : lpss_priv
+	    826e8800-826e8fff : idma64.2
+	      826e8800-826e8fff : idma64.2 idma64.2
+	  826e9000-826e9fff : 0000:00:15.0
+	    826e9000-826e91ff : lpss_dev
+	      826e9000-826e91ff : i2c_designware.1 lpss_dev
+	    826e9200-826e92ff : lpss_priv
+	    826e9800-826e9fff : idma64.1
+	      826e9800-826e9fff : idma64.1 idma64.1
+	  826ea000-826eafff : 0000:00:14.2
+	  826eb000-826ebfff : 0000:00:10.1
+	    826eb000-826eb1ff : lpss_dev
+	      826eb000-826eb1ff : i2c_designware.0 lpss_dev
+	    826eb200-826eb2ff : lpss_priv
+	  826ec000-826ecfff : 0000:00:10.0
+	  826ed000-826ed3ff : 0000:00:09.0
+	    826ed000-826ed3ff : intel_th_pci
+	  826ee000-826eefff : 0000:00:08.0
+	    826ee000-826eefff : gna
+	  82700000-8273ffff : 0000:00:1d.1
+	    82700000-8273ffff : 0000:00:1d.1
+	  82740000-8277ffff : 0000:00:1d.2
+	    82740000-8277ffff : 0000:00:1d.2
 	  90000000-9fffffff : 0000:00:02.0
 	c0000000-cfffffff : PCI MMCONFIG 0000 [bus 00-ff]
-	  c0000000-cfffffff : pnp 00:00
-	fd000000-fd68ffff : pnp 00:01
+	  c0000000-cfffffff : pnp 00:02
+	fd000000-fd68ffff : pnp 00:03
 	fd690000-fd69ffff : INTC1020:00
 	fd6a0000-fd6affff : INTC1020:00
 	  fd6a0000-fd6affff : INTC1020:00 INTC1020:00
@@ -325,27 +337,30 @@
 	  fd6d0000-fd6dffff : INTC1020:00 INTC1020:00
 	fd6e0000-fd6effff : INTC1020:00
 	  fd6e0000-fd6effff : INTC1020:00 INTC1020:00
-	fd6f0000-fdffffff : pnp 00:01
-	fe000000-fe01ffff : pnp 00:01
-	fe200000-fe7fffff : pnp 00:01
+	fd6f0000-fdffffff : pnp 00:03
+	fe000000-fe01ffff : pnp 00:03
+	fe200000-fe7fffff : pnp 00:03
 	fec00000-fec003ff : IOAPIC 0
-	fec80000-fec87fff : pnp 00:00
+	fec80000-fec87fff : pnp 00:02
 	fed00000-fed003ff : HPET 0
+	  fed00000-fed003ff : PNP0103:00
 	fed20000-fed7ffff : Reserved
 	  fed40000-fed44fff : MSFT0101:00
 	fed90000-fed90fff : dmar0
 	fed91000-fed91fff : dmar1
-	feda0000-feda0fff : pnp 00:00
-	feda1000-feda1fff : pnp 00:00
-	fee00000-feefffff : pnp 00:00
+	feda0000-feda0fff : pnp 00:02
+	feda1000-feda1fff : pnp 00:02
+	fee00000-feefffff : pnp 00:02
 	  fee00000-fee00fff : Local APIC
-	ff648000-ffffffff : Reserved
+	ff642000-ffffffff : Reserved
 	100000000-2803fffff : System RAM
+	  12ca00000-12d8011b0 : Kernel code
+	  12d8011b1-12df9c3ff : Kernel data
+	  12e94d000-12effffff : Kernel bss
 	280400000-283ffffff : RAM buffer
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
 	/dev/nvme0n1p3: TYPE="ext4"
-	/dev/mmcblk0: TYPE="ext4"
 	/dev/sda3: TYPE="ext4"
 	/dev/sdb2: TYPE="ext4"
 	/dev/sdb3: TYPE="ext4"
@@ -353,14 +368,14 @@
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS3 type:mmio base:0xfe042000 irq:3
-	seri:/dev/ttyS4 type:mmio base:0x825DC000 irq:16 bdf:"00:1e.0"
-	seri:/dev/ttyS5 type:mmio base:0x825DB000 irq:17 bdf:"00:1e.1"
+	seri:/dev/ttyS4 type:mmio base:0x826E0000 irq:16 bdf:"00:1e.0"
+	seri:/dev/ttyS5 type:mmio base:0x826DF000 irq:17 bdf:"00:1e.1"
 	</TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
-	3, 4, 5, 6, 7, 10, 11, 12, 13, 15
+	3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	8085828 kB
+	8056040 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -652,6 +667,11 @@
         <clos_number>16</clos_number>
       </capability>
       <capability id="CDP"/>
+      <capability id="Software SRAM">
+        <start>0x40000000</start>
+        <end>0x4003ffff</end>
+        <size>262144</size>
+      </capability>
     </cache>
     <cache level="3" id="0x0" type="3">
       <cache_size>4194304</cache_size>
@@ -670,11 +690,17 @@
         <processor>0x2</processor>
         <processor>0x6</processor>
       </processors>
+      <capability id="Software SRAM">
+        <start>0x40000000</start>
+        <end>0x4007ffff</end>
+        <size>524288</size>
+      </capability>
     </cache>
   </caches>
   <memory>
     <range start="0x0000000000000000" end="0x000000000009ffff" size="655360"/>
-    <range start="0x0000000000100000" end="0x00000000781dffff" size="2014183424"/>
+    <range start="0x0000000000100000" end="0x000000003fffffff" size="1072693248"/>
+    <range start="0x0000000040088000" end="0x0000000076353fff" size="908902400"/>
     <range start="0x0000000100000000" end="0x00000002803fffff" size="6446645248"/>
   </memory>
   <devices>
@@ -701,6 +727,7 @@
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="per-vector masking"/>
         </capability>
         <capability id="Power Management"/>
@@ -714,8 +741,10 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x088000</class>
-        <resource type="memory" min="0x825ea000" max="0x825eafff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <resource type="memory" min="0x826ee000" max="0x826eefff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Vendor-Specific"/>
         <capability id="Power Management"/>
         <capability id="Conventional PCI Advanced Features"/>
@@ -727,12 +756,11 @@
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x130000</class>
         <resource type="memory" min="0x81800000" max="0x81ffffff" len="0x800000" id="bar2" width="64" prefetchable="0"/>
-        <resource type="memory" min="0x82400000" max="0x824fffff" len="0x100000" id="bar0" width="64" prefetchable="0"/>
-        <resource type="memory" min="0x825e9000" max="0x825e93ff" len="0x400" id="bar4" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x82500000" max="0x825fffff" len="0x100000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826ed000" max="0x826ed3ff" len="0x400" id="bar4" width="64" prefetchable="0"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
       </device>
@@ -742,7 +770,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x825e8000" max="0x825e8fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826ec000" max="0x826ecfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -752,7 +780,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x825e7000" max="0x825e7fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826eb000" max="0x826ebfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -770,12 +798,11 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c0330</class>
-        <resource type="memory" min="0x825c0000" max="0x825cffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826c0000" max="0x826cffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -787,8 +814,8 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x050000</class>
-        <resource type="memory" min="0x825d0000" max="0x825d3fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
-        <resource type="memory" min="0x825e6000" max="0x825e6fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826d4000" max="0x826d7fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826ea000" max="0x826eafff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
       </device>
       <device address="0x150000" id="0x4b78">
@@ -797,7 +824,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x825e5000" max="0x825e5fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e9000" max="0x826e9fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -807,7 +834,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x825e4000" max="0x825e4fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e8000" max="0x826e8fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -817,7 +844,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x825e3000" max="0x825e3fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e7000" max="0x826e7fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -827,9 +854,10 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x078000</class>
-        <resource type="memory" min="0x825e2000" max="0x825e2fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e6000" max="0x826e6fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -843,10 +871,12 @@
         <resource type="io_port" min="0x2060" max="0x207f" len="0x20" id="bar4"/>
         <resource type="io_port" min="0x2080" max="0x2087" len="0x8" id="bar2"/>
         <resource type="io_port" min="0x2088" max="0x208b" len="0x4" id="bar3"/>
-        <resource type="memory" min="0x825d6000" max="0x825d7fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
-        <resource type="memory" min="0x825e0000" max="0x825e07ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
-        <resource type="memory" min="0x825e1000" max="0x825e10ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <resource type="memory" min="0x826da000" max="0x826dbfff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x826e4000" max="0x826e47ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x826e5000" max="0x826e50ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
@@ -856,7 +886,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x825df000" max="0x825dffff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e3000" max="0x826e3fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -866,7 +896,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x080501</class>
-        <resource type="memory" min="0x825de000" max="0x825defff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e2000" max="0x826e2fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -876,7 +906,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x080501</class>
-        <resource type="memory" min="0x825dd000" max="0x825ddfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e1000" max="0x826e1fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -886,10 +916,11 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0000ff</class>
-        <resource type="memory" min="0x82580000" max="0x825bffff" len="0x40000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x82680000" max="0x826bffff" len="0x40000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
           <capability id="per-vector masking"/>
         </capability>
@@ -898,39 +929,67 @@
         <vendor>0x8086</vendor>
         <identifier>0x4b38</identifier>
         <class>0x060400</class>
-        <resource type="memory" min="0x82300000" max="0x823fffff" len="0x100000"/>
+        <resource type="memory" min="0x82400000" max="0x824fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
         <capability id="ACS"/>
+        <capability id="TPM"/>
+        <capability id="L1 PM Substates"/>
         <capability id="Secondary PCI Express"/>
         <capability id="DPC"/>
         <bus type="pci" address="0x1">
-          <device address="0x0" id="0xf1a6">
-            <vendor>0x8086</vendor>
-            <identifier>0xf1a6</identifier>
-            <subsystem_vendor>0x8086</subsystem_vendor>
-            <subsystem_identifier>0x390b</subsystem_identifier>
+          <device address="0x0" id="0x2263">
+            <vendor>0x126f</vendor>
+            <identifier>0x2263</identifier>
+            <subsystem_vendor>0x126f</subsystem_vendor>
+            <subsystem_identifier>0x2263</subsystem_identifier>
             <class>0x010802</class>
-            <resource type="memory" min="0x82300000" max="0x82303fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
+            <resource type="memory" min="0x82400000" max="0x82403fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
             <capability id="L1 PM Substates"/>
           </device>
         </bus>
+      </device>
+      <device address="0x1c0004" id="0x4b3c">
+        <vendor>0x8086</vendor>
+        <identifier>0x4b3c</identifier>
+        <class>0x060400</class>
+        <capability id="PCI Express"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
+        <capability id="Subsystem ID and Subsystem Vendor ID"/>
+        <capability id="Power Management"/>
+        <capability id="Advanced Error Reporting"/>
+        <capability id="ACS"/>
+        <capability id="TPM"/>
+        <capability id="Virtual Channel"/>
+        <capability id="L1 PM Substates"/>
+        <capability id="Secondary PCI Express"/>
+        <capability id="DPC"/>
+        <bus type="pci" address="0x2"/>
       </device>
       <device address="0x1d0000" id="0x4bb3">
         <vendor>0x8086</vendor>
@@ -942,6 +1001,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
           <capability id="per-vector masking"/>
         </capability>
@@ -952,13 +1012,12 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x020018</class>
-        <resource type="memory" min="0x82600000" max="0x8263ffff" len="0x40000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x82700000" max="0x8273ffff" len="0x40000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>32</count>
-          </capability>
+          <count>32</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
           <capability id="per-vector masking"/>
         </capability>
@@ -969,13 +1028,12 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x020019</class>
-        <resource type="memory" min="0x82640000" max="0x8267ffff" len="0x40000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x82740000" max="0x8277ffff" len="0x40000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>32</count>
-          </capability>
+          <count>32</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
           <capability id="per-vector masking"/>
         </capability>
@@ -986,7 +1044,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x078000</class>
-        <resource type="memory" min="0x825dc000" max="0x825dcfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826e0000" max="0x826e0fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -996,7 +1054,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x078000</class>
-        <resource type="memory" min="0x825db000" max="0x825dbfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826df000" max="0x826dffff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
@@ -1006,14 +1064,13 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x020000</class>
-        <resource type="memory" min="0x82502000" max="0x82503fff" len="0x2000" id="bar0" width="64" prefetchable="0"/>
-        <resource type="memory" min="0x825da000" max="0x825dafff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x82602000" max="0x82603fff" len="0x2000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826de000" max="0x826defff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>32</count>
-          </capability>
+          <count>32</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
           <capability id="per-vector masking"/>
         </capability>
@@ -1026,6 +1083,21 @@
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x060100</class>
       </device>
+      <device address="0x1f0003" id="0x4b58">
+        <vendor>0x8086</vendor>
+        <identifier>0x4b58</identifier>
+        <subsystem_vendor>0x8086</subsystem_vendor>
+        <subsystem_identifier>0x7270</subsystem_identifier>
+        <class>0x040300</class>
+        <resource type="memory" min="0x82300000" max="0x823fffff" len="0x100000" id="bar4" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826d0000" max="0x826d3fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
+        <capability id="Power Management"/>
+        <capability id="Vendor-Specific"/>
+        <capability id="MSI">
+          <count>1</count>
+          <capability id="64-bit address"/>
+        </capability>
+      </device>
       <device address="0x1f0004" id="0x4b23">
         <vendor>0x8086</vendor>
         <identifier>0x4b23</identifier>
@@ -1033,7 +1105,7 @@
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c0500</class>
         <resource type="io_port" min="0x2040" max="0x205f" len="0x20" id="bar4"/>
-        <resource type="memory" min="0x825d9000" max="0x825d90ff" len="0x100" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x826dd000" max="0x826dd0ff" len="0x100" id="bar0" width="64" prefetchable="0"/>
       </device>
       <device address="0x1f0005" id="0x4b24">
         <vendor>0x8086</vendor>
@@ -1041,7 +1113,7 @@
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x0c8000</class>
-        <resource type="memory" min="0x82501000" max="0x82501fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
+        <resource type="memory" min="0x82601000" max="0x82601fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
       </device>
       <device address="0x1f0007" id="0x4b26">
         <vendor>0x8086</vendor>
@@ -1052,9 +1124,8 @@
         <resource type="memory" min="0x81000000" max="0x817fffff" len="0x800000" id="bar2" width="64" prefetchable="0"/>
         <resource type="memory" min="0x82200000" max="0x822fffff" len="0x100000" id="bar0" width="64" prefetchable="0"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
       </device>

--- a/misc/config_tools/data/nuc11tnbi5/nuc11tnbi5.xml
+++ b/misc/config_tools/data/nuc11tnbi5/nuc11tnbi5.xml
@@ -90,8 +90,8 @@
 	58:00.0 0200: 8086:15f2 (rev 03)
 	</PCI_VID_PID>
   <WAKE_VECTOR_INFO>
-	#define WAKE_VECTOR_32          0x40CDA00CUL
-	#define WAKE_VECTOR_64          0x40CDA018UL
+	#define WAKE_VECTOR_32          0x40CD800CUL
+	#define WAKE_VECTOR_64          0x40CD8018UL
 	</WAKE_VECTOR_INFO>
   <RESET_REGISTER_INFO>
 	#define RESET_REGISTER_ADDRESS  0xCF9UL
@@ -227,15 +227,15 @@
 	  000ec000-000effff : PCI Bus 0000:00
 	  000f0000-000fffff : PCI Bus 0000:00
 	    000f0000-000fffff : System ROM
-	00100000-2f7dffff : System RAM
-	2f7e0000-2f87efff : Reserved
-	2f87f000-32239fff : System RAM
-	3223a000-3223afff : Reserved
-	3223b000-38138fff : System RAM
-	38139000-40b53fff : Reserved
-	40b54000-40c1ffff : ACPI Tables
-	40c20000-40cddfff : ACPI Non-volatile Storage
-	40cde000-417fefff : Reserved
+	00100000-2f7cefff : System RAM
+	2f7cf000-2f86dfff : Reserved
+	2f86e000-33e6afff : System RAM
+	33e6b000-33e6bfff : Reserved
+	33e6c000-38136fff : System RAM
+	38137000-40b51fff : Reserved
+	40b52000-40c1dfff : ACPI Tables
+	40c1e000-40cdbfff : ACPI Non-volatile Storage
+	40cdc000-417fefff : Reserved
 	417ff000-417fffff : System RAM
 	41800000-47ffffff : Reserved
 	48e00000-4f7fffff : Reserved
@@ -291,13 +291,13 @@
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : pnp 00:05
 	100000000-3b07fffff : System RAM
-	  203400000-204200ed0 : Kernel code
-	  204200ed1-204c534bf : Kernel data
-	  204f1b000-2053fffff : Kernel bss
+	  2f3c00000-2f4a00ed0 : Kernel code
+	  2f4a00ed1-2f545353f : Kernel data
+	  2f571d000-2f5bfffff : Kernel bss
 	3b0800000-3b3ffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
-	    4000000000-40001d4fff : efifb
+	    4000000000-40007e8fff : efifb
 	  4010000000-4016ffffff : 0000:00:02.0
 	  4017000000-4017000fff : 0000:00:15.0
 	    4017000000-40170001ff : lpss_dev
@@ -335,8 +335,8 @@
 	  603d1b3000-603d1b3fff : 0000:00:08.0
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
-	/dev/sda3: TYPE="ext4"
 	/dev/nvme0n1p3: TYPE="ext4"
+	/dev/sda3: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
@@ -345,7 +345,7 @@
 	3, 5, 6, 7, 10, 11, 12, 13, 14, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	11884916 kB
+	11884896 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -745,7 +745,7 @@
   </caches>
   <memory>
     <range start="0x0000000000000000" end="0x000000000009efff" size="651264"/>
-    <range start="0x0000000000100000" end="0x0000000038138fff" size="939757568"/>
+    <range start="0x0000000000100000" end="0x0000000038136fff" size="939749376"/>
     <range start="0x00000000417ff000" end="0x00000000417fffff" size="4096"/>
     <range start="0x0000000100000000" end="0x00000003b07fffff" size="11551113216"/>
   </memory>
@@ -777,6 +777,7 @@
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="per-vector masking"/>
         </capability>
         <capability id="Power Management"/>
@@ -791,7 +792,9 @@
         <class>0x060400</class>
         <resource type="memory" min="0x6a400000" max="0x6a4fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -814,14 +817,19 @@
             <resource type="memory" min="0x6a400000" max="0x6a403fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -836,7 +844,9 @@
         <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
         <resource type="memory" min="0x5e000000" max="0x6a1fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="ACS"/>
@@ -850,7 +860,9 @@
         <resource type="io_port" min="0x5000" max="0x5fff" len="0x1000"/>
         <resource type="memory" min="0x50000000" max="0x5c1fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="ACS"/>
@@ -864,7 +876,9 @@
         <subsystem_identifier>0x3002</subsystem_identifier>
         <class>0x088000</class>
         <resource type="memory" min="0x603d1b3000" max="0x603d1b3fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Vendor-Specific"/>
         <capability id="Power Management"/>
         <capability id="Conventional PCI Advanced Features"/>
@@ -878,9 +892,8 @@
         <resource type="memory" min="0x603d190000" max="0x603d19ffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -896,9 +909,16 @@
         <resource type="memory" min="0x603d1b2000" max="0x603d1b2fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>4</table_bir>
+          <table_offset>0xfa20000</table_offset>
+          <pba_bir>0</pba_bir>
+          <pba_offset>0x2000000</pba_offset>
+        </capability>
       </device>
       <device address="0xd0003" id="0x9a1d" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
@@ -910,9 +930,16 @@
         <resource type="memory" min="0x603d1b1000" max="0x603d1b1fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>4</table_bir>
+          <table_offset>0xfa20000</table_offset>
+          <pba_bir>0</pba_bir>
+          <pba_offset>0x2000000</pba_offset>
+        </capability>
       </device>
       <device address="0x140000" id="0xa0ed" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
@@ -923,9 +950,8 @@
         <resource type="memory" min="0x603d180000" max="0x603d18ffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -950,10 +976,17 @@
         <resource type="memory" min="0x603d1a4000" max="0x603d1a7fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="PCI Express"/>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>1</table_bir>
+          <table_offset>0x10000000</table_offset>
+          <pba_bir>1</pba_bir>
+          <pba_offset>0x0</pba_offset>
+        </capability>
         <capability id="LTR"/>
         <capability id="Vendor-Specific Extended"/>
       </device>
@@ -986,6 +1019,7 @@
         <resource type="memory" min="0x603d1ad000" max="0x603d1adfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
@@ -1002,7 +1036,9 @@
         <resource type="memory" min="0x6a500000" max="0x6a501fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
         <resource type="memory" min="0x6a502000" max="0x6a5027ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
         <resource type="memory" min="0x6a503000" max="0x6a5030ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
@@ -1012,7 +1048,9 @@
         <class>0x060400</class>
         <resource type="memory" min="0x6a200000" max="0x6a3fffff" len="0x200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1032,10 +1070,17 @@
             <resource type="memory" min="0x6a300000" max="0x6a303fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -1063,6 +1108,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>

--- a/misc/config_tools/data/nuc7i7dnb/nuc7i7dnb.xml
+++ b/misc/config_tools/data/nuc7i7dnb/nuc7i7dnb.xml
@@ -17,7 +17,7 @@
 	00:02.0 VGA compatible controller: Intel Corporation UHD Graphics 620 (rev 07)
 	Region 0: Memory at de000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at c0000000 (64-bit, prefetchable) [size=256M]
-	00:08.0 System peripheral: Intel Corporation Xeon E3-1200 v5/v6 / E3-1500 v5 / 6th/7th Gen Core Processor Gaussian Mixture Model
+	00:08.0 System peripheral: Intel Corporation Xeon E3-1200 v5/v6 / E3-1500 v5 / 6th/7th/8th Gen Core Processor Gaussian Mixture Model
 	Region 0: Memory at df252000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:14.0 USB controller: Intel Corporation Sunrise Point-LP USB 3.0 xHCI Controller (rev 21)
 	Region 0: Memory at df230000 (64-bit, non-prefetchable) [size=64K]
@@ -37,7 +37,7 @@
 	Region 5: Memory at df24b000 (32-bit, non-prefetchable) [size=2K]
 	00:1c.0 PCI bridge: Intel Corporation Sunrise Point-LP PCI Express Root Port #3 (rev f1)
 	00:1d.0 PCI bridge: Intel Corporation Sunrise Point-LP PCI Express Root Port #9 (rev f1)
-	00:1f.0 ISA bridge: Intel Corporation Intel(R) 100 Series Chipset Family LPC Controller/eSPI Controller - 9D4E (rev 21)
+	00:1f.0 ISA bridge: Intel Corporation Sunrise Point LPC Controller/eSPI Controller (rev 21)
 	00:1f.2 Memory controller: Intel Corporation Sunrise Point-LP PMC (rev 21)
 	Region 0: Memory at df244000 (32-bit, non-prefetchable) [disabled] [size=16K]
 	00:1f.3 Audio device: Intel Corporation Sunrise Point-LP HD Audio (rev 21)
@@ -49,7 +49,7 @@
 	Region 0: Memory at df200000 (32-bit, non-prefetchable) [size=128K]
 	01:00.0 Network controller: Intel Corporation Wireless 8265 / 8275 (rev 78)
 	Region 0: Memory at df100000 (64-bit, non-prefetchable) [size=8K]
-	02:00.0 Non-Volatile memory controller: Intel Corporation SSD Pro 7600p/760p/E 6100p Series (rev 03)
+	02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)
 	Region 0: Memory at df000000 (64-bit, non-prefetchable) [size=16K]
 	</PCI_DEVICE>
   <PCI_VID_PID>
@@ -71,7 +71,7 @@
 	00:1f.4 0c05: 8086:9d23 (rev 21)
 	00:1f.6 0200: 8086:156f (rev 21)
 	01:00.0 0280: 8086:24fd (rev 78)
-	02:00.0 0108: 8086:f1a6 (rev 03)
+	02:00.0 0108: 126f:2263 (rev 03)
 	</PCI_VID_PID>
   <WAKE_VECTOR_INFO>
 	#define WAKE_VECTOR_32          0x8A9FAF8CUL
@@ -146,7 +146,9 @@
 	"Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz"
 	</CPU_BRAND>
   <CX_INFO>
-	/* Cx data is not available */
+	{{SPACE_FFixedHW, 0x00U, 0x00U, 0x00U, 0x00UL}, 0x01U, 0x01U, 0x00U},	/* C1 */
+	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x1816UL}, 0x02U, 0x97U, 0x00U},	/* C2 */
+	{{SPACE_SYSTEM_IO, 0x08U, 0x00U, 0x00U, 0x1819UL}, 0x03U, 0x40AU, 0x00U},	/* C3 */
 	</CX_INFO>
   <PX_INFO>
 	{0x835UL, 0x00UL, 0x0AUL, 0x0AUL, 0x002A00UL, 0x002A00UL},	/* P0 */
@@ -196,17 +198,16 @@
 	  000ec000-000effff : PCI Bus 0000:00
 	  000f0000-000fffff : System ROM
 	00100000-3fffffff : System RAM
-	  20600000-214031d0 : Kernel code
-	  214031d1-21b5f87f : Kernel data
-	  21cfc000-21dfffff : Kernel bss
 	40000000-403fffff : Reserved
 	  40000000-403fffff : pnp 00:00
-	40400000-7d9bf017 : System RAM
-	7d9bf018-7d9cfe57 : System RAM
-	7d9cfe58-81aecfff : System RAM
+	40400000-7ee14017 : System RAM
+	7ee14018-7ee24e57 : System RAM
+	7ee24e58-81aecfff : System RAM
 	81aed000-81aedfff : ACPI Non-volatile Storage
 	81aee000-81aeefff : Reserved
-	81aef000-8a486fff : System RAM
+	81aef000-86741fff : System RAM
+	86742000-867a3fff : Reserved
+	867a4000-8a486fff : System RAM
 	8a487000-8a94dfff : Reserved
 	8a94e000-8a99afff : ACPI Tables
 	8a99b000-8a9fafff : ACPI Non-volatile Storage
@@ -222,6 +223,7 @@
 	      df000000-df003fff : nvme
 	  df100000-df1fffff : PCI Bus 0000:01
 	    df100000-df101fff : 0000:01:00.0
+	      df100000-df101fff : iwlwifi
 	  df200000-df21ffff : 0000:00:1f.6
 	    df200000-df21ffff : e1000e
 	  df220000-df22ffff : 0000:00:1f.3
@@ -244,17 +246,18 @@
 	    df24e000-df24efff : mei_me
 	  df24f000-df24ffff : 0000:00:15.1
 	    df24f000-df24f1ff : lpss_dev
-	      df24f000-df24f1ff : lpss_dev
+	      df24f000-df24f1ff : i2c_designware.1 lpss_dev
 	    df24f200-df24f2ff : lpss_priv
 	    df24f800-df24ffff : idma64.1
-	      df24f800-df24ffff : idma64.1
+	      df24f800-df24ffff : idma64.1 idma64.1
 	  df250000-df250fff : 0000:00:15.0
 	    df250000-df2501ff : lpss_dev
-	      df250000-df2501ff : lpss_dev
+	      df250000-df2501ff : i2c_designware.0 lpss_dev
 	    df250200-df2502ff : lpss_priv
 	    df250800-df250fff : idma64.0
-	      df250800-df250fff : idma64.0
+	      df250800-df250fff : idma64.0 idma64.0
 	  df251000-df251fff : 0000:00:14.2
+	    df251000-df251fff : Intel PCH thermal driver
 	  df252000-df252fff : 0000:00:08.0
 	  dffe0000-dfffffff : pnp 00:06
 	e0000000-efffffff : PCI MMCONFIG 0000 [bus 00-ff]
@@ -263,15 +266,13 @@
 	fd000000-fe7fffff : PCI Bus 0000:00
 	  fd000000-fdabffff : pnp 00:07
 	  fdac0000-fdacffff : INT344B:00
-	    fdac0000-fdacffff : INT344B:00
+	    fdac0000-fdacffff : INT344B:00 INT344B:00
 	  fdad0000-fdadffff : pnp 00:07
 	  fdae0000-fdaeffff : INT344B:00
-	    fdae0000-fdaeffff : INT344B:00
+	    fdae0000-fdaeffff : INT344B:00 INT344B:00
 	  fdaf0000-fdafffff : INT344B:00
-	    fdaf0000-fdafffff : INT344B:00
-	  fdb00000-fdffffff : pnp 00:07
-	    fdc6000c-fdc6000f : iTCO_wdt
-	      fdc6000c-fdc6000f : iTCO_wdt
+	    fdaf0000-fdafffff : INT344B:00 INT344B:00
+	  fdc6000c-fdc6000f : wdat_wdt
 	  fe000000-fe010fff : Reserved
 	  fe028000-fe028fff : pnp 00:09
 	  fe029000-fe029fff : pnp 00:09
@@ -288,30 +289,36 @@
 	fed19000-fed19fff : pnp 00:06
 	fed20000-fed3ffff : pnp 00:06
 	fed40000-fed44fff : MSFT0101:00
-	  fed40000-fed44fff : MSFT0101:00
+	  fed40000-fed44fff : MSFT0101:00 MSFT0101:00
 	fed45000-fed8ffff : pnp 00:06
-	fed90000-fed93fff : pnp 00:06
+	fed90000-fed90fff : dmar0
+	fed91000-fed91fff : dmar1
 	fee00000-fee00fff : Local APIC
 	  fee00000-fee00fff : Reserved
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : INT0800:00
 	    ff000000-ffffffff : pnp 00:06
 	100000000-46dffffff : System RAM
+	  324e00000-325c00db6 : Kernel code
+	  325e00000-32633afff : Kernel rodata
+	  326400000-326680cbf : Kernel data
+	  326937000-326dfffff : Kernel bss
 	46e000000-46fffffff : RAM buffer
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
-	/dev/nvme0n1p2: TYPE="ext4"
+	/dev/sdb3: TYPE="ext4"
+	/dev/nvme0n1p3: TYPE="ext4"
 	/dev/sda2: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
-	seri:/dev/ttyS1 type:portio base:0xF0A0 irq:19
+	seri:/dev/ttyS4 type:portio base:0xF0A0 irq:19
 	</TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
 	3, 5, 6, 7, 10, 11, 12, 13, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	16296460 kB
+	16266660 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -398,6 +405,7 @@
       <capability id="smap"/>
       <capability id="clflushopt"/>
       <capability id="intel_pt"/>
+      <capability id="md_clear"/>
       <capability id="ibrs_ibpb"/>
       <capability id="stibp"/>
       <capability id="l1d_flush"/>
@@ -673,7 +681,7 @@
     <range start="0x0000000100000000" end="0x000000046dffffff" size="14730395648"/>
   </memory>
   <devices>
-    <bus type="pci" address="0x0" id="0x5914">
+    <bus type="pci" address="0x0" id="0x5914" description="Host bridge: Intel Corporation Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers">
       <vendor>0x8086</vendor>
       <identifier>0x5914</identifier>
       <subsystem_vendor>0x8086</subsystem_vendor>
@@ -695,7 +703,7 @@
       <resource type="memory" min="0x90000000" max="0xdfffffff" len="0x50000000"/>
       <resource type="memory" min="0xfd000000" max="0xfe7fffff" len="0x1800000"/>
       <capability id="Vendor-Specific"/>
-      <device address="0x20000" id="0x5917">
+      <device address="0x20000" id="0x5917" description="VGA compatible controller: Intel Corporation UHD Graphics 620">
         <vendor>0x8086</vendor>
         <identifier>0x5917</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -706,24 +714,28 @@
         <resource type="memory" min="0xde000000" max="0xdeffffff" len="0x1000000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="PASID"/>
         <capability id="ATS"/>
         <capability id="PRI"/>
       </device>
-      <device address="0x80000" id="0x1911">
+      <device address="0x80000" id="0x1911" description="System peripheral: Intel Corporation Xeon E3-1200 v5/v6 / E3-1500 v5 / 6th/7th/8th Gen Core Processor Gaussian Mixture Model">
         <vendor>0x8086</vendor>
         <identifier>0x1911</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x2070</subsystem_identifier>
         <class>0x088000</class>
         <resource type="memory" min="0xdf252000" max="0xdf252fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Conventional PCI Advanced Features"/>
       </device>
-      <device address="0x140000" id="0x9d2f">
+      <device address="0x140000" id="0x9d2f" description="USB controller: Intel Corporation Sunrise Point-LP USB 3.0 xHCI Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9d2f</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -732,13 +744,12 @@
         <resource type="memory" min="0xdf230000" max="0xdf23ffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
       </device>
-      <device address="0x140002" id="0x9d31">
+      <device address="0x140002" id="0x9d31" description="Signal processing controller: Intel Corporation Sunrise Point-LP Thermal subsystem">
         <vendor>0x8086</vendor>
         <identifier>0x9d31</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -746,9 +757,11 @@
         <class>0x118000</class>
         <resource type="memory" min="0xdf251000" max="0xdf251fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
       </device>
-      <device address="0x150000" id="0x9d60">
+      <device address="0x150000" id="0x9d60" description="Signal processing controller: Intel Corporation Sunrise Point-LP Serial IO I2C Controller #0">
         <vendor>0x8086</vendor>
         <identifier>0x9d60</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -758,7 +771,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x150001" id="0x9d61">
+      <device address="0x150001" id="0x9d61" description="Signal processing controller: Intel Corporation Sunrise Point-LP Serial IO I2C Controller #1">
         <vendor>0x8086</vendor>
         <identifier>0x9d61</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -768,7 +781,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x160000" id="0x9d3a">
+      <device address="0x160000" id="0x9d3a" description="Communication controller: Intel Corporation Sunrise Point-LP CSME HECI #1">
         <vendor>0x8086</vendor>
         <identifier>0x9d3a</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -777,10 +790,11 @@
         <resource type="memory" min="0xdf24e000" max="0xdf24efff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
-      <device address="0x160003" id="0x9d3d">
+      <device address="0x160003" id="0x9d3d" description="Serial controller: Intel Corporation Sunrise Point-LP Active Management Technology - SOL">
         <vendor>0x8086</vendor>
         <identifier>0x9d3d</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -789,11 +803,12 @@
         <resource type="io_port" min="0xf0a0" max="0xf0a7" len="0x8" id="bar0"/>
         <resource type="memory" min="0xdf24d000" max="0xdf24dfff" len="0x1000" id="bar1" width="32" prefetchable="0"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Power Management"/>
       </device>
-      <device address="0x170000" id="0x9d03">
+      <device address="0x170000" id="0x9d03" description="SATA controller: Intel Corporation Sunrise Point-LP SATA Controller [AHCI mode]">
         <vendor>0x8086</vendor>
         <identifier>0x9d03</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -805,17 +820,21 @@
         <resource type="memory" min="0xdf248000" max="0xdf249fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
         <resource type="memory" min="0xdf24b000" max="0xdf24b7ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
         <resource type="memory" min="0xdf24c000" max="0xdf24c0ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
-      <device address="0x1c0000" id="0x9d12">
+      <device address="0x1c0000" id="0x9d12" description="PCI bridge: Intel Corporation Sunrise Point-LP PCI Express Root Port #3">
         <vendor>0x8086</vendor>
         <identifier>0x9d12</identifier>
         <class>0x060400</class>
         <resource type="memory" min="0xdf100000" max="0xdf1fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -823,7 +842,7 @@
         <capability id="L1 PM Substates"/>
         <capability id="Secondary PCI Express"/>
         <bus type="pci" address="0x1">
-          <device address="0x0" id="0x24fd">
+          <device address="0x0" id="0x24fd" description="Network controller: Intel Corporation Wireless 8265 / 8275">
             <vendor>0x8086</vendor>
             <identifier>0x24fd</identifier>
             <subsystem_vendor>0x8086</subsystem_vendor>
@@ -832,6 +851,7 @@
             <resource type="memory" min="0xdf100000" max="0xdf101fff" len="0x2000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
             </capability>
             <capability id="PCI Express"/>
@@ -842,13 +862,15 @@
           </device>
         </bus>
       </device>
-      <device address="0x1d0000" id="0x9d18">
+      <device address="0x1d0000" id="0x9d18" description="PCI bridge: Intel Corporation Sunrise Point-LP PCI Express Root Port #9">
         <vendor>0x8086</vendor>
         <identifier>0x9d18</identifier>
         <class>0x060400</class>
         <resource type="memory" min="0xdf000000" max="0xdf0fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -856,23 +878,28 @@
         <capability id="L1 PM Substates"/>
         <capability id="Secondary PCI Express"/>
         <bus type="pci" address="0x2">
-          <device address="0x0" id="0xf1a6">
-            <vendor>0x8086</vendor>
-            <identifier>0xf1a6</identifier>
-            <subsystem_vendor>0x8086</subsystem_vendor>
-            <subsystem_identifier>0x390b</subsystem_identifier>
+          <device address="0x0" id="0x2263" description="Non-Volatile memory controller: Silicon Motion, Inc.">
+            <vendor>0x126f</vendor>
+            <identifier>0x2263</identifier>
+            <subsystem_vendor>0x126f</subsystem_vendor>
+            <subsystem_identifier>0x2263</subsystem_identifier>
             <class>0x010802</class>
             <resource type="memory" min="0xdf000000" max="0xdf003fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -880,14 +907,14 @@
           </device>
         </bus>
       </device>
-      <device address="0x1f0000" id="0x9d4e">
+      <device address="0x1f0000" id="0x9d4e" description="ISA bridge: Intel Corporation Sunrise Point LPC Controller/eSPI Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9d4e</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x2070</subsystem_identifier>
         <class>0x060100</class>
       </device>
-      <device address="0x1f0002" id="0x9d21">
+      <device address="0x1f0002" id="0x9d21" description="Memory controller: Intel Corporation Sunrise Point-LP PMC">
         <vendor>0x8086</vendor>
         <identifier>0x9d21</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -895,7 +922,7 @@
         <class>0x058000</class>
         <resource type="memory" min="0xdf244000" max="0xdf247fff" len="0x4000" id="bar0" width="32" prefetchable="0"/>
       </device>
-      <device address="0x1f0003" id="0x9d71">
+      <device address="0x1f0003" id="0x9d71" description="Audio device: Intel Corporation Sunrise Point-LP HD Audio">
         <vendor>0x8086</vendor>
         <identifier>0x9d71</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -905,10 +932,11 @@
         <resource type="memory" min="0xdf240000" max="0xdf243fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
-      <device address="0x1f0004" id="0x9d23">
+      <device address="0x1f0004" id="0x9d23" description="SMBus: Intel Corporation Sunrise Point-LP SMBus">
         <vendor>0x8086</vendor>
         <identifier>0x9d23</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -917,7 +945,7 @@
         <resource type="io_port" min="0xf040" max="0xf05f" len="0x20" id="bar4"/>
         <resource type="memory" min="0xdf24a000" max="0xdf24a0ff" len="0x100" id="bar0" width="64" prefetchable="0"/>
       </device>
-      <device address="0x1f0006" id="0x156f">
+      <device address="0x1f0006" id="0x156f" description="Ethernet controller: Intel Corporation Ethernet Connection I219-LM">
         <vendor>0x8086</vendor>
         <identifier>0x156f</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -926,6 +954,7 @@
         <resource type="memory" min="0xdf200000" max="0xdf21ffff" len="0x20000" id="bar0" width="32" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Conventional PCI Advanced Features"/>

--- a/misc/config_tools/data/tgl-rvp/tgl-rvp.xml
+++ b/misc/config_tools/data/tgl-rvp/tgl-rvp.xml
@@ -12,83 +12,83 @@
 	Version: 1
 	</BASE_BOARD_INFO>
   <PCI_DEVICE>
-	00:00.0 Host bridge: Intel Corporation 11th Gen Core Processor Host Bridge/DRAM Registers (rev 01)
-	00:02.0 VGA compatible controller: Intel Corporation UHD Graphics (rev 01)
+	00:00.0 Host bridge: Intel Corporation Device 9a14 (rev 01)
+	00:02.0 VGA compatible controller: Intel Corporation Device 9a49 (rev 01)
 	Region 0: Memory at 607c000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at 4000000000 (64-bit, prefetchable) [size=256M]
 	Region 0: Memory at 0000004010000000 (64-bit, non-prefetchable)
 	Region 2: Memory at 0000004020000000 (64-bit, prefetchable)
 	00:04.0 Signal processing controller: Intel Corporation Device 9a03 (rev 01)
 	Region 0: Memory at 607d480000 (64-bit, non-prefetchable) [size=128K]
-	00:06.0 PCI bridge: Intel Corporation 11th Gen Core Processor PCIe Controller (rev 01)
-	00:07.0 PCI bridge: Intel Corporation Tiger Lake-LP Thunderbolt PCI Express Root Port #0 (rev 01)
-	00:07.1 PCI bridge: Intel Corporation Tiger Lake-LP Thunderbolt PCI Express Root Port #1 (rev 01)
-	00:07.2 PCI bridge: Intel Corporation Tiger Lake-LP Thunderbolt PCI Express Root Port #2 (rev 01)
-	00:07.3 PCI bridge: Intel Corporation Tiger Lake-LP Thunderbolt PCI Express Root Port #3 (rev 01)
+	00:06.0 PCI bridge: Intel Corporation Device 9a09 (rev 01)
+	00:07.0 PCI bridge: Intel Corporation Device 9a23 (rev 01)
+	00:07.1 PCI bridge: Intel Corporation Device 9a25 (rev 01)
+	00:07.2 PCI bridge: Intel Corporation Device 9a27 (rev 01)
+	00:07.3 PCI bridge: Intel Corporation Device 9a29 (rev 01)
 	00:08.0 System peripheral: Intel Corporation Device 9a11 (rev 01)
 	Region 0: Memory at 607d4ef000 (64-bit, non-prefetchable) [disabled] [size=4K]
 	00:0a.0 Signal processing controller: Intel Corporation Device 9a0d (rev 01)
 	Region 0: Memory at 607d4d0000 (64-bit, non-prefetchable) [size=32K]
-	00:0d.0 USB controller: Intel Corporation Tiger Lake-LP Thunderbolt USB Controller (rev 01)
+	00:0d.0 USB controller: Intel Corporation Device 9a13 (rev 01)
 	Region 0: Memory at 607d4c0000 (64-bit, non-prefetchable) [size=64K]
 	00:0d.1 USB controller: Intel Corporation Device 9a15 (rev 01)
-	Region 0: Memory at 607d200000 (64-bit, non-prefetchable) [size=2M]
-	Region 2: Memory at 607d4ee000 (64-bit, non-prefetchable) [size=4K]
-	00:0d.2 USB controller: Intel Corporation Tiger Lake-LP Thunderbolt NHI #0 (rev 01)
+	Region 0: Memory at 607d200000 (64-bit, non-prefetchable) [disabled] [size=2M]
+	Region 2: Memory at 607d4ee000 (64-bit, non-prefetchable) [disabled] [size=4K]
+	00:0d.2 USB controller: Intel Corporation Device 9a1b (rev 01)
 	Region 0: Memory at 607d440000 (64-bit, non-prefetchable) [size=256K]
 	Region 2: Memory at 607d4ed000 (64-bit, non-prefetchable) [size=4K]
-	00:0d.3 USB controller: Intel Corporation Tiger Lake-LP Thunderbolt NHI #1 (rev 01)
+	00:0d.3 USB controller: Intel Corporation Device 9a1d (rev 01)
 	Region 0: Memory at 607d400000 (64-bit, non-prefetchable) [size=256K]
 	Region 2: Memory at 607d4ec000 (64-bit, non-prefetchable) [size=4K]
 	00:10.0 Serial bus controller [0c80]: Intel Corporation Device a0d8 (rev 20)
 	Region 0: Memory at 607d4eb000 (64-bit, non-prefetchable) [size=4K]
 	00:10.5 Host bridge: Intel Corporation Device a0af (rev 20)
-	00:12.0 Serial controller: Intel Corporation Tiger Lake-LP Integrated Sensor Hub (rev 20)
+	00:12.0 Serial controller: Intel Corporation Device a0fc (rev 20)
 	Region 0: Memory at 607d4b0000 (64-bit, non-prefetchable) [size=64K]
-	00:14.0 USB controller: Intel Corporation Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller (rev 20)
+	00:14.0 USB controller: Intel Corporation Device a0ed (rev 20)
 	Region 0: Memory at 607d4a0000 (64-bit, non-prefetchable) [size=64K]
 	00:14.1 USB controller: Intel Corporation Device a0ee (rev 20)
 	Region 0: Memory at 607d000000 (64-bit, non-prefetchable) [size=2M]
 	Region 2: Memory at 607d4ea000 (64-bit, non-prefetchable) [size=4K]
-	00:14.2 RAM memory: Intel Corporation Tiger Lake-LP Shared SRAM (rev 20)
+	00:14.2 RAM memory: Intel Corporation Device a0ef (rev 20)
 	Region 0: Memory at 607d4d8000 (64-bit, non-prefetchable) [disabled] [size=16K]
 	Region 2: Memory at 607d4e9000 (64-bit, non-prefetchable) [disabled] [size=4K]
-	00:15.0 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #0 (rev 20)
+	00:15.0 Serial bus controller [0c80]: Intel Corporation Device a0e8 (rev 20)
 	Region 0: Memory at 607d4e8000 (64-bit, non-prefetchable) [virtual] [size=4K]
-	00:15.1 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #1 (rev 20)
+	00:15.1 Serial bus controller [0c80]: Intel Corporation Device a0e9 (rev 20)
 	Region 0: Memory at 607d4e7000 (64-bit, non-prefetchable) [virtual] [size=4K]
-	00:15.2 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #2 (rev 20)
+	00:15.2 Serial bus controller [0c80]: Intel Corporation Device a0ea (rev 20)
 	Region 0: Memory at 607d4e6000 (64-bit, non-prefetchable) [virtual] [size=4K]
-	00:15.3 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #3 (rev 20)
+	00:15.3 Serial bus controller [0c80]: Intel Corporation Device a0eb (rev 20)
 	Region 0: Memory at 607d4e5000 (64-bit, non-prefetchable) [virtual] [size=4K]
-	00:16.0 Communication controller: Intel Corporation Tiger Lake-LP Management Engine Interface (rev 20)
+	00:16.0 Communication controller: Intel Corporation Device a0e0 (rev 20)
 	Region 0: Memory at 607d4e4000 (64-bit, non-prefetchable) [size=4K]
 	00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)
 	Region 0: Memory at 86620000 (32-bit, non-prefetchable) [size=8K]
 	Region 1: Memory at 86624000 (32-bit, non-prefetchable) [size=256]
 	Region 5: Memory at 86623000 (32-bit, non-prefetchable) [size=2K]
-	00:19.0 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #4 (rev 20)
+	00:19.0 Serial bus controller [0c80]: Intel Corporation Device a0c5 (rev 20)
 	Region 0: Memory at 607d4e3000 (64-bit, non-prefetchable) [virtual] [size=4K]
-	00:19.1 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #5 (rev 20)
+	00:19.1 Serial bus controller [0c80]: Intel Corporation Device a0c6 (rev 20)
 	Region 0: Memory at 607d4e2000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:1c.0 PCI bridge: Intel Corporation Device a0bc (rev 20)
-	00:1e.0 Communication controller: Intel Corporation Tiger Lake-LP Serial IO UART Controller #0 (rev 20)
-	Region 0: Memory at 607d4e1000 (64-bit, non-prefetchable) [size=4K]
-	00:1e.3 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP Serial IO SPI Controller #1 (rev 20)
+	00:1e.0 Communication controller: Intel Corporation Device a0a8 (rev 20)
+	Region 0: Memory at 607d4e1000 (64-bit, non-prefetchable) [virtual] [size=4K]
+	00:1e.3 Serial bus controller [0c80]: Intel Corporation Device a0ab (rev 20)
 	Region 0: Memory at 607d4e0000 (64-bit, non-prefetchable) [virtual] [size=4K]
 	00:1e.4 Ethernet controller: Intel Corporation Device a0ac (rev 20)
 	Region 0: Memory at 607d4dc000 (64-bit, non-prefetchable) [size=8K]
 	Region 2: Memory at 607d4df000 (64-bit, non-prefetchable) [size=4K]
 	00:1f.0 ISA bridge: Intel Corporation Device a088 (rev 20)
-	00:1f.4 SMBus: Intel Corporation Tiger Lake-LP SMBus Controller (rev 20)
+	00:1f.4 SMBus: Intel Corporation Device a0a3 (rev 20)
 	Region 0: Memory at 607d4de000 (64-bit, non-prefetchable) [size=256]
-	00:1f.5 Serial bus controller [0c80]: Intel Corporation Tiger Lake-LP SPI Controller (rev 20)
+	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device a0a4 (rev 20)
 	Region 0: Memory at 4f800000 (32-bit, non-prefetchable) [size=4K]
 	00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V (rev 20)
 	Region 0: Memory at 86600000 (32-bit, non-prefetchable) [size=128K]
 	01:00.0 Non-Volatile memory controller: Intel Corporation SSD 600P Series (rev 03)
 	Region 0: Memory at 86400000 (64-bit, non-prefetchable) [size=16K]
-	aa:00.0 Ethernet controller: Intel Corporation Intel(R) Ethernet Controller I225-LM (rev 03)
+	aa:00.0 Ethernet controller: Intel Corporation Device 15f2 (rev 03)
 	Region 0: Memory at 86200000 (32-bit, non-prefetchable) [size=1M]
 	Region 3: Memory at 86300000 (32-bit, non-prefetchable) [size=16K]
 	</PCI_DEVICE>
@@ -268,25 +268,26 @@
 	0009f000-000fffff : Reserved
 	  000a0000-000bffff : PCI Bus 0000:00
 	  000f0000-000fffff : System ROM
-	00100000-394ca017 : System RAM
-	394ca018-394fb857 : System RAM
-	394fb858-39522fff : System RAM
-	39523000-39523fff : Reserved
-	39524000-3cd3cfff : System RAM
+	00100000-37d8c017 : System RAM
+	37d8c018-37dbd857 : System RAM
+	37dbd858-394eafff : System RAM
+	394eb000-39505fff : Reserved
+	39506000-39506fff : System RAM
+	39507000-39507fff : Reserved
+	39508000-3cd3cfff : System RAM
 	3cd3d000-3ff10fff : Reserved
 	  3cdbc618-3cdbc618 : wdat_wdt
-	    3cdbc618-3cdbc618 : wdat_wdt wdat_wdt
 	3ff11000-3ffb2fff : ACPI Non-volatile Storage
 	  3ff5b000-3ff5bfff : USBC000:00
 	3ffb3000-4007efff : ACPI Tables
 	4007f000-4007ffff : System RAM
 	40080000-40080fff : Reserved
 	40081000-46bfffff : System RAM
-	46c00000-4f7fffff : Reserved
+	46c00000-48ffffff : Reserved
+	49100000-4f7fffff : Reserved
 	  4b800000-4f7fffff : Graphics Stolen Memory
 	4f800000-bfffffff : PCI Bus 0000:00
 	  4f800000-4f800fff : 0000:00:1f.5
-	    4f800000-4f800fff : 0000:00:1f.5 0000:00:1f.5
 	  50000000-5c1fffff : PCI Bus 0000:80
 	  5e000000-6a1fffff : PCI Bus 0000:56
 	  6c000000-781fffff : PCI Bus 0000:2c
@@ -344,12 +345,12 @@
 	fee00000-feefffff : pnp 00:04
 	  fee00000-fee00fff : Local APIC
 	ff400000-ffffffff : Reserved
-	100000000-4907fffff : System RAM
-	  378600000-3796036d6 : Kernel code
-	  379800000-379d9ffff : Kernel rodata
-	  379e00000-37a0859bf : Kernel data
-	  37ab2e000-37b1fffff : Kernel bss
-	490800000-493ffffff : RAM buffer
+	100000000-2a07fffff : System RAM
+	  1e3000000-1e3e00db6 : Kernel code
+	  1e4000000-1e4553fff : Kernel rodata
+	  1e4600000-1e487a83f : Kernel data
+	  1e4b34000-1e4ffffff : Kernel bss
+	2a0800000-2a3ffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
 	  4010000000-4016ffffff : 0000:00:02.0
@@ -361,7 +362,7 @@
 	  607c000000-607cffffff : 0000:00:02.0
 	  607d000000-607d1fffff : dwc_usb3
 	    607d000000-607d1fffff : 0000:00:14.1
-	      607d00c100-607d1fffff : dwc3.2.auto dwc_usb3
+	      607d00c100-607d1fffff : dwc3.1.auto dwc_usb3
 	  607d200000-607d3fffff : 0000:00:0d.1
 	  607d400000-607d43ffff : 0000:00:0d.3
 	    607d400000-607d43ffff : thunderbolt
@@ -376,11 +377,6 @@
 	  607d4c0000-607d4cffff : 0000:00:0d.0
 	    607d4c0000-607d4cffff : xhci-hcd
 	  607d4d0000-607d4d7fff : 0000:00:0a.0
-	    607d4d4000-607d4d48ff : telem0
-	    607d4d6198-607d4d61a7 : pmt_telemetry.1.auto
-	      607d4d6198-607d4d61a7 : pmt_telemetry.1.auto pmt_telemetry.1.auto
-	    607d4d61a8-607d4d61b7 : pmt_telemetry.1.auto
-	      607d4d61a8-607d4d61b7 : pmt_telemetry.1.auto pmt_telemetry.1.auto
 	  607d4d8000-607d4dbfff : 0000:00:14.2
 	  607d4dc000-607d4ddfff : 0000:00:1e.4
 	    607d4dc000-607d4ddfff : 0000:00:1e.4
@@ -448,11 +444,11 @@
 	  607d4ef000-607d4effff : 0000:00:08.0
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
+	/dev/sdb3: TYPE="ext4"
 	/dev/nvme0n1p3: TYPE="ext4"
 	/dev/sda3: TYPE="ext4"
-	/dev/sdb2: TYPE="ext4"
-	/dev/sdb3: TYPE="ext4"
-	/dev/sdb4: TYPE="ext4"
+	/dev/sdc1: TYPE="ext4"
+	/dev/sdc2: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
@@ -462,7 +458,7 @@
 	3, 5, 6, 7, 10, 11, 12, 13, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	15673924 kB
+	7698096 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -867,10 +863,10 @@
     <range start="0x0000000000100000" end="0x000000003cd3cfff" size="1019465728"/>
     <range start="0x000000004007f000" end="0x000000004007ffff" size="4096"/>
     <range start="0x0000000040081000" end="0x0000000046bfffff" size="112717824"/>
-    <range start="0x0000000100000000" end="0x00000004907fffff" size="15309209600"/>
+    <range start="0x0000000100000000" end="0x00000002a07fffff" size="6987710464"/>
   </memory>
   <devices>
-    <bus type="pci" address="0x0" id="0x9a14">
+    <bus type="pci" address="0x0" id="0x9a14" description="Host bridge: Intel Corporation">
       <vendor>0x8086</vendor>
       <identifier>0x9a14</identifier>
       <subsystem_vendor>0x8086</subsystem_vendor>
@@ -880,7 +876,7 @@
       <resource type="memory" min="0x4f800000" max="0xbfffffff" len="0x70800000"/>
       <resource type="memory" min="0x4000000000" max="0x7fffffffff" len="0x4000000000"/>
       <capability id="Vendor-Specific"/>
-      <device address="0x20000" id="0x9a49">
+      <device address="0x20000" id="0x9a49" description="VGA compatible controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a49</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -892,6 +888,7 @@
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="per-vector masking"/>
         </capability>
         <capability id="Power Management"/>
@@ -900,24 +897,28 @@
         <capability id="PRI"/>
         <capability id="SR-IOV"/>
       </device>
-      <device address="0x40000" id="0x9a03">
+      <device address="0x40000" id="0x9a03" description="Signal processing controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a03</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x118000</class>
         <resource type="memory" min="0x607d480000" max="0x607d49ffff" len="0x20000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x60000" id="0x9a09">
+      <device address="0x60000" id="0x9a09" description="PCI bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a09</identifier>
         <class>0x060400</class>
         <resource type="memory" min="0x86400000" max="0x864fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -930,7 +931,7 @@
         <capability id="Physical Layer 16.0 GT/s"/>
         <capability id="Lane Margining at the Receiver"/>
         <bus type="pci" address="0x1">
-          <device address="0x0" id="0xf1a5">
+          <device address="0x0" id="0xf1a5" description="Non-Volatile memory controller: Intel Corporation SSD 600P Series">
             <vendor>0x8086</vendor>
             <identifier>0xf1a5</identifier>
             <subsystem_vendor>0x8086</subsystem_vendor>
@@ -939,7 +940,13 @@
             <resource type="memory" min="0x86400000" max="0x86403fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -947,75 +954,85 @@
           </device>
         </bus>
       </device>
-      <device address="0x70000" id="0x9a23">
+      <device address="0x70000" id="0x9a23" description="PCI bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a23</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
         <resource type="memory" min="0x7a000000" max="0x861fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="ACS"/>
         <capability id="DPC"/>
         <bus type="pci" address="0x2"/>
       </device>
-      <device address="0x70001" id="0x9a25">
+      <device address="0x70001" id="0x9a25" description="PCI bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a25</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x5000" max="0x5fff" len="0x1000"/>
         <resource type="memory" min="0x6c000000" max="0x781fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="ACS"/>
         <capability id="DPC"/>
         <bus type="pci" address="0x2c"/>
       </device>
-      <device address="0x70002" id="0x9a27">
+      <device address="0x70002" id="0x9a27" description="PCI bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a27</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x6000" max="0x6fff" len="0x1000"/>
         <resource type="memory" min="0x5e000000" max="0x6a1fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="ACS"/>
         <capability id="DPC"/>
         <bus type="pci" address="0x56"/>
       </device>
-      <device address="0x70003" id="0x9a29">
+      <device address="0x70003" id="0x9a29" description="PCI bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a29</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x7000" max="0x7fff" len="0x1000"/>
         <resource type="memory" min="0x50000000" max="0x5c1fffff" len="0xc200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="ACS"/>
         <capability id="DPC"/>
         <bus type="pci" address="0x80"/>
       </device>
-      <device address="0x80000" id="0x9a11">
+      <device address="0x80000" id="0x9a11" description="System peripheral: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a11</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x088000</class>
         <resource type="memory" min="0x607d4ef000" max="0x607d4effff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Vendor-Specific"/>
         <capability id="Power Management"/>
         <capability id="Conventional PCI Advanced Features"/>
       </device>
-      <device address="0xa0000" id="0x9a0d">
+      <device address="0xa0000" id="0x9a0d" description="Signal processing controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a0d</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1028,7 +1045,7 @@
         <capability id="Designated Vendor-Specific"/>
         <capability id="Designated Vendor-Specific"/>
       </device>
-      <device address="0xd0000" id="0x9a13">
+      <device address="0xd0000" id="0x9a13" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a13</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1037,15 +1054,14 @@
         <resource type="memory" min="0x607d4c0000" max="0x607d4cffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0xd0001" id="0x9a15">
+      <device address="0xd0001" id="0x9a15" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a15</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1056,7 +1072,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0xd0002" id="0x9a1b">
+      <device address="0xd0002" id="0x9a1b" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a1b</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1066,11 +1082,18 @@
         <resource type="memory" min="0x607d4ed000" max="0x607d4edfff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>5</table_bir>
+          <table_offset>0xfa20000</table_offset>
+          <pba_bir>0</pba_bir>
+          <pba_offset>0x2000000</pba_offset>
+        </capability>
       </device>
-      <device address="0xd0003" id="0x9a1d">
+      <device address="0xd0003" id="0x9a1d" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0x9a1d</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1080,11 +1103,18 @@
         <resource type="memory" min="0x607d4ec000" max="0x607d4ecfff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
-        <capability id="MSI-X"/>
+        <capability id="MSI-X">
+          <table_size>16</table_size>
+          <table_bir>5</table_bir>
+          <table_offset>0xfa20000</table_offset>
+          <pba_bir>0</pba_bir>
+          <pba_offset>0x2000000</pba_offset>
+        </capability>
       </device>
-      <device address="0x100000" id="0xa0d8">
+      <device address="0x100000" id="0xa0d8" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0d8</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1094,7 +1124,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x100005" id="0xa0af">
+      <device address="0x100005" id="0xa0af" description="Host bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0af</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1102,7 +1132,7 @@
         <class>0x060000</class>
         <capability id="PCI Express"/>
       </device>
-      <device address="0x120000" id="0xa0fc">
+      <device address="0x120000" id="0xa0fc" description="Serial controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0fc</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1112,7 +1142,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x140000" id="0xa0ed">
+      <device address="0x140000" id="0xa0ed" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0ed</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1121,15 +1151,14 @@
         <resource type="memory" min="0x607d4a0000" max="0x607d4affff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x140001" id="0xa0ee">
+      <device address="0x140001" id="0xa0ee" description="USB controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0ee</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1140,7 +1169,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x140002" id="0xa0ef">
+      <device address="0x140002" id="0xa0ef" description="RAM memory: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0ef</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1150,7 +1179,7 @@
         <resource type="memory" min="0x607d4e9000" max="0x607d4e9fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
       </device>
-      <device address="0x150000" id="0xa0e8">
+      <device address="0x150000" id="0xa0e8" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0e8</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1160,7 +1189,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x150001" id="0xa0e9">
+      <device address="0x150001" id="0xa0e9" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0e9</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1170,7 +1199,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x150002" id="0xa0ea">
+      <device address="0x150002" id="0xa0ea" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0ea</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1180,7 +1209,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x150003" id="0xa0eb">
+      <device address="0x150003" id="0xa0eb" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0eb</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1190,7 +1219,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x160000" id="0xa0e0">
+      <device address="0x160000" id="0xa0e0" description="Communication controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0e0</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1199,11 +1228,12 @@
         <resource type="memory" min="0x607d4e4000" max="0x607d4e4fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x170000" id="0xa0d3">
+      <device address="0x170000" id="0xa0d3" description="SATA controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0d3</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1215,11 +1245,13 @@
         <resource type="memory" min="0x86620000" max="0x86621fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
         <resource type="memory" min="0x86623000" max="0x866237ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
         <resource type="memory" min="0x86624000" max="0x866240ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
-      <device address="0x190000" id="0xa0c5">
+      <device address="0x190000" id="0xa0c5" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0c5</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1229,7 +1261,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x190001" id="0xa0c6">
+      <device address="0x190001" id="0xa0c6" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0c6</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1239,13 +1271,15 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x1c0000" id="0xa0bc">
+      <device address="0x1c0000" id="0xa0bc" description="PCI bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0bc</identifier>
         <class>0x060400</class>
         <resource type="memory" min="0x86200000" max="0x863fffff" len="0x200000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -1254,7 +1288,7 @@
         <capability id="Secondary PCI Express"/>
         <capability id="DPC"/>
         <bus type="pci" address="0xaa">
-          <device address="0x0" id="0x15f2">
+          <device address="0x0" id="0x15f2" description="Ethernet controller: Intel Corporation">
             <vendor>0x8086</vendor>
             <identifier>0x15f2</identifier>
             <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1264,10 +1298,17 @@
             <resource type="memory" min="0x86300000" max="0x86303fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -1277,17 +1318,17 @@
           </device>
         </bus>
       </device>
-      <device address="0x1e0000" id="0xa0a8">
+      <device address="0x1e0000" id="0xa0a8" description="Communication controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0a8</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x078000</class>
-        <resource type="memory" min="0x607d4e1000" max="0x607d4e1fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
+        <resource type="memory" min="0x0" max="0xfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x1e0003" id="0xa0ab">
+      <device address="0x1e0003" id="0xa0ab" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0ab</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1297,7 +1338,7 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x1e0004" id="0xa0ac">
+      <device address="0x1e0004" id="0xa0ac" description="Ethernet controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0ac</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1308,22 +1349,21 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>32</count>
-          </capability>
+          <count>32</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
           <capability id="per-vector masking"/>
         </capability>
         <capability id="PCI Express"/>
       </device>
-      <device address="0x1f0000" id="0xa088">
+      <device address="0x1f0000" id="0xa088" description="ISA bridge: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa088</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x060100</class>
       </device>
-      <device address="0x1f0004" id="0xa0a3">
+      <device address="0x1f0004" id="0xa0a3" description="SMBus: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0a3</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1332,7 +1372,7 @@
         <resource type="io_port" min="0xefa0" max="0xefbf" len="0x20" id="bar4"/>
         <resource type="memory" min="0x607d4de000" max="0x607d4de0ff" len="0x100" id="bar0" width="64" prefetchable="0"/>
       </device>
-      <device address="0x1f0005" id="0xa0a4">
+      <device address="0x1f0005" id="0xa0a4" description="Serial bus controller: Intel Corporation">
         <vendor>0x8086</vendor>
         <identifier>0xa0a4</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1340,7 +1380,7 @@
         <class>0x0c8000</class>
         <resource type="memory" min="0x4f800000" max="0x4f800fff" len="0x1000" id="bar0" width="32" prefetchable="0"/>
       </device>
-      <device address="0x1f0006" id="0x15fc">
+      <device address="0x1f0006" id="0x15fc" description="Ethernet controller: Intel Corporation Ethernet Connection (13) I219-V">
         <vendor>0x8086</vendor>
         <identifier>0x15fc</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -1349,6 +1389,7 @@
         <resource type="memory" min="0x86600000" max="0x8661ffff" len="0x20000" id="bar0" width="32" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>

--- a/misc/config_tools/data/whl-ipc-i5/whl-ipc-i5.xml
+++ b/misc/config_tools/data/whl-ipc-i5/whl-ipc-i5.xml
@@ -13,36 +13,36 @@
 	Version: V1.0
 	</BASE_BOARD_INFO>
   <PCI_DEVICE>
-	00:00.0 Host bridge: Intel Corporation Device 3e34 (rev 0b)
-	00:02.0 VGA compatible controller: Intel Corporation Device 3ea0
+	00:00.0 Host bridge: Intel Corporation Coffee Lake HOST and DRAM Controller (rev 0b)
+	00:02.0 VGA compatible controller: Intel Corporation UHD Graphics 620 (Whiskey Lake)
 	Region 0: Memory at a0000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at 90000000 (64-bit, prefetchable) [size=256M]
-	00:12.0 Signal processing controller: Intel Corporation Device 9df9 (rev 30)
+	00:12.0 Signal processing controller: Intel Corporation Cannon Point-LP Thermal Controller (rev 30)
 	Region 0: Memory at a141e000 (64-bit, non-prefetchable) [size=4K]
-	00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)
+	00:14.0 USB controller: Intel Corporation Cannon Point-LP USB 3.1 xHCI Controller (rev 30)
 	Region 0: Memory at a1400000 (64-bit, non-prefetchable) [size=64K]
-	00:14.2 RAM memory: Intel Corporation Device 9def (rev 30)
+	00:14.2 RAM memory: Intel Corporation Cannon Point-LP Shared SRAM (rev 30)
 	Region 0: Memory at a1416000 (64-bit, non-prefetchable) [disabled] [size=8K]
 	Region 2: Memory at a141d000 (64-bit, non-prefetchable) [disabled] [size=4K]
-	00:16.0 Communication controller: Intel Corporation Device 9de0 (rev 30)
+	00:16.0 Communication controller: Intel Corporation Cannon Point-LP MEI Controller #1 (rev 30)
 	Region 0: Memory at a141c000 (64-bit, non-prefetchable) [size=4K]
-	00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)
+	00:17.0 SATA controller: Intel Corporation Cannon Point-LP SATA Controller [AHCI Mode] (rev 30)
 	Region 0: Memory at a1414000 (32-bit, non-prefetchable) [size=8K]
 	Region 1: Memory at a141b000 (32-bit, non-prefetchable) [size=256]
 	Region 5: Memory at a141a000 (32-bit, non-prefetchable) [size=2K]
 	00:1a.0 SD Host controller: Intel Corporation Device 9dc4 (rev 30)
 	Region 0: Memory at a1419000 (64-bit, non-prefetchable) [size=4K]
-	00:1c.0 PCI bridge: Intel Corporation Device 9db8 (rev f0)
-	00:1c.4 PCI bridge: Intel Corporation Device 9dbc (rev f0)
-	00:1d.0 PCI bridge: Intel Corporation Device 9db0 (rev f0)
-	00:1d.1 PCI bridge: Intel Corporation Device 9db1 (rev f0)
-	00:1f.0 ISA bridge: Intel Corporation Device 9d84 (rev 30)
-	00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)
+	00:1c.0 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #1 (rev f0)
+	00:1c.4 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #5 (rev f0)
+	00:1d.0 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #9 (rev f0)
+	00:1d.1 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #10 (rev f0)
+	00:1f.0 ISA bridge: Intel Corporation Cannon Point-LP LPC Controller (rev 30)
+	00:1f.3 Audio device: Intel Corporation Cannon Point-LP High Definition Audio Controller (rev 30)
 	Region 0: Memory at a1410000 (64-bit, non-prefetchable) [size=16K]
 	Region 4: Memory at a1000000 (64-bit, non-prefetchable) [size=1M]
-	00:1f.4 SMBus: Intel Corporation Device 9da3 (rev 30)
+	00:1f.4 SMBus: Intel Corporation Cannon Point-LP SMBus Controller (rev 30)
 	Region 0: Memory at a1418000 (64-bit, non-prefetchable) [size=256]
-	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 9da4 (rev 30)
+	00:1f.5 Serial bus controller [0c80]: Intel Corporation Cannon Point-LP SPI Controller (rev 30)
 	Region 0: Memory at fe010000 (32-bit, non-prefetchable) [size=4K]
 	02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)
 	Region 0: Memory at a1300000 (64-bit, non-prefetchable) [size=16K]
@@ -170,11 +170,11 @@
 	00100000-3fffffff : System RAM
 	40000000-403fffff : Reserved
 	  40000000-403fffff : pnp 00:00
-	40400000-829ba017 : System RAM
-	829ba018-829ca657 : System RAM
-	829ca658-829cb017 : System RAM
-	829cb018-829db057 : System RAM
-	829db058-83b29fff : System RAM
+	40400000-8289a017 : System RAM
+	8289a018-828aa657 : System RAM
+	828aa658-828ab017 : System RAM
+	828ab018-828bb057 : System RAM
+	828bb058-83b29fff : System RAM
 	83b2a000-83b2afff : ACPI Non-volatile Storage
 	83b2b000-83b2bfff : Reserved
 	83b2c000-89fbefff : System RAM
@@ -189,7 +189,7 @@
 	  90000000-9fffffff : 0000:00:02.0
 	  a0000000-a0ffffff : 0000:00:02.0
 	  a1000000-a10fffff : 0000:00:1f.3
-	    a1000000-a10fffff : Audio DSP
+	    a1000000-a10fffff : ICH HD audio
 	  a1100000-a11fffff : PCI Bus 0000:04
 	    a1100000-a111ffff : 0000:04:00.0
 	      a1100000-a111ffff : igb
@@ -206,7 +206,7 @@
 	  a1400000-a140ffff : 0000:00:14.0
 	    a1400000-a140ffff : xhci-hcd
 	  a1410000-a1413fff : 0000:00:1f.3
-	    a1410000-a1413fff : Audio DSP
+	    a1410000-a1413fff : ICH HD audio
 	  a1414000-a1415fff : 0000:00:17.0
 	    a1414000-a1415fff : ahci
 	  a1416000-a1417fff : 0000:00:14.2
@@ -251,29 +251,30 @@
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : pnp 00:0e
 	100000000-26dffffff : System RAM
-	  22f600000-2302010d6 : Kernel code
-	  230400000-230724fff : Kernel rodata
-	  230800000-2309a09bf : Kernel data
-	  230eb0000-230ffffff : Kernel bss
+	  165400000-166200db6 : Kernel code
+	  166400000-16693afff : Kernel rodata
+	  166a00000-166c80cbf : Kernel data
+	  166f37000-1673fffff : Kernel bss
 	26e000000-26fffffff : RAM buffer
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
-	/dev/nvme0n1p3: TYPE="ext4"
-	/dev/sda2: TYPE="ext4"
+	/dev/sda3: TYPE="ext4"
+	/dev/nvme0n1p2: TYPE="ext4"
 	/dev/sdb2: TYPE="ext4"
-	/dev/sdb3: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
 	seri:/dev/ttyS1 type:portio base:0x2F8 irq:3
 	seri:/dev/ttyS2 type:portio base:0x3E8 irq:7
 	seri:/dev/ttyS3 type:portio base:0x2E8 irq:7
+	seri:/dev/ttyS4 type:portio base:0x2F0 irq:7
+	seri:/dev/ttyS5 type:portio base:0x2E0 irq:7
 	</TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
-	5, 6, 10, 11, 13, 14, 15
+	6, 10, 11, 13, 14, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	8019828 kB
+	8016876 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -634,7 +635,7 @@
     <range start="0x0000000100000000" end="0x000000026dffffff" size="6140461056"/>
   </memory>
   <devices>
-    <bus type="pci" address="0x0" id="0x3e34" description="Host bridge: Intel Corporation">
+    <bus type="pci" address="0x0" id="0x3e34" description="Host bridge: Intel Corporation Coffee Lake HOST and DRAM Controller">
       <vendor>0x8086</vendor>
       <identifier>0x3e34</identifier>
       <subsystem_vendor>0x8086</subsystem_vendor>
@@ -644,7 +645,7 @@
       <resource type="memory" min="0x90000000" max="0xdfffffff" len="0x50000000"/>
       <resource type="memory" min="0xfc800000" max="0xfe7fffff" len="0x2000000"/>
       <capability id="Vendor-Specific"/>
-      <device address="0x20000" id="0x3ea0" description="VGA compatible controller: Intel Corporation">
+      <device address="0x20000" id="0x3ea0" description="VGA compatible controller: Intel Corporation UHD Graphics 620 (Whiskey Lake)">
         <vendor>0x8086</vendor>
         <identifier>0x3ea0</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -655,13 +656,15 @@
         <resource type="memory" min="0xa0000000" max="0xa0ffffff" len="0x1000000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="PASID"/>
         <capability id="ATS"/>
         <capability id="PRI"/>
       </device>
-      <device address="0x120000" id="0x9df9" description="Signal processing controller: Intel Corporation">
+      <device address="0x120000" id="0x9df9" description="Signal processing controller: Intel Corporation Cannon Point-LP Thermal Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9df9</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -669,9 +672,11 @@
         <class>0x118000</class>
         <resource type="memory" min="0xa141e000" max="0xa141efff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
       </device>
-      <device address="0x140000" id="0x9ded" description="USB controller: Intel Corporation">
+      <device address="0x140000" id="0x9ded" description="USB controller: Intel Corporation Cannon Point-LP USB 3.1 xHCI Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9ded</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -680,14 +685,13 @@
         <resource type="memory" min="0xa1400000" max="0xa140ffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x140002" id="0x9def" description="RAM memory: Intel Corporation">
+      <device address="0x140002" id="0x9def" description="RAM memory: Intel Corporation Cannon Point-LP Shared SRAM">
         <vendor>0x8086</vendor>
         <identifier>0x9def</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -697,7 +701,7 @@
         <resource type="memory" min="0xa141d000" max="0xa141dfff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
       </device>
-      <device address="0x160000" id="0x9de0" description="Communication controller: Intel Corporation">
+      <device address="0x160000" id="0x9de0" description="Communication controller: Intel Corporation Cannon Point-LP MEI Controller #1">
         <vendor>0x8086</vendor>
         <identifier>0x9de0</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -706,11 +710,12 @@
         <resource type="memory" min="0xa141c000" max="0xa141cfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x170000" id="0x9dd3" description="SATA controller: Intel Corporation">
+      <device address="0x170000" id="0x9dd3" description="SATA controller: Intel Corporation Cannon Point-LP SATA Controller [AHCI Mode]">
         <vendor>0x8086</vendor>
         <identifier>0x9dd3</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -722,7 +727,9 @@
         <resource type="memory" min="0xa1414000" max="0xa1415fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
         <resource type="memory" min="0xa141a000" max="0xa141a7ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
         <resource type="memory" min="0xa141b000" max="0xa141b0ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
@@ -736,23 +743,27 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x1c0000" id="0x9db8" description="PCI bridge: Intel Corporation">
+      <device address="0x1c0000" id="0x9db8" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #1">
         <vendor>0x8086</vendor>
         <identifier>0x9db8</identifier>
         <class>0x060400</class>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <bus type="pci" address="0x1"/>
       </device>
-      <device address="0x1c0004" id="0x9dbc" description="PCI bridge: Intel Corporation">
+      <device address="0x1c0004" id="0x9dbc" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #5">
         <vendor>0x8086</vendor>
         <identifier>0x9dbc</identifier>
         <class>0x060400</class>
         <resource type="memory" min="0xa1300000" max="0xa13fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -770,14 +781,19 @@
             <resource type="memory" min="0xa1300000" max="0xa1303fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
             <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
             <capability id="LTR"/>
@@ -785,14 +801,16 @@
           </device>
         </bus>
       </device>
-      <device address="0x1d0000" id="0x9db0" description="PCI bridge: Intel Corporation">
+      <device address="0x1d0000" id="0x9db0" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #9">
         <vendor>0x8086</vendor>
         <identifier>0x9db0</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
         <resource type="memory" min="0xa1200000" max="0xa12fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -812,10 +830,17 @@
             <resource type="memory" min="0xa1220000" max="0xa1223fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -823,14 +848,16 @@
           </device>
         </bus>
       </device>
-      <device address="0x1d0001" id="0x9db1" description="PCI bridge: Intel Corporation">
+      <device address="0x1d0001" id="0x9db1" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #10">
         <vendor>0x8086</vendor>
         <identifier>0x9db1</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x3000" max="0x3fff" len="0x1000"/>
         <resource type="memory" min="0xa1100000" max="0xa11fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -850,10 +877,17 @@
             <resource type="memory" min="0xa1120000" max="0xa1123fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -861,14 +895,14 @@
           </device>
         </bus>
       </device>
-      <device address="0x1f0000" id="0x9d84" description="ISA bridge: Intel Corporation">
+      <device address="0x1f0000" id="0x9d84" description="ISA bridge: Intel Corporation Cannon Point-LP LPC Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9d84</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x060100</class>
       </device>
-      <device address="0x1f0003" id="0x9dc8" description="Audio device: Intel Corporation">
+      <device address="0x1f0003" id="0x9dc8" description="Audio device: Intel Corporation Cannon Point-LP High Definition Audio Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9dc8</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -879,10 +913,11 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
-      <device address="0x1f0004" id="0x9da3" description="SMBus: Intel Corporation">
+      <device address="0x1f0004" id="0x9da3" description="SMBus: Intel Corporation Cannon Point-LP SMBus Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9da3</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -891,7 +926,7 @@
         <resource type="io_port" min="0xefa0" max="0xefbf" len="0x20" id="bar4"/>
         <resource type="memory" min="0xa1418000" max="0xa14180ff" len="0x100" id="bar0" width="64" prefetchable="0"/>
       </device>
-      <device address="0x1f0005" id="0x9da4" description="Serial bus controller: Intel Corporation">
+      <device address="0x1f0005" id="0x9da4" description="Serial bus controller: Intel Corporation Cannon Point-LP SPI Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9da4</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>

--- a/misc/config_tools/data/whl-ipc-i7/whl-ipc-i7.xml
+++ b/misc/config_tools/data/whl-ipc-i7/whl-ipc-i7.xml
@@ -13,38 +13,38 @@
 	Version: V1.0
 	</BASE_BOARD_INFO>
   <PCI_DEVICE>
-	00:00.0 Host bridge: Intel Corporation Device 3e34 (rev 0b)
-	00:02.0 VGA compatible controller: Intel Corporation Device 3ea0
+	00:00.0 Host bridge: Intel Corporation Coffee Lake HOST and DRAM Controller (rev 0b)
+	00:02.0 VGA compatible controller: Intel Corporation UHD Graphics 620 (Whiskey Lake)
 	Region 0: Memory at a0000000 (64-bit, non-prefetchable) [size=16M]
 	Region 2: Memory at 90000000 (64-bit, prefetchable) [size=256M]
-	00:12.0 Signal processing controller: Intel Corporation Device 9df9 (rev 30)
+	00:12.0 Signal processing controller: Intel Corporation Cannon Point-LP Thermal Controller (rev 30)
 	Region 0: Memory at 400011a000 (64-bit, non-prefetchable) [size=4K]
-	00:14.0 USB controller: Intel Corporation Device 9ded (rev 30)
+	00:14.0 USB controller: Intel Corporation Cannon Point-LP USB 3.1 xHCI Controller (rev 30)
 	Region 0: Memory at 4000100000 (64-bit, non-prefetchable) [size=64K]
-	00:14.2 RAM memory: Intel Corporation Device 9def (rev 30)
+	00:14.2 RAM memory: Intel Corporation Cannon Point-LP Shared SRAM (rev 30)
 	Region 0: Memory at 4000114000 (64-bit, non-prefetchable) [disabled] [size=8K]
 	Region 2: Memory at 4000119000 (64-bit, non-prefetchable) [disabled] [size=4K]
-	00:16.0 Communication controller: Intel Corporation Device 9de0 (rev 30)
+	00:16.0 Communication controller: Intel Corporation Cannon Point-LP MEI Controller #1 (rev 30)
 	Region 0: Memory at 4000118000 (64-bit, non-prefetchable) [size=4K]
-	00:17.0 SATA controller: Intel Corporation Device 9dd3 (rev 30)
+	00:17.0 SATA controller: Intel Corporation Cannon Point-LP SATA Controller [AHCI Mode] (rev 30)
 	Region 0: Memory at a1300000 (32-bit, non-prefetchable) [size=8K]
 	Region 1: Memory at a1303000 (32-bit, non-prefetchable) [size=256]
 	Region 5: Memory at a1302000 (32-bit, non-prefetchable) [size=2K]
 	00:1a.0 SD Host controller: Intel Corporation Device 9dc4 (rev 30)
 	Region 0: Memory at 4000117000 (64-bit, non-prefetchable) [size=4K]
-	00:1c.0 PCI bridge: Intel Corporation Device 9db8 (rev f0)
-	00:1c.4 PCI bridge: Intel Corporation Device 9dbc (rev f0)
-	00:1d.0 PCI bridge: Intel Corporation Device 9db0 (rev f0)
-	00:1d.1 PCI bridge: Intel Corporation Device 9db1 (rev f0)
-	00:1f.0 ISA bridge: Intel Corporation Device 9d84 (rev 30)
-	00:1f.3 Audio device: Intel Corporation Device 9dc8 (rev 30)
+	00:1c.0 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #1 (rev f0)
+	00:1c.4 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #5 (rev f0)
+	00:1d.0 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #9 (rev f0)
+	00:1d.1 PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #10 (rev f0)
+	00:1f.0 ISA bridge: Intel Corporation Cannon Point-LP LPC Controller (rev 30)
+	00:1f.3 Audio device: Intel Corporation Cannon Point-LP High Definition Audio Controller (rev 30)
 	Region 0: Memory at 4000110000 (64-bit, non-prefetchable) [size=16K]
 	Region 4: Memory at 4000000000 (64-bit, non-prefetchable) [size=1M]
-	00:1f.4 SMBus: Intel Corporation Device 9da3 (rev 30)
+	00:1f.4 SMBus: Intel Corporation Cannon Point-LP SMBus Controller (rev 30)
 	Region 0: Memory at 4000116000 (64-bit, non-prefetchable) [size=256]
-	00:1f.5 Serial bus controller [0c80]: Intel Corporation Device 9da4 (rev 30)
+	00:1f.5 Serial bus controller [0c80]: Intel Corporation Cannon Point-LP SPI Controller (rev 30)
 	Region 0: Memory at fe010000 (32-bit, non-prefetchable) [size=4K]
-	02:00.0 Non-Volatile memory controller: Device 1987:5013 (rev 01)
+	02:00.0 Non-Volatile memory controller: Intel Corporation SSD Pro 7600p/760p/E 6100p Series (rev 03)
 	Region 0: Memory at a1200000 (64-bit, non-prefetchable) [size=16K]
 	03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
 	Region 0: Memory at a1100000 (32-bit, non-prefetchable) [size=128K]
@@ -70,7 +70,7 @@
 	00:1f.3 0403: 8086:9dc8 (rev 30)
 	00:1f.4 0c05: 8086:9da3 (rev 30)
 	00:1f.5 0c80: 8086:9da4 (rev 30)
-	02:00.0 0108: 1987:5013 (rev 01)
+	02:00.0 0108: 8086:f1a6 (rev 03)
 	03:00.0 0200: 8086:157b (rev 03)
 	04:00.0 0200: 8086:157b (rev 03)
 	</PCI_VID_PID>
@@ -170,14 +170,14 @@
 	00100000-3fffffff : System RAM
 	40000000-403fffff : Reserved
 	  40000000-403fffff : pnp 00:00
-	40400000-82383017 : System RAM
-	82383018-82393657 : System RAM
-	82393658-82394017 : System RAM
-	82394018-823a4057 : System RAM
-	823a4058-834f2fff : System RAM
-	834f3000-834f3fff : ACPI Non-volatile Storage
-	834f4000-834f4fff : Reserved
-	834f5000-89f8cfff : System RAM
+	40400000-82339017 : System RAM
+	82339018-82349657 : System RAM
+	82349658-8234a017 : System RAM
+	8234a018-8235a057 : System RAM
+	8235a058-835c8fff : System RAM
+	835c9000-835c9fff : ACPI Non-volatile Storage
+	835ca000-835cafff : Reserved
+	835cb000-89f8cfff : System RAM
 	89f8d000-8a3f8fff : Reserved
 	8a3f9000-8a475fff : ACPI Tables
 	8a476000-8a8aafff : ACPI Non-volatile Storage
@@ -200,6 +200,7 @@
 	      a1120000-a1123fff : igb
 	  a1200000-a12fffff : PCI Bus 0000:02
 	    a1200000-a1203fff : 0000:02:00.0
+	      a1200000-a1203fff : nvme
 	  a1300000-a1301fff : 0000:00:17.0
 	    a1300000-a1301fff : ahci
 	  a1302000-a13027ff : 0000:00:17.0
@@ -235,18 +236,18 @@
 	ff000000-ffffffff : Reserved
 	  ff000000-ffffffff : pnp 00:0e
 	100000000-26dffffff : System RAM
-	  12ce00000-12da010d6 : Kernel code
-	  12dc00000-12df24fff : Kernel rodata
-	  12e000000-12e1a09bf : Kernel data
-	  12e6b0000-12e7fffff : Kernel bss
+	  1b7400000-1b8200db6 : Kernel code
+	  1b8400000-1b893afff : Kernel rodata
+	  1b8a00000-1b8c80cbf : Kernel data
+	  1b8f37000-1b93fffff : Kernel bss
 	26e000000-26fffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-40000fffff : 0000:00:1f.3
-	    4000000000-40000fffff : Audio DSP
+	    4000000000-40000fffff : ICH HD audio
 	  4000100000-400010ffff : 0000:00:14.0
 	    4000100000-400010ffff : xhci-hcd
 	  4000110000-4000113fff : 0000:00:1f.3
-	    4000110000-4000113fff : Audio DSP
+	    4000110000-4000113fff : ICH HD audio
 	  4000114000-4000115fff : 0000:00:14.2
 	  4000116000-40001160ff : 0000:00:1f.4
 	  4000117000-4000117fff : 0000:00:1a.0
@@ -259,26 +260,27 @@
 	</IOMEM_INFO>
   <BLOCK_DEVICE_INFO>
 	/dev/sda3: TYPE="ext4"
-	/dev/sdb2: TYPE="ext4"
-	/dev/sdb3: TYPE="ext4"
+	/dev/nvme0n1p2: TYPE="ext4"
 	</BLOCK_DEVICE_INFO>
   <TTYS_INFO>
 	seri:/dev/ttyS0 type:portio base:0x3F8 irq:4
 	seri:/dev/ttyS1 type:portio base:0x2F8 irq:3
 	seri:/dev/ttyS2 type:portio base:0x3E8 irq:7
 	seri:/dev/ttyS3 type:portio base:0x2E8 irq:7
+	seri:/dev/ttyS4 type:portio base:0x2F0 irq:7
+	seri:/dev/ttyS5 type:portio base:0x2E0 irq:7
 	</TTYS_INFO>
   <AVAILABLE_IRQ_INFO>
-	5, 6, 10, 11, 13, 14, 15
+	6, 10, 11, 13, 14, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	8019628 kB
+	8016676 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
 	</CPU_PROCESSOR_INFO>
   <MAX_MSIX_TABLE_NUM>
-	9
+	16
 	</MAX_MSIX_TABLE_NUM>
   <processors>
     <model description="Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz">
@@ -627,13 +629,13 @@
     <range start="0x0000000000000000" end="0x000000000005efff" size="389120"/>
     <range start="0x0000000000060000" end="0x000000000009ffff" size="262144"/>
     <range start="0x0000000000100000" end="0x000000003fffffff" size="1072693248"/>
-    <range start="0x0000000040400000" end="0x00000000834f2fff" size="1125068800"/>
-    <range start="0x00000000834f5000" end="0x0000000089f8cfff" size="111771648"/>
+    <range start="0x0000000040400000" end="0x00000000835c8fff" size="1125945344"/>
+    <range start="0x00000000835cb000" end="0x0000000089f8cfff" size="110895104"/>
     <range start="0x000000008aeff000" end="0x000000008aefffff" size="4096"/>
     <range start="0x0000000100000000" end="0x000000026dffffff" size="6140461056"/>
   </memory>
   <devices>
-    <bus type="pci" address="0x0" id="0x3e34" description="Host bridge: Intel Corporation">
+    <bus type="pci" address="0x0" id="0x3e34" description="Host bridge: Intel Corporation Coffee Lake HOST and DRAM Controller">
       <vendor>0x8086</vendor>
       <identifier>0x3e34</identifier>
       <subsystem_vendor>0x8086</subsystem_vendor>
@@ -644,7 +646,7 @@
       <resource type="memory" min="0xfc800000" max="0xfe7fffff" len="0x2000000"/>
       <resource type="memory" min="0x4000000000" max="0x7fffffffff" len="0x4000000000"/>
       <capability id="Vendor-Specific"/>
-      <device address="0x20000" id="0x3ea0" description="VGA compatible controller: Intel Corporation">
+      <device address="0x20000" id="0x3ea0" description="VGA compatible controller: Intel Corporation UHD Graphics 620 (Whiskey Lake)">
         <vendor>0x8086</vendor>
         <identifier>0x3ea0</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -655,13 +657,15 @@
         <resource type="memory" min="0xa0000000" max="0xa0ffffff" len="0x1000000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Vendor-Specific"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="PASID"/>
         <capability id="ATS"/>
         <capability id="PRI"/>
       </device>
-      <device address="0x120000" id="0x9df9" description="Signal processing controller: Intel Corporation">
+      <device address="0x120000" id="0x9df9" description="Signal processing controller: Intel Corporation Cannon Point-LP Thermal Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9df9</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -669,9 +673,11 @@
         <class>0x118000</class>
         <resource type="memory" min="0x400011a000" max="0x400011afff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
       </device>
-      <device address="0x140000" id="0x9ded" description="USB controller: Intel Corporation">
+      <device address="0x140000" id="0x9ded" description="USB controller: Intel Corporation Cannon Point-LP USB 3.1 xHCI Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9ded</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -680,14 +686,13 @@
         <resource type="memory" min="0x4000100000" max="0x400010ffff" len="0x10000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
-          <capability id="multiple-message">
-            <count>8</count>
-          </capability>
+          <count>8</count>
+          <capability id="multiple-message"/>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x140002" id="0x9def" description="RAM memory: Intel Corporation">
+      <device address="0x140002" id="0x9def" description="RAM memory: Intel Corporation Cannon Point-LP Shared SRAM">
         <vendor>0x8086</vendor>
         <identifier>0x9def</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -697,7 +702,7 @@
         <resource type="memory" min="0x4000119000" max="0x4000119fff" len="0x1000" id="bar2" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
       </device>
-      <device address="0x160000" id="0x9de0" description="Communication controller: Intel Corporation">
+      <device address="0x160000" id="0x9de0" description="Communication controller: Intel Corporation Cannon Point-LP MEI Controller #1">
         <vendor>0x8086</vendor>
         <identifier>0x9de0</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -706,11 +711,12 @@
         <resource type="memory" min="0x4000118000" max="0x4000118fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
         <capability id="Power Management"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x170000" id="0x9dd3" description="SATA controller: Intel Corporation">
+      <device address="0x170000" id="0x9dd3" description="SATA controller: Intel Corporation Cannon Point-LP SATA Controller [AHCI Mode]">
         <vendor>0x8086</vendor>
         <identifier>0x9dd3</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -722,7 +728,9 @@
         <resource type="memory" min="0xa1300000" max="0xa1301fff" len="0x2000" id="bar0" width="32" prefetchable="0"/>
         <resource type="memory" min="0xa1302000" max="0xa13027ff" len="0x800" id="bar5" width="32" prefetchable="0"/>
         <resource type="memory" min="0xa1303000" max="0xa13030ff" len="0x100" id="bar1" width="32" prefetchable="0"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Power Management"/>
         <capability id="Reserved (0x12)"/>
       </device>
@@ -736,23 +744,27 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
       </device>
-      <device address="0x1c0000" id="0x9db8" description="PCI bridge: Intel Corporation">
+      <device address="0x1c0000" id="0x9db8" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #1">
         <vendor>0x8086</vendor>
         <identifier>0x9db8</identifier>
         <class>0x060400</class>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <bus type="pci" address="0x1"/>
       </device>
-      <device address="0x1c0004" id="0x9dbc" description="PCI bridge: Intel Corporation">
+      <device address="0x1c0004" id="0x9dbc" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #5">
         <vendor>0x8086</vendor>
         <identifier>0x9dbc</identifier>
         <class>0x060400</class>
         <resource type="memory" min="0xa1200000" max="0xa12fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -761,38 +773,45 @@
         <capability id="Secondary PCI Express"/>
         <capability id="DPC"/>
         <bus type="pci" address="0x2">
-          <device address="0x0" id="0x5013" description="Non-Volatile memory controller:">
-            <vendor>0x1987</vendor>
-            <identifier>0x5013</identifier>
-            <subsystem_vendor>0x1987</subsystem_vendor>
-            <subsystem_identifier>0x5013</subsystem_identifier>
+          <device address="0x0" id="0xf1a6" description="Non-Volatile memory controller: Intel Corporation SSD Pro 7600p/760p/E 6100p Series">
+            <vendor>0x8086</vendor>
+            <identifier>0xf1a6</identifier>
+            <subsystem_vendor>0x8086</subsystem_vendor>
+            <subsystem_identifier>0x390b</subsystem_identifier>
             <class>0x010802</class>
             <resource type="memory" min="0xa1200000" max="0xa1203fff" len="0x4000" id="bar0" width="64" prefetchable="0"/>
-            <capability id="PCI Express"/>
-            <capability id="MSI-X"/>
+            <capability id="Power Management"/>
             <capability id="MSI">
-              <capability id="multiple-message">
-                <count>8</count>
-              </capability>
+              <count>8</count>
+              <capability id="multiple-message"/>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="Power Management"/>
-            <capability id="LTR"/>
-            <capability id="L1 PM Substates"/>
+            <capability id="PCI Express"/>
+            <capability id="MSI-X">
+              <table_size>16</table_size>
+              <table_bir>1</table_bir>
+              <table_offset>0x1000000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="Advanced Error Reporting"/>
             <capability id="Secondary PCI Express"/>
+            <capability id="LTR"/>
+            <capability id="L1 PM Substates"/>
           </device>
         </bus>
       </device>
-      <device address="0x1d0000" id="0x9db0" description="PCI bridge: Intel Corporation">
+      <device address="0x1d0000" id="0x9db0" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #9">
         <vendor>0x8086</vendor>
         <identifier>0x9db0</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x4000" max="0x4fff" len="0x1000"/>
         <resource type="memory" min="0xa1100000" max="0xa11fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -812,10 +831,17 @@
             <resource type="memory" min="0xa1120000" max="0xa1123fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -823,14 +849,16 @@
           </device>
         </bus>
       </device>
-      <device address="0x1d0001" id="0x9db1" description="PCI bridge: Intel Corporation">
+      <device address="0x1d0001" id="0x9db1" description="PCI bridge: Intel Corporation Cannon Point-LP PCI Express Root Port #10">
         <vendor>0x8086</vendor>
         <identifier>0x9db1</identifier>
         <class>0x060400</class>
         <resource type="io_port" min="0x3000" max="0x3fff" len="0x1000"/>
         <resource type="memory" min="0xa1000000" max="0xa10fffff" len="0x100000"/>
         <capability id="PCI Express"/>
-        <capability id="MSI"/>
+        <capability id="MSI">
+          <count>1</count>
+        </capability>
         <capability id="Subsystem ID and Subsystem Vendor ID"/>
         <capability id="Power Management"/>
         <capability id="Advanced Error Reporting"/>
@@ -850,10 +878,17 @@
             <resource type="memory" min="0xa1020000" max="0xa1023fff" len="0x4000" id="bar3" width="32" prefetchable="0"/>
             <capability id="Power Management"/>
             <capability id="MSI">
+              <count>1</count>
               <capability id="64-bit address"/>
               <capability id="per-vector masking"/>
             </capability>
-            <capability id="MSI-X"/>
+            <capability id="MSI-X">
+              <table_size>5</table_size>
+              <table_bir>7</table_bir>
+              <table_offset>0x30000</table_offset>
+              <pba_bir>1</pba_bir>
+              <pba_offset>0x0</pba_offset>
+            </capability>
             <capability id="PCI Express"/>
             <capability id="Advanced Error Reporting"/>
             <capability id="Device Serial Number"/>
@@ -861,14 +896,14 @@
           </device>
         </bus>
       </device>
-      <device address="0x1f0000" id="0x9d84" description="ISA bridge: Intel Corporation">
+      <device address="0x1f0000" id="0x9d84" description="ISA bridge: Intel Corporation Cannon Point-LP LPC Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9d84</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
         <subsystem_identifier>0x7270</subsystem_identifier>
         <class>0x060100</class>
       </device>
-      <device address="0x1f0003" id="0x9dc8" description="Audio device: Intel Corporation">
+      <device address="0x1f0003" id="0x9dc8" description="Audio device: Intel Corporation Cannon Point-LP High Definition Audio Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9dc8</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -879,10 +914,11 @@
         <capability id="Power Management"/>
         <capability id="Vendor-Specific"/>
         <capability id="MSI">
+          <count>1</count>
           <capability id="64-bit address"/>
         </capability>
       </device>
-      <device address="0x1f0004" id="0x9da3" description="SMBus: Intel Corporation">
+      <device address="0x1f0004" id="0x9da3" description="SMBus: Intel Corporation Cannon Point-LP SMBus Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9da3</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>
@@ -891,7 +927,7 @@
         <resource type="io_port" min="0xefa0" max="0xefbf" len="0x20" id="bar4"/>
         <resource type="memory" min="0x4000116000" max="0x40001160ff" len="0x100" id="bar0" width="64" prefetchable="0"/>
       </device>
-      <device address="0x1f0005" id="0x9da4" description="Serial bus controller: Intel Corporation">
+      <device address="0x1f0005" id="0x9da4" description="Serial bus controller: Intel Corporation Cannon Point-LP SPI Controller">
         <vendor>0x8086</vendor>
         <identifier>0x9da4</identifier>
         <subsystem_vendor>0x8086</subsystem_vendor>


### PR DESCRIPTION
The PR 6236 has modified the board.xml format for MAX_MSIX_TABLE_NUM fix.
To compromise this PR, updates all the source file board.xmls.

Tracked-On: #6235
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>