### PR TITLE
config_tools: fix the issue that fail to generate launch script

### DIFF
--- a/misc/config_tools/library/scenario_cfg_lib.py
+++ b/misc/config_tools/library/scenario_cfg_lib.py
@@ -350,7 +350,7 @@ def vm_cpu_affinity_check(config_file, id_cpus_per_vm_dic, item):
     cpu_affinity = common.get_leaf_tag_map(config_file, "cpu_affinity", "pcpu_id")
     for vm_i in id_cpus_per_vm_dic.keys():
         for cpu in id_cpus_per_vm_dic[vm_i]:
-            if cpu in use_cpus and not cpu_sharing_enabled:
+            if cpu is not None and cpu in use_cpus and not cpu_sharing_enabled:
                 key = "vm:id={},{}".format(vm_i, item)
                 err_dic[key] = "The same pcpu was configurated in <pcpu_id>/<cpu_affinity>, but CPU sharing is disabled by 'SCHED_NOOP'. Please re-configurate them!"
                 return err_dic


### PR DESCRIPTION
fix the issue that fail to generate launch script when to disable
CPU sharing.

Tracked-On: #6428
Signed-off-by: Kunhui-Li <kunhuix.li@intel.com>