### PR TITLE
board_inspector: add _CID to vACPI device objects

### DIFF
--- a/misc/config_tools/board_inspector/extractors/50-acpi.py
+++ b/misc/config_tools/board_inspector/extractors/50-acpi.py
@@ -439,6 +439,12 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
                 hid = "<unknown>"
             add_object_to_device(interpreter, namepath, "_HID", result)
 
+        # Create the XML element for the device and create its ancestors if necessary
+        element = get_device_element(devices_node, namepath, hid)
+        if hid in buses.keys():
+            element.tag = "bus"
+            element.set("type", buses[hid])
+
         # Compatible ID
         cids = []
         if interpreter.context.has_symbol(f"{namepath}._CID"):
@@ -458,13 +464,9 @@ def fetch_device_info(devices_node, interpreter, namepath, args):
                 elif isinstance(cid_datum, datatypes.String):
                     cids.append(cid_datum.get())
 
-        # Create the XML element for the device and create its ancestors if necessary
-        element = get_device_element(devices_node, namepath, hid)
-        if hid in buses.keys():
-            element.tag = "bus"
-            element.set("type", buses[hid])
-        for cid in cids:
-            add_child(element, "compatible_id", cid)
+            for cid in cids:
+                add_child(element, "compatible_id", cid)
+            add_object_to_device(interpreter, namepath, "_CID", cid_object)
 
         # Unique ID
         uid = ""

--- a/misc/config_tools/data/tgl-rvp/tgl-rvp.xml
+++ b/misc/config_tools/data/tgl-rvp/tgl-rvp.xml
@@ -265,9 +265,9 @@
 	0009f000-000fffff : Reserved
 	  000a0000-000bffff : PCI Bus 0000:00
 	  000f0000-000fffff : System ROM
-	00100000-394e5fff : System RAM
-	394e6000-39500fff : Reserved
-	39501000-39503fff : System RAM
+	00100000-394e7fff : System RAM
+	394e8000-39502fff : Reserved
+	39503000-39503fff : System RAM
 	39504000-39504fff : Reserved
 	39505000-3cd3cfff : System RAM
 	3cd3d000-3ff10fff : Reserved
@@ -335,10 +335,10 @@
 	  fee00000-fee00fff : Local APIC
 	ff400000-ffffffff : Reserved
 	100000000-4907fffff : System RAM
-	  447600000-448400db6 : Kernel code
-	  448600000-448b53fff : Kernel rodata
-	  448c00000-448e7a83f : Kernel data
-	  449134000-4495fffff : Kernel bss
+	  26da00000-26e800db6 : Kernel code
+	  26ea00000-26ef53fff : Kernel rodata
+	  26f000000-26f27a83f : Kernel data
+	  26f534000-26f9fffff : Kernel bss
 	490800000-493ffffff : RAM buffer
 	4000000000-7fffffffff : PCI Bus 0000:00
 	  4000000000-400fffffff : 0000:00:02.0
@@ -447,7 +447,7 @@
 	3, 5, 6, 7, 10, 11, 12, 13, 15
 	</AVAILABLE_IRQ_INFO>
   <TOTAL_MEM_INFO>
-	15685496 kB
+	15685504 kB
 	</TOTAL_MEM_INFO>
   <CPU_PROCESSOR_INFO>
 	0, 1, 2, 3
@@ -1032,7 +1032,7 @@
           <acpi_object>\_SB_.PC00.CLP0</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b824e055c2f035f53425f50433030434c5030085f5354410a0f085f4849440d494e543334373200085f55494400085f41445200085f43525311260a238e1e00010001020000010600801a06004d005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824c065c2f035f53425f50433030434c5030085f5354410a0f085f4849440d494e543334373200085f4349440d494e543334373200085f55494400085f41445200085f43525311260a238e1e00010001020000010600801a06004d005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>y</present>
             <enabled>y</enabled>
@@ -1692,29 +1692,29 @@
         <device address="0x120006">
           <acpi_object>\_SB_.PC00.SPI2</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303053504932085f4144520c06001200</aml_template>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D6</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D7</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.TP3_</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DB</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DA</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.TP1_</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D9</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.TP2_</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DC</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D8</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DE</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D6</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DD</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D9</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.TP3_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DE</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D7</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.TP2_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.TP1_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D8</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DB</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DC</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2DA</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI2.S2D0</dependency>
           <device id="SPI2001" address="0x0">
             <acpi_object>\_SB_.PC00.SPI2.S2D0</acpi_object>
             <compatible_id>SPI2001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324430085f53544100085f4849440d5350493230303100085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324430085f53544100085f4849440d5350493230303100085f4349440d5350493230303100085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1736,7 +1736,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D1</acpi_object>
             <compatible_id>SPI2003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324431085f53544100085f4849440d5350493230303300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000100005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324431085f53544100085f4849440d5350493230303300085f4349440d5350493230303300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000100005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1749,7 +1749,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D2</acpi_object>
             <compatible_id>SPI2002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324432085f53544100085f4849440d5350493230303200085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324432085f53544100085f4849440d5350493230303200085f4349440d5350493230303200085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1762,7 +1762,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D3</acpi_object>
             <compatible_id>SPI2004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324433085f53544100085f4849440d5350493230303400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010100005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324433085f53544100085f4849440d5350493230303400085f4349440d5350493230303400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010100005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1775,7 +1775,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D4</acpi_object>
             <compatible_id>SPI2005</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324434085f53544100085f4849440d5350493230303500085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324434085f53544100085f4849440d5350493230303500085f4349440d5350493230303500085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1788,7 +1788,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D5</acpi_object>
             <compatible_id>SPI2007</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324435085f53544100085f4849440d5350493230303700085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000100005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324435085f53544100085f4849440d5350493230303700085f4349440d5350493230303700085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000100005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1801,7 +1801,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D6</acpi_object>
             <compatible_id>SPI2006</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324436085f53544100085f4849440d5350493230303600085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324436085f53544100085f4849440d5350493230303600085f4349440d5350493230303600085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1814,7 +1814,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D7</acpi_object>
             <compatible_id>SPI2008</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324437085f53544100085f4849440d5350493230303800085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010100005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324437085f53544100085f4849440d5350493230303800085f4349440d5350493230303800085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010100005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1827,7 +1827,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D8</acpi_object>
             <compatible_id>SPI2009</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324438085f53544100085f4849440d5350493230303900085f55494401085f41445200085f43525311290a268e21000100020200000109008096980008000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324438085f53544100085f4849440d5350493230303900085f4349440d5350493230303900085f55494401085f41445200085f43525311290a268e21000100020200000109008096980008000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1840,7 +1840,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2D9</acpi_object>
             <compatible_id>SPI2010</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324439085f53544100085f4849440d5350493230313000085f55494401085f41445200085f43525311290a268e21000100020200000109002a50fe0008000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324439085f53544100085f4849440d5350493230313000085f4349440d5350493230313000085f55494401085f41445200085f43525311290a268e21000100020200000109002a50fe0008000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1853,7 +1853,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2DA</acpi_object>
             <compatible_id>SPI2011</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324441085f53544100085f4849440d5350493230313100085f55494401085f41445200085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324441085f53544100085f4849440d5350493230313100085f4349440d5350493230313100085f55494401085f41445200085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1866,7 +1866,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2DB</acpi_object>
             <compatible_id>SPI2012</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324442085f53544100085f4849440d5350493230313200085f55494401085f41445200085f43525311290a268e210001000202000001090000366e0108000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324442085f53544100085f4849440d5350493230313200085f4349440d5350493230313200085f55494401085f41445200085f43525311290a268e210001000202000001090000366e0108000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1879,7 +1879,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2DC</acpi_object>
             <compatible_id>SPI2013</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324443085f53544100085f4849440d5350493230313300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0010000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324443085f53544100085f4849440d5350493230313300085f4349440d5350493230313300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0010000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1892,7 +1892,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2DD</acpi_object>
             <compatible_id>SPI2014</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324444085f53544100085f4849440d5350493230313400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0018000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324444085f53544100085f4849440d5350493230313400085f4349440d5350493230313400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0018000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1905,7 +1905,7 @@
             <acpi_object>\_SB_.PC00.SPI2.S2DE</acpi_object>
             <compatible_id>SPI2015</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493253324445085f53544100085f4849440d5350493230313500085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0020000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493253324445085f53544100085f4849440d5350493230313500085f4349440d5350493230313500085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0020000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1917,7 +1917,7 @@
           <device id="SPT0001">
             <acpi_object>\_SB_.PC00.SPI2.TP1_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049325450315f085f53544100085f4849440d5350543030303100085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049325450315f085f53544100085f4849440d5350543030303100085f4349440d574954545465737400085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1929,7 +1929,7 @@
           <device id="SPT0002">
             <acpi_object>\_SB_.PC00.SPI2.TP2_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049325450325f085f53544100085f4849440d5350543030303200085f43525311290a268e2100010002020000010900404b4c0008000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049325450325f085f53544100085f4849440d5350543030303200085f4349440d574954545465737400085f43525311290a268e2100010002020000010900404b4c0008000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -1941,7 +1941,7 @@
           <device id="SPT0003">
             <acpi_object>\_SB_.PC00.SPI2.TP3_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049325450335f085f53544100085f4849440d5350543030303300085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504932007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049325450335f085f53544100085f4849440d5350543030303300085f4349440d574954545465737400085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504932007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2133,32 +2133,32 @@
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
           <dependency type="provides resources to">\_SB_.PC00.I2C0.EEP0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.I0D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT01</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT03</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.PA01</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.I0D0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.I0D1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.EEP1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT05</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT06</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT04</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPD0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPD0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C0.PA03</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPL1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C0.PA02</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT01</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C0.WT02</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.PA01</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT03</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT04</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.I0D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.I0D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.EEP1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.TPD0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT06</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.TPL1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.WT05</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.PA02</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C0.I0D2</dependency>
           <device id="EEP0000" address="0x0">
             <acpi_object>\_SB_.PC00.I2C0.EEP0</acpi_object>
             <compatible_id>EEP0000</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433045455030085f53544100085f4849440d4545503030303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433045455030085f53544100085f4849440d4545503030303000085f4349440d4545503030303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2171,7 +2171,7 @@
             <acpi_object>\_SB_.PC00.I2C0.EEP1</acpi_object>
             <compatible_id>EEP0004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433045455031085f53544100085f4849440d4545503030303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433045455031085f53544100085f4849440d4545503030303400085f4349440d4545503030303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2184,7 +2184,7 @@
             <acpi_object>\_SB_.PC00.I2C0.I0D0</acpi_object>
             <compatible_id>IIC0001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433049304430085f53544100085f4849440d4949433030303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433049304430085f53544100085f4849440d4949433030303100085f4349440d4949433030303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2197,7 +2197,7 @@
             <acpi_object>\_SB_.PC00.I2C0.I0D1</acpi_object>
             <compatible_id>IIC0002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433049304431085f53544100085f4849440d4949433030303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433049304431085f53544100085f4849440d4949433030303200085f4349440d4949433030303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2210,7 +2210,7 @@
             <acpi_object>\_SB_.PC00.I2C0.I0D2</acpi_object>
             <compatible_id>IIC0003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433049304432085f53544100085f4849440d4949433030303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433049304432085f53544100085f4849440d4949433030303300085f4349440d4949433030303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2258,7 +2258,7 @@
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C0.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824e055c2f045f53425f504330304932433054504430085f53544100085f4849440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
+            <aml_template>5b824c065c2f045f53425f504330304932433054504430085f53544100085f4849440d504e503043353000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2271,7 +2271,7 @@
           <device id="XXXX0000">
             <acpi_object>\_SB_.PC00.I2C0.TPL1</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824f055c2f045f53425f504330304932433054504c31085f53544100085f4849440d585858583030303000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
