### PR TITLE
[release_2.3.1] hv: minor coding style fix in list.h

### DIFF
--- a/hypervisor/include/lib/list.h
+++ b/hypervisor/include/lib/list.h
@@ -119,7 +119,7 @@ static inline void list_splice_init(struct list_head *list,
 }
 
 #define container_of(ptr, type, member) \
-	((type *)((char *)(ptr)-offsetof(type, member)))
+	((type *)(((char *)(ptr)) - offsetof(type, member)))
 
 #define list_for_each(pos, head) \
 	for ((pos) = (head)->next; (pos) != (head); (pos) = (pos)->next)


### PR DESCRIPTION
 To add brakets for '(char *)(ptr)' in MACRO
 container_of(), which may be used recursively.

Tracked-On: #6284
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>