### PR TITLE
config_tools: refine the configuration data description

### DIFF
--- a/misc/config_tools/schema/config.xsd
+++ b/misc/config_tools/schema/config.xsd
@@ -24,10 +24,17 @@ hypervisor shell.</xs:documentation>
     <xs:element name="SERIAL_CONSOLE" type="SerialConsoleOptions" default="/dev/ttyS0">
       <xs:annotation>
         <xs:documentation>Specify the host serial device used for hypervisor debugging.
-This option is only valid if the Service VM :ref:`vm.legacy_vuart` is
-enabled. Leave this field empty if the Service VM's :ref:`vm.console_vuart` is enabled. Uses
-:option:`vm.os_config.bootargs` for :ref:`vm.console_vuart`
-configuration.</xs:documentation>
+This entry is valid if and only if `hv.DEBUG_OPTIONS.RELEASE` is n.
+This entry impacts the content of `vm.(legacy_vuart id="0").base` when `vm.vm_type` is SOS_VM,
+which specifies the PIO base for Service VM legacy vUART 0 (used for console).
+The determination of the PIO base for Service VM legacy vUART 0 follows the rules below:
+
+- If hv.DEBUG_OPTIONS.SERIAL_CONSOLE is one of [ttys0, ttys1, ttys2, ttys3] and it's a PIO in the
+  native environment, the PIO base of Service VM legacy vUART 0 would be the same as the PIO base
+  corresponding to hv.DEBUG_OPTIONS.SERIAL_CONSOLE in the native environment.
+- Otherwise, a PIO base would be assigned to Service VM legacy vUART 0 from the available PIO list.
+
+The above logic is implemented in the configuration tools.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MEM_LOGLEVEL" type="LogLevelType" default="5">
@@ -274,13 +281,12 @@ initialization.</xs:documentation>
     </xs:element>
     <xs:element name="MAX_PT_IRQ_ENTRIES" type="xs:integer" default="256">
       <xs:annotation>
-        <xs:documentation>Maximum number of interrupt source for PT
-devices.</xs:documentation>
+        <xs:documentation>The pre-defined number of interrupt sources of all pass-through devices.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MAX_MSIX_TABLE_NUM" default="64">
         <xs:annotation>
-          <xs:documentation>Maximum number of MSI-X tables per device.
+          <xs:documentation>Pre-defined maximum number of virtual MSI-X Table entries per device.
 If this value is empty, then the default value will be calculated from the board XML file.</xs:documentation>
         </xs:annotation>
       <xs:simpleType>

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -178,7 +178,10 @@ value ``n``.</xs:documentation>
     <xs:element name="CLOS_MASK" type="xs:string"  minOccurs="0" maxOccurs="unbounded">
       <xs:annotation>
         <xs:documentation>Specify the cache capacity bitmask for the CLOS; only continuous '1' bits
-are allowed. The value will be ignored when hardware does not support RDT.</xs:documentation>
+are allowed. The value will be ignored when hardware does not support RDT.
+This entry takes effect only if `hv.FEATURES.RDT.RDT_ENABLED` is y.
+As `vm.clos.vcpu_clos` specifies the index of the CLOS to be associated with the given vCPU,
+`hv.FEATURES.RDT.CLOS_MASK` of that CLOS would impact the performance of the given vCPU.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element name="MBA_DELAY" type="xs:string" minOccurs="0"  maxOccurs="unbounded">


### PR DESCRIPTION
This patch refines the configuration data description so that it is
consistent with the current implementation of the configuration tools.

Tracked-On: #6377

Signed-off-by: Shiqing Gao <shiqing.gao@intel.com>