+            <aml_template>5b824d065c2f045f53425f504330304932433054504c31085f53544100085f4849440d585858583030303000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2284,7 +2284,7 @@
           <device id="STK0001">
             <acpi_object>\_SB_.PC00.I2C0.WT01</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433057543031085f53544100085f4849440d53544b3030303100085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433057543031085f53544100085f4849440d53544b3030303100085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2296,7 +2296,7 @@
           <device id="STK0002">
             <acpi_object>\_SB_.PC00.I2C0.WT02</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433057543032085f53544100085f4849440d53544b3030303200085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433057543032085f53544100085f4849440d53544b3030303200085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2308,7 +2308,7 @@
           <device id="STK0003">
             <acpi_object>\_SB_.PC00.I2C0.WT03</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433057543033085f53544100085f4849440d53544b3030303300085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433057543033085f53544100085f4849440d53544b3030303300085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2320,7 +2320,7 @@
           <device id="STK0004">
             <acpi_object>\_SB_.PC00.I2C0.WT04</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433057543034085f53544100085f4849440d53544b3030303400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433057543034085f53544100085f4849440d53544b3030303400085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2332,7 +2332,7 @@
           <device id="STK0005">
             <acpi_object>\_SB_.PC00.I2C0.WT05</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433057543035085f53544100085f4849440d53544b3030303500085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433057543035085f53544100085f4849440d53544b3030303500085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2344,7 +2344,7 @@
           <device id="STK0006">
             <acpi_object>\_SB_.PC00.I2C0.WT06</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433057543036085f53544100085f4849440d53544b3030303600085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324330007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433057543036085f53544100085f4849440d53544b3030303600085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324330007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2366,23 +2366,23 @@
           <resource type="memory" min="0x607d4eb000" max="0x607d4ebfff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.EEP2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT15</dependency>
           <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.EEP3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT13</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.I1D1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.WT16</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT11</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.WT14</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT12</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C1.I1D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.I1D1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C1.I1D2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.I1D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT13</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.EEP2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT12</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT15</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C1.WT11</dependency>
           <device id="EEP1000" address="0x0">
             <acpi_object>\_SB_.PC00.I2C1.EEP2</acpi_object>
             <compatible_id>EEP1000</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433145455032085f53544100085f4849440d4545503130303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433145455032085f53544100085f4849440d4545503130303000085f4349440d4545503130303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2395,7 +2395,7 @@
             <acpi_object>\_SB_.PC00.I2C1.EEP3</acpi_object>
             <compatible_id>EEP1004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433145455033085f53544100085f4849440d4545503130303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433145455033085f53544100085f4849440d4545503130303400085f4349440d4545503130303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2408,7 +2408,7 @@
             <acpi_object>\_SB_.PC00.I2C1.I1D0</acpi_object>
             <compatible_id>IIC1001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433149314430085f53544100085f4849440d4949433130303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433149314430085f53544100085f4849440d4949433130303100085f4349440d4949433130303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2421,7 +2421,7 @@
             <acpi_object>\_SB_.PC00.I2C1.I1D1</acpi_object>
             <compatible_id>IIC1002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433149314431085f53544100085f4849440d4949433130303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433149314431085f53544100085f4849440d4949433130303200085f4349440d4949433130303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2434,7 +2434,7 @@
             <acpi_object>\_SB_.PC00.I2C1.I1D2</acpi_object>
             <compatible_id>IIC1003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433149314432085f53544100085f4849440d4949433130303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433149314432085f53544100085f4849440d4949433130303300085f4349440d4949433130303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2446,7 +2446,7 @@
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C1.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824e055c2f045f53425f504330304932433154504430085f53544100085f4849440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
+            <aml_template>5b824c065c2f045f53425f504330304932433154504430085f53544100085f4849440d504e503043353000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2459,7 +2459,7 @@
           <device id="XXXX0000">
             <acpi_object>\_SB_.PC00.I2C1.TPL1</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824f055c2f045f53425f504330304932433154504c31085f53544100085f4849440d585858583030303000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
+            <aml_template>5b824d065c2f045f53425f504330304932433154504c31085f53544100085f4849440d585858583030303000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2472,7 +2472,7 @@
           <device id="STK0001">
             <acpi_object>\_SB_.PC00.I2C1.WT11</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433157543131085f53544100085f4849440d53544b3030303100085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433157543131085f53544100085f4849440d53544b3030303100085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2484,7 +2484,7 @@
           <device id="STK0002">
             <acpi_object>\_SB_.PC00.I2C1.WT12</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433157543132085f53544100085f4849440d53544b3030303200085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433157543132085f53544100085f4849440d53544b3030303200085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2496,7 +2496,7 @@
           <device id="STK0003">
             <acpi_object>\_SB_.PC00.I2C1.WT13</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433157543133085f53544100085f4849440d53544b3030303300085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433157543133085f53544100085f4849440d53544b3030303300085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2508,7 +2508,7 @@
           <device id="STK0004">
             <acpi_object>\_SB_.PC00.I2C1.WT14</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433157543134085f53544100085f4849440d53544b3030303400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433157543134085f53544100085f4849440d53544b3030303400085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2520,7 +2520,7 @@
           <device id="STK0005">
             <acpi_object>\_SB_.PC00.I2C1.WT15</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433157543135085f53544100085f4849440d53544b3030303500085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433157543135085f53544100085f4849440d53544b3030303500085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2532,7 +2532,7 @@
           <device id="STK0006">
             <acpi_object>\_SB_.PC00.I2C1.WT16</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433157543136085f53544100085f4849440d53544b3030303600085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324331007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433157543136085f53544100085f4849440d53544b3030303600085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324331007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2554,27 +2554,27 @@
           <resource type="memory" min="0x607d4ea000" max="0x607d4eafff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT23</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT22</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.I2D0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT25</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.I2D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT21</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT26</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.WT24</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.CAM0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.I2D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.I2D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK2</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.EEP4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C2.PMIC</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT26</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.I2D2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT25</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT21</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.I2D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT23</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C2.EEP5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.PMIC</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.CAM0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C2.WT22</dependency>
           <device id="INT3471" address="0x0">
             <acpi_object>\_SB_.PC00.I2C2.CAM0</acpi_object>
             <compatible_id>INT3471</compatible_id>
             <acpi_uid>0</acpi_uid>
