### PR TITLE
config_tools: fix formatting of configured INTx allocation

### DIFF
--- a/misc/config_tools/static_allocators/intx.py
+++ b/misc/config_tools/static_allocators/intx.py
@@ -104,9 +104,9 @@ def alloc_device_irqs(board_etree, scenario_etree, allocation_etree):
         vm_type = vm.find("vm_type").text
         vm_id = int(vm.get("id"))
         if lib.lib.is_pre_launched_vm(vm_type):
-            pt_intx_node = common.get_node("pt_intx", vm)
-            if pt_intx_node is not None:
-                pt_intx_mapping = dict(eval(f"[{pt_intx_node.text.replace(')(', '), (')}]"))
+            pt_intx_text = common.get_node("pt_intx/text()", vm)
+            if pt_intx_text is not None:
+                pt_intx_mapping = dict(eval(f"[{pt_intx_text.replace(')(', '), (')}]"))
                 for irq in pt_intx_mapping.keys():
                     irq_allocation[vm_id][irq].append("(Explicitly assigned in scenario configuration)")
             for pci_dev in vm.xpath("pci_devs/pci_dev/text()"):
@@ -181,8 +181,8 @@ def alloc_device_irqs(board_etree, scenario_etree, allocation_etree):
         vm_node = common.get_node(f"/acrn-config/vm[@id = '{vm_id}']", allocation_etree)
         if vm_node is None:
             vm_node = common.append_node("/acrn-config/vm", None, allocation_etree, id = str(vm_id))
-        pt_intx_node = common.get_node(f"//vm[@id='{vm_id}']/pt_intx", scenario_etree)
-        pt_intx_mapping = dict(eval(f"[{pt_intx_node.text.replace(')(', '), (')}]")) if pt_intx_node is not None else {}
+        pt_intx_text = common.get_node(f"//vm[@id='{vm_id}']/pt_intx/text()", scenario_etree)
+        pt_intx_mapping = dict(eval(f"[{pt_intx_text.replace(')(', '), (')}]")) if pt_intx_text is not None else {}
         for irq, devs in alloc.items():
             for dev in devs:
                 if dev.startswith("("):  # Allocation in the scenario configuration need not go to allocation.xml

--- a/misc/config_tools/xforms/lib.xsl
+++ b/misc/config_tools/xforms/lib.xsl
@@ -20,6 +20,8 @@
 
   <!-- C code common variables -->
   <xsl:variable name="newline" select="'&#xa;'" />
+  <xsl:variable name="tab" select="'&#x9;'" />
+  <xsl:variable name="whitespaces" select="concat(' ', '&#xd;', $tab, $newline)" />
   <xsl:variable name="quot" select="'&#x22;'" />
   <xsl:variable name="end_of_initializer" select="concat(',', $newline)" />
   <xsl:variable name="end_of_array_initializer" select="concat('};', $newline)" />
@@ -603,7 +605,7 @@
 
   <func:function name="acrn:get-intx-mapping">
     <xsl:param name="pt_intx_nodes" />
-    <xsl:variable name="joined" select="translate(acrn:string-join($pt_intx_nodes/text(), '', '', ''), ' ', '')" />
+    <xsl:variable name="joined" select="translate(acrn:string-join($pt_intx_nodes/text(), '', '', ''), $whitespaces, '')" />
     <xsl:variable name="unique_mapping" select="set:distinct(str:split(str:replace($joined, ')(', ').('), '.'))" />
     <func:result select="$unique_mapping" />
   </func:function>


### PR DESCRIPTION
There could be multiple ways in the scenario configuration to specify that
no INTx allocation is explicitly allocation to a prelaunched VM:

  * Do not have a `pt_intx` node at all.

  * Have a `pt_intx` node with no text.

  * Have a `pt_intx` node with a text that has nothing but whitespaces,
    tabs and newlines.

The current implementation only supports the first way, and will cause
build-time failures when a scenario configuration uses the latter two. The
following changes are introduced by this patch to fix such errors.

  * The INTx static allocator queries the text() of `pt_intx` nodes
    directly to gracefully handle `pt_intx` nodes with no text.

  * The XSLT of pt_intx.c clears all kinds of white spaces from the text of
    `pt_intx` nodes before calculating the set of allocated INTx mappings.

Tracked-On: #6287
Signed-off-by: Junjie Mao <junjie.mao@intel.com>