### PR TITLE
[Release 2.5]HV: vm_load: build vrsdp after VM image loaded

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -897,9 +897,6 @@ void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config)
 	err = create_vm(vm_id, vm_config->cpu_affinity, vm_config, &vm);
 
 	if (err == 0) {
-		if (is_prelaunched_vm(vm)) {
-			build_vrsdp(vm);
-		}
 
 		if (is_sos_vm(vm)) {
 			/* We need to ensure all modules of pre-launched VMs have been loaded already
@@ -922,6 +919,7 @@ void prepare_vm(uint16_t vm_id, struct acrn_vm_config *vm_config)
 		err = vm_sw_loader(vm);
 
 		if (is_prelaunched_vm(vm)) {
+			build_vrsdp(vm);
 			loaded_pre_vm_nr++;
 		}
 


### PR DESCRIPTION
The vRSDP region of pre-launched VM is located at 0xf2400, it could be
overlapped with the memory space of the raw image so be overriden by
raw image loading. In this case VM would be failed to find ACPI table.
This patch fix this issue by loading raw image first and then building
vRSDP later.

Tracked-On: #6305

Signed-off-by: Victor Sun <victor.sun@intel.com>