-            <aml_template>5b8249105c2f045f53425f504330304932433243414d30085f53544100085f4849440d494e543334373100085f5549440d3000085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324332008e1e00010001020000010600801a06000e005c5f53422e504330302e49324332008e1e00010001020000010600801a060050005c5f53422e504330302e49324332008e1e00010001020000010600801a060051005c5f53422e504330302e49324332008e1e00010001020000010600801a060052005c5f53422e504330302e49324332008e1e00010001020000010600801a060053005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8247115c2f045f53425f504330304932433243414d30085f53544100085f4849440d494e543334373100085f4349440d494e543334373100085f5549440d3000085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324332008e1e00010001020000010600801a06000e005c5f53422e504330302e49324332008e1e00010001020000010600801a060050005c5f53422e504330302e49324332008e1e00010001020000010600801a060051005c5f53422e504330302e49324332008e1e00010001020000010600801a060052005c5f53422e504330302e49324332008e1e00010001020000010600801a060053005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2592,7 +2592,7 @@
             <acpi_object>\_SB_.PC00.I2C2.EEP4</acpi_object>
             <compatible_id>EEP2000</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433245455034085f53544100085f4849440d4545503230303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433245455034085f53544100085f4849440d4545503230303000085f4349440d4545503230303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2605,7 +2605,7 @@
             <acpi_object>\_SB_.PC00.I2C2.EEP5</acpi_object>
             <compatible_id>EEP2004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433245455035085f53544100085f4849440d4545503230303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433245455035085f53544100085f4849440d4545503230303400085f4349440d4545503230303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2618,7 +2618,7 @@
             <acpi_object>\_SB_.PC00.I2C2.I2D0</acpi_object>
             <compatible_id>IIC2001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433249324430085f53544100085f4849440d4949433230303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433249324430085f53544100085f4849440d4949433230303100085f4349440d4949433230303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2631,7 +2631,7 @@
             <acpi_object>\_SB_.PC00.I2C2.I2D1</acpi_object>
             <compatible_id>IIC2002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433249324431085f53544100085f4849440d4949433230303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433249324431085f53544100085f4849440d4949433230303200085f4349440d4949433230303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2644,7 +2644,7 @@
             <acpi_object>\_SB_.PC00.I2C2.I2D2</acpi_object>
             <compatible_id>IIC2003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433249324432085f53544100085f4849440d4949433230303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433249324432085f53544100085f4849440d4949433230303300085f4349440d4949433230303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2657,7 +2657,7 @@
             <acpi_object>\_SB_.PC00.I2C2.PMIC</acpi_object>
             <compatible_id>INT3472</compatible_id>
             <acpi_uid>0</acpi_uid>
-            <aml_template>5b8243065c2f045f53425f5043303049324332504d4943085f53544100085f4849440d494e543334373200085f5549440d3000085f41445200085f43525311260a238e1e00010001020000010600801a06004c005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8241075c2f045f53425f5043303049324332504d4943085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440d3000085f41445200085f43525311260a238e1e00010001020000010600801a06004c005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2669,7 +2669,7 @@
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C2.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824e055c2f045f53425f504330304932433254504430085f53544100085f4849440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
+            <aml_template>5b824c065c2f045f53425f504330304932433254504430085f53544100085f4849440d504e503043353000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2682,7 +2682,7 @@
           <device id="XXXX0000">
             <acpi_object>\_SB_.PC00.I2C2.TPL1</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824f055c2f045f53425f504330304932433254504c31085f53544100085f4849440d585858583030303000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
+            <aml_template>5b824d065c2f045f53425f504330304932433254504c31085f53544100085f4849440d585858583030303000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2695,7 +2695,7 @@
           <device id="STK0001">
             <acpi_object>\_SB_.PC00.I2C2.WT21</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433257543231085f53544100085f4849440d53544b3030303100085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433257543231085f53544100085f4849440d53544b3030303100085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2707,7 +2707,7 @@
           <device id="STK0002">
             <acpi_object>\_SB_.PC00.I2C2.WT22</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433257543232085f53544100085f4849440d53544b3030303200085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433257543232085f53544100085f4849440d53544b3030303200085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2719,7 +2719,7 @@
           <device id="STK0003">
             <acpi_object>\_SB_.PC00.I2C2.WT23</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433257543233085f53544100085f4849440d53544b3030303300085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433257543233085f53544100085f4849440d53544b3030303300085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2731,7 +2731,7 @@
           <device id="STK0004">
             <acpi_object>\_SB_.PC00.I2C2.WT24</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433257543234085f53544100085f4849440d53544b3030303400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433257543234085f53544100085f4849440d53544b3030303400085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2743,7 +2743,7 @@
           <device id="STK0005">
             <acpi_object>\_SB_.PC00.I2C2.WT25</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433257543235085f53544100085f4849440d53544b3030303500085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433257543235085f53544100085f4849440d53544b3030303500085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2755,7 +2755,7 @@
           <device id="STK0006">
             <acpi_object>\_SB_.PC00.I2C2.WT26</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433257543236085f53544100085f4849440d53544b3030303600085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324332007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433257543236085f53544100085f4849440d53544b3030303600085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324332007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2777,35 +2777,35 @@
           <resource type="memory" min="0x607d4e9000" max="0x607d4e9fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.CLP3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT32</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK3</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C3.EEP7</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.I3D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT32</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT35</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C3.EEP6</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT34</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.I3D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT36</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C3.I3D2</dependency>
           <dependency type="provides resources to">\_SB_.PC00.CLP0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.LNK1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.CLP4</dependency>
           <dependency type="provides resources to">\_SB_.PC00.CLP1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C3.WT33</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT35</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT34</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.CLP4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.I3D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.I3D0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.WT36</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C3.I3D1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.LNK3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
           <device id="EEP3000" address="0x0">
             <acpi_object>\_SB_.PC00.I2C3.EEP6</acpi_object>
             <compatible_id>EEP3000</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433345455036085f53544100085f4849440d4545503330303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433345455036085f53544100085f4849440d4545503330303000085f4349440d4545503330303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2818,7 +2818,7 @@
             <acpi_object>\_SB_.PC00.I2C3.EEP7</acpi_object>
             <compatible_id>EEP3004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433345455037085f53544100085f4849440d4545503330303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433345455037085f53544100085f4849440d4545503330303400085f4349440d4545503330303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2831,7 +2831,7 @@
             <acpi_object>\_SB_.PC00.I2C3.I3D0</acpi_object>
             <compatible_id>IIC3001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433349334430085f53544100085f4849440d4949433330303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433349334430085f53544100085f4849440d4949433330303100085f4349440d4949433330303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2844,7 +2844,7 @@
             <acpi_object>\_SB_.PC00.I2C3.I3D1</acpi_object>
             <compatible_id>IIC3002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433349334431085f53544100085f4849440d4949433330303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433349334431085f53544100085f4849440d4949433330303200085f4349440d4949433330303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2857,7 +2857,7 @@
             <acpi_object>\_SB_.PC00.I2C3.I3D2</acpi_object>
             <compatible_id>IIC3003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433349334432085f53544100085f4849440d4949433330303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433349334432085f53544100085f4849440d4949433330303300085f4349440d4949433330303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2869,7 +2869,7 @@
           <device id="PNP0C50">
             <acpi_object>\_SB_.PC00.I2C3.TPD0</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824e055c2f045f53425f504330304932433354504430085f53544100085f4849440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
+            <aml_template>5b824c065c2f045f53425f504330304932433354504430085f53544100085f4849440d504e503043353000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906001501760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2882,7 +2882,7 @@
           <device id="XXXX0000">
             <acpi_object>\_SB_.PC00.I2C3.TPL1</acpi_object>
             <compatible_id>PNP0C50</compatible_id>
-            <aml_template>5b824f055c2f045f53425f504330304932433354504c31085f53544100085f4849440d585858583030303000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
+            <aml_template>5b824d065c2f045f53425f504330304932433354504c31085f53544100085f4849440d585858583030303000085f4349440d504e503043353000085f435253112f0a2c8e1e00010001020000010600801a060000005c5f53422e504330302e49324330008906000101760000007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2895,7 +2895,7 @@
           <device id="STK0001">
             <acpi_object>\_SB_.PC00.I2C3.WT31</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b82285c2f045f53425f504330304932433357543331085f53544100085f4849440d53544b3030303100</aml_template>
+            <aml_template>5b82375c2f045f53425f504330304932433357543331085f53544100085f4849440d53544b3030303100085f4349440d574954545465737400</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2905,7 +2905,7 @@
           <device id="STK0002">
             <acpi_object>\_SB_.PC00.I2C3.WT32</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433357543332085f53544100085f4849440d53544b3030303200085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433357543332085f53544100085f4849440d53544b3030303200085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2917,7 +2917,7 @@
           <device id="STK0003">
             <acpi_object>\_SB_.PC00.I2C3.WT33</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433357543333085f53544100085f4849440d53544b3030303300085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433357543333085f53544100085f4849440d53544b3030303300085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2929,7 +2929,7 @@
           <device id="STK0004">
             <acpi_object>\_SB_.PC00.I2C3.WT34</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433357543334085f53544100085f4849440d53544b3030303400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433357543334085f53544100085f4849440d53544b3030303400085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2941,7 +2941,7 @@
           <device id="STK0005">
             <acpi_object>\_SB_.PC00.I2C3.WT35</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433357543335085f53544100085f4849440d53544b3030303500085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433357543335085f53544100085f4849440d53544b3030303500085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -2953,7 +2953,7 @@
           <device id="STK0006">
             <acpi_object>\_SB_.PC00.I2C3.WT36</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433357543336085f53544100085f4849440d53544b3030303600085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324333007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433357543336085f53544100085f4849440d53544b3030303600085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324333007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3065,23 +3065,23 @@
           <resource type="memory" min="0x607d4e7000" max="0x607d4e7fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.CAM1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.EEP8</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.WT46</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.I4D0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.I4D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.WT41</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C4.I4D1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C4.WT42</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C4.WT44</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.I4D2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.CAM1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C4.EEP9</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.I4D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.I4D1</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C4.WT45</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C4.WT43</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.WT41</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.EEP8</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C4.WT46</dependency>
           <device id="INT3474" address="0x0">
             <acpi_object>\_SB_.PC00.I2C4.CAM1</acpi_object>
             <compatible_id>INT3474</compatible_id>
             <acpi_uid>0</acpi_uid>
