### PR TITLE
config-tools: add native log area address

### DIFF
--- a/misc/config_tools/board_inspector/extractors/50-acpi.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi.py
@@ -126,7 +126,9 @@ def parse_tpm(elem):
         for parameter in tpm2.start_method_specific_parameters:
             add_child(start_method, "parameter", hex(parameter))
         if hasattr(tpm2, "log_area_minimum_length"):
-            add_child(elem, "capability", None, id="log_area")
+            log_area = add_child(elem, "capability", None, id="log_area")
+            add_child(log_area, "log_area_minimum_length", hex(tpm2.log_area_minimum_length))
+            add_child(log_area, "log_area_start_address", hex(tpm2.log_area_start_address))
     except Exception as e:
         logging.info(f"Parse ACPI TPM2 failed: {str(e)}")
         logging.info(f"Will not extract information from ACPI TPM2")

--- a/misc/config_tools/xforms/misc_cfg.h.xsl
+++ b/misc/config_tools/xforms/misc_cfg.h.xsl
@@ -192,6 +192,7 @@
         <xsl:value-of select="acrn:define('VM0_TPM_BUFFER_SIZE', '0x5000', 'UL')" />
         <xsl:if test="//capability[@id='log_area']">
           <xsl:value-of select="acrn:define('VM0_TPM_EVENTLOG_BASE_ADDR', //allocation-data/acrn-config/vm[@id = '0']/log_area_start_address, 'UL')" />
+          <xsl:value-of select="acrn:define('VM0_TPM_EVENTLOG_BASE_ADDR_HPA', //capability[@id='log_area']/log_area_start_address, 'UL')" />
           <xsl:value-of select="acrn:define('VM0_TPM_EVENTLOG_SIZE', //allocation-data/acrn-config/vm[@id = '0']/log_area_minimum_length, 'UL')" />
         </xsl:if>
       </xsl:if>

--- a/misc/config_tools/xforms/vm_configurations.c.xsl
+++ b/misc/config_tools/xforms/vm_configurations.c.xsl
@@ -252,7 +252,7 @@
       <xsl:if test="//capability[@id='log_area']">
         <xsl:value-of select="acrn:initializer('res[1]', '{', true())" />
         <xsl:value-of select="acrn:initializer('user_vm_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR')" />
-        <xsl:value-of select="acrn:initializer('host_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR')" />
+        <xsl:value-of select="acrn:initializer('host_pa', 'VM0_TPM_EVENTLOG_BASE_ADDR_HPA')" />
         <xsl:value-of select="acrn:initializer('size', 'VM0_TPM_EVENTLOG_SIZE')" />
         <xsl:value-of select="acrn:initializer('mem_type', 'EPT_WB')" />
         <xsl:text>},</xsl:text>


### PR DESCRIPTION
Extract the log area address from TPM2 acpi table and add node
log_area_start_address to board.xml. This emelment is used by host_pa of
mmiodevs.

Tracked-On: #6320
Signed-off-by: Yang,Yu-chu <yu-chu.yang@intel.com>