### PR TITLE
[Release 2.5]HV: debug: support 64bit BAR pci uart with 32bit space

### DIFF
--- a/hypervisor/debug/uart16550.c
+++ b/hypervisor/debug/uart16550.c
@@ -155,7 +155,9 @@ void uart16550_init(bool early_boot)
 				uart.reg_width = 1;
 				pci_pdev_write_cfg(uart.bdf, PCIR_COMMAND, 2U, cmd | PCIM_CMD_PORTEN);
 			} else {
-				if ((bar0 & 0xfU) == 0U) { /* 32 bits MMIO Space */
+				uint32_t bar_hi = pci_pdev_read_cfg(uart.bdf, pci_bar_offset(1), 4U);
+
+				if (((bar0 & 0xfU) == 0U) || (((bar0 & 0xfU) == 4U) && (bar_hi == 0U))) {
 					uart.type = MMIO;
 					uart.mmio_base_vaddr = hpa2hva_early((bar0 & PCI_BASE_ADDRESS_MEM_MASK));
 					pci_pdev_write_cfg(uart.bdf, PCIR_COMMAND, 2U, cmd | PCIM_CMD_MEMEN);


### PR DESCRIPTION
Currently the HV console does not support PCI UART with 64bit BAR, but in the
case that the BAR is in 64bit and the BAR space is below 4GB (i.e. the high
32bit address of the 64bit BAR is zero), HV should be able to support it.

Tracked-On: #6334

Signed-off-by: Victor Sun <victor.sun@intel.com>