-            <aml_template>5b8243065c2f045f53425f504330304932433443414d31085f53544100085f4849440d494e543334373400085f5549440d3000085f41445200085f43525311260a238e1e00010001020000010600801a060036005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8241075c2f045f53425f504330304932433443414d31085f53544100085f4849440d494e543334373400085f4349440d494e543334373400085f5549440d3000085f41445200085f43525311260a238e1e00010001020000010600801a060036005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3094,7 +3094,7 @@
             <acpi_object>\_SB_.PC00.I2C4.EEP8</acpi_object>
             <compatible_id>EEP4000</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433445455038085f53544100085f4849440d4545503430303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433445455038085f53544100085f4849440d4545503430303000085f4349440d4545503430303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3107,7 +3107,7 @@
             <acpi_object>\_SB_.PC00.I2C4.EEP9</acpi_object>
             <compatible_id>EEP4004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433445455039085f53544100085f4849440d4545503430303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433445455039085f53544100085f4849440d4545503430303400085f4349440d4545503430303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3120,7 +3120,7 @@
             <acpi_object>\_SB_.PC00.I2C4.I4D0</acpi_object>
             <compatible_id>IIC4001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433449344430085f53544100085f4849440d4949433430303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433449344430085f53544100085f4849440d4949433430303100085f4349440d4949433430303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3133,7 +3133,7 @@
             <acpi_object>\_SB_.PC00.I2C4.I4D1</acpi_object>
             <compatible_id>IIC4002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433449344431085f53544100085f4849440d4949433430303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433449344431085f53544100085f4849440d4949433430303200085f4349440d4949433430303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3146,7 +3146,7 @@
             <acpi_object>\_SB_.PC00.I2C4.I4D2</acpi_object>
             <compatible_id>IIC4003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433449344432085f53544100085f4849440d4949433430303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433449344432085f53544100085f4849440d4949433430303300085f4349440d4949433430303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3158,7 +3158,7 @@
           <device id="STK0001">
             <acpi_object>\_SB_.PC00.I2C4.WT41</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433457543431085f53544100085f4849440d53544b3030303100085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433457543431085f53544100085f4849440d53544b3030303100085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3170,7 +3170,7 @@
           <device id="STK0002">
             <acpi_object>\_SB_.PC00.I2C4.WT42</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433457543432085f53544100085f4849440d53544b3030303200085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433457543432085f53544100085f4849440d53544b3030303200085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3182,7 +3182,7 @@
           <device id="STK0003">
             <acpi_object>\_SB_.PC00.I2C4.WT43</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433457543433085f53544100085f4849440d53544b3030303300085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433457543433085f53544100085f4849440d53544b3030303300085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3194,7 +3194,7 @@
           <device id="STK0004">
             <acpi_object>\_SB_.PC00.I2C4.WT44</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433457543434085f53544100085f4849440d53544b3030303400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433457543434085f53544100085f4849440d53544b3030303400085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3206,7 +3206,7 @@
           <device id="STK0005">
             <acpi_object>\_SB_.PC00.I2C4.WT45</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433457543435085f53544100085f4849440d53544b3030303500085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433457543435085f53544100085f4849440d53544b3030303500085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3218,7 +3218,7 @@
           <device id="STK0006">
             <acpi_object>\_SB_.PC00.I2C4.WT46</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433457543436085f53544100085f4849440d53544b3030303600085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324334007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433457543436085f53544100085f4849440d53544b3030303600085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324334007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3240,26 +3240,26 @@
           <resource type="memory" min="0x607d4e6000" max="0x607d4e6fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA02</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA04</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.I5D0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.EEPA</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.WT55</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA02</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.PA01</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT56</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA03</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.I5D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT51</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.EEPB</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT53</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA04</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.WT52</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT54</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.I5D2</dependency>
           <dependency type="provides resources to">\_SB_.PC00.I2C5.I5D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.EEPB</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.PA03</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT51</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT54</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT53</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.I2C5.WT56</dependency>
           <device id="EEP5000" address="0x0">
             <acpi_object>\_SB_.PC00.I2C5.EEPA</acpi_object>
             <compatible_id>EEP5000</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433545455041085f53544100085f4849440d4545503530303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433545455041085f53544100085f4849440d4545503530303000085f4349440d4545503530303000085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0050005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3272,7 +3272,7 @@
             <acpi_object>\_SB_.PC00.I2C5.EEPB</acpi_object>
             <compatible_id>EEP5004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433545455042085f53544100085f4849440d4545503530303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433545455042085f53544100085f4849440d4545503530303400085f4349440d4545503530303400085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060050005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3285,7 +3285,7 @@
             <acpi_object>\_SB_.PC00.I2C5.I5D0</acpi_object>
             <compatible_id>IIC5001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433549354430085f53544100085f4849440d4949433530303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433549354430085f53544100085f4849440d4949433530303100085f4349440d4949433530303100085f55494401085f41445200085f43525311260a238e1e00010001020000010600a086010015005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3298,7 +3298,7 @@
             <acpi_object>\_SB_.PC00.I2C5.I5D1</acpi_object>
             <compatible_id>IIC5002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433549354431085f53544100085f4849440d4949433530303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433549354431085f53544100085f4849440d4949433530303200085f4349440d4949433530303200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060025005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3311,7 +3311,7 @@
             <acpi_object>\_SB_.PC00.I2C5.I5D2</acpi_object>
             <compatible_id>IIC5003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8241065c2f045f53425f504330304932433549354432085f53544100085f4849440d4949433530303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b824f065c2f045f53425f504330304932433549354432085f53544100085f4849440d4949433530303300085f4349440d4949433530303300085f55494401085f41445200085f43525311260a238e1e0001000102000001060040420f0035005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3371,7 +3371,7 @@
           <device id="STK0001">
             <acpi_object>\_SB_.PC00.I2C5.WT51</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433557543531085f53544100085f4849440d53544b3030303100085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433557543531085f53544100085f4849440d53544b3030303100085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a08601007f005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3383,7 +3383,7 @@
           <device id="STK0002">
             <acpi_object>\_SB_.PC00.I2C5.WT52</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433557543532085f53544100085f4849440d53544b3030303200085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433557543532085f53544100085f4849440d53544b3030303200085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600a086010011005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3395,7 +3395,7 @@
           <device id="STK0003">
             <acpi_object>\_SB_.PC00.I2C5.WT53</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433557543533085f53544100085f4849440d53544b3030303300085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433557543533085f53544100085f4849440d53544b3030303300085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600801a060012005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3407,7 +3407,7 @@
           <device id="STK0004">
             <acpi_object>\_SB_.PC00.I2C5.WT54</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433557543534085f53544100085f4849440d53544b3030303400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433557543534085f53544100085f4849440d53544b3030303400085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040420f0013005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3419,7 +3419,7 @@
           <device id="STK0005">
             <acpi_object>\_SB_.PC00.I2C5.WT55</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433557543535085f53544100085f4849440d53544b3030303500085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433557543535085f53544100085f4849440d53544b3030303500085f4349440d574954545465737400085f43525311260a238e1e00010001020000010600c05c150014005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3431,7 +3431,7 @@
           <device id="STK0006">
             <acpi_object>\_SB_.PC00.I2C5.WT56</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8245055c2f045f53425f504330304932433557543536085f53544100085f4849440d53544b3030303600085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324335007900</aml_template>
+            <aml_template>5b8244065c2f045f53425f504330304932433557543536085f53544100085f4849440d53544b3030303600085f4349440d574954545465737400085f43525311260a238e1e0001000102000001060040e1330015005c5f53422e504330302e49324335007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3444,8 +3444,8 @@
         <device address="0x190002">
           <acpi_object>\_SB_.PC00.UA02</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303055413032085f4144520c02001900</aml_template>
-          <dependency type="provides resources to">\_SB_.PC00.UA02.SER3</dependency>
           <dependency type="provides resources to">\_SB_.PC00.UA02.SER4</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.UA02.SER3</dependency>
           <dependency type="provides resources to">\_SB_.PC00.UA02.UT21</dependency>
           <device id="SER2002">
             <acpi_object>\_SB_.PC00.UA02.SER3</acpi_object>
@@ -3473,7 +3473,7 @@
             <acpi_object>\_SB_.PC00.UA02.UT21</acpi_object>
             <compatible_id>UARTTest</compatible_id>
             <acpi_uid>0</acpi_uid>
-            <aml_template>5b824f055c2f045f53425f504330305541303255543231085f53544100085f4849440d55544b3030303100085f55494400085f435253112a0a278e2200010003023500010a0000c201004000400000c05c5f53422e504330302e55413032007900</aml_template>
+            <aml_template>5b824e065c2f045f53425f504330305541303255543231085f53544100085f4849440d55544b3030303100085f4349440d554152545465737400085f55494400085f435253112a0a278e2200010003023500010a0000c201004000400000c05c5f53422e504330302e55413032007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3879,8 +3879,8 @@
           <resource type="memory" min="0x607d4e5000" max="0x607d4e5fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.UA00.UT01</dependency>
           <dependency type="provides resources to">\_SB_.PC00.UA00.BTH0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.UA00.UT01</dependency>
           <dependency type="provides resources to">\_SB_.PC00.UA00.SER0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.UA00.SER1</dependency>
           <device id="INT33E1">
@@ -3923,7 +3923,7 @@
             <acpi_object>\_SB_.PC00.UA00.UT01</acpi_object>
             <compatible_id>UARTTest</compatible_id>
             <acpi_uid>0</acpi_uid>
