### PR TITLE
hv: Squash warning of code scanning tool

### DIFF
--- a/hypervisor/quirks/smbios.c
+++ b/hypervisor/quirks/smbios.c
@@ -190,7 +190,8 @@ static int copy_smbios_to_guest(struct acrn_vm *vm)
                     struct smbios_entry_point *eps = &smbios_eps.eps;
                     eps->st_addr = (uint32_t)gpa;
                     /* the intermediate checksum covers the structure table field */
-                    recalc_checksum((uint8_t *)eps->int_anchor, 0xf, &eps->int_checksum);
+                    recalc_checksum((uint8_t *)eps + offsetof(struct smbios_entry_point, int_anchor),
+                        0xf, &eps->int_checksum);
                 } else {
                     /* SMBIOS3 (_SM3_) */
                     struct smbios3_entry_point *eps3 = &smbios_eps.eps3;


### PR DESCRIPTION
The original use of recalc_checksum(eps->int_anchor, ...) may cause
an array bound overflow warning from code scanning tool. This patch
changes it to use offsetof to avoid using int_anchor directly.

Tracked-On: #6380
Signed-off-by: Yifan Liu <yifan1.liu@intel.com>