### PR TITLE
ICX-d LCC bring-up

### DIFF
--- a/hypervisor/arch/x86/guest/vcpuid.c
+++ b/hypervisor/arch/x86/guest/vcpuid.c
@@ -121,6 +121,9 @@ static void init_vcpuid_entry(uint32_t leaf, uint32_t subleaf,
 
 			entry->ebx &= ~(CPUID_EBX_PQM | CPUID_EBX_PQE);
 
+			/* mask LA57 */
+			entry->ecx &= ~CPUID_ECX_LA57;
+
 			/* mask SGX and SGX_LC */
 			entry->ebx &= ~CPUID_EBX_SGX;
 			entry->ecx &= ~CPUID_ECX_SGX_LC;

--- a/hypervisor/include/arch/x86/asm/page.h
+++ b/hypervisor/include/arch/x86/asm/page.h
@@ -8,12 +8,12 @@
 #define PAGE_H
 
 #include <asm/lib/spinlock.h>
+#include <board_info.h>
 
 #define PAGE_SHIFT	12U
 #define PAGE_SIZE	(1U << PAGE_SHIFT)
 #define PAGE_MASK	0xFFFFFFFFFFFFF000UL
 
-#define MAXIMUM_PA_WIDTH	46U	/* maximum physical-address width */
 #define MAX_PHY_ADDRESS_SPACE	(1UL << MAXIMUM_PA_WIDTH)
 
 /* size of the low MMIO address space: 2GB */

--- a/misc/config_tools/xforms/board_info.h.xsl
+++ b/misc/config_tools/xforms/board_info.h.xsl
@@ -37,6 +37,10 @@
   <xsl:template match="board-data/acrn-config">
     <xsl:call-template name="MAX_PCPU_NUM" />
     <xsl:call-template name="MAX_VMSIX_ON_MSI_PDEVS_NUM" />
+    <xsl:variable name="physical_address_bits" select="//processors/model/attribute[@id='physical_address_bits']/text()" />
+    <xsl:if test="$physical_address_bits">
+      <xsl:value-of select="acrn:define('MAXIMUM_PA_WIDTH', $physical_address_bits[1], 'U')" />
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="allocation-data/acrn-config">


### PR DESCRIPTION
Update platform maximum physical address width to 52 bits and mask off LA57 from cpuid.

Tracked-On: #6357
Signed-off-by: Liang Yi yi.liang@intel.com