### PR TITLE
dm: mitigate reset attack

### DIFF
--- a/devicemodel/core/vmmapi.c
+++ b/devicemodel/core/vmmapi.c
@@ -376,6 +376,8 @@ vm_map_memseg_vma(struct vmctx *ctx, size_t len, vm_paddr_t gpa,
 int
 vm_setup_memory(struct vmctx *ctx, size_t memsize)
 {
+	int ret;
+
 	/*
 	 * If 'memsize' cannot fit entirely in the 'lowmem' segment then
 	 * create another 'highmem' segment above 4GB for the remainder.
@@ -390,7 +392,13 @@ vm_setup_memory(struct vmctx *ctx, size_t memsize)
 
 	ctx->biosmem = high_bios_size();
 
-	return hugetlb_setup_memory(ctx);
+	ret = hugetlb_setup_memory(ctx);
+	if (ret == 0) {
+		/* mitigate reset attack */
+		bzero((void *)ctx->baseaddr, ctx->lowmem);
+		bzero((void *)(ctx->baseaddr + ctx->highmem_gpa_base), ctx->highmem);
+	}
+	return ret;
 }
 
 void
@@ -411,10 +419,7 @@ vm_unsetup_memory(struct vmctx *ctx)
 
 	if (!is_rtvm) {
 		bzero((void *)ctx->baseaddr, ctx->lowmem);
-		if (ctx->highmem > 0) {
-			bzero((void *)(ctx->baseaddr + ctx->highmem_gpa_base),
-					ctx->highmem);
-		}
+		bzero((void *)(ctx->baseaddr + ctx->highmem_gpa_base), ctx->highmem);
 	}
 
 	hugetlb_unsetup_memory(ctx);


### PR DESCRIPTION
When a platform reboots or shuts down, the contents of RAM are not immediately
lost but begins to decay. During this period, there is a short timeframe during
which an attacker can turn the platform back on to boot into a program that
dumps the contents of memory (e.g., cold boot attacks). Encryption keys and
other secrets can be easily compromised through this method.

We already erasing the guest memory data when the guest is shut down normally.
However, if the guest is shut down abnormally, the contents of RAM may still
there. This patch mitigate this kind reset attack for a DM launched VM by
erasing the guest memory data by the guest has been created.

Tracked-On: #6061
Signed-off-by: Li Fei1 <fei1.li@intel.com>