### PR TITLE
HV: fix two minor bug

### DIFF
--- a/hypervisor/arch/x86/cpu_caps.c
+++ b/hypervisor/arch/x86/cpu_caps.c
@@ -430,11 +430,6 @@ static int32_t check_vmx_mmu_cap(void)
 	} else if (!pcpu_has_vmx_ept_vpid_cap(VMX_EPT_2MB_PAGE)) {
 		printf("%s, ept not support 2MB large page\n", __func__);
 		ret = -ENODEV;
-	} else if (pcpu_has_vmx_ept_vpid_cap(VMX_EPT_1GB_PAGE) !=
-				pcpu_has_cap(X86_FEATURE_PAGE1GB)) {
-		/* This just for simple large_page_support in arch/x86/page.c */
-		ret = -ENODEV;
-		printf("%s ept support 1GB large page while mmu is not or opposite\n", __func__);
 	} else {
 		/* No other state currently, do nothing */
 	}

--- a/hypervisor/arch/x86/mmu.c
+++ b/hypervisor/arch/x86/mmu.c
@@ -29,6 +29,7 @@
 
 #include <types.h>
 #include <asm/lib/atomic.h>
+#include <asm/cpufeatures.h>
 #include <asm/pgtable.h>
 #include <asm/cpu_caps.h>
 #include <asm/mmu.h>
@@ -72,7 +73,7 @@ static inline bool ppt_large_page_support(enum _page_table_level level, __unused
 	if (level == IA32E_PD) {
 		support = true;
 	} else if (level == IA32E_PDPT) {
-		support = pcpu_has_vmx_ept_vpid_cap(VMX_EPT_1GB_PAGE);
+		support = pcpu_has_cap(X86_FEATURE_PAGE1GB);
 	} else {
 		support = false;
 	}

--- a/hypervisor/dm/vpci/vpci.c
+++ b/hypervisor/dm/vpci/vpci.c
@@ -482,6 +482,17 @@ static void write_cfg_header(struct pci_vdev *vdev,
 				pci_vdev_write_vcfg(vdev, offset, bytes, val);
 			}
 		}
+
+		/* According to PCIe Spec, for a RW register bits, If the optional feature
+		 * that is associated with the bits is not implemented, the bits are permitted
+		 * to be hardwired to 0b. However Zephyr would use INTx Line Register as writable
+		 * even this PCI device has no INTx, so emulate INTx Line Register as writable.
+		 */
+		if (offset == PCIR_INTERRUPT_LINE) {
+			val &= 0xfU;
+			pci_vdev_write_vcfg(vdev, offset, bytes, val);
+		}
+
 	}
 }
 


### PR DESCRIPTION
1. remove the constraint "MMU and EPT must both support large page or not"
2. modify Interrupt Line Register as writable

Tracked-On: #6330
Signed-off-by: Fei Li <fei1.li@intel.com>