-            <aml_template>5b824f055c2f045f53425f504330305541303055543031085f53544100085f4849440d55544b3030303100085f55494400085f435253112a0a278e2200010003023500010a0000c201004000400000c05c5f53422e504330302e55413030007900</aml_template>
+            <aml_template>5b824e065c2f045f53425f504330305541303055543031085f53544100085f4849440d55544b3030303100085f4349440d554152545465737400085f55494400085f435253112a0a278e2200010003023500010a0000c201004000400000c05c5f53422e504330302e55413030007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3936,9 +3936,9 @@
         <device address="0x1e0001">
           <acpi_object>\_SB_.PC00.UA01</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303055413031085f4144520c01001e00</aml_template>
-          <dependency type="provides resources to">\_SB_.PC00.UA01.SER3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.UA01.UT11</dependency>
           <dependency type="provides resources to">\_SB_.PC00.UA01.SER2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.UA01.UT11</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.UA01.SER3</dependency>
           <device id="SER1001">
             <acpi_object>\_SB_.PC00.UA01.SER2</acpi_object>
             <aml_template>5b8249055c2f045f53425f504330305541303153455232085f53544100085f4849440d5345523130303100085f435253112a0a278e2200010003023d00010a00008403002000200002c05c5f53422e504330302e55413031007900</aml_template>
@@ -3965,7 +3965,7 @@
             <acpi_object>\_SB_.PC00.UA01.UT11</acpi_object>
             <compatible_id>UARTTest</compatible_id>
             <acpi_uid>0</acpi_uid>
-            <aml_template>5b824f055c2f045f53425f504330305541303155543131085f53544100085f4849440d55544b3030303100085f55494400085f435253112a0a278e2200010003023500010a0000c201004000400000c05c5f53422e504330302e55413031007900</aml_template>
+            <aml_template>5b824e065c2f045f53425f504330305541303155543131085f53544100085f4849440d55544b3030303100085f4349440d554152545465737400085f55494400085f435253112a0a278e2200010003023500010a0000c201004000400000c05c5f53422e504330302e55413031007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -3978,29 +3978,29 @@
         <device address="0x1e0002">
           <acpi_object>\_SB_.PC00.SPI0</acpi_object>
           <aml_template>5b821a5c2f035f53425f5043303053504930085f4144520c02001e00</aml_template>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D4</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.TP2_</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D6</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D7</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DB</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D0</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.TP1_</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.TP3_</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D8</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DC</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DD</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D3</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DE</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D2</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DB</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D9</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DD</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.TP1_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D2</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.TP2_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DE</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.TP3_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D4</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI0.S0DA</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D7</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI0.S0D3</dependency>
           <device id="SPI0001" address="0x0">
             <acpi_object>\_SB_.PC00.SPI0.S0D0</acpi_object>
             <compatible_id>SPI0001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304430085f53544100085f4849440d5350493030303100085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304430085f53544100085f4849440d5350493030303100085f4349440d5350493030303100085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4013,7 +4013,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D1</acpi_object>
             <compatible_id>SPI0003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304431085f53544100085f4849440d5350493030303300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000100005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304431085f53544100085f4849440d5350493030303300085f4349440d5350493030303300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000100005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4026,7 +4026,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D2</acpi_object>
             <compatible_id>SPI0002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304432085f53544100085f4849440d5350493030303200085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304432085f53544100085f4849440d5350493030303200085f4349440d5350493030303200085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4039,7 +4039,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D3</acpi_object>
             <compatible_id>SPI0004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304433085f53544100085f4849440d5350493030303400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010100005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304433085f53544100085f4849440d5350493030303400085f4349440d5350493030303400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010100005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4052,7 +4052,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D4</acpi_object>
             <compatible_id>SPI0005</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304434085f53544100085f4849440d5350493030303500085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304434085f53544100085f4849440d5350493030303500085f4349440d5350493030303500085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4065,7 +4065,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D5</acpi_object>
             <compatible_id>SPI0007</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304435085f53544100085f4849440d5350493030303700085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000100005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304435085f53544100085f4849440d5350493030303700085f4349440d5350493030303700085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000100005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4078,7 +4078,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D6</acpi_object>
             <compatible_id>SPI0006</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304436085f53544100085f4849440d5350493030303600085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304436085f53544100085f4849440d5350493030303600085f4349440d5350493030303600085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4091,7 +4091,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D7</acpi_object>
             <compatible_id>SPI0008</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304437085f53544100085f4849440d5350493030303800085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010100005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304437085f53544100085f4849440d5350493030303800085f4349440d5350493030303800085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010100005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4104,7 +4104,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D8</acpi_object>
             <compatible_id>SPI0009</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304438085f53544100085f4849440d5350493030303900085f55494401085f41445200085f43525311290a268e21000100020200000109008096980008000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304438085f53544100085f4849440d5350493030303900085f4349440d5350493030303900085f55494401085f41445200085f43525311290a268e21000100020200000109008096980008000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4117,7 +4117,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0D9</acpi_object>
             <compatible_id>SPI0010</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304439085f53544100085f4849440d5350493030313000085f55494401085f41445200085f43525311290a268e21000100020200000109002a50fe0008000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304439085f53544100085f4849440d5350493030313000085f4349440d5350493030313000085f55494401085f41445200085f43525311290a268e21000100020200000109002a50fe0008000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4130,7 +4130,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0DA</acpi_object>
             <compatible_id>SPI0011</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304441085f53544100085f4849440d5350493030313100085f55494401085f41445200085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304441085f53544100085f4849440d5350493030313100085f4349440d5350493030313100085f55494401085f41445200085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4143,7 +4143,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0DB</acpi_object>
             <compatible_id>SPI0012</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304442085f53544100085f4849440d5350493030313200085f55494401085f41445200085f43525311290a268e210001000202000001090000366e0108000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304442085f53544100085f4849440d5350493030313200085f4349440d5350493030313200085f55494401085f41445200085f43525311290a268e210001000202000001090000366e0108000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4156,7 +4156,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0DC</acpi_object>
             <compatible_id>SPI0013</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304443085f53544100085f4849440d5350493030313300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0010000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304443085f53544100085f4849440d5350493030313300085f4349440d5350493030313300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0010000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4169,7 +4169,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0DD</acpi_object>
             <compatible_id>SPI0014</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304444085f53544100085f4849440d5350493030313400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0018000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304444085f53544100085f4849440d5350493030313400085f4349440d5350493030313400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0018000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4182,7 +4182,7 @@
             <acpi_object>\_SB_.PC00.SPI0.S0DE</acpi_object>
             <compatible_id>SPI0015</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493053304445085f53544100085f4849440d5350493030313500085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0020000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493053304445085f53544100085f4849440d5350493030313500085f4349440d5350493030313500085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0020000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4194,7 +4194,7 @@
           <device id="SPT0001">
             <acpi_object>\_SB_.PC00.SPI0.TP1_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049305450315f085f53544100085f4849440d5350543030303100085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049305450315f085f53544100085f4849440d5350543030303100085f4349440d574954545465737400085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4206,7 +4206,7 @@
           <device id="SPT0002">
             <acpi_object>\_SB_.PC00.SPI0.TP2_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049305450325f085f53544100085f4849440d5350543030303200085f43525311290a268e2100010002020000010900404b4c0008000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049305450325f085f53544100085f4849440d5350543030303200085f4349440d574954545465737400085f43525311290a268e2100010002020000010900404b4c0008000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4218,7 +4218,7 @@
           <device id="SPT0003">
             <acpi_object>\_SB_.PC00.SPI0.TP3_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049305450335f085f53544100085f4849440d5350543030303300085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504930007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049305450335f085f53544100085f4849440d5350543030303300085f4349440d574954545465737400085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504930007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4240,29 +4240,29 @@
           <resource type="memory" min="0x607d4e4000" max="0x607d4e4fff" len="0x1000" id="bar0" width="64" prefetchable="0"/>
           <capability id="Power Management"/>
           <capability id="Vendor-Specific"/>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D2</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI1.S1DA</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D5</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D7</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D8</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI1.S1DB</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.TP2_</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D7</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D3</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D6</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D9</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI1.S1DD</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D4</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D5</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1DC</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D1</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D0</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D9</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.TP1_</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D6</dependency>
-          <dependency type="provides resources to">\_SB_.PC00.SPI1.TP3_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D3</dependency>
           <dependency type="provides resources to">\_SB_.PC00.SPI1.S1DE</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.TP1_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.TP3_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.TP2_</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D0</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D1</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1DC</dependency>
