### PR TITLE
Release 2.5：Mmiodev del before add

### DIFF
--- a/hypervisor/arch/x86/guest/vm.c
+++ b/hypervisor/arch/x86/guest/vm.c
@@ -304,6 +304,10 @@ static void prepare_prelaunched_vm_memmap(struct acrn_vm *vm, const struct acrn_
 
 	for (i = 0U; i < MAX_MMIO_DEV_NUM; i++) {
 		for (j = 0; j < MMIODEV_RES_NUM; j++) {
+			/* If mmio resource is included in ACPI DATA e820 entry, it is already mapped to RAM
+			 * delete this potential mapping first
+			 */
+			(void)deassign_mmio_dev(vm, &vm_config->mmiodevs[i].mmiores[j]);
 			(void)assign_mmio_dev(vm, &vm_config->mmiodevs[i].mmiores[j]);
 		}
 


### PR DESCRIPTION
If mmio resource is included in ACPI DATA e820 entry, it is will be
mapped to RAM first. Then pre-launched VM can't map mmio resource GPA
to its MMIO HPA.

Tracked-On: #6320
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>