### PR TITLE
config_tools: rename two missed PSRAMs to SSRAMs

### DIFF
--- a/misc/config_tools/schema/checks/pre_launched_vm_support.xsd
+++ b/misc/config_tools/schema/checks/pre_launched_vm_support.xsd
@@ -36,7 +36,7 @@ or little cores are assigned, but not both.</xs:documentation>
     </xs:annotation>
   </xs:assert>
 
-  <xs:assert test="hv//PSRAM_ENABLED = 'n' or empty(vm[vm_type='PRE_RT_VM']) or
+  <xs:assert test="hv//SSRAM_ENABLED = 'n' or empty(vm[vm_type='PRE_RT_VM']) or
 		   every $cap in caches/cache[@level=3]/capability[@id='Software SRAM'] satisfies
 		   (compare($cap/end, '0x80000000') &lt; 0 or compare($cap/start, '0xf8000000') &gt;= 0)">
     <xs:annotation acrn:severity="warning">

--- a/misc/config_tools/static_allocators/gpa.py
+++ b/misc/config_tools/static_allocators/gpa.py
@@ -334,7 +334,7 @@ def allocate_pci_bar(board_etree, scenario_etree, allocation_etree):
 
 def allocate_ssram_region(board_etree, scenario_etree, allocation_etree):
     # Guest physical address of the SW SRAM allocated to a pre-launched VM
-    enabled = common.get_node("//PSRAM_ENABLED/text()", scenario_etree)
+    enabled = common.get_node("//SSRAM_ENABLED/text()", scenario_etree)
     if enabled == "y":
         pre_rt_vms = common.get_node("//vm[vm_type ='PRE_RT_VM']", scenario_etree)
         if pre_rt_vms is not None:


### PR DESCRIPTION
The term PSRAM is now obsoleted and should be replaced with SSRAM, as has been
done by commit 9facbb43b3c5 ("config-tool: rename PSRAM to SSRAM"). However,
there are two places in the configuration toolset that still uses PSRAM. This
patch updates these missed occurrences accordingly.

Tracked-On: #6012
Signed-off-by: Junjie Mao <junjie.mao@intel.com>