### PR TITLE
config_tools: disable TPM2 passthrough on other platforms

### DIFF
--- a/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/cfl-k700-i7/hybrid_rt.xml
@@ -119,7 +119,7 @@
         <pci_dev>09:00.0 Non-Volatile memory controller: Silicon Motion, Inc. Device 2263 (rev 03)</pci_dev>
     </pci_devs>
     <mmio_resources>
-        <TPM2>y</TPM2>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">

--- a/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i5/hybrid_rt.xml
@@ -118,7 +118,7 @@
         <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
     <mmio_resources>
-        <TPM2>y</TPM2>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">

--- a/misc/config_tools/data/whl-ipc-i7/hybrid_rt.xml
+++ b/misc/config_tools/data/whl-ipc-i7/hybrid_rt.xml
@@ -118,7 +118,7 @@
         <pci_dev>03:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)</pci_dev>
     </pci_devs>
     <mmio_resources>
-        <TPM2>y</TPM2>
+        <TPM2>n</TPM2>
     </mmio_resources>
   </vm>
   <vm id="1">


### PR DESCRIPTION
Disables TPM2 passthrough on other platforms except TGL
follow the 6410 PR.

Tracked-On: #6288
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>