### PR TITLE
config-tools: support of passthrough dTPM2 

### DIFF
--- a/hypervisor/Makefile
+++ b/hypervisor/Makefile
@@ -392,7 +392,7 @@ pre_build: $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)
 	$(MAKE) -C $(PRE_BUILD_DIR) BOARD=$(BOARD) SCENARIO=$(SCENARIO) TARGET_DIR=$(HV_CONFIG_DIR)
 	@$(HV_OBJDIR)/hv_prebuild_check.out
 	@echo "generate the binary of ACPI tables for pre-launched VMs ..."
-	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(BOARD) --scenario $(SCENARIO) --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)/acpi
+	python3 ../misc/config_tools/acpi_gen/bin_gen.py --board $(HV_OBJDIR)/.board.xml --scenario $(HV_OBJDIR)/.scenario.xml --asl $(HV_CONFIG_DIR) --out $(HV_OBJDIR)
 
 .PHONY: header
 header: $(VERSION) $(HV_CONFIG_H) $(HV_CONFIG_TIMESTAMP)

--- a/misc/config_tools/acpi_gen/bin_gen.py
+++ b/misc/config_tools/acpi_gen/bin_gen.py
@@ -5,9 +5,14 @@
 
 """
 
+import logging
 import os, sys, subprocess, argparse, re, shutil
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'board_inspector'))
+import lxml.etree
 from acpi_const import *
-
+import acpiparser.tpm2
+import lib.cdata
+import common
 
 def asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path):
     '''
@@ -61,9 +66,38 @@ def asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path):
         print('compile ACPI ASL code to {} successfully'.format(dest_vm_acpi_bin_path))
     return rmsg
 
+def tpm2_acpi_gen(acpi_bin, board_etree, scenario_etree, allocation_etree):
+    tpm2_enabled = common.get_node("//vm[@id = '0']/mmio_resources/TPM2/text()", scenario_etree)
+    if tpm2_enabled is not None and tpm2_enabled == 'y':
+        tpm2_node = common.get_node("//device[@id = 'MSFT0101' or compatible_id = 'MSFT0101']", board_etree)
+        if tpm2_node is not None:
+            _data_len = 0x4c if common.get_node("//capability[@id = 'log_area']", board_etree) is not None else 0x40
+            _data = bytearray(_data_len)
+            ctype_data = acpiparser.tpm2.TPM2(_data)
+            ctype_data.header.signature = "TPM2".encode()
+            ctype_data.header.length = _data_len
+            ctype_data.header.revision = 0x3
+            ctype_data.header.oemid = "ACRN  ".encode()
+            ctype_data.header.oemtableid = "ACRNTPM2".encode()
+            ctype_data.header.oemrevision = 0x1
+            ctype_data.header.creatorid = "INTL".encode()
+            ctype_data.header.creatorrevision = 0x20190703
+            ctype_data.address_of_control_area = 0xFED40040
+            ctype_data.start_method = int(common.get_node("//capability[@id = 'start_method']/value/text()", tpm2_node), 16)
+            start_method_parameters = tpm2_node.xpath("//parameter/text()")
+            for i in range(len(start_method_parameters)):
+                ctype_data.start_method_specific_parameters[i] = int(start_method_parameters[i], 16)
+            if common.get_node("//capability[@id = 'log_area']", board_etree) is not None:
+                ctype_data.log_area_minimum_length = int(common.get_node("//log_area_minimum_length/text()", allocation_etree), 16)
+                ctype_data.log_area_start_address = int(common.get_node("//log_area_start_address/text()", allocation_etree), 16)
+            ctype_data.header.checksum = (~(sum(lib.cdata.to_bytes(ctype_data))) + 1) & 0xFF
+            acpi_bin.seek(ACPI_TPM2_ADDR_OFFSET)
+            acpi_bin.write(lib.cdata.to_bytes(ctype_data))
+        else:
+            logging.warning("Passtrhough tpm2 is enabled in scenario but the device is not presented on board.")
+            logging.warning("Check there is tpm2 device on board and re-generate the xml using board inspector with --advanced option.")
 
-
-def aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, acpi_bin_name):
+def aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, acpi_bin_name, board_etree, scenario_etree, allocation_etree):
     '''
     create the binary of ACPI table.
     :param dest_vm_acpi_bin_path: the path of the aml code of ACPI tables
@@ -95,11 +129,6 @@ def aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, acpi_bin_name):
         with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[4][1]), 'rb') as asl:
             acpi_bin.write(asl.read())
 
-        if 'tpm2.asl' in os.listdir(dest_vm_acpi_path):
-            acpi_bin.seek(ACPI_TPM2_ADDR_OFFSET)
-            with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[5][1]), 'rb') as asl:
-                acpi_bin.write(asl.read())
-
         acpi_bin.seek(ACPI_DSDT_ADDR_OFFSET)
         with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[6][1]), 'rb') as asl:
             acpi_bin.write(asl.read())
@@ -112,6 +141,10 @@ def aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, acpi_bin_name):
             acpi_bin.seek(ACPI_RTCT_ADDR_OFFSET)
             with open(os.path.join(dest_vm_acpi_bin_path, ACPI_TABLE_LIST[8][1]), 'rb') as asl:
                 acpi_bin.write(asl.read())
+
+        vm_id = acpi_bin_name.split('.')[0].split('ACPI_VM')[1]
+        if vm_id == '0':
+            tpm2_acpi_gen(acpi_bin, board_etree, scenario_etree, allocation_etree)
 
         acpi_bin.seek(0xfffff)
         acpi_bin.write(b'\0')
@@ -178,16 +211,22 @@ def check_iasl():
 
 def main(args):
 
-    board_type = args.board
-    scenario_name = args.scenario
+    board_etree = lxml.etree.parse(args.board)
+    scenario_etree = lxml.etree.parse(args.scenario)
+
+    scenario_name = common.get_node("//@scenario", scenario_etree)
+
     if args.asl is None:
         DEST_ACPI_PATH = os.path.join(VM_CONFIGS_PATH, 'scenarios', scenario_name)
     else:
         DEST_ACPI_PATH = os.path.join(common.SOURCE_ROOT_DIR, args.asl, 'scenarios', scenario_name)
     if args.out is None:
-        DEST_ACPI_BIN_PATH = os.path.join(common.SOURCE_ROOT_DIR, 'build', 'hypervisor', 'acpi')
+        hypervisor_out = os.path.join(common.SOURCE_ROOT_DIR, 'build', 'hypervisor')
     else:
-        DEST_ACPI_BIN_PATH = args.out
+        hypervisor_out = args.out
+    DEST_ACPI_BIN_PATH = os.path.join(hypervisor_out, 'acpi')
+
+    allocation_etree = lxml.etree.parse(os.path.join(hypervisor_out, 'configs', 'allocation.xml'))
 
     if os.path.isdir(DEST_ACPI_BIN_PATH):
         shutil.rmtree(DEST_ACPI_BIN_PATH)
@@ -204,20 +243,20 @@ def main(args):
             os.makedirs(dest_vm_acpi_bin_path)
             if asl_to_aml(dest_vm_acpi_path, dest_vm_acpi_bin_path):
                 return 1
-            aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, config+'.bin')
+            aml_to_bin(dest_vm_acpi_path, dest_vm_acpi_bin_path, config+'.bin', board_etree, scenario_etree, allocation_etree)
 
     return 0
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(usage="python3 bin_gen.py --board [board] --scenario [scenario]"
                                            "[ --out [output dir of acpi ASL code]]",
-                                     description="the tool to generate ACPI binary for Pre-launched VMs.")
-    parser.add_argument("--board", required=True, help="the board type.")
-    parser.add_argument("--scenario", required=True, help="the scenario name.")
+                                     description="the tool to generate ACPI binary for Pre-launched VMs")
+    parser.add_argument("--board", required=True, help="the XML file summarizing characteristics of the target board")
+    parser.add_argument("--scenario", required=True, help="the XML file specifying the scenario to be set up")
     parser.add_argument("--asl", default=None, help="the input folder to store the ACPI ASL code. ")
     parser.add_argument("--out", default=None, help="the output folder to store the ACPI binary code. "
                                                     "If not specified, the path for the binary code is"
-                                                    "build/acpi/")
+                                                    "build/hypervisor/acpi/")
 
     args = parser.parse_args()
     rc = main(args)

--- a/misc/config_tools/board_inspector/acpiparser/__init__.py
+++ b/misc/config_tools/board_inspector/acpiparser/__init__.py
@@ -13,6 +13,7 @@ from acpiparser.facp import FACP
 from acpiparser.rtct import RTCT
 from acpiparser.rdt import parse_resource_data
 from acpiparser.prt import parse_pci_routing
+from acpiparser.tpm2 import TPM2
 
 def parse_table(signature, path=None):
     if not path:
@@ -31,6 +32,7 @@ parse_asf = make_parser('ASF!')
 parse_dsdt = make_parser('DSDT')
 parse_dmar = make_parser('DMAR')
 parse_facp = make_parser('FACP')
+parse_tpm2 = make_parser('TPM2')
 
 def parse_rtct(path=None):
     if not path:

--- a/misc/config_tools/board_inspector/acpiparser/tpm2.py
+++ b/misc/config_tools/board_inspector/acpiparser/tpm2.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2021 Intel Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import ctypes
+import logging
+
+import lib.cdata as cdata
+from acpiparser._utils import TableHeader
+
+def tpm2_optional_data(data_len):
+    start_method_data_len = 0
+    has_log_area = False
+    if data_len <= 12:
+        start_method_data_len = data_len
+    elif data_len == 24:
+        start_method_data_len = 12
+        has_log_area = True
+    else:
+        start_method_data_len = 12
+        logging.warning(f"TPM2 data length: {data_len + 52} is greater than 64 bytes but less than 76 bytes.")
+        logging.warning(f"The TPM2 data is still processed but the 65 to {data_len + 52} bytes are discard.")
+    return start_method_data_len, has_log_area
+
+def tpm2_factory(start_method_data_len, has_log_area):
+    class TPM2(cdata.Struct):
+        _pack_ = 1
+        _fields_ = [
+            ('header', TableHeader),
+            ('platform_class', ctypes.c_uint16),
+            ('reserved', ctypes.c_uint16),
+            ('address_of_control_area', ctypes.c_uint64),
+            ('start_method', ctypes.c_uint32),
+            ('start_method_specific_parameters', ctypes.c_ubyte * start_method_data_len),
+        ] + ([
+            ('log_area_minimum_length', ctypes.c_uint32),
+            ('log_area_start_address', ctypes.c_uint64),
+        ] if has_log_area else [])
+
+    return TPM2
+
+def TPM2(val):
+    """Create class based on decode of a TPM2 table from filename."""
+    if isinstance(val, str):
+        base_length = 52
+        data = open(val, mode='rb').read()
+        start_method_data_len, has_log_area = tpm2_optional_data(len(data) - base_length)
+        return tpm2_factory(start_method_data_len, has_log_area).from_buffer_copy(data)
+    elif isinstance(val, bytearray):
+        return tpm2_factory(12, True).from_buffer(val) if len(val) > 64 else tpm2_factory(12, False).from_buffer(val)

--- a/misc/config_tools/board_inspector/extractors/50-acpi.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+import ctypes
 import logging
 import lxml.etree
 from collections import defaultdict
@@ -12,6 +13,8 @@ from acpiparser.aml.tree import Visitor, Direction
 import acpiparser.aml.builder as builder
 import acpiparser.aml.context as context
 import acpiparser.aml.datatypes as datatypes
+
+from acpiparser import parse_dsdt, parse_tpm2
 from acpiparser.aml.interpreter import ConcreteInterpreter
 from acpiparser.aml.exception import UndefinedSymbol, FutureWork
 from acpiparser.aml.visitors import GenerateBinaryVisitor
@@ -108,6 +111,23 @@ def parse_address_space_resource(idx, item, elem):
 def parse_extended_irq(idx, item, elem):
     irqs = ", ".join(map(str, item._INT))
     add_child(elem, "resource", id=f"res{idx}", type="irq", int=irqs)
+
+def parse_tpm(elem):
+    try:
+        tpm2 = parse_tpm2()
+
+        control_area = add_child(elem, "capability", None, id="control_area")
+        add_child(control_area, "address_of_control_area", hex(tpm2.address_of_control_area))
+        start_method = add_child(elem, "capability", None, id="start_method")
+        add_child(start_method, "value", hex(tpm2.start_method))
+        for parameter in tpm2.start_method_specific_parameters:
+            add_child(start_method, "parameter", hex(parameter))
+        if hasattr(tpm2, "log_area_minimum_length"):
+            add_child(elem, "capability", None, id="log_area")
+    except Exception as e:
+        logging.info(f"Parse ACPI TPM2 failed: {str(e)}")
+        logging.info(f"Will not extract information from ACPI TPM2")
+        return
 
 resource_parsers = {
     (0, SMALL_RESOURCE_ITEM_IRQ_FORMAT): parse_irq,
@@ -455,6 +475,9 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
             desc = result.get().decode(encoding="utf-16").strip("\00")
             element.set("description", desc)
             add_object_to_device(interpreter, namepath, "_STR", result)
+
+        if "MSFT0101" in [hid, *cids]:
+            parse_tpm(element)
 
         # Address
         if interpreter.context.has_symbol(f"{namepath}._ADR"):

--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -59,6 +59,9 @@ PCI_VUART_VBAR1_SIZE = 4 * SIZE_K
 # Constants for vmsix bar
 VMSIX_VBAR_SIZE = 4 * SIZE_K
 
+# Constants for tpm2 log area minimum length
+LOG_AREA_MIN_LEN = 256 * SIZE_K
+
 class MmioWindow(namedtuple(
         "MmioWindow", [
             "start",
@@ -288,27 +291,7 @@ def alloc_mmio(mems, devdict, used_mem):
         devdict_base[bar_name] = bar_window.start
     return devdict_base
 
-def allocate_ssram_region(board_etree, scenario_etree, allocation_etree):
-    # Guest physical address of the SW SRAM allocated to a pre-launched VM
-    enabled = common.get_node("//PSRAM_ENABLED/text()", scenario_etree)
-    if enabled == "y":
-        pre_rt_vms = common.get_node("//vm[vm_type ='PRE_RT_VM']", scenario_etree)
-        if pre_rt_vms is not None:
-            vm_id = pre_rt_vms.get("id")
-            l3_sw_sram = board_etree.xpath("//cache[@level='3']/capability[@id='Software SRAM']")
-            if l3_sw_sram:
-                start = min(map(lambda x: int(x.find("start").text, 16), l3_sw_sram))
-                end = max(map(lambda x: int(x.find("end").text, 16), l3_sw_sram))
-
-                allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
-                if allocation_vm_node is None:
-                    allocation_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = vm_id)
-                common.append_node("./ssram/start_gpa", hex(start), allocation_vm_node)
-                common.append_node("./ssram/end_gpa", hex(end), allocation_vm_node)
-
-def fn(board_etree, scenario_etree, allocation_etree):
-    allocate_ssram_region(board_etree, scenario_etree, allocation_etree)
-
+def allocate_pci_bar(board_etree, scenario_etree, allocation_etree):
     native_low_mem, native_high_mem = get_pci_hole_native(board_etree)
     create_native_pci_hole_node(allocation_etree, native_low_mem, native_high_mem)
 
@@ -348,3 +331,77 @@ def fn(board_etree, scenario_etree, allocation_etree):
         devdict_base_64_bits = alloc_mmio(low_mem + high_mem, devdict_64bits, used_low_mem + used_high_mem)
         create_device_node(allocation_etree, vm_id, devdict_base_32_bits)
         create_device_node(allocation_etree, vm_id, devdict_base_64_bits)
+
+def allocate_ssram_region(board_etree, scenario_etree, allocation_etree):
+    # Guest physical address of the SW SRAM allocated to a pre-launched VM
+    enabled = common.get_node("//PSRAM_ENABLED/text()", scenario_etree)
+    if enabled == "y":
+        pre_rt_vms = common.get_node("//vm[vm_type ='PRE_RT_VM']", scenario_etree)
+        if pre_rt_vms is not None:
+            vm_id = pre_rt_vms.get("id")
+            l3_sw_sram = board_etree.xpath("//cache[@level='3']/capability[@id='Software SRAM']")
+            if l3_sw_sram:
+                start = min(map(lambda x: int(x.find("start").text, 16), l3_sw_sram))
+                end = max(map(lambda x: int(x.find("end").text, 16), l3_sw_sram))
+
+                allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
+                if allocation_vm_node is None:
+                    allocation_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = vm_id)
+                common.append_node("./ssram/start_gpa", hex(start), allocation_vm_node)
+                common.append_node("./ssram/end_gpa", hex(end), allocation_vm_node)
+
+def allocate_log_area(board_etree, scenario_etree, allocation_etree):
+    tpm2_enabled = common.get_node(f"//vm[@id = '0']/mmio_resources/TPM2/text()", scenario_etree)
+    if tpm2_enabled is None or tpm2_enabled == 'n':
+        return
+
+    if common.get_node("//capability[@id='log_area']", board_etree) is not None:
+        # VIRT_ACPI_DATA_ADDR
+        log_area_end_address = 0x7FFF0000
+        log_area_start_address = log_area_end_address - LOG_AREA_MIN_LEN
+        allocation_vm_node = common.get_node(f"/acrn-config/vm[@id = '0']", allocation_etree)
+        if allocation_vm_node is None:
+            allocation_vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = '0')
+        common.append_node("./log_area_start_address", hex(log_area_start_address).upper(), allocation_vm_node)
+        common.append_node("./log_area_minimum_length", hex(LOG_AREA_MIN_LEN).upper(), allocation_vm_node)
+
+"""
+            Pre-launched VM gpa layout:
+ +--------------------------------------------------+ <--End of VM high pci hole
+ |      64 bits vbar of emulated PCI devices        |    Offset 0x8000000000
+ +--------------------------------------------------+ <--Start of VM high pci hole
+ |                                                  |    Offset 0x4000000000
+...                                                ...
+ |                                                  |
+ +--------------------------------------------------+ <--End of VM low pci hole
+ |   32 and 64 bits vbar of emulated PCI devices    |    Offset 0xE0000000
+ +--------------------------------------------------+ <--Start of VM low pci hole
+ |                                                  |    Offset 0x80000000
+...                                                ...
+ |            TPM2 log area at  0x7FFB0000          |
+...                                                ...
+ |                                                  |
+ +--------------------------------------------------+ <--Offset 0
+
+                  SOS VM gpa layout:
+ +--------------------------------------------------+ <--End of native high pci hole
+ |      64 bits vbar of emulated PCI devices        |
+ +--------------------------------------------------+ <--Start of native high pci hole
+ |                                                  |
+...                                                ...
+ |                                                  |
+ +--------------------------------------------------+ <--End of native low pci hole
+ |   32 and 64 bits vbar of emulated PCI devices    |
+ +--------------------------------------------------+ <--Start of native low pci hole
+ |                                                  |
+...                                                ...
+ |                                                  |
+ |                                                  |
+ |                                                  |
+ +--------------------------------------------------+ <--Offset 0
+
+"""
+def fn(board_etree, scenario_etree, allocation_etree):
+    allocate_ssram_region(board_etree, scenario_etree, allocation_etree)
+    allocate_log_area(board_etree, scenario_etree, allocation_etree)
+    allocate_pci_bar(board_etree, scenario_etree, allocation_etree)

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -190,6 +190,10 @@
         <xsl:value-of select="acrn:define('VM0_TPM_BUFFER_BASE_ADDR', '0xFED40000', 'UL')" />
         <xsl:value-of select="acrn:define('VM0_TPM_BUFFER_BASE_ADDR_GPA', '0xFED40000', 'UL')" />
         <xsl:value-of select="acrn:define('VM0_TPM_BUFFER_SIZE', '0x5000', 'UL')" />
+        <xsl:if test="//capability[@id='log_area']">
+          <xsl:value-of select="acrn:define('VM0_TPM_EVENTLOG_BASE_ADDR', //allocation-data/acrn-config/vm[@id = '0']/log_area_start_address, 'UL')" />
+          <xsl:value-of select="acrn:define('VM0_TPM_EVENTLOG_SIZE', //allocation-data/acrn-config/vm[@id = '0']/log_area_minimum_length, 'UL')" />
+        </xsl:if>
       </xsl:if>
     </xsl:if>
   </xsl:if>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -17,6 +17,7 @@
     <xsl:value-of select="acrn:include('asm/vm_config.h')" />
     <xsl:value-of select="acrn:include('vuart.h')" />
     <xsl:value-of select="acrn:include('asm/pci_dev.h')" />
+    <xsl:value-of select="acrn:include('asm/pgtable.h')" />
 
     <xsl:apply-templates select="config-data/acrn-config" />
   </xsl:template>
@@ -240,18 +241,35 @@
       <xsl:value-of select="acrn:ifdef('VM0_PASSTHROUGH_TPM')" />
       <xsl:value-of select="acrn:initializer('pt_tpm2', 'true')" />
       <xsl:value-of select="acrn:initializer('mmiodevs[0]', '{', true())" />
+      <xsl:value-of select="acrn:initializer('name', concat($quot, 'tpm2', $quot))" />
+      <xsl:value-of select="acrn:initializer('res[0]', '{', true())" />
       <xsl:value-of select="acrn:initializer('user_vm_pa', 'VM0_TPM_BUFFER_BASE_ADDR_GPA')" />
-      <xsl:value-of select="acrn:initializer('service_vm_pa', 'VM0_TPM_BUFFER_BASE_ADDR')" />
+      <xsl:value-of select="acrn:initializer('host_pa', 'VM0_TPM_BUFFER_BASE_ADDR')" />
       <xsl:value-of select="acrn:initializer('size', 'VM0_TPM_BUFFER_SIZE')" />
+      <xsl:value-of select="acrn:initializer('mem_type', 'EPT_UNCACHED')" />
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
+      <xsl:if test="//capability[@id='log_area']">
+        <xsl:value-of select="acrn:initializer('res[1]', '{', true())" />
+        <xsl:value-of select="acrn:initializer('user_vm_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR')" />
+        <xsl:value-of select="acrn:initializer('host_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR')" />
+        <xsl:value-of select="acrn:initializer('size', 'VM0_TPM_EVENTLOG_SIZE')" />
+        <xsl:value-of select="acrn:initializer('mem_type', 'EPT_WB')" />
+        <xsl:text>},</xsl:text>
+        <xsl:value-of select="$newline" />
+      </xsl:if>
       <xsl:text>},</xsl:text>
       <xsl:value-of select="$newline" />
       <xsl:value-of select="$endif" />
       <xsl:value-of select="acrn:ifdef('P2SB_BAR_ADDR')" />
       <xsl:value-of select="acrn:initializer('pt_p2sb_bar', 'true')" />
       <xsl:value-of select="acrn:initializer('mmiodevs[0]', '{', true())" />
+      <xsl:value-of select="acrn:initializer('res[0]', '{', true())" />
       <xsl:value-of select="acrn:initializer('user_vm_pa', 'P2SB_BAR_ADDR_GPA')" />
-      <xsl:value-of select="acrn:initializer('service_vm_pa', 'P2SB_BAR_ADDR')" />
+      <xsl:value-of select="acrn:initializer('host_pa', 'P2SB_BAR_ADDR')" />
       <xsl:value-of select="acrn:initializer('size', 'P2SB_BAR_SIZE')" />
+      <xsl:text>},</xsl:text>
+      <xsl:value-of select="$newline" />
       <xsl:text>},</xsl:text>
       <xsl:value-of select="$newline" />
       <xsl:value-of select="$endif" />


### PR DESCRIPTION
1. Parse and insert tpm2 acpi table information to board.xml
2. Allocate tpm2 log area address
3. Create tpm2 mmiodev in vm_configurations.c
4. Create virtual tpm2 acpi table