### PR TITLE
HV: two minor refine to support running ACRN on qemu

### DIFF
--- a/hypervisor/arch/x86/cpu.c
+++ b/hypervisor/arch/x86/cpu.c
@@ -538,36 +538,38 @@ static void init_pcpu_xsave(void)
 	uint64_t xcr0, xss;
 	uint32_t eax, ecx, unused, xsave_area_size;
 
-	CPU_CR_READ(cr4, &val64);
-	val64 |= CR4_OSXSAVE;
-	CPU_CR_WRITE(cr4, val64);
+	if (pcpu_has_cap(X86_FEATURE_XSAVE)) {
+		CPU_CR_READ(cr4, &val64);
+		val64 |= CR4_OSXSAVE;
+		CPU_CR_WRITE(cr4, val64);
 
-	if (get_pcpu_id() == BSP_CPU_ID) {
-		cpuid_subleaf(CPUID_FEATURES, 0x0U, &unused, &unused, &ecx, &unused);
+		if (get_pcpu_id() == BSP_CPU_ID) {
+			cpuid_subleaf(CPUID_FEATURES, 0x0U, &unused, &unused, &ecx, &unused);
 
-		/* if set, update it */
-		if ((ecx & CPUID_ECX_OSXSAVE) != 0U) {
-			cpu_info = get_pcpu_info();
-			cpu_info->cpuid_leaves[FEAT_1_ECX] |= CPUID_ECX_OSXSAVE;
+			/* if set, update it */
+			if ((ecx & CPUID_ECX_OSXSAVE) != 0U) {
+				cpu_info = get_pcpu_info();
+				cpu_info->cpuid_leaves[FEAT_1_ECX] |= CPUID_ECX_OSXSAVE;
 
-			/* set xcr0 and xss with the componets bitmap get from cpuid */
-			xcr0 = ((uint64_t)cpu_info->cpuid_leaves[FEAT_D_0_EDX] << 32U)
-				+ cpu_info->cpuid_leaves[FEAT_D_0_EAX];
-			xss = ((uint64_t)cpu_info->cpuid_leaves[FEAT_D_1_EDX] << 32U)
-				+ cpu_info->cpuid_leaves[FEAT_D_1_ECX];
-			write_xcr(0, xcr0);
-			msr_write(MSR_IA32_XSS, xss);
+				/* set xcr0 and xss with the componets bitmap get from cpuid */
+				xcr0 = ((uint64_t)cpu_info->cpuid_leaves[FEAT_D_0_EDX] << 32U)
+					+ cpu_info->cpuid_leaves[FEAT_D_0_EAX];
+				xss = ((uint64_t)cpu_info->cpuid_leaves[FEAT_D_1_EDX] << 32U)
+					+ cpu_info->cpuid_leaves[FEAT_D_1_ECX];
+				write_xcr(0, xcr0);
+				msr_write(MSR_IA32_XSS, xss);
 
-			/* get xsave area size, containing all the state components
-			 * corresponding to bits currently set in XCR0 | IA32_XSS */
-			cpuid_subleaf(CPUID_XSAVE_FEATURES, 1U,
-				&eax,
-				&xsave_area_size,
-				&ecx,
-				&unused);
-			if (xsave_area_size > XSAVE_STATE_AREA_SIZE) {
-				panic("XSAVE area (%d bytes) exceeds the pre-allocated 4K region\n",
-						xsave_area_size);
+				/* get xsave area size, containing all the state components
+				 * corresponding to bits currently set in XCR0 | IA32_XSS */
+				cpuid_subleaf(CPUID_XSAVE_FEATURES, 1U,
+					&eax,
+					&xsave_area_size,
+					&ecx,
+					&unused);
+				if (xsave_area_size > XSAVE_STATE_AREA_SIZE) {
+					panic("XSAVE area (%d bytes) exceeds the pre-allocated 4K region\n",
+							xsave_area_size);
+				}
 			}
 		}
 	}

--- a/hypervisor/arch/x86/guest/vmcs.c
+++ b/hypervisor/arch/x86/guest/vmcs.c
@@ -321,7 +321,7 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 	 */
 	value32 = check_vmx_ctrl(MSR_IA32_VMX_PROCBASED_CTLS2,
 			VMX_PROCBASED_CTLS2_VAPIC | VMX_PROCBASED_CTLS2_EPT |VMX_PROCBASED_CTLS2_VPID |
-			VMX_PROCBASED_CTLS2_RDTSCP | VMX_PROCBASED_CTLS2_UNRESTRICT |
+			VMX_PROCBASED_CTLS2_RDTSCP | VMX_PROCBASED_CTLS2_UNRESTRICT | VMX_PROCBASED_CTLS2_XSVE_XRSTR |
 			VMX_PROCBASED_CTLS2_PAUSE_LOOP | VMX_PROCBASED_CTLS2_UWAIT_PAUSE);
 
 	/* SDM Vol3, 25.3,  setting "enable INVPCID" VM-execution to 1 with "INVLPG exiting" disabled,
@@ -348,9 +348,11 @@ static void init_exec_ctrl(struct acrn_vcpu *vcpu)
 		exec_vmwrite32(VMX_TPR_THRESHOLD, 0U);
 	}
 
-	if (pcpu_has_cap(X86_FEATURE_OSXSAVE)) {
+	if ((value32 & VMX_PROCBASED_CTLS2_XSVE_XRSTR) != 0U) {
 		exec_vmwrite64(VMX_XSS_EXITING_BITMAP_FULL, 0UL);
-		value32 |= VMX_PROCBASED_CTLS2_XSVE_XRSTR;
+		vcpu->arch.xsave_enabled = true;
+	} else {
+		value32 &= ~VMX_PROCBASED_CTLS2_XSVE_XRSTR;
 	}
 
 	value32 |= VMX_PROCBASED_CTLS2_WBINVD;

--- a/hypervisor/arch/x86/guest/vmsr.c
+++ b/hypervisor/arch/x86/guest/vmsr.c
@@ -903,11 +903,15 @@ int32_t wrmsr_vmexit_handler(struct acrn_vcpu *vcpu)
 	}
 	case MSR_IA32_XSS:
 	{
-		if ((v & ~(MSR_IA32_XSS_PT | MSR_IA32_XSS_HDC)) != 0UL) {
-			err = -EACCES;
+		if (vcpu->arch.xsave_enabled) {
+			if ((v & ~(MSR_IA32_XSS_PT | MSR_IA32_XSS_HDC)) != 0UL) {
+				err = -EACCES;
+			} else {
+				vcpu_set_guest_msr(vcpu, MSR_IA32_XSS, v);
+				msr_write(msr, v);
+			}
 		} else {
-			vcpu_set_guest_msr(vcpu, MSR_IA32_XSS, v);
-			msr_write(msr, v);
+			err = -EACCES;
 		}
 		break;
 	}

--- a/hypervisor/arch/x86/vtd.c
+++ b/hypervisor/arch/x86/vtd.c
@@ -251,10 +251,9 @@ static inline void dmar_wait_completion(const struct dmar_drhd_rt *dmar_unit, ui
 	__unused uint64_t start = cpu_ticks();
 
 	do {
-		*status = iommu_read32(dmar_unit, offset);
-		ASSERT(((cpu_ticks() - start) < TICKS_PER_MS),
-			"DMAR OP Timeout!");
+		ASSERT(((cpu_ticks() - start) < TICKS_PER_MS), "DMAR OP Timeout!");
 		asm_pause();
+		*status = iommu_read32(dmar_unit, offset);
 	} while( (*status & mask) == pre_condition);
 }
 

--- a/hypervisor/include/arch/x86/asm/guest/vcpu.h
+++ b/hypervisor/include/arch/x86/asm/guest/vcpu.h
@@ -253,6 +253,7 @@ struct acrn_vcpu_arch {
 	uint8_t lapic_mask;
 	bool irq_window_enabled;
 	bool emulating_lock;
+	bool xsave_enabled;
 	uint32_t nrexits;
 
 	/* VCPU context state information */


### PR DESCRIPTION
Before supporting to run ACRN on qemu, ACRN always runs on the hardware platforms.
In order to achieve better performance, there're some constrains about the hardware
platforms, like the hardware platforms must support XSAVE Feature or the VTD mmio read
must be quickly and so on. However, these constrains are not met on most of the virtual
platforms which QEMU emulated. This patch set does two minor refine to support running
ACRN on qemu:
1. Check whether condition is met before check whether time is out after iommu_read32.
    This is because iommu_read32 would cause time out on some virtual platform in
    spite of the current DMAR status meets the pre_condition.
2. ACRN could run without XSAVE Capability. So remove XSAVE dependence to support
    more (hardware or virtual) platforms.

V2:
  add X86_FEATURE_COMPACTION_EXT dependence back.

V3:
  1. Inject UD when guest try to call xsetbv when guest doesn't support XSAVE.
  2. Assume the platform must both support XSAVE Capability on CPU side on XSAVE_CTL
     on VMX side or not, in this case, we could pass through CR4.OSXSAVE bit.

v4
 1. revert vCPUID change
 2. for vsetbv: (a) inject GP when the current privilege level is not 0.
                (b) injecy UD when CR4.OSXSAVE[bit 18] = 0
 3. rename check_xsave_cap to check_xsave_combined_cap_valid

Tracked-On: #6287
Signed-off-by: Fei Li <fei1.li@intel.com>