### PR TITLE
ACRN:DM: Fix the Null pointer error

### DIFF
--- a/devicemodel/hw/pci/virtio/virtio_console.c
+++ b/devicemodel/hw/pci/virtio/virtio_console.c
@@ -1042,7 +1042,7 @@ virtio_console_teardown_backend(void *param)
 static int
 virtio_console_close_all(struct virtio_console *console)
 {
-	int i, rc = 0;
+	int i, rc = 0, nports_num;
 	struct virtio_console_port *port;
 	struct virtio_console_backend *be;
 
@@ -1060,8 +1060,16 @@ virtio_console_close_all(struct virtio_console *console)
 		if (be && !be->evp)
 			virtio_console_close_backend(be);
 	}
+	/*
+	 * The mevent_delete function will call teardown to delete
+	 * the console if the console->nports = 1, after the console
+	 * be destroyed there will be a NULL pointer issue.
+	 * Why don't check the console ? because the console delete
+	 * is not at the same thread.
+	 * */
 
-	for (i = 0; i < console->nports; i++) {
+	nports_num = console->nports;
+	for (i = 0; i < nports_num; i++) {
 		port = &console->ports[i];
 
 		if (!port->enabled)


### PR DESCRIPTION
Function virtio_console_close_all will close all consoles, if the console->nports
value is 1, after the console be destroyed by the mevent teardown function, when
get the nports from the console, there will cause the NULL pointer. Fix the issue.

Tracked-On: #6431
Signed-off-by: Liu Long <long.liu@intel.com>
Reviewed-by: Jian Jun Chen <jian.jun.chen@intel.com>
Acked-by: Wang, Yu1 <yu1.wang@intel.com>