+          <dependency type="provides resources to">\_SB_.PC00.SPI1.S1D2</dependency>
           <device id="SPI1001" address="0x0">
             <acpi_object>\_SB_.PC00.SPI1.S1D0</acpi_object>
             <compatible_id>SPI1001</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314430085f53544100085f4849440d5350493130303100085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314430085f53544100085f4849440d5350493130303100085f4349440d5350493130303100085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4284,7 +4284,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D1</acpi_object>
             <compatible_id>SPI1003</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314431085f53544100085f4849440d5350493130303300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000100005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314431085f53544100085f4849440d5350493130303300085f4349440d5350493130303300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008000100005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4297,7 +4297,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D2</acpi_object>
             <compatible_id>SPI1002</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314432085f53544100085f4849440d5350493130303200085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314432085f53544100085f4849440d5350493130303200085f4349440d5350493130303200085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4310,7 +4310,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D3</acpi_object>
             <compatible_id>SPI1004</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314433085f53544100085f4849440d5350493130303400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010100005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314433085f53544100085f4849440d5350493130303400085f4349440d5350493130303400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0008010100005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4323,7 +4323,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D4</acpi_object>
             <compatible_id>SPI1005</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314434085f53544100085f4849440d5350493130303500085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314434085f53544100085f4849440d5350493130303500085f4349440d5350493130303500085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4336,7 +4336,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D5</acpi_object>
             <compatible_id>SPI1007</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314435085f53544100085f4849440d5350493130303700085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000100005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314435085f53544100085f4849440d5350493130303700085f4349440d5350493130303700085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008000100005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4349,7 +4349,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D6</acpi_object>
             <compatible_id>SPI1006</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314436085f53544100085f4849440d5350493130303600085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314436085f53544100085f4849440d5350493130303600085f4349440d5350493130303600085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4362,7 +4362,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D7</acpi_object>
             <compatible_id>SPI1008</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314437085f53544100085f4849440d5350493130303800085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010100005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314437085f53544100085f4849440d5350493130303800085f4349440d5350493130303800085f55494401085f41445200085f43525311290a268e210001000202020001090040420f0008010100005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4375,7 +4375,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D8</acpi_object>
             <compatible_id>SPI1009</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314438085f53544100085f4849440d5350493130303900085f55494401085f41445200085f43525311290a268e21000100020200000109008096980008000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314438085f53544100085f4849440d5350493130303900085f4349440d5350493130303900085f55494401085f41445200085f43525311290a268e21000100020200000109008096980008000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4388,7 +4388,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1D9</acpi_object>
             <compatible_id>SPI1010</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314439085f53544100085f4849440d5350493130313000085f55494401085f41445200085f43525311290a268e21000100020200000109002a50fe0008000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314439085f53544100085f4849440d5350493130313000085f4349440d5350493130313000085f55494401085f41445200085f43525311290a268e21000100020200000109002a50fe0008000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4401,7 +4401,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1DA</acpi_object>
             <compatible_id>SPI1011</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314441085f53544100085f4849440d5350493130313100085f55494401085f41445200085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314441085f53544100085f4849440d5350493130313100085f4349440d5350493130313100085f55494401085f41445200085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4414,7 +4414,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1DB</acpi_object>
             <compatible_id>SPI1012</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314442085f53544100085f4849440d5350493130313200085f55494401085f41445200085f43525311290a268e210001000202000001090000366e0108000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314442085f53544100085f4849440d5350493130313200085f4349440d5350493130313200085f55494401085f41445200085f43525311290a268e210001000202000001090000366e0108000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4427,7 +4427,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1DC</acpi_object>
             <compatible_id>SPI1013</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314443085f53544100085f4849440d5350493130313300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0010000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314443085f53544100085f4849440d5350493130313300085f4349440d5350493130313300085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0010000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4440,7 +4440,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1DD</acpi_object>
             <compatible_id>SPI1014</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314444085f53544100085f4849440d5350493130313400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0018000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314444085f53544100085f4849440d5350493130313400085f4349440d5350493130313400085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0018000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4453,7 +4453,7 @@
             <acpi_object>\_SB_.PC00.SPI1.S1DE</acpi_object>
             <compatible_id>SPI1015</compatible_id>
             <acpi_uid>1</acpi_uid>
-            <aml_template>5b8244065c2f045f53425f504330305350493153314445085f53544100085f4849440d5350493130313500085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0020000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8242075c2f045f53425f504330305350493153314445085f53544100085f4849440d5350493130313500085f4349440d5350493130313500085f55494401085f41445200085f43525311290a268e210001000202000001090040420f0020000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4465,7 +4465,7 @@
           <device id="SPT0001">
             <acpi_object>\_SB_.PC00.SPI1.TP1_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049315450315f085f53544100085f4849440d5350543030303100085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049315450315f085f53544100085f4849440d5350543030303100085f4349440d574954545465737400085f43525311290a268e210001000202000001090040420f0008000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4477,7 +4477,7 @@
           <device id="SPT0002">
             <acpi_object>\_SB_.PC00.SPI1.TP2_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049315450325f085f53544100085f4849440d5350543030303200085f43525311290a268e2100010002020000010900404b4c0008000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049315450325f085f53544100085f4849440d5350543030303200085f4349440d574954545465737400085f43525311290a268e2100010002020000010900404b4c0008000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4489,7 +4489,7 @@
           <device id="SPT0003">
             <acpi_object>\_SB_.PC00.SPI1.TP3_</acpi_object>
             <compatible_id>WITTTest</compatible_id>
-            <aml_template>5b8248055c2f045f53425f50433030535049315450335f085f53544100085f4849440d5350543030303300085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504931007900</aml_template>
+            <aml_template>5b8247065c2f045f53425f50433030535049315450335f085f53544100085f4849440d5350543030303300085f4349440d574954545465737400085f43525311290a268e2100010002020000010900002d310108000000005c5f53422e504330302e53504931007900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -4532,7 +4532,7 @@
           <device id="INT3F0D">
             <acpi_object>\_SB_.PC00.LPCB.CWDT</acpi_object>
             <compatible_id>PNP0C02</compatible_id>
-            <aml_template>5b82385c2f045f53425f504330304c50434243574454085f5354410a0f085f4849440c25d43f0d085f435253110d0a0a47015418541804047900</aml_template>
+            <aml_template>5b8243045c2f045f53425f504330304c50434243574454085f5354410a0f085f4849440c25d43f0d085f4349440c41d00c02085f435253110d0a0a47015418541804047900</aml_template>
             <status>
               <present>y</present>
               <enabled>y</enabled>
@@ -4626,7 +4626,7 @@
             <device id="INT33D2">
               <acpi_object>\_SB_.PC00.LPCB.H_EC.BIND</acpi_object>
               <compatible_id>PNP0C40</compatible_id>
-              <aml_template>5b822c5c2f055f53425f504330304c504342485f454342494e44085f53544100085f4849440d494e543333443200</aml_template>
+              <aml_template>5b823a5c2f055f53425f504330304c504342485f454342494e44085f53544100085f4849440d494e543333443200085f4349440d504e503043343000</aml_template>
               <status>
                 <present>n</present>
                 <enabled>n</enabled>
@@ -4646,7 +4646,7 @@
             <device id="INT33D3">
               <acpi_object>\_SB_.PC00.LPCB.H_EC.CIND</acpi_object>
               <compatible_id>PNP0C60</compatible_id>
-              <aml_template>5b822c5c2f055f53425f504330304c504342485f454343494e44085f53544100085f4849440d494e543333443300</aml_template>
+              <aml_template>5b823a5c2f055f53425f504330304c504342485f454343494e44085f53544100085f4849440d494e543333443300085f4349440d504e503043363000</aml_template>
               <status>
                 <present>n</present>
                 <enabled>n</enabled>
@@ -4656,7 +4656,7 @@
             <device id="INT33D4">
               <acpi_object>\_SB_.PC00.LPCB.H_EC.DIND</acpi_object>
               <compatible_id>PNP0C70</compatible_id>
-              <aml_template>5b822c5c2f055f53425f504330304c504342485f454344494e44085f53544100085f4849440d494e543333443400</aml_template>
+              <aml_template>5b823a5c2f055f53425f504330304c504342485f454344494e44085f53544100085f4849440d494e543333443400085f4349440d504e503043373000</aml_template>
               <status>
                 <present>n</present>
                 <enabled>n</enabled>
@@ -4900,7 +4900,7 @@
           <device id="MSFT0001">
             <acpi_object>\_SB_.PC00.LPCB.PS2K</acpi_object>
             <compatible_id>PNP0303</compatible_id>
-            <aml_template>5b824a045c2f045f53425f504330304c5043425053324b085f5354410a0f085f4849440d4d5346543030303100085f43525311190a1647016000600001014701640064000101230200017900</aml_template>
+            <aml_template>5b8244055c2f045f53425f504330304c5043425053324b085f5354410a0f085f4849440d4d5346543030303100085f4349440c41d00303085f43525311190a1647016000600001014701640064000101230200017900</aml_template>
             <status>
               <present>y</present>
               <enabled>y</enabled>
@@ -4913,7 +4913,7 @@
           <device id="MSFT0003">
             <acpi_object>\_SB_.PC00.LPCB.PS2M</acpi_object>
             <compatible_id>PNP0F03</compatible_id>
-            <aml_template>5b82385c2f045f53425f504330304c5043425053324d085f53544100085f4849440d4d5346543030303300085f43525311090a06230010017900</aml_template>
+            <aml_template>5b8243045c2f045f53425f504330304c5043425053324d085f53544100085f4849440d4d5346543030303300085f4349440c41d00f03085f43525311090a06230010017900</aml_template>
             <status>
               <present>n</present>
               <enabled>n</enabled>
@@ -5069,7 +5069,7 @@
             <acpi_object>\_SB_.PC00.HDAS.SNDW</acpi_object>
             <compatible_id>PRP00001</compatible_id>
             <compatible_id>PNP0A05</compatible_id>
-            <aml_template>5b82255c2f045f53425f5043303048444153534e4457085f5354410a0b085f4144520c00000040</aml_template>
+            <aml_template>5b8241045c2f045f53425f5043303048444153534e4457085f5354410a0b085f4349441215020d5052503030303031000d504e503041303500085f4144520c00000040</aml_template>
             <status>
               <present>y</present>
               <enabled>y</enabled>
@@ -5112,7 +5112,7 @@
             <acpi_object>\_SB_.PC00.HDAS.UAOL</acpi_object>
             <compatible_id>PRP00001</compatible_id>
             <compatible_id>PNP0A05</compatible_id>
-            <aml_template>5b82255c2f045f53425f504330304844415355414f4c085f5354410a0b085f4144520c00000050</aml_template>
+            <aml_template>5b8241045c2f045f53425f504330304844415355414f4c085f5354410a0b085f4349441215020d5052503030303031000d504e503041303500085f4144520c00000050</aml_template>
             <status>
               <present>y</present>
               <enabled>y</enabled>
