### PR TITLE
doc:add more explanation on parameter --windows

### DIFF
--- a/doc/tutorials/using_windows_as_uos.rst
+++ b/doc/tutorials/using_windows_as_uos.rst
@@ -292,6 +292,9 @@ Explanation for acrn-dm Popular Command Lines
 * ``--ovmf /home/acrn/work/OVMF.fd``:
   Make sure it points to your OVMF binary path.
 
+* ``--windows``:
+  Specify this to use the Windows ORACLE virtio device when enabling secure boot in Windows; otherwise, the REDHAT virtio device will be used.
+
 Secure Boot Enabling
 ********************
 Refer to the steps in :ref:`How-to-enable-secure-boot-for-windows` for

--- a/doc/tutorials/waag-secure-boot.rst
+++ b/doc/tutorials/waag-secure-boot.rst
@@ -571,9 +571,11 @@ to import PK, KEK, and DB into OVMF, Ubuntu 16.04 used.
 
 Notes:
 
-   1. According to Microsoft documentation, after enabling secure boot, kernel
+   1. According to Microsoft documentation, after enabling secure boot, the kernel
       mode driver must be signed by a trusted certification authority
-      (CA).
+      (CA). Specify the acrn-dm parameter ``--windows`` to use the Windows
+      ORACLE virtio device driver. The default REDHAT virtio device driver is
+      not signed and may lead to problems in the secure boot process.
 
    2. A cross-signed driver using a SHA-1 or SHA-256 certificate issued
       after July 29th, 2015 is not recommended for Windows 10.


### PR DESCRIPTION
acrn-dm --windows parameter is used for specify
the Windows ORACLE virtio device driver,which is
used when enable secure boot in Windows, otherwise
the default REDHAT virtio device driver will be
used which is not certified by Microsoft

Signed-off-by: Liu, Hang1 <hang1.liu@intel.com>