### PR TITLE
FIXME: temporarily disable TPM2 passthrough

### DIFF
--- a/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
+++ b/misc/config_tools/data/ehl-crb-b/hybrid_rt.xml
@@ -130,7 +130,7 @@
             <pci_dev>00:1d.2 Ethernet controller: Intel Corporation Device 4bb0</pci_dev>
         </pci_devs>
         <mmio_resources>
-            <TPM2>y</TPM2>
+            <TPM2>n</TPM2>
         </mmio_resources>
     </vm>
     <vm id="1">


### PR DESCRIPTION
On some boards it is seen that the log area of the physical TPM2 is
programmed to be 0. If TPM2 is passed through to a pre-launched VM in such
cases, a piece of memory starting from GPA 0 will be unmapped from the
Service VM, leading to Service VM crash due to early BIOS corruption
checks.

This patch temporarily disables TPM2 passthrough on such platforms. A
thorough fix should be proposed later to gracefully handle such cases.

Tracked-On: #6288
Signed-off-by: Junjie Mao <junjie.mao@intel.com>