### PR TITLE
[release_2.5] dm: fix potential NULL pointer access in virtio_console.c

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -390,7 +390,7 @@ virtio_console_notify_tx(void *vdev, struct virtio_vq_info *vq)
 
 	while (vq_has_descs(vq)) {
 		vq_getchain(vq, &idx, iov, 1, flags);
-		if (port != NULL)
+		if ((port != NULL) && (port->cb != NULL))
 			port->cb(port, port->arg, iov, 1);
 
 		/*


### PR DESCRIPTION
 "port->cb" in 'virtio_console_notify_tx()'
 function maybe NULL when malicious inputs
 are injected from virtio frondend in guest.

Tracked-On: #6388
Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>