### PR TITLE
config_tools: update lpc slot number

### DIFF
--- a/misc/config_tools/library/launch_cfg_lib.py
+++ b/misc/config_tools/library/launch_cfg_lib.py
@@ -40,10 +40,10 @@ PASSTHRU_DEVS = ['usb_xdci', 'ipu', 'ipu_i2c', 'cse', 'audio', 'sata',
 
 PT_SLOT = {
         "hostbridge":0,
-        "isa":1,
+        "lpc":1,
         "pci-gvt":2,
         "virtio-blk":3,
-        "lpc":31,
+        "igd-lpc":31,
     }
 
 


### PR DESCRIPTION
Update lpc slot to origin value 1 from 31 because GOP driver has assumption
to config space layout of the device on 00:1f.0.

Tracked-On: #6340
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>