### PR TITLE
hv: uc-lock: Fix do not trap #GP

### DIFF
--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -406,6 +406,9 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	if (is_ac_enabled()) {
 		value32 = (value32 | (1U << IDT_AC));
 	}
+	if (is_gp_enabled()) {
+		value32 = (value32 | (1U << IDT_GP));
+	}
 	exec_vmwrite32(VMX_EXCEPTION_BITMAP, value32);
 
 	/* Set up page fault error code mask - second paragraph * pg 2902


### PR DESCRIPTION
If HV enable trigger #GP for uc-lock, and is about to emulate guest uc-lock
instructions, should trap guest #GP. Guest uc-lock instrucction trigger #GP,
cause vmexit for #GP, HV handle this vmexit and emulate uc-lock
instruction.

Tracked-On: #6299
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>