### PR TITLE
dm: update the GPU OpRegion size to 20KB

### DIFF
--- a/devicemodel/include/pci_core.h
+++ b/devicemodel/include/pci_core.h
@@ -292,7 +292,7 @@ void destory_mmio_rsvd_rgns(struct pci_vdev *vdev);
  */
 #define GPU_DSM_GPA			0x7C000000
 #define GPU_DSM_SIZE			0x4000000
-#define GPU_OPREGION_SIZE		0x4000
+#define GPU_OPREGION_SIZE		0x5000
 /*
  * TODO: Forced DSM/OPREGION size requires native BIOS configuration.
  * This limitation need remove in future


### PR DESCRIPTION
The address of OpRegion is not 4KB aligned,
if the OpRegion + extended VBT size is 16KB,
then it will take up to 5 physical pages in host.
So update the OpRegion size to 20KB
to expose the whole OpRegion to guest.

Tracked-On: #6270

Signed-off-by: Liu,Junming <junming.liu@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>