@@ -5169,7 +5169,7 @@
           <acpi_object>\_SB_.PC00.CLP1</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>1</acpi_uid>
-          <aml_template>5b824d055c2f035f53425f50433030434c5031085f53544100085f4849440d494e543334373200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824b065c2f035f53425f50433030434c5031085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5182,7 +5182,7 @@
           <acpi_object>\_SB_.PC00.CLP2</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>2</acpi_uid>
-          <aml_template>5b824e055c2f035f53425f50433030434c5032085f53544100085f4849440d494e543334373200085f5549440a02085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824c065c2f035f53425f50433030434c5032085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a02085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5195,7 +5195,7 @@
           <acpi_object>\_SB_.PC00.CLP3</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>3</acpi_uid>
-          <aml_template>5b824e055c2f035f53425f50433030434c5033085f53544100085f4849440d494e543334373200085f5549440a03085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824c065c2f035f53425f50433030434c5033085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a03085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5208,7 +5208,7 @@
           <acpi_object>\_SB_.PC00.CLP4</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>4</acpi_uid>
-          <aml_template>5b824e055c2f035f53425f50433030434c5034085f53544100085f4849440d494e543334373200085f5549440a04085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824c065c2f035f53425f50433030434c5034085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a04085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5221,7 +5221,7 @@
           <acpi_object>\_SB_.PC00.CLP5</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>5</acpi_uid>
-          <aml_template>5b824e055c2f035f53425f50433030434c5035085f53544100085f4849440d494e543334373200085f5549440a05085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824c065c2f035f53425f50433030434c5035085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a05085f41445200085f43525311260a238e1e00010001020000010600801a060049005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5234,7 +5234,7 @@
           <acpi_object>\_SB_.PC00.DOCK</acpi_object>
           <compatible_id>PNP0C15</compatible_id>
           <acpi_uid>SADDLESTRING</acpi_uid>
-          <aml_template>5b82385c2f035f53425f50433030444f434b085f53544100085f4849440d414243443030303000085f5549440d534144444c45535452494e4700</aml_template>
+          <aml_template>5b8243045c2f035f53425f50433030444f434b085f53544100085f4849440d414243443030303000085f4349440c41d00c15085f5549440d534144444c45535452494e4700</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5245,7 +5245,7 @@
           <acpi_object>\_SB_.PC00.DSC0</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b823b5c2f035f53425f5043303044534330085f53544100085f4849440d494e543334373200085f55494400085f41445200085f43525311050a027900</aml_template>
+          <aml_template>5b824a045c2f035f53425f5043303044534330085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f55494400085f41445200085f43525311050a027900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5256,7 +5256,7 @@
           <acpi_object>\_SB_.PC00.DSC1</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>1</acpi_uid>
-          <aml_template>5b8244085c2f035f53425f5043303044534331085f5354410a0f085f4849440d494e543334373200085f55494401085f41445200085f435253114c040a488c200001010100020000000000001700001900230000008d005c5f53422e47504930008c200001010100020000000000001700001900230000008f005c5f53422e47504930007900</aml_template>
+          <aml_template>5b8242095c2f035f53425f5043303044534331085f5354410a0f085f4849440d494e543334373200085f4349440d494e543334373200085f55494401085f41445200085f435253114c040a488c200001010100020000000000001700001900230000008d005c5f53422e47504930008c200001010100020000000000001700001900230000008f005c5f53422e47504930007900</aml_template>
           <status>
             <present>y</present>
             <enabled>y</enabled>
@@ -5270,7 +5270,7 @@
           <acpi_object>\_SB_.PC00.DSC2</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>2</acpi_uid>
-          <aml_template>5b8244085c2f035f53425f5043303044534332085f53544100085f4849440d494e543334373200085f5549440a02085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
+          <aml_template>5b8242095c2f035f53425f5043303044534332085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a02085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5284,7 +5284,7 @@
           <acpi_object>\_SB_.PC00.DSC3</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>3</acpi_uid>
-          <aml_template>5b8244085c2f035f53425f5043303044534333085f53544100085f4849440d494e543334373200085f5549440a03085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
+          <aml_template>5b8242095c2f035f53425f5043303044534333085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a03085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5298,7 +5298,7 @@
           <acpi_object>\_SB_.PC00.DSC4</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>4</acpi_uid>
-          <aml_template>5b8244085c2f035f53425f5043303044534334085f53544100085f4849440d494e543334373200085f5549440a04085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
+          <aml_template>5b8242095c2f035f53425f5043303044534334085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a04085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5312,7 +5312,7 @@
           <acpi_object>\_SB_.PC00.DSC5</acpi_object>
           <compatible_id>INT3472</compatible_id>
           <acpi_uid>5</acpi_uid>
-          <aml_template>5b8244085c2f035f53425f5043303044534335085f53544100085f4849440d494e543334373200085f5549440a05085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
+          <aml_template>5b8242095c2f035f53425f5043303044534335085f53544100085f4849440d494e543334373200085f4349440d494e543334373200085f5549440a05085f41445200085f435253114c040a488c20000101010002000000000000170000190023000000b6005c5f53422e47504930008c20000101010002000000000000170000190023000000ab005c5f53422e47504930007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5326,7 +5326,7 @@
           <acpi_object>\_SB_.PC00.FLM0</acpi_object>
           <compatible_id>PWRC0000</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8242085c2f035f53425f50433030464c4d30085f53544100085f4849440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a5005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324331007900</aml_template>
+          <aml_template>5b8241095c2f035f53425f50433030464c4d30085f53544100085f4849440d505752433030303000085f4349440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a5005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324331007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5341,7 +5341,7 @@
           <acpi_object>\_SB_.PC00.FLM1</acpi_object>
           <compatible_id>PWRC0000</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8242085c2f035f53425f50433030464c4d31085f53544100085f4849440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324332007900</aml_template>
+          <aml_template>5b8241095c2f035f53425f50433030464c4d31085f53544100085f4849440d505752433030303000085f4349440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324332007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5349,14 +5349,14 @@
           </status>
           <resource type="LargeResourceItemGPIOConnection" id="res0"/>
           <resource type="LargeResourceItemGenericSerialBusConnection" id="res1"/>
-          <dependency type="consumes resources from">\_SB_.PC00.I2C2</dependency>
           <dependency type="consumes resources from">\_SB_.GPI0</dependency>
+          <dependency type="consumes resources from">\_SB_.PC00.I2C2</dependency>
         </device>
         <device id="TXNW3643">
           <acpi_object>\_SB_.PC00.FLM2</acpi_object>
           <compatible_id>TXNW3643</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8242085c2f035f53425f50433030464c4d32085f53544100085f4849440d54584e573336343300085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000b2005c5f53422e47504930008e1e00010001020000010600801a060063005c5f53422e504330302e49324332007900</aml_template>
+          <aml_template>5b8241095c2f035f53425f50433030464c4d32085f53544100085f4849440d54584e573336343300085f4349440d54584e573336343300085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000b2005c5f53422e47504930008e1e00010001020000010600801a060063005c5f53422e504330302e49324332007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5364,14 +5364,14 @@
           </status>
           <resource type="LargeResourceItemGPIOConnection" id="res0"/>
           <resource type="LargeResourceItemGenericSerialBusConnection" id="res1"/>
-          <dependency type="consumes resources from">\_SB_.PC00.I2C2</dependency>
           <dependency type="consumes resources from">\_SB_.GPI0</dependency>
+          <dependency type="consumes resources from">\_SB_.PC00.I2C2</dependency>
         </device>
         <device id="PWRC0000">
           <acpi_object>\_SB_.PC00.FLM3</acpi_object>
           <compatible_id>PWRC0000</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8242085c2f035f53425f50433030464c4d33085f53544100085f4849440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8241095c2f035f53425f50433030464c4d33085f53544100085f4849440d505752433030303000085f4349440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5386,7 +5386,7 @@
           <acpi_object>\_SB_.PC00.FLM4</acpi_object>
           <compatible_id>PWRC0000</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8242085c2f035f53425f50433030464c4d34085f53544100085f4849440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8241095c2f035f53425f50433030464c4d34085f53544100085f4849440d505752433030303000085f4349440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5401,7 +5401,7 @@
           <acpi_object>\_SB_.PC00.FLM5</acpi_object>
           <compatible_id>PWRC0000</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8242085c2f035f53425f50433030464c4d35085f53544100085f4849440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8241095c2f035f53425f50433030464c4d35085f53544100085f4849440d505752433030303000085f4349440d505752433030303000085f55494400085f41445200085f435253114a040a468c20000101010002000000000000170000190023000000a3005c5f53422e47504930008e1e00010001020000010600801a060067005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5416,7 +5416,7 @@
           <acpi_object>\_SB_.PC00.LNK0</acpi_object>
           <compatible_id>SONY362A</compatible_id>
           <acpi_uid>0</acpi_uid>
-          <aml_template>5b8241085c2f035f53425f504330304c4e4b30085f5354410a0f085f4849440d534f4e593336324100085f55494400085f41445200085f4352531148040a448e1e00010001020000010600801a06001a005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8240095c2f035f53425f504330304c4e4b30085f5354410a0f085f4849440d534f4e593336324100085f4349440d534f4e593336324100085f55494400085f41445200085f4352531148040a448e1e00010001020000010600801a06001a005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>y</present>
             <enabled>y</enabled>
@@ -5430,7 +5430,7 @@
           <acpi_object>\_SB_.PC00.LNK1</acpi_object>
           <compatible_id>SONY488A</compatible_id>
           <acpi_uid>1</acpi_uid>
