### PR TITLE
Board inspector enhancements to parse DSDT on platforms with multiple host bridges

### DIFF
--- a/misc/config_tools/board_inspector/acpiparser/aml/builder.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/builder.py
@@ -116,7 +116,7 @@ def build_value(value):
         return DefPackage(
             PkgLength(),
             len(value.elements),
-            PackageElementList(elements))
+            PackageElementList(*elements))
     elif isinstance(value, (str, datatypes.String)):
         if isinstance(value, str):
             return String(value)

--- a/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
+++ b/misc/config_tools/board_inspector/acpiparser/aml/interpreter.py
@@ -329,7 +329,11 @@ class ConcreteInterpreter(Interpreter):
             self.context.change_scope(tree.scope)
             device_path = self.context.parent(sym.name)
             bus_id = self.interpret_method_call(f"_BBN").get()
-            device_id = self.interpret_method_call(f"{device_path}._ADR").get()
+            if self.context.has_symbol(f"{device_path}._ADR"):
+                device_id = self.interpret_method_call(f"{device_path}._ADR").get()
+            elif self.context.has_symbol(f"{device_path}._BBN"):
+                # Device objects representing PCI host bridges may not have an _ADR object
+                device_id = 0
             self.context.pop_scope()
             op_region = OperationRegion.open_pci_configuration_space(bus_id, device_id, offset, length)
             pass

--- a/misc/config_tools/board_inspector/extractors/50-acpi.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi.py
@@ -474,7 +474,9 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
             bus_number = result.get()
             if isinstance(bus_number, int):
                 bus_number = hex(bus_number)
-            element.set("address", bus_number)
+            # To avoid confusion to the later extractors, do not recognize _BBN for non-present host bridges.
+            if sta == None or (sta & 0x1) != 0:
+                element.set("address", bus_number)
             add_object_to_device(interpreter, namepath, "_BBN", result)
 
         # Status

--- a/misc/config_tools/board_inspector/extractors/50-acpi.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi.py
@@ -86,13 +86,16 @@ def parse_irq(idx, item, elem):
     add_child(elem, "resource", id=f"res{idx}", type="irq", int=irqs)
 
 def parse_io_port(idx, item, elem):
-    add_child(elem, "resource", id=f"res{idx}", type="io_port", min=hex(item._MIN), max=hex(item._MAX), len=hex(item._LEN))
+    add_child(elem, "resource", id=f"res{idx}", type="io_port",
+              min=hex(item._MIN), max=hex(item._MAX), len=hex(item._LEN))
 
 def parse_fixed_io_port(idx, item, elem):
-    add_child(elem, "resource", id=f"res{idx}", type="io_port", min=hex(item._BAS), max=hex(item._BAS + item._LEN - 1), len=hex(item._LEN))
+    add_child(elem, "resource", id=f"res{idx}", type="io_port",
+              min=hex(item._BAS), max=hex(item._BAS + item._LEN - 1 if item._LEN else 0), len=hex(item._LEN))
 
 def parse_fixed_memory_range(idx, item, elem):
-    add_child(elem, "resource", id=f"res{idx}", type="memory", min=hex(item._BAS), max=hex(item._BAS + item._LEN - 1), len=hex(item._LEN))
+    add_child(elem, "resource", id=f"res{idx}", type="memory",
+              min=hex(item._BAS), max=hex(item._BAS + item._LEN - 1 if item._LEN else 0), len=hex(item._LEN))
 
 def parse_address_space_resource(idx, item, elem):
     if item._TYP == 0:


### PR DESCRIPTION
On platforms with multiple host bridges (as is shown in `lspci -t`), the DSDT of the platform typically contains multiple device objects with the `_HID` or `_CID` `PNP0A08`, each of which having its own bus number (as is reported by `_BBN`). Some of these objects can be disabled, i.e. with `_STA` being defined and evaluates to 0.

This patch series enhances the board inspector to extract precise information about multiple-host-bridge platforms. This include:

* Only put the bus numbers of present host bridges in the board XML.
* Support buffer assignments and indexing, which may be used in DSDT to generate `_CRS` (i.e. current resource descriptors) of the host bridges.