### PR TITLE
Various fixes to the board inspector for wider applicability

### DIFF
--- a/misc/config_tools/board_inspector/acpiparser/aml/context.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/context.py
@@ -233,10 +233,6 @@ class Context:
         else:
             raise InvalidPath(new_scope)
 
-    def enter_scope(self, name):
-        self.__scope_history.append(copy(self.__current_scope))
-        self.__current_scope.append(name)
-
     def pop_scope(self):
         assert(self.__scope_history)
         self.__current_scope = self.__scope_history.pop()

--- a/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
@@ -398,10 +398,13 @@ class ConcreteInterpreter(Interpreter):
         #
         # As a workaround, check if both the left and right hand sides are integers first. If either is not the case,
         # the condition is evaluated to False.
-        if isinstance(lhs, Integer) and isinstance(rhs, Integer):
-            res = Integer(op(lhs.get(), rhs.get()))
-        else:
-            res = Integer(0)
+        try:
+            res = Integer(op(lhs.to_integer().get(), rhs.to_integer().get()))
+        except NotImplementedError:
+            if isinstance(lhs, String) and isinstance(rhs, String):
+                res = Integer(op(lhs.get(), rhs.get()))
+            else:
+                res = Integer(0)
         if len(tree.children) >= 3:
             target = self.interpret(tree.children[2])
             if target:

--- a/misc/config_tools/board_inspector/acpiparser/aml/parser.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/parser.py
@@ -491,7 +491,7 @@ def DefCreateWordField_hook_named(context, tree, name):
 def DefDevice_hook_named(context, tree, name):
     sym = DeviceDecl(name, tree)
     context.register_symbol(sym)
-    context.enter_scope(name)
+    context.change_scope(name)
 
 def DefDevice_hook_post(context, tree):
     context.pop_scope()


### PR DESCRIPTION
When applying the board inspector on a wider range of boards, we identified the following issues.

1. The AML interpreter does not support some AML opcodes that are used by the DSDT on other boards, including OnesOp, DefMatch and DefSizeof.
2. The workaround introduced by commit e5ba06cbe80a only evaluates branch predications on integers, while conditions on strings or operation fields are also common.

This PR fixes the above two issues as well as clean up a duplicate method in the implementation of the AML parser.