### PR TITLE
config_tools: update lpc slot number in script

### DIFF
--- a/misc/config_tools/launch_config/com.py
+++ b/misc/config_tools/launch_config/com.py
@@ -636,7 +636,7 @@ def dm_arg_set(names, sel, virt_io, dm, vmid, config):
             break
 
     if uos_type != "PREEMPT-RT LINUX":
-        print("   -s 31:0,lpc \\", file=config)
+        print("   -s 1:0,lpc \\", file=config)
 
     # redirect console
     if dm['vuart0'][vmid] == "Enable":


### PR DESCRIPTION
Update lpc slot to origin value 1 from 31 in the script too,
because GOP driver has assumption to config space layout of
the device on 00:1f.0.

Tracked-On: #6340
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>