### PR TITLE
config_tools: update launch xml for only one NVME

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_1uos_hardrt.xml
@@ -36,9 +36,9 @@
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_2uos.xml
@@ -75,14 +75,14 @@
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
-		<sata desc="vm sata device">00:17.0 SATA controller: Intel Corporation Device 4b63 (rev 10)</sata>
+		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
+++ b/misc/config_tools/data/ehl-crb-b/industry_launch_6uos.xml
@@ -75,14 +75,14 @@
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
-		<sata desc="vm sata device">00:17.0 SATA controller: Intel Corporation Device 4b63 (rev 10)</sata>
+		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/generic_board/industry_launch_6uos.xml
+++ b/misc/config_tools/data/generic_board/industry_launch_6uos.xml
@@ -75,14 +75,14 @@
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
-		<sata desc="vm sata device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</sata>
+		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/nuc11tnbi5/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc11tnbi5/industry_launch_6uos.xml
@@ -75,14 +75,14 @@
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
-		<sata desc="vm sata device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</sata>
+		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_1uos_hardrt.xml
@@ -32,13 +32,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_2uos.xml
@@ -76,13 +76,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
+++ b/misc/config_tools/data/nuc7i7dnb/industry_launch_6uos.xml
@@ -76,13 +76,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Intel Corporation Device f1a6 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_2uos.xml
@@ -75,14 +75,14 @@
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
-		<sata desc="vm sata device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</sata>
+		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
+++ b/misc/config_tools/data/tgl-rvp/industry_launch_6uos.xml
@@ -75,14 +75,14 @@
 		<bluetooth desc="vm bluetooth"></bluetooth>
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
-		<sata desc="vm sata device">00:17.0 SATA controller: Intel Corporation Device a0d3 (rev 20)</sata>
+		<sata desc="vm sata device"></sata>
 		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_1uos_hardrt.xml
@@ -32,13 +32,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_2uos.xml
@@ -76,13 +76,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i5/industry_launch_6uos.xml
@@ -76,13 +76,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_1uos_hardrt.xml
@@ -32,13 +32,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_2uos.xml
@@ -76,13 +76,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>

--- a/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
+++ b/misc/config_tools/data/whl-ipc-i7/industry_launch_6uos.xml
@@ -76,13 +76,13 @@
 		<sd_card desc="vm sd card device"></sd_card>
 		<ethernet desc="vm ethernet device"></ethernet>
 		<sata desc="vm sata device"></sata>
-		<nvme desc="vm nvme device">02:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</nvme>
+		<nvme desc="vm nvme device"></nvme>
 	</passthrough_devices>
 
 	<virtio_devices>
-		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX]."></network>
+		<network desc="virtio network devices setting. Input format: tap_name,[vhost],[mac=XX:XX:XX:XX:XX:XX].">RT</network>
 		<input desc="virtio input device"></input>
-		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img"></block>
+		<block desc="virtio block device setting. format: [blk partition:][img path] e.g.: /dev/sda3:./a/b.img">./core-image-weston-intel-corei7-64.wic</block>
 		<console desc="virtio console device,input format: [@]stdio|tty|pty|sock:portname[=portpath][,[@]stdio|tty|pty:portname[=portpath]]">@stdio:stdio_port</console>
 	</virtio_devices>
     </uos>


### PR DESCRIPTION
Update launch xml to use image to launch hard rt vm since
we changed the platforms from two disk to only one NVME disk.

Tracked-On: #6315
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>