### PR TITLE
Makefile:add targz-pkg entry in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ SHELL := /bin/bash
 # global helper variables
 T := $(CURDIR)
 
+# ACRN Version Information
+include VERSION
+export FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)
+
 ifdef TARGET_DIR
   $(warning TARGET_DIR is obsoleted because generated configuration files are now stored in the build directory)
 endif
@@ -69,6 +73,7 @@ HV_OUT := $(ROOT_OUT)/hypervisor
 DM_OUT := $(ROOT_OUT)/devicemodel
 TOOLS_OUT := $(ROOT_OUT)/misc
 DOC_OUT := $(ROOT_OUT)/doc
+TARBALL_OUT := $(ROOT_OUT)/tarball
 BUILD_VERSION ?=
 BUILD_TAG ?=
 HV_CFG_LOG = $(HV_OUT)/cfg.log
@@ -175,3 +180,9 @@ tools-install:
 
 life_mngr-install:
 	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) acrn-life-mngr-install
+
+.PHONY: targz-pkg
+targz-pkg:
+	$(MAKE) install DESTDIR=$(TARBALL_OUT)
+	cd $(TARBALL_OUT) && \
+	tar -zcvf $(ROOT_OUT)/acrn-$(FULL_VERSION).tar.gz *

--- a/devicemodel/Makefile
+++ b/devicemodel/Makefile
@@ -1,10 +1,8 @@
 #
 # ACRN-DM
 #
-include ../VERSION
 include ../paths.make
 
-FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)
 BASEDIR := $(shell pwd)
 DM_OBJDIR ?= $(CURDIR)/build
 DM_BUILD_VERSION ?=

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -2,9 +2,6 @@
 # acrn-hypervisor/hypervisor/Makefile
 #
 
-include ../VERSION
-FULL_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)$(EXTRA_VERSION)
-
 API_MAJOR_VERSION=1
 API_MINOR_VERSION=0
 


### PR DESCRIPTION
User could use make targz-pkg command to generate tar package in
build directory,which could help user simplify the process
of installing acrn hypervisor in target board. user need to copy the
tarball package to target board,and extract it to "/" directory.

Tracked-On: #6355
Signed-off-by: liu hang1 <hang1.liu@intel.com>
Reviewed-by: VanCutsem, Geoffroy <geoffroy.vancutsem@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>