-          <aml_template>5b824f055c2f035f53425f504330304c4e4b31085f5354410a0f085f4849440d534f4e593438384100085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060037005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b824e065c2f035f53425f504330304c4e4b31085f5354410a0f085f4849440d534f4e593438384100085f4349440d534f4e593438384100085f55494401085f41445200085f43525311260a238e1e00010001020000010600801a060037005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>y</present>
             <enabled>y</enabled>
@@ -5443,7 +5443,7 @@
           <acpi_object>\_SB_.PC00.LNK2</acpi_object>
           <compatible_id>SONY362A</compatible_id>
           <acpi_uid>2</acpi_uid>
-          <aml_template>5b8240065c2f035f53425f504330304c4e4b32085f5354410a0f085f4849440d534f4e593336324100085f5549440a02085f41445200085f43525311260a238e1e00010001020000010600801a06001a005c5f53422e504330302e49324332007900</aml_template>
+          <aml_template>5b824f065c2f035f53425f504330304c4e4b32085f5354410a0f085f4849440d534f4e593336324100085f4349440d534f4e593336324100085f5549440a02085f41445200085f43525311260a238e1e00010001020000010600801a06001a005c5f53422e504330302e49324332007900</aml_template>
           <status>
             <present>y</present>
             <enabled>y</enabled>
@@ -5456,7 +5456,7 @@
           <acpi_object>\_SB_.PC00.LNK3</acpi_object>
           <compatible_id>INT33BE</compatible_id>
           <acpi_uid>3</acpi_uid>
-          <aml_template>5b8244105c2f035f53425f504330304c4e4b33085f53544100085f4849440d494e543333424500085f5549440a03085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333008e1e00010001020000010600801a060050005c5f53422e504330302e49324333008e1e00010001020000010600801a060051005c5f53422e504330302e49324333008e1e00010001020000010600801a060052005c5f53422e504330302e49324333008e1e00010001020000010600801a060053005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8242115c2f035f53425f504330304c4e4b33085f53544100085f4849440d494e543333424500085f4349440d494e543333424500085f5549440a03085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333008e1e00010001020000010600801a060050005c5f53422e504330302e49324333008e1e00010001020000010600801a060051005c5f53422e504330302e49324333008e1e00010001020000010600801a060052005c5f53422e504330302e49324333008e1e00010001020000010600801a060053005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5474,7 +5474,7 @@
           <acpi_object>\_SB_.PC00.LNK4</acpi_object>
           <compatible_id>INT33BE</compatible_id>
           <acpi_uid>4</acpi_uid>
-          <aml_template>5b8244105c2f035f53425f504330304c4e4b34085f53544100085f4849440d494e543333424500085f5549440a04085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333008e1e00010001020000010600801a060050005c5f53422e504330302e49324333008e1e00010001020000010600801a060051005c5f53422e504330302e49324333008e1e00010001020000010600801a060052005c5f53422e504330302e49324333008e1e00010001020000010600801a060053005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8242115c2f035f53425f504330304c4e4b34085f53544100085f4849440d494e543333424500085f4349440d494e543333424500085f5549440a04085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333008e1e00010001020000010600801a060050005c5f53422e504330302e49324333008e1e00010001020000010600801a060051005c5f53422e504330302e49324333008e1e00010001020000010600801a060052005c5f53422e504330302e49324333008e1e00010001020000010600801a060053005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5492,7 +5492,7 @@
           <acpi_object>\_SB_.PC00.LNK5</acpi_object>
           <compatible_id>INT33BE</compatible_id>
           <acpi_uid>5</acpi_uid>
-          <aml_template>5b8244105c2f035f53425f504330304c4e4b35085f53544100085f4849440d494e543333424500085f5549440a05085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333008e1e00010001020000010600801a060050005c5f53422e504330302e49324333008e1e00010001020000010600801a060051005c5f53422e504330302e49324333008e1e00010001020000010600801a060052005c5f53422e504330302e49324333008e1e00010001020000010600801a060053005c5f53422e504330302e49324333007900</aml_template>
+          <aml_template>5b8242115c2f035f53425f504330304c4e4b35085f53544100085f4849440d494e543333424500085f4349440d494e543333424500085f5549440a05085f41445200085f435253114c0c0ac88e1e00010001020000010600801a060010005c5f53422e504330302e49324333008e1e00010001020000010600801a06000c005c5f53422e504330302e49324333008e1e00010001020000010600801a060050005c5f53422e504330302e49324333008e1e00010001020000010600801a060051005c5f53422e504330302e49324333008e1e00010001020000010600801a060052005c5f53422e504330302e49324333008e1e00010001020000010600801a060053005c5f53422e504330302e49324333007900</aml_template>
           <status>
             <present>n</present>
             <enabled>n</enabled>
@@ -5582,18 +5582,18 @@
         <resource id="res3" type="memory" min="0xfd6a0000" max="0xfd6affff" len="0x10000"/>
         <resource id="res2" type="memory" min="0xfd6d0000" max="0xfd6dffff" len="0x10000"/>
         <resource id="res1" type="memory" min="0xfd6e0000" max="0xfd6effff" len="0x10000"/>
-        <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC5</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC3</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.DSC4</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
-        <dependency type="provides resources to">\_SB_.PC00.UA00.BTH0</dependency>
         <dependency type="provides resources to">\_SB_.PC00.DSC2</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM0</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC5</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM3</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM2</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC3</dependency>
         <dependency type="provides resources to">\_SB_.PC00.DSC1</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.DSC4</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM4</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM1</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.UA00.BTH0</dependency>
+        <dependency type="provides resources to">\_SB_.PC00.FLM5</dependency>
       </device>
       <device id="INTC1051">
         <acpi_object>\_SB_.HIDD</acpi_object>
@@ -5645,7 +5645,7 @@
         <acpi_object>\_SB_.PEPD</acpi_object>
         <compatible_id>PNP0D80</compatible_id>
         <acpi_uid>1</acpi_uid>
-        <aml_template>5b82265c2e5f53425f50455044085f5354410a0f085f4849440d494e543333413100085f55494401</aml_template>
+        <aml_template>5b82305c2e5f53425f50455044085f5354410a0f085f4849440d494e543333413100085f4349440c41d00d80085f55494401</aml_template>
         <status>
           <present>y</present>
           <enabled>y</enabled>
@@ -5686,7 +5686,7 @@
       <device id="INT340E">
         <acpi_object>\_SB_.PTID</acpi_object>
         <compatible_id>PNP0C02</compatible_id>
-        <aml_template>5b821c5c2e5f53425f50544944085f5354410a0f085f4849440c25d4340e</aml_template>
+        <aml_template>5b82265c2e5f53425f50544944085f5354410a0f085f4849440c25d4340e085f4349440c41d00c02</aml_template>
         <status>
           <present>y</present>
           <enabled>y</enabled>
@@ -5696,7 +5696,7 @@
       <device id="INT3394">
         <acpi_object>\_SB_.PTMD</acpi_object>
         <compatible_id>PNP0C02</compatible_id>
-        <aml_template>5b82155c2e5f53425f50544d44085f4849440c25d43394</aml_template>
+        <aml_template>5b821f5c2e5f53425f50544d44085f4849440c25d43394085f4349440c41d00c02</aml_template>
       </device>
       <device id="PNP0C0C">
         <acpi_object>\_SB_.PWRB</acpi_object>
@@ -5749,7 +5749,7 @@
       <device id="INTC6000" description="TPM 2.0 Device">
         <acpi_object>\_SB_.TPM_</acpi_object>
         <compatible_id>MSFT0101</compatible_id>
-        <aml_template>5b82470b5c2e5f53425f54504d5f5b8054504d52000c0000d4fe0b00505b813854504d520041434330080038494e544520494e5456080018494e545320494e54462053545330200040044649464f20004004544944302014145f53544100a00a93414343300affa400a40a0f085f4849440d494e54433630303000085f53545211210a1e540050004d00200032002e00300020004400650076006900630065000000085f43525311110a0e860900010000d4fe005000007900</aml_template>
+        <aml_template>5b82460c5c2e5f53425f54504d5f5b8054504d52000c0000d4fe0b00505b813854504d520041434330080038494e544520494e5456080018494e545320494e54462053545330200040044649464f20004004544944302014145f53544100a00a93414343300affa400a40a0f085f4849440d494e54433630303000085f4349440d4d5346543031303100085f53545211210a1e540050004d00200032002e00300020004400650076006900630065000000085f43525311110a0e860900010000d4fe005000007900</aml_template>
         <status>
           <present>y</present>
           <enabled>y</enabled>
@@ -5793,7 +5793,7 @@
         <acpi_object>\_SB_.UBTC</acpi_object>
         <compatible_id>PNP0CA0</compatible_id>
         <acpi_uid>0</acpi_uid>
-        <aml_template>5b823f5c2e5f53425f55425443085f5354410a0f085f4849440c5662c000085f55494400085f41445200085f43525311110a0e8609000100b0f53f001000007900</aml_template>
+        <aml_template>5b824a045c2e5f53425f55425443085f5354410a0f085f4849440c5662c000085f4349440c41d00ca0085f55494400085f41445200085f43525311110a0e8609000100b0f53f001000007900</aml_template>
         <status>
           <present>y</present>
           <enabled>y</enabled>


### PR DESCRIPTION
ACPI device drivers use both _HID and _CID to identify devices they
match. This patch copies _CID objects to vACPI devices so that guest
drivers can recognize the passthrough devices properly.

Tracked-On: #6288
Signed-off-by: Junjie Mao <junjie.mao@intel.com>