### PR TITLE
hv:  expose PMC to core partition VM

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -395,8 +395,14 @@ int32_t set_vcpuid_entries(struct acrn_vm *vm)
 				result = set_vcpuid_sgx(vm);
 				break;
 			/* These features are disabled */
-			/* PMU is not supported */
+			/* PMU is not supported except for core partition VM, like RTVM */
 			case 0x0aU:
+				if (is_lapic_pt_configured(vm)) {
+					init_vcpuid_entry(i, 0U, 0U, &entry);
+					result = set_vcpuid_entry(vm, &entry);
+				}
+				break;
+
 			/* Intel RDT */
 			case 0x0fU:
 			case 0x10U:

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -305,9 +305,12 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	value32 &= ~VMX_PROCBASED_CTLS_INVLPG;
 
 	/*
-	 * Enable VM_EXIT for rdpmc execution.
+	 * Enable VM_EXIT for rdpmc execution except core partition VM, like RTVM
 	 */
-	value32 |= VMX_PROCBASED_CTLS_RDPMC;
+	if (!is_lapic_pt_configured(vcpu->vm)) {
+		value32 |= VMX_PROCBASED_CTLS_RDPMC;
+	}
+
 	vcpu->arch.proc_vm_exec_ctrls = value32;
 	exec_vmwrite32(VMX_PROC_VM_EXEC_CONTROLS, value32);
 	pr_dbg("VMX_PROC_VM_EXEC_CONTROLS: 0x%x ", value32);

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -80,8 +80,7 @@ static const uint32_t emulated_guest_msrs[NUM_GUEST_MSRS] = {
 #endif
 };
 
-#define NUM_MTRR_MSRS	13U
-static const uint32_t mtrr_msrs[NUM_MTRR_MSRS] = {
+static const uint32_t mtrr_msrs[] = {
 	MSR_IA32_MTRR_CAP,
 	MSR_IA32_MTRR_DEF_TYPE,
 	MSR_IA32_MTRR_FIX64K_00000,
@@ -98,13 +97,7 @@ static const uint32_t mtrr_msrs[NUM_MTRR_MSRS] = {
 };
 
 /* Following MSRs are intercepted, but it throws GPs for any guest accesses */
-#define NUM_ALWAYS_UNSUPPORTED_MSRS	92U
-#ifndef CONFIG_NVMX_ENABLED
-#define NUM_UNSUPPORTED_MSRS	(NUM_ALWAYS_UNSUPPORTED_MSRS + NUM_VMX_MSRS)
-#else
-#define NUM_UNSUPPORTED_MSRS	NUM_ALWAYS_UNSUPPORTED_MSRS
-#endif
-static const uint32_t unsupported_msrs[NUM_UNSUPPORTED_MSRS] = {
+static const uint32_t unsupported_msrs[] = {
 	/* Variable MTRRs are not supported */
 	MSR_IA32_MTRR_PHYSBASE_0,
 	MSR_IA32_MTRR_PHYSMASK_0,
@@ -370,13 +363,13 @@ void init_msr_emulation(struct acrn_vcpu *vcpu)
 		enable_msr_interception(msr_bitmap, emulated_guest_msrs[i], INTERCEPT_READ_WRITE);
 	}
 
-	for (i = 0U; i < NUM_MTRR_MSRS; i++) {
+	for (i = 0U; i < ARRAY_SIZE(mtrr_msrs); i++) {
 		enable_msr_interception(msr_bitmap, mtrr_msrs[i], INTERCEPT_READ_WRITE);
 	}
 
 	intercept_x2apic_msrs(msr_bitmap, INTERCEPT_READ_WRITE);
 
-	for (i = 0U; i < NUM_UNSUPPORTED_MSRS; i++) {
+	for (i = 0U; i < ARRAY_SIZE(unsupported_msrs); i++) {
 		enable_msr_interception(msr_bitmap, unsupported_msrs[i], INTERCEPT_READ_WRITE);
 	}
 


### PR DESCRIPTION
for core partition VM (like RTVM), PMC is always used for performance
    profiling / tuning, so expose PMC capability and pass-through its MSRs
    to the VM.

Tracked-On: #6307
Signed-off-by: Minggui Cao <minggui.cao@intel.com>
Acked-by: Eddie Dong <eddie.dong@intel.com>