### PR TITLE
Makefile: add missing deps in top-level and hypervisor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ clean:
 .PHONY: install life_mngr-install
 install: hypervisor-install devicemodel-install tools-install
 
-hypervisor-install:
+hypervisor-install: hypervisor
 	$(MAKE) $(HV_MAKEOPTS) install
 
 hypervisor-install-debug:
@@ -167,10 +167,10 @@ apl-up2-hybrid-install-debug:
 sbl-hypervisor-install-debug: kbl-nuc-i7-industry-install-debug \
 			      apl-up2-hybrid-install-debug
 
-devicemodel-install:
+devicemodel-install: tools-install devicemodel
 	$(MAKE) -C $(T)/devicemodel DM_OBJDIR=$(DM_OUT) install
 
-tools-install:
+tools-install: tools
 	$(MAKE) -C $(T)/misc OUT_DIR=$(TOOLS_OUT) RELEASE=$(RELEASE) install
 
 life_mngr-install:

--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -378,7 +378,7 @@ PRE_BUILD_DIR := ../misc/hv_prebuild
 .PHONY: all
 all: pre_build $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 
-install: $(HV_OBJDIR)/$(HV_FILE).32.out
+install: $(HV_OBJDIR)/$(HV_FILE).32.out $(HV_OBJDIR)/$(HV_FILE).bin
 	install -D $(HV_OBJDIR)/$(HV_FILE).32.out $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).32.out
 	install -D $(HV_OBJDIR)/$(HV_FILE).bin $(DESTDIR)$(libdir)/acrn/$(HV_FILE).$(BOARD).$(SCENARIO).bin
 	@if [ -e "$(HV_OBJDIR)/acpi" ];then \


### PR DESCRIPTION
Add a couple of missing dependencies in the ACRN Makefiles:
1. 'acrn.bin' is required before the hypervisor can be installed
2. The 'acrn_mngr.h' needs to be installed ('tools-install') in
the build folder.

Tracked-On: